### PR TITLE
Support poratlbe, filter expressions with AzureVectorStore

### DIFF
--- a/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/AzureAiSearchFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/AzureAiSearchFilterExpressionConverter.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore;
+
+import java.util.List;
+
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.ExpressionType;
+import org.springframework.ai.vectorstore.filter.Filter.Group;
+import org.springframework.ai.vectorstore.filter.Filter.Key;
+import org.springframework.ai.vectorstore.filter.converter.AbstractFilterExpressionConverter;
+import org.springframework.util.Assert;
+
+/**
+ * Converts {@link Expression} into Azure Search OData filter syntax.
+ * https://learn.microsoft.com/en-us/azure/search/search-query-odata-filter
+ *
+ * @author Christian Tzolov
+ */
+public class AzureAiSearchFilterExpressionConverter extends AbstractFilterExpressionConverter {
+
+	private final List<String> allowedIdentifierNames;
+
+	public AzureAiSearchFilterExpressionConverter(List<String> allowedIdentifierNames) {
+		Assert.notNull(allowedIdentifierNames, "The allowedIdentifierNames can not null.");
+		this.allowedIdentifierNames = allowedIdentifierNames;
+	}
+
+	@Override
+	protected void doExpression(Expression expression, StringBuilder context) {
+		if (expression.type() == ExpressionType.IN || expression.type() == ExpressionType.NIN) {
+			context.append(getOperationSymbol(expression));
+			context.append("(");
+			this.convertOperand(expression.left(), context);
+			context.append(", ");
+			this.convertOperand(expression.right(), context);
+			context.append(", ',')");
+		}
+		else {
+			this.convertOperand(expression.left(), context);
+			context.append(getOperationSymbol(expression));
+			this.convertOperand(expression.right(), context);
+		}
+	}
+
+	protected void doStartValueRange(Filter.Value listValue, StringBuilder context) {
+		context.append("'");
+	}
+
+	protected void doEndValueRange(Filter.Value listValue, StringBuilder context) {
+		context.append("'");
+	}
+
+	private String getOperationSymbol(Expression exp) {
+		switch (exp.type()) {
+			case AND:
+				return " and ";
+			case OR:
+				return " or ";
+			case EQ:
+				return " eq ";
+			case NE:
+				return " ne ";
+			case LT:
+				return " lt ";
+			case LTE:
+				return " le ";
+			case GT:
+				return " gt ";
+			case GTE:
+				return " ge ";
+			case IN:
+				return " search.in";
+			case NIN:
+				return " not search.in";
+			default:
+				throw new RuntimeException("Not supported expression type: " + exp.type());
+		}
+	}
+
+	@Override
+	public void doKey(Key key, StringBuilder context) {
+		var hasOuterQuotes = hasOuterQuotes(key.key());
+		var identifier = (hasOuterQuotes) ? removeOuterQuotes(key.key()) : key.key();
+		var prefixedIdentifier = withMetaPrefix(identifier);
+		if (hasOuterQuotes) {
+			prefixedIdentifier = "'" + prefixedIdentifier.trim() + "'";
+		}
+		context.append(prefixedIdentifier);
+	}
+
+	public String withMetaPrefix(String identifier) {
+
+		if (this.allowedIdentifierNames.contains(identifier)) {
+			return "meta_" + identifier;
+		}
+
+		throw new IllegalArgumentException("Not allowed filter identifier name: " + identifier);
+	}
+
+	@Override
+	protected void doValue(Filter.Value filterValue, StringBuilder context) {
+		if (filterValue.value() instanceof List list) {
+			doStartValueRange(filterValue, context);
+			int c = 0;
+			for (Object v : list) {
+				// this.doSingleValue(v, context);
+				context.append(v);
+				if (c++ < list.size() - 1) {
+					this.doAddValueRangeSpitter(filterValue, context);
+				}
+			}
+			this.doEndValueRange(filterValue, context);
+		}
+		else {
+			this.doSingleValue(filterValue.value(), context);
+		}
+	}
+
+	@Override
+	protected void doSingleValue(Object value, StringBuilder context) {
+		if (value instanceof String) {
+			context.append(String.format("'%s'", value));
+		}
+		else {
+			context.append(value);
+		}
+	}
+
+	@Override
+	public void doStartGroup(Group group, StringBuilder context) {
+		context.append("(");
+	}
+
+	@Override
+	public void doEndGroup(Group group, StringBuilder context) {
+		context.append(")");
+	}
+
+}

--- a/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/AzureVectorStore.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.vectorstore;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -41,9 +42,12 @@ import com.azure.search.documents.models.IndexingResult;
 import com.azure.search.documents.models.SearchOptions;
 import com.azure.search.documents.models.VectorSearchOptions;
 import com.azure.search.documents.models.VectorizedQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.vectorstore.filter.converter.FilterExpressionConverter;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -61,6 +65,12 @@ import org.springframework.util.StringUtils;
  */
 public class AzureVectorStore implements VectorStore, InitializingBean {
 
+	private static final Logger logger = LoggerFactory.getLogger(AzureVectorStore.class);
+
+	private static final String SPRING_AI_VECTOR_CONFIG = "spring-ai-vector-config";
+
+	private static final String SPRING_AI_VECTOR_PROFILE = "spring-ai-vector-profile";
+
 	public static final String DEFAULT_INDEX_NAME = "spring_ai_azure_vector_store";
 
 	private static final String ID_FIELD_NAME = "id";
@@ -77,11 +87,15 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 
 	private static final Double DEFAULT_SIMILARITY_THRESHOLD = 0.0;
 
+	private static final String METADATA_FIELD_PREFIX = "meta_";
+
 	private final SearchIndexClient searchIndexClient;
 
 	private final EmbeddingClient embeddingClient;
 
 	private SearchClient searchClient;
+
+	private final FilterExpressionConverter filterExpressionConverter;
 
 	private int defaultTopK = DEFAULT_TOP_K;
 
@@ -90,16 +104,73 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 	private String indexName = DEFAULT_INDEX_NAME;
 
 	/**
+	 * List of metadata fields (as field name and type) that can be used in similarity
+	 * search query filter expressions. The {@link Document#getMetadata()} can contain
+	 * arbitrary number of metadata entries, but only the fields listed here can be used
+	 * in the search filter expressions.
+	 *
+	 * If new entries are added ot the filterMetadataFields the affected documents must be
+	 * (re)updated.
+	 */
+	private final List<MetadataField> filterMetadataFields;
+
+	public record MetadataField(String name, SearchFieldDataType fieldType) {
+
+		public static MetadataField text(String name) {
+			return new MetadataField(name, SearchFieldDataType.STRING);
+		}
+
+		public static MetadataField int32(String name) {
+			return new MetadataField(name, SearchFieldDataType.INT32);
+		}
+
+		public static MetadataField int64(String name) {
+			return new MetadataField(name, SearchFieldDataType.INT64);
+		}
+
+		public static MetadataField decimal(String name) {
+			return new MetadataField(name, SearchFieldDataType.DOUBLE);
+		}
+
+		public static MetadataField bool(String name) {
+			return new MetadataField(name, SearchFieldDataType.BOOLEAN);
+		}
+
+		public static MetadataField date(String name) {
+			return new MetadataField(name, SearchFieldDataType.DATE_TIME_OFFSET);
+		}
+	}
+
+	/**
 	 * Constructs a new AzureCognitiveSearchVectorStore.
 	 * @param searchIndexClient A pre-configured Azure {@link SearchIndexClient} that CRUD
 	 * for Azure search indexes and factory for {@link SearchClient}.
 	 * @param embeddingClient The client for embedding operations.
 	 */
 	public AzureVectorStore(SearchIndexClient searchIndexClient, EmbeddingClient embeddingClient) {
+		this(searchIndexClient, embeddingClient, List.of());
+	}
+
+	/**
+	 * Constructs a new AzureCognitiveSearchVectorStore.
+	 * @param searchIndexClient A pre-configured Azure {@link SearchIndexClient} that CRUD
+	 * for Azure search indexes and factory for {@link SearchClient}.
+	 * @param embeddingClient The client for embedding operations.
+	 * @param filterMetadataFields List of metadata fields (as field name and type) that
+	 * can be used in similarity search query filter expressions.
+	 */
+	public AzureVectorStore(SearchIndexClient searchIndexClient, EmbeddingClient embeddingClient,
+			List<MetadataField> filterMetadataFields) {
+
 		Assert.notNull(embeddingClient, "The embedding client can not be null.");
 		Assert.notNull(searchIndexClient, "The search index client can not be null.");
+		Assert.notNull(filterMetadataFields, "The filterMetadataFields can not be null.");
+
 		this.searchIndexClient = searchIndexClient;
 		this.embeddingClient = embeddingClient;
+		this.filterMetadataFields = filterMetadataFields;
+		this.filterExpressionConverter = new AzureAiSearchFilterExpressionConverter(
+				filterMetadataFields.stream().map(MetadataField::name).toList());
 	}
 
 	/**
@@ -145,8 +216,16 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 			searchDocument.put(ID_FIELD_NAME, document.getId());
 			searchDocument.put(EMBEDDING_FIELD_NAME, embeddings);
 			searchDocument.put(CONTENT_FIELD_NAME, document.getContent());
-			// TODO: Consider alternate/native field type for metadata
 			searchDocument.put(METADATA_FIELD_NAME, new JSONObject(document.getMetadata()).toJSONString());
+
+			// Add the filterable metadata fields as top level fields, allowing filler
+			// expressions on them.
+			for (MetadataField mf : this.filterMetadataFields) {
+				if (document.getMetadata().containsKey(mf.name())) {
+					searchDocument.put(METADATA_FIELD_PREFIX + mf.name(), document.getMetadata().get(mf.name()));
+				}
+			}
+
 			return searchDocument;
 		}).toList();
 
@@ -198,11 +277,6 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 
 		Assert.notNull(request, "The search request must not be null.");
 
-		if (request.getFilterExpression() != null) {
-			throw new UnsupportedOperationException(
-					"The [" + this.getClass() + "] doesn't support metadata filtering!");
-		}
-
 		var searchEmbedding = toFloatList(embeddingClient.embed(request.getQuery()));
 
 		final var vectorQuery = new VectorizedQuery(searchEmbedding).setKNearestNeighborsCount(request.getTopK())
@@ -210,9 +284,15 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 			// list of field names.
 			.setFields(EMBEDDING_FIELD_NAME);
 
-		final var searchResults = searchClient.search(null,
-				new SearchOptions().setVectorSearchOptions(new VectorSearchOptions().setQueries(vectorQuery)),
-				Context.NONE);
+		var searchOptions = new SearchOptions()
+			.setVectorSearchOptions(new VectorSearchOptions().setQueries(vectorQuery));
+
+		if (request.hasFilterExpression()) {
+			String oDataFilter = this.filterExpressionConverter.convertExpression(request.getFilterExpression());
+			searchOptions.setFilter(oDataFilter);
+		}
+
+		final var searchResults = searchClient.search(null, searchOptions, Context.NONE);
 
 		return searchResults.stream()
 			.filter(result -> result.getScore() >= request.getSimilarityThreshold())
@@ -250,32 +330,44 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 
 		int dimensions = this.embeddingClient.dimensions();
 
-		SearchIndex searchIndex = new SearchIndex(this.indexName).setFields(
-				new SearchField(ID_FIELD_NAME, SearchFieldDataType.STRING).setKey(true)
-					.setFilterable(true)
-					.setSortable(true),
-				new SearchField(EMBEDDING_FIELD_NAME, SearchFieldDataType.collection(SearchFieldDataType.SINGLE))
-					.setSearchable(true)
-					.setVectorSearchDimensions(dimensions)
-					// This must match a vector search configuration name.
-					.setVectorSearchProfileName("my-vector-profile"),
-				new SearchField(CONTENT_FIELD_NAME, SearchFieldDataType.STRING).setSearchable(true).setFilterable(true),
-				new SearchField(METADATA_FIELD_NAME, SearchFieldDataType.STRING).setSearchable(true)
-					.setFilterable(true))
-			// VectorSearch configuration is required for a vector field. The name used
-			// for the vector search
-			// algorithm configuration must match the configuration used by the search
-			// field used for vector search.
-			.setVectorSearch(new VectorSearch()
-				.setProfiles(
-						Collections.singletonList(new VectorSearchProfile("my-vector-profile", "my-vector-config")))
-				.setAlgorithms(Collections.singletonList(
-						new HnswAlgorithmConfiguration("my-vector-config").setParameters(new HnswParameters().setM(4)
-							.setEfConstruction(400)
-							.setEfSearch(1000)
-							.setMetric(VectorSearchAlgorithmMetric.COSINE)))));
+		List<SearchField> fields = new ArrayList<>();
 
-		var index = this.searchIndexClient.createOrUpdateIndex(searchIndex);
+		fields.add(new SearchField(ID_FIELD_NAME, SearchFieldDataType.STRING).setKey(true)
+			.setFilterable(true)
+			.setSortable(true));
+		fields.add(new SearchField(EMBEDDING_FIELD_NAME, SearchFieldDataType.collection(SearchFieldDataType.SINGLE))
+			.setSearchable(true)
+			.setVectorSearchDimensions(dimensions)
+			// This must match a vector search configuration name.
+			.setVectorSearchProfileName(SPRING_AI_VECTOR_PROFILE));
+		fields.add(new SearchField(CONTENT_FIELD_NAME, SearchFieldDataType.STRING).setSearchable(true)
+			.setFilterable(true));
+		fields.add(new SearchField(METADATA_FIELD_NAME, SearchFieldDataType.STRING).setSearchable(true)
+			.setFilterable(true));
+
+		for (MetadataField filterableMetadataField : this.filterMetadataFields) {
+			fields.add(new SearchField(METADATA_FIELD_PREFIX + filterableMetadataField.name(),
+					filterableMetadataField.fieldType())
+				.setSearchable(false)
+				.setFacetable(true));
+		}
+
+		SearchIndex searchIndex = new SearchIndex(this.indexName).setFields(fields)
+			// VectorSearch configuration is required for a vector field. The name used
+			// for the vector search algorithm configuration must match the configuration
+			// used by the search field used for vector search.
+			.setVectorSearch(new VectorSearch()
+				.setProfiles(Collections
+					.singletonList(new VectorSearchProfile(SPRING_AI_VECTOR_PROFILE, SPRING_AI_VECTOR_CONFIG)))
+				.setAlgorithms(Collections.singletonList(new HnswAlgorithmConfiguration(SPRING_AI_VECTOR_CONFIG)
+					.setParameters(new HnswParameters().setM(4)
+						.setEfConstruction(400)
+						.setEfSearch(1000)
+						.setMetric(VectorSearchAlgorithmMetric.COSINE)))));
+
+		SearchIndex index = this.searchIndexClient.createOrUpdateIndex(searchIndex);
+
+		logger.info("Created search index: " + index.getName());
 
 		this.searchClient = this.searchIndexClient.getSearchClient(this.indexName);
 	}

--- a/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/AzureVectorStore.java
@@ -169,8 +169,7 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 		this.searchIndexClient = searchIndexClient;
 		this.embeddingClient = embeddingClient;
 		this.filterMetadataFields = filterMetadataFields;
-		this.filterExpressionConverter = new AzureAiSearchFilterExpressionConverter(
-				filterMetadataFields.stream().map(MetadataField::name).toList());
+		this.filterExpressionConverter = new AzureAiSearchFilterExpressionConverter(filterMetadataFields);
 	}
 
 	/**

--- a/vector-stores/spring-ai-azure/src/test/java/org/springframework/ai/vectorstore/AzureAiSearchFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-azure/src/test/java/org/springframework/ai/vectorstore/AzureAiSearchFilterExpressionConverterTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.Group;
+import org.springframework.ai.vectorstore.filter.Filter.Key;
+import org.springframework.ai.vectorstore.filter.Filter.Value;
+import org.springframework.ai.vectorstore.filter.converter.FilterExpressionConverter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.AND;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.EQ;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.GTE;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.IN;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.LTE;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.NE;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.NIN;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.OR;
+
+/**
+ * @author Christian Tzolov
+ */
+public class AzureAiSearchFilterExpressionConverterTests {
+
+	private static String format(String text) {
+		return text.trim().replace(" " + System.lineSeparator(), System.lineSeparator()) + "\n";
+	}
+
+	@Test
+	public void testMissingFilterName() {
+
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of());
+
+		assertThatThrownBy(() -> {
+			converter.convertExpression(new Expression(EQ, new Key("country"), new Value("BG")));
+		}).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Not allowed filter identifier name: country");
+	}
+
+	@Test
+	public void testEQ() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("country"));
+
+		// country == "BG"
+		String vectorExpr = converter.convertExpression(new Expression(EQ, new Key("country"), new Value("BG")));
+		assertThat(format(vectorExpr)).isEqualTo("""
+				meta_country eq 'BG'
+				""");
+	}
+
+	@Test
+	public void tesEqAndGte() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("genre", "year"));
+
+		// genre == "drama" AND year >= 2020
+		String vectorExpr = converter
+			.convertExpression(new Expression(AND, new Expression(EQ, new Key("genre"), new Value("drama")),
+					new Expression(GTE, new Key("year"), new Value(2020))));
+		assertThat(format(vectorExpr)).isEqualTo("""
+				meta_genre eq 'drama' and meta_year ge 2020
+				""");
+	}
+
+	@Test
+	public void tesIn() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("genre"));
+
+		// genre in ["comedy", "documentary", "drama"]
+		String vectorExpr = converter.convertExpression(
+				new Expression(IN, new Key("genre"), new Value(List.of("comedy", "documentary", "drama"))));
+		assertThat(format(vectorExpr)).isEqualTo("""
+				search.in(meta_genre, 'comedy,documentary,drama', ',')
+				""");
+	}
+
+	@Test
+	public void tesNin() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("genre"));
+
+		// genre in ["comedy", "documentary", "drama"]
+		String vectorExpr = converter.convertExpression(
+				new Expression(NIN, new Key("genre"), new Value(List.of("comedy", "documentary", "drama"))));
+		assertThat(format(vectorExpr)).isEqualTo("""
+				not search.in(meta_genre, 'comedy,documentary,drama', ',')
+				""");
+	}
+
+	@Test
+	public void testNe() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of("city", "year", "country"));
+
+		// year >= 2020 OR country == "BG" AND city != "Sofia"
+		String vectorExpr = converter
+			.convertExpression(new Expression(OR, new Expression(GTE, new Key("year"), new Value(2020)),
+					new Expression(AND, new Expression(EQ, new Key("country"), new Value("BG")),
+							new Expression(NE, new Key("city"), new Value("Sofia")))));
+		assertThat(format(vectorExpr)).isEqualTo("""
+				meta_year ge 2020 or meta_country eq 'BG' and meta_city ne 'Sofia'
+				""");
+	}
+
+	@Test
+	public void testGroup() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of("city", "year", "country"));
+
+		// (year >= 2020 OR country == "BG") AND city != "Sofia"
+		String vectorExpr = converter.convertExpression(new Expression(AND,
+				new Group(new Expression(OR, new Expression(GTE, new Key("year"), new Value(2020)),
+						new Expression(EQ, new Key("country"), new Value("BG")))),
+				new Expression(NE, new Key("city"), new Value("Sofia"))));
+
+		assertThat(format(vectorExpr)).isEqualTo("""
+				(meta_year ge 2020 or meta_country eq 'BG') and meta_city ne 'Sofia'
+				""");
+	}
+
+	@Test
+	public void tesBoolean() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of("isOpen", "year", "country"));
+
+		// isOpen == true AND year >= 2020 AND country IN ["BG", "NL", "US"]
+		String vectorExpr = converter.convertExpression(new Expression(AND,
+				new Expression(AND, new Expression(EQ, new Key("isOpen"), new Value(true)),
+						new Expression(GTE, new Key("year"), new Value(2020))),
+				new Expression(IN, new Key("country"), new Value(List.of("BG", "NL", "US")))));
+
+		assertThat(format(vectorExpr)).isEqualTo("""
+				meta_isOpen eq true and meta_year ge 2020 and  search.in(meta_country, 'BG,NL,US', ',')
+				""");
+	}
+
+	@Test
+	public void testDecimal() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("temperature"));
+
+		// temperature >= -15.6 && temperature <= +20.13
+		String vectorExpr = converter
+			.convertExpression(new Expression(AND, new Expression(GTE, new Key("temperature"), new Value(-15.6)),
+					new Expression(LTE, new Key("temperature"), new Value(20.13))));
+
+		assertThat(format(vectorExpr)).isEqualTo("""
+				meta_temperature ge -15.6 and meta_temperature le 20.13
+				""");
+	}
+
+	@Test
+	public void testComplexIdentifiers() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("country 1 2 3"));
+
+		String vectorExpr = converter
+			.convertExpression(new Expression(EQ, new Key("\"country 1 2 3\""), new Value("BG")));
+		assertThat(format(vectorExpr)).isEqualTo("""
+				'meta_country 1 2 3' eq 'BG'
+				""");
+
+		vectorExpr = converter.convertExpression(new Expression(EQ, new Key("'country 1 2 3'"), new Value("BG")));
+		assertThat(format(vectorExpr)).isEqualTo("""
+				'meta_country 1 2 3' eq 'BG'
+				""");
+	}
+
+}

--- a/vector-stores/spring-ai-azure/src/test/java/org/springframework/ai/vectorstore/AzureAiSearchFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-azure/src/test/java/org/springframework/ai/vectorstore/AzureAiSearchFilterExpressionConverterTests.java
@@ -16,10 +16,12 @@
 
 package org.springframework.ai.vectorstore;
 
+import java.util.Date;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.vectorstore.AzureVectorStore.MetadataField;
 import org.springframework.ai.vectorstore.filter.Filter.Expression;
 import org.springframework.ai.vectorstore.filter.Filter.Group;
 import org.springframework.ai.vectorstore.filter.Filter.Key;
@@ -58,8 +60,24 @@ public class AzureAiSearchFilterExpressionConverterTests {
 	}
 
 	@Test
+	public void testDate() {
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of(MetadataField.date("activationDate")));
+
+		// country >= 1970-01-01T00:00:02Z
+		String vectorExpr = converter
+			.convertExpression(new Expression(EQ, new Key("activationDate"), new Value(new Date(2000))));
+		assertThat(vectorExpr).isEqualTo("meta_activationDate eq 1970-01-01T00:00:02Z");
+
+		vectorExpr = converter
+			.convertExpression(new Expression(EQ, new Key("activationDate"), new Value("1970-01-01T00:00:02Z")));
+		assertThat(vectorExpr).isEqualTo("meta_activationDate eq 1970-01-01T00:00:02Z");
+	}
+
+	@Test
 	public void testEQ() {
-		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("country"));
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of(MetadataField.text("country")));
 
 		// country == "BG"
 		String vectorExpr = converter.convertExpression(new Expression(EQ, new Key("country"), new Value("BG")));
@@ -70,7 +88,8 @@ public class AzureAiSearchFilterExpressionConverterTests {
 
 	@Test
 	public void tesEqAndGte() {
-		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("genre", "year"));
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of(MetadataField.text("genre"), MetadataField.int32("year")));
 
 		// genre == "drama" AND year >= 2020
 		String vectorExpr = converter
@@ -83,7 +102,8 @@ public class AzureAiSearchFilterExpressionConverterTests {
 
 	@Test
 	public void tesIn() {
-		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("genre"));
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of(MetadataField.text("genre")));
 
 		// genre in ["comedy", "documentary", "drama"]
 		String vectorExpr = converter.convertExpression(
@@ -95,7 +115,8 @@ public class AzureAiSearchFilterExpressionConverterTests {
 
 	@Test
 	public void tesNin() {
-		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("genre"));
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of(MetadataField.text("genre")));
 
 		// genre in ["comedy", "documentary", "drama"]
 		String vectorExpr = converter.convertExpression(
@@ -108,7 +129,7 @@ public class AzureAiSearchFilterExpressionConverterTests {
 	@Test
 	public void testNe() {
 		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
-				List.of("city", "year", "country"));
+				List.of(MetadataField.text("city"), MetadataField.int64("year"), MetadataField.text("country")));
 
 		// year >= 2020 OR country == "BG" AND city != "Sofia"
 		String vectorExpr = converter
@@ -123,7 +144,7 @@ public class AzureAiSearchFilterExpressionConverterTests {
 	@Test
 	public void testGroup() {
 		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
-				List.of("city", "year", "country"));
+				List.of(MetadataField.text("city"), MetadataField.int64("year"), MetadataField.text("country")));
 
 		// (year >= 2020 OR country == "BG") AND city != "Sofia"
 		String vectorExpr = converter.convertExpression(new Expression(AND,
@@ -139,7 +160,7 @@ public class AzureAiSearchFilterExpressionConverterTests {
 	@Test
 	public void tesBoolean() {
 		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
-				List.of("isOpen", "year", "country"));
+				List.of(MetadataField.bool("isOpen"), MetadataField.int64("year"), MetadataField.text("country")));
 
 		// isOpen == true AND year >= 2020 AND country IN ["BG", "NL", "US"]
 		String vectorExpr = converter.convertExpression(new Expression(AND,
@@ -154,7 +175,8 @@ public class AzureAiSearchFilterExpressionConverterTests {
 
 	@Test
 	public void testDecimal() {
-		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("temperature"));
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of(MetadataField.decimal("temperature")));
 
 		// temperature >= -15.6 && temperature <= +20.13
 		String vectorExpr = converter
@@ -168,7 +190,8 @@ public class AzureAiSearchFilterExpressionConverterTests {
 
 	@Test
 	public void testComplexIdentifiers() {
-		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(List.of("country 1 2 3"));
+		FilterExpressionConverter converter = new AzureAiSearchFilterExpressionConverter(
+				List.of(MetadataField.text("country 1 2 3")));
 
 		String vectorExpr = converter
 			.convertExpression(new Expression(EQ, new Key("\"country 1 2 3\""), new Value("BG")));


### PR DESCRIPTION
Support generic, portable [metadata filters](https://docs.spring.io/spring-ai/reference/api/vectordbs.html#_metadata_filters) with AzureVectorStore. 
For example the:
```java
vectorStore.similaritySearch(
   SearchRequest
      .query("The World")
      .withTopK(TOP_K)
      .withSimilarityThreshold(SIMILARITY_THRESHOLD)
      .withFilterExpression("country in ['UK', 'NL'] && year >= 2020"));
```
Internally will converted to the [Azure Search OData filters](https://learn.microsoft.com/en-us/azure/search/search-query-odata-filte) like: `$filter search.in(meta_country, 'UK,NL', ',') and meta_year ge 2020`.

All portable operations are supported, but you have to list explicitly the metadata fields used in filter expression. 


