### PR TITLE
Add hint about cloning the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The Spring AI project provides a Spring-friendly API and abstractions for develo
 
 Let's make your `@Beans` intelligent!
 
+## Cloning the repo
+
+You need [Git Large File Storage](https://git-lfs.com/) installed to clone the repo.
 
 ## Project Links
 


### PR DESCRIPTION
I learned the hard way that GLFS must be installed to clone the repo and added a hint to the README.