### PR TITLE
Update GitHub repo URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/miscellaneous.md
+++ b/.github/ISSUE_TEMPLATE/miscellaneous.md
@@ -10,7 +10,7 @@ assignees: ''
 For anything other than bug reports and feature requests (performance, refactoring, etc),
 just go ahead and file the issue. Please provide as many details as possible.
 
-If you have a question or a support request, please open a new discussion on [GitHub Discussions](https://github.com/spring-projects-experimental/spring-ai/discussions)
+If you have a question or a support request, please open a new discussion on [GitHub Discussions](https://github.com/spring-projects/spring-ai/discussions)
 or ask a question on [StackOverflow](https://stackoverflow.com/questions/tagged/spring-ai).
 
 Please do **not** create issues on the [Issue Tracker](https://github.com/spring-projects/spring-ai/issues) for questions or support requests.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spring AI [![build status](https://github.com/spring-projects-experimental/spring-ai/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/spring-projects-experimental/spring-ai/actions/workflows/continuous-integration.yml)
+# Spring AI [![build status](https://github.com/spring-projects/spring-ai/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/spring-projects/spring-ai/actions/workflows/continuous-integration.yml)
 
 Welcome to the Spring AI project!
 
@@ -17,8 +17,8 @@ To clone it you have to either:
 ## Project Links
 
 * [Documentation](https://docs.spring.io/spring-ai/reference/)
-* [Issues](https://github.com/spring-projects-experimental/spring-ai/issues)
-* [Discussions](https://github.com/spring-projects-experimental/spring-ai/discussions) - Go here if you have a question, suggestion, or feedback!
+* [Issues](https://github.com/spring-projects/spring-ai/issues)
+* [Discussions](https://github.com/spring-projects/spring-ai/discussions) - Go here if you have a question, suggestion, or feedback!
 * [JavaDocs](https://docs.spring.io/spring-ai/docs/current-SNAPSHOT/)
 
 ## Educational Resources

--- a/document-readers/pdf-reader/pom.xml
+++ b/document-readers/pdf-reader/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Document Reader - PDF</name>
 	<description>Spring AI PDF document reader</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/document-readers/tika-reader/pom.xml
+++ b/document-readers/tika-reader/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Document Reader - Tika</name>
 	<description>Spring AI Tika document reader</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/embedding-clients/spring-ai-postgresml-embedding-client/pom.xml
+++ b/embedding-clients/spring-ai-postgresml-embedding-client/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Embedding Client - PostgresML</name>
 	<description>Spring AI PostgresML Embedding Client</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/embedding-clients/transformers-embedding/pom.xml
+++ b/embedding-clients/transformers-embedding/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Transormers Embedding Client</name>
 	<description>Spring AI Transformers Embedding Client</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/embedding-clients/transformers-embedding/src/main/java/org/springframework/ai/embedding/TransformersEmbeddingClient.java
+++ b/embedding-clients/transformers-embedding/src/main/java/org/springframework/ai/embedding/TransformersEmbeddingClient.java
@@ -40,11 +40,11 @@ public class TransformersEmbeddingClient implements EmbeddingClient, Initializin
 	private static final Log logger = LogFactory.getLog(TransformersEmbeddingClient.class);
 
 	// ONNX tokenizer for the all-MiniLM-L6-v2 model
-	public final static String DEFAULT_ONNX_TOKENIZER_URI = "https://raw.githubusercontent.com/spring-projects-experimental/spring-ai/main/embedding-clients/transformers-embedding/src/main/resources/onnx/all-MiniLM-L6-v2/tokenizer.json";
+	public final static String DEFAULT_ONNX_TOKENIZER_URI = "https://raw.githubusercontent.com/spring-projects/spring-ai/main/embedding-clients/transformers-embedding/src/main/resources/onnx/all-MiniLM-L6-v2/tokenizer.json";
 
 	// ONNX model for all-MiniLM-L6-v2 pre-trained transformer:
 	// https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
-	public final static String DEFAULT_ONNX_MODEL_URI = "https://github.com/spring-projects-experimental/spring-ai/raw/main/embedding-clients/transformers-embedding/src/main/resources/onnx/all-MiniLM-L6-v2/model.onnx";
+	public final static String DEFAULT_ONNX_MODEL_URI = "https://github.com/spring-projects/spring-ai/raw/main/embedding-clients/transformers-embedding/src/main/resources/onnx/all-MiniLM-L6-v2/model.onnx";
 
 	public final static String DEFAULT_MODEL_OUTPUT_NAME = "last_hidden_state";
 

--- a/embedding-clients/transformers-embedding/src/test/java/org/springframework/ai/embedding/ResourceCacheServiceTests.java
+++ b/embedding-clients/transformers-embedding/src/test/java/org/springframework/ai/embedding/ResourceCacheServiceTests.java
@@ -101,7 +101,7 @@ public class ResourceCacheServiceTests {
 	public void cacheHttpResources() throws IOException {
 		var cache = new ResourceCacheService(tempDir);
 
-		var originalResourceUri1 = "https://raw.githubusercontent.com/spring-projects-experimental/spring-ai/main/spring-ai-core/src/main/resources/embedding/embedding-model-dimensions.properties";
+		var originalResourceUri1 = "https://raw.githubusercontent.com/spring-projects/spring-ai/main/spring-ai-core/src/main/resources/embedding/embedding-model-dimensions.properties";
 		var cachedResource1 = cache.getCachedResource(originalResourceUri1);
 
 		assertThat(cachedResource1).isNotEqualTo(new DefaultResourceLoader().getResource(originalResourceUri1));

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>0.7.1-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<name>Spring AI</name>
 	<description>Building AI applications with Spring Boot</description>
@@ -44,17 +44,17 @@
 		<url>https://spring.io</url>
 	</organization>
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 	<issueManagement>
 		<system>Github Issues</system>
-		<url>https://github.com/spring-projects-experimental/spring-ai/issues</url>
+		<url>https://github.com/spring-projects/spring-ai/issues</url>
 	</issueManagement>
 	<ciManagement>
 		<system>Github Actions</system>
-		<url>https://github.com/spring-projects-experimental/spring-ai/actions</url>
+		<url>https://github.com/spring-projects/spring-ai/actions</url>
 	</ciManagement>
 	<distributionManagement>
 		<snapshotRepository>

--- a/spring-ai-azure-openai/pom.xml
+++ b/spring-ai-azure-openai/pom.xml
@@ -10,12 +10,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Azure OpenAI</name>
 	<description>OpenAI support</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/spring-ai-core/pom.xml
+++ b/spring-ai-core/pom.xml
@@ -11,12 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Core</name>
 	<description>Core domain for AI programming</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/spring-ai-core/src/main/java/org/springframework/ai/parser/README.md
+++ b/spring-ai-core/src/main/java/org/springframework/ai/parser/README.md
@@ -1,7 +1,7 @@
 # Output Parsing
 
 * [Documentation](https://docs.spring.io/spring-ai/reference/concepts.html#_output_parsing)
-* [Usage examples](https://github.com/spring-projects-experimental/spring-ai/blob/main/spring-ai-openai/src/test/java/org/springframework/ai/openai/client/ClientIT.java)
+* [Usage examples](https://github.com/spring-projects/spring-ai/blob/main/spring-ai-openai/src/test/java/org/springframework/ai/openai/client/ClientIT.java)
 
 The output of AI models traditionally arrives as a java.util.String, even if you ask for the reply to be in JSON. It may be the correct JSON, but it isn’t a JSON data structure. It is just a string. Also, asking "for JSON" as part of the prompt isn’t 100% accurate.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/aiclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/aiclient.adoc
@@ -249,7 +249,7 @@ You can find the Javadoc https://docs.spring.io/spring-ai/docs/current-SNAPSHOT/
 
 == Feedback and Contributions
 
-The project's https://github.com/spring-projects-experimental/spring-ai/discussions[GitHub discussions] is a great place to send feedback.
+The project's https://github.com/spring-projects/spring-ai/discussions[GitHub discussions] is a great place to send feedback.
 
 == Related Resources
 

--- a/spring-ai-docs/src/main/javadoc/overview.html
+++ b/spring-ai-docs/src/main/javadoc/overview.html
@@ -1,7 +1,7 @@
 <html>
 <body>
 <p>
-	This document is the API specification for <a href="https://github.com/spring-projects-experimental/spring-ai" target="_top">Spring AI</a>
+	This document is the API specification for <a href="https://github.com/spring-projects/spring-ai" target="_top">Spring AI</a>
 </p>
 <div id="overviewBody">
 	<p>

--- a/spring-ai-huggingface/pom.xml
+++ b/spring-ai-huggingface/pom.xml
@@ -10,12 +10,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI HuggingFace</name>
 	<description>HuggingFace support</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/spring-ai-openai/pom.xml
+++ b/spring-ai-openai/pom.xml
@@ -10,12 +10,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI OpenAI</name>
 	<description>OpenAI support</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -11,12 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Auto Configuration</name>
 	<description>Spring AI Auto Configuration</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-azure-openai/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-azure-openai/pom.xml
@@ -11,12 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Starter - Azure OpenAI</name>
 	<description>Spring AI Azure OpenAI Auto Configuration</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-ollama/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-ollama/pom.xml
@@ -11,12 +11,12 @@
     <packaging>jar</packaging>
     <name>Spring AI Starter - Ollama</name>
     <description>Spring AI Ollama Auto Configuration</description>
-    <url>https://github.com/spring-projects-experimental/spring-ai</url>
+    <url>https://github.com/spring-projects/spring-ai</url>
 
     <scm>
-        <url>https://github.com/spring-projects-experimental/spring-ai</url>
-        <connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-        <developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
     </scm>
 
     <dependencies>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-openai/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-openai/pom.xml
@@ -11,12 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Starter - OpenAI</name>
 	<description>Spring AI Open AI Auto Configuration</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-transformers-embedding/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-transformers-embedding/pom.xml
@@ -11,12 +11,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Starter - Transformers Embedding</name>
 	<description>Spring Transformers Embedding Auto Configuration</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/spring-ai-test/pom.xml
+++ b/spring-ai-test/pom.xml
@@ -10,12 +10,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Test</name>
 	<description>Test support for AI programming</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/vector-stores/spring-ai-azure/pom.xml
+++ b/vector-stores/spring-ai-azure/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI - Azure AI Search Vector Store</name>
 	<description>Spring AI - Azure AI Search Vector Store</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/vector-stores/spring-ai-chroma/pom.xml
+++ b/vector-stores/spring-ai-chroma/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Chroma Vector Store</name>
 	<description>Spring AI Chroma Vector Store</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/vector-stores/spring-ai-milvus-store/pom.xml
+++ b/vector-stores/spring-ai-milvus-store/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Milvus Vector Store</name>
 	<description>Spring AI Milvus Vector Store</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/vector-stores/spring-ai-neo4j-store/pom.xml
+++ b/vector-stores/spring-ai-neo4j-store/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Vector Store - neo4j</name>
 	<description>Spring AI Neo4j Vector Store</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<dependencies>

--- a/vector-stores/spring-ai-pgvector-store/pom.xml
+++ b/vector-stores/spring-ai-pgvector-store/pom.xml
@@ -12,12 +12,12 @@
 	<packaging>jar</packaging>
 	<name>Spring AI Vector Store - pgvector</name>
 	<description>Spring AI PGVector Vector Store</description>
-	<url>https://github.com/spring-projects-experimental/spring-ai</url>
+	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
-		<url>https://github.com/spring-projects-experimental/spring-ai</url>
-		<connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-		<developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
 	<properties>

--- a/vector-stores/spring-ai-pinecone/pom.xml
+++ b/vector-stores/spring-ai-pinecone/pom.xml
@@ -12,12 +12,12 @@
     <packaging>jar</packaging>
     <name>spring-ai-pinecone</name>
     <description>spring-ai-pinecone</description>
-    <url>https://github.com/spring-projects-experimental/spring-ai</url>
+    <url>https://github.com/spring-projects/spring-ai</url>
 
     <scm>
-        <url>https://github.com/spring-projects-experimental/spring-ai</url>
-        <connection>git://github.com/spring-projects-experimental/spring-ai.git</connection>
-        <developerConnection>git@github.com:spring-projects-experimental/spring-ai.git</developerConnection>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
     </scm>
 
     <properties>


### PR DESCRIPTION
This PR updates GitHub repo URLs for this project to reflect its organization change from "spring-projects-experimental" to "spring-projects".