### PR TITLE
Add Vertex AI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
 		<module>vector-stores/spring-ai-chroma</module>
 		<module>vector-stores/spring-ai-azure</module>
 		<module>vector-stores/spring-ai-weaviate</module>
+		<module>spring-ai-vertex-ai</module>
 
 	</modules>
 
@@ -81,7 +82,7 @@
         <maven.compiler.target>17</maven.compiler.target>
 
 		<!-- production dependencies -->
-		<spring-boot.version>3.1.3</spring-boot.version>
+		<spring-boot.version>3.2.0</spring-boot.version>
 		<stringtemplate.version>4.0.2</stringtemplate.version>
 		<open-ai-client.version>0.16.0</open-ai-client.version>
 		<azure-open-ai-client.version>1.0.0-beta.3</azure-open-ai-client.version>

--- a/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/client/AzureOpenAiClientMetadataTests.java
+++ b/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/client/AzureOpenAiClientMetadataTests.java
@@ -81,7 +81,7 @@ class AzureOpenAiClientMetadataTests {
 		Generation generation = response.getGeneration();
 
 		assertThat(generation).isNotNull()
-			.extracting(Generation::getText)
+			.extracting(Generation::getContent)
 			.isEqualTo("No! You will actually land with a resounding thud. This is the way!");
 
 		assertPromptMetadata(response);

--- a/spring-ai-core/pom.xml
+++ b/spring-ai-core/pom.xml
@@ -41,6 +41,12 @@
 
 		<dependency>
 			<groupId>org.springframework</groupId>
+			<artifactId>spring-webflux</artifactId>
+			<version>6.1.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
 			<artifactId>spring-messaging</artifactId>
 		</dependency>
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/client/AiClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/client/AiClient.java
@@ -24,9 +24,8 @@ public interface AiClient {
 
 	default String generate(String message) {
 		Prompt prompt = new Prompt(new UserMessage(message));
-		return generate(prompt).getGeneration().getText();
+		return generate(prompt).getGeneration().getContent();
 	}
 
 	AiResponse generate(Prompt prompt);
-
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/client/AiClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/client/AiClient.java
@@ -28,4 +28,5 @@ public interface AiClient {
 	}
 
 	AiResponse generate(Prompt prompt);
+
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/client/AiResponse.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/client/AiResponse.java
@@ -37,7 +37,8 @@ public class AiResponse {
 
 	/**
 	 * Construct a new {@link AiResponse} instance without metadata.
-	 * @param generations the {@link List} of {@link Generation} returned by the AI provider.
+	 * @param generations the {@link List} of {@link Generation} returned by the AI
+	 * provider.
 	 */
 	public AiResponse(List<Generation> generations) {
 		this(generations, GenerationMetadata.NULL);
@@ -45,8 +46,10 @@ public class AiResponse {
 
 	/**
 	 * Construct a new {@link AiResponse} instance.
-	 * @param generations the {@link List} of {@link Generation} returned by the AI provider.
-	 * @param metadata {@link GenerationMetadata} containing information about the use of the AI provider's API.
+	 * @param generations the {@link List} of {@link Generation} returned by the AI
+	 * provider.
+	 * @param metadata {@link GenerationMetadata} containing information about the use of
+	 * the AI provider's API.
 	 */
 	public AiResponse(List<Generation> generations, GenerationMetadata metadata) {
 		this.metadata = metadata;
@@ -56,8 +59,8 @@ public class AiResponse {
 	/**
 	 * The {@link List} of {@link Generation generated outputs}.
 	 * <p>
-	 * It is a {@link List} of {@link List lists} because the Prompt could request multiple output {@link Generation
-	 * generations}.
+	 * It is a {@link List} of {@link List lists} because the Prompt could request
+	 * multiple output {@link Generation generations}.
 	 * @return the {@link List} of {@link Generation generated outputs}.
 	 */
 	public List<Generation> getGenerations() {
@@ -72,14 +75,16 @@ public class AiResponse {
 	}
 
 	/**
-	 * @return Returns {@link GenerationMetadata} containing information about the use of the AI provider's API.
+	 * @return Returns {@link GenerationMetadata} containing information about the use of
+	 * the AI provider's API.
 	 */
 	public GenerationMetadata getGenerationMetadata() {
 		return this.metadata;
 	}
 
 	/**
-	 * @return {@link PromptMetadata} containing information on prompt processing by the AI.
+	 * @return {@link PromptMetadata} containing information on prompt processing by the
+	 * AI.
 	 */
 	public PromptMetadata getPromptMetadata() {
 		PromptMetadata promptMetadata = this.promptMetadata;
@@ -87,8 +92,10 @@ public class AiResponse {
 	}
 
 	/**
-	 * Builder method used to include {@link PromptMetadata} returned in the AI response when processing the prompt.
-	 * @param promptMetadata {@link PromptMetadata} returned by the AI in the response when processing the prompt.
+	 * Builder method used to include {@link PromptMetadata} returned in the AI response
+	 * when processing the prompt.
+	 * @param promptMetadata {@link PromptMetadata} returned by the AI in the response
+	 * when processing the prompt.
 	 * @return this {@link AiResponse}.
 	 * @see #getPromptMetadata()
 	 */

--- a/spring-ai-core/src/main/java/org/springframework/ai/client/AiResponse.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/client/AiResponse.java
@@ -15,26 +15,39 @@
  */
 package org.springframework.ai.client;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.ai.metadata.GenerationMetadata;
 import org.springframework.ai.metadata.PromptMetadata;
 import org.springframework.lang.Nullable;
 
+/**
+ * The chat completion (e.g. generation) response returned by an AI provider.
+ */
 public class AiResponse {
 
 	private final GenerationMetadata metadata;
 
+	/**
+	 * List of generated messages returned by the AI provider.
+	 */
 	private final List<Generation> generations;
 
 	private PromptMetadata promptMetadata;
 
+	/**
+	 * Construct a new {@link AiResponse} instance without metadata.
+	 * @param generations the {@link List} of {@link Generation} returned by the AI provider.
+	 */
 	public AiResponse(List<Generation> generations) {
 		this(generations, GenerationMetadata.NULL);
 	}
 
+	/**
+	 * Construct a new {@link AiResponse} instance.
+	 * @param generations the {@link List} of {@link Generation} returned by the AI provider.
+	 * @param metadata {@link GenerationMetadata} containing information about the use of the AI provider's API.
+	 */
 	public AiResponse(List<Generation> generations, GenerationMetadata metadata) {
 		this.metadata = metadata;
 		this.generations = List.copyOf(generations);
@@ -43,33 +56,30 @@ public class AiResponse {
 	/**
 	 * The {@link List} of {@link Generation generated outputs}.
 	 * <p>
-	 * It is a {@link List} of {@link List lists} because the Prompt could request
-	 * multiple output {@link Generation generations}.
+	 * It is a {@link List} of {@link List lists} because the Prompt could request multiple output {@link Generation
+	 * generations}.
 	 * @return the {@link List} of {@link Generation generated outputs}.
 	 */
 	public List<Generation> getGenerations() {
 		return this.generations;
 	}
 
+	/**
+	 * @return Returns the first {@link Generation} in the generations list.
+	 */
 	public Generation getGeneration() {
 		return this.generations.get(0);
 	}
 
 	/**
-	 * Returns {@link GenerationMetadata} containing information about the use of the AI
-	 * provider's API.
-	 * @return {@link GenerationMetadata} containing information about the use of the AI
-	 * provider's API.
+	 * @return Returns {@link GenerationMetadata} containing information about the use of the AI provider's API.
 	 */
 	public GenerationMetadata getGenerationMetadata() {
 		return this.metadata;
 	}
 
 	/**
-	 * Returns {@link PromptMetadata} containing information on prompt processing by the
-	 * AI.
-	 * @return {@link PromptMetadata} containing information on prompt processing by the
-	 * AI.
+	 * @return {@link PromptMetadata} containing information on prompt processing by the AI.
 	 */
 	public PromptMetadata getPromptMetadata() {
 		PromptMetadata promptMetadata = this.promptMetadata;
@@ -77,10 +87,8 @@ public class AiResponse {
 	}
 
 	/**
-	 * Builder method used to include {@link PromptMetadata} returned in the AI response
-	 * when processing the prompt.
-	 * @param promptMetadata {@link PromptMetadata} returned by the AI in the response
-	 * when processing the prompt.
+	 * Builder method used to include {@link PromptMetadata} returned in the AI response when processing the prompt.
+	 * @param promptMetadata {@link PromptMetadata} returned by the AI in the response when processing the prompt.
 	 * @return this {@link AiResponse}.
 	 * @see #getPromptMetadata()
 	 */

--- a/spring-ai-core/src/main/java/org/springframework/ai/client/Generation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/client/Generation.java
@@ -24,7 +24,6 @@ import org.springframework.ai.prompt.messages.AbstractMessage;
 import org.springframework.ai.prompt.messages.MessageType;
 import org.springframework.lang.Nullable;
 
-
 /**
  * Represents a response returned by the AI.
  */

--- a/spring-ai-core/src/main/java/org/springframework/ai/client/Generation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/client/Generation.java
@@ -20,14 +20,15 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.springframework.ai.metadata.ChoiceMetadata;
+import org.springframework.ai.prompt.messages.AbstractMessage;
+import org.springframework.ai.prompt.messages.MessageType;
 import org.springframework.lang.Nullable;
 
-public class Generation {
 
-	// Just text for now
-	private final String text;
-
-	private Map<String, Object> info;
+/**
+ * Represents a response returned by the AI.
+ */
+public class Generation extends AbstractMessage {
 
 	private ChoiceMetadata choiceMetadata;
 
@@ -35,17 +36,12 @@ public class Generation {
 		this(text, Collections.emptyMap());
 	}
 
-	public Generation(String text, Map<String, Object> info) {
-		this.text = text;
-		this.info = Map.copyOf(info);
+	public Generation(String content, Map<String, Object> properties) {
+		super(MessageType.ASSISTANT, content, properties);
 	}
 
-	public String getText() {
-		return this.text;
-	}
-
-	public Map<String, Object> getInfo() {
-		return this.info;
+	public Generation(String content, Map<String, Object> properties, MessageType type) {
+		super(type, content, properties);
 	}
 
 	public ChoiceMetadata getChoiceMetadata() {
@@ -60,7 +56,7 @@ public class Generation {
 
 	@Override
 	public String toString() {
-		return "Generation{" + "text='" + text + '\'' + ", info=" + info + '}';
+		return "Generation{" + "text='" + content + '\'' + ", info=" + properties + '}';
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
@@ -86,4 +86,42 @@ public abstract class AbstractMessage implements Message {
 		return this.messageType.getValue();
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((content == null) ? 0 : content.hashCode());
+		result = prime * result + ((properties == null) ? 0 : properties.hashCode());
+		result = prime * result + ((messageType == null) ? 0 : messageType.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		AbstractMessage other = (AbstractMessage) obj;
+		if (content == null) {
+			if (other.content != null)
+				return false;
+		}
+		else if (!content.equals(other.content))
+			return false;
+		if (properties == null) {
+			if (other.properties != null)
+				return false;
+		}
+		else if (!properties.equals(other.properties))
+			return false;
+		if (messageType != other.messageType)
+			return false;
+		return true;
+	}
+
+	
+
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/messages/AbstractMessage.java
@@ -122,6 +122,4 @@ public abstract class AbstractMessage implements Message {
 		return true;
 	}
 
-	
-
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/KeywordMetadataEnricher.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/KeywordMetadataEnricher.java
@@ -65,7 +65,7 @@ public class KeywordMetadataEnricher implements DocumentTransformer {
 
 			var template = new PromptTemplate(String.format(KEYWORDS_TEMPLATE, keywordCount));
 			Prompt prompt = template.create(Map.of(CONTEXT_STR_PLACEHOLDER, document.getContent()));
-			String keywords = this.aiClient.generate(prompt).getGeneration().getText();
+			String keywords = this.aiClient.generate(prompt).getGeneration().getContent();
 			document.getMetadata().putAll(Map.of(EXCERPT_KEYWORDS_METADATA_KEY, keywords));
 		}
 		return documents;

--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/SummaryMetadataEnricher.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/SummaryMetadataEnricher.java
@@ -102,7 +102,7 @@ public class SummaryMetadataEnricher implements DocumentTransformer {
 
 			Prompt prompt = new PromptTemplate(this.summaryTemplate)
 				.create(Map.of(CONTEXT_STR_PLACEHOLDER, documentContext));
-			documentSummaries.add(this.aiClient.generate(prompt).getGeneration().getText());
+			documentSummaries.add(this.aiClient.generate(prompt).getGeneration().getContent());
 		}
 
 		for (int i = 0; i < documentSummaries.size(); i++) {

--- a/spring-ai-core/src/test/java/org/springframework/ai/client/AiClientTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/client/AiClientTests.java
@@ -71,7 +71,7 @@ class AiClientTests {
 		verify(mockClient, times(1)).generate(eq(userMessage));
 		verify(mockClient, times(1)).generate(isA(Prompt.class));
 		verify(response, times(1)).getGeneration();
-		verify(generation, times(1)).getText();
+		verify(generation, times(1)).getContent();
 		verifyNoMoreInteractions(mockClient, generation, response);
 	}
 

--- a/spring-ai-huggingface/src/test/java/org/springframework/ai/huggingface/client/ClientIT.java
+++ b/spring-ai-huggingface/src/test/java/org/springframework/ai/huggingface/client/ClientIT.java
@@ -47,7 +47,7 @@ public class ClientIT {
 				 """;
 		Prompt prompt = new Prompt(mistral7bInstruct);
 		AiResponse aiResponse = huggingfaceAiClient.generate(prompt);
-		assertThat(aiResponse.getGeneration().getText()).isNotEmpty();
+		assertThat(aiResponse.getGeneration().getContent()).isNotEmpty();
 		String expectedResponse = """
 				```json
 				{
@@ -56,9 +56,9 @@ public class ClientIT {
 				    "address": "#1 Samuel St."
 				}
 				```""";
-		assertThat(aiResponse.getGeneration().getText()).isEqualTo(expectedResponse);
-		assertThat(aiResponse.getGeneration().getInfo()).containsKey("generated_tokens");
-		assertThat(aiResponse.getGeneration().getInfo()).containsEntry("generated_tokens", 39);
+		assertThat(aiResponse.getGeneration().getContent()).isEqualTo(expectedResponse);
+		assertThat(aiResponse.getGeneration().getProperties()).containsKey("generated_tokens");
+		assertThat(aiResponse.getGeneration().getProperties()).containsEntry("generated_tokens", 39);
 
 	}
 

--- a/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/client/OllamaClientTests.java
+++ b/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/client/OllamaClientTests.java
@@ -21,7 +21,7 @@ public class OllamaClientTests {
 		Assertions.assertNotNull(aiResponse);
 		Assertions.assertFalse(CollectionUtils.isEmpty(aiResponse.getGenerations()));
 		Assertions.assertNotNull(aiResponse.getGeneration());
-		Assertions.assertNotNull(aiResponse.getGeneration().getText());
+		Assertions.assertNotNull(aiResponse.getGeneration().getContent());
 	}
 
 	private static OllamaClient getOllamaClient() {

--- a/spring-ai-openai/src/test/java/org/springframework/ai/openai/testutils/AbstractIT.java
+++ b/spring-ai-openai/src/test/java/org/springframework/ai/openai/testutils/AbstractIT.java
@@ -39,7 +39,7 @@ public abstract class AbstractIT {
 
 	protected void evaluateQuestionAndAnswer(String question, AiResponse response, boolean factBased) {
 		assertThat(response).isNotNull();
-		String answer = response.getGeneration().getText();
+		String answer = response.getGeneration().getContent();
 		logger.info("Question: " + question);
 		logger.info("Answer:" + answer);
 		PromptTemplate userPromptTemplate = new PromptTemplate(userEvaluatorResource,
@@ -53,12 +53,12 @@ public abstract class AbstractIT {
 		}
 		Message userMessage = userPromptTemplate.createMessage();
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
-		String yesOrNo = openAiClient.generate(prompt).getGeneration().getText();
+		String yesOrNo = openAiClient.generate(prompt).getGeneration().getContent();
 		logger.info("Is Answer related to question: " + yesOrNo);
 		if (yesOrNo.equalsIgnoreCase("no")) {
 			SystemMessage notRelatedSystemMessage = new SystemMessage(qaEvaluatorNotRelatedResource);
 			prompt = new Prompt(List.of(userMessage, notRelatedSystemMessage));
-			String reasonForFailure = openAiClient.generate(prompt).getGeneration().getText();
+			String reasonForFailure = openAiClient.generate(prompt).getGeneration().getContent();
 			fail(reasonForFailure);
 		}
 		else {

--- a/spring-ai-test/src/main/java/org/springframework/ai/evaluation/BasicEvaluationTest.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/evaluation/BasicEvaluationTest.java
@@ -55,7 +55,7 @@ public class BasicEvaluationTest {
 
 	protected void evaluateQuestionAndAnswer(String question, AiResponse response, boolean factBased) {
 		assertThat(response).isNotNull();
-		String answer = response.getGeneration().getText();
+		String answer = response.getGeneration().getContent();
 		logger.info("Question: " + question);
 		logger.info("Answer:" + answer);
 		PromptTemplate userPromptTemplate = new PromptTemplate(userEvaluatorResource,
@@ -69,12 +69,12 @@ public class BasicEvaluationTest {
 		}
 		Message userMessage = userPromptTemplate.createMessage();
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
-		String yesOrNo = openAiClient.generate(prompt).getGeneration().getText();
+		String yesOrNo = openAiClient.generate(prompt).getGeneration().getContent();
 		logger.info("Is Answer related to question: " + yesOrNo);
 		if (yesOrNo.equalsIgnoreCase("no")) {
 			SystemMessage notRelatedSystemMessage = new SystemMessage(qaEvaluatorNotRelatedResource);
 			prompt = new Prompt(List.of(userMessage, notRelatedSystemMessage));
-			String reasonForFailure = openAiClient.generate(prompt).getGeneration().getText();
+			String reasonForFailure = openAiClient.generate(prompt).getGeneration().getContent();
 			fail(reasonForFailure);
 		}
 		else {

--- a/spring-ai-vertex-ai/pom.xml
+++ b/spring-ai-vertex-ai/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai</artifactId>
+		<version>0.8.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-ai-vertex-ai</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Vertex AI</name>
+	<description>Vertex AI support</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-core</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-aiplatform</artifactId>
+			<version>3.32.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>6.1.1</version>
+		</dependency>
+
+
+		<!-- Spring Framework -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/api/VertexAiApi.java
+++ b/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/api/VertexAiApi.java
@@ -1,0 +1,614 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertex.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.Assert;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+// @formatter:off
+/**
+ * Vertex AI API client for the Generative Language model.
+ * https://developers.generativeai.google/api/rest/generativelanguage
+ * https://cloud.google.com/vertex-ai/docs/generative-ai/learn/streaming
+ *
+ * Provides methods to generate a response from the model given an input
+ * https://developers.generativeai.google/api/rest/generativelanguage/models/generateMessage
+ *
+ * as well as to generate embeddings for the input text:
+ * https://developers.generativeai.google/api/rest/generativelanguage/models/embedText
+ *
+ *
+ * Supported models:
+ *
+ * <pre>
+ * name=models/chat-bison-001,
+ * 		version=001,
+ * 		displayName=Chat Bison,
+ * 		description=Chat-optimized generative language model.,
+ * 		inputTokenLimit=4096,
+ * 		outputTokenLimit=1024,
+ * 		supportedGenerationMethods=[generateMessage, countMessageTokens],
+ * 		temperature=0.25,
+ * 		topP=0.95,
+ *		topK=40
+ *
+ * name=models/text-bison-001,
+ *		version=001,
+ *		displayName=Text Bison,
+ *		description=Model targeted for text generation.,
+ * 		inputTokenLimit=8196,
+ *		outputTokenLimit=1024,
+ *		supportedGenerationMethods=[generateText, countTextTokens, createTunedTextModel],
+ *		temperature=0.7,
+ *		topP=0.95,
+ *		topK=40
+ *
+ * name=models/embedding-gecko-001,
+ * 		version=001,
+ * 		displayName=Embedding Gecko, description=Obtain a distributed representation of a text.,
+ * 		inputTokenLimit=1024,
+ * 		outputTokenLimit=1,
+ * 		supportedGenerationMethods=[embedText, countTextTokens],
+ * 		temperature=null,
+ * 		topP=null,
+ * 		topK=null
+ * </pre>
+ *
+ * @author Christian Tzolov
+ */
+public class VertexAiApi {
+
+	/**
+	 * The default generation model. This model is used to generate responses for the
+	 * input text.
+	 */
+	public static final String DEFAULT_GENERATE_MODEL = "chat-bison-001";
+
+	/**
+	 * The default embedding model. This model is used to generate embeddings for the
+	 * input text.
+	 */
+	public static final String DEFAULT_EMBEDDING_MODEL = "embedding-gecko-001";
+
+	private static final String DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta3";
+
+	private final RestClient restClient;
+
+	private final String apiKey;
+
+	private final String generateModel;
+
+	private final String embeddingModel;
+
+	/**
+	 * Create an new chat completion api.
+	 * @param apiKey vertex apiKey.
+	 */
+	public VertexAiApi(String apiKey) {
+		this(DEFAULT_BASE_URL, apiKey, DEFAULT_GENERATE_MODEL, DEFAULT_EMBEDDING_MODEL, RestClient.builder());
+	}
+
+	/**
+	 * Create an new chat completion api.
+	 * @param baseUrl api base URL.
+	 * @param apiKey vertex apiKey.
+	 * @param model vertex model.
+	 * @param embeddingModel vertex embedding model.
+	 * @param restClientBuilder RestClient builder.
+	 */
+	public VertexAiApi(String baseUrl, String apiKey, String model, String embeddingModel,
+			RestClient.Builder restClientBuilder) {
+
+		this.generateModel = model;
+		this.embeddingModel = embeddingModel;
+		this.apiKey = apiKey;
+
+		Consumer<HttpHeaders> jsonContentHeaders = headers -> {
+			headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+			headers.setContentType(MediaType.APPLICATION_JSON);
+		};
+
+		ResponseErrorHandler responseErrorHandler = new ResponseErrorHandler() {
+			@Override
+			public boolean hasError(ClientHttpResponse response) throws IOException {
+				return response.getStatusCode().isError();
+			}
+
+			@Override
+			public void handleError(ClientHttpResponse response) throws IOException {
+				if (response.getStatusCode().isError()) {
+					throw new RuntimeException(String.format("%s - %s", response.getStatusCode().value(),
+							new ObjectMapper().readValue(response.getBody(), ResponseError.class)));
+				}
+			}
+		};
+
+		this.restClient = restClientBuilder.baseUrl(baseUrl)
+			.defaultHeaders(jsonContentHeaders)
+			.defaultStatusHandler(responseErrorHandler)
+			.build();
+	}
+
+	/**
+	 * Generates a response from the model given an input.
+	 * @param request Request body.
+	 * @return Response body.
+	 */
+	public GenerateMessageResponse generateMessage(GenerateMessageRequest request) {
+		Assert.notNull(request, "The request body can not be null.");
+
+		return this.restClient.post()
+			.uri("/models/{model}:generateMessage?key={apiKey}", this.generateModel, this.apiKey)
+			.body(request)
+			.retrieve()
+			.body(GenerateMessageResponse.class);
+	}
+
+	/**
+	 * Generates a response from the model given an input.
+	 * @param text Text to embed.
+	 * @return Embedding response.
+	 */
+	public Embedding embedText(String text) {
+		Assert.hasText(text, "The text can not be null or empty.");
+
+		@JsonInclude(Include.NON_NULL)
+		record EmbeddingResponse(Embedding embedding) {
+		}
+
+		return this.restClient.post()
+			.uri("/models/{model}:embedText?key={apiKey}", this.embeddingModel, this.apiKey)
+			.body(Map.of("text", text))
+			.retrieve()
+			.body(EmbeddingResponse.class)
+			.embedding();
+	}
+
+	/**
+	 * Generates a response from the model given an input.
+	 * @param texts List of texts to embed.
+	 * @return Embedding response containing a list of embeddings.
+	 */
+	public List<Embedding> batchEmbedText(List<String> texts) {
+		Assert.notNull(texts, "The texts can not be null.");
+
+		@JsonInclude(Include.NON_NULL)
+		record BatchEmbeddingResponse(List<Embedding> embeddings) {
+		}
+
+		return this.restClient.post()
+			.uri("/models/{model}:batchEmbedText?key={apiKey}", this.embeddingModel, this.apiKey)
+			// https://developers.generativeai.google/api/rest/generativelanguage/models/batchEmbedText#request-body
+			.body(Map.of("texts", texts))
+			.retrieve()
+			.body(BatchEmbeddingResponse.class)
+			.embeddings();
+	}
+
+	/**
+	 * Returns the number of tokens in the message prompt.
+	 * @param prompt Message prompt to count tokens for.
+	 * @return Number of tokens in the message prompt.
+	 */
+	public Integer countMessageTokens(MessagePrompt prompt) {
+
+		Assert.notNull(prompt, "The message prompt can not be null.");
+
+		record TokenCount(@JsonProperty("tokenCount") Integer tokenCount) {
+		}
+
+		return this.restClient.post()
+			.uri("/models/{model}:countMessageTokens?key={apiKey}", this.generateModel, this.apiKey)
+			.body(Map.of("prompt", prompt))
+			.retrieve()
+			.body(TokenCount.class)
+			.tokenCount();
+	}
+
+	/**
+	 * Returns the list of models available for use.
+	 * @return List of models available for use.
+	 */
+	public List<String> listModels() {
+
+		@JsonInclude(Include.NON_NULL)
+		record ModelList(@JsonProperty("models") List<ModelName> models) {
+			record ModelName(String name) {
+			}
+		}
+
+		return this.restClient.get()
+			.uri("/models?key={apiKey}", this.apiKey)
+			.retrieve()
+			.body(ModelList.class)
+			.models()
+			.stream()
+			.map(ModelList.ModelName::name)
+			.toList();
+	}
+
+	/**
+	 * Returns the model details.
+	 * @param modelName Name of the model to get details for.
+	 * @return Model details.
+	 */
+	public Model getModel(String modelName) {
+
+		Assert.hasText(modelName, "The model name can not be null or empty.");
+
+		if (modelName.startsWith("models/")) {
+			modelName = modelName.substring("models/".length());
+		}
+
+		return this.restClient.get()
+			.uri("/models/{model}?key={apiKey}", modelName, this.apiKey)
+			.retrieve()
+			.body(Model.class);
+	}
+
+	/**
+	 * API error response.
+	 *
+	 * @param error Error details.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record ResponseError(
+			@JsonProperty("error") Error error) {
+
+		/**
+		 * Error details.
+		 *
+		 * @param message Error message.
+		 * @param code Error code.
+		 * @param status Error status.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record Error(
+				@JsonProperty("message") String message,
+				@JsonProperty("code") String code,
+				@JsonProperty("status") String status) {
+		}
+	}
+
+	/**
+	 * Information about a Generative Language Model.
+	 *
+	 * @param name The resource name of the Model. Format: `models/{model} with a {model}
+	 * naming convention of:`
+	 *
+	 * <pre>
+	 * {baseModelId}-{version}
+	 * </pre>
+	 * @param baseModelId The name of the base model, pass this to the generation request.
+	 * @param version The version of the model. This represents the major version.
+	 * @param displayName The human-readable name of the model. E.g. "Chat Bison". The
+	 * name can be up to 128 characters long and can consist of any UTF-8 characters.
+	 * @param description A short description of the model.
+	 * @param inputTokenLimit Maximum number of input tokens allowed for this model.
+	 * @param outputTokenLimit Maximum number of output tokens allowed for this model.
+	 * @param supportedGenerationMethods List of supported generation methods for this
+	 * model. The method names are defined as Pascal case strings, such as generateMessage
+	 * which correspond to API methods.
+	 * @param temperature Controls the randomness of the output. Values can range over
+	 * [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more
+	 * varied, while a value closer to 0.0 will typically result in less surprising
+	 * responses from the model. This value specifies default to be used by the backend
+	 * while making the call to the model.
+	 * @param topP For Nucleus sampling. Nucleus sampling considers the smallest set of
+	 * tokens whose probability sum is at least topP. This value specifies default to be
+	 * used by the backend while making the call to the model.
+	 * @param topK For Top-k sampling. Top-k sampling considers the set of topK most
+	 * probable tokens. This value specifies default to be used by the backend while
+	 * making the call to the model.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record Model(
+			@JsonProperty("name") String name,
+			@JsonProperty("baseModelId") String baseModelId,
+			@JsonProperty("version") String version,
+			@JsonProperty("displayName") String displayName,
+			@JsonProperty("description") String description,
+			@JsonProperty("inputTokenLimit") Integer inputTokenLimit,
+			@JsonProperty("outputTokenLimit") Integer outputTokenLimit,
+			@JsonProperty("supportedGenerationMethods") List<String> supportedGenerationMethods,
+			@JsonProperty("temperature") Float temperature,
+			@JsonProperty("topP") Float topP,
+			@JsonProperty("topK") Integer topK) {
+	}
+
+	/**
+	 * A list of floats representing the embedding.
+	 *
+	 * @param value The embedding values.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record Embedding(
+			@JsonProperty("value") List<Double> value) {
+
+	}
+
+	/**
+	 * The base unit of structured text. A Message includes an author and the content of
+	 * the Message. The author is used to tag messages when they are fed to the model as
+	 * text.
+	 *
+	 * @param author (optional) Author of the message. This serves as a key for tagging
+	 * the content of this Message when it is fed to the model as text.The author can be
+	 * any alphanumeric string.
+	 * @param content The text content of the structured Message.
+	 * @param citationMetadata (output only) Citation information for model-generated
+	 * content in this Message. If this Message was generated as output from the model,
+	 * this field may be populated with attribution information for any text included in
+	 * the content. This field is used only on output.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record Message(
+			@JsonProperty("author") String author,
+			@JsonProperty("content") String content,
+			@JsonProperty("citationMetadata") CitationMetadata citationMetadata) {
+
+		/**
+		 * Short-hand constructor for a message without citation metadata.
+		 * @param author (optional) Author of the message.
+		 * @param content The text content of the structured Message.
+		 */
+		public Message(String author, String content) {
+			this(author, content, null);
+		}
+
+		/**
+		 * A collection of source attributions for a piece of content.
+		 *
+		 * Citations to sources for a specific response.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record CitationMetadata(
+				@JsonProperty("citationSources") List<CitationSource> citationSources) {
+		}
+
+		/**
+		 * A citation to a source for a portion of a specific response.
+		 *
+		 * @param startIndex (optional) Start of segment of the response that is
+		 * attributed to this source. Index indicates the start of the segment, measured
+		 * in bytes.
+		 * @param endIndex (optional) End of the attributed segment, exclusive.
+		 * @param uri (optional) URI that is attributed as a source for a portion of the
+		 * text.
+		 * @param license (optional) License for the GitHub project that is attributed as
+		 * a source for segment.License info is required for code citations.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record CitationSource(
+				@JsonProperty("startIndex") Integer startIndex,
+				@JsonProperty("endIndex") Integer endIndex,
+				@JsonProperty("uri") String uri,
+				@JsonProperty("license") String license) {
+		}
+	}
+
+	/**
+	 * All of the structured input text passed to the model as a prompt.
+	 *
+	 * A MessagePrompt contains a structured set of fields that provide context for the
+	 * conversation, examples of user input/model output message pairs that prime the
+	 * model to respond in different ways, and the conversation history or list of
+	 * messages representing the alternating turns of the conversation between the user
+	 * and the model.
+	 *
+	 * @param context (optional) Text that should be provided to the model first to ground
+	 * the response. If not empty, this context will be given to the model first before
+	 * the examples and messages. When using a context be sure to provide it with every
+	 * request to maintain continuity. This field can be a description of your prompt to
+	 * the model to help provide context and guide the responses. Examples: "Translate the
+	 * phrase from English to French." or "Given a statement, classify the sentiment as
+	 * happy, sad or neutral." Anything included in this field will take precedence over
+	 * message history if the total input size exceeds the model's inputTokenLimit and the
+	 * input request is truncated.
+	 * @param examples (optional) Examples of what the model should generate. This
+	 * includes both user input and the response that the model should emulate. These
+	 * examples are treated identically to conversation messages except that they take
+	 * precedence over the history in messages: If the total input size exceeds the
+	 * model's inputTokenLimit the input will be truncated. Items will be dropped from
+	 * messages before examples.
+	 * @param messages (optional) A snapshot of the recent conversation history sorted
+	 * chronologically. Turns alternate between two authors. If the total input size
+	 * exceeds the model's inputTokenLimit the input will be truncated: The oldest items
+	 * will be dropped from messages.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record MessagePrompt(
+			@JsonProperty("context") String context,
+			@JsonProperty("examples") List<Example> examples,
+			@JsonProperty("messages") List<Message> messages) {
+
+		/**
+		 * Shortcut constructor for a message prompt without context.
+		 * @param messages The conversation history used by the model.
+		 */
+		public MessagePrompt(List<Message> messages) {
+			this(null, null, messages);
+		}
+
+		/**
+		 * Shortcut constructor for a message prompt without context.
+		 * @param context An input/output example used to instruct the Model. It
+		 * demonstrates how the model should respond or format its response.
+		 * @param messages The conversation history used by the model.
+		 */
+		public MessagePrompt(String context, List<Message> messages) {
+			this(context, null, messages);
+		}
+
+		/**
+		 * An input/output example used to instruct the Model. It demonstrates how the
+		 * model should respond or format its response.
+		 *
+		 * @param input An example of an input Message from the user.
+		 * @param output An example of an output Message from the model.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record Example(
+				@JsonProperty("input") Message input,
+				@JsonProperty("output") Message output) {
+		}
+	}
+
+	/**
+	 * Message generation request body.
+	 *
+	 * @param prompt The structured textual input given to the model as a prompt. Given a
+	 * prompt, the model will return what it predicts is the next message in the
+	 * discussion.
+	 * @param temperature (optional) Controls the randomness of the output. Values can
+	 * range over [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that
+	 * are more varied, while a value closer to 0.0 will typically result in less
+	 * surprising responses from the model.
+	 * @param candidateCount (optional) The number of generated response messages to
+	 * return. This value must be between [1, 8], inclusive. If unset, this will default
+	 * to 1.
+	 * @param topP (optional) The maximum cumulative probability of tokens to consider
+	 * when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling
+	 * considers the smallest set of tokens whose probability sum is at least topP.
+	 * @param topK (optional) The maximum number of tokens to consider when sampling. The
+	 * model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of
+	 * topK most probable tokens.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record GenerateMessageRequest(
+			@JsonProperty("prompt") MessagePrompt prompt,
+			@JsonProperty("temperature") Float temperature,
+			@JsonProperty("candidateCount") Integer candidateCount,
+			@JsonProperty("topP") Float topP,
+			@JsonProperty("topK") Integer topK) {
+
+		/**
+		 * Shortcut constructor to create a GenerateMessageRequest with only the prompt
+		 * parameter.
+		 * @param prompt The structured textual input given to the model as a prompt.
+		 */
+		public GenerateMessageRequest(MessagePrompt prompt) {
+			this(prompt, null, null, null, null);
+		}
+
+		/**
+		 * Shortcut constructor to create a GenerateMessageRequest with only the prompt
+		 * and temperature parameters.
+		 * @param prompt The structured textual input given to the model as a prompt.
+		 * @param temperature (optional) Controls the randomness of the output.
+		 * @param topK (optional) The maximum number of tokens to consider when sampling.
+		 */
+		public GenerateMessageRequest(MessagePrompt prompt, Float temperature, Integer topK) {
+			this(prompt, temperature, null, null, topK);
+		}
+	}
+
+	/**
+	 * The response from the model. This includes candidate messages and conversation
+	 * history in the form of chronologically-ordered messages.
+	 *
+	 * @param candidates Candidate response messages from the model.
+	 * @param messages The conversation history used by the model.
+	 * @param filters A set of content filtering metadata for the prompt and response
+	 * text. This indicates which SafetyCategory(s) blocked a candidate from this
+	 * response, the lowest HarmProbability that triggered a block, and the HarmThreshold
+	 * setting for that category.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record GenerateMessageResponse(
+			@JsonProperty("candidates") List<Message> candidates,
+			@JsonProperty("messages") List<Message> messages,
+			@JsonProperty("filters") List<ContentFilter> filters) {
+
+		/**
+		 * Content filtering metadata associated with processing a single request. It
+		 * contains a reason and an optional supporting string. The reason may be
+		 * unspecified.
+		 *
+		 * @param reason The reason content was blocked during request processing.
+		 * @param message A string that describes the filtering behavior in more detail.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record ContentFilter(
+				@JsonProperty("reason") BlockedReason reason,
+				@JsonProperty("message") String message) {
+
+			/**
+			 * Reasons why content may have been blocked.
+			 */
+			public enum BlockedReason {
+
+				/**
+				 * A blocked reason was not specified.
+				 */
+				BLOCKED_REASON_UNSPECIFIED,
+				/**
+				 * Content was blocked by safety settings.
+				 */
+				SAFETY,
+				/**
+				 * Content was blocked, but the reason is uncategorized.
+				 */
+				OTHER
+
+			}
+		}
+	}
+
+	/**
+	 * Main method to test the VertexAiApi.
+	 * @param args blank.
+	 */
+	public static void main(String[] args) {
+		VertexAiApi vertexAiApi = new VertexAiApi(System.getenv("PALM_API_KEY"));
+
+		var prompt = new MessagePrompt(List.of(new Message("0", "Hello, how are you?")));
+
+		GenerateMessageRequest request = new GenerateMessageRequest(prompt);
+
+		GenerateMessageResponse response = vertexAiApi.generateMessage(request);
+
+		System.out.println(response);
+
+		System.out.println(vertexAiApi.embedText("Hello, how are you?"));
+
+		System.out.println(vertexAiApi.batchEmbedText(List.of("Hello, how are you?", "I am fine, thank you!")));
+
+		System.out.println(vertexAiApi.countMessageTokens(prompt));
+
+		System.out.println(vertexAiApi.listModels());
+
+		System.out.println(vertexAiApi.listModels().stream().map(vertexAiApi::getModel).toList());
+
+	}
+
+}
+// @formatter:on

--- a/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClient.java
+++ b/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClient.java
@@ -27,7 +27,6 @@ import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.vertex.api.VertexAiApi;
 
 /**
- *
  * @author Christian Tzolov
  */
 public class VertexAiEmbeddingClient implements EmbeddingClient {

--- a/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClient.java
+++ b/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClient.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertex.embedding;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.vertex.api.VertexAiApi;
+
+/**
+ *
+ * @author Christian Tzolov
+ */
+public class VertexAiEmbeddingClient implements EmbeddingClient {
+
+	private final VertexAiApi vertexAiApi;
+
+	public VertexAiEmbeddingClient(VertexAiApi vertexAiApi) {
+		this.vertexAiApi = vertexAiApi;
+	}
+
+	@Override
+	public List<Double> embed(String text) {
+		return this.vertexAiApi.embedText(text).value();
+	}
+
+	@Override
+	public List<Double> embed(Document document) {
+		return embed(document.getContent());
+	}
+
+	@Override
+	public List<List<Double>> embed(List<String> texts) {
+		List<VertexAiApi.Embedding> vertexEmbeddings = this.vertexAiApi.batchEmbedText(texts);
+		return vertexEmbeddings.stream().map(e -> e.value()).toList();
+	}
+
+	@Override
+	public EmbeddingResponse embedForResponse(List<String> texts) {
+		List<VertexAiApi.Embedding> vertexEmbeddings = this.vertexAiApi.batchEmbedText(texts);
+		int index = 0;
+		List<Embedding> embeddings = new ArrayList<>();
+		for (VertexAiApi.Embedding vertexEmbedding : vertexEmbeddings) {
+			embeddings.add(new Embedding(vertexEmbedding.value(), index++));
+		}
+		return new EmbeddingResponse(embeddings, Map.of());
+	}
+
+}

--- a/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClient.java
+++ b/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClient.java
@@ -39,8 +39,11 @@ public class VertexAiChatGenerationClient implements AiClient {
 	private final VertexAiApi vertexAiApi;
 
 	private Float temperature;
+
 	private Float topP;
+
 	private Integer candidateCount;
+
 	private Integer maxTokens;
 
 	public VertexAiChatGenerationClient(VertexAiApi vertexAiApi) {
@@ -51,15 +54,16 @@ public class VertexAiChatGenerationClient implements AiClient {
 	public AiResponse generate(Prompt prompt) {
 
 		String vertexContext = prompt.getMessages()
-				.stream()
-				.filter(m -> m.getMessageType() == MessageType.SYSTEM)
-				.map(m -> m.getContent())
-				.collect(Collectors.joining("\n"));
+			.stream()
+			.filter(m -> m.getMessageType() == MessageType.SYSTEM)
+			.map(m -> m.getContent())
+			.collect(Collectors.joining("\n"));
 
-		List<VertexAiApi.Message> vertexMessages = prompt.getMessages().stream()
-				.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
-				.map(m -> new VertexAiApi.Message(m.getMessageType().getValue(), m.getContent()))
-				.toList();
+		List<VertexAiApi.Message> vertexMessages = prompt.getMessages()
+			.stream()
+			.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
+			.map(m -> new VertexAiApi.Message(m.getMessageType().getValue(), m.getContent()))
+			.toList();
 
 		Assert.isTrue(!CollectionUtils.isEmpty(vertexMessages), "No user or assistant messages found in the prompt!");
 
@@ -70,9 +74,12 @@ public class VertexAiChatGenerationClient implements AiClient {
 
 		GenerateMessageResponse response = this.vertexAiApi.generateMessage(request);
 
-		List<Generation> generations = response.candidates().stream().map(vmsg -> new Generation(vmsg.content()))
-				.collect(Collectors.toList());
+		List<Generation> generations = response.candidates()
+			.stream()
+			.map(vmsg -> new Generation(vmsg.content()))
+			.collect(Collectors.toList());
 
 		return new AiResponse(generations);
 	}
+
 }

--- a/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClient.java
+++ b/spring-ai-vertex-ai/src/main/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClient.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertex.generation;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.ai.client.AiClient;
+import org.springframework.ai.client.AiResponse;
+import org.springframework.ai.client.Generation;
+import org.springframework.ai.prompt.Prompt;
+import org.springframework.ai.prompt.messages.MessageType;
+import org.springframework.ai.vertex.api.VertexAiApi;
+import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageRequest;
+import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageResponse;
+import org.springframework.ai.vertex.api.VertexAiApi.MessagePrompt;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * @author Christian Tzolov
+ */
+public class VertexAiChatGenerationClient implements AiClient {
+
+	private final VertexAiApi vertexAiApi;
+
+	private Float temperature;
+	private Float topP;
+	private Integer candidateCount;
+	private Integer maxTokens;
+
+	public VertexAiChatGenerationClient(VertexAiApi vertexAiApi) {
+		this.vertexAiApi = vertexAiApi;
+	}
+
+	@Override
+	public AiResponse generate(Prompt prompt) {
+
+		String vertexContext = prompt.getMessages()
+				.stream()
+				.filter(m -> m.getMessageType() == MessageType.SYSTEM)
+				.map(m -> m.getContent())
+				.collect(Collectors.joining("\n"));
+
+		List<VertexAiApi.Message> vertexMessages = prompt.getMessages().stream()
+				.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
+				.map(m -> new VertexAiApi.Message(m.getMessageType().getValue(), m.getContent()))
+				.toList();
+
+		Assert.isTrue(!CollectionUtils.isEmpty(vertexMessages), "No user or assistant messages found in the prompt!");
+
+		var vertexPrompt = new MessagePrompt(vertexContext, vertexMessages);
+
+		GenerateMessageRequest request = new GenerateMessageRequest(vertexPrompt, this.temperature, this.candidateCount,
+				this.topP, this.maxTokens);
+
+		GenerateMessageResponse response = this.vertexAiApi.generateMessage(request);
+
+		List<Generation> generations = response.candidates().stream().map(vmsg -> new Generation(vmsg.content()))
+				.collect(Collectors.toList());
+
+		return new AiResponse(generations);
+	}
+}

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiIT.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiIT.java
@@ -30,8 +30,9 @@ import org.springframework.ai.vertex.api.VertexAiApi.MessagePrompt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration tests for {@link VertexAiApi}. Requires a valid API key to be set via the {@code PALM_API_KEY}
- * environment and at the moment Google enables is it only in the US region (so use VPN for testing).
+ * Integration tests for {@link VertexAiApi}. Requires a valid API key to be set via the
+ * {@code PALM_API_KEY} environment and at the moment Google enables is it only in the US
+ * region (so use VPN for testing).
  *
  * @author Christian Tzolov
  */
@@ -105,8 +106,10 @@ public class VertexAiApiIT {
 		assertThat(response).hasSizeGreaterThan(0);
 		assertThat(response).contains("models/chat-bison-001", "models/text-bison-001", "models/embedding-gecko-001");
 
-		System.out.println(" - " + response.stream().map(vertexAiApi::getModel).map(VertexAiApi.Model::toString)
-				.collect(Collectors.joining("\n - ")));
+		System.out.println(" - " + response.stream()
+			.map(vertexAiApi::getModel)
+			.map(VertexAiApi.Model::toString)
+			.collect(Collectors.joining("\n - ")));
 	}
 
 	@Test
@@ -118,4 +121,5 @@ public class VertexAiApiIT {
 		assertThat(model).isNotNull();
 		assertThat(model.displayName()).isEqualTo("Chat Bison");
 	}
+
 }

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiIT.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiIT.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertex.api;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.vertex.api.VertexAiApi.Embedding;
+import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageRequest;
+import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageResponse;
+import org.springframework.ai.vertex.api.VertexAiApi.MessagePrompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link VertexAiApi}. Requires a valid API key to be set via the {@code PALM_API_KEY}
+ * environment and at the moment Google enables is it only in the US region (so use VPN for testing).
+ *
+ * @author Christian Tzolov
+ */
+@EnabledIfEnvironmentVariable(named = "PALM_API_KEY", matches = ".*")
+public class VertexAiApiIT {
+
+	VertexAiApi vertexAiApi = new VertexAiApi(System.getenv("PALM_API_KEY"));
+
+	@Test
+	public void generateMessage() {
+
+		var prompt = new MessagePrompt(List.of(new VertexAiApi.Message("0", "Hello, how are you?")));
+
+		GenerateMessageRequest request = new GenerateMessageRequest(prompt);
+
+		GenerateMessageResponse response = vertexAiApi.generateMessage(request);
+
+		assertThat(response).isNotNull();
+
+		// Vertex returns the prompt messages in the response's messages list.
+		assertThat(response.messages()).hasSize(1);
+		assertThat(response.messages().get(0)).isEqualTo(prompt.messages().get(0));
+
+		// Vertex returns the answer in the response's candidates list.
+		assertThat(response.candidates()).hasSize(1);
+		assertThat(response.candidates().get(0).author()).isNotBlank();
+		assertThat(response.candidates().get(0).content()).isNotBlank();
+	}
+
+	@Test
+	public void embedText() {
+
+		var text = "Hello, how are you?";
+
+		Embedding response = vertexAiApi.embedText(text);
+
+		assertThat(response).isNotNull();
+		assertThat(response.value()).hasSize(768);
+	}
+
+	@Test
+	public void batchEmbedText() {
+
+		var text = List.of("Hello, how are you?", "I am fine, thank you!");
+
+		List<Embedding> response = vertexAiApi.batchEmbedText(text);
+
+		assertThat(response).isNotNull();
+		assertThat(response).hasSize(2);
+		assertThat(response.get(0).value()).hasSize(768);
+		assertThat(response.get(1).value()).hasSize(768);
+	}
+
+	@Test
+	public void countMessageTokens() {
+
+		var text = "Hello, how are you?";
+
+		var prompt = new MessagePrompt(List.of(new VertexAiApi.Message("0", text)));
+		int response = vertexAiApi.countMessageTokens(prompt);
+
+		assertThat(response).isEqualTo(17);
+	}
+
+	@Test
+	public void listModels() {
+
+		List<String> response = vertexAiApi.listModels();
+
+		assertThat(response).isNotNull();
+		assertThat(response).hasSizeGreaterThan(0);
+		assertThat(response).contains("models/chat-bison-001", "models/text-bison-001", "models/embedding-gecko-001");
+
+		System.out.println(" - " + response.stream().map(vertexAiApi::getModel).map(VertexAiApi.Model::toString)
+				.collect(Collectors.joining("\n - ")));
+	}
+
+	@Test
+	public void getModel() {
+
+		VertexAiApi.Model model = vertexAiApi.getModel("models/chat-bison-001");
+
+		System.out.println(model);
+		assertThat(model).isNotNull();
+		assertThat(model.displayName()).isEqualTo("Chat Bison");
+	}
+}

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiTests.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiTests.java
@@ -45,7 +45,6 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
- *
  * @author Christian Tzolov
  */
 @RestClientTest(VertexAiApiTests.Config.class)
@@ -78,11 +77,12 @@ public class VertexAiApiTests {
 				List.of(new VertexAiApi.Message("0", "I'm fine, thank you.")),
 				List.of(new VertexAiApi.GenerateMessageResponse.ContentFilter(BlockedReason.SAFETY, "reason")));
 
-		server.expect(requestToUriTemplate("/models/{model}:generateMessage?key={apiKey}",
-				VertexAiApi.DEFAULT_GENERATE_MODEL, TEST_API_KEY))
-				.andExpect(method(HttpMethod.POST))
-				.andExpect(content().json(objectMapper.writeValueAsString(request)))
-				.andRespond(withSuccess(objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+		server
+			.expect(requestToUriTemplate("/models/{model}:generateMessage?key={apiKey}",
+					VertexAiApi.DEFAULT_GENERATE_MODEL, TEST_API_KEY))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().json(objectMapper.writeValueAsString(request)))
+			.andRespond(withSuccess(objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
 
 		GenerateMessageResponse response = client.generateMessage(request);
 
@@ -98,13 +98,13 @@ public class VertexAiApiTests {
 
 		Embedding expectedEmbedding = new Embedding(List.of(0.1, 0.2, 0.3));
 
-		server.expect(requestToUriTemplate("/models/{model}:embedText?key={apiKey}",
-				VertexAiApi.DEFAULT_EMBEDDING_MODEL, TEST_API_KEY))
-				.andExpect(method(HttpMethod.POST))
-				.andExpect(content().json(objectMapper.writeValueAsString(Map.of("text", text))))
-				.andRespond(
-						withSuccess(objectMapper.writeValueAsString(Map.of("embedding", expectedEmbedding)),
-								MediaType.APPLICATION_JSON));
+		server
+			.expect(requestToUriTemplate("/models/{model}:embedText?key={apiKey}", VertexAiApi.DEFAULT_EMBEDDING_MODEL,
+					TEST_API_KEY))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().json(objectMapper.writeValueAsString(Map.of("text", text))))
+			.andRespond(withSuccess(objectMapper.writeValueAsString(Map.of("embedding", expectedEmbedding)),
+					MediaType.APPLICATION_JSON));
 
 		Embedding embedding = client.embedText(text);
 
@@ -121,12 +121,13 @@ public class VertexAiApiTests {
 		List<Embedding> expectedEmbeddings = List.of(new Embedding(List.of(0.1, 0.2, 0.3)),
 				new Embedding(List.of(0.4, 0.5, 0.6)));
 
-		server.expect(requestToUriTemplate("/models/{model}:batchEmbedText?key={apiKey}",
-				VertexAiApi.DEFAULT_EMBEDDING_MODEL, TEST_API_KEY))
-				.andExpect(method(HttpMethod.POST))
-				.andExpect(content().json(objectMapper.writeValueAsString(Map.of("texts", texts))))
-				.andRespond(withSuccess(objectMapper.writeValueAsString(Map.of("embeddings", expectedEmbeddings)),
-						MediaType.APPLICATION_JSON));
+		server
+			.expect(requestToUriTemplate("/models/{model}:batchEmbedText?key={apiKey}",
+					VertexAiApi.DEFAULT_EMBEDDING_MODEL, TEST_API_KEY))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(content().json(objectMapper.writeValueAsString(Map.of("texts", texts))))
+			.andRespond(withSuccess(objectMapper.writeValueAsString(Map.of("embeddings", expectedEmbeddings)),
+					MediaType.APPLICATION_JSON));
 
 		List<Embedding> embeddings = client.batchEmbedText(texts);
 

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiTests.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertex.api;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.vertex.api.VertexAiApi.Embedding;
+import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageRequest;
+import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageResponse;
+import org.springframework.ai.vertex.api.VertexAiApi.MessagePrompt;
+import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageResponse.ContentFilter.BlockedReason;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestToUriTemplate;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ *
+ * @author Christian Tzolov
+ */
+@RestClientTest(VertexAiApiTests.Config.class)
+public class VertexAiApiTests {
+
+	private final static String TEST_API_KEY = "test-api-key";
+
+	@Autowired
+	private VertexAiApi client;
+
+	@Autowired
+	private MockRestServiceServer server;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@AfterEach
+	void resetMockServer() {
+		server.reset();
+	}
+
+	@Test
+	public void generateMessage() throws JsonProcessingException {
+
+		GenerateMessageRequest request = new GenerateMessageRequest(
+				new MessagePrompt(List.of(new VertexAiApi.Message("0", "Hello, how are you?"))));
+
+		GenerateMessageResponse expectedResponse = new GenerateMessageResponse(
+				List.of(new VertexAiApi.Message("1", "Hello, how are you?")),
+				List.of(new VertexAiApi.Message("0", "I'm fine, thank you.")),
+				List.of(new VertexAiApi.GenerateMessageResponse.ContentFilter(BlockedReason.SAFETY, "reason")));
+
+		server.expect(requestToUriTemplate("/models/{model}:generateMessage?key={apiKey}",
+				VertexAiApi.DEFAULT_GENERATE_MODEL, TEST_API_KEY))
+				.andExpect(method(HttpMethod.POST))
+				.andExpect(content().json(objectMapper.writeValueAsString(request)))
+				.andRespond(withSuccess(objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
+
+		GenerateMessageResponse response = client.generateMessage(request);
+
+		assertThat(response).isEqualTo(expectedResponse);
+
+		server.verify();
+	}
+
+	@Test
+	public void embedText() throws JsonProcessingException {
+
+		String text = "Hello, how are you?";
+
+		Embedding expectedEmbedding = new Embedding(List.of(0.1, 0.2, 0.3));
+
+		server.expect(requestToUriTemplate("/models/{model}:embedText?key={apiKey}",
+				VertexAiApi.DEFAULT_EMBEDDING_MODEL, TEST_API_KEY))
+				.andExpect(method(HttpMethod.POST))
+				.andExpect(content().json(objectMapper.writeValueAsString(Map.of("text", text))))
+				.andRespond(
+						withSuccess(objectMapper.writeValueAsString(Map.of("embedding", expectedEmbedding)),
+								MediaType.APPLICATION_JSON));
+
+		Embedding embedding = client.embedText(text);
+
+		assertThat(embedding).isEqualTo(expectedEmbedding);
+
+		server.verify();
+	}
+
+	@Test
+	public void batchEmbedText() throws JsonProcessingException {
+
+		List<String> texts = List.of("Hello, how are you?", "I'm fine, thank you.");
+
+		List<Embedding> expectedEmbeddings = List.of(new Embedding(List.of(0.1, 0.2, 0.3)),
+				new Embedding(List.of(0.4, 0.5, 0.6)));
+
+		server.expect(requestToUriTemplate("/models/{model}:batchEmbedText?key={apiKey}",
+				VertexAiApi.DEFAULT_EMBEDDING_MODEL, TEST_API_KEY))
+				.andExpect(method(HttpMethod.POST))
+				.andExpect(content().json(objectMapper.writeValueAsString(Map.of("texts", texts))))
+				.andRespond(withSuccess(objectMapper.writeValueAsString(Map.of("embeddings", expectedEmbeddings)),
+						MediaType.APPLICATION_JSON));
+
+		List<Embedding> embeddings = client.batchEmbedText(texts);
+
+		assertThat(embeddings).isEqualTo(expectedEmbeddings);
+
+		server.verify();
+	}
+
+	@SpringBootConfiguration
+	static class Config {
+
+		@Bean
+		public VertexAiApi audioApi(RestClient.Builder builder) {
+			return new VertexAiApi("", TEST_API_KEY, VertexAiApi.DEFAULT_GENERATE_MODEL,
+					VertexAiApi.DEFAULT_EMBEDDING_MODEL, builder);
+		}
+
+	}
+
+}

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClientIT.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClientIT.java
@@ -1,0 +1,46 @@
+package org.springframework.ai.vertex.embedding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.vertex.api.VertexAiApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "PALM_API_KEY", matches = ".*")
+class VertexAiEmbeddingClientIT {
+
+	@Autowired
+	private VertexAiEmbeddingClient embeddingClient;
+
+	@Test
+	void simpleEmbedding() {
+		assertThat(embeddingClient).isNotNull();
+		EmbeddingResponse embeddingResponse = embeddingClient.embedForResponse(List.of("Hello World"));
+		assertThat(embeddingResponse.getData()).hasSize(1);
+		assertThat(embeddingResponse.getData().get(0).getEmbedding()).isNotEmpty();
+		assertThat(embeddingClient.dimensions()).isEqualTo(768);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public VertexAiApi vertexAiApi() {
+			return new VertexAiApi(System.getenv("PALM_API_KEY"));
+		}
+
+		@Bean
+		public VertexAiEmbeddingClient vertexAiEmbedding(VertexAiApi vertexAiApi) {
+			return new VertexAiEmbeddingClient(vertexAiApi);
+		}
+	}
+}

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClientIT.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/embedding/VertexAiEmbeddingClientIT.java
@@ -42,5 +42,7 @@ class VertexAiEmbeddingClientIT {
 		public VertexAiEmbeddingClient vertexAiEmbedding(VertexAiApi vertexAiApi) {
 			return new VertexAiEmbeddingClient(vertexAiApi);
 		}
+
 	}
+
 }

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClientIT.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClientIT.java
@@ -124,6 +124,7 @@ class VertexAiChatGenerationClientIT {
 		public VertexAiChatGenerationClient vertexAiEmbedding(VertexAiApi vertexAiApi) {
 			return new VertexAiChatGenerationClient(vertexAiApi);
 		}
+
 	}
 
 }

--- a/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClientIT.java
+++ b/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/generation/VertexAiChatGenerationClientIT.java
@@ -1,4 +1,4 @@
-package org.springframework.ai.openai.client;
+package org.springframework.ai.vertex.generation;
 
 import java.util.Arrays;
 import java.util.List;
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import org.springframework.ai.client.AiResponse;
 import org.springframework.ai.client.Generation;
-import org.springframework.ai.openai.OpenAiTestConfiguration;
-import org.springframework.ai.openai.testutils.AbstractIT;
 import org.springframework.ai.parser.BeanOutputParser;
 import org.springframework.ai.parser.ListOutputParser;
 import org.springframework.ai.parser.MapOutputParser;
@@ -19,16 +17,23 @@ import org.springframework.ai.prompt.PromptTemplate;
 import org.springframework.ai.prompt.SystemPromptTemplate;
 import org.springframework.ai.prompt.messages.Message;
 import org.springframework.ai.prompt.messages.UserMessage;
+import org.springframework.ai.vertex.api.VertexAiApi;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = OpenAiTestConfiguration.class)
-@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
-class OpenAiClientIT extends AbstractIT {
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "PALM_API_KEY", matches = ".*")
+class VertexAiChatGenerationClientIT {
+
+	@Autowired
+	private VertexAiChatGenerationClient client;
 
 	@Value("classpath:/prompts/system-message.st")
 	private Resource systemResource;
@@ -42,11 +47,11 @@ class OpenAiClientIT extends AbstractIT {
 		SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(systemResource);
 		Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", name, "voice", voice));
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
-		AiResponse response = openAiClient.generate(prompt);
-		// needs fine tuning... evaluateQuestionAndAnswer(request, response, false);
+		AiResponse response = client.generate(prompt);
+		assertThat(response.getGeneration().getContent()).contains("Bartholomew");
 	}
 
-	@Test
+	// @Test
 	void outputParser() {
 		DefaultConversionService conversionService = new DefaultConversionService();
 		ListOutputParser outputParser = new ListOutputParser(conversionService);
@@ -57,16 +62,16 @@ class OpenAiClientIT extends AbstractIT {
 				{format}
 				""";
 		PromptTemplate promptTemplate = new PromptTemplate(template,
-				Map.of("subject", "ice cream flavors", "format", format));
+				Map.of("subject", "ice cream flavors.", "format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = this.openAiClient.generate(prompt).getGeneration();
+		Generation generation = this.client.generate(prompt).getGeneration();
 
 		List<String> list = outputParser.parse(generation.getContent());
 		assertThat(list).hasSize(5);
 
 	}
 
-	@Test
+	// @Test
 	void mapOutputParser() {
 		MapOutputParser outputParser = new MapOutputParser();
 
@@ -78,34 +83,17 @@ class OpenAiClientIT extends AbstractIT {
 		PromptTemplate promptTemplate = new PromptTemplate(template,
 				Map.of("subject", "an array of numbers from 1 to 9 under they key name 'numbers'", "format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = openAiClient.generate(prompt).getGeneration();
+		Generation generation = client.generate(prompt).getGeneration();
 
 		Map<String, Object> result = outputParser.parse(generation.getContent());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
 
-	@Test
-	void beanOutputParser() {
-
-		BeanOutputParser<ActorsFilms> outputParser = new BeanOutputParser<>(ActorsFilms.class);
-
-		String format = outputParser.getFormat();
-		String template = """
-				Generate the filmography for a random actor.
-				{format}
-				""";
-		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
-		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = openAiClient.generate(prompt).getGeneration();
-
-		ActorsFilms actorsFilms = outputParser.parse(generation.getContent());
-	}
-
 	record ActorsFilmsRecord(String actor, List<String> movies) {
 	}
 
-	@Test
+	// @Test
 	void beanOutputParserRecords() {
 
 		BeanOutputParser<ActorsFilmsRecord> outputParser = new BeanOutputParser<>(ActorsFilmsRecord.class);
@@ -117,11 +105,25 @@ class OpenAiClientIT extends AbstractIT {
 				""";
 		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = openAiClient.generate(prompt).getGeneration();
+		Generation generation = client.generate(prompt).getGeneration();
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generation.getContent());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public VertexAiApi vertexAiApi() {
+			return new VertexAiApi(System.getenv("PALM_API_KEY"));
+		}
+
+		@Bean
+		public VertexAiChatGenerationClient vertexAiEmbedding(VertexAiApi vertexAiApi) {
+			return new VertexAiChatGenerationClient(vertexAiApi);
+		}
 	}
 
 }

--- a/spring-ai-vertex-ai/src/test/resources/prompts/system-message.st
+++ b/spring-ai-vertex-ai/src/test/resources/prompts/system-message.st
@@ -1,0 +1,4 @@
+"You are a helpful AI assistant. Your name is {name}.
+You are an AI assistant that helps people find information.
+Your name is {name}
+You should reply to the user's request with your name and also in the style of a {voice}.


### PR DESCRIPTION
 - Rename Generation#text to content and info to properties.
 - Make Generation extend the AbstractMessage and default to ASSISTANT message type.
 - Add vevertex-ai project with native api client for generation and embedding.
 - Add unit and IT tests for the vertex-ai native client.
 - Add AiClient and EmbeddingClient implementation for the the Vertex AI along with ITs.
