### PR TITLE
Fix documentation links

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/aiclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/aiclient.adoc
@@ -72,7 +72,7 @@ For instance, OpenAI recognizes message categories for distinct conversational r
 While the term, `MessageType`, might imply a specific message format, in this context, it effectively designates the role a message plays in the dialogue.
 
 For AI models that do not use specific roles, the `UserMessage` implementation acts as a standard category, typically representing user-generated inquiries or instructions.
-To understand the practical application and the relationship between `Prompt` and `Message`, especially in the context of these roles or message categories, see the detailed explanations in the <<Prompts>> section.
+To understand the practical application and the relationship between `Prompt` and `Message`, especially in the context of these roles or message categories, see the detailed explanations in the xref:api/prompt.adoc[Prompts] section.
 
 === AiResponse
 
@@ -123,7 +123,7 @@ Others are welcome. The list is not at all closed.
 
 == OpenAI-Compatible Models
 
-A variety of models compatible with the OpenAI API are available, including those that can be operated locally, such as [LocalAI](https://github.com/mudler/LocalAI). The standard configuration for connecting to the OpenAI API is through the `spring.ai.openai.baseUrl` property, which defaults to `https://api.openai.com`.
+A variety of models compatible with the OpenAI API are available, including those that can be operated locally, such as https://github.com/mudler/LocalAI[LocalAI]. The standard configuration for connecting to the OpenAI API is through the `spring.ai.openai.baseUrl` property, which defaults to `https://api.openai.com`.
 
 To link the OpenAI client to a compatible model that uses the OpenAI API, you should adjust the `spring.ai.openai.baseUrl` property to the corresponding URL of the model you wish to connect to.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
@@ -12,7 +12,7 @@ Vector databases are used to integrate your data with AI models.
 The first step in their usage is to load your data into a vector database.
 Then, when a user query is to be sent to the AI model, a set of similar documents is first retrieved.
 These documents then serve as the context for the user's question and are sent to the AI model, along with the user's query.
-This technique is known as <<concept-rag,Retrieval Augmented Generation (RAG)>>.
+This technique is known as xref:concepts.adoc#concept-rag[Retrieval Augmented Generation (RAG)].
 
 The following sections describe the Spring AI interface for using multiple vector database implementations and some high-level sample usage.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -17,6 +17,6 @@ To simplify setup, Spring Boot starters are available to help set up essential d
 There is also a collection of sample applications to help you explore the project's features.
 Lastly, the new Spring CLI project also enables you to get started quickly by using the `spring boot new ai` command for new projects or `spring boot add ai` for adding AI capabilities to your existing application.
 
-The <<concepts,next section>> provides a high-level overview of AI concepts and their representation in Spring AI.
-The <<getting-started,Getting Started>> section shows you how to create your first AI application.
+The xref:concepts.adoc[next section] provides a high-level overview of AI concepts and their representation in Spring AI.
+The xref:getting-started.adoc[Getting Started] section shows you how to create your first AI application.
 Subsequent sections delve into each component and common use cases with a code-focused approach.


### PR DESCRIPTION
Fix links in the documentation on pages

- Overview
- AiClient
- Vector Databases
