### PR TITLE
Fix broken Asciidoctor syntax in aiclient.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/aiclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/aiclient.adoc
@@ -116,6 +116,7 @@ The `AiClient` interface has the following available implementations:
 * https://ollama.ai/[Ollama]: Run large language models locally.
 
 Planned implementations
+
 * Amazon Bedrock: This can provide access to many AI models.
 * Google Vertex: Providing access to 'Bard' (AKA Palm2).
 


### PR DESCRIPTION
This PR fixes a broken Asciidoctor syntax in the `aiclient.adoc`.