### PR TITLE
Replace Neo4j embedding storing with new function.

### DIFF
--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
@@ -235,9 +235,7 @@ public class Neo4jVectorStore implements VectorStore, InitializingBean {
 							SET u.id = row.id,
 								u += row.properties
 						WITH row, u
-						CALL db.create.setVectorProperty(u, $embeddingProperty, row.embedding)
-						YIELD node
-						RETURN count(node)
+						CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.embedding)
 					""".formatted(this.config.quotedLabel);
 			session.run(statement, Map.of("rows", rows, "embeddingProperty", this.config.embeddingProperty)).consume();
 		}

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
@@ -41,10 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class Neo4jVectorStoreIT {
 
-	// Neo4j 5.12 has a bug wrt checking limits, so either 5.11 or anything higher than
-	// 5.12 works
+	// Needs to be Neo4j 5.13+, because Neo4j 5.13 deprecated the used embedding storing function.
 	@Container
-	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.11"))
+	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.14"))
 		.withRandomPassword();
 
 	List<Document> documents = List.of(


### PR DESCRIPTION
The old function got replaced and might get removed in future versions. To ensure that the store is compatible with Neo4j 5.LATEST, this commit changes the store function for embeddings to use the 5.13+ function.

The correct baseline database version is already mentioned in the README.

Thank you for taking time to contribute this pull request!
