### PR TITLE
Fix "FROM" group ID in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Let's make your `@Beans` intelligent!
 
 We are transitioning the project's Group ID:
 
-* **FROM**: `org.springframework.ai`
+* **FROM**: `org.springframework.experimental.ai`
 * **TO**: `org.springframework.ai`
 
 Artifacts will still be hosted in the snapshot repository as shown below.


### PR DESCRIPTION
This PR fixes "FROM" group ID in the `README.md` by restoring "experimental" as it seems to have been dropped in 6d3c429e95a6906a1e674ac5bfb1bf5f9b8c37f2 accidentally.