### PR TITLE
Add text splitter to Tika document reader

### DIFF
--- a/document-readers/tika-reader/src/main/java/org/springframework/ai/reader/tika/TikaDocumentReader.java
+++ b/document-readers/tika-reader/src/main/java/org/springframework/ai/reader/tika/TikaDocumentReader.java
@@ -60,6 +60,11 @@ public class TikaDocumentReader implements DocumentReader {
 	public static final String METADATA_SOURCE = "source";
 
 	/**
+	 * Default chunk size for splitting the extracted text.
+	 */
+	private static final int DEFAULT_CHUNK_SIZE = 800;
+
+	/**
 	 * Parser to automatically detect the type of document and extract text.
 	 */
 	private final AutoDetectParser parser;
@@ -83,6 +88,11 @@ public class TikaDocumentReader implements DocumentReader {
 	 * The resource pointing to the document.
 	 */
 	private final Resource resource;
+
+	/**
+	 * Chunk size for splitting the extracted text.
+	 */
+	private int chunkSize = DEFAULT_CHUNK_SIZE;
 
 	/**
 	 * Formatter for the extracted text.
@@ -142,6 +152,14 @@ public class TikaDocumentReader implements DocumentReader {
 	}
 
 	/**
+	 * Sets the chunk size for splitting the extracted text.
+	 * @param chunkSize Chunk size for splitting the extracted text
+	 */
+	public void setChunkSize(int chunkSize) {
+		this.chunkSize = chunkSize;
+	}
+
+	/**
 	 * Extracts and returns the list of documents from the resource.
 	 * @return List of extracted {@link Document}
 	 */
@@ -149,7 +167,7 @@ public class TikaDocumentReader implements DocumentReader {
 	public List<Document> get() {
 		try (InputStream stream = this.resource.getInputStream()) {
 			this.parser.parse(stream, this.handler, this.metadata, this.context);
-			return textSplitter.split(this.handler.toString(), 800)
+			return textSplitter.split(this.handler.toString(), chunkSize)
 				.stream()
 				.filter(StringUtils::hasText)
 				.map(this::toDocument)

--- a/document-readers/tika-reader/src/test/java/org/springframework/ai/reader/tika/TikaDocumentReaderTests.java
+++ b/document-readers/tika-reader/src/test/java/org/springframework/ai/reader/tika/TikaDocumentReaderTests.java
@@ -27,17 +27,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TikaDocumentReaderTests {
 
 	@ParameterizedTest
-	@CsvSource({
-			"classpath:/word-sample.docx,word-sample.docx,Two kinds of links are possible, those that refer to an external website",
-			"classpath:/word-sample.doc,word-sample.doc,The limited permissions granted above are perpetual and will not be revoked by OASIS",
-			"classpath:/sample2.pdf,sample2.pdf,Consult doc/pdftex/manual.pdf from your tetex distribution for more",
-			"classpath:/sample.ppt,sample.ppt,Sed ipsum tortor, fringilla a consectetur eget, cursus posuere sem.",
-			"classpath:/sample.pptx,sample.pptx,Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-			"https://docs.spring.io/spring-ai/reference/,https://docs.spring.io/spring-ai/reference/,help set up essential dependencies and classes." })
-	public void testDocx(String resourceUri, String resourceName, String contentSnipped) {
+	@CsvSource({ "classpath:/word-sample.docx,word-sample.docx,3,This document has embedded the Ubuntu font family.",
+			"classpath:/word-sample.doc,word-sample.doc,3,The paper size is set to Letter, which is 8 ½ x 11.",
+			"classpath:/sample2.pdf,sample2.pdf,3,put all source .tex files in one directory, then chdir to the directory",
+			"classpath:/sample.ppt,sample.ppt,1,Sed ipsum tortor, fringilla a consectetur eget, cursus posuere sem.",
+			"classpath:/sample.pptx,sample.pptx,1,Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			"https://docs.spring.io/spring-ai/reference/,https://docs.spring.io/spring-ai/reference/,2,help set up essential dependencies and classes." })
+	public void testDocx(String resourceUri, String resourceName, int documentCount, String contentSnipped) {
 
 		var docs = new TikaDocumentReader(resourceUri).get();
-		assertThat(docs).hasSize(1);
+		assertThat(docs).hasSize(documentCount);
 
 		var doc = docs.get(0);
 


### PR DESCRIPTION
This makes it possible for `TikaDocumentReader` to read large PDFs.