### PR TITLE
Enable a TextSplitter in TikaDocumentReader to allow for files with large content to be read.

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
@@ -82,6 +82,6 @@ public abstract class TextSplitter implements DocumentTransformer {
 		return documents;
 	}
 
-	protected abstract List<String> splitText(String text);
+	public abstract List<String> splitText(String text);
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -38,7 +38,7 @@ public class TokenTextSplitter extends TextSplitter {
 	private final Encoding encoding = registry.getEncoding(EncodingType.CL100K_BASE);
 
 	@Override
-	protected List<String> splitText(String text) {
+	public List<String> splitText(String text) {
 		return split(text, defaultChunkSize);
 	}
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/transformer/splitter/TextSplitterTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/transformer/splitter/TextSplitterTests.java
@@ -35,7 +35,7 @@ public class TextSplitterTests {
 	static TextSplitter testTextSplitter = new TextSplitter() {
 
 		@Override
-		protected List<String> splitText(String text) {
+		public List<String> splitText(String text) {
 			int chuckSize = text.length() / 2;
 
 			List<String> chunks = new ArrayList<>();


### PR DESCRIPTION

This is a variation of https://github.com/spring-projects/spring-ai/pull/166, based on my last comment in that PR. 
