### PR TITLE
Refactor toString() method in Embedding class

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/embedding/Embedding.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/embedding/Embedding.java
@@ -39,7 +39,7 @@ public class Embedding {
 
 	@Override
 	public String toString() {
-		String message = this.embedding.size() == 0 ? "<empty>" : "<has data>";
+		String message = this.embedding.isEmpty() ? "<empty>" : "<has data>";
 		return "Embedding{" + "embedding=" + message + ", index=" + index + '}';
 	}
 


### PR DESCRIPTION
This pull request updates the toString() method in the Embedding class.

The change replaces the usage of size() with isEmpty() when checking the embedding collection, making the code more concise and semantically accurate.