### PR TITLE
Add NotNull Validation & Add Nullable Annotation

### DIFF
--- a/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiGenerationMetadata.java
+++ b/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiGenerationMetadata.java
@@ -39,6 +39,8 @@ public class OpenAiGenerationMetadata implements GenerationMetadata {
 
 	public static OpenAiGenerationMetadata from(OpenAiApi.ChatCompletion result) {
 		Assert.notNull(result, "OpenAI ChatCompletionResult must not be null");
+		Assert.notNull(result.id(), "ChatCompletionResult id must not be null");
+		Assert.notNull(result.usage(), "ChatCompletionResult usage must not be null");
 		OpenAiUsage usage = OpenAiUsage.from(result.usage());
 		OpenAiGenerationMetadata generationMetadata = new OpenAiGenerationMetadata(result.id(), usage);
 		OpenAiHttpResponseHeadersInterceptor.applyTo(generationMetadata);

--- a/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
+++ b/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
@@ -50,8 +50,8 @@ public class OpenAiRateLimit implements RateLimit {
 
 	private final Duration tokensReset;
 
-	public OpenAiRateLimit(Long requestsLimit, Long requestsRemaining, Duration requestsReset, Long tokensLimit,
-			Long tokensRemaining, Duration tokensReset) {
+	public OpenAiRateLimit(@Nullable Long requestsLimit, @Nullable Long requestsRemaining, Duration requestsReset,
+						   @Nullable Long tokensLimit, @Nullable Long tokensRemaining, Duration tokensReset) {
 
 		this.requestsLimit = requestsLimit;
 		this.requestsRemaining = requestsRemaining;

--- a/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
+++ b/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiRateLimit.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai.metadata;
 import java.time.Duration;
 
 import org.springframework.ai.metadata.RateLimit;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link RateLimit} implementation for {@literal OpenAI}.
@@ -33,12 +34,16 @@ public class OpenAiRateLimit implements RateLimit {
 
 	private static final String RATE_LIMIT_STRING = "{ @type: %1$s, requestsLimit: %2$s, requestsRemaining: %3$s, requestsReset: %4$s, tokensLimit: %5$s; tokensRemaining: %6$s; tokensReset: %7$s }";
 
+	@Nullable
 	private final Long requestsLimit;
 
+	@Nullable
 	private final Long requestsRemaining;
 
+	@Nullable
 	private final Long tokensLimit;
 
+	@Nullable
 	private final Long tokensRemaining;
 
 	private final Duration requestsReset;
@@ -57,21 +62,25 @@ public class OpenAiRateLimit implements RateLimit {
 	}
 
 	@Override
+	@Nullable
 	public Long getRequestsLimit() {
 		return this.requestsLimit;
 	}
 
 	@Override
+	@Nullable
 	public Long getTokensLimit() {
 		return this.tokensLimit;
 	}
 
 	@Override
+	@Nullable
 	public Long getRequestsRemaining() {
 		return this.requestsRemaining;
 	}
 
 	@Override
+	@Nullable
 	public Long getTokensRemaining() {
 		return this.tokensRemaining;
 	}


### PR DESCRIPTION
While looking at the OpenAiGeneration metadata class and the OpenAiRateLimit class, we found a point of concern for NPE. 

- For the OpenAiGenerationMetadata.From() method, we verified this because the internal block uses id and usage.
- For OpenAiRateLimit classes, @Nullable Annotation has been added because null can be inserted into the long type from outside.