### PR TITLE
Refactor ContentFormatTransformer for Improved Readability

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/ContentFormatTransformer.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/ContentFormatTransformer.java
@@ -51,42 +51,44 @@ public class ContentFormatTransformer implements DocumentTransformer {
 	 * @return
 	 */
 	public List<Document> apply(List<Document> documents) {
-
-		if (this.contentFormatter != null) {
-
-			documents.forEach(document -> {
-				// Update formatter
-				if (document.getContentFormatter() instanceof DefaultContentFormatter
-						&& this.contentFormatter instanceof DefaultContentFormatter) {
-
-					DefaultContentFormatter docFormatter = (DefaultContentFormatter) document.getContentFormatter();
-					DefaultContentFormatter toUpdateFormatter = (DefaultContentFormatter) this.contentFormatter;
-
-					var updatedEmbedExcludeKeys = new ArrayList<>(docFormatter.getExcludedEmbedMetadataKeys());
-					updatedEmbedExcludeKeys.addAll(toUpdateFormatter.getExcludedEmbedMetadataKeys());
-
-					var updatedInterfaceExcludeKeys = new ArrayList<>(docFormatter.getExcludedInferenceMetadataKeys());
-					updatedInterfaceExcludeKeys.addAll(toUpdateFormatter.getExcludedInferenceMetadataKeys());
-
-					var builder = DefaultContentFormatter.builder()
-						.withExcludedEmbedMetadataKeys(updatedEmbedExcludeKeys)
-						.withExcludedInferenceMetadataKeys(updatedInterfaceExcludeKeys)
-						.withMetadataTemplate(docFormatter.getMetadataTemplate())
-						.withMetadataSeparator(docFormatter.getMetadataSeparator());
-
-					if (!this.disableTemplateRewrite) {
-						builder.withTextTemplate(docFormatter.getTextTemplate());
-					}
-					document.setContentFormatter(builder.build());
-				}
-				else {
-					// Override formatter
-					document.setContentFormatter(this.contentFormatter);
-				}
-			});
+		if (contentFormatter != null) {
+			documents.forEach(this::processDocument);
 		}
 
 		return documents;
 	}
 
+	private void processDocument(Document document) {
+		if (document.getContentFormatter() instanceof DefaultContentFormatter docFormatter &&
+				contentFormatter instanceof DefaultContentFormatter toUpdateFormatter) {
+			updateFormatter(document, docFormatter, toUpdateFormatter);
+
+		} else {
+			overrideFormatter(document);
+		}
+	}
+
+	private void updateFormatter(Document document, DefaultContentFormatter docFormatter, DefaultContentFormatter toUpdateFormatter) {
+		List<String> updatedEmbedExcludeKeys = new ArrayList<>(docFormatter.getExcludedEmbedMetadataKeys());
+		updatedEmbedExcludeKeys.addAll(toUpdateFormatter.getExcludedEmbedMetadataKeys());
+
+		List<String> updatedInterfaceExcludeKeys = new ArrayList<>(docFormatter.getExcludedInferenceMetadataKeys());
+		updatedInterfaceExcludeKeys.addAll(toUpdateFormatter.getExcludedInferenceMetadataKeys());
+
+		DefaultContentFormatter.Builder builder = DefaultContentFormatter.builder()
+				.withExcludedEmbedMetadataKeys(updatedEmbedExcludeKeys)
+				.withExcludedInferenceMetadataKeys(updatedInterfaceExcludeKeys)
+				.withMetadataTemplate(docFormatter.getMetadataTemplate())
+				.withMetadataSeparator(docFormatter.getMetadataSeparator());
+
+		if (!disableTemplateRewrite) {
+			builder.withTextTemplate(docFormatter.getTextTemplate());
+		}
+
+		document.setContentFormatter(builder.build());
+	}
+
+	private void overrideFormatter(Document document) {
+		document.setContentFormatter(contentFormatter);
+	}
 }


### PR DESCRIPTION
- Extract Method
- Replace explicit instanceof checks and casting with pattern matching in the apply method of ContentFormatTransformer.
- Change var to explicit type