### PR TITLE
Refactor Azure OpenAi

### DIFF
--- a/models/spring-ai-azure-openai/README_AZURE_OPENAI.md
+++ b/models/spring-ai-azure-openai/README_AZURE_OPENAI.md
@@ -1,0 +1,78 @@
+# 1. Azure OpenAI
+
+Provides Azure OpenAI Chat and Embedding clients.
+Leverages the native [OpenAIClient](https://learn.microsoft.com/en-us/java/api/overview/azure/ai-openai-readme?view=azure-java-preview#streaming-chat-completions) to interact with the [Amazon AI Studio models and deployment](https://oai.azure.com/).
+
+## 1.1 Prerequisites
+
+1. Azure Subscription: You will need an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use any Azure service.
+2. Azure AI, Azure OpenAI Service: Create [Azure OpenAI](https://portal.azure.com/#create/Microsoft.CognitiveServicesOpenAI).
+Once the service is created, obtain the endpoint and apiKey from the `Keys and Endpoint` section under `Resource Management`.
+3. Use the [Azure Ai Studio](https://oai.azure.com/portal) to deploy the models you are going to use.
+
+## 1.2 AzureOpenAiChatClient
+
+[AzureOpenAiChatClient](./src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatClient.java) implements the Spring-Ai `ChatClient` and `StreamingChatClient` on top of the `OpenAIClient`.
+
+[AzureOpenAiEmbeddingClient](./src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingClient.java) implements the Spring-Ai `EmbeddingClient` on top of the `OpenAIClient`.
+
+
+You can configure the AzureOpenAiChatClient and AzureOpenAiEmbeddingClientlike this:
+
+```java
+@Bean
+public OpenAIClient openAIClient() {
+	return new OpenAIClientBuilder()
+			.credential(new AzureKeyCredential({YOUR_AZURE_OPENAI_API_KEY}))
+			.endpoint({YOUR_AZURE_OPENAI_ENDPOINT})
+			.buildClient();
+}
+
+@Bean
+public AzureOpenAiChatClient cohereChatClient(OpenAIClient openAIClient) {
+	return new AzureOpenAiChatClient(openAIClient)
+				.withModel("gpt-35-turbo")
+				.withMaxTokens(200)
+				.withTemperature(0.8);
+}
+
+@Bean
+public AzureOpenAiEmbeddingClient cohereEmbeddingClient(OpenAIClient openAIClient) {
+	return new AzureOpenAiEmbeddingClient(openAIClient, "text-embedding-ada-002-v1");
+}
+```
+
+## 1.3 Azure OpenAi Auto-Configuration and Spring Boot Starter
+
+You can leverage the `spring-ai-azure-openai-spring-boot-starter` Boot starter.
+For this add the following dependency:
+
+```xml
+<dependency>
+	<artifactId>spring-ai-azure-openai-spring-boot-starter</artifactId>
+	<groupId>org.springframework.ai</groupId>
+    <version>0.8.0-SNAPSHOT</version>
+</dependency>
+```
+
+Use the `AzureOpenAiConnectionProperties` to configure the Azure OpenAI access:
+
+| Property  | Description | Default |
+| ------------- | ------------- | ------------- |
+| spring.ai.azure.openai.apiKey  | Azure AI Open AI credentials api key.  | From the Azure AI OpenAI `Keys and Endpoint` section under `Resource Management` |
+| spring.ai.azure.openai.endpoint  | Azure AI Open AI endpoint.  | From the Azure AI OpenAI `Keys and Endpoint` section under `Resource Management` |
+
+Use the `AzureOpenAiChatProperties` to configure the Chat client:
+
+| Property  | Description | Default |
+| ------------- | ------------- | ------------- |
+| spring.ai.azure.openai.chat.model  | The model id to use.  | gpt-35-turbo |
+| spring.ai.azure.openai.chat.temperature  | Controls the randomness of the output. Values can range over [0.0,1.0]  | 0.7 |
+| spring.ai.azure.openai.chat.topP  | An alternative to sampling with temperature called nucleus sampling.  |  |
+| spring.ai.azure.openai.chat.maxTokens  | The maximum number of tokens to generate.  |  |
+
+Use the `AzureOpenAiEmbeddingProperties` to configure the Embedding client:
+
+| Property  | Description | Default |
+| ------------- | ------------- | ------------- |
+| spring.ai.azure.openai.embedding.model  | The model id to use for embedding  | text-embedding-ada-002 |

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatClient.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatClient.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.azure.openai.client;
+package org.springframework.ai.azure.openai;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,13 +29,16 @@ import com.azure.ai.openai.models.ChatRequestSystemMessage;
 import com.azure.ai.openai.models.ChatRequestUserMessage;
 import com.azure.ai.openai.models.ChatResponseMessage;
 import com.azure.ai.openai.models.ContentFilterResultsForPrompt;
+import com.azure.core.util.IterableStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 
 import org.springframework.ai.azure.openai.metadata.AzureOpenAiGenerationMetadata;
 import org.springframework.ai.chat.ChatClient;
 import org.springframework.ai.chat.ChatResponse;
 import org.springframework.ai.chat.Generation;
+import org.springframework.ai.chat.StreamingChatClient;
 import org.springframework.ai.metadata.ChoiceMetadata;
 import org.springframework.ai.metadata.PromptMetadata;
 import org.springframework.ai.metadata.PromptMetadata.PromptFilterMetadata;
@@ -55,35 +57,80 @@ import org.springframework.util.Assert;
  * @see ChatClient
  * @see com.azure.ai.openai.OpenAIClient
  */
-public class AzureOpenAiChatClient implements ChatClient {
+public class AzureOpenAiChatClient implements ChatClient, StreamingChatClient {
 
+	/**
+	 * The sampling temperature to use that controls the apparent creativity of generated
+	 * completions. Higher values will make output more random while lower values will
+	 * make results more focused and deterministic. It is not recommended to modify
+	 * temperature and top_p for the same completions request as the interaction of these
+	 * two settings is difficult to predict.
+	 */
 	private Double temperature = 0.7;
 
+	/**
+	 * An alternative to sampling with temperature called nucleus sampling. This value
+	 * causes the model to consider the results of tokens with the provided probability
+	 * mass. As an example, a value of 0.15 will cause only the tokens comprising the top
+	 * 15% of probability mass to be considered. It is not recommended to modify
+	 * temperature and top_p for the same completions request as the interaction of these
+	 * two settings is difficult to predict.
+	 */
+	private Double topP;
+
+	/**
+	 * Creates an instance of ChatCompletionsOptions class.
+	 */
 	private String model = "gpt-35-turbo";
+
+	/**
+	 * The maximum number of tokens to generate.
+	 */
+	private Integer maxTokens;
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	private final OpenAIClient openAIClient;
 
-	public AzureOpenAiChatClient(OpenAIClient microsoftOpenAiChatClient) {
-		Assert.notNull(microsoftOpenAiChatClient, "com.azure.ai.openai.OpenAIClient must not be null");
-		this.openAIClient = microsoftOpenAiChatClient;
+	public AzureOpenAiChatClient(OpenAIClient microsoftOpenAiClient) {
+		Assert.notNull(microsoftOpenAiClient, "com.azure.ai.openai.OpenAIClient must not be null");
+		this.openAIClient = microsoftOpenAiClient;
 	}
 
 	public String getModel() {
 		return this.model;
 	}
 
-	public void setModel(String model) {
+	public AzureOpenAiChatClient withModel(String model) {
 		this.model = model;
+		return this;
 	}
 
 	public Double getTemperature() {
 		return this.temperature;
 	}
 
-	public void setTemperature(Double temperature) {
+	public AzureOpenAiChatClient withTemperature(Double temperature) {
 		this.temperature = temperature;
+		return this;
+	}
+
+	public Double getTopP() {
+		return topP;
+	}
+
+	public AzureOpenAiChatClient withTopP(Double topP) {
+		this.topP = topP;
+		return this;
+	}
+
+	public Integer getMaxTokens() {
+		return maxTokens;
+	}
+
+	public AzureOpenAiChatClient withMaxTokens(Integer maxTokens) {
+		this.maxTokens = maxTokens;
+		return this;
 	}
 
 	@Override
@@ -94,6 +141,7 @@ public class AzureOpenAiChatClient implements ChatClient {
 		ChatCompletionsOptions options = new ChatCompletionsOptions(List.of(azureChatMessage));
 		options.setTemperature(this.getTemperature());
 		options.setModel(this.getModel());
+
 		logger.trace("Azure Chat Message: {}", azureChatMessage);
 
 		ChatCompletions chatCompletions = this.openAIClient.getChatCompletions(this.getModel(), options);
@@ -114,12 +162,8 @@ public class AzureOpenAiChatClient implements ChatClient {
 	@Override
 	public ChatResponse generate(Prompt prompt) {
 
-		List<ChatRequestMessage> azureMessages = prompt.getMessages().stream().map(this::fromSpringAiMessage).toList();
-
-		ChatCompletionsOptions options = new ChatCompletionsOptions(azureMessages);
-
-		options.setTemperature(this.getTemperature());
-		options.setModel(this.getModel());
+		ChatCompletionsOptions options = toAzureChatCompletionsOptions(prompt);
+		options.setStream(false);
 
 		logger.trace("Azure ChatCompletionsOptions: {}", options);
 
@@ -135,6 +179,44 @@ public class AzureOpenAiChatClient implements ChatClient {
 
 		return new ChatResponse(generations, AzureOpenAiGenerationMetadata.from(chatCompletions))
 			.withPromptMetadata(generatePromptMetadata(chatCompletions));
+	}
+
+	@Override
+	public Flux<ChatResponse> generateStream(Prompt prompt) {
+
+		ChatCompletionsOptions options = toAzureChatCompletionsOptions(prompt);
+		options.setStream(true);
+
+		IterableStream<ChatCompletions> chatCompletionsStream = this.openAIClient
+			.getChatCompletionsStream(this.getModel(), options);
+
+		return Flux.fromStream(chatCompletionsStream.stream()
+			// Note: the first chat completions can be ignored when using Azure OpenAI
+			// service which is a
+			// known service bug.
+			.skip(1)
+			.map(ChatCompletions::getChoices)
+			.flatMap(List::stream)
+			.map(choice -> {
+				System.out.println(choice.getDelta());
+				var content = (choice.getDelta() != null) ? choice.getDelta().getContent() : null;
+				var generation = new Generation(content).withChoiceMetadata(generateChoiceMetadata(choice));
+				return new ChatResponse(List.of(generation));
+			}));
+	}
+
+	private ChatCompletionsOptions toAzureChatCompletionsOptions(Prompt prompt) {
+
+		List<ChatRequestMessage> azureMessages = prompt.getMessages().stream().map(this::fromSpringAiMessage).toList();
+
+		ChatCompletionsOptions options = new ChatCompletionsOptions(azureMessages);
+
+		options.setTemperature(this.getTemperature());
+		options.setModel(this.getModel());
+		options.setTopP(this.getTopP());
+		options.setMaxTokens(this.getMaxTokens());
+
+		return options;
 	}
 
 	private ChatRequestMessage fromSpringAiMessage(Message message) {

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatClient.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatClient.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.azure.openai;
 
-import java.util.Collections;
 import java.util.List;
 
 import com.azure.ai.openai.OpenAIClient;
@@ -192,13 +191,11 @@ public class AzureOpenAiChatClient implements ChatClient, StreamingChatClient {
 
 		return Flux.fromStream(chatCompletionsStream.stream()
 			// Note: the first chat completions can be ignored when using Azure OpenAI
-			// service which is a
-			// known service bug.
+			// service which is a known service bug.
 			.skip(1)
 			.map(ChatCompletions::getChoices)
 			.flatMap(List::stream)
 			.map(choice -> {
-				System.out.println(choice.getDelta());
 				var content = (choice.getDelta() != null) ? choice.getDelta().getContent() : null;
 				var generation = new Generation(content).withChoiceMetadata(generateChoiceMetadata(choice));
 				return new ChatResponse(List.of(generation));
@@ -250,7 +247,7 @@ public class AzureOpenAiChatClient implements ChatClient, StreamingChatClient {
 	}
 
 	private <T> List<T> nullSafeList(List<T> list) {
-		return list != null ? list : Collections.emptyList();
+		return list != null ? list : List.of();
 	}
 
 }

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingClient.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingClient.java
@@ -1,4 +1,4 @@
-package org.springframework.ai.azure.openai.embedding;
+package org.springframework.ai.azure.openai;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
@@ -1,17 +1,19 @@
-package org.springframework.ai.openai.client;
+package org.springframework.ai.azure.openai;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.OpenAIClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import org.springframework.ai.chat.ChatResponse;
 import org.springframework.ai.chat.Generation;
-import org.springframework.ai.openai.OpenAiTestConfiguration;
-import org.springframework.ai.openai.testutils.AbstractIT;
 import org.springframework.ai.parser.BeanOutputParser;
 import org.springframework.ai.parser.ListOutputParser;
 import org.springframework.ai.parser.MapOutputParser;
@@ -20,31 +22,39 @@ import org.springframework.ai.prompt.PromptTemplate;
 import org.springframework.ai.prompt.SystemPromptTemplate;
 import org.springframework.ai.prompt.messages.Message;
 import org.springframework.ai.prompt.messages.UserMessage;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.convert.support.DefaultConversionService;
-import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = OpenAiTestConfiguration.class)
-@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
-class OpenAiChatClientIT extends AbstractIT {
+@SpringBootTest(classes = AzureOpenAiChatClientIT.TestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_ENDPOINT", matches = ".+")
+class AzureOpenAiChatClientIT {
 
-	@Value("classpath:/prompts/system-message.st")
-	private Resource systemResource;
+	@Autowired
+	private AzureOpenAiChatClient chatClient;
+
+	record ActorsFilms(String actor, List<String> movies) {
+	}
 
 	@Test
 	void roleTest() {
-		UserMessage userMessage = new UserMessage(
-				"Tell me about 3 famous pirates from the Golden Age of Piracy and why they did.");
-		SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(systemResource);
-		Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", "Bob", "voice", "pirate"));
+		Message systemMessage = new SystemPromptTemplate("""
+				You are a helpful AI assistant. Your name is {name}.
+				You are an AI assistant that helps people find information.
+				Your name is {name}
+				You should reply to the user's request with your name and also in the style of a {voice}.
+				""").createMessage(Map.of("name", "Bob", "voice", "pirate"));
+
+		UserMessage userMessage = new UserMessage("Tell me about 5 famous pirates from the Golden Age of Piracy?");
+
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
-		ChatResponse response = openAiChatClient.generate(prompt);
-		assertThat(response.getGenerations()).hasSize(1);
-		assertThat(response.getGenerations().get(0).getContent()).contains("Blackbeard");
-		// needs fine tuning... evaluateQuestionAndAnswer(request, response, false);
+		ChatResponse response = chatClient.generate(prompt);
+		assertThat(response.getGeneration().getContent()).contains("Blackbeard");
 	}
 
 	@Test
@@ -60,7 +70,7 @@ class OpenAiChatClientIT extends AbstractIT {
 		PromptTemplate promptTemplate = new PromptTemplate(template,
 				Map.of("subject", "ice cream flavors", "format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = this.openAiChatClient.generate(prompt).getGeneration();
+		Generation generation = chatClient.generate(prompt).getGeneration();
 
 		List<String> list = outputParser.parse(generation.getContent());
 		assertThat(list).hasSize(5);
@@ -79,7 +89,7 @@ class OpenAiChatClientIT extends AbstractIT {
 		PromptTemplate promptTemplate = new PromptTemplate(template,
 				Map.of("subject", "an array of numbers from 1 to 9 under they key name 'numbers'", "format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = openAiChatClient.generate(prompt).getGeneration();
+		Generation generation = chatClient.generate(prompt).getGeneration();
 
 		Map<String, Object> result = outputParser.parse(generation.getContent());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
@@ -98,9 +108,10 @@ class OpenAiChatClientIT extends AbstractIT {
 				""";
 		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = openAiChatClient.generate(prompt).getGeneration();
+		Generation generation = chatClient.generate(prompt).getGeneration();
 
 		ActorsFilms actorsFilms = outputParser.parse(generation.getContent());
+		assertThat(actorsFilms.actor()).isNotNull();
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {
@@ -118,7 +129,7 @@ class OpenAiChatClientIT extends AbstractIT {
 				""";
 		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
-		Generation generation = openAiChatClient.generate(prompt).getGeneration();
+		Generation generation = chatClient.generate(prompt).getGeneration();
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generation.getContent());
 		System.out.println(actorsFilms);
@@ -139,19 +150,39 @@ class OpenAiChatClientIT extends AbstractIT {
 		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 
-		String generationTextFromStream = openStreamingChatClient.generateStream(prompt)
+		String generationTextFromStream = chatClient.generateStream(prompt)
 			.collectList()
 			.block()
 			.stream()
 			.map(ChatResponse::getGenerations)
 			.flatMap(List::stream)
 			.map(Generation::getContent)
+			.filter(Objects::nonNull)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
 		System.out.println(actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public OpenAIClient openAIClient() {
+			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
+				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
+				.buildClient();
+		}
+
+		@Bean
+		public AzureOpenAiChatClient cohereChatClient(OpenAIClient openAIClient) {
+			return new AzureOpenAiChatClient(openAIClient).withModel("gpt-35-turbo")
+				// .withModel("gpt-35-turbo-16k")
+				.withMaxTokens(200);
+		}
+
 	}
 
 }

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
@@ -50,7 +50,7 @@ class AzureOpenAiChatClientIT {
 				You should reply to the user's request with your name and also in the style of a {voice}.
 				""").createMessage(Map.of("name", "Bob", "voice", "pirate"));
 
-		UserMessage userMessage = new UserMessage("Tell me about 5 famous pirates from the Golden Age of Piracy?");
+		UserMessage userMessage = new UserMessage("Generate the names of 5 famous pirates.");
 
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = chatClient.generate(prompt);

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
@@ -11,6 +11,8 @@ import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.ChatResponse;
 import org.springframework.ai.chat.Generation;
@@ -34,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_ENDPOINT", matches = ".+")
 class AzureOpenAiChatClientIT {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Autowired
 	private AzureOpenAiChatClient chatClient;
@@ -132,7 +136,9 @@ class AzureOpenAiChatClientIT {
 		Generation generation = chatClient.generate(prompt).getGeneration();
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generation.getContent());
-		System.out.println(actorsFilms);
+
+		logger.info("actorsFilms: " + actorsFilms);
+
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -161,7 +167,7 @@ class AzureOpenAiChatClientIT {
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
-		System.out.println(actorsFilms);
+		logger.info("Films:" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingClientIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingClientIT.java
@@ -30,7 +30,6 @@ class AzureOpenAiEmbeddingClientIT {
 		EmbeddingResponse embeddingResponse = embeddingClient.embedForResponse(List.of("Hello World"));
 		assertThat(embeddingResponse.getData()).hasSize(1);
 		assertThat(embeddingResponse.getData().get(0).getEmbedding()).isNotEmpty();
-		System.out.println(embeddingClient.dimensions());
 		assertThat(embeddingClient.dimensions()).isEqualTo(1536);
 	}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingClientIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingClientIT.java
@@ -1,0 +1,68 @@
+package org.springframework.ai.azure.openai;
+
+import java.util.List;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.OpenAIClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_ENDPOINT", matches = ".+")
+class AzureOpenAiEmbeddingClientIT {
+
+	@Autowired
+	private AzureOpenAiEmbeddingClient embeddingClient;
+
+	@Test
+	void singleEmbedding() {
+		assertThat(embeddingClient).isNotNull();
+		EmbeddingResponse embeddingResponse = embeddingClient.embedForResponse(List.of("Hello World"));
+		assertThat(embeddingResponse.getData()).hasSize(1);
+		assertThat(embeddingResponse.getData().get(0).getEmbedding()).isNotEmpty();
+		System.out.println(embeddingClient.dimensions());
+		assertThat(embeddingClient.dimensions()).isEqualTo(1536);
+	}
+
+	@Test
+	void batchEmbedding() {
+		assertThat(embeddingClient).isNotNull();
+		EmbeddingResponse embeddingResponse = embeddingClient
+			.embedForResponse(List.of("Hello World", "World is big and salvation is near"));
+		assertThat(embeddingResponse.getData()).hasSize(2);
+		assertThat(embeddingResponse.getData().get(0).getEmbedding()).isNotEmpty();
+		assertThat(embeddingResponse.getData().get(0).getIndex()).isEqualTo(0);
+		assertThat(embeddingResponse.getData().get(1).getEmbedding()).isNotEmpty();
+		assertThat(embeddingResponse.getData().get(1).getIndex()).isEqualTo(1);
+
+		assertThat(embeddingClient.dimensions()).isEqualTo(1536);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public OpenAIClient openAIClient() {
+			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
+				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
+				.buildClient();
+		}
+
+		@Bean
+		public AzureOpenAiEmbeddingClient cohereEmbeddingClient(OpenAIClient openAIClient) {
+			return new AzureOpenAiEmbeddingClient(openAIClient, "text-embedding-ada-002-v1");
+		}
+
+	}
+
+}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/MockAzureOpenAiTestConfiguration.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/MockAzureOpenAiTestConfiguration.java
@@ -19,7 +19,6 @@ package org.springframework.ai.azure.openai;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 
-import org.springframework.ai.azure.openai.client.AzureOpenAiChatClient;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatClientMetadataTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatClientMetadataTests.java
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.azure.openai.client;
-
-import static org.assertj.core.api.Assertions.assertThat;
+package org.springframework.ai.azure.openai.metadata;
 
 import java.nio.charset.StandardCharsets;
 
 import com.azure.ai.openai.models.ContentFilterResult;
 import com.azure.ai.openai.models.ContentFilterResultDetailsForPrompt;
 import com.azure.ai.openai.models.ContentFilterResultsForChoice;
-import com.azure.ai.openai.models.ContentFilterResultsForPrompt;
-// import com.azure.ai.openai.models.ContentFilterResultsForPrompt;
 import com.azure.ai.openai.models.ContentFilterSeverity;
-
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.azure.openai.AzureOpenAiChatClient;
 import org.springframework.ai.azure.openai.MockAzureOpenAiTestConfiguration;
 import org.springframework.ai.chat.ChatResponse;
 import org.springframework.ai.chat.Generation;
@@ -55,6 +51,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.WebRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit Tests for {@link AzureOpenAiChatClient} asserting AI metadata.

--- a/models/spring-ai-bedrock/README_ANTHROPIC_CHAT.md
+++ b/models/spring-ai-bedrock/README_ANTHROPIC_CHAT.md
@@ -31,14 +31,10 @@ AnthropicChatRequest request = AnthropicChatRequest
 
 AnthropicChatResponse response = anthropicChatApi.chatCompletion(request);
 
-System.out.println(response.completion());
-
 // Streaming response
 Flux<AnthropicChatResponse> responseStream = anthropicChatApi.chatCompletionStream(request);
 
 List<AnthropicChatResponse> responses = responseStream.collectList().block();
-
-System.out.println(responses);
 ```
 
 Follow the [AnthropicChatBedrockApi.java](./src/main/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApi.java)'s JavaDoc for further information.

--- a/models/spring-ai-bedrock/README_LLAMA2_CHAT.md
+++ b/models/spring-ai-bedrock/README_LLAMA2_CHAT.md
@@ -29,14 +29,10 @@ Llama2ChatRequest request = Llama2ChatRequest.builder("Hello, my name is")
 
 Llama2ChatResponse response = llama2ChatApi.chatCompletion(request);
 
-System.out.println(response.generation());
-
 // Streaming response
 Flux<Llama2ChatResponse> responseStream = llama2ChatApi.chatCompletionStream(request);
 
 List<Llama2ChatResponse> responses = responseStream.collectList().block();
-
-System.out.println(responses);
 ```
 
 Follow the [Llama2ChatBedrockApi.java](./src/main/java/org/springframework/ai/bedrock/llama2/api/Llama2ChatBedrockApi.java)'s JavaDoc for further information.

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatClientIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatClientIT.java
@@ -8,6 +8,9 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.ai.chat.ChatResponse;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -36,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
 class BedrockAnthropicChatClientIT {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Autowired
 	private BedrockAnthropicChatClient client;
@@ -143,7 +148,7 @@ class BedrockAnthropicChatClientIT {
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
-		System.out.println(actorsFilms);
+		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApiIT.java
@@ -52,15 +52,12 @@ public class AnthropicChatBedrockApiIT {
 
 		AnthropicChatResponse response = anthropicChatApi.chatCompletion(request);
 
-		System.out.println(response.completion());
 		assertThat(response).isNotNull();
 		assertThat(response.completion()).isNotEmpty();
 		assertThat(response.completion()).contains("Blackbeard");
 		assertThat(response.stopReason()).isEqualTo("stop_sequence");
 		assertThat(response.stop()).isEqualTo("\n\nHuman:");
 		assertThat(response.amazonBedrockInvocationMetrics()).isNull();
-
-		System.out.println(response);
 	}
 
 	@Test

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatClientIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatClientIT.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
@@ -37,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
 class BedrockCohereChatClientIT {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Autowired
 	private BedrockCohereChatClient client;
@@ -143,7 +147,7 @@ class BedrockCohereChatClientIT {
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
-		System.out.println(actorsFilms);
+		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/BedrockLlama2ChatClientIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/BedrockLlama2ChatClientIT.java
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.ai.chat.ChatResponse;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -38,6 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
 class BedrockLlama2ChatClientIT {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Autowired
 	private BedrockLlama2ChatClient client;
@@ -148,7 +153,7 @@ class BedrockLlama2ChatClientIT {
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
-		System.out.println(actorsFilms);
+		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/api/Llama2ChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/api/Llama2ChatBedrockApiIT.java
@@ -50,7 +50,6 @@ public class Llama2ChatBedrockApiIT {
 
 		Llama2ChatResponse response = llama2ChatApi.chatCompletion(request);
 
-		System.out.println(response.generation());
 		assertThat(response).isNotNull();
 		assertThat(response.generation()).isNotEmpty();
 		assertThat(response.promptTokenCount()).isEqualTo(6);

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanChatClientIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanChatClientIT.java
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.ai.chat.ChatResponse;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -38,6 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
 class BedrockTitanChatClientIT {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Autowired
 	private BedrockTitanChatClient client;
@@ -149,7 +154,7 @@ class BedrockTitanChatClientIT {
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
-		System.out.println(actorsFilms);
+		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApiIT.java
@@ -62,7 +62,6 @@ public class TitanEmbeddingBedrockApiIT {
 			.getContentAsByteArray();
 
 		String imageBase64 = Base64.getEncoder().encodeToString(image);
-		System.out.println(imageBase64.length());
 
 		TitanEmbeddingRequest request = TitanEmbeddingRequest.builder().withInputImage(imageBase64).build();
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
@@ -75,8 +75,6 @@ public class OllamaApiIT {
 
 		GenerateResponse response = ollamaApi.generate(request);
 
-		System.out.println(response);
-
 		assertThat(response).isNotNull();
 		assertThat(response.model()).isEqualTo(response.model());
 		assertThat(response.response()).contains("Sofia");
@@ -94,8 +92,6 @@ public class OllamaApiIT {
 			.build();
 
 		ChatResponse response = ollamaApi.chat(request);
-
-		System.out.println(response);
 
 		assertThat(response).isNotNull();
 		assertThat(response.model()).isEqualTo(response.model());
@@ -118,7 +114,6 @@ public class OllamaApiIT {
 		Flux<ChatResponse> response = ollamaApi.streamingChat(request);
 
 		List<ChatResponse> responses = response.collectList().block();
-		System.out.println(responses);
 
 		assertThat(response).isNotNull();
 		assertThat(responses.stream()

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaOptionsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaOptionsTests.java
@@ -36,7 +36,7 @@ public class OllamaOptionsTests {
 			.withStop(List.of("a", "b", "c"));
 
 		var optionsMap = options.toMap();
-		System.out.println(optionsMap);
+
 		assertThat(optionsMap).containsEntry("temperature", 3.14);
 		assertThat(optionsMap).containsEntry("embedding_only", false);
 		assertThat(optionsMap).containsEntry("top_k", 30);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/ActorsFilms.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/ActorsFilms.java
@@ -1,4 +1,4 @@
-package org.springframework.ai.openai.client;
+package org.springframework.ai.openai.chat;
 
 import java.util.List;
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatClientIT.java
@@ -1,0 +1,157 @@
+package org.springframework.ai.openai.chat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.Generation;
+import org.springframework.ai.openai.OpenAiTestConfiguration;
+import org.springframework.ai.openai.testutils.AbstractIT;
+import org.springframework.ai.parser.BeanOutputParser;
+import org.springframework.ai.parser.ListOutputParser;
+import org.springframework.ai.parser.MapOutputParser;
+import org.springframework.ai.prompt.Prompt;
+import org.springframework.ai.prompt.PromptTemplate;
+import org.springframework.ai.prompt.SystemPromptTemplate;
+import org.springframework.ai.prompt.messages.Message;
+import org.springframework.ai.prompt.messages.UserMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = OpenAiTestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiChatClientIT extends AbstractIT {
+
+	@Value("classpath:/prompts/system-message.st")
+	private Resource systemResource;
+
+	@Test
+	void roleTest() {
+		UserMessage userMessage = new UserMessage(
+				"Tell me about 3 famous pirates from the Golden Age of Piracy and why they did.");
+		SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(systemResource);
+		Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", "Bob", "voice", "pirate"));
+		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
+		ChatResponse response = openAiChatClient.generate(prompt);
+		assertThat(response.getGenerations()).hasSize(1);
+		assertThat(response.getGenerations().get(0).getContent()).contains("Blackbeard");
+		// needs fine tuning... evaluateQuestionAndAnswer(request, response, false);
+	}
+
+	@Test
+	void outputParser() {
+		DefaultConversionService conversionService = new DefaultConversionService();
+		ListOutputParser outputParser = new ListOutputParser(conversionService);
+
+		String format = outputParser.getFormat();
+		String template = """
+				List five {subject}
+				{format}
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template,
+				Map.of("subject", "ice cream flavors", "format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+		Generation generation = this.openAiChatClient.generate(prompt).getGeneration();
+
+		List<String> list = outputParser.parse(generation.getContent());
+		assertThat(list).hasSize(5);
+
+	}
+
+	@Test
+	void mapOutputParser() {
+		MapOutputParser outputParser = new MapOutputParser();
+
+		String format = outputParser.getFormat();
+		String template = """
+				Provide me a List of {subject}
+				{format}
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template,
+				Map.of("subject", "an array of numbers from 1 to 9 under they key name 'numbers'", "format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+		Generation generation = openAiChatClient.generate(prompt).getGeneration();
+
+		Map<String, Object> result = outputParser.parse(generation.getContent());
+		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+	}
+
+	@Test
+	void beanOutputParser() {
+
+		BeanOutputParser<ActorsFilms> outputParser = new BeanOutputParser<>(ActorsFilms.class);
+
+		String format = outputParser.getFormat();
+		String template = """
+				Generate the filmography for a random actor.
+				{format}
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+		Generation generation = openAiChatClient.generate(prompt).getGeneration();
+
+		ActorsFilms actorsFilms = outputParser.parse(generation.getContent());
+	}
+
+	record ActorsFilmsRecord(String actor, List<String> movies) {
+	}
+
+	@Test
+	void beanOutputParserRecords() {
+
+		BeanOutputParser<ActorsFilmsRecord> outputParser = new BeanOutputParser<>(ActorsFilmsRecord.class);
+
+		String format = outputParser.getFormat();
+		String template = """
+				Generate the filmography of 5 movies for Tom Hanks.
+				{format}
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+		Generation generation = openAiChatClient.generate(prompt).getGeneration();
+
+		ActorsFilmsRecord actorsFilms = outputParser.parse(generation.getContent());
+		System.out.println(actorsFilms);
+		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
+		assertThat(actorsFilms.movies()).hasSize(5);
+	}
+
+	@Test
+	void beanStreamOutputParserRecords() {
+
+		BeanOutputParser<ActorsFilmsRecord> outputParser = new BeanOutputParser<>(ActorsFilmsRecord.class);
+
+		String format = outputParser.getFormat();
+		String template = """
+				Generate the filmography of 5 movies for Tom Hanks.
+				{format}
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+
+		String generationTextFromStream = openStreamingChatClient.generateStream(prompt)
+			.collectList()
+			.block()
+			.stream()
+			.map(ChatResponse::getGenerations)
+			.flatMap(List::stream)
+			.map(Generation::getContent)
+			.collect(Collectors.joining());
+
+		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
+		System.out.println(actorsFilms);
+		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
+		assertThat(actorsFilms.movies()).hasSize(5);
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatClientIT.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.ChatResponse;
 import org.springframework.ai.chat.Generation;
@@ -30,6 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = OpenAiTestConfiguration.class)
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenAiChatClientIT extends AbstractIT {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Value("classpath:/prompts/system-message.st")
 	private Resource systemResource;
@@ -121,7 +125,7 @@ class OpenAiChatClientIT extends AbstractIT {
 		Generation generation = openAiChatClient.generate(prompt).getGeneration();
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generation.getContent());
-		System.out.println(actorsFilms);
+		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -149,7 +153,7 @@ class OpenAiChatClientIT extends AbstractIT {
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
-		System.out.println(actorsFilms);
+		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatClientWithGenerationMetadataTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatClientWithGenerationMetadataTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.openai.client;
+package org.springframework.ai.openai.chat;
 
 import java.time.Duration;
 
@@ -28,6 +28,7 @@ import org.springframework.ai.metadata.PromptMetadata;
 import org.springframework.ai.metadata.RateLimit;
 import org.springframework.ai.metadata.Usage;
 import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.client.OpenAiChatClient;
 import org.springframework.ai.openai.metadata.support.OpenAiApiResponseHeaders;
 import org.springframework.ai.prompt.Prompt;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/models/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiIT.java
+++ b/models/spring-ai-vertex-ai/src/test/java/org/springframework/ai/vertex/api/VertexAiApiIT.java
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.vertex.api.VertexAiApi.Embedding;
 import org.springframework.ai.vertex.api.VertexAiApi.GenerateMessageRequest;
@@ -38,6 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @EnabledIfEnvironmentVariable(named = "PALM_API_KEY", matches = ".*")
 public class VertexAiApiIT {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	VertexAiApi vertexAiApi = new VertexAiApi(System.getenv("PALM_API_KEY"));
 
@@ -106,7 +110,7 @@ public class VertexAiApiIT {
 		assertThat(response).hasSizeGreaterThan(0);
 		assertThat(response).contains("models/chat-bison-001", "models/text-bison-001", "models/embedding-gecko-001");
 
-		System.out.println(" - " + response.stream()
+		logger.info(" - " + response.stream()
 			.map(vertexAiApi::getModel)
 			.map(VertexAiApi.Model::toString)
 			.collect(Collectors.joining("\n - ")));
@@ -117,7 +121,6 @@ public class VertexAiApiIT {
 
 		VertexAiApi.Model model = vertexAiApi.getModel("models/chat-bison-001");
 
-		System.out.println(model);
 		assertThat(model).isNotNull();
 		assertThat(model.displayName()).isEqualTo("PaLM 2 Chat (Legacy)");
 	}

--- a/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTests.java
@@ -55,7 +55,6 @@ class PromptTests {
 		Prompt prompt = pt.create(model);
 		assertThat(prompt.getContents()).isNotNull();
 		assertThat(prompt.getMessages()).isNotEmpty().hasSize(1);
-		System.out.println(prompt.getContents());
 
 		String systemTemplate = "You are a helpful assistant that translates {input_language} to {output_language}.";
 		// system_message_prompt = SystemMessagePromptTemplate.from_template(template)

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiChatProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.autoconfigure.azure.openai;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(AzureOpenAiChatProperties.CONFIG_PREFIX)
+public class AzureOpenAiChatProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.chat";
+
+	/**
+	 * The sampling temperature to use that controls the apparent creativity of generated
+	 * completions. Higher values will make output more random while lower values will
+	 * make results more focused and deterministic. It is not recommended to modify
+	 * temperature and top_p for the same completions request as the interaction of these
+	 * two settings is difficult to predict.
+	 */
+	private Double temperature = 0.7;
+
+	/**
+	 * An alternative to sampling with temperature called nucleus sampling. This value
+	 * causes the model to consider the results of tokens with the provided probability
+	 * mass. As an example, a value of 0.15 will cause only the tokens comprising the top
+	 * 15% of probability mass to be considered. It is not recommended to modify
+	 * temperature and top_p for the same completions request as the interaction of these
+	 * two settings is difficult to predict.
+	 */
+	private Double topP;
+
+	/**
+	 * Creates an instance of ChatCompletionsOptions class.
+	 */
+	private String model = "gpt-35-turbo";
+
+	/**
+	 * The maximum number of tokens to generate.
+	 */
+	private Integer maxTokens;
+
+	public Double getTemperature() {
+		return temperature;
+	}
+
+	public void setTemperature(Double temperature) {
+		this.temperature = temperature;
+	}
+
+	public String getModel() {
+		return model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	public Double getTopP() {
+		return topP;
+	}
+
+	public void setTopP(Double topP) {
+		this.topP = topP;
+	}
+
+	public Integer getMaxTokens() {
+		return maxTokens;
+	}
+
+	public void setMaxTokens(Integer maxTokens) {
+		this.maxTokens = maxTokens;
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiConnectionProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiConnectionProperties.java
@@ -18,49 +18,29 @@ package org.springframework.ai.autoconfigure.azure.openai;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(AzureOpenAiProperties.CONFIG_PREFIX)
-public class AzureOpenAiProperties {
+@ConfigurationProperties(AzureOpenAiConnectionProperties.CONFIG_PREFIX)
+public class AzureOpenAiConnectionProperties {
 
-	// TODO look into Spring Cloud Azure project for credentials as well as
-	// e.g. com.azure.core.credential.AzureKeyCredential
 	public static final String CONFIG_PREFIX = "spring.ai.azure.openai";
 
+	/**
+	 * Azure OpenAI API key. From the Azure AI OpenAI `Keys and Endpoint` section under
+	 * `Resource Management`.
+	 */
 	private String apiKey;
 
+	/**
+	 * Azure OpenAI API endpoint. From the Azure AI OpenAI `Keys and Endpoint` section
+	 * under `Resource Management`.
+	 */
 	private String endpoint;
-
-	private Double temperature = 0.7;
-
-	private String model = "gpt-35-turbo";
-
-	private String embeddingModel = "text-embedding-ada-002";
 
 	public String getEndpoint() {
 		return endpoint;
 	}
 
-	/**
-	 * Sets the service endpoint that will be connected to by clients.
-	 * @param endpoint The URL of the service endpoint
-	 */
 	public void setEndpoint(String endpoint) {
 		this.endpoint = endpoint;
-	}
-
-	public Double getTemperature() {
-		return temperature;
-	}
-
-	public void setTemperature(Double temperature) {
-		this.temperature = temperature;
-	}
-
-	public String getModel() {
-		return model;
-	}
-
-	public void setModel(String model) {
-		this.model = model;
 	}
 
 	public void setApiKey(String apiKey) {
@@ -69,14 +49,6 @@ public class AzureOpenAiProperties {
 
 	public String getApiKey() {
 		return apiKey;
-	}
-
-	public String getEmbeddingModel() {
-		return embeddingModel;
-	}
-
-	public void setEmbeddingModel(String embeddingModel) {
-		this.embeddingModel = embeddingModel;
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiEmbeddingProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiEmbeddingProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.autoconfigure.azure.openai;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(AzureOpenAiEmbeddingProperties.CONFIG_PREFIX)
+public class AzureOpenAiEmbeddingProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.embedding";
+
+	/**
+	 * The text embedding model to use for the embedding client.
+	 */
+	private String model = "text-embedding-ada-002";
+
+	public String getModel() {
+		return model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiAutoConfigurationIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.autoconfigure.azure;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.autoconfigure.azure.openai.AzureOpenAiAutoConfiguration;
+import org.springframework.ai.azure.openai.AzureOpenAiChatClient;
+import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingClient;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.Generation;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.prompt.Prompt;
+import org.springframework.ai.prompt.SystemPromptTemplate;
+import org.springframework.ai.prompt.messages.Message;
+import org.springframework.ai.prompt.messages.UserMessage;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Tzolov
+ * @since 0.8.0
+ */
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_ENDPOINT", matches = ".+")
+public class AzureOpenAiAutoConfigurationIT {
+
+	private static String CHAT_MODEL_NAME = "gpt-35-turbo";
+
+	private static String EMBEDDING_MODEL_NAME = "text-embedding-ada-002";
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withPropertyValues(
+	// @formatter:off
+			"spring.ai.azure.openai.api-key=" + System.getenv("AZURE_OPENAI_API_KEY"),
+			"spring.ai.azure.openai.endpoint=" + System.getenv("AZURE_OPENAI_ENDPOINT"),
+
+			"spring.ai.azure.openai.chat.model=" + CHAT_MODEL_NAME,
+			"spring.ai.azure.openai.chat.temperature=0.8",
+			"spring.ai.azure.openai.chat.maxTokens=123",
+
+			"spring.ai.azure.openai.embedding.model=" + EMBEDDING_MODEL_NAME
+			// @formatter:on
+	).withConfiguration(AutoConfigurations.of(AzureOpenAiAutoConfiguration.class));
+
+	private final Message systemMessage = new SystemPromptTemplate("""
+			You are a helpful AI assistant. Your name is {name}.
+			You are an AI assistant that helps people find information.
+			Your name is {name}
+			You should reply to the user's request with your name and also in the style of a {voice}.
+			""").createMessage(Map.of("name", "Bob", "voice", "pirate"));
+
+	private final UserMessage userMessage = new UserMessage(
+			"Tell me about 3 famous pirates from the Golden Age of Piracy and why they did.");
+
+	@Test
+	public void chatCompletion() {
+		contextRunner.run(context -> {
+			AzureOpenAiChatClient chatClient = context.getBean(AzureOpenAiChatClient.class);
+			ChatResponse response = chatClient.generate(new Prompt(List.of(userMessage, systemMessage)));
+			assertThat(response.getGeneration().getContent()).contains("Blackbeard");
+		});
+	}
+
+	@Test
+	public void chatCompletionStreaming() {
+		contextRunner.run(context -> {
+
+			AzureOpenAiChatClient chatClient = context.getBean(AzureOpenAiChatClient.class);
+
+			Flux<ChatResponse> response = chatClient.generateStream(new Prompt(List.of(userMessage, systemMessage)));
+
+			List<ChatResponse> responses = response.collectList().block();
+			assertThat(responses.size()).isGreaterThan(1);
+
+			String stitchedResponseContent = responses.stream()
+				.map(ChatResponse::getGenerations)
+				.flatMap(List::stream)
+				.map(Generation::getContent)
+				.collect(Collectors.joining());
+
+			assertThat(stitchedResponseContent).contains("Blackbeard");
+		});
+	}
+
+	@Test
+	void embedding() {
+		contextRunner.run(context -> {
+			AzureOpenAiEmbeddingClient embeddingClient = context.getBean(AzureOpenAiEmbeddingClient.class);
+
+			EmbeddingResponse embeddingResponse = embeddingClient
+				.embedForResponse(List.of("Hello World", "World is big and salvation is near"));
+			assertThat(embeddingResponse.getData()).hasSize(2);
+			assertThat(embeddingResponse.getData().get(0).getEmbedding()).isNotEmpty();
+			assertThat(embeddingResponse.getData().get(0).getIndex()).isEqualTo(0);
+			assertThat(embeddingResponse.getData().get(1).getEmbedding()).isNotEmpty();
+			assertThat(embeddingResponse.getData().get(1).getIndex()).isEqualTo(1);
+
+			assertThat(embeddingClient.dimensions()).isEqualTo(1536);
+		});
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiAutoConfigurationPropertyTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiAutoConfigurationPropertyTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.autoconfigure.azure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.autoconfigure.azure.openai.AzureOpenAiAutoConfiguration;
+import org.springframework.ai.autoconfigure.azure.openai.AzureOpenAiChatProperties;
+import org.springframework.ai.autoconfigure.azure.openai.AzureOpenAiConnectionProperties;
+import org.springframework.ai.autoconfigure.azure.openai.AzureOpenAiEmbeddingProperties;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Tzolov
+ * @since 0.8.0
+ */
+public class AzureOpenAiAutoConfigurationPropertyTests {
+
+	@Test
+	public void chatPropertiesTest() {
+
+		new ApplicationContextRunner().withPropertyValues(
+		// @formatter:off
+				"spring.ai.azure.openai.api-key=TEST_API_KEY",
+				"spring.ai.azure.openai.endpoint=TEST_ENDPOINT",
+				"spring.ai.azure.openai.chat.model=MODEL_XYZ",
+				"spring.ai.azure.openai.chat.temperature=0.55",
+				"spring.ai.azure.openai.chat.topP=0.56",
+				"spring.ai.azure.openai.chat.maxTokens=123")
+			// @formatter:on
+			.withConfiguration(AutoConfigurations.of(AzureOpenAiAutoConfiguration.class))
+			.run(context -> {
+				var chatProperties = context.getBean(AzureOpenAiChatProperties.class);
+				var connectionProperties = context.getBean(AzureOpenAiConnectionProperties.class);
+
+				assertThat(connectionProperties.getApiKey()).isEqualTo("TEST_API_KEY");
+				assertThat(connectionProperties.getEndpoint()).isEqualTo("TEST_ENDPOINT");
+
+				assertThat(chatProperties.getModel()).isEqualTo("MODEL_XYZ");
+
+				assertThat(chatProperties.getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.getTopP()).isEqualTo(0.56);
+				assertThat(chatProperties.getMaxTokens()).isEqualTo(123);
+			});
+	}
+
+	@Test
+	public void embeddingPropertiesTest() {
+
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.azure.openai.api-key=TEST_API_KEY",
+					"spring.ai.azure.openai.endpoint=TEST_ENDPOINT", "spring.ai.azure.openai.embedding.model=MODEL_XYZ")
+			.withConfiguration(AutoConfigurations.of(AzureOpenAiAutoConfiguration.class))
+			.run(context -> {
+				var chatProperties = context.getBean(AzureOpenAiEmbeddingProperties.class);
+				var connectionProperties = context.getBean(AzureOpenAiConnectionProperties.class);
+
+				assertThat(connectionProperties.getApiKey()).isEqualTo("TEST_API_KEY");
+				assertThat(connectionProperties.getEndpoint()).isEqualTo("TEST_ENDPOINT");
+
+				assertThat(chatProperties.getModel()).isEqualTo("MODEL_XYZ");
+			});
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/transformers/TransformersEmbeddingClientAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/transformers/TransformersEmbeddingClientAutoConfigurationIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.autoconfigure.embedding.transformer;
+package org.springframework.ai.autoconfigure.transformers;
 
 import java.io.File;
 import java.util.List;
@@ -22,6 +22,8 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.ai.autoconfigure.embedding.transformer.TransformersEmbeddingClientAutoConfiguration;
+import org.springframework.ai.autoconfigure.embedding.transformer.TransformersEmbeddingClientProperties;
 import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.ai.embedding.TransformersEmbeddingClient;
 import org.springframework.boot.autoconfigure.AutoConfigurations;


### PR DESCRIPTION
 - Clean the AzureOpenAiChatClient and add support  for StreamingChatClient.
 - Streamline the AzureOpenAiEmbeddingClient.
 - Move the AzureOpenAiChatClient and AzureOpenAiEmbeddingClient to top org.sf.ai.azure.opoenai package.
 - Add ITs for AzureOpenAiChatClient and AzureOpenAiEmbeddingClient
 - Fix the AzureOpenAiAutoConfiguration
   - Split property file into AzureOpienAiConnectionProperties, AzureOpenAiChatProperties and AzureOpenAiEmbeddingProperties.
   - Add ITs for the auto-configuration
 - Add improve package structure
 - Add README docs