### PR TITLE
fix: copy embedding dimension

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfiguration.java
@@ -51,6 +51,7 @@ public class MilvusVectorStoreAutoConfiguration {
 			.withIndexType(properties.getIndexType())
 			.withMetricType(properties.getMetricType())
 			.withIndexParameters(properties.getIndexParameters())
+			.withEmbeddingDimension(properties.getEmbeddingDimension())
 			.build();
 
 		return new MilvusVectorStore(milvusClient, embeddingClient, config);


### PR DESCRIPTION
add missing copy params