### PR TITLE
Enable updating the pinecone vector store namespace

### DIFF
--- a/vector-stores/spring-ai-pinecone/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
@@ -60,9 +60,18 @@ public class PineconeVectorStore implements VectorStore {
 
 	private final PineconeConnection pineconeConnection;
 
-	private final String pineconeNamespace;
-
 	private final ObjectMapper objectMapper;
+
+	private String pineconeNamespace;
+
+	/**
+	 * Change the Index Name.
+	 * @param pineconeNamespace The Azure VectorStore index name to use.
+	 */
+	public void setPineconeNamespace(String pineconeNamespace) {
+		Assert.hasText(pineconeNamespace, "The Pinecone namespace can not be empty.");
+		this.pineconeNamespace = pineconeNamespace;
+	}
 
 	/**
 	 * Configuration class for the PineconeVectorStore.


### PR DESCRIPTION
When using pinecone, it would be nice to not have to create a new vectorStore instance for different namespaces. This PR is to simply:
- ~~add a setter to update the pinecone namespace used during requests~~
- Add additional functions that allow passing a custom namespace during add, search and delete
