### PR TITLE
Add AssistantPromptTemplate override method createMessage()

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/prompt/AssistantPromptTemplate.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/prompt/AssistantPromptTemplate.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.prompt;
 
 import org.springframework.ai.prompt.messages.AssistantMessage;
+import org.springframework.ai.prompt.messages.Message;
 
 import java.util.Map;
 
@@ -34,6 +35,16 @@ public class AssistantPromptTemplate extends PromptTemplate {
 	@Override
 	public Prompt create(Map<String, Object> model) {
 		return new Prompt(new AssistantMessage(render(model)));
+	}
+
+	@Override
+	public Message createMessage() {
+		return new AssistantMessage(render());
+	}
+
+	@Override
+	public Message createMessage(Map<String, Object> model) {
+		return new AssistantMessage(render(model));
 	}
 
 }


### PR DESCRIPTION
I found that when using the project, the `MessageType` is still `USER` instead of the expected `ASSISTANT` when using `AssistantPromptTemplate`. 

I'm not sure if this issue is an oversight, a bug, or intentional. Therefore, I submitted this PR. If it's not an oversight or bug, please close the PR.