### PR TITLE
Fix a typo in openai.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/clients/openai.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/clients/openai.adoc
@@ -53,21 +53,23 @@ Here is an example of a simple `@Controller` class that uses the `ChatClient` im
 public class ChatController {
 
     private final ChatClient chatClient;
+    private final StreamingChatClient streamingChatClient;
 
     @Autowired
-    public ChatController(ChatClient chatClient) {
+    public ChatController(ChatClient chatClient, StreamingChatClient streamingChatClient) {
         this.chatClient = chatClient;
+        this.streamingChatClient = streamingChatClient;
     }
 
-    @GetMapping("/ai/generate")
+    @GetMapping("/open-ai/generate")
     public Map generate(@RequestParam(value = "message", defaultValue = "Tell me a joke") String message) {
         return Map.of("generation", chatClient.generate(message));
     }
 
-    @GetMapping("/ai/generateStream")
-	public Flux<ChatResponse> generateStream(P@RequestParam(value = "message", defaultValue = "Tell me a joke") String message) {
+    @GetMapping("/open-ai/generateStream")
+	public Flux<ChatResponse> generateStream(@RequestParam(value = "message", defaultValue = "Tell me a joke") String message) {
         Prompt prompt = new Prompt(new UserMessage(message));
-        return chatClient.generateStream(prompt);
+        return streamingChatClient.generate(prompt);
     }
 }
 ----


### PR DESCRIPTION
- `@RequestParam` annotation was incorrectly written as `P@RequestParam`
- fix generateStream example
- Improved API visibility

---

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring) ✅
* Rebase your changes on the latest `main` branch and squash your commits ✅
* Add/Update unit tests as needed ✅
* Run a build and make sure all tests pass prior to submission ✅
