### PR TITLE
Use `ObjectMapper` with `FAIL_ON_UNKNOWN_PROPERTIES` false during error handling

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -96,10 +96,10 @@ public class OpenAiApi {
 				if (response.getStatusCode().isError()) {
 					if (response.getStatusCode().is4xxClientError()) {
 						throw new OpenAiApiClientErrorException(String.format("%s - %s", response.getStatusCode().value(),
-							new ObjectMapper().readValue(response.getBody(), ResponseError.class)));
+							OpenAiApi.this.objectMapper.readValue(response.getBody(), ResponseError.class)));
 					}
 					throw new OpenAiApiException(String.format("%s - %s", response.getStatusCode().value(),
-							new ObjectMapper().readValue(response.getBody(), ResponseError.class)));
+							OpenAiApi.this.objectMapper.readValue(response.getBody(), ResponseError.class)));
 				}
 			}
 		};


### PR DESCRIPTION
Some OpenAI compatible servers have unknown properties in the error response, so it is better to use an existing ObjectMapper in the ErrorHandler.
