### PR TITLE
#279: Normalize Line Endings to LF in BeanOutputParser

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/util/LineEndingsNormalizer.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/util/LineEndingsNormalizer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.util;
+
+/**
+ * A utility class for normalizing line endings in strings. This class is specifically
+ * designed to handle differences in line ending characters across different operating
+ * systems. It primarily addresses the discrepancy between Unix-based systems (which use
+ * '\n') and Windows (which uses '\r\n').
+ *
+ * <p>
+ * The normalization process replaces non-Unix style line endings ('\r\n') with Unix-style
+ * line endings ('\n'). On systems with Unix-style line endings, this utility performs no
+ * operation, effectively acting as a no-op. This design ensures minimal performance
+ * overhead on systems where line ending normalization is not required and may be entirely
+ * optimized away by the JIT.
+ * </p>
+ *
+ * <p>
+ * This utility can be particularly useful in scenarios where consistent line ending
+ * characters are necessary, such as in text processing, file I/O operations, or when
+ * dealing with multi-platform string manipulations.
+ * </p>
+ *
+ * Usage example: <pre>
+ *     LineEndingsNormalizer normalizer = new LineEndingsNormalizer();
+ *     String normalizedText = normalizer.normalize(inputText);
+ * </pre>
+ *
+ * @author Kirk Lund
+ */
+public class LineEndingsNormalizer {
+
+	/**
+	 * The line ending separator to normalize.
+	 */
+	private final String normalizedLineSeparator;
+
+	/**
+	 * Indicates if normalization of line endings is required.
+	 */
+	private final boolean requiresNormalization;
+
+	/**
+	 * Constructs a new LineEndingsNormalizer instance. It determines at instantiation if
+	 * normalization is necessary.
+	 */
+	public LineEndingsNormalizer(StandardLineEnding normalizedLineEnding) {
+		this(normalizedLineEnding, requiresNormalization(normalizedLineEnding));
+	}
+
+	/**
+	 * Package-private constructor primarily for testing purposes.
+	 * @param normalizedLineEnding Specifies the line ending to normalize to.
+	 * @param requiresNormalization Specifies if normalization of line endings is
+	 * required.
+	 */
+	LineEndingsNormalizer(StandardLineEnding normalizedLineEnding, boolean requiresNormalization) {
+		this.normalizedLineSeparator = normalizedLineEnding.lineSeparator();
+		this.requiresNormalization = requiresNormalization;
+	}
+
+	/**
+	 * Normalizes line endings in the provided string. If the platform has non-Unix line,
+	 * this method replaces all platform line endings (System.lineSeparator()) with
+	 * Unix-style line endings ('\n'). On other operating systems, the input string is
+	 * returned unmodified.
+	 * @param input The string in which line endings are to be normalized.
+	 * @return The string with normalized line endings.
+	 */
+	public String normalize(String input) {
+		if (requiresNormalization) {
+			return input.replace(System.lineSeparator(), normalizedLineSeparator);
+		}
+		return input;
+	}
+
+	/**
+	 * Determines if the specified normalizedLineEnding requires normalization when
+	 * running on the current platform.
+	 * @param normalizedLineEnding Specifies the line ending to normalize to.
+	 * @return true if the specified normalizedLineEnding requires normalization.
+	 */
+	public static boolean requiresNormalization(StandardLineEnding normalizedLineEnding) {
+		StandardLineEnding currentLineEnding = StandardLineEnding.findByLineSeparator(System.lineSeparator());
+		return requiresNormalization(currentLineEnding, normalizedLineEnding);
+	}
+
+	static boolean requiresNormalization(StandardLineEnding currentLineEnding,
+			StandardLineEnding normalizedLineEnding) {
+		return !currentLineEnding.lineSeparator().equals(normalizedLineEnding.lineSeparator());
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/util/StandardLineEnding.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/util/StandardLineEnding.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.util;
+
+/**
+ * Enum representing standard line endings used across different platforms. This enum
+ * provides a standardized way to reference common line separator characters such as
+ * Carriage Return (CR), Line Feed (LF), and the combination of both (CRLF).
+ */
+public enum StandardLineEnding {
+
+	/**
+	 * Carriage Return (CR) character, commonly used as a line ending in Mac OS systems up
+	 * to version 9, and in some network protocols.
+	 */
+	CR("\r"),
+
+	/**
+	 * Line Feed (LF) character, used as a line ending in Unix and Unix-like systems
+	 * including Linux and macOS X, and in many network protocols.
+	 */
+	LF("\n"),
+
+	/**
+	 * Carriage Return (CR) followed by Line Feed (LF), used as a line ending in Windows
+	 * operating systems, and in some network protocols.
+	 */
+	CRLF("\r\n");
+
+	private final String lineSeparator;
+
+	StandardLineEnding(String lineSeparator) {
+		this.lineSeparator = lineSeparator;
+	}
+
+	/**
+	 * Returns the line separator string associated with the line ending.
+	 * @return The line separator string.
+	 */
+	public String lineSeparator() {
+		return lineSeparator;
+	}
+
+	/**
+	 * Returns the string representation of the line ending.This method is overridden to
+	 * return the actual line separator string.
+	 * @return The line separator string.
+	 */
+	@Override
+	public String toString() {
+		return lineSeparator();
+	}
+
+	/**
+	 * Finds the corresponding StandardLineEnding enum constant for a given line separator
+	 * string.
+	 * @param lineSeparator The line separator string.
+	 * @return The corresponding StandardLineEnding enum constant, or null if not found.
+	 * @throws IllegalArgumentException if the line separator is not a recognized
+	 * standard.
+	 */
+	public static StandardLineEnding findByLineSeparator(String lineSeparator) {
+		for (StandardLineEnding ending : values()) {
+			if (ending.lineSeparator().equals(lineSeparator)) {
+				return ending;
+			}
+		}
+		throw new IllegalArgumentException("Unrecognized line separator: '" + lineSeparator + "'");
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/util/LineEndingsNormalizerTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/util/LineEndingsNormalizerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.springframework.ai.util.LineEndingsNormalizer.requiresNormalization;
+import static org.springframework.ai.util.StandardLineEnding.CR;
+import static org.springframework.ai.util.StandardLineEnding.CRLF;
+import static org.springframework.ai.util.StandardLineEnding.LF;
+
+/**
+ * @author Kirk Lund
+ */
+@ExtendWith(MockitoExtension.class)
+class LineEndingsNormalizerTest {
+
+	@Test
+	void requiresNormalization_forLineEndingCR_returnsTrue_onWindows() {
+		assumeThat(System.lineSeparator()).isEqualTo(CRLF.lineSeparator());
+
+		boolean requiresNormalization = requiresNormalization(CR);
+
+		assertThat(requiresNormalization).isTrue();
+	}
+
+	@Test
+	void requiresNormalization_forLineEndingLF_returnsTrue_onWindows() {
+		assumeThat(System.lineSeparator()).isEqualTo(CRLF.lineSeparator());
+
+		boolean requiresNormalization = requiresNormalization(LF);
+
+		assertThat(requiresNormalization).isTrue();
+	}
+
+	@Test
+	void requiresNormalization_forLineEndingCRLF_returnsFalse_onWindows() {
+		assumeThat(System.lineSeparator()).isEqualTo(CRLF.lineSeparator());
+
+		boolean requiresNormalization = requiresNormalization(CRLF);
+
+		assertThat(requiresNormalization).isFalse();
+	}
+
+	@Test
+	void requiresNormalization_withExplicitCurrentAndNormalizedEndings() {
+		for (StandardLineEnding current : StandardLineEnding.values()) {
+			for (StandardLineEnding normalized : StandardLineEnding.values()) {
+				boolean requiresNormalization = requiresNormalization(current, normalized);
+				assertThat(requiresNormalization).isEqualTo(!current.equals(normalized));
+			}
+		}
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/util/StandardLineEndingTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/util/StandardLineEndingTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.ai.util.StandardLineEnding.CR;
+import static org.springframework.ai.util.StandardLineEnding.CRLF;
+import static org.springframework.ai.util.StandardLineEnding.LF;
+import static org.springframework.ai.util.StandardLineEnding.findByLineSeparator;
+
+/**
+ * @author Kirk Lund
+ */
+class StandardLineEndingTest {
+
+	@Test
+	void lineSeparator_returnsSlashR_forCR() {
+		assertThat(CR.lineSeparator()).isEqualTo("\r");
+	}
+
+	@Test
+	void lineSeparator_returnsSlashN_forLF() {
+		assertThat(LF.lineSeparator()).isEqualTo("\n");
+	}
+
+	@Test
+	void lineSeparator_returnsSlashRSlashN_forCRLF() {
+		assertThat(CRLF.lineSeparator()).isEqualTo("\r\n");
+	}
+
+	@Test
+	void findByLineSeparator_returnsCR_forSlashR() {
+		assertThat(findByLineSeparator("\r")).isEqualTo(CR);
+	}
+
+	@Test
+	void findByLineSeparator_returnsLF_forSlashN() {
+		assertThat(findByLineSeparator("\n")).isEqualTo(LF);
+	}
+
+	@Test
+	void findByLineSeparator_returnsCR_forSlashRSlashN() {
+		assertThat(findByLineSeparator("\r\n")).isEqualTo(CRLF);
+	}
+
+}


### PR DESCRIPTION
This commit modifies BeanOutputParser to utilize the newly introduced LineEndingsNormalizer utility, ensuring all platform-specific line endings are normalized to LF (Unix-style). The LineEndingsNormalizer is designed to perform a no-op if the platform's default line ending matches the specified target line ending.

This change addresses and fixes BeanOutputParserTest failures observed on the Windows platform by ensuring consistent line ending normalization across different operating systems.

---

Note: There are failures in spring-ai-weaviate-store on Windows as well but I'd prefer to submit that as its own PR since its a different sub-module. I think it's better to keep this PR focused.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring) [done]
* Rebase your changes on the latest `main` branch and squash your commits [done]
* Add/Update unit tests as needed [done]
* Run a build and make sure all tests pass prior to submission [done: mac and windows]
