### PR TITLE
Allow configuration of vector index name.

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfiguration.java
@@ -56,6 +56,7 @@ public class Neo4jVectorStoreAutoConfiguration {
 			.withDistanceType(properties.getDistanceType())
 			.withLabel(properties.getLabel())
 			.withEmbeddingProperty(properties.getEmbeddingProperty())
+			.withIndexName(properties.getIndexName())
 			.build();
 
 		return new Neo4jVectorStore(driver, embeddingClient, config);

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreProperties.java
@@ -37,6 +37,8 @@ public class Neo4jVectorStoreProperties {
 
 	private String embeddingProperty = Neo4jVectorStore.DEFAULT_EMBEDDING_PROPERTY;
 
+	private String indexName = Neo4jVectorStore.DEFAULT_INDEX_NAME;
+
 	public String getDatabaseName() {
 		return databaseName;
 	}
@@ -75,6 +77,14 @@ public class Neo4jVectorStoreProperties {
 
 	public void setEmbeddingProperty(String embeddingProperty) {
 		this.embeddingProperty = embeddingProperty;
+	}
+
+	public String getIndexName() {
+		return this.indexName;
+	}
+
+	public void setIndexName(String indexName) {
+		this.indexName = indexName;
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
@@ -66,11 +66,13 @@ public class Neo4jVectorStoreAutoConfigurationIT {
 	void addAndSearch() {
 		contextRunner
 			.withPropertyValues("spring.ai.vectorstore.neo4j.label=my_test_label",
-					"spring.ai.vectorstore.neo4j.embeddingDimension=384")
+					"spring.ai.vectorstore.neo4j.embeddingDimension=384",
+					"spring.ai.vectorstore.neo4j.indexName=customIndexName")
 			.run(context -> {
 				var properties = context.getBean(Neo4jVectorStoreProperties.class);
 				assertThat(properties.getLabel()).isEqualTo("my_test_label");
 				assertThat(properties.getEmbeddingDimension()).isEqualTo(384);
+				assertThat(properties.getIndexName()).isEqualTo("customIndexName");
 
 				VectorStore vectorStore = context.getBean(VectorStore.class);
 				vectorStore.add(documents);


### PR DESCRIPTION
At the moment, it is not possible to configure SpringAI to use an existing index in the database.
This commit enables the user to provide the index name for auto configuration or builder usage.