### PR TITLE
Add option to skip `CREATE EXTENSION` in `PostgresMlEmbeddingClient`

### DIFF
--- a/models/spring-ai-postgresml/src/test/java/org/springframework/ai/postgresml/PostgresMlEmbeddingClientIT.java
+++ b/models/spring-ai-postgresml/src/test/java/org/springframework/ai/postgresml/PostgresMlEmbeddingClientIT.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,7 +42,7 @@ class PostgresMlEmbeddingClientIT {
 	@Container
 	@ServiceConnection
 	static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(
-			DockerImageName.parse("ghcr.io/postgresml/postgresml:2.7.3").asCompatibleSubstituteFor("postgres"))
+			DockerImageName.parse("ghcr.io/postgresml/postgresml:2.7.13").asCompatibleSubstituteFor("postgres"))
 		.withCommand("sleep", "infinity")
 		.withLabel("org.springframework.boot.service-connection", "postgres")
 		.withUsername("postgresml")
@@ -54,7 +54,7 @@ class PostgresMlEmbeddingClientIT {
 	@Autowired
 	JdbcTemplate jdbcTemplate;
 
-	@AfterEach
+	@BeforeEach
 	void dropPgmlExtension() {
 		this.jdbcTemplate.execute("DROP EXTENSION IF EXISTS pgml");
 	}
@@ -65,7 +65,6 @@ class PostgresMlEmbeddingClientIT {
 		embeddingClient.afterPropertiesSet();
 		List<Double> embed = embeddingClient.embed("Hello World!");
 		assertThat(embed).hasSize(768);
-		// embeddingClient.dropPgmlExtension();
 	}
 
 	@Test
@@ -75,7 +74,6 @@ class PostgresMlEmbeddingClientIT {
 		embeddingClient.afterPropertiesSet();
 		List<Double> embed = embeddingClient.embed(new Document("Hello World!"));
 		assertThat(embed).hasSize(768);
-		// embeddingClient.dropPgmlExtension();
 	}
 
 	@Test
@@ -85,18 +83,16 @@ class PostgresMlEmbeddingClientIT {
 		embeddingClient.afterPropertiesSet();
 		List<Double> embed = embeddingClient.embed(new Document("Hello World!"));
 		assertThat(embed).hasSize(384);
-		// embeddingClient.dropPgmlExtension();
 	}
 
 	@Test
 	void embedWithKwargs() {
 		PostgresMlEmbeddingClient embeddingClient = new PostgresMlEmbeddingClient(this.jdbcTemplate,
 				"distilbert-base-uncased", PostgresMlEmbeddingClient.VectorType.PG_ARRAY, Map.of("device", "cpu"),
-				MetadataMode.EMBED);
+				MetadataMode.EMBED, false);
 		embeddingClient.afterPropertiesSet();
 		List<Double> embed = embeddingClient.embed(new Document("Hello World!"));
 		assertThat(embed).hasSize(768);
-		// embeddingClient.dropPgmlExtension();
 	}
 
 	@ParameterizedTest
@@ -117,7 +113,6 @@ class PostgresMlEmbeddingClientIT {
 		assertThat(embeddingResponse.getResults().get(1).getOutput()).hasSize(768);
 		assertThat(embeddingResponse.getResults().get(2).getIndex()).isEqualTo(2);
 		assertThat(embeddingResponse.getResults().get(2).getOutput()).hasSize(768);
-		// embeddingClient.dropPgmlExtension();
 	}
 
 	@Test

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/postgresml/PostgresMlAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/postgresml/PostgresMlAutoConfiguration.java
@@ -39,7 +39,7 @@ public class PostgresMlAutoConfiguration {
 			PostgresMlProperties postgresMlProperties) {
 		return new PostgresMlEmbeddingClient(jdbcTemplate, postgresMlProperties.getEmbedding().getTransformer(),
 				postgresMlProperties.getEmbedding().getVectorType(), postgresMlProperties.getEmbedding().getKwargs(),
-				postgresMlProperties.getEmbedding().getMetadataMode());
+				postgresMlProperties.getEmbedding().getMetadataMode(), postgresMlProperties.isSkipCreateExtension());
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/postgresml/PostgresMlProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/postgresml/PostgresMlProperties.java
@@ -42,6 +42,8 @@ public class PostgresMlProperties {
 
 	private MetadataMode metadataMode = MetadataMode.EMBED;
 
+	private boolean skipCreateExtension = false;
+
 	public PostgresMlProperties.Embedding getEmbedding() {
 		return this.embedding;
 	}
@@ -76,6 +78,15 @@ public class PostgresMlProperties {
 
 	public void setMetadataMode(MetadataMode metadataMode) {
 		this.metadataMode = metadataMode;
+	}
+
+	public boolean isSkipCreateExtension() {
+		return skipCreateExtension;
+	}
+
+	public PostgresMlProperties setSkipCreateExtension(boolean skipCreateExtension) {
+		this.skipCreateExtension = skipCreateExtension;
+		return this;
 	}
 
 	public static class Embedding {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/postgresml/PostgresMlPropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/postgresml/PostgresMlPropertiesTests.java
@@ -35,7 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Utkarsh Srivastava
  */
 @SpringBootTest(properties = { "spring.ai.postgresml.metadata-mode=all", "spring.ai.postgresml.kwargs.key1=value1",
-		"spring.ai.postgresml.kwargs.key2=value2", "spring.ai.postgresml.embedding.transformer=abc123" })
+		"spring.ai.postgresml.kwargs.key2=value2", "spring.ai.postgresml.embedding.transformer=abc123",
+		"spring.ai.postgresml.skip-create-extension=true" })
 class PostgresMlPropertiesTests {
 
 	@Autowired
@@ -48,6 +49,7 @@ class PostgresMlPropertiesTests {
 		assertThat(this.postgresMlProperties.getVectorType()).isEqualTo(PostgresMlEmbeddingClient.VectorType.PG_ARRAY);
 		assertThat(this.postgresMlProperties.getKwargs()).isEqualTo(Map.of("key1", "value1", "key2", "value2"));
 		assertThat(this.postgresMlProperties.getMetadataMode()).isEqualTo(MetadataMode.ALL);
+		assertThat(this.postgresMlProperties.isSkipCreateExtension()).isTrue();
 
 		PostgresMlProperties.Embedding embedding = this.postgresMlProperties.getEmbedding();
 


### PR DESCRIPTION
This pull request introduces an option to skip the execution of `CREATE EXTENSION` within the `PostgresMlEmbeddingClient`. This enhancement is aimed at environments where pgml or the vector extension is already available and thus, re-executing `CREATE EXTENSION` is unnecessary. 
