### PR TITLE
Remove slash according to api

### DIFF
--- a/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/chroma/ChromaApi.java
+++ b/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/chroma/ChromaApi.java
@@ -307,7 +307,7 @@ public class ChromaApi {
 	public List<Collection> listCollections() {
 
 		return this.restTemplate
-			.exchange(this.baseUrl + "/api/v1/collections/", HttpMethod.GET, new HttpEntity<>(httpHeaders()),
+			.exchange(this.baseUrl + "/api/v1/collections", HttpMethod.GET, new HttpEntity<>(httpHeaders()),
 					CollectionList.class)
 			.getBody();
 	}


### PR DESCRIPTION
### Remove slash according to api

- According to `api.yaml`, `/api/v1/collections` path doesn't need slash so remove it 