### PR TITLE
Support filter expressions in Neo4j vector store.

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/converter/Neo4jVectorFilterExpressionConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/converter/Neo4jVectorFilterExpressionConverter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.filter.converter;
+
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.Group;
+import org.springframework.ai.vectorstore.filter.Filter.Key;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+
+/**
+ * Converts {@link Expression} into Neo4j condition expression format.
+ *
+ * @author Gerrit Meier
+ */
+public class Neo4jVectorFilterExpressionConverter extends AbstractFilterExpressionConverter {
+
+	@Override
+	protected void doExpression(Expression expression, StringBuilder context) {
+		if (expression.type() == Filter.ExpressionType.NIN) {
+			// shift the "<left> not in <right>" into "not <left> in <right>"
+			this.doNot(new Expression(Filter.ExpressionType.NOT,
+					new Expression(Filter.ExpressionType.IN, expression.left(), expression.right())), context);
+		}
+		else {
+			this.convertOperand(expression.left(), context);
+			context.append(this.getOperationSymbol(expression));
+			this.convertOperand(expression.right(), context);
+		}
+	}
+
+	private String getOperationSymbol(Expression exp) {
+		return switch (exp.type()) {
+			case AND -> " AND ";
+			case OR -> " OR ";
+			case EQ -> " = ";
+			case NE -> " != ";
+			case LT -> " < ";
+			case LTE -> " <= ";
+			case GT -> " > ";
+			case GTE -> " >= ";
+			case IN -> " IN ";
+			case NOT, NIN -> " NOT ";
+			// you never know what the future might bring
+			default -> throw new RuntimeException("Not supported expression type: " + exp.type());
+		};
+	}
+
+	@Override
+	protected void doNot(Expression expression, StringBuilder context) {
+		Filter.ExpressionType expressionType = expression.type();
+		// should not happen, but better safe than sorry
+		if (expressionType != Filter.ExpressionType.NOT) {
+			throw new RuntimeException(
+					"Unsupported expression type %s. Only NOT is supported here".formatted(expressionType));
+		}
+
+		// explicitly prefix the embedded expression with NOT
+		context.append("NOT ").append(this.convertOperand(expression.left()));
+	}
+
+	@Override
+	protected void doKey(Key key, StringBuilder context) {
+		context.append("node.").append("`metadata.").append(key.key().replace("\"", "")).append("`");
+	}
+
+	@Override
+	protected void doStartGroup(Group group, StringBuilder context) {
+		context.append("(");
+	}
+
+	@Override
+	protected void doEndGroup(Group group, StringBuilder context) {
+		context.append(")");
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/filter/converter/Neo4jVectorFilterExpressionConverterTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/filter/converter/Neo4jVectorFilterExpressionConverterTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.filter.converter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.Group;
+import org.springframework.ai.vectorstore.filter.Filter.Key;
+import org.springframework.ai.vectorstore.filter.Filter.Value;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.AND;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.EQ;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.GTE;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.IN;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.LTE;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.NE;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.NIN;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.NOT;
+import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.OR;
+
+/**
+ * @author Gerrit Meier
+ */
+public class Neo4jVectorFilterExpressionConverterTests {
+
+	FilterExpressionConverter converter = new Neo4jVectorFilterExpressionConverter();
+
+	@Test
+	public void testEQ() {
+		// country = "BG"
+		String vectorExpr = converter.convertExpression(new Expression(EQ, new Key("country"), new Value("BG")));
+		assertThat(vectorExpr).isEqualTo("node.`metadata.country` = \"BG\"");
+	}
+
+	@Test
+	public void tesEqAndGte() {
+		// genre = "drama" AND year >= 2020
+		String vectorExpr = converter
+			.convertExpression(new Expression(AND, new Expression(EQ, new Key("genre"), new Value("drama")),
+					new Expression(GTE, new Key("year"), new Value(2020))));
+		assertThat(vectorExpr).isEqualTo("node.`metadata.genre` = \"drama\" AND node.`metadata.year` >= 2020");
+	}
+
+	@Test
+	public void tesIn() {
+		// genre in ["comedy", "documentary", "drama"]
+		String vectorExpr = converter.convertExpression(
+				new Expression(IN, new Key("genre"), new Value(List.of("comedy", "documentary", "drama"))));
+		assertThat(vectorExpr).isEqualTo("node.`metadata.genre` IN [\"comedy\",\"documentary\",\"drama\"]");
+	}
+
+	@Test
+	public void tesNIn() {
+		// genre in ["comedy", "documentary", "drama"]
+		String vectorExpr = converter.convertExpression(
+				new Expression(NIN, new Key("genre"), new Value(List.of("comedy", "documentary", "drama"))));
+		assertThat(vectorExpr).isEqualTo("NOT node.`metadata.genre` IN [\"comedy\",\"documentary\",\"drama\"]");
+	}
+
+	@Test
+	public void testNe() {
+		// year >= 2020 OR country = "BG" AND city != "Sofia"
+		String vectorExpr = converter
+			.convertExpression(new Expression(OR, new Expression(GTE, new Key("year"), new Value(2020)),
+					new Expression(AND, new Expression(EQ, new Key("country"), new Value("BG")),
+							new Expression(NE, new Key("city"), new Value("Sofia")))));
+		assertThat(vectorExpr).isEqualTo(
+				"node.`metadata.year` >= 2020 OR node.`metadata.country` = \"BG\" AND node.`metadata.city` != \"Sofia\"");
+	}
+
+	@Test
+	public void testGroup() {
+		// (year >= 2020 OR country = "BG") AND NOT city IN ["Sofia", "Plovdiv"]
+		String vectorExpr = converter.convertExpression(new Expression(AND,
+				new Group(new Expression(OR, new Expression(GTE, new Key("year"), new Value(2020)),
+						new Expression(EQ, new Key("country"), new Value("BG")))),
+				new Expression(NOT, new Expression(IN, new Key("city"), new Value(List.of("Sofia", "Plovdiv"))))));
+		assertThat(vectorExpr).isEqualTo(
+				"(node.`metadata.year` >= 2020 OR node.`metadata.country` = \"BG\") AND NOT node.`metadata.city` IN [\"Sofia\",\"Plovdiv\"]");
+	}
+
+	@Test
+	public void testBoolean() {
+		// isOpen = true AND year >= 2020 AND country IN ["BG", "NL", "US"]
+		String vectorExpr = converter.convertExpression(new Expression(AND,
+				new Expression(AND, new Expression(EQ, new Key("isOpen"), new Value(true)),
+						new Expression(GTE, new Key("year"), new Value(2020))),
+				new Expression(IN, new Key("country"), new Value(List.of("BG", "NL", "US")))));
+
+		assertThat(vectorExpr).isEqualTo(
+				"node.`metadata.isOpen` = true AND node.`metadata.year` >= 2020 AND node.`metadata.country` IN [\"BG\",\"NL\",\"US\"]");
+	}
+
+	@Test
+	public void testDecimal() {
+		// temperature >= -15.6 AND temperature <= +20.13
+		String vectorExpr = converter
+			.convertExpression(new Expression(AND, new Expression(GTE, new Key("temperature"), new Value(-15.6)),
+					new Expression(LTE, new Key("temperature"), new Value(20.13))));
+
+		assertThat(vectorExpr)
+			.isEqualTo("node.`metadata.temperature` >= -15.6 AND node.`metadata.temperature` <= 20.13");
+	}
+
+	@Test
+	public void testComplexIdentifiers() {
+		String vectorExpr = converter
+			.convertExpression(new Expression(EQ, new Key("\"country 1 2 3\""), new Value("BG")));
+		assertThat(vectorExpr).isEqualTo("node.`metadata.country 1 2 3` = \"BG\"");
+	}
+
+}

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
@@ -22,6 +22,7 @@ import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.Values;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.vectorstore.filter.converter.Neo4jVectorFilterExpressionConverter;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
@@ -222,6 +223,8 @@ public class Neo4jVectorStore implements VectorStore, InitializingBean {
 
 	public static final String DEFAULT_EMBEDDING_PROPERTY = "embedding";
 
+	private final Neo4jVectorFilterExpressionConverter filterExpressionConverter = new Neo4jVectorFilterExpressionConverter();
+
 	private final Driver driver;
 
 	private final EmbeddingClient embeddingClient;
@@ -277,24 +280,25 @@ public class Neo4jVectorStore implements VectorStore, InitializingBean {
 
 	@Override
 	public List<Document> similaritySearch(SearchRequest request) {
-		if (request.getFilterExpression() != null) {
-			throw new UnsupportedOperationException(
-					"The [" + this.getClass() + "] doesn't support metadata filtering!");
-		}
-
 		Assert.isTrue(request.getTopK() > 0, "The number of documents to returned must be greater than zero");
 		Assert.isTrue(request.getSimilarityThreshold() >= 0 && request.getSimilarityThreshold() <= 1,
 				"The similarity score is bounded between 0 and 1; least to most similar respectively.");
 
 		var embedding = Values.value(toFloatArray(this.embeddingClient.embed(request.getQuery())));
 		try (var session = this.driver.session(this.config.sessionConfig)) {
+			StringBuilder condition = new StringBuilder("score >= $threshold");
+			if (request.hasFilterExpression()) {
+				condition.append(" AND ")
+					.append(this.filterExpressionConverter.convertExpression(request.getFilterExpression()));
+			}
+			String query = """
+					CALL db.index.vector.queryNodes($indexName, $numberOfNearestNeighbours, $embeddingValue)
+					YIELD node, score
+					WHERE %s
+					RETURN node, score""".formatted(condition);
+
 			return session
-				.run("""
-						CALL db.index.vector.queryNodes($indexName, $numberOfNearestNeighbours, $embeddingValue)
-						YIELD node, score
-						WHERE score >= $threshold
-						RETURN node, score
-						""",
+				.run(query,
 						Map.of("indexName", this.config.indexName, "numberOfNearestNeighbours", request.getTopK(),
 								"embeddingValue", embedding, "threshold", request.getSimilarityThreshold()))
 				.list(Neo4jVectorStore::recordToDocument);


### PR DESCRIPTION
I am not sure about the whole `StringBuilder` things there.
Also, I needed to take care of moving the `NOT` in front of the clauses. The idea of inverting the logics if using `NOT` in the abstract converter is nice but did not really match the, in my opinion, pragmatic prefix in Neo4j's Cypher with the negation.

Stole the tests from PgVector, again :)