### PR TITLE
Use the new vector index creation syntax for Neo4j

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
@@ -13,7 +13,7 @@ Those indexes are powered by Lucene using a Hierarchical Navigable Small World G
 
 == Prerequisites
 
-* A running Neo4j (5.13+) instance. The following options are available:
+* A running Neo4j (5.15+) instance. The following options are available:
 ** link:https://hub.docker.com/_/neo4j[Docker] image
 ** link:https://neo4j.com/download/[Neo4j Desktop]
 ** link:https://neo4j.com/cloud/aura-free/[Neo4j Aura]

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
@@ -45,10 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 public class Neo4jVectorStoreAutoConfigurationIT {
 
-	// Needs to be Neo4j 5.13+, because Neo4j 5.13 deprecated the used embedding storing
+	// Needs to be Neo4j 5.15+, because Neo4j 5.15 deprecated the used embedding storing
 	// function.
 	@Container
-	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.14"))
+	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.15"))
 		.withRandomPassword();
 
 	List<Document> documents = List.of(

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
@@ -39,10 +39,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class Neo4jVectorStoreIT {
 
-	// Needs to be Neo4j 5.13+, because Neo4j 5.13 deprecated the used embedding storing
+	// Needs to be Neo4j 5.15+, because Neo4j 5.15 deprecated the old vector index
+	// creation
 	// function.
 	@Container
-	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.14"))
+	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.15"))
 		.withRandomPassword();
 
 	List<Document> documents = List.of(


### PR DESCRIPTION
To make the Neo4j module more future-proof, this commit replaces the old vector index creation syntax with the new style. Also, the new pattern is in line with the standard Neo4j index creation and supports the _IF NOT EXISTS_ clause to run idempotent. This allows us to remove the preceding call to check if the index exists.

As a consequent, the module will require Neo4j to be at least on version 5.15.
