### PR TITLE
updated native hints

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/NativeAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/NativeAutoConfiguration.java
@@ -1,0 +1,13 @@
+package org.springframework.ai.autoconfigure;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+
+/**
+ * exists only to bring in the generic resource hints common to everything
+ */
+@Configuration
+@ImportRuntimeHints(NativeHints.class)
+class NativeAutoConfiguration {
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/NativeHints.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/NativeHints.java
@@ -1,9 +1,9 @@
 package org.springframework.ai.autoconfigure;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi;
@@ -25,8 +25,8 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 
 import java.io.IOException;
-import java.util.Objects;
-import java.util.Set;
+import java.lang.reflect.Executable;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /***
@@ -41,86 +41,26 @@ public class NativeHints implements RuntimeHintsRegistrar {
 	@Override
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
 
-		for (var h : Set.of(new BedrockAiHints(), new VertexAiHints(), new OpenAiHints(), new PdfReaderHints(),
-				new KnuddelsHints(), new OllamaHints()))
-			h.registerHints(hints, classLoader);
+		/*
+		 * These hints register resources, NOT types, so no ClassNotFoundExceptions to
+		 * worry about. If they break, we just eat the exception and move on. These 3
+		 * things don't have autoconfigs, either, so it makes sense to stash them here.
+		 * hints for every other kind of thing should be registered on the appropriate
+		 * autoconfig, guarded by @ConditionalOnClass checks
+		 */
 
-		hints.resources().registerResource(new ClassPathResource("embedding/embedding-model-dimensions.properties"));
-	}
-
-	private static Set<TypeReference> findJsonAnnotatedClasses(Class<?> packageClass) {
-		var packageName = packageClass.getPackageName();
-		var classPathScanningCandidateComponentProvider = new ClassPathScanningCandidateComponentProvider(false);
-		classPathScanningCandidateComponentProvider.addIncludeFilter(new AnnotationTypeFilter(JsonInclude.class));
-		return classPathScanningCandidateComponentProvider.findCandidateComponents(packageName)
-			.stream()
-			.map(bd -> TypeReference.of(Objects.requireNonNull(bd.getBeanClassName())))
-			.peek(tr -> {
-				if (log.isDebugEnabled())
-					log.debug("registering [" + tr.getName() + ']');
-			})
-			.collect(Collectors.toUnmodifiableSet());
-	}
-
-	static class VertexAiHints implements RuntimeHintsRegistrar {
-
-		@Override
-		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-			var mcs = MemberCategory.values();
-			for (var tr : findJsonAnnotatedClasses(VertexAiApi.class))
-				hints.reflection().registerType(tr, mcs);
+		for (var h : Set.of(new PdfReaderHints(), new KnuddelsHints(), new SpringAiCoreHints())) {
+			try {
+				h.registerHints(hints, classLoader);
+			}
+			catch (Throwable throwable) {
+				// don't care.
+			}
 		}
 
 	}
 
-	static class OllamaHints implements RuntimeHintsRegistrar {
-
-		@Override
-		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-			var mcs = MemberCategory.values();
-			for (var tr : findJsonAnnotatedClasses(OllamaApi.class))
-				hints.reflection().registerType(tr, mcs);
-			for (var tr : findJsonAnnotatedClasses(OllamaOptions.class))
-				hints.reflection().registerType(tr, mcs);
-		}
-
-	}
-
-	static class BedrockAiHints implements RuntimeHintsRegistrar {
-
-		@Override
-		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-			var mcs = MemberCategory.values();
-			for (var tr : findJsonAnnotatedClasses(Ai21Jurassic2ChatBedrockApi.class))
-				hints.reflection().registerType(tr, mcs);
-			for (var tr : findJsonAnnotatedClasses(CohereChatBedrockApi.class))
-				hints.reflection().registerType(tr, mcs);
-			for (var tr : findJsonAnnotatedClasses(CohereEmbeddingBedrockApi.class))
-				hints.reflection().registerType(tr, mcs);
-			for (var tr : findJsonAnnotatedClasses(Llama2ChatBedrockApi.class))
-				hints.reflection().registerType(tr, mcs);
-			for (var tr : findJsonAnnotatedClasses(TitanChatBedrockApi.class))
-				hints.reflection().registerType(tr, mcs);
-			for (var tr : findJsonAnnotatedClasses(TitanEmbeddingBedrockApi.class))
-				hints.reflection().registerType(tr, mcs);
-			for (var tr : findJsonAnnotatedClasses(AnthropicChatBedrockApi.class))
-				hints.reflection().registerType(tr, mcs);
-		}
-
-	}
-
-	static class OpenAiHints implements RuntimeHintsRegistrar {
-
-		@Override
-		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-			var mcs = MemberCategory.values();
-			for (var tr : findJsonAnnotatedClasses(OpenAiApi.class))
-				hints.reflection().registerType(tr, mcs);
-		}
-
-	}
-
-	static class KnuddelsHints implements RuntimeHintsRegistrar {
+	public static class KnuddelsHints implements RuntimeHintsRegistrar {
 
 		@Override
 		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
@@ -129,7 +69,7 @@ public class NativeHints implements RuntimeHintsRegistrar {
 
 	}
 
-	static class PdfReaderHints implements RuntimeHintsRegistrar {
+	public static class PdfReaderHints implements RuntimeHintsRegistrar {
 
 		@Override
 		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
@@ -152,6 +92,172 @@ public class NativeHints implements RuntimeHintsRegistrar {
 				throw new RuntimeException(e);
 			}
 
+		}
+
+	}
+
+	public static class SpringAiCoreHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			for (var r : Set.of("antlr4/org/springframework/ai/vectorstore/filter/antlr4/Filters.g4",
+					"embedding/embedding-model-dimensions.properties"))
+				hints.resources().registerResource(new ClassPathResource(r));
+		}
+
+	}
+
+	public static class StabilityAiHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			var mcs = MemberCategory.values();
+			for (var tr : findJsonAnnotatedClasses(StabilityAiHints.class))
+				hints.reflection().registerType(tr, mcs);
+
+		}
+
+	}
+
+	private static boolean hasJacksonAnnotations(Class<?> type) {
+		var hasAnnotation = false;
+		var annotationsToFind = Set.of(JsonProperty.class, JsonInclude.class);
+
+		for (var annotationToFind : annotationsToFind) {
+
+			if (type.isAnnotationPresent(annotationToFind)) {
+				hasAnnotation = true;
+			}
+
+			var executables = new HashSet<Executable>();
+			executables.addAll(List.of(type.getMethods()));
+			executables.addAll(List.of(type.getConstructors()));
+			executables.addAll(List.of(type.getDeclaredConstructors()));
+
+			for (var executable : executables) {
+				//
+				if (executable.isAnnotationPresent(annotationToFind)) {
+					hasAnnotation = true;
+				}
+
+				///
+				for (var p : executable.getParameters()) {
+					if (p.isAnnotationPresent(annotationToFind)) {
+						hasAnnotation = true;
+					}
+				}
+			}
+
+			if (type.getRecordComponents() != null) {
+				for (var r : type.getRecordComponents()) {
+					if (r.isAnnotationPresent(annotationToFind)) {
+						hasAnnotation = true;
+					}
+				}
+			}
+
+			for (var f : type.getFields()) {
+				if (f.isAnnotationPresent(annotationToFind)) {
+					hasAnnotation = true;
+				}
+			}
+		}
+
+		return hasAnnotation;
+	}
+
+	private static Set<Class<?>> discoverJacksonAnnotatedTypesFromRootType(Class<?> type) {
+		var jsonTypes = new HashSet<Class<?>>();
+		var classesToInspect = new HashSet<Class<?>>();
+		classesToInspect.add(type);
+		classesToInspect.addAll(Arrays.asList(type.getNestMembers()));
+		for (var n : classesToInspect) {
+			if (hasJacksonAnnotations(n)) {
+				jsonTypes.add(n);
+			}
+		}
+		return jsonTypes;
+	}
+
+	private static Set<TypeReference> findJsonAnnotatedClasses(Class<?> packageClass) {
+		var packageName = packageClass.getPackageName();
+		var classPathScanningCandidateComponentProvider = new ClassPathScanningCandidateComponentProvider(false);
+		classPathScanningCandidateComponentProvider.addIncludeFilter(new AnnotationTypeFilter(JsonInclude.class));
+		classPathScanningCandidateComponentProvider.addIncludeFilter((metadataReader, metadataReaderFactory) -> {
+			try {
+				var clazz = Class.forName(metadataReader.getClassMetadata().getClassName());
+				return (!discoverJacksonAnnotatedTypesFromRootType(clazz).isEmpty());
+			}
+			catch (ClassNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+
+		});
+		return classPathScanningCandidateComponentProvider//
+			.findCandidateComponents(packageName)//
+			.stream()//
+			.map(bd -> TypeReference.of(Objects.requireNonNull(bd.getBeanClassName())))//
+			.peek(tr -> {
+				if (log.isDebugEnabled())
+					log.debug("registering [" + tr.getName() + ']');
+			})
+			.collect(Collectors.toUnmodifiableSet());
+	}
+
+	public static class VertexAiHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			var mcs = MemberCategory.values();
+			for (var tr : findJsonAnnotatedClasses(VertexAiApi.class))
+				hints.reflection().registerType(tr, mcs);
+		}
+
+	}
+
+	public static class OllamaHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			var mcs = MemberCategory.values();
+			for (var tr : findJsonAnnotatedClasses(OllamaApi.class))
+				hints.reflection().registerType(tr, mcs);
+			for (var tr : findJsonAnnotatedClasses(OllamaOptions.class))
+				hints.reflection().registerType(tr, mcs);
+		}
+
+	}
+
+	public static class BedrockAiHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			var mcs = MemberCategory.values();
+			for (var tr : findJsonAnnotatedClasses(Ai21Jurassic2ChatBedrockApi.class))
+				hints.reflection().registerType(tr, mcs);
+			for (var tr : findJsonAnnotatedClasses(CohereChatBedrockApi.class))
+				hints.reflection().registerType(tr, mcs);
+			for (var tr : findJsonAnnotatedClasses(CohereEmbeddingBedrockApi.class))
+				hints.reflection().registerType(tr, mcs);
+			for (var tr : findJsonAnnotatedClasses(Llama2ChatBedrockApi.class))
+				hints.reflection().registerType(tr, mcs);
+			for (var tr : findJsonAnnotatedClasses(TitanChatBedrockApi.class))
+				hints.reflection().registerType(tr, mcs);
+			for (var tr : findJsonAnnotatedClasses(TitanEmbeddingBedrockApi.class))
+				hints.reflection().registerType(tr, mcs);
+			for (var tr : findJsonAnnotatedClasses(AnthropicChatBedrockApi.class))
+				hints.reflection().registerType(tr, mcs);
+		}
+
+	}
+
+	public static class OpenAiHints implements RuntimeHintsRegistrar {
+
+		@Override
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+			var mcs = MemberCategory.values();
+			for (var tr : findJsonAnnotatedClasses(OpenAiApi.class))
+				hints.reflection().registerType(tr, mcs);
 		}
 
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiAutoConfiguration.java
@@ -21,6 +21,7 @@ import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
 
 import com.azure.core.util.ClientOptions;
+import org.springframework.ai.autoconfigure.NativeHints;
 import org.springframework.ai.azure.openai.AzureOpenAiChatClient;
 import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingClient;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -28,12 +29,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.util.Assert;
 
 @AutoConfiguration
 @ConditionalOnClass(OpenAIClientBuilder.class)
 @EnableConfigurationProperties({ AzureOpenAiChatProperties.class, AzureOpenAiEmbeddingProperties.class,
 		AzureOpenAiConnectionProperties.class })
+@ImportRuntimeHints(NativeHints.OpenAiHints.class)
 public class AzureOpenAiAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/anthropic/BedrockAnthropicChatAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/anthropic/BedrockAnthropicChatAutoConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 @EnableConfigurationProperties({ BedrockAnthropicChatProperties.class, BedrockAwsConnectionProperties.class })
 @ConditionalOnProperty(prefix = BedrockAnthropicChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
 @Import(BedrockAwsConnectionConfiguration.class)
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.BedrockAiHints.class)
 public class BedrockAnthropicChatAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereChatAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereChatAutoConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 @EnableConfigurationProperties({ BedrockCohereChatProperties.class, BedrockAwsConnectionProperties.class })
 @ConditionalOnProperty(prefix = BedrockCohereChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
 @Import(BedrockAwsConnectionConfiguration.class)
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.BedrockAiHints.class)
 public class BedrockCohereChatAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereEmbeddingAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereEmbeddingAutoConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 @EnableConfigurationProperties({ BedrockCohereEmbeddingProperties.class, BedrockAwsConnectionProperties.class })
 @ConditionalOnProperty(prefix = BedrockCohereEmbeddingProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
 @Import(BedrockAwsConnectionConfiguration.class)
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.BedrockAiHints.class)
 public class BedrockCohereEmbeddingAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/llama2/BedrockLlama2ChatAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/llama2/BedrockLlama2ChatAutoConfiguration.java
@@ -46,7 +46,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 @EnableConfigurationProperties({ BedrockLlama2ChatProperties.class, BedrockAwsConnectionProperties.class })
 @ConditionalOnProperty(prefix = BedrockLlama2ChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
 @Import(BedrockAwsConnectionConfiguration.class)
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.BedrockAiHints.class)
 public class BedrockLlama2ChatAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanChatAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanChatAutoConfiguration.java
@@ -43,7 +43,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 @EnableConfigurationProperties({ BedrockTitanChatProperties.class, BedrockAwsConnectionProperties.class })
 @ConditionalOnProperty(prefix = BedrockTitanChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
 @Import(BedrockAwsConnectionConfiguration.class)
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.BedrockAiHints.class)
 public class BedrockTitanChatAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanEmbeddingAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanEmbeddingAutoConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 @EnableConfigurationProperties({ BedrockTitanEmbeddingProperties.class, BedrockAwsConnectionProperties.class })
 @ConditionalOnProperty(prefix = BedrockTitanEmbeddingProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true")
 @Import(BedrockAwsConnectionConfiguration.class)
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.BedrockAiHints.class)
 public class BedrockTitanEmbeddingAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.web.client.RestClient;
 @ConditionalOnClass(OllamaApi.class)
 @EnableConfigurationProperties({ OllamaChatProperties.class, OllamaEmbeddingProperties.class,
 		OllamaConnectionProperties.class })
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.OllamaHints.class)
 public class OllamaAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.web.client.RestClient;
 @ConditionalOnClass(OpenAiApi.class)
 @EnableConfigurationProperties({ OpenAiConnectionProperties.class, OpenAiChatProperties.class,
 		OpenAiEmbeddingProperties.class, OpenAiImageProperties.class })
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.OpenAiHints.class)
 /**
  * @author Christian Tzolov
  */

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/stabilityai/StabilityAiImageAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/stabilityai/StabilityAiImageAutoConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.web.client.RestClient;
 @AutoConfiguration(after = RestClientAutoConfiguration.class)
 @ConditionalOnClass(StabilityAiApi.class)
 @EnableConfigurationProperties({ StabilityAiImageProperties.class })
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.StabilityAiHints.class)
 public class StabilityAiImageAutoConfiguration {
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vertexai/VertexAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vertexai/VertexAiAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.RestClient;
 
 @AutoConfiguration(after = RestClientAutoConfiguration.class)
 @ConditionalOnClass(VertexAiApi.class)
-@ImportRuntimeHints(NativeHints.class)
+@ImportRuntimeHints(NativeHints.VertexAiHints.class)
 @EnableConfigurationProperties({ VertexAiConnectionProperties.class, VertexAiChatProperties.class,
 		VertexAiEmbeddingProperties.class })
 public class VertexAiAutoConfiguration {

--- a/spring-ai-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -19,3 +19,4 @@ org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoCon
 org.springframework.ai.autoconfigure.vectorstore.azure.AzureVectorStoreAutoConfiguration
 org.springframework.ai.autoconfigure.vectorstore.weaviate.WeaviateVectorStoreAutoConfiguration
 org.springframework.ai.autoconfigure.vectorstore.neo4j.Neo4jVectorStoreAutoConfiguration
+org.springframework.ai.autoconfigure.NativeAutoConfiguration


### PR DESCRIPTION
hi 

this teases out the native hints so that , for example, there's no attempt to load classes for vertex when openai is on the classpath. 

also, i expanded the algorithm to discover more things to be registered for reflection. now, the code looks for types annotated with `@JsonInclude` and types with a use of `@JsonProperty`