### PR TITLE
Update PgVectorFilterExpressionConverter.java

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/converter/PgVectorFilterExpressionConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/converter/PgVectorFilterExpressionConverter.java
@@ -64,7 +64,7 @@ public class PgVectorFilterExpressionConverter extends AbstractFilterExpressionC
 
 	@Override
 	protected void doKey(Key key, StringBuilder context) {
-		context.append("$." + key.key());
+		context.append("$." + String.format("\"%s\"", key.key()));
 	}
 
 	@Override


### PR DESCRIPTION
Fix for filtering failing on Postgres if the key contains characters such as a hyphen - wrapping the key in quotes ensures this query can run.
