### PR TITLE
fix: BOOL_VALUE case in QdrantObjectFactory

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStorePropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStorePropertiesTests.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Christian Tzolov
  */
-public class PgVectorStorePropertiesTests {
+public class QdrantVectorStorePropertiesTests {
 
 	@Test
 	public void defaultValues() {

--- a/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactory.java
+++ b/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactory.java
@@ -58,13 +58,14 @@ class QdrantObjectFactory {
 			case DOUBLE_VALUE:
 				return value.getDoubleValue();
 			case BOOL_VALUE:
-				return value.hasBoolValue();
+				return value.getBoolValue();
 			case LIST_VALUE:
 				return object(value.getListValue());
 			case STRUCT_VALUE:
 				return toObjectMap(value.getStructValue().getFieldsMap());
-			case KIND_NOT_SET:
 			case NULL_VALUE:
+				return null;
+			case KIND_NOT_SET:
 			default:
 				logger.warn("Unsupported value type: " + value.getKindCase());
 				return null;


### PR DESCRIPTION
## Description
This PR
- As the title goes.
- Renames the Qdrant Auto-configure test file.