### PR TITLE
fix description of openapi-chat  in upgrade-notes

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -65,10 +65,10 @@ to
 
 The following OpenAi Autoconfiguration chat properties has changed
 
-* from `spring.ai.openai.model` to `spring.ai.openai.chat.model`.
-* from `spring.ai.openai.temperature` to `spring.ai.openai.chat.temperature`.
+* from `spring.ai.openai.model` to `spring.ai.openai.chat.options.model`.
+* from `spring.ai.openai.temperature` to `spring.ai.openai.chat.options.temperature`.
 
-Find updated documentation about the OpenAi properties: https://docs.spring.io/spring-ai/reference/api/clients/openai.html
+Find updated documentation about the OpenAi properties: https://docs.spring.io/spring-ai/reference/api/clients/openai-chat.html
 
 === December 27, 2023 Update
 


### PR DESCRIPTION
## Motivation:
There are some incorrect descriptions and 404 page-link in the `https://docs.spring.io/spring-ai/reference/upgrade-notes.html`, and I have made some modifications based on the code and the configuration page on the official website.

## Other
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
yes, done
![image](https://github.com/spring-projects/spring-ai/assets/35491928/f20efcb7-5a7d-4468-8fe0-b0bbd626eab5)

* Rebase your changes on the latest `main` branch and squash your commits
yes,done
* Add/Update unit tests as needed
fix document, not nedd
* Run a build and make sure all tests pass prior to submission
fix document, not nedd

