### PR TITLE
Limit request for embedding client in pg vector store

### DIFF
--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
@@ -236,7 +236,9 @@ public class PgVectorStore implements VectorStore, InitializingBean {
 						var document = documents.get(i);
 						var content = document.getContent();
 						var json = toJson(document.getMetadata());
-						var pGvector = new PGvector(toFloatArray(embeddingClient.embed(document)));
+						var embedding = !document.getEmbedding().isEmpty() ? document.getEmbedding()
+								: embeddingClient.embed(document);
+						var pGvector = new PGvector(toFloatArray(embedding));
 
 						StatementCreatorUtils.setParameterValue(ps, 1, SqlTypeValue.TYPE_UNKNOWN,
 								UUID.fromString(document.getId()));


### PR DESCRIPTION
This is the purpose of the PR :

In the class PgVectorStore line 239 uses embeddingClient to embed documents.

On the other hand, we have a setEmbedding method in the Document class that lets you add the document embedding. To do this, the developer should use embeddingClient to retrieve the embedding.  (use case A)

So, if we use setEmbedding to embed the document, line 239 of class PgVectorStore will make one more request to embed the document.

To avoid this situation, we check that the document hasn't already been embedded before making an embedding request.

![embedding_clent](https://github.com/spring-projects/spring-ai/assets/6693893/e93414df-264b-425b-a56c-bd6277086298)

@tzolov you can see the topic, it may be on other vector store implementations, we can find double requests in some cases