### PR TITLE
Refactor Options

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptions.java
@@ -25,14 +25,8 @@ public interface ChatOptions extends ModelOptions {
 
 	Float getTemperature();
 
-	void setTemperature(Float temperature);
-
 	Float getTopP();
 
-	void setTopP(Float topP);
-
 	Integer getTopK();
-
-	void setTopK(Integer topK);
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptionsBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptionsBuilder.java
@@ -18,47 +18,11 @@ package org.springframework.ai.chat.prompt;
 
 public class ChatOptionsBuilder {
 
-	private class ChatOptionsImpl implements ChatOptions {
+	private Float temperature;
 
-		private Float temperature;
+	private Float topP;
 
-		private Float topP;
-
-		private Integer topK;
-
-		@Override
-		public Float getTemperature() {
-			return temperature;
-		}
-
-		@Override
-		public void setTemperature(Float temperature) {
-			this.temperature = temperature;
-		}
-
-		@Override
-		public Float getTopP() {
-			return topP;
-		}
-
-		@Override
-		public void setTopP(Float topP) {
-			this.topP = topP;
-		}
-
-		@Override
-		public Integer getTopK() {
-			return topK;
-		}
-
-		@Override
-		public void setTopK(Integer topK) {
-			this.topK = topK;
-		}
-
-	}
-
-	private final ChatOptionsImpl options = new ChatOptionsImpl();
+	private Integer topK;
 
 	private ChatOptionsBuilder() {
 	}
@@ -67,23 +31,65 @@ public class ChatOptionsBuilder {
 		return new ChatOptionsBuilder();
 	}
 
+	/**
+	 * Constructs a new immutable object based on the provided ChatOptions object.
+	 * @param options The original ChatOptions object to base the new object on.
+	 * @return ChatOptionsBuilder to construct a new ChatOptions object.
+	 */
+	public static ChatOptionsBuilder builder(ChatOptions options) {
+		return builder().withTopK(options.getTopK())
+			.withTopP(options.getTopP())
+			.withTemperature(options.getTemperature());
+	}
+
 	public ChatOptionsBuilder withTemperature(Float temperature) {
-		options.setTemperature(temperature);
+		this.temperature = temperature;
 		return this;
 	}
 
 	public ChatOptionsBuilder withTopP(Float topP) {
-		options.setTopP(topP);
+		this.topP = topP;
 		return this;
 	}
 
 	public ChatOptionsBuilder withTopK(Integer topK) {
-		options.setTopK(topK);
+		this.topK = topK;
 		return this;
 	}
 
 	public ChatOptions build() {
-		return options;
+		return new ChatOptionsImpl(this.temperature, this.topP, this.topK);
+	}
+
+	private class ChatOptionsImpl implements ChatOptions {
+
+		private final Float temperature;
+
+		private final Float topP;
+
+		private final Integer topK;
+
+		ChatOptionsImpl(Float temperature, Float topP, Integer topK) {
+			this.temperature = temperature;
+			this.topP = topP;
+			this.topK = topK;
+		}
+
+		@Override
+		public Float getTemperature() {
+			return temperature;
+		}
+
+		@Override
+		public Float getTopP() {
+			return topP;
+		}
+
+		@Override
+		public Integer getTopK() {
+			return topK;
+		}
+
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
@@ -18,11 +18,12 @@ package org.springframework.ai.model.function;
 
 import java.util.List;
 import java.util.Set;
+import org.springframework.ai.chat.prompt.ChatOptions;
 
 /**
  * @author Christian Tzolov
  */
-public interface FunctionCallingOptions {
+public interface FunctionCallingOptions extends ChatOptions {
 
 	/**
 	 * Function Callbacks to be registered with the ChatClient. For Prompt Options the
@@ -35,32 +36,9 @@ public interface FunctionCallingOptions {
 	List<FunctionCallback> getFunctionCallbacks();
 
 	/**
-	 * Set the Function Callbacks to be registered with the ChatClient.
-	 * @param functionCallbacks the Function Callbacks to be registered with the
-	 * ChatClient.
-	 */
-	void setFunctionCallbacks(List<FunctionCallback> functionCallbacks);
-
-	/**
 	 * @return List of function names from the ChatClient registry to be used in the next
 	 * chat completion requests.
 	 */
 	Set<String> getFunctions();
-
-	/**
-	 * Set the list of function names from the ChatClient registry to be used in the next
-	 * chat completion requests.
-	 * @param functions the list of function names from the ChatClient registry to be used
-	 * in the next chat completion requests.
-	 */
-	void setFunctions(Set<String> functions);
-
-	/**
-	 * @return Returns FunctionCallingOptionsBuilder to create a new instance of
-	 * FunctionCallingOptions.
-	 */
-	public static FunctionCallingOptionsBuilder builder() {
-		return new FunctionCallingOptionsBuilder();
-	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/ChatBuilderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/ChatBuilderTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.ChatOptionsBuilder;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.model.function.FunctionCallbackWrapper;
+import org.springframework.ai.model.function.FunctionCallingOptions;
+import org.springframework.ai.model.function.FunctionCallingOptionsBuilder;
+
+/**
+ * Unit Tests for {@link Prompt}.
+ *
+ * @author youngmon
+ * @since 0.8.1
+ */
+public class ChatBuilderTests {
+
+	@Test
+	void createNewChatOptionsTest() {
+		Float temperature = 1.1f;
+		Float topP = 2.2f;
+		Integer topK = 111;
+
+		ChatOptions options = ChatOptionsBuilder.builder()
+			.withTemperature(temperature)
+			.withTopK(topK)
+			.withTopP(topP)
+			.build();
+
+		assertThat(options.getTemperature()).isEqualTo(temperature);
+		assertThat(options.getTopP()).isEqualTo(topP);
+		assertThat(options.getTopK()).isEqualTo(topK);
+	}
+
+	@Test
+	void duplicateChatOptionsTest() {
+		Float initTemperature = 1.1f;
+		Float initTopP = 2.2f;
+		Integer initTopK = 111;
+
+		ChatOptions options = ChatOptionsBuilder.builder()
+			.withTemperature(initTemperature)
+			.withTopP(initTopP)
+			.withTopK(initTopK)
+			.build();
+
+		Integer newTopK = 222;
+
+		ChatOptions newOptions = ChatOptionsBuilder.builder(options)
+			// setTopK
+			.withTopK(newTopK)
+			.build();
+
+		assertThat(newOptions.getTemperature()).isEqualTo(initTemperature);
+		assertThat(newOptions.getTopP()).isEqualTo(initTopP);
+		assertThat(newOptions.getTopK()).isEqualTo(newTopK);
+	}
+
+	@Test
+	void createFunctionCallingOptionTest() {
+		Float temperature = 1.1f;
+		Float topP = 2.2f;
+		Integer topK = 111;
+		List<FunctionCallback> functionCallbacks = new ArrayList<>();
+		Set<String> functions = new HashSet<>();
+
+		String func = "func";
+		FunctionCallback cb = FunctionCallbackWrapper.<Integer, Integer>builder(i -> i)
+			.withName("cb")
+			.withDescription("cb")
+			.build();
+
+		functions.add(func);
+		functionCallbacks.add(cb);
+
+		FunctionCallingOptions options = FunctionCallingOptionsBuilder.builder()
+			.withFunctionCallbacks(functionCallbacks)
+			.withFunctions(functions)
+			.withTopK(topK)
+			.withTopP(topP)
+			.withTemperature(temperature)
+			.build();
+
+		// Callback Functions
+		assertThat(options.getFunctionCallbacks()).isNotNull();
+		assertThat(options.getFunctionCallbacks().size()).isEqualTo(1);
+		assertThat(options.getFunctionCallbacks().contains(cb));
+
+		// Functions
+		assertThat(options.getFunctions()).isNotNull();
+		assertThat(options.getFunctions().size()).isEqualTo(1);
+		assertThat(options.getFunctions().contains(func));
+
+		// Immutable
+		options.getFunctionCallbacks().add(cb);
+		assertThat(options.getFunctionCallbacks().size()).isEqualTo(1);
+		options.getFunctions().add(func + func);
+		assertThat(options.getFunctions().size()).isEqualTo(1);
+
+		FunctionCallingOptions newOptions = FunctionCallingOptionsBuilder.builder(options)
+			.withFunction(func + func)
+			.withFunctionCallback(cb)
+			.build();
+
+		assertThat(newOptions.getFunctions().size()).isEqualTo(2);
+		assertThat(newOptions.getFunctionCallbacks().size()).isEqualTo(2);
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -28,7 +28,7 @@ import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;
 import org.springframework.ai.chat.ChatResponse;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.function.FunctionCallingOptions;
+import org.springframework.ai.model.function.FunctionCallingOptionsBuilder;
 import org.springframework.ai.model.function.FunctionCallingOptionsBuilder.PortableFunctionCallingOptions;
 import org.springframework.ai.openai.OpenAiChatClient;
 import org.springframework.ai.openai.OpenAiChatOptions;
@@ -87,7 +87,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 			// Test weatherFunction
 			UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");
 
-			PortableFunctionCallingOptions functionOptions = FunctionCallingOptions.builder()
+			PortableFunctionCallingOptions functionOptions = FunctionCallingOptionsBuilder.builder()
 				.withFunction("weatherFunction")
 				.build();
 


### PR DESCRIPTION
In the original code, Builders and Setters were used concurrently.
This approach could compromise object immutability in multi-threaded environments,
potentially leading to undesirable side effects.

To mitigate this, Setters have been removed to enhance and ensure object immutability.

- Remove setters
- Add a builder method that references existing objects
- Enhance the immutability of collections returned by getters
- Add test code reflecting the changes