### PR TITLE
Refactored to optimize Document embedding reuse:

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
@@ -52,7 +52,7 @@ public class Document {
 	/**
 	 * Document content.
 	 */
-	private String content;
+	private final String content;
 
 	/**
 	 * Embedding of the document. Note: ephemeral field.

--- a/spring-ai-core/src/main/java/org/springframework/ai/embedding/EmbeddingClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/embedding/EmbeddingClient.java
@@ -18,6 +18,7 @@ package org.springframework.ai.embedding;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.model.ModelClient;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 import java.util.List;
 
@@ -45,6 +46,22 @@ public interface EmbeddingClient extends ModelClient<EmbeddingRequest, Embedding
 	 * @return the embedded vector.
 	 */
 	List<Double> embed(Document document);
+
+	/**
+	 * Uses Document's existing if available, otherwise generates and caches the
+	 * embedding.
+	 * @param document the document to embed.
+	 * @return the embedded vector.
+	 */
+	default List<Double> cachedEmbed(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		if (!CollectionUtils.isEmpty(document.getEmbedding())) {
+			return document.getEmbedding();
+		}
+		var embeddings = this.embed(document);
+		document.setEmbedding(embeddings);
+		return embeddings;
+	}
 
 	/**
 	 * Embeds a batch of texts into vectors.

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
@@ -62,8 +62,10 @@ public class SimpleVectorStore implements VectorStore {
 	public void add(List<Document> documents) {
 		for (Document document : documents) {
 			logger.info("Calling EmbeddingClient for document id = {}", document.getId());
-			List<Double> embedding = this.embeddingClient.embed(document);
-			document.setEmbedding(embedding);
+			if (document.getEmbedding().isEmpty()) {
+				List<Double> embedding = this.embeddingClient.embed(document);
+				document.setEmbedding(embedding);
+			}
 			this.store.put(document.getId(), document);
 		}
 	}

--- a/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -211,7 +211,8 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 		}
 
 		final var searchDocuments = documents.stream().map(document -> {
-			final var embeddings = this.embeddingClient.embed(document);
+
+			List<Double> embeddings = this.embeddingClient.cachedEmbed(document);
 			SearchDocument searchDocument = new SearchDocument();
 			searchDocument.put(ID_FIELD_NAME, document.getId());
 			searchDocument.put(EMBEDDING_FIELD_NAME, embeddings);

--- a/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/vectorsore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/vectorsore/ChromaVectorStore.java
@@ -95,7 +95,7 @@ public class ChromaVectorStore implements VectorStore, InitializingBean {
 			ids.add(document.getId());
 			metadatas.add(document.getMetadata());
 			contents.add(document.getContent());
-			document.setEmbedding(this.embeddingClient.embed(document));
+			document.setEmbedding(this.embeddingClient.cachedEmbed(document));
 			embeddings.add(JsonUtils.toFloatArray(document.getEmbedding()));
 		}
 

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -268,7 +268,8 @@ public class MilvusVectorStore implements VectorStore, InitializingBean {
 		List<List<Float>> embeddingArray = new ArrayList<>();
 
 		for (Document document : documents) {
-			List<Double> embedding = this.embeddingClient.embed(document);
+
+			List<Double> embedding = this.embeddingClient.cachedEmbed(document);
 
 			docIdArray.add(document.getId());
 			// Use a (future) DocumentTextLayoutFormatter instance to extract

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
@@ -55,8 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Neo4jVectorStoreIT {
 
 	// Needs to be Neo4j 5.15+, because Neo4j 5.15 deprecated the old vector index
-	// creation
-	// function.
+	// creation function.
 	@Container
 	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.15"))
 		.withRandomPassword();

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
@@ -235,7 +235,7 @@ public class PgVectorStore implements VectorStore, InitializingBean {
 						var document = documents.get(i);
 						var content = document.getContent();
 						var json = toJson(document.getMetadata());
-						var pGvector = new PGvector(toFloatArray(embeddingClient.embed(document)));
+						var pGvector = new PGvector(toFloatArray(embeddingClient.cachedEmbed(document)));
 
 						StatementCreatorUtils.setParameterValue(ps, 1, SqlTypeValue.TYPE_UNKNOWN,
 								UUID.fromString(document.getId()));

--- a/vector-stores/spring-ai-pinecone/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
@@ -232,7 +232,7 @@ public class PineconeVectorStore implements VectorStore {
 
 		List<Vector> upsertVectors = documents.stream().map(document -> {
 			// Compute and assign an embedding to the document.
-			document.setEmbedding(this.embeddingClient.embed(document));
+			document.setEmbedding(this.embeddingClient.cachedEmbed(document));
 
 			return Vector.newBuilder()
 				.setId(document.getId())

--- a/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -213,7 +213,7 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 		try {
 			List<PointStruct> points = documents.stream().map(document -> {
 				// Compute and assign an embedding to the document.
-				document.setEmbedding(this.embeddingClient.embed(document));
+				document.setEmbedding(this.embeddingClient.cachedEmbed(document));
 
 				return PointStruct.newBuilder()
 					.setId(id(UUID.fromString(document.getId())))

--- a/vector-stores/spring-ai-redis/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
@@ -305,8 +305,7 @@ public class RedisVectorStore implements VectorStore, InitializingBean {
 	public void add(List<Document> documents) {
 		Pipeline pipeline = this.jedis.pipelined();
 		for (Document document : documents) {
-			var embedding = this.embeddingClient.embed(document);
-			document.setEmbedding(embedding);
+			var embedding = this.embeddingClient.cachedEmbed(document);
 
 			var fields = new HashMap<String, Object>();
 			fields.put(this.config.embeddingFieldName, embedding);

--- a/vector-stores/spring-ai-weaviate/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
@@ -421,10 +421,7 @@ public class WeaviateVectorStore implements VectorStore, InitializingBean {
 
 	private WeaviateObject toWeaviateObject(Document document) {
 
-		if (CollectionUtils.isEmpty(document.getEmbedding())) {
-			List<Double> embedding = this.embeddingClient.embed(document);
-			document.setEmbedding(embedding);
-		}
+		this.embeddingClient.cachedEmbed(document);
 
 		// https://weaviate.io/developers/weaviate/config-refs/datatypes
 		Map<String, Object> fields = new HashMap<>();


### PR DESCRIPTION
 - Introduced logic to utilize existing Document embeddings when not empty, avoiding unnecessary calls to embeddingClient.embed.
 - Ensured immutability of the Document#content field by making it final.
 - Implemented a default method cachedEmbed in the EmbeddingClient interface, responsible for checking existing document embeddings and adding them if absent.
 - Updated all Vector Store implementations to employ cachedEmbed upon document addition.
 - Ensured that embedding fields are returned with resolved documents in select Vector Store implementations for consistency.