### PR TITLE
Add MistralAI links to getting started doc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -135,6 +135,7 @@ Each of the following sections in the documentation shows which dependencies you
 ** xref:api/embeddings/bedrock-cohere-embedding.adoc[Spring AI Bedrock Cohere Embeddings]
 ** xref:api/embeddings/bedrock-titan-embedding.adoc[Spring AI Bedrock Titan Embeddings]
 ** xref:api/embeddings/vertexai-embeddings.adoc[Spring AI VertexAI Embeddings]
+** xref:api/embeddings/mistralai-embeddings.adoc[Spring AI MistralAI Embeddings]
 
 === Chat Models
 * xref:api/chatclient.adoc[Chat Completion API]
@@ -149,6 +150,7 @@ Each of the following sections in the documentation shows which dependencies you
 *** xref:api/clients/bedrock/bedrock-llama2.adoc[Llama2 Chat Completion]
 *** xref:api/clients/bedrock/bedrock-titan.adoc[Titan Chat Completion]
 *** xref:api/clients/bedrock/bedrock-anthropic.adoc[Anthropic Chat Completion]
+** xref:api/clients/mistralai-chat.adoc[MistralAI Chat Completion] (streaming and function-calling support)
 // ** xref:api/clients/bedrock/bedrock-jurassic.adoc[Jurassic2 Chat Completion] (WIP, no streaming support)
 
 === Image Generation Models


### PR DESCRIPTION
MistralAI Chat Completion API and  Embedding API is missing in getting started doc section.

This PR add MistralAI links to getting started doc section. 