### PR TITLE
feat FunctionCallingOptions

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
@@ -28,8 +28,10 @@ public interface FunctionCallingOptions {
 	 * functionCallbacks are automatically enabled for the duration of the prompt
 	 * execution. For Default Options the FunctionCallbacks are registered but disabled by
 	 * default. You have to use "functions" property to list the function names from the
-	 * ChatClient registry to be used in the chat completion requests.
-	 * @return Return the Function Callbacks to be registered with the ChatClient.
+	 * ChatClient registry to be used in the chat completion requests. Attempting to
+	 * modify this list will result in an {@link UnsupportedOperationException}.
+	 * @return Return the Function Callbacks to be registered with the ChatClient as
+	 * immutable List.
 	 */
 	List<FunctionCallback> getFunctionCallbacks();
 
@@ -41,8 +43,10 @@ public interface FunctionCallingOptions {
 	void setFunctionCallbacks(List<FunctionCallback> functionCallbacks);
 
 	/**
+	 * Returns a Set of Functions as immutable Set. Attempting to modify this set will
+	 * result in an {@link UnsupportedOperationException}.
 	 * @return List of function names from the ChatClient registry to be used in the next
-	 * chat completion requests.
+	 * chat completion requests as immutable Set.
 	 */
 	Set<String> getFunctions();
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptionsBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptionsBuilder.java
@@ -16,6 +16,7 @@
 package org.springframework.ai.model.function;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -94,7 +95,7 @@ public class FunctionCallingOptionsBuilder {
 
 		@Override
 		public List<FunctionCallback> getFunctionCallbacks() {
-			return this.functionCallbacks;
+			return Collections.unmodifiableList(this.functionCallbacks);
 		}
 
 		public void setFunctionCallbacks(List<FunctionCallback> functionCallbacks) {
@@ -104,7 +105,7 @@ public class FunctionCallingOptionsBuilder {
 
 		@Override
 		public Set<String> getFunctions() {
-			return this.functions;
+			return Collections.unmodifiableSet(this.functions);
 		}
 
 		public void setFunctions(Set<String> functions) {


### PR DESCRIPTION
This change enhances safety in multi-threaded environments by returning unmodifiable objects from getters.

- getter returns unmodifiable Collection

Fixes #407 