### PR TITLE
Added Bedrock Anthropic3 support

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/AnthropicChatOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/AnthropicChatOptions.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+import java.util.List;
+
+/**
+ * @author Christian Tzolov
+ */
+@JsonInclude(Include.NON_NULL)
+public class AnthropicChatOptions implements ChatOptions {
+
+	// @formatter:off
+	/**
+	 * Controls the randomness of the output. Values can range over [0.0,1.0], inclusive. A value closer to 1.0 will
+	 * produce responses that are more varied, while a value closer to 0.0 will typically result in less surprising
+	 * responses from the generative. This value specifies default to be used by the backend while making the call to
+	 * the generative.
+	 */
+	private @JsonProperty("temperature") Float temperature;
+
+	/**
+	 * Specify the maximum number of tokens to use in the generated response. Note that the models may stop before
+	 * reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate. We
+	 * recommend a limit of 4,000 tokens for optimal performance.
+	 */
+	private @JsonProperty("max_tokens") Integer maxTokens;
+
+	/**
+	 * Specify the number of token choices the generative uses to generate the next token.
+	 */
+	private @JsonProperty("top_k") Integer topK;
+
+	/**
+	 * The maximum cumulative probability of tokens to consider when sampling. The generative uses combined Top-k and
+	 * nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least topP.
+	 */
+	private @JsonProperty("top_p") Float topP;
+
+	/**
+	 * Configure up to four sequences that the generative recognizes. After a stop sequence, the generative stops
+	 * generating further tokens. The returned text doesn't contain the stop sequence.
+	 */
+	private @JsonProperty("stop_sequences") List<String> stopSequences;
+
+	/**
+	 * The version of the generative to use. The default value is bedrock-2023-05-31.
+	 */
+	private @JsonProperty("anthropic_version") String anthropicVersion;
+	// @formatter:on
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private final AnthropicChatOptions options = new AnthropicChatOptions();
+
+		public Builder withTemperature(Float temperature) {
+			this.options.setTemperature(temperature);
+			return this;
+		}
+
+		public Builder withMaxTokens(Integer maxTokens) {
+			this.options.setMaxTokens(maxTokens);
+			return this;
+		}
+
+		public Builder withTopK(Integer topK) {
+			this.options.setTopK(topK);
+			return this;
+		}
+
+		public Builder withTopP(Float topP) {
+			this.options.setTopP(topP);
+			return this;
+		}
+
+		public Builder withStopSequences(List<String> stopSequences) {
+			this.options.setStopSequences(stopSequences);
+			return this;
+		}
+
+		public Builder withAnthropicVersion(String anthropicVersion) {
+			this.options.setAnthropicVersion(anthropicVersion);
+			return this;
+		}
+
+		public AnthropicChatOptions build() {
+			return this.options;
+		}
+
+	}
+
+	@Override
+	public Float getTemperature() {
+		return this.temperature;
+	}
+
+	public void setTemperature(Float temperature) {
+		this.temperature = temperature;
+	}
+
+	public Integer getMaxTokens() {
+		return this.maxTokens;
+	}
+
+	public void setMaxTokens(Integer maxTokens) {
+		this.maxTokens = maxTokens;
+	}
+
+	@Override
+	public Integer getTopK() {
+		return this.topK;
+	}
+
+	public void setTopK(Integer topK) {
+		this.topK = topK;
+	}
+
+	@Override
+	public Float getTopP() {
+		return this.topP;
+	}
+
+	public void setTopP(Float topP) {
+		this.topP = topP;
+	}
+
+	public List<String> getStopSequences() {
+		return this.stopSequences;
+	}
+
+	public void setStopSequences(List<String> stopSequences) {
+		this.stopSequences = stopSequences;
+	}
+
+	public String getAnthropicVersion() {
+		return this.anthropicVersion;
+	}
+
+	public void setAnthropicVersion(String anthropicVersion) {
+		this.anthropicVersion = anthropicVersion;
+	}
+
+}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropicChatClient.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropicChatClient.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3;
+
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatRequest;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatResponse;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatStreamingResponse.StreamingType;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicMessage;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.ChatCompletionMessage;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.ChatCompletionMessage.Role;
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.Generation;
+import org.springframework.ai.chat.StreamingChatClient;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.ModelOptionsUtils;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * Java {@link ChatClient} and {@link StreamingChatClient} for the Bedrock Anthropic chat
+ * generative.
+ *
+ * @author Christian Tzolov
+ * @since 0.8.0
+ */
+public class BedrockAnthropicChatClient implements ChatClient, StreamingChatClient {
+
+	private final AnthropicChatBedrockApi anthropicChatApi;
+
+	private final AnthropicChatOptions defaultOptions;
+
+	public BedrockAnthropicChatClient(AnthropicChatBedrockApi chatApi) {
+		this(chatApi,
+				AnthropicChatOptions.builder()
+					.withTemperature(0.8f)
+					.withMaxTokens(500)
+					.withTopK(10)
+					.withAnthropicVersion(AnthropicChatBedrockApi.DEFAULT_ANTHROPIC_VERSION)
+					.build());
+	}
+
+	public BedrockAnthropicChatClient(AnthropicChatBedrockApi chatApi, AnthropicChatOptions options) {
+		this.anthropicChatApi = chatApi;
+		this.defaultOptions = options;
+	}
+
+	@Override
+	public ChatResponse call(Prompt prompt) {
+
+		AnthropicChatRequest request = createRequest(prompt);
+
+		AnthropicChatResponse response = this.anthropicChatApi.chatCompletion(request);
+
+		return new ChatResponse(List.of(new Generation(response.content().get(0).text())));
+	}
+
+	@Override
+	public Flux<ChatResponse> stream(Prompt prompt) {
+
+		AnthropicChatRequest request = createRequest(prompt);
+
+		Flux<AnthropicChatBedrockApi.AnthropicChatStreamingResponse> fluxResponse = this.anthropicChatApi
+			.chatCompletionStream(request);
+
+		AtomicReference<Integer> inputTokens = new AtomicReference<>(0);
+		return fluxResponse.map(response -> {
+			if (response.type() == StreamingType.MESSAGE_START) {
+				inputTokens.set(response.message().usage().inputTokens());
+			}
+			String content = response.type() == StreamingType.CONTENT_BLOCK_DELTA ? response.delta().text() : "";
+
+			var generation = new Generation(content);
+
+			if (response.type() == StreamingType.MESSAGE_DELTA) {
+				generation = generation.withGenerationMetadata(ChatGenerationMetadata
+					.from(response.delta().stopReason(), new AnthropicChatBedrockApi.AnthropicUsage(inputTokens.get(),
+							response.usage().outputTokens())));
+			}
+
+			return new ChatResponse(List.of(generation));
+		});
+	}
+
+	/**
+	 * Accessible for testing.
+	 */
+	AnthropicChatRequest createRequest(Prompt prompt) {
+
+		AnthropicChatRequest request = AnthropicChatRequest.builder(toAnthropicMessages(prompt))
+			.withSystem(toAnthropicSystemContext(prompt))
+			.build();
+
+		if (this.defaultOptions != null) {
+			request = ModelOptionsUtils.merge(request, this.defaultOptions, AnthropicChatRequest.class);
+		}
+
+		if (prompt.getOptions() != null) {
+			if (prompt.getOptions() instanceof ChatOptions runtimeOptions) {
+				AnthropicChatOptions updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(runtimeOptions,
+						ChatOptions.class, AnthropicChatOptions.class);
+				request = ModelOptionsUtils.merge(updatedRuntimeOptions, request, AnthropicChatRequest.class);
+			}
+			else {
+				throw new IllegalArgumentException("Prompt options are not of type ChatOptions: "
+						+ prompt.getOptions().getClass().getSimpleName());
+			}
+		}
+
+		return request;
+	}
+
+	/**
+	 * Extracts system context from prompt.
+	 * @param prompt The prompt.
+	 * @return The system context.
+	 */
+	private String toAnthropicSystemContext(Prompt prompt) {
+
+		return prompt.getInstructions()
+			.stream()
+			.filter(m -> m.getMessageType() == MessageType.SYSTEM)
+			.map(Message::getContent)
+			.collect(Collectors.joining("\n"));
+	}
+
+	/**
+	 * Extracts list of messages from prompt.
+	 * @param prompt The prompt.
+	 * @return The list of {@link ChatCompletionMesssage}.
+	 */
+	private List<ChatCompletionMessage> toAnthropicMessages(Prompt prompt) {
+
+		return prompt.getInstructions()
+			.stream()
+			.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
+			.map(message -> new ChatCompletionMessage(
+					List.of(new AnthropicMessage(AnthropicMessage.Type.TEXT, message.getContent())),
+					Role.valueOf(message.getMessageType().getValue().toUpperCase())))
+			.toList();
+	}
+
+}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApi.java
@@ -246,7 +246,9 @@ public class AnthropicChatBedrockApi extends
 	 *
 	 * @param id The unique response identifier.
 	 * @param model  The ID for the Anthropic Claude model that made the request.
-	 * @param content The generated text.
+	 * @param type The type of the response.
+	 * @param role The role of the response.
+	 * @param content The list of generated text.
 	 * @param stopReason The reason the model stopped generating text:
 	 *        end_turn – The model reached a natural stopping point.
 	 *        max_tokens – The generated text exceeded the value of the max_tokens input field or exceeded the maximum
@@ -277,6 +279,7 @@ public class AnthropicChatBedrockApi extends
 	 * @param index The delta index.
 	 * @param content_block The generated text.
 	 * @param delta The delta.
+	 * @param usage The usage data.
 	 */
 	@JsonInclude(Include.NON_NULL)
 	public record AnthropicChatStreamingResponse(
@@ -327,6 +330,8 @@ public class AnthropicChatBedrockApi extends
 		 * https://docs.anthropic.com/claude/reference/messages-streaming		 *
 		 * @param type The type of the message.
 		 * @param text The text message.
+		 * @param stopReason The stop reason.
+		 * @param stopSequence The stop sequence.
 		 */
 		@JsonInclude(Include.NON_NULL)
 		public record Delta(

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApi.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatRequest;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatResponse;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatStreamingResponse;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi;
+import org.springframework.util.Assert;
+import reactor.core.publisher.Flux;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.util.List;
+
+/**
+ * @author Christian Tzolov
+ * @since 0.8.0
+ */
+// @formatter:off
+public class AnthropicChatBedrockApi extends
+		AbstractBedrockApi<AnthropicChatRequest, AnthropicChatResponse, AnthropicChatStreamingResponse> {
+
+
+	/**
+	 * Default version of the Anthropic chat model.
+	 */
+	public static final String DEFAULT_ANTHROPIC_VERSION = "bedrock-2023-05-31";
+
+
+	/**
+	 * Create a new AnthropicChatBedrockApi instance using the default credentials provider chain, the default object.
+	 * @param modelId The model id to use. See the {@link AnthropicChatModel} for the supported models.
+	 * @param region The AWS region to use.
+	 */
+	public AnthropicChatBedrockApi(String modelId, String region) {
+		super(modelId, region);
+	}
+
+	/**
+	 * Create a new AnthropicChatBedrockApi instance using the provided credentials provider, region and object mapper.
+	 *
+	 * @param modelId The model id to use. See the {@link AnthropicChatModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 */
+	public AnthropicChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, String region,
+			ObjectMapper objectMapper) {
+		super(modelId, credentialsProvider, region, objectMapper);
+	}
+
+	// https://github.com/build-on-aws/amazon-bedrock-java-examples/blob/main/example_code/bedrock-runtime/src/main/java/aws/community/examples/InvokeBedrockStreamingAsync.java
+
+	// https://docs.anthropic.com/claude/reference/complete_post
+
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/br-product-ids.html
+
+	// Anthropic Claude models: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-claude.html
+
+	/**
+	 * AnthropicChatRequest encapsulates the request parameters for the Anthropic messages model.
+	 * https://docs.anthropic.com/claude/reference/messages_post
+	 *
+	 * @param messages A list of messages comprising the conversation so far.
+	 * @param system A system prompt, providing context and instructions to Claude, such as specifying a particular goal
+	 * or role.
+	 * @param temperature (default 0.5) The temperature to use for the chat. You should either alter temperature or
+	 * top_p, but not both.
+	 * @param maxTokens (default 200) Specify the maximum number of tokens to use in the generated response.
+	 * Note that the models may stop before reaching this maximum. This parameter only specifies the absolute maximum
+	 * number of tokens to generate. We recommend a limit of 4,000 tokens for optimal performance.
+	 * @param topK (default 250) Specify the number of token choices the model uses to generate the next token.
+	 * @param topP (default 1) Nucleus sampling to specify the cumulative probability of the next token in range [0,1].
+	 * In nucleus sampling, we compute the cumulative distribution over all the options for each subsequent token in
+	 * decreasing probability order and cut it off once it reaches a particular probability specified by top_p. You
+	 * should either alter temperature or top_p, but not both.
+	 * @param stopSequences (defaults to "\n\nHuman:") Configure up to four sequences that the model recognizes. After a
+	 * stop sequence, the model stops generating further tokens. The returned text doesn't contain the stop sequence.
+	 * @param anthropicVersion The version of the model to use. The default value is bedrock-2023-05-31.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record AnthropicChatRequest(
+			@JsonProperty("messages") List<ChatCompletionMessage> messages,
+			@JsonProperty("system") String system,
+			@JsonProperty("temperature") Float temperature,
+			@JsonProperty("max_tokens") Integer maxTokens,
+			@JsonProperty("top_k") Integer topK,
+			@JsonProperty("top_p") Float topP,
+			@JsonProperty("stop_sequences") List<String> stopSequences,
+			@JsonProperty("anthropic_version") String anthropicVersion) {
+
+		public static Builder builder(List<ChatCompletionMessage> messages) {
+			return new Builder(messages);
+		}
+
+		public static class Builder {
+			private final List<ChatCompletionMessage> messages;
+			private String system;
+			private Float temperature;// = 0.7f;
+			private Integer maxTokens;// = 500;
+			private Integer topK;// = 10;
+			private Float topP;
+			private List<String> stopSequences;
+			// private String anthropicVersion = DEFAULT_ANTHROPIC_VERSION;
+			private String anthropicVersion;
+
+			private Builder(List<ChatCompletionMessage> messages) {
+				this.messages = messages;
+			}
+
+			public Builder withSystem(String system) {
+				this.system = system;
+				return this;
+			}
+			public Builder withTemperature(Float temperature) {
+				this.temperature = temperature;
+				return this;
+			}
+
+			public Builder withMaxTokens(Integer maxTokens) {
+				this.maxTokens = maxTokens;
+				return this;
+			}
+
+			public Builder withTopK(Integer topK) {
+				this.topK = topK;
+				return this;
+			}
+
+			public Builder withTopP(Float tpoP) {
+				this.topP = tpoP;
+				return this;
+			}
+
+			public Builder withStopSequences(List<String> stopSequences) {
+				this.stopSequences = stopSequences;
+				return this;
+			}
+
+			public Builder withAnthropicVersion(String anthropicVersion) {
+				this.anthropicVersion = anthropicVersion;
+				return this;
+			}
+
+			public AnthropicChatRequest build() {
+				return new AnthropicChatRequest(
+						messages,
+						system,
+						temperature,
+						maxTokens,
+						topK,
+						topP,
+						stopSequences,
+						anthropicVersion
+				);
+			}
+		}
+	}
+
+	/**
+	 * Encapsulates an input message.
+	 * TODO: Add support for images.
+	 * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html#model-parameters-anthropic-claude-messages-request-response
+	 *
+	 * @param type The type of the message.
+	 * @param text The text message.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record AnthropicMessage(
+			@JsonProperty("type") Type type,
+			@JsonProperty("text") String text) {
+
+		/**
+		 * The type of this message.
+		 */
+		public enum Type {
+			/**
+			 * Text message.
+			 */
+			@JsonProperty("text") TEXT,
+			/**
+			 * Image message.
+			 */
+			@JsonProperty("image") IMAGE
+		}
+	}
+
+	/**
+	 * Message comprising the conversation.
+	 *
+	 * @param content The contents of the message.
+	 * @param role The role of the messages author. Could be one of the {@link Role} types.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record ChatCompletionMessage(
+			@JsonProperty("content") List<AnthropicMessage> content,
+			@JsonProperty("role") Role role) {
+
+		/**
+		 * The role of the author of this message.
+		 */
+		public enum Role {
+				/**
+			 * User message.
+			 */
+			@JsonProperty("user") USER,
+			/**
+			 * Assistant message.
+			 */
+			@JsonProperty("assistant") ASSISTANT
+		}
+	}
+
+	/**
+	 * Encapsulates the metrics about the model invocation.
+	 * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html#model-parameters-anthropic-claude-messages-request-response
+	 *
+	 * @param inputTokens The number of tokens in the input prompt.
+	 * @param outputTokens The number of tokens in the generated text.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record AnthropicUsage(
+			@JsonProperty("input_tokens") Integer inputTokens,
+			@JsonProperty("output_tokens") Integer outputTokens) {
+	}
+
+	/**
+	 * AnthropicChatResponse encapsulates the response parameters for the Anthropic messages model.
+	 *
+	 * @param id The unique response identifier.
+	 * @param model  The ID for the Anthropic Claude model that made the request.
+	 * @param content The generated text.
+	 * @param stopReason The reason the model stopped generating text:
+	 *        end_turn – The model reached a natural stopping point.
+	 *        max_tokens – The generated text exceeded the value of the max_tokens input field or exceeded the maximum
+	 *        number of tokens that the model supports.
+	 *        stop_sequence – The model generated one of the stop sequences that you specified in the stop_sequences
+	 *        input field.
+	 * @param stopSequence The stop sequence that caused the model to stop generating text.
+	 * @param usage Metrics about the model invocation.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record AnthropicChatResponse(
+			@JsonProperty("id") String id,
+			@JsonProperty("model") String model,
+			@JsonProperty("type") String type,
+			@JsonProperty("role") String role,
+			@JsonProperty("content") List<AnthropicMessage> content,
+			@JsonProperty("stop_reason") String stopReason,
+			@JsonProperty("stop_sequence") String stopSequence,
+			@JsonProperty("usage") AnthropicUsage usage) {
+	}
+
+	/**
+	 * AnthropicChatStreamingResponse encapsulates the streaming response parameters for the Anthropic messages model.
+	 * https://docs.anthropic.com/claude/reference/messages-streaming
+	 *
+	 * @param type The streaming type.
+	 * @param message The message details that made the request.
+	 * @param index The delta index.
+	 * @param content_block The generated text.
+	 * @param delta The delta.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record AnthropicChatStreamingResponse(
+			@JsonProperty("type") StreamingType type,
+			@JsonProperty("message") AnthropicChatResponse message,
+			@JsonProperty("index") Integer index,
+			@JsonProperty("content_block") AnthropicMessage content_block,
+			@JsonProperty("delta") Delta delta,
+			@JsonProperty("usage") AnthropicUsage usage) {
+
+		/**
+		 * The streaming type of this message.
+		 */
+		public enum StreamingType {
+			/**
+			 * Message start.
+			 */
+			@JsonProperty("message_start") MESSAGE_START,
+			/**
+			 * Content block start.
+			 */
+			@JsonProperty("content_block_start") CONTENT_BLOCK_START,
+			/**
+			 * Ping.
+			 */
+			@JsonProperty("ping") PING,
+			/**
+			 * Content block delta.
+			 */
+			@JsonProperty("content_block_delta") CONTENT_BLOCK_DELTA,
+			/**
+			 * Content block stop.
+			 */
+			@JsonProperty("content_block_stop") CONTENT_BLOCK_STOP,
+			/**
+			 * Message delta.
+			 */
+			@JsonProperty("message_delta") MESSAGE_DELTA,
+			/**
+			 * Message stop.
+			 */
+			@JsonProperty("message_stop") MESSAGE_STOP
+		}
+
+
+		/**
+		 * Encapsulates a delta.
+		 * https://docs.anthropic.com/claude/reference/messages-streaming		 *
+		 * @param type The type of the message.
+		 * @param text The text message.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record Delta(
+				@JsonProperty("type") String type,
+				@JsonProperty("text") String text,
+				@JsonProperty("stop_reason") String stopReason,
+				@JsonProperty("stop_sequence") String stopSequence
+		) {
+		}
+
+	}
+
+	/**
+	 * Anthropic models version.
+	 */
+	public enum AnthropicChatModel {
+		/**
+		 * anthropic.claude-instant-v1
+		 */
+		CLAUDE_INSTANT_V1("anthropic.claude-instant-v1"),
+		/**
+		 * anthropic.claude-v2
+		 */
+		CLAUDE_V2("anthropic.claude-v2"),
+		/**
+		 * anthropic.claude-v2:1
+		 */
+		CLAUDE_V21("anthropic.claude-v2:1"),
+		/**
+		 * anthropic.claude-3-sonnet-20240229-v1:0
+		 */
+		CLAUDE_V3_SONNET("anthropic.claude-3-sonnet-20240229-v1:0");
+
+		private final String id;
+
+		/**
+		 * @return The model id.
+		 */
+		public String id() {
+			return id;
+		}
+
+		AnthropicChatModel(String value) {
+			this.id = value;
+		}
+	}
+
+	@Override
+	public AnthropicChatResponse chatCompletion(AnthropicChatRequest anthropicRequest) {
+		Assert.notNull(anthropicRequest, "'anthropicRequest' must not be null");
+		return this.internalInvocation(anthropicRequest, AnthropicChatResponse.class);
+	}
+
+	@Override
+	public Flux<AnthropicChatStreamingResponse> chatCompletionStream(AnthropicChatRequest anthropicRequest) {
+		Assert.notNull(anthropicRequest, "'anthropicRequest' must not be null");
+		return this.internalInvocationStream(anthropicRequest, AnthropicChatStreamingResponse.class);
+	}
+
+}
+// @formatter:on

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApiIT.java
@@ -18,11 +18,13 @@ package org.springframework.ai.bedrock.anthropic.api;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatRequest;
@@ -40,8 +42,14 @@ public class AnthropicChatBedrockApiIT {
 
 	private final Logger logger = LoggerFactory.getLogger(AnthropicChatBedrockApiIT.class);
 
-	private AnthropicChatBedrockApi anthropicChatApi = new AnthropicChatBedrockApi(AnthropicChatModel.CLAUDE_V2.id(),
+	private AnthropicChatBedrockApi anthropicChatApi2 = new AnthropicChatBedrockApi(AnthropicChatModel.CLAUDE_V2.id(),
 			Region.EU_CENTRAL_1.id());
+
+	private AnthropicChatBedrockApi anthropicChatApi = new AnthropicChatBedrockApi(
+			AnthropicChatModel.CLAUDE_V2.id(),
+			EnvironmentVariableCredentialsProvider.create(),
+			Region.US_WEST_2.id(),
+			new ObjectMapper());
 
 	@Test
 	public void chatCompletion() {

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropicChatClientIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropicChatClientIT.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.Generation;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.chat.prompt.SystemPromptTemplate;
+import org.springframework.ai.parser.BeanOutputParser;
+import org.springframework.ai.parser.ListOutputParser;
+import org.springframework.ai.parser.MapOutputParser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.io.Resource;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+class BedrockAnthropicChatClientIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(BedrockAnthropicChatClientIT.class);
+
+	@Autowired
+	private BedrockAnthropicChatClient client;
+
+	@Value("classpath:/prompts/system-message.st")
+	private Resource systemResource;
+
+	@Test
+	void roleTest() {
+		UserMessage userMessage = new UserMessage(
+				"Tell me about 3 famous pirates from the Golden Age of Piracy and why they did.");
+		SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(systemResource);
+		Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", "Bob", "voice", "pirate"));
+
+		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
+
+		ChatResponse response = client.call(prompt);
+
+		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+	}
+
+	@Test
+	void outputParser() {
+		DefaultConversionService conversionService = new DefaultConversionService();
+		ListOutputParser outputParser = new ListOutputParser(conversionService);
+
+		String format = outputParser.getFormat();
+		String template = """
+				List five {subject}
+				{format}
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template,
+				Map.of("subject", "ice cream flavors.", "format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+		Generation generation = this.client.call(prompt).getResult();
+
+		List<String> list = outputParser.parse(generation.getOutput().getContent());
+		assertThat(list).hasSize(5);
+	}
+
+	@Test
+	void mapOutputParser() {
+		MapOutputParser outputParser = new MapOutputParser();
+
+		String format = outputParser.getFormat();
+		String template = """
+				Provide me a List of {subject}
+				{format}
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template,
+				Map.of("subject", "an array of numbers from 1 to 9 under they key name 'numbers'", "format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+		Generation generation = client.call(prompt).getResult();
+
+		Map<String, Object> result = outputParser.parse(generation.getOutput().getContent());
+		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+	}
+
+	record ActorsFilmsRecord(String actor, List<String> movies) {
+	}
+
+	@Test
+	void beanOutputParserRecords() {
+
+		BeanOutputParser<ActorsFilmsRecord> outputParser = new BeanOutputParser<>(ActorsFilmsRecord.class);
+
+		String format = outputParser.getFormat();
+		String template = """
+				Generate the filmography of 5 movies for Tom Hanks.
+				Remove non JSON tex blocks from the output.
+				{format}
+				Provide your answer in the JSON format with the feature names as the keys.
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+		Generation generation = client.call(prompt).getResult();
+
+		ActorsFilmsRecord actorsFilms = outputParser.parse(generation.getOutput().getContent());
+		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
+		assertThat(actorsFilms.movies()).hasSize(5);
+	}
+
+	@Test
+	void beanStreamOutputParserRecords() {
+
+		BeanOutputParser<ActorsFilmsRecord> outputParser = new BeanOutputParser<>(ActorsFilmsRecord.class);
+
+		String format = outputParser.getFormat();
+		String template = """
+				Generate the filmography of 5 movies for Tom Hanks.
+				{format}
+				Remove Markdown code blocks from the output.
+				""";
+		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		Prompt prompt = new Prompt(promptTemplate.createMessage());
+
+		String generationTextFromStream = client.stream(prompt)
+			.collectList()
+			.block()
+			.stream()
+			.map(ChatResponse::getResults)
+			.flatMap(List::stream)
+			.map(Generation::getOutput)
+			.map(AssistantMessage::getContent)
+			.collect(Collectors.joining());
+
+		ActorsFilmsRecord actorsFilms = outputParser.parse(generationTextFromStream);
+		logger.info("" + actorsFilms);
+		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
+		assertThat(actorsFilms.movies()).hasSize(5);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public AnthropicChatBedrockApi anthropicApi() {
+			return new AnthropicChatBedrockApi(AnthropicChatBedrockApi.AnthropicChatModel.CLAUDE_V2.id(),
+					EnvironmentVariableCredentialsProvider.create(), Region.EU_CENTRAL_1.id(), new ObjectMapper());
+		}
+
+		@Bean
+		public BedrockAnthropicChatClient anthropicChatClient(AnthropicChatBedrockApi anthropicApi) {
+			return new BedrockAnthropicChatClient(anthropicApi);
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropicCreateRequestTests.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropicCreateRequestTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+public class BedrockAnthropicCreateRequestTests {
+
+	private AnthropicChatBedrockApi anthropicChatApi = new AnthropicChatBedrockApi(AnthropicChatModel.CLAUDE_V2.id(),
+			Region.EU_CENTRAL_1.id());
+
+	@Test
+	public void createRequestWithChatOptions() {
+
+		var client = new BedrockAnthropicChatClient(anthropicChatApi,
+				AnthropicChatOptions.builder()
+					.withTemperature(66.6f)
+					.withTopK(66)
+					.withTopP(0.66f)
+					.withMaxTokens(666)
+					.withAnthropicVersion("X.Y.Z")
+					.withStopSequences(List.of("stop1", "stop2"))
+					.build());
+
+		var request = client.createRequest(new Prompt("Test message content"));
+
+		assertThat(request.messages()).isNotEmpty();
+		assertThat(request.temperature()).isEqualTo(66.6f);
+		assertThat(request.topK()).isEqualTo(66);
+		assertThat(request.topP()).isEqualTo(0.66f);
+		assertThat(request.maxTokens()).isEqualTo(666);
+		assertThat(request.anthropicVersion()).isEqualTo("X.Y.Z");
+		assertThat(request.stopSequences()).containsExactly("stop1", "stop2");
+
+		request = client.createRequest(new Prompt("Test message content",
+				AnthropicChatOptions.builder()
+					.withTemperature(99.9f)
+					.withTopP(0.99f)
+					.withMaxTokens(999)
+					.withAnthropicVersion("zzz")
+					.withStopSequences(List.of("stop3", "stop4"))
+					.build()
+
+		));
+
+		assertThat(request.messages()).isNotEmpty();
+		assertThat(request.temperature()).isEqualTo(99.9f);
+		assertThat(request.topK()).as("unchanged from the default options").isEqualTo(66);
+		assertThat(request.topP()).isEqualTo(0.99f);
+		assertThat(request.maxTokens()).isEqualTo(999);
+		assertThat(request.anthropicVersion()).isEqualTo("zzz");
+		assertThat(request.stopSequences()).containsExactly("stop3", "stop4");
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApiIT.java
@@ -92,7 +92,7 @@ public class AnthropicChatBedrockApiIT {
 				List.of(anthropicAssistantMessage), Role.ASSISTANT);
 
 		AnthropicMessage anthropicFollowupMessage = new AnthropicMessage(AnthropicMessage.Type.TEXT,
-				"Why are they famoust");
+				"Why are they famous?");
 		ChatCompletionMessage chatCompletionFollowupMessage = new ChatCompletionMessage(
 				List.of(anthropicFollowupMessage), Role.USER);
 

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/api/AnthropicChatBedrockApiIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatModel;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatRequest;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatResponse;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicChatStreamingResponse.StreamingType;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.AnthropicMessage;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.ChatCompletionMessage;
+import org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.ChatCompletionMessage.Role;
+import reactor.core.publisher.Flux;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.ai.bedrock.anthropic3.api.AnthropicChatBedrockApi.DEFAULT_ANTHROPIC_VERSION;
+
+;
+
+/**
+ * @author Christian Tzolov
+ */
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+public class AnthropicChatBedrockApiIT {
+
+	private final Logger logger = LoggerFactory.getLogger(AnthropicChatBedrockApiIT.class);
+
+	private AnthropicChatBedrockApi anthropicChatApi = new AnthropicChatBedrockApi(
+			AnthropicChatModel.CLAUDE_INSTANT_V1.id(), EnvironmentVariableCredentialsProvider.create(),
+			Region.US_WEST_2.id(), new ObjectMapper());
+
+	@Test
+	public void chatCompletion() {
+
+		AnthropicMessage anthropicMessage = new AnthropicMessage(AnthropicMessage.Type.TEXT, "Name 3 famous pirates");
+		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage(List.of(anthropicMessage), Role.USER);
+		AnthropicChatRequest request = AnthropicChatRequest.builder(List.of(chatCompletionMessage))
+			.withTemperature(0.8f)
+			.withMaxTokens(300)
+			.withTopK(10)
+			.withAnthropicVersion(DEFAULT_ANTHROPIC_VERSION)
+			.build();
+
+		AnthropicChatResponse response = anthropicChatApi.chatCompletion(request);
+
+		System.out.println(response.content());
+		assertThat(response).isNotNull();
+		assertThat(response.content().get(0).text()).isNotEmpty();
+		assertThat(response.content().get(0).text()).contains("Blackbeard");
+		assertThat(response.stopReason()).isEqualTo("end_turn");
+		assertThat(response.stopSequence()).isNull();
+		assertThat(response.usage().inputTokens()).isGreaterThan(10);
+		assertThat(response.usage().outputTokens()).isGreaterThan(100);
+
+		logger.info("" + response);
+	}
+
+	@Test
+	public void chatMultiCompletion() {
+
+		AnthropicMessage anthropicInitialMessage = new AnthropicMessage(AnthropicMessage.Type.TEXT,
+				"Name 3 famous pirates");
+		ChatCompletionMessage chatCompletionInitialMessage = new ChatCompletionMessage(List.of(anthropicInitialMessage),
+				Role.USER);
+
+		AnthropicMessage anthropicAssistantMessage = new AnthropicMessage(AnthropicMessage.Type.TEXT,
+				"Here are 3 famous pirates: Blackbeard, Calico Jack, Henry Morgan");
+		ChatCompletionMessage chatCompletionAssistantMessage = new ChatCompletionMessage(
+				List.of(anthropicAssistantMessage), Role.ASSISTANT);
+
+		AnthropicMessage anthropicFollowupMessage = new AnthropicMessage(AnthropicMessage.Type.TEXT,
+				"Why are they famoust");
+		ChatCompletionMessage chatCompletionFollowupMessage = new ChatCompletionMessage(
+				List.of(anthropicFollowupMessage), Role.USER);
+
+		AnthropicChatRequest request = AnthropicChatRequest
+			.builder(List.of(chatCompletionInitialMessage, chatCompletionAssistantMessage,
+					chatCompletionFollowupMessage))
+			.withTemperature(0.8f)
+			.withMaxTokens(400)
+			.withTopK(10)
+			.withAnthropicVersion(DEFAULT_ANTHROPIC_VERSION)
+			.build();
+
+		AnthropicChatResponse response = anthropicChatApi.chatCompletion(request);
+
+		System.out.println(response.content());
+		assertThat(response).isNotNull();
+		assertThat(response.content().get(0).text()).isNotEmpty();
+		assertThat(response.content().get(0).text()).contains("Blackbeard");
+		assertThat(response.stopReason()).isEqualTo("end_turn");
+		assertThat(response.stopSequence()).isNull();
+		assertThat(response.usage().inputTokens()).isGreaterThan(30);
+		assertThat(response.usage().outputTokens()).isGreaterThan(200);
+
+		logger.info("" + response);
+	}
+
+	@Test
+	public void chatCompletionStream() {
+		AnthropicMessage anthropicMessage = new AnthropicMessage(AnthropicMessage.Type.TEXT, "Name 3 famous pirates");
+		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage(List.of(anthropicMessage), Role.USER);
+
+		AnthropicChatRequest request = AnthropicChatRequest.builder(List.of(chatCompletionMessage))
+			.withTemperature(0.8f)
+			.withMaxTokens(300)
+			.withTopK(10)
+			.withAnthropicVersion(DEFAULT_ANTHROPIC_VERSION)
+			.build();
+
+		Flux<AnthropicChatBedrockApi.AnthropicChatStreamingResponse> responseStream = anthropicChatApi
+			.chatCompletionStream(request);
+
+		List<AnthropicChatBedrockApi.AnthropicChatStreamingResponse> responses = responseStream.collectList().block();
+		assertThat(responses).isNotNull();
+		assertThat(responses).hasSizeGreaterThan(10);
+		assertThat(responses.stream()
+			.filter(message -> message.type() == StreamingType.CONTENT_BLOCK_DELTA)
+			.map(message -> message.delta().text())
+			.collect(Collectors.joining())).contains("Blackbeard");
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 		<azure-open-ai-client.version>1.0.0-beta.7</azure-open-ai-client.version>
 		<jtokkit.version>1.0.0</jtokkit.version>
 		<victools.version>4.31.1</victools.version>
-		<bedrockruntime.version>2.24.8</bedrockruntime.version>
+		<bedrockruntime.version>2.25.3</bedrockruntime.version>
 		<jackson.version>2.16.1</jackson.version>
 		<djl.version>0.26.0</djl.version>
 		<onnxruntime.version>1.17.0</onnxruntime.version>

--- a/spring-ai-core/pom.xml
+++ b/spring-ai-core/pom.xml
@@ -100,7 +100,7 @@
 			<scope>test</scope>
 		</dependency>
 
-	</dependencies>
+    </dependencies>
 
 	<profiles>
 		<profile>


### PR DESCRIPTION
# Created anthropic messages API for Claude 3

This package is an adaption of the existing anthropic package which supports the more recent Messages API. The API is compatible with all existing Bedrock models.

It does not currently support the Image input message type.

I would welcome guidance on how to best incorporate such support given there is already an existing anthropic package which supports only the Text Completions API. @tzolov in particular as author of the original Text Completions implementations.


