### PR TITLE
#426 -Fixed typo in Bedrock Titan chat option exception

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatOptions.java
@@ -121,11 +121,11 @@ public class BedrockTitanChatOptions implements ChatOptions {
 
 	@Override
 	public Integer getTopK() {
-		throw new UnsupportedOperationException("Bedrock Titian Chat does not support the 'TopK' option.");
+		throw new UnsupportedOperationException("Bedrock Titan Chat does not support the 'TopK' option.");
 	}
 
 	public void setTopK(Integer topK) {
-		throw new UnsupportedOperationException("Bedrock Titian Chat does not support the 'TopK' option.'");
+		throw new UnsupportedOperationException("Bedrock Titan Chat does not support the 'TopK' option.'");
 	}
 
 }


### PR DESCRIPTION
Fixed typo in Bedrock Titan chat option for UnsupportedOperationException. 

I have changed the type from 'Titian' to 'Titan'

This fix is against issue - [link](https://github.com/spring-projects/spring-ai/issues/426)