### PR TITLE
Fix typo in model name, fixed #442

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/clients/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/clients/openai-chat.adoc
@@ -217,7 +217,7 @@ var openAiApi = new OpenAiApi(System.getenv("OPENAI_API_KEY"));
 
 var chatClient = new OpenAiChatClient(openAiApi)
     .withDefaultOptions(OpenAiChatOptions.builder()
-            .withModel("gpt-35-turbo")
+            .withModel("gpt-3.5-turbo")
             .withTemperature(0.4)
             .withMaxTokens(200)
         .build());


### PR DESCRIPTION
Fixed #442 
```java
var openAiApi = new OpenAiApi(System.getenv("OPENAI_API_KEY"));

var chatClient = new OpenAiChatClient(openAiApi)
    .withDefaultOptions(OpenAiChatOptions.builder()
            .withModel("gpt-3.5-turbo")            // gpt-35-turbo => gpt-3.5-turbo
            .withTemperature(0.4)
            .withMaxTokens(200)
        .build());

ChatResponse response = chatClient.call(
    new Prompt("Generate the names of 5 famous pirates."));
```
