### PR TITLE
Use default stringtemplate delimiters for prompt templates

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
@@ -53,7 +53,7 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 			throw new RuntimeException("Failed to read resource", ex);
 		}
 		try {
-			this.st = new ST(this.template, '{', '}');
+			this.st = new ST(this.template);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("The template string is not valid.", ex);
@@ -64,7 +64,7 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 		this.template = template;
 		// If the template string is not valid, an exception will be thrown
 		try {
-			this.st = new ST(this.template, '{', '}');
+			this.st = new ST(this.template);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("The template string is not valid.", ex);
@@ -75,7 +75,7 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 		this.template = template;
 		// If the template string is not valid, an exception will be thrown
 		try {
-			this.st = new ST(this.template, '{', '}');
+			this.st = new ST(this.template);
 			for (Entry<String, Object> entry : model.entrySet()) {
 				add(entry.getKey(), entry.getValue());
 				dynamicModel.put(entry.getKey(), entry.getValue());
@@ -95,7 +95,7 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 		}
 		// If the template string is not valid, an exception will be thrown
 		try {
-			this.st = new ST(this.template, '{', '}');
+			this.st = new ST(this.template);
 			for (Entry<String, Object> entry : model.entrySet()) {
 				add(entry.getKey(), entry.getValue());
 				dynamicModel.put(entry.getKey(), entry.getValue());

--- a/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
@@ -42,7 +42,7 @@ public class PromptTemplateTest {
 		model.put("key3", 100);
 
 		// Create a simple template with placeholders for keys in the generative
-		String template = "This is a {key1}, it is {key2}, and it costs {key3}";
+		String template = "This is a <key1>, it is <key2>, and it costs <key3>";
 		PromptTemplate promptTemplate = new PromptTemplate(template, model);
 
 		// The expected result after rendering the template with the generative
@@ -55,6 +55,33 @@ public class PromptTemplateTest {
 		model.put("key3", 200);
 		expected = "This is a value1, it is true, and it costs 200";
 		result = promptTemplate.render(model);
+		assertEquals(expected, result);
+	}
+	@Test
+	public void testRenderJson() {
+		Map<String, Object> model = new HashMap<>();
+		model.put("jsonValue", "bar");
+
+		String template = "{'foo': '<jsonValue>'}";
+		PromptTemplate promptTemplate = new PromptTemplate(template, model);
+
+		String expected = "{'foo': 'bar'}";
+		String result = promptTemplate.render();
+
+		assertEquals(expected, result);
+	}
+
+	@Test
+	public void testRenderEscapedString() {
+		Map<String, Object> model = new HashMap<>();
+		model.put("xmlValue", "bar");
+
+		String template = "\\<foo><xmlValue>\\</foo>";
+		PromptTemplate promptTemplate = new PromptTemplate(template, model);
+
+		String expected = "<foo>bar</foo>";
+		String result = promptTemplate.render();
+
 		assertEquals(expected, result);
 	}
 
@@ -74,7 +101,7 @@ public class PromptTemplateTest {
 		model.put("key3", resource);
 
 		// Create a simple template with placeholders for keys in the generative
-		String template = "{key1}, {key2}, {key3}";
+		String template = "<key1>, <key2>, <key3>";
 		PromptTemplate promptTemplate = new PromptTemplate(template, model);
 
 		// The expected result after rendering the template with the generative
@@ -93,7 +120,7 @@ public class PromptTemplateTest {
 		model.put("key1", "value1");
 
 		// Create a simple template that includes a key not present in the generative
-		String template = "This is a {key2}!";
+		String template = "This is a <key2>!";
 		PromptTemplate promptTemplate = new PromptTemplate(template, model);
 
 		// Rendering the template with a missing key should throw an exception

--- a/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTests.java
@@ -33,7 +33,7 @@ class PromptTests {
 	@Test
 	void newApiPlaygroundTests() {
 		// Create a String, a PromptValue or Messages
-		String templateText = "Hello '{firstName}' '{lastName}' from Unix";
+		String templateText = "Hello '<firstName>' '<lastName>' from Unix";
 		PromptTemplate pt = new PromptTemplate(templateText);
 
 		final Map<String, Object> model = new HashMap<>();
@@ -94,7 +94,7 @@ class PromptTests {
 
 	@Test
 	void testSingleInputVariable() {
-		String template = "This is a {foo} test";
+		String template = "This is a <foo> test";
 		PromptTemplate promptTemplate = new PromptTemplate(template);
 		Set<String> inputVariables = promptTemplate.getInputVariables();
 		assertThat(inputVariables).isNotEmpty();
@@ -104,7 +104,7 @@ class PromptTests {
 
 	@Test
 	void testMultipleInputVariables() {
-		String template = "This {bar} is a {foo} test";
+		String template = "This <bar> is a <foo> test";
 		PromptTemplate promptTemplate = new PromptTemplate(template);
 		Set<String> inputVariables = promptTemplate.getInputVariables();
 		assertThat(inputVariables).isNotEmpty();
@@ -114,7 +114,7 @@ class PromptTests {
 
 	@Test
 	void testMultipleInputVariablesWithRepeats() {
-		String template = "This {bar} is a {foo} test {foo}.";
+		String template = "This <bar> is a <foo> test <foo>.";
 		PromptTemplate promptTemplate = new PromptTemplate(template);
 		Set<String> inputVariables = promptTemplate.getInputVariables();
 		assertThat(inputVariables).isNotEmpty();
@@ -124,7 +124,7 @@ class PromptTests {
 
 	@Test
 	void testBadFormatOfTemplateString() {
-		String template = "This is a {foo test";
+		String template = "This is a <foo test";
 		Assertions.assertThatThrownBy(() -> {
 			new PromptTemplate(template);
 		}).isInstanceOf(IllegalArgumentException.class).hasMessage("The template string is not valid.");

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/prompt.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/prompt.adoc
@@ -194,12 +194,12 @@ The method `Prompt create(Map<String, Object> model)`: Expands prompt creation c
 
 == Example Usage
 
-A simple example taken from the https://github.com/Azure-Samples/spring-ai-azure-workshop/blob/main/2-README-prompt-templating.md[AI Workshop on PromptTemplates] is shown below.
+A simple example taken from the https://github.com/Azure-Samples/spring-ai-azure-workshop/blob/main/2-README-prompt-templating.md[AI Workshop on PromptTemplates] is shown below. Context variable will be delimited by `<` and `>`. The delimiters can be escaped with `\` as stated in the https://github.com/antlr/stringtemplate4/blob/master/doc/cheatsheet.md#stringtemplate-cheat-sheet[StringTemplate documentation].
 
 
 ```java
 
-PromptTemplate promptTemplate = new PromptTemplate("Tell me a {adjective} joke about {topic}");
+PromptTemplate promptTemplate = new PromptTemplate("Tell me a <adjective> joke about <topic>");
 
 Prompt prompt = promptTemplate.create(Map.of("adjective", adjective, "topic", topic));
 
@@ -218,8 +218,8 @@ Message userMessage = new UserMessage(userText);
 
 String systemText = """
   You are a helpful AI assistant that helps people find information.
-  Your name is {name}
-  You should reply to the user's request with your name and also in the style of a {voice}.
+  Your name is <name>
+  You should reply to the user's request with your name and also in the style of a <voice>.
   """;
 
 SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(systemText);


### PR DESCRIPTION
The current set delimiters `{` and `}` do not follow the stringtemplate default and need escaping if you want to build a prompt with JSON (as described in issue #355).  This pull request will address this issue.