### PR TITLE
Allow more customization for Neo4j store (id and constraint).

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfiguration.java
@@ -45,6 +45,8 @@ public class Neo4jVectorStoreAutoConfiguration {
 			.withLabel(properties.getLabel())
 			.withEmbeddingProperty(properties.getEmbeddingProperty())
 			.withIndexName(properties.getIndexName())
+			.withIdProperty(properties.getIdProperty())
+			.withConstraintName(properties.getConstraintName())
 			.build();
 
 		return new Neo4jVectorStore(driver, embeddingClient, config);

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreProperties.java
@@ -38,6 +38,10 @@ public class Neo4jVectorStoreProperties {
 
 	private String indexName = Neo4jVectorStore.DEFAULT_INDEX_NAME;
 
+	private String idProperty = Neo4jVectorStore.DEFAULT_ID_PROPERTY;
+
+	private String constraintName = Neo4jVectorStore.DEFAULT_CONSTRAINT_NAME;
+
 	public String getDatabaseName() {
 		return this.databaseName;
 	}
@@ -84,6 +88,22 @@ public class Neo4jVectorStoreProperties {
 
 	public void setIndexName(String indexName) {
 		this.indexName = indexName;
+	}
+
+	public String getIdProperty() {
+		return this.idProperty;
+	}
+
+	public void setIdProperty(String idProperty) {
+		this.idProperty = idProperty;
+	}
+
+	public String getConstraintName() {
+		return this.constraintName;
+	}
+
+	public void setConstraintName(String constraintName) {
+		this.constraintName = constraintName;
 	}
 
 }

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jVectorStoreIT.java
@@ -58,7 +58,7 @@ class Neo4jVectorStoreIT {
 	// creation
 	// function.
 	@Container
-	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.15"))
+	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.18"))
 		.withRandomPassword();
 
 	List<Document> documents = List.of(


### PR DESCRIPTION
Some users' use-cases going not the complete SpringAI path from document creation to search (and chat) but are working with an already existing dataset (incl. embeddings).
To align with their needs, some more customization will allow them to work with those data instead of patching their dataset to match SpringAI's `Document` definition without any benefit for them.

Unrelated to this change, the Neo4j test version increased to be current.
