### PR TITLE
Add Service Connection support for Testcontainers

### DIFF
--- a/document-readers/pdf-reader/pom.xml
+++ b/document-readers/pdf-reader/pom.xml
@@ -55,6 +55,7 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-ollama/pom.xml
+++ b/models/spring-ai-ollama/pom.xml
@@ -71,6 +71,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/models/spring-ai-postgresml/pom.xml
+++ b/models/spring-ai-postgresml/pom.xml
@@ -54,12 +54,14 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-transformers/pom.xml
+++ b/models/spring-ai-transformers/pom.xml
@@ -82,6 +82,7 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-bedrock-ai</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-mistral-ai</module>
 		<module>spring-ai-retry</module>
+		<module>spring-ai-spring-boot-testcontainers</module>
 	</modules>
 
 	<organization>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
 		<qdrant.version>1.7.1</qdrant.version>
 
 		<!-- testing dependencies -->
-		<testcontainers.version>1.19.6</testcontainers.version>
+		<testcontainers.version>1.19.7</testcontainers.version>
 
 		<!-- documentation dependencies -->
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -301,6 +301,12 @@
                 <artifactId>spring-ai-qdrant-store-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-spring-boot-testcontainers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -52,6 +52,7 @@
 ** xref:api/etl-pipeline.adoc[]
 ** xref:api/testing.adoc[]
 ** xref:api/generic-model.adoc[]
+* xref:api/testcontainers.adoc[Testcontainers]
 * xref:contribution-guidelines.adoc[Contribution Guidelines]
 * Appendices
 ** xref:upgrade-notes.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testcontainers.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testcontainers.adoc
@@ -1,0 +1,28 @@
+[[testcontainers]]
+= Testcontainers
+
+== Service Connections
+
+The following service connection factories are provided in the spring-ai-spring-boot-testcontainers jar:
+
+[cols="|,|"]
+|====
+| Connection Details	 | Matched on
+| `ChromaConnectionDetails`
+| Containers of type `ChromaDBContainer`
+
+| `MilvusServiceClientConnectionDetails`
+| Containers of type `MilvusContainer`
+
+| `OllamaConnectionDetails`
+| Containers of type `OllamaContainer`
+
+| `QdrantConnectionDetails`
+| Containers of type `QdrantContainer`
+
+| `RedisConnectionDetails`
+| Containers of type `RedisStackContainer`
+
+| `WeaviateConnectionDetails`
+| Containers of type `WeaviateContainer`
+|====

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -265,6 +265,7 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -298,7 +299,7 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>qdrant</artifactId>
-			<version>1.19.6</version>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.web.client.RestClient;
  * {@link AutoConfiguration Auto-configuration} for Ollama Chat Client.
  *
  * @author Christian Tzolov
+ * @author Eddú Meléndez
  * @since 0.8.0
  */
 @AutoConfiguration(after = RestClientAutoConfiguration.class)
@@ -40,9 +41,15 @@ import org.springframework.web.client.RestClient;
 public class OllamaAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean(OllamaConnectionDetails.class)
+	public PropertiesOllamaConnectionDetails ollamaConnectionDetails(OllamaConnectionProperties properties) {
+		return new PropertiesOllamaConnectionDetails(properties);
+	}
+
+	@Bean
 	@ConditionalOnMissingBean
-	public OllamaApi ollamaApi(OllamaConnectionProperties properties, RestClient.Builder restClientBuilder) {
-		return new OllamaApi(properties.getBaseUrl(), restClientBuilder);
+	public OllamaApi ollamaApi(OllamaConnectionDetails connectionDetails, RestClient.Builder restClientBuilder) {
+		return new OllamaApi(connectionDetails.getBaseUrl(), restClientBuilder);
 	}
 
 	@Bean
@@ -63,6 +70,21 @@ public class OllamaAutoConfiguration {
 
 		return new OllamaEmbeddingClient(ollamaApi).withModel(properties.getModel())
 			.withDefaultOptions(properties.getOptions());
+	}
+
+	private static class PropertiesOllamaConnectionDetails implements OllamaConnectionDetails {
+
+		private final OllamaConnectionProperties properties;
+
+		PropertiesOllamaConnectionDetails(OllamaConnectionProperties properties) {
+			this.properties = properties;
+		}
+
+		@Override
+		public String getBaseUrl() {
+			return this.properties.getBaseUrl();
+		}
+
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaConnectionDetails.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaConnectionDetails.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.ollama;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * @author Eddú Meléndez
+ */
+public interface OllamaConnectionDetails extends ConnectionDetails {
+
+	String getBaseUrl();
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaConnectionDetails.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaConnectionDetails.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.vectorstore.chroma;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * @author Eddú Meléndez
+ */
+public interface ChromaConnectionDetails extends ConnectionDetails {
+
+	String getHost();
+
+	int getPort();
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfiguration.java
@@ -30,11 +30,18 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Christian Tzolov
+ * @author Eddú Meléndez
  */
 @AutoConfiguration
 @ConditionalOnClass({ EmbeddingClient.class, RestTemplate.class, ChromaVectorStore.class, ObjectMapper.class })
 @EnableConfigurationProperties({ ChromaApiProperties.class, ChromaVectorStoreProperties.class })
 public class ChromaVectorStoreAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(ChromaConnectionDetails.class)
+	PropertiesChromaConnectionDetails chromaConnectionDetails(ChromaApiProperties properties) {
+		return new PropertiesChromaConnectionDetails(properties);
+	}
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -44,9 +51,10 @@ public class ChromaVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ChromaApi chromaApi(ChromaApiProperties apiProperties, RestTemplate restTemplate) {
+	public ChromaApi chromaApi(ChromaApiProperties apiProperties, RestTemplate restTemplate,
+			ChromaConnectionDetails connectionDetails) {
 
-		String chromaUrl = String.format("%s:%s", apiProperties.getHost(), apiProperties.getPort());
+		String chromaUrl = String.format("%s:%s", connectionDetails.getHost(), connectionDetails.getPort());
 
 		var chromaApi = new ChromaApi(chromaUrl, restTemplate, new ObjectMapper());
 
@@ -65,6 +73,26 @@ public class ChromaVectorStoreAutoConfiguration {
 	public ChromaVectorStore vectorStore(EmbeddingClient embeddingClient, ChromaApi chromaApi,
 			ChromaVectorStoreProperties storeProperties) {
 		return new ChromaVectorStore(embeddingClient, chromaApi, storeProperties.getCollectionName());
+	}
+
+	private static class PropertiesChromaConnectionDetails implements ChromaConnectionDetails {
+
+		private final ChromaApiProperties properties;
+
+		PropertiesChromaConnectionDetails(ChromaApiProperties properties) {
+			this.properties = properties;
+		}
+
+		@Override
+		public String getHost() {
+			return this.properties.getHost();
+		}
+
+		@Override
+		public int getPort() {
+			return this.properties.getPort();
+		}
+
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusServiceClientConnectionDetails.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusServiceClientConnectionDetails.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.vectorstore.milvus;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * @author Eddú Meléndez
+ */
+public interface MilvusServiceClientConnectionDetails extends ConnectionDetails {
+
+	String getHost();
+
+	int getPort();
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantConnectionDetails.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantConnectionDetails.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.vectorstore.qdrant;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * @author Eddú Meléndez
+ */
+public interface QdrantConnectionDetails extends ConnectionDetails {
+
+	String getHost();
+
+	int getPort();
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * @author Anush Shetty
+ * @author Eddú Meléndez
  * @since 0.8.1
  */
 @AutoConfiguration
@@ -34,18 +35,45 @@ import org.springframework.context.annotation.Bean;
 public class QdrantVectorStoreAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean(QdrantConnectionDetails.class)
+	PropertiesQdrantConnectionDetails qdrantConnectionDetails(QdrantVectorStoreProperties properties) {
+		return new PropertiesQdrantConnectionDetails(properties);
+	}
+
+	@Bean
 	@ConditionalOnMissingBean
-	public QdrantVectorStore vectorStore(EmbeddingClient embeddingClient, QdrantVectorStoreProperties properties) {
+	public QdrantVectorStore vectorStore(EmbeddingClient embeddingClient, QdrantVectorStoreProperties properties,
+			QdrantConnectionDetails connectionDetails) {
 
 		var config = QdrantVectorStoreConfig.builder()
 			.withCollectionName(properties.getCollectionName())
-			.withHost(properties.getHost())
-			.withPort(properties.getPort())
+			.withHost(connectionDetails.getHost())
+			.withPort(connectionDetails.getPort())
 			.withTls(properties.isUseTls())
 			.withApiKey(properties.getApiKey())
 			.build();
 
 		return new QdrantVectorStore(config, embeddingClient);
+	}
+
+	private static class PropertiesQdrantConnectionDetails implements QdrantConnectionDetails {
+
+		private final QdrantVectorStoreProperties properties;
+
+		PropertiesQdrantConnectionDetails(QdrantVectorStoreProperties properties) {
+			this.properties = properties;
+		}
+
+		@Override
+		public String getHost() {
+			return this.properties.getHost();
+		}
+
+		@Override
+		public int getPort() {
+			return this.properties.getPort();
+		}
+
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/redis/RedisConnectionDetails.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/redis/RedisConnectionDetails.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.vectorstore.redis;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * @author Eddú Meléndez
+ */
+public interface RedisConnectionDetails extends ConnectionDetails {
+
+	String getUri();
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateConnectionDetails.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateConnectionDetails.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.vectorstore.weaviate;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+public interface WeaviateConnectionDetails extends ConnectionDetails {
+
+	String getHost();
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * @author Christian Tzolov
+ * @author Eddú Meléndez
  */
 @AutoConfiguration
 @ConditionalOnClass({ EmbeddingClient.class, WeaviateVectorStore.class })
@@ -34,13 +35,20 @@ import org.springframework.context.annotation.Bean;
 public class WeaviateVectorStoreAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean(WeaviateConnectionDetails.class)
+	public PropertiesWeaviateConnectionDetails weaviateConnectionDetails(WeaviateVectorStoreProperties properties) {
+		return new PropertiesWeaviateConnectionDetails(properties);
+	}
+
+	@Bean
 	@ConditionalOnMissingBean
-	public WeaviateVectorStore vectorStore(EmbeddingClient embeddingClient, WeaviateVectorStoreProperties properties) {
+	public WeaviateVectorStore vectorStore(EmbeddingClient embeddingClient, WeaviateVectorStoreProperties properties,
+			WeaviateConnectionDetails connectionDetails) {
 
 		WeaviateVectorStoreConfig.Builder configBuilder = WeaviateVectorStore.WeaviateVectorStoreConfig.builder()
 			.withScheme(properties.getScheme())
 			.withApiKey(properties.getApiKey())
-			.withHost(properties.getHost())
+			.withHost(connectionDetails.getHost())
 			.withHeaders(properties.getHeaders())
 			.withObjectClass(properties.getObjectClass())
 			.withFilterableMetadataFields(properties.getFilterField()
@@ -51,6 +59,21 @@ public class WeaviateVectorStoreAutoConfiguration {
 			.withConsistencyLevel(properties.getConsistencyLevel());
 
 		return new WeaviateVectorStore(configBuilder.build(), embeddingClient);
+	}
+
+	private static class PropertiesWeaviateConnectionDetails implements WeaviateConnectionDetails {
+
+		private final WeaviateVectorStoreProperties properties;
+
+		PropertiesWeaviateConnectionDetails(WeaviateVectorStoreProperties properties) {
+			this.properties = properties;
+		}
+
+		@Override
+		public String getHost() {
+			return this.properties.getHost();
+		}
+
 	}
 
 }

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>spring-ai-spring-boot-testcontainers</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Testcontainers</name>
+    <description>Spring AI Testcontainers</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-spring-boot-autoconfigure</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf-java.version}</version>
+        </dependency>
+
+        <!-- production dependencies -->
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-postgresml</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-azure-openai</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-huggingface</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-ollama</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Transformers Embedding Client -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-transformers</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Pinecone Vector Store-->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-pinecone</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Because of Pinecone compatability issues downgrade
+        netty-codec-http2 from 4.1.101.Final to 4.1.100.Final -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.100.Final</version>
+        </dependency>
+
+        <!-- Milvus Vector Store -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-milvus-store</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- PG Vector Store-->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-pgvector-store</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.pgvector</groupId>
+            <artifactId>pgvector</artifactId>
+            <version>${pgvector.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Chroma Vector Store -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-chroma-store</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Azure Vector Store -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-azure-vector-store</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Weaviate Vector Store -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-weaviate-store</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Redis Vector Store-->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-redis</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Override Jedis version -->
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+
+        <!-- Vertex AI PaLM2 -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-vertex-ai-palm2</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Vertex AI Gemini -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-vertex-ai-gemini</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Stability AI LLM -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-stability-ai</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Bedrock -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-bedrock</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Mistral AI LLM -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-mistral-ai</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Neo4j Vector Store-->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-neo4j-store</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Qdrant Vector Store-->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-qdrant</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-test</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+<!--            <scope>test</scope>-->
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+<!--            <scope>test</scope>-->
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.redis</groupId>
+            <artifactId>testcontainers-redis</artifactId>
+            <version>2.0.1</version>
+<!--            <scope>test</scope>-->
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>neo4j</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>qdrant</artifactId>
+            <version>1.19.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>weaviate</artifactId>
+            <version>1.19.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>chromadb</artifactId>
+            <version>1.19.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>milvus</artifactId>
+            <version>1.19.7</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+
+    </dependencies>
+
+</project>

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -331,6 +331,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>ollama</artifactId>
+            <version>1.19.7</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
             <version>1.5.0</version>

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -54,27 +54,6 @@
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-postgresml</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-azure-openai</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-huggingface</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-ollama</artifactId>
             <version>${project.parent.version}</version>
             <optional>true</optional>
@@ -88,22 +67,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Pinecone Vector Store-->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-pinecone</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Because of Pinecone compatability issues downgrade
-        netty-codec-http2 from 4.1.101.Final to 4.1.100.Final -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>4.1.100.Final</version>
-        </dependency>
-
         <!-- Milvus Vector Store -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
@@ -112,39 +75,10 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- PG Vector Store-->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-pgvector-store</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>com.pgvector</groupId>
-            <artifactId>pgvector</artifactId>
-            <version>${pgvector.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Chroma Vector Store -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-chroma-store</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Azure Vector Store -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-azure-vector-store</artifactId>
             <version>${project.parent.version}</version>
             <optional>true</optional>
         </dependency>
@@ -170,60 +104,6 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>5.1.0</version>
-        </dependency>
-
-        <!-- Vertex AI PaLM2 -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-vertex-ai-palm2</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Vertex AI Gemini -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-vertex-ai-gemini</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Stability AI LLM -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-stability-ai</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Bedrock -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-bedrock</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Mistral AI LLM -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-mistral-ai</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Neo4j Vector Store-->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-neo4j-store</artifactId>
-            <version>${project.parent.version}</version>
-            <optional>true</optional>
         </dependency>
 
         <!-- Qdrant Vector Store-->
@@ -261,22 +141,10 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-testcontainers</artifactId>
-<!--            <scope>test</scope>-->
-        </dependency>
-
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
-<!--            <scope>test</scope>-->
-        </dependency>
-
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -290,7 +158,6 @@
             <groupId>com.redis</groupId>
             <artifactId>testcontainers-redis</artifactId>
             <version>2.0.1</version>
-<!--            <scope>test</scope>-->
         </dependency>
 
         <dependency>
@@ -301,48 +168,38 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>neo4j</artifactId>
-            <version>${testcontainers.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.testcontainers</groupId>
             <artifactId>qdrant</artifactId>
-            <version>1.19.7</version>
+            <version>${testcontainers.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>weaviate</artifactId>
-            <version>1.19.7</version>
+            <version>${testcontainers.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>chromadb</artifactId>
-            <version>1.19.7</version>
+            <version>${testcontainers.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
-            <version>1.19.7</version>
+            <version>${testcontainers.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>ollama</artifactId>
-            <version>1.19.7</version>
+            <version>${testcontainers.version}</version>
+            <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-            <version>1.5.0</version>
-            <scope>test</scope>
-        </dependency>
-
 
     </dependencies>
 

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaContainerConnectionDetailsFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.chroma;
+
+import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.testcontainers.chromadb.ChromaDBContainer;
+
+/**
+ * @author Eddú Meléndez
+ */
+class ChromaContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<ChromaDBContainer, ChromaConnectionDetails> {
+
+	@Override
+	public ChromaConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<ChromaDBContainer> source) {
+		return new ChromaDBContainerConnectionDetails(source);
+	}
+
+	/**
+	 * {@link ChromaConnectionDetails} backed by a {@link ContainerConnectionSource}.
+	 */
+	private static final class ChromaDBContainerConnectionDetails extends ContainerConnectionDetails<ChromaDBContainer>
+			implements ChromaConnectionDetails {
+
+		private ChromaDBContainerConnectionDetails(ContainerConnectionSource<ChromaDBContainer> source) {
+			super(source);
+		}
+
+		@Override
+		public String getHost() {
+			return "http://%s".formatted(getContainer().getHost());
+		}
+
+		@Override
+		public int getPort() {
+			return getContainer().getMappedPort(8000);
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/milvus/MilvusContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/milvus/MilvusContainerConnectionDetailsFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.milvus;
+
+import org.springframework.ai.autoconfigure.vectorstore.milvus.MilvusServiceClientConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.testcontainers.milvus.MilvusContainer;
+
+/**
+ * @author Eddú Meléndez
+ */
+class MilvusContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<MilvusContainer, MilvusServiceClientConnectionDetails> {
+
+	@Override
+	public MilvusServiceClientConnectionDetails getContainerConnectionDetails(
+			ContainerConnectionSource<MilvusContainer> source) {
+		return new MilvusContainerConnectionDetails(source);
+	}
+
+	/**
+	 * {@link MilvusServiceClientConnectionDetails} backed by a
+	 * {@link ContainerConnectionSource}.
+	 */
+	private static final class MilvusContainerConnectionDetails extends ContainerConnectionDetails<MilvusContainer>
+			implements MilvusServiceClientConnectionDetails {
+
+		private MilvusContainerConnectionDetails(ContainerConnectionSource<MilvusContainer> source) {
+			super(source);
+		}
+
+		@Override
+		public String getHost() {
+			return getContainer().getHost();
+		}
+
+		@Override
+		public int getPort() {
+			return getContainer().getMappedPort(19530);
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.ollama;
+
+import org.springframework.ai.autoconfigure.ollama.OllamaConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.testcontainers.ollama.OllamaContainer;
+
+/**
+ * @author Eddú Meléndez
+ */
+class OllamaContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<OllamaContainer, OllamaConnectionDetails> {
+
+	@Override
+	public OllamaConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<OllamaContainer> source) {
+		return new OllamaContainerConnectionDetails(source);
+	}
+
+	/**
+	 * {@link OllamaConnectionDetails} backed by a {@link ContainerConnectionSource}.
+	 */
+	private static final class OllamaContainerConnectionDetails extends ContainerConnectionDetails<OllamaContainer>
+			implements OllamaConnectionDetails {
+
+		private OllamaContainerConnectionDetails(ContainerConnectionSource<OllamaContainer> source) {
+			super(source);
+		}
+
+		@Override
+		public String getBaseUrl() {
+			return getContainer().getEndpoint();
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerConnectionDetailsFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.qdrant;
+
+import org.springframework.ai.autoconfigure.vectorstore.qdrant.QdrantConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.testcontainers.qdrant.QdrantContainer;
+
+/**
+ * @author Eddú Meléndez
+ */
+class QdrantContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<QdrantContainer, QdrantConnectionDetails> {
+
+	@Override
+	public QdrantConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<QdrantContainer> source) {
+		return new QdrantContainerConnectionDetails(source);
+	}
+
+	/**
+	 * {@link QdrantConnectionDetails} backed by a {@link ContainerConnectionSource}.
+	 */
+	private static final class QdrantContainerConnectionDetails extends ContainerConnectionDetails<QdrantContainer>
+			implements QdrantConnectionDetails {
+
+		private QdrantContainerConnectionDetails(ContainerConnectionSource<QdrantContainer> source) {
+			super(source);
+		}
+
+		@Override
+		public String getHost() {
+			return getContainer().getHost();
+		}
+
+		@Override
+		public int getPort() {
+			return getContainer().getMappedPort(6334);
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/redis/RedisContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/redis/RedisContainerConnectionDetailsFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.redis;
+
+import com.redis.testcontainers.RedisStackContainer;
+import org.springframework.ai.autoconfigure.vectorstore.redis.RedisConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+
+/**
+ * @author Eddú Meléndez
+ */
+class RedisContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<RedisStackContainer, RedisConnectionDetails> {
+
+	@Override
+	public RedisConnectionDetails getContainerConnectionDetails(ContainerConnectionSource<RedisStackContainer> source) {
+		return new RedisContainerConnectionDetails(source);
+	}
+
+	/**
+	 * {@link RedisConnectionDetails} backed by a {@link ContainerConnectionSource}.
+	 */
+	private static final class RedisContainerConnectionDetails extends ContainerConnectionDetails<RedisStackContainer>
+			implements RedisConnectionDetails {
+
+		private RedisContainerConnectionDetails(ContainerConnectionSource<RedisStackContainer> source) {
+			super(source);
+		}
+
+		@Override
+		public String getUri() {
+			return getContainer().getRedisURI();
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/weaviate/WeaviateContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/weaviate/WeaviateContainerConnectionDetailsFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.weaviate;
+
+import org.springframework.ai.autoconfigure.vectorstore.weaviate.WeaviateConnectionDetails;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.testcontainers.weaviate.WeaviateContainer;
+
+/**
+ * @author Eddú Meléndez
+ */
+class WeaviateContainerConnectionDetailsFactory
+		extends ContainerConnectionDetailsFactory<WeaviateContainer, WeaviateConnectionDetails> {
+
+	@Override
+	public WeaviateConnectionDetails getContainerConnectionDetails(
+			ContainerConnectionSource<WeaviateContainer> source) {
+		return new WeaviateContainerConnectionDetails(source);
+	}
+
+	/**
+	 * {@link WeaviateConnectionDetails} backed by a {@link ContainerConnectionSource}.
+	 */
+	private static final class WeaviateContainerConnectionDetails extends ContainerConnectionDetails<WeaviateContainer>
+			implements WeaviateConnectionDetails {
+
+		private WeaviateContainerConnectionDetails(ContainerConnectionSource<WeaviateContainer> source) {
+			super(source);
+		}
+
+		@Override
+		public String getHost() {
+			return getContainer().getHttpHostAddress();
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
-org.springframework.ai.testcontainers.service.connection.chroma.ChromaContainerConnectionDetailsFactory
+org.springframework.ai.testcontainers.service.connection.chroma.ChromaContainerConnectionDetailsFactory,\
+org.springframework.ai.testcontainers.service.connection.milvus.MilvusContainerConnectionDetailsFactory

--- a/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
+org.springframework.ai.testcontainers.service.connection.chroma.ChromaContainerConnectionDetailsFactory

--- a/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
 org.springframework.ai.testcontainers.service.connection.chroma.ChromaContainerConnectionDetailsFactory,\
 org.springframework.ai.testcontainers.service.connection.milvus.MilvusContainerConnectionDetailsFactory,\
+org.springframework.ai.testcontainers.service.connection.ollama.OllamaContainerConnectionDetailsFactory,\
 org.springframework.ai.testcontainers.service.connection.qdrant.QdrantContainerConnectionDetailsFactory,\
 org.springframework.ai.testcontainers.service.connection.redis.RedisContainerConnectionDetailsFactory,\
 org.springframework.ai.testcontainers.service.connection.weaviate.WeaviateContainerConnectionDetailsFactory

--- a/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
 org.springframework.ai.testcontainers.service.connection.chroma.ChromaContainerConnectionDetailsFactory,\
 org.springframework.ai.testcontainers.service.connection.milvus.MilvusContainerConnectionDetailsFactory,\
-org.springframework.ai.testcontainers.service.connection.qdrant.QdrantContainerConnectionDetailsFactory
+org.springframework.ai.testcontainers.service.connection.qdrant.QdrantContainerConnectionDetailsFactory,\
+org.springframework.ai.testcontainers.service.connection.redis.RedisContainerConnectionDetailsFactory

--- a/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
 org.springframework.ai.testcontainers.service.connection.chroma.ChromaContainerConnectionDetailsFactory,\
-org.springframework.ai.testcontainers.service.connection.milvus.MilvusContainerConnectionDetailsFactory
+org.springframework.ai.testcontainers.service.connection.milvus.MilvusContainerConnectionDetailsFactory,\
+org.springframework.ai.testcontainers.service.connection.qdrant.QdrantContainerConnectionDetailsFactory

--- a/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
+++ b/spring-ai-spring-boot-testcontainers/src/main/resources/META-INF/spring.factories
@@ -2,4 +2,5 @@ org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFacto
 org.springframework.ai.testcontainers.service.connection.chroma.ChromaContainerConnectionDetailsFactory,\
 org.springframework.ai.testcontainers.service.connection.milvus.MilvusContainerConnectionDetailsFactory,\
 org.springframework.ai.testcontainers.service.connection.qdrant.QdrantContainerConnectionDetailsFactory,\
-org.springframework.ai.testcontainers.service.connection.redis.RedisContainerConnectionDetailsFactory
+org.springframework.ai.testcontainers.service.connection.redis.RedisContainerConnectionDetailsFactory,\
+org.springframework.ai.testcontainers.service.connection.weaviate.WeaviateContainerConnectionDetailsFactory

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaContainerConnectionDetailsFactoryTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.chroma;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.vectorstore.chroma.ChromaVectorStoreAutoConfiguration;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.transformers.TransformersEmbeddingClient;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.chromadb.ChromaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig
+@Testcontainers
+@TestPropertySource(properties = "spring.ai.vectorstore.chroma.store.collectionName=TestCollection")
+class ChromaContainerConnectionDetailsFactoryTest {
+
+	@Container
+	@ServiceConnection
+	static ChromaDBContainer chroma = new ChromaDBContainer("ghcr.io/chroma-core/chroma:0.4.15");
+
+	@Autowired
+	private VectorStore vectorStore;
+
+	@Test
+	public void addAndSearchWithFilters() {
+		var bgDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+				Map.of("country", "Bulgaria"));
+		var nlDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+				Map.of("country", "Netherlands"));
+
+		vectorStore.add(List.of(bgDocument, nlDocument));
+
+		var request = SearchRequest.query("The World").withTopK(5);
+
+		List<Document> results = vectorStore.similaritySearch(request);
+		assertThat(results).hasSize(2);
+
+		results = vectorStore
+			.similaritySearch(request.withSimilarityThresholdAll().withFilterExpression("country == 'Bulgaria'"));
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
+
+		results = vectorStore
+			.similaritySearch(request.withSimilarityThresholdAll().withFilterExpression("country == 'Netherlands'"));
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
+
+		// Remove all documents from the store
+		vectorStore.delete(List.of(bgDocument, nlDocument).stream().map(doc -> doc.getId()).toList());
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(ChromaVectorStoreAutoConfiguration.class)
+	static class Config {
+
+		@Bean
+		public EmbeddingClient embeddingClient() {
+			return new TransformersEmbeddingClient();
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/milvus/MilvusContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/milvus/MilvusContainerConnectionDetailsFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.milvus;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.ResourceUtils;
+import org.springframework.ai.autoconfigure.vectorstore.milvus.MilvusVectorStoreAutoConfiguration;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.transformers.TransformersEmbeddingClient;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig
+@Testcontainers
+@TestPropertySource(properties = { "spring.ai.vectorstore.milvus.metricType=COSINE",
+		"spring.ai.vectorstore.milvus.indexType=IVF_FLAT", "spring.ai.vectorstore.milvus.embeddingDimension=384",
+		"spring.ai.vectorstore.milvus.collectionName=myTestCollection" })
+class MilvusContainerConnectionDetailsFactoryTest {
+
+	@Container
+	@ServiceConnection
+	static MilvusContainer milvusContainer = new MilvusContainer("milvusdb/milvus:v2.3.8");
+
+	List<Document> documents = List.of(
+			new Document(ResourceUtils.getText("classpath:/test/data/spring.ai.txt"), Map.of("spring", "great")),
+			new Document(ResourceUtils.getText("classpath:/test/data/time.shelter.txt")), new Document(
+					ResourceUtils.getText("classpath:/test/data/great.depression.txt"), Map.of("depression", "bad")));
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(MilvusVectorStoreAutoConfiguration.class))
+		.withUserConfiguration(Config.class);
+
+	@Autowired
+	private VectorStore vectorStore;
+
+	@Test
+	public void addAndSearch() {
+		vectorStore.add(documents);
+
+		List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Spring").withTopK(1));
+
+		assertThat(results).hasSize(1);
+		Document resultDoc = results.get(0);
+		assertThat(resultDoc.getId()).isEqualTo(documents.get(0).getId());
+		assertThat(resultDoc.getContent())
+			.contains("Spring AI provides abstractions that serve as the foundation for developing AI applications.");
+		assertThat(resultDoc.getMetadata()).hasSize(2);
+		assertThat(resultDoc.getMetadata()).containsKeys("spring", "distance");
+
+		// Remove all documents from the store
+		vectorStore.delete(documents.stream().map(doc -> doc.getId()).toList());
+
+		results = vectorStore.similaritySearch(SearchRequest.query("Spring").withTopK(1));
+		assertThat(results).hasSize(0);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(MilvusVectorStoreAutoConfiguration.class)
+	static class Config {
+
+		@Bean
+		public EmbeddingClient embeddingClient() {
+			return new TransformersEmbeddingClient();
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.ollama;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.ollama.OllamaEmbeddingClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.ollama.OllamaContainer;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ */
+@SpringJUnitConfig
+@Testcontainers
+@TestPropertySource(properties = "spring.ai.ollama.embedding.options.model="
+		+ OllamaContainerConnectionDetailsFactoryTest.MODEL_NAME)
+class OllamaContainerConnectionDetailsFactoryTest {
+
+	private static final Log logger = LogFactory.getLog(OllamaContainerConnectionDetailsFactoryTest.class);
+
+	static final String MODEL_NAME = "orca-mini";
+
+	@Container
+	@ServiceConnection
+	static OllamaContainer ollama = new OllamaContainer("ollama/ollama:0.1.23");
+
+	@Autowired
+	private OllamaEmbeddingClient embeddingClient;
+
+	@BeforeAll
+	public static void beforeAll() throws IOException, InterruptedException {
+		logger.info("Start pulling the '" + MODEL_NAME + " ' generative ... would take several minutes ...");
+		ollama.execInContainer("ollama", "pull", MODEL_NAME);
+		logger.info(MODEL_NAME + " pulling competed!");
+	}
+
+	@Test
+	public void singleTextEmbedding() {
+		EmbeddingResponse embeddingResponse = this.embeddingClient.embedForResponse(List.of("Hello World"));
+		assertThat(embeddingResponse.getResults()).hasSize(1);
+		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
+		assertThat(this.embeddingClient.dimensions()).isEqualTo(3200);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration({ RestClientAutoConfiguration.class, OllamaAutoConfiguration.class })
+	static class Config {
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerConnectionDetailsFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.qdrant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.vectorstore.qdrant.QdrantVectorStoreAutoConfiguration;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.transformers.TransformersEmbeddingClient;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.qdrant.QdrantContainer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig
+@Testcontainers
+@TestPropertySource(properties = "spring.ai.vectorstore.qdrant.collectionName=test_collection")
+public class QdrantContainerConnectionDetailsFactoryTest {
+
+	@Container
+	@ServiceConnection
+	static QdrantContainer qdrantContainer = new QdrantContainer("qdrant/qdrant:v1.7.4");
+
+	List<Document> documents = List.of(
+			new Document(getText("classpath:/test/data/spring.ai.txt"), Map.of("spring", "great")),
+			new Document(getText("classpath:/test/data/time.shelter.txt")),
+			new Document(getText("classpath:/test/data/great.depression.txt"), Map.of("depression", "bad")));
+
+	@Autowired
+	private VectorStore vectorStore;
+
+	@Test
+	public void addAndSearch() {
+		vectorStore.add(documents);
+
+		List<Document> results = vectorStore
+			.similaritySearch(SearchRequest.query("What is Great Depression?").withTopK(1));
+
+		assertThat(results).hasSize(1);
+		Document resultDoc = results.get(0);
+		assertThat(resultDoc.getId()).isEqualTo(documents.get(2).getId());
+		assertThat(resultDoc.getMetadata()).containsKeys("depression", "distance");
+
+		// Remove all documents from the store
+		vectorStore.delete(documents.stream().map(doc -> doc.getId()).toList());
+		results = vectorStore.similaritySearch(SearchRequest.query("Great Depression").withTopK(1));
+		assertThat(results).hasSize(0);
+	}
+
+	public static String getText(String uri) {
+		var resource = new DefaultResourceLoader().getResource(uri);
+		try {
+			return resource.getContentAsString(StandardCharsets.UTF_8);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(QdrantVectorStoreAutoConfiguration.class)
+	static class Config {
+
+		@Bean
+		public EmbeddingClient embeddingClient() {
+			return new TransformersEmbeddingClient();
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/redis/RedisContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/redis/RedisContainerConnectionDetailsFactoryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.redis;
+
+import com.redis.testcontainers.RedisStackContainer;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.ResourceUtils;
+import org.springframework.ai.autoconfigure.vectorstore.redis.RedisVectorStoreAutoConfiguration;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.transformers.TransformersEmbeddingClient;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig
+@Testcontainers
+@TestPropertySource(
+		properties = { "spring.ai.vectorstore.redis.index=myIdx", "spring.ai.vectorstore.redis.prefix=doc:" })
+class RedisContainerConnectionDetailsFactoryTest {
+
+	@Container
+	@ServiceConnection
+	static RedisStackContainer redisContainer = new RedisStackContainer(
+			RedisStackContainer.DEFAULT_IMAGE_NAME.withTag(RedisStackContainer.DEFAULT_TAG));
+
+	private List<Document> documents = List.of(
+			new Document(ResourceUtils.getText("classpath:/test/data/spring.ai.txt"), Map.of("spring", "great")),
+			new Document(ResourceUtils.getText("classpath:/test/data/time.shelter.txt")), new Document(
+					ResourceUtils.getText("classpath:/test/data/great.depression.txt"), Map.of("depression", "bad")));
+
+	@Autowired
+	private VectorStore vectorStore;
+
+	@Test
+	void addAndSearch() {
+		vectorStore.add(documents);
+
+		List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Spring").withTopK(1));
+
+		assertThat(results).hasSize(1);
+		Document resultDoc = results.get(0);
+		assertThat(resultDoc.getId()).isEqualTo(documents.get(0).getId());
+		assertThat(resultDoc.getContent())
+			.contains("Spring AI provides abstractions that serve as the foundation for developing AI applications.");
+
+		// Remove all documents from the store
+		vectorStore.delete(documents.stream().map(doc -> doc.getId()).toList());
+
+		results = vectorStore.similaritySearch(SearchRequest.query("Spring").withTopK(1));
+		assertThat(results).isEmpty();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(RedisVectorStoreAutoConfiguration.class)
+	static class Config {
+
+		@Bean
+		public EmbeddingClient embeddingClient() {
+			return new TransformersEmbeddingClient();
+		}
+
+	}
+
+}

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/weaviate/WeaviateContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/weaviate/WeaviateContainerConnectionDetailsFactoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.weaviate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.vectorstore.weaviate.WeaviateVectorStoreAutoConfiguration;
+import org.springframework.ai.autoconfigure.vectorstore.weaviate.WeaviateVectorStoreProperties;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.ai.transformers.TransformersEmbeddingClient;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.WeaviateVectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.weaviate.WeaviateContainer;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig
+@Testcontainers
+@TestPropertySource(properties = { "spring.ai.vectorstore.weaviate.filter-field.country=TEXT",
+		"spring.ai.vectorstore.weaviate.filter-field.year=NUMBER",
+		"spring.ai.vectorstore.weaviate.filter-field.active=BOOLEAN",
+		"spring.ai.vectorstore.weaviate.filter-field.price=NUMBER" })
+class WeaviateContainerConnectionDetailsFactoryTest {
+
+	@Container
+	@ServiceConnection
+	static WeaviateContainer weaviateContainer = new WeaviateContainer("semitechnologies/weaviate:1.22.4");
+
+	@Autowired
+	private WeaviateVectorStoreProperties properties;
+
+	@Autowired
+	private VectorStore vectorStore;
+
+	@Test
+	public void addAndSearchWithFilters() {
+		assertThat(properties.getFilterField()).hasSize(4);
+
+		assertThat(properties.getFilterField().get("country"))
+			.isEqualTo(WeaviateVectorStore.WeaviateVectorStoreConfig.MetadataField.Type.TEXT);
+		assertThat(properties.getFilterField().get("year"))
+			.isEqualTo(WeaviateVectorStore.WeaviateVectorStoreConfig.MetadataField.Type.NUMBER);
+		assertThat(properties.getFilterField().get("active"))
+			.isEqualTo(WeaviateVectorStore.WeaviateVectorStoreConfig.MetadataField.Type.BOOLEAN);
+		assertThat(properties.getFilterField().get("price"))
+			.isEqualTo(WeaviateVectorStore.WeaviateVectorStoreConfig.MetadataField.Type.NUMBER);
+
+		var bgDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+				Map.of("country", "Bulgaria", "price", 3.14, "active", true, "year", 2020));
+		var nlDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+				Map.of("country", "Netherlands", "price", 1.57, "active", false, "year", 2023));
+
+		vectorStore.add(List.of(bgDocument, nlDocument));
+
+		var request = SearchRequest.query("The World").withTopK(5);
+
+		List<Document> results = vectorStore.similaritySearch(request);
+		assertThat(results).hasSize(2);
+
+		results = vectorStore
+			.similaritySearch(request.withSimilarityThresholdAll().withFilterExpression("country == 'Bulgaria'"));
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
+
+		results = vectorStore
+			.similaritySearch(request.withSimilarityThresholdAll().withFilterExpression("country == 'Netherlands'"));
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
+
+		results = vectorStore.similaritySearch(
+				request.withSimilarityThresholdAll().withFilterExpression("price > 1.57 && active == true"));
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
+
+		results = vectorStore
+			.similaritySearch(request.withSimilarityThresholdAll().withFilterExpression("year in [2020, 2023]"));
+		assertThat(results).hasSize(2);
+
+		results = vectorStore
+			.similaritySearch(request.withSimilarityThresholdAll().withFilterExpression("year > 2020 && year <= 2023"));
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
+
+		// Remove all documents from the store
+		vectorStore.delete(List.of(bgDocument, nlDocument).stream().map(doc -> doc.getId()).toList());
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(WeaviateVectorStoreAutoConfiguration.class)
+	static class Config {
+
+		@Bean
+		public EmbeddingClient embeddingClient() {
+			return new TransformersEmbeddingClient();
+		}
+
+	}
+
+}

--- a/vector-stores/spring-ai-qdrant/pom.xml
+++ b/vector-stores/spring-ai-qdrant/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>qdrant</artifactId>
-            <version>1.19.6</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/vector-stores/spring-ai-redis/pom.xml
+++ b/vector-stores/spring-ai-redis/pom.xml
@@ -71,6 +71,7 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Add `Connection Details` and `Service Connection` support for Testcontainers to the following services:

- ChromaDB
- Milvus
- Qdrant
- Redis
- Weaviate
- Ollama

Fixes #151