### PR TITLE
Add PostgresMlAutoConfiguration to AutoConfiguration.imports

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -23,3 +23,4 @@ org.springframework.ai.autoconfigure.vectorstore.weaviate.WeaviateVectorStoreAut
 org.springframework.ai.autoconfigure.vectorstore.neo4j.Neo4jVectorStoreAutoConfiguration
 org.springframework.ai.autoconfigure.vectorstore.qdrant.QdrantVectorStoreAutoConfiguration
 org.springframework.ai.autoconfigure.retry.SpringAiRetryAutoConfiguration
+org.springframework.ai.autoconfigure.postgresml.PostgresMlAutoConfiguration


### PR DESCRIPTION
It seems to have been missed in https://github.com/spring-projects/spring-ai/issues/242.