### PR TITLE
Remove withReuse in MongoDBAtlasContainer

### DIFF
--- a/vector-stores/spring-ai-mongodb-atlas-store/src/test/java/org/springframework/ai/vectorstore/MongoDBAtlasContainer.java
+++ b/vector-stores/spring-ai-mongodb-atlas-store/src/test/java/org/springframework/ai/vectorstore/MongoDBAtlasContainer.java
@@ -29,7 +29,7 @@ public class MongoDBAtlasContainer extends GenericContainer<MongoDBAtlasContaine
 				"atlas deployments setup local-test --type local --port 27778 --bindIpAll --username root --password root --force && tail -f /dev/null");
 		withExposedPorts(27778);
 		waitingFor(Wait.forLogMessage(".*Deployment created!.*\\n", 1));
-		withStartupTimeout(Duration.ofMinutes(5)).withReuse(true);
+		withStartupTimeout(Duration.ofMinutes(5));
 	}
 
 	public String getConnectionString() {


### PR DESCRIPTION
`Reuse Container` is a Testcontainers experimental feature. It requires `testcontainers.reuse.enable=true` in `~/.testcontainers.properties` in order to take effect but in order to avoid surprises, this commit remove it.

See https://java.testcontainers.org/features/reuse/
