### PR TITLE
Update azure-openai-embeddings.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
@@ -66,7 +66,7 @@ The prefix `spring.ai.azure.openai` is the property prefix to configure the conn
 |====
 
 
-The prefix `spring.ai.azure.openai.embeddings` is the property prefix that configures the `EmbeddingClient` implementation for Azure OpenAI
+The prefix `spring.ai.azure.openai.embedding` is the property prefix that configures the `EmbeddingClient` implementation for Azure OpenAI
 
 [cols="3,5,1"]
 |====


### PR DESCRIPTION
Corrected the property prefix related to embeddings for Azure Open AI. The prefix had 'embeddings' in plural. The actual prefix is spring.ai.azure.openai.embedding

@pivotal-cla This is an Obvious Fix.