### PR TITLE
Update getting-started documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/speech.adoc
@@ -1,5 +1,5 @@
 [[Speech]]
-= Speech API
+= Text-To-Speech (TTS) API
 
 Spring AI provides support for OpenAI's Speech API.
 When additional providers for Speech are implemented, a common `SpeechClient`  and `StreamingSpeechClient` interface will be extracted.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -158,6 +158,14 @@ Each of the following sections in the documentation shows which dependencies you
 ** xref:api/image/openai-image.adoc[OpenAI Image Generation]
 ** xref:api/image/stabilityai-image.adoc[StabilityAI Image Generation]
 
+=== Transcription Models
+* xref:api/transcriptions.adoc[]
+** xref:api/transcriptions/openai-transcriptions.adoc[OpenAI Transcriptions]
+
+=== Text-To-Speech (TTS) Models
+* xref:api/speech.adoc[]
+** xref:api/speech/openai-speech.adoc[OpenAI Text-To-Speech]
+
 === Vector Databases
 * xref:api/vectordbs.adoc[Vector Database API]
 ** xref:api/vectordbs/azure.adoc[ Azure Vector Search] - The https://learn.microsoft.com/en-us/azure/search/vector-search-overview[Azure] vector store.


### PR DESCRIPTION
- Adding Transcription Models and Text-To-Speech in 'Add dependencies for specific components' section
- Rename title Speech API to Text-To-Speech (TTS) API in speech.doc
