### PR TITLE
Update spring-boot version to 3.2.4

### DIFF
--- a/document-readers/pdf-reader/pom.xml
+++ b/document-readers/pdf-reader/pom.xml
@@ -55,7 +55,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-ollama/pom.xml
+++ b/models/spring-ai-ollama/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/models/spring-ai-postgresml/pom.xml
+++ b/models/spring-ai-postgresml/pom.xml
@@ -54,14 +54,12 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-transformers/pom.xml
+++ b/models/spring-ai-transformers/pom.xml
@@ -82,7 +82,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- production dependencies -->
-		<spring-boot.version>3.2.3</spring-boot.version>
+		<spring-boot.version>3.2.4-SNAPSHOT</spring-boot.version>
 		<spring-framework.version>6.1.4</spring-framework.version>
 		<stringtemplate.version>4.0.2</stringtemplate.version>
 		<azure-open-ai-client.version>1.0.0-beta.7</azure-open-ai-client.version>
@@ -142,9 +142,6 @@
 		<azure-search.version>11.6.1</azure-search.version>
 		<weaviate-client.version>4.5.1</weaviate-client.version>
 		<qdrant.version>1.7.1</qdrant.version>
-
-		<!-- testing dependencies -->
-		<testcontainers.version>1.19.7</testcontainers.version>
 
 		<!-- documentation dependencies -->
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!-- production dependencies -->
-		<spring-boot.version>3.2.4-SNAPSHOT</spring-boot.version>
+		<spring-boot.version>3.2.4</spring-boot.version>
 		<spring-framework.version>6.1.4</spring-framework.version>
 		<stringtemplate.version>4.0.2</stringtemplate.version>
 		<azure-open-ai-client.version>1.0.0-beta.7</azure-open-ai-client.version>

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -286,21 +286,18 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -320,14 +317,12 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>neo4j</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>qdrant</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -304,7 +304,7 @@
 		<dependency>
 			<groupId>com.redis</groupId>
 			<artifactId>testcontainers-redis</artifactId>
-			<version>2.0.1</version>
+			<version>2.2.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -329,7 +329,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>com.redis</groupId>
             <artifactId>testcontainers-redis</artifactId>
-            <version>2.0.1</version>
+            <version>2.2.0</version>
             <optional>true</optional>
         </dependency>
 

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -143,14 +143,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -169,35 +167,30 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>qdrant</artifactId>
-            <version>${testcontainers.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>weaviate</artifactId>
-            <version>${testcontainers.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>chromadb</artifactId>
-            <version>${testcontainers.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>milvus</artifactId>
-            <version>${testcontainers.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>ollama</artifactId>
-            <version>${testcontainers.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -104,6 +104,7 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>5.1.0</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Qdrant Vector Store-->
@@ -156,6 +157,7 @@
             <groupId>com.redis</groupId>
             <artifactId>testcontainers-redis</artifactId>
             <version>2.0.1</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/vector-stores/spring-ai-chroma/pom.xml
+++ b/vector-stores/spring-ai-chroma/pom.xml
@@ -49,14 +49,12 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>chromadb</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-elasticsearch-store/pom.xml
+++ b/vector-stores/spring-ai-elasticsearch-store/pom.xml
@@ -69,7 +69,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-milvus-store/pom.xml
+++ b/vector-stores/spring-ai-milvus-store/pom.xml
@@ -65,14 +65,12 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>milvus</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-mongodb-atlas-store/pom.xml
+++ b/vector-stores/spring-ai-mongodb-atlas-store/pom.xml
@@ -52,7 +52,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/vector-stores/spring-ai-neo4j-store/pom.xml
+++ b/vector-stores/spring-ai-neo4j-store/pom.xml
@@ -55,14 +55,12 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>neo4j</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-pgvector-store/pom.xml
+++ b/vector-stores/spring-ai-pgvector-store/pom.xml
@@ -74,14 +74,12 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-qdrant/pom.xml
+++ b/vector-stores/spring-ai-qdrant/pom.xml
@@ -72,14 +72,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>qdrant</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>

--- a/vector-stores/spring-ai-redis/pom.xml
+++ b/vector-stores/spring-ai-redis/pom.xml
@@ -71,7 +71,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-redis/pom.xml
+++ b/vector-stores/spring-ai-redis/pom.xml
@@ -21,7 +21,7 @@
 	</scm>
 
 	<properties>
-		<testcontainers-redis.version>2.0.1</testcontainers-redis.version>
+		<testcontainers-redis.version>2.2.0</testcontainers-redis.version>
 		<jedis.version>5.1.0</jedis.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>

--- a/vector-stores/spring-ai-weaviate/pom.xml
+++ b/vector-stores/spring-ai-weaviate/pom.xml
@@ -68,14 +68,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>weaviate</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Spring Boot 3.2.4 offers Testcontainers 1.19.7, which provides all the modules needed by Spring AI. So, fixed testcontainers version has been removed.

Also, testcontainers-redis has been updated to 2.2.0.
