### PR TITLE
Allow Retry on choosen status codes

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatClientIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatClientIT.java
@@ -50,7 +50,7 @@ import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = AnthropicTestConfiguration.class)
+@SpringBootTest(classes = AnthropicTestConfiguration.class, properties = "spring.ai.retry.on-http-codes=429")
 @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
 class AnthropicChatClientIT {
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -67,7 +67,8 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 | spring.ai.retry.backoff.multiplier | Backoff interval multiplier. |  5
 | spring.ai.retry.backoff.max-interval | Maximum backoff duration. |  3 min.
 | spring.ai.retry.on-client-errors | If false, throw a NonTransientAiException, and do not attempt retry for `4xx` client error codes | false
-| spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should not trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should NOT trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.on-http-codes | List of HTTP status codes that should trigger a retry (e.g. to throw TransientAiException). | empty
 |====
 
 NOTE: currently the retry policies are not applicable for the streaming API.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -63,6 +63,7 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 | spring.ai.retry.backoff.max-interval | Maximum backoff duration. |  3 min.
 | spring.ai.retry.on-client-errors | If false, throw a NonTransientAiException, and do not attempt retry for `4xx` client error codes | false
 | spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should not trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.on-http-codes | List of HTTP status codes that should trigger a retry (e.g. to throw TransientAiException). | empty
 |====
 
 ==== Connection Properties

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -63,6 +63,7 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 | spring.ai.retry.backoff.max-interval | Maximum backoff duration. |  3 min.
 | spring.ai.retry.on-client-errors | If false, throw a NonTransientAiException, and do not attempt retry for `4xx` client error codes | false
 | spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should not trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.on-http-codes | List of HTTP status codes that should trigger a retry (e.g. to throw TransientAiException). | empty
 |====
 
 ==== Connection Properties

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/mistralai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/mistralai-embeddings.adoc
@@ -63,6 +63,7 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 | spring.ai.retry.backoff.max-interval | Maximum backoff duration. |  3 min.
 | spring.ai.retry.on-client-errors | If false, throw a NonTransientAiException, and do not attempt retry for `4xx` client error codes | false
 | spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should not trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.on-http-codes | List of HTTP status codes that should trigger a retry (e.g. to throw TransientAiException). | empty
 |====
 
 ==== Connection Properties

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
@@ -64,6 +64,7 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 | spring.ai.retry.backoff.max-interval | Maximum backoff duration. |  3 min.
 | spring.ai.retry.on-client-errors | If false, throw a NonTransientAiException, and do not attempt retry for `4xx` client error codes | false
 | spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should not trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.on-http-codes | List of HTTP status codes that should trigger a retry (e.g. to throw TransientAiException). | empty
 |====
 
 ==== Connection Properties

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/openai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/openai-image.adoc
@@ -89,6 +89,7 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 | spring.ai.retry.backoff.max-interval | Maximum backoff duration. |  3 min.
 | spring.ai.retry.on-client-errors | If false, throw a NonTransientAiException, and do not attempt retry for `4xx` client error codes | false
 | spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should not trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.on-http-codes | List of HTTP status codes that should trigger a retry (e.g. to throw TransientAiException). | empty
 |====
 
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/retry/SpringAiRetryProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/retry/SpringAiRetryProperties.java
@@ -55,6 +55,11 @@ public class SpringAiRetryProperties {
 	private List<Integer> excludeOnHttpCodes = new ArrayList<>();
 
 	/**
+	 * List of HTTP status codes that should trigger a retry.
+	 */
+	private List<Integer> onHttpCodes = new ArrayList<>();
+
+	/**
 	 * Exponential Backoff properties.
 	 */
 	public static class Backoff {
@@ -126,6 +131,14 @@ public class SpringAiRetryProperties {
 
 	public void setOnClientErrors(boolean onClientErrors) {
 		this.onClientErrors = onClientErrors;
+	}
+
+	public List<Integer> getOnHttpCodes() {
+		return this.onHttpCodes;
+	}
+
+	public void setOnHttpCodes(List<Integer> onHttpCodes) {
+		this.onHttpCodes = onHttpCodes;
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/retry/SpringAiRetryPropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/retry/SpringAiRetryPropertiesTests.java
@@ -37,10 +37,10 @@ public class SpringAiRetryPropertiesTests {
 				var retryProperties = context.getBean(SpringAiRetryProperties.class);
 
 				assertThat(retryProperties.getMaxAttempts()).isEqualTo(10);
-				assertThat(retryProperties.isOnClientErrors()).isFalse(); // do not retry
-																			// on 4xx
-																			// errors
+				// do not retry on 4xx errors
+				assertThat(retryProperties.isOnClientErrors()).isFalse();
 				assertThat(retryProperties.getExcludeOnHttpCodes()).isEmpty();
+				assertThat(retryProperties.getOnHttpCodes()).isEmpty();
 				assertThat(retryProperties.getBackoff().getInitialInterval().toMillis()).isEqualTo(2000);
 				assertThat(retryProperties.getBackoff().getMultiplier()).isEqualTo(5);
 				assertThat(retryProperties.getBackoff().getMaxInterval().toMillis()).isEqualTo(3 * 60000);
@@ -55,6 +55,7 @@ public class SpringAiRetryPropertiesTests {
 				"spring.ai.retry.max-attempts=100",
 				"spring.ai.retry.on-client-errors=false",
 				"spring.ai.retry.exclude-on-http-codes=404,500",
+				"spring.ai.retry.on-http-codes=429",
 				"spring.ai.retry.backoff.initial-interval=1000",
 				"spring.ai.retry.backoff.multiplier=2",
 				"spring.ai.retry.backoff.max-interval=60000" )
@@ -66,6 +67,7 @@ public class SpringAiRetryPropertiesTests {
 				assertThat(retryProperties.getMaxAttempts()).isEqualTo(100);
 				assertThat(retryProperties.isOnClientErrors()).isFalse();
 				assertThat(retryProperties.getExcludeOnHttpCodes()).containsExactly(404, 500);
+				assertThat(retryProperties.getOnHttpCodes()).containsExactly(429);
 				assertThat(retryProperties.getBackoff().getInitialInterval().toMillis()).isEqualTo(1000);
 				assertThat(retryProperties.getBackoff().getMultiplier()).isEqualTo(2);
 				assertThat(retryProperties.getBackoff().getMaxInterval().toMillis()).isEqualTo(60000);


### PR DESCRIPTION
 - Add a new autoconfig property spring.ai.retry.on-http-codes that list status codes (scuh as 429) for which the retry should be attemptd.
 - Updated the docs.

