### PR TITLE
Update openai-chat.adoc - replace withDefaultOptions()

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -265,13 +265,13 @@ Next, create a `OpenAiChatClient` and use it for text generations:
 [source,java]
 ----
 var openAiApi = new OpenAiApi(System.getenv("OPENAI_API_KEY"));
-
-var chatClient = new OpenAiChatClient(openAiApi)
-    .withDefaultOptions(OpenAiChatOptions.builder()
+var openAiChatOptions = OpenAiChatOptions.builder()
             .withModel("gpt-3.5-turbo")
             .withTemperature(0.4)
             .withMaxTokens(200)
-        .build());
+        .build();
+var chatClient = new OpenAiChatClient(openAiApi, openAiChatOptions)
+
 
 ChatResponse response = chatClient.call(
     new Prompt("Generate the names of 5 famous pirates."));


### PR DESCRIPTION
I found the  `.withDefaultOptions()` is no longer found with `new OpenAiChatClient`  in the 0.8 SNAPSHOT while trying out the sample code, I have tried with my codebase and it responded with no errors, this is my first time contributing so please bear with me 😅 and thank you for the hard work!

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
