### PR TITLE
AzureVectorStore - Correct message grammar in the add method for a scenario when the document was not uploaded successfully

### DIFF
--- a/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -233,7 +233,7 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 
 		for (IndexingResult indexingResult : result.getResults()) {
 			Assert.isTrue(indexingResult.isSucceeded(),
-					String.format("Document with key %s upload is not successfully", indexingResult.getKey()));
+					String.format("Document with key %s did not upload successfully", indexingResult.getKey()));
 		}
 	}
 


### PR DESCRIPTION
For a scenario when you are adding documents to the Azure AI Search Vector store (using the AzureVectorStore java implementation), I noticed when the document content is not loaded successfully a message of this nature could be thrown  
"Document with key 1 upload is not successfully".
This sounds grammatically incorrect. So I have updated the message to "Document with key 1 did not upload successfully".

Exact change as follows -

```
for (IndexingResult indexingResult : result.getResults()) {
			Assert.isTrue(indexingResult.isSucceeded(),
					String.format("Document with key %s did not upload successfully", indexingResult.getKey()));
		}
```

@pivotal-cla This is an Obvious Fix.