### PR TITLE
Fix Usage in Ollama ChatResponse

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/metadata/OllamaChatResponseMetadata.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/metadata/OllamaChatResponseMetadata.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.ollama.metadata;
+
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ChatResponseMetadata} implementation for {@literal Ollama}
+ *
+ * @see ChatResponseMetadata
+ * @author Fu Cheng
+ */
+public class OllamaChatResponseMetadata implements ChatResponseMetadata {
+
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, usage: %2$s, rateLimit: %3$s }";
+
+	public static OllamaChatResponseMetadata from(OllamaApi.ChatResponse response) {
+		Assert.notNull(response, "OllamaApi.ChatResponse must not be null");
+		Usage usage = OllamaUsage.from(response);
+		return new OllamaChatResponseMetadata(usage);
+	}
+
+	private final Usage usage;
+
+	protected OllamaChatResponseMetadata(Usage usage) {
+		this.usage = usage;
+	}
+
+	@Override
+	public Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public String toString() {
+		return AI_METADATA_STRING.formatted(getClass().getTypeName(), getUsage(), getRateLimit());
+	}
+
+}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/metadata/OllamaUsage.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/metadata/OllamaUsage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.ollama.metadata;
+
+import java.util.Optional;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.util.Assert;
+
+/**
+ * {@link Usage} implementation for {@literal Ollama}
+ *
+ * @see Usage
+ * @author Fu Cheng
+ */
+public class OllamaUsage implements Usage {
+
+	protected static final String AI_USAGE_STRING = "{ promptTokens: %1$d, generationTokens: %2$d, totalTokens: %3$d }";
+
+	public static OllamaUsage from(OllamaApi.ChatResponse response) {
+		Assert.notNull(response, "OllamaApi.ChatResponse must not be null");
+		return new OllamaUsage(response);
+	}
+
+	private final OllamaApi.ChatResponse response;
+
+	public OllamaUsage(OllamaApi.ChatResponse response) {
+		this.response = response;
+	}
+
+	@Override
+	public Long getPromptTokens() {
+		return Optional.ofNullable(response.promptEvalCount()).map(Integer::longValue).orElse(0L);
+	}
+
+	@Override
+	public Long getGenerationTokens() {
+		return Optional.ofNullable(response.evalCount()).map(Integer::longValue).orElse(0L);
+	}
+
+	@Override
+	public String toString() {
+		return AI_USAGE_STRING.formatted(getPromptTokens(), getGenerationTokens(), getTotalTokens());
+	}
+
+}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatClientIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatClientIT.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.prompt.ChatOptionsBuilder;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.testcontainers.containers.GenericContainer;
@@ -103,6 +104,18 @@ class OllamaChatClientIT {
 		response = client.call(new Prompt(List.of(userMessage, systemMessage), ollamaOptions));
 		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
 
+	}
+
+	@Test
+	void usageTest() {
+		Prompt prompt = new Prompt("Tell me a joke");
+		ChatResponse response = client.call(prompt);
+		Usage usage = response.getMetadata().getUsage();
+
+		assertThat(usage).isNotNull();
+		assertThat(usage.getPromptTokens()).isPositive();
+		assertThat(usage.getGenerationTokens()).isPositive();
+		assertThat(usage.getTotalTokens()).isPositive();
 	}
 
 	@Test


### PR DESCRIPTION
The `Usage` of Ollama `ChatResponse` was put into `ChatGenerationMetadata` as content filter metadata. The correct place should be in the `Usage` of `ChatResponseMetadata`. New implementations of `ChatResponseMetadata` and `Usage` are created for Ollama.

Fix #397 


