### PR TITLE
Add the default model to the initial Vertex AI Gemini autoconfiguration chat properties

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vertexai/gemini/VertexAiGeminiChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vertexai/gemini/VertexAiGeminiChatProperties.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.autoconfigure.vertexai.gemini;
 
+import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatClient;
 import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -29,12 +30,15 @@ public class VertexAiGeminiChatProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vertex.ai.gemini.chat";
 
+	public static final String DEFAULT_MODEL = VertexAiGeminiChatClient.ChatModel.GEMINI_PRO_VISION.getValue();
+
 	/**
 	 * Vertex AI Gemini API generative options.
 	 */
 	private VertexAiGeminiChatOptions options = VertexAiGeminiChatOptions.builder()
 		.withTemperature(0.7f)
 		.withCandidateCount(1)
+		.withModel(DEFAULT_MODEL)
 		.build();
 
 	public VertexAiGeminiChatOptions getOptions() {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/VertexAiGeminiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/VertexAiGeminiAutoConfigurationIT.java
@@ -40,9 +40,7 @@ public class VertexAiGeminiAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.vertex.ai.gemini.project-id=" + System.getenv("VERTEX_AI_GEMINI_PROJECT_ID"),
-				"spring.ai.vertex.ai.gemini.location=" + System.getenv("VERTEX_AI_GEMINI_LOCATION"),
-				"spring.ai.vertex.ai.gemini.chat.options.model="
-						+ VertexAiGeminiChatClient.ChatModel.GEMINI_PRO_VISION.getValue())
+				"spring.ai.vertex.ai.gemini.location=" + System.getenv("VERTEX_AI_GEMINI_LOCATION"))
 		.withConfiguration(AutoConfigurations.of(VertexAiGeminiAutoConfiguration.class));
 
 	@Test


### PR DESCRIPTION
I'm not sure if there is a reason for it, but Vertex AI Gemini basic autoconfiguration didn't carry a default model, unlike some other implementations (like OpenAI's). 

Setting the default model makes it a little bit more _plugandplay'able_.