### PR TITLE
Fixing metadata for text splitting

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
@@ -53,26 +53,27 @@ public abstract class TextSplitter implements DocumentTransformer {
 
 	private List<Document> doSplitDocuments(List<Document> documents) {
 		List<String> texts = new ArrayList<>();
-		Map<String, Object> metadata = new HashMap<>();
+		List<Map<String, Object>> metadataList = new ArrayList<>();
 		List<ContentFormatter> formatters = new ArrayList<>();
 
 		for (Document doc : documents) {
 			texts.add(doc.getContent());
-			metadata.putAll(doc.getMetadata());
+			metadataList.add(doc.getMetadata());
 			formatters.add(doc.getContentFormatter());
 		}
 
-		return createDocuments(texts, formatters, metadata);
+		return createDocuments(texts, formatters, metadataList);
 	}
 
 	private List<Document> createDocuments(List<String> texts, List<ContentFormatter> formatters,
-			Map<String, Object> metadata) {
+			List<Map<String, Object>> metadataList) {
 
 		// Process the data in a column oriented way and recreate the Document
 		List<Document> documents = new ArrayList<>();
 
 		for (int i = 0; i < texts.size(); i++) {
 			String text = texts.get(i);
+			Map<String, Object> metadata = metadataList.get(i);
 			List<String> chunks = splitText(text);
 			if (chunks.size() > 1) {
 				logger.info("Splitting up document into " + chunks.size() + " chunks.");


### PR DESCRIPTION

A correction has been made to the "page_number" value, which corresponded to the last page number.

Each chunk of text on a page will now have the page number as the 'page_number' metadata, instead of the last page number for the entire block.