### PR TITLE
fix: AzureOpenAiChatOptions to handle null values for presencePenalty and frequencyPenalty

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -174,7 +174,9 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions, ChatOptio
 		}
 
 		public Builder withFrequencyPenalty(Float frequencyPenalty) {
-			this.options.frequencyPenalty = frequencyPenalty.doubleValue();
+            if(frequencyPenalty != null) {
+                this.options.frequencyPenalty = frequencyPenalty.doubleValue();
+            }
 			return this;
 		}
 
@@ -194,7 +196,9 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions, ChatOptio
 		}
 
 		public Builder withPresencePenalty(Float presencePenalty) {
-			this.options.presencePenalty = presencePenalty.doubleValue();
+            if(presencePenalty != null) {
+                this.options.presencePenalty = presencePenalty.doubleValue();
+            }
 			return this;
 		}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
@@ -17,9 +17,14 @@ package org.springframework.ai.azure.openai;
 
 import com.azure.ai.openai.OpenAIClient;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,4 +56,39 @@ public class AzureChatCompletionsOptionsTests {
 		assertThat(requestOptions.getTemperature()).isEqualTo(99.9f);
 	}
 
+    private static Stream<Arguments> providePresencePenaltyAndFrequencyPenaltyTest() {
+        return Stream.of(
+                Arguments.of(0.0f, 0.0f),
+                Arguments.of(0.0f, 1.0f),
+                Arguments.of(1.0f, 0.0f),
+                Arguments.of(1.0f, 1.0f),
+                Arguments.of(1.0f, null),
+                Arguments.of(null, 1.0f),
+                Arguments.of(null, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePresencePenaltyAndFrequencyPenaltyTest")
+    public void createChatOptionsWithPresencePenaltyAndFrequencyPenalty(Float presencePenalty, Float frequencyPenalty) {
+        var options = AzureOpenAiChatOptions.builder()
+                .withMaxTokens(800)
+                .withTemperature(0.7F)
+                .withTopP(0.95F)
+                .withPresencePenalty(presencePenalty)
+                .withFrequencyPenalty(frequencyPenalty)
+                .build();
+
+        if (presencePenalty == null) {
+            assertThat(options.getPresencePenalty()).isEqualTo(null);
+        } else {
+            assertThat(options.getPresencePenalty().floatValue()).isEqualTo(presencePenalty);
+        }
+
+        if (frequencyPenalty == null) {
+            assertThat(options.getFrequencyPenalty()).isEqualTo(null);
+        } else {
+            assertThat(options.getFrequencyPenalty().floatValue()).isEqualTo(frequencyPenalty);
+        }
+    }
 }


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring) ✅
* Rebase your changes on the latest `main` branch and squash your commits ✅
* Add/Update unit tests as needed ✅
* Run a build and make sure all tests pass prior to submission ✅

---

I discovered a null safety issue while working with spring-ai in Kotlin. 
The `AzureOpenAiChatOptions` builder does not handle null values properly. 

Specifically, the `withFrequencyPenalty` and `withPresencePenalty` methods call `doubleValue()` without checking if the parameter is null.

Here is the problematic code:

```java
public Builder withFrequencyPenalty(Float frequencyPenalty) {
    this.options.frequencyPenalty = frequencyPenalty.doubleValue();
    return this;
}

public Builder withPresencePenalty(Float presencePenalty) {
    this.options.presencePenalty = presencePenalty.doubleValue();
    return this;
}
```

I managed to work around this issue in Kotlin by ensuring null safety as shown below:

```kotlin
val chatOptions = this.chatOptions?.let {
    AzureOpenAiChatOptions().apply {
        maxTokens = it.maxTokens
        temperature = it.temperature
        topP = it.topP
        logitBias = it.logitBias
        user = it.user
        n = it.n
        stop = it.stop
        presencePenalty = it.presencePenalty?.toDouble() // like this
        frequencyPenalty = it.frequencyPenalty?.toDouble() // like this
    }
}

...

```

However, I believe it would be beneficial to address this issue at its source. 
Therefore, I am submitting this pull request with additional test cases to highlight and resolve this issue.