### PR TITLE
Feat: Add additional parameter to WatsonxAiChatOptions

### DIFF
--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatClient.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatClient.java
@@ -64,6 +64,7 @@ public class WatsonxAiChatClient implements ChatClient, StreamingChatClient {
 					.withMaxNewTokens(20)
 					.withMinNewTokens(0)
 					.withRepetitionPenalty(1.0f)
+					.withStopSequences(List.of())
 					.build());
 	}
 

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatClient.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatClient.java
@@ -114,7 +114,10 @@ public class WatsonxAiChatClient implements ChatClient, StreamingChatClient {
 		}
 
 		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ChatOptions runtimeOptions) {
+			if (prompt.getOptions() instanceof WatsonxAiChatOptions runtimeOptions) {
+				options = ModelOptionsUtils.merge(runtimeOptions, options, WatsonxAiChatOptions.class);
+			}
+			else if (prompt.getOptions() instanceof ChatOptions runtimeOptions) {
 				var updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(runtimeOptions, ChatOptions.class,
 						WatsonxAiChatOptions.class);
 

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
@@ -89,7 +89,7 @@ public class WatsonxAiChatOptions implements ChatOptions {
     /**
      * Sets how many tokens must the LLM generate. (Default: 0)
      */
-    @JsonProperty("min_new_tokens") private Integer minNewTokens = 0;
+    @JsonProperty("min_new_tokens") private Integer minNewTokens;
 
     /**
      * Sets when the LLM should stop.
@@ -103,7 +103,7 @@ public class WatsonxAiChatOptions implements ChatOptions {
      * (e.g., 1.8) will penalize repetitions more strongly, while a lower value (e.g.,
      * 1.1) will be more lenient. (Default: 1.0)
      */
-    @JsonProperty("repetition_penalty") private Float repetitionPenalty;
+    @JsonProperty("repetition_penalty") private Float repetitionPenalty = 1.0f;
 
     /**
      * Produce repeatable results, set the same random seed value every time. (Default: randomly generated)
@@ -118,6 +118,7 @@ public class WatsonxAiChatOptions implements ChatOptions {
     /**
      * Set additional request params (some model have non-predefined options)
      */
+    @JsonProperty("additional")
     private Map<String, Object> additional = new HashMap<>();
 
     @JsonIgnore

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
@@ -96,14 +96,14 @@ public class WatsonxAiChatOptions implements ChatOptions {
      * (e.g., ["\n\n\n"]) then when the LLM generates three consecutive line breaks it will terminate.
      * Stop sequences are ignored until after the number of tokens that are specified in the Min tokens parameter are generated.
      */
-    @JsonProperty("stop_sequences") private List<String> stopSequences = List.of();
+    @JsonProperty("stop_sequences") private List<String> stopSequences;
 
     /**
      * Sets how strongly to penalize repetitions. A higher value
      * (e.g., 1.8) will penalize repetitions more strongly, while a lower value (e.g.,
      * 1.1) will be more lenient. (Default: 1.0)
      */
-    @JsonProperty("repetition_penalty") private Float repetitionPenalty = 1.0f;
+    @JsonProperty("repetition_penalty") private Float repetitionPenalty;
 
     /**
      * Produce repeatable results, set the same random seed value every time. (Default: randomly generated)

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
@@ -298,7 +298,10 @@ public class WatsonxAiChatOptions implements ChatOptions {
     public Map<String, Object> toMap() {
         try {
             var json = mapper.writeValueAsString(this);
-            return mapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+            var map = mapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+            map.remove("additional");
+
+            return map;
         }
         catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
@@ -20,10 +20,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.ai.chat.prompt.ChatOptions;
 
 /**
@@ -37,6 +40,7 @@ import org.springframework.ai.chat.prompt.ChatOptions;
  * valid Parameters and values</a>
  */
 // @formatter:off
+
 public class WatsonxAiChatOptions implements ChatOptions {
 
     /**

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
@@ -27,9 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.springframework.ai.chat.prompt.ChatOptions;
 
 /**

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatOptions.java
@@ -320,9 +320,7 @@ public class WatsonxAiChatOptions implements ChatOptions {
     }
 
     private static String convertToSnakeCase(String text) {
-        if(text.indexOf('_') != -1) return text.toLowerCase();
         return text.replaceAll("([a-z])([A-Z]+)", "$1_$2").toLowerCase();
     }
-
 }
 // @formatter:on

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/api/WatsonxAiRequest.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/api/WatsonxAiRequest.java
@@ -63,7 +63,7 @@ public class WatsonxAiRequest {
     public static Builder builder(String input) { return new Builder(input); }
 
     public static class Builder {
-        private final String input;
+        public static final String MODEL_PARAMETER_IS_REQUIRED = "Model parameter is required";private final String input;
         private Map<String, Object> parameters;
         private String model = "";
 
@@ -72,7 +72,7 @@ public class WatsonxAiRequest {
         }
 
         public Builder withParameters(Map<String, Object> parameters) {
-            Assert.notNull(parameters.get("model"), "Model parameter is required");
+            Assert.notNull(parameters.get("model"), MODEL_PARAMETER_IS_REQUIRED);
             this.model = parameters.get("model").toString();
             this.parameters = WatsonxAiChatOptions.filterNonSupportedFields(parameters);
             return this;

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/api/WatsonxAiRequest.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/api/WatsonxAiRequest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.ai.watsonx.WatsonxAiChatOptions;
+import org.springframework.util.Assert;
 
 // @formatter:off
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -71,6 +72,7 @@ public class WatsonxAiRequest {
         }
 
         public Builder withParameters(Map<String, Object> parameters) {
+            Assert.notNull(parameters.get("model"), "Model parameter is required");
             this.model = parameters.get("model").toString();
             this.parameters = WatsonxAiChatOptions.filterNonSupportedFields(parameters);
             return this;

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/api/WatsonxAiRequest.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/api/WatsonxAiRequest.java
@@ -63,7 +63,8 @@ public class WatsonxAiRequest {
     public static Builder builder(String input) { return new Builder(input); }
 
     public static class Builder {
-        public static final String MODEL_PARAMETER_IS_REQUIRED = "Model parameter is required";private final String input;
+        public static final String MODEL_PARAMETER_IS_REQUIRED = "Model parameter is required";
+        private final String input;
         private Map<String, Object> parameters;
         private String model = "";
 

--- a/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/api/WatsonxAiChatOptionTest.java
+++ b/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/api/WatsonxAiChatOptionTest.java
@@ -60,18 +60,18 @@ public class WatsonxAiChatOptionTest {
 	@Test
 	public void testOptionsWithAdditionalParamsOneByOne() {
 		WatsonxAiChatOptions options = WatsonxAiChatOptions.builder()
-				.withDecodingMethod("sample")
-				.withTemperature(1.2f)
-				.withTopK(20)
-				.withTopP(0.5f)
-				.withMaxNewTokens(100)
-				.withMinNewTokens(20)
-				.withStopSequences(List.of("\n\n\n"))
-				.withRepetitionPenalty(1.1f)
-				.withRandomSeed(4)
-				.withAdditionalProperty("HAP", true)
-				.withAdditionalProperty("typicalP", 0.5f)
-				.build();
+			.withDecodingMethod("sample")
+			.withTemperature(1.2f)
+			.withTopK(20)
+			.withTopP(0.5f)
+			.withMaxNewTokens(100)
+			.withMinNewTokens(20)
+			.withStopSequences(List.of("\n\n\n"))
+			.withRepetitionPenalty(1.1f)
+			.withRandomSeed(4)
+			.withAdditionalProperty("HAP", true)
+			.withAdditionalProperty("typicalP", 0.5f)
+			.build();
 
 		var optionsMap = options.toMap();
 
@@ -91,17 +91,17 @@ public class WatsonxAiChatOptionTest {
 	@Test
 	public void testOptionsWithAdditionalParamsMap() {
 		WatsonxAiChatOptions options = WatsonxAiChatOptions.builder()
-				.withDecodingMethod("sample")
-				.withTemperature(1.2f)
-				.withTopK(20)
-				.withTopP(0.5f)
-				.withMaxNewTokens(100)
-				.withMinNewTokens(20)
-				.withStopSequences(List.of("\n\n\n"))
-				.withRepetitionPenalty(1.1f)
-				.withRandomSeed(4)
-				.withAdditionalProperties(Map.of("HAP", true, "typicalP", 0.5f, "test_value", "test"))
-				.build();
+			.withDecodingMethod("sample")
+			.withTemperature(1.2f)
+			.withTopK(20)
+			.withTopP(0.5f)
+			.withMaxNewTokens(100)
+			.withMinNewTokens(20)
+			.withStopSequences(List.of("\n\n\n"))
+			.withRepetitionPenalty(1.1f)
+			.withRandomSeed(4)
+			.withAdditionalProperties(Map.of("HAP", true, "typicalP", 0.5f, "test_value", "test"))
+			.build();
 
 		var optionsMap = options.toMap();
 
@@ -118,7 +118,6 @@ public class WatsonxAiChatOptionTest {
 		assertThat(optionsMap).containsEntry("typical_p", 0.5);
 		assertThat(optionsMap).containsEntry("test_value", "test");
 	}
-
 
 	@Test
 	public void testFilterOut() {

--- a/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/api/WatsonxAiChatOptionTest.java
+++ b/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/api/WatsonxAiChatOptionTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.springframework.ai.watsonx.WatsonxAiChatOptions;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Pablo Sanchidrian Herrera
@@ -55,6 +56,69 @@ public class WatsonxAiChatOptionTest {
 		assertThat(optionsMap).containsEntry("repetition_penalty", 1.1);
 		assertThat(optionsMap).containsEntry("random_seed", 4);
 	}
+
+	@Test
+	public void testOptionsWithAdditionalParamsOneByOne() {
+		WatsonxAiChatOptions options = WatsonxAiChatOptions.builder()
+				.withDecodingMethod("sample")
+				.withTemperature(1.2f)
+				.withTopK(20)
+				.withTopP(0.5f)
+				.withMaxNewTokens(100)
+				.withMinNewTokens(20)
+				.withStopSequences(List.of("\n\n\n"))
+				.withRepetitionPenalty(1.1f)
+				.withRandomSeed(4)
+				.withAdditionalProperty("HAP", true)
+				.withAdditionalProperty("typicalP", 0.5f)
+				.build();
+
+		var optionsMap = options.toMap();
+
+		assertThat(optionsMap).containsEntry("decoding_method", "sample");
+		assertThat(optionsMap).containsEntry("temperature", 1.2);
+		assertThat(optionsMap).containsEntry("top_k", 20);
+		assertThat(optionsMap).containsEntry("top_p", 0.5);
+		assertThat(optionsMap).containsEntry("max_new_tokens", 100);
+		assertThat(optionsMap).containsEntry("min_new_tokens", 20);
+		assertThat(optionsMap).containsEntry("stop_sequences", List.of("\n\n\n"));
+		assertThat(optionsMap).containsEntry("repetition_penalty", 1.1);
+		assertThat(optionsMap).containsEntry("random_seed", 4);
+		assertThat(optionsMap).containsEntry("hap", true);
+		assertThat(optionsMap).containsEntry("typical_p", 0.5);
+	}
+
+	@Test
+	public void testOptionsWithAdditionalParamsMap() {
+		WatsonxAiChatOptions options = WatsonxAiChatOptions.builder()
+				.withDecodingMethod("sample")
+				.withTemperature(1.2f)
+				.withTopK(20)
+				.withTopP(0.5f)
+				.withMaxNewTokens(100)
+				.withMinNewTokens(20)
+				.withStopSequences(List.of("\n\n\n"))
+				.withRepetitionPenalty(1.1f)
+				.withRandomSeed(4)
+				.withAdditionalProperties(Map.of("HAP", true, "typicalP", 0.5f, "test_value", "test"))
+				.build();
+
+		var optionsMap = options.toMap();
+
+		assertThat(optionsMap).containsEntry("decoding_method", "sample");
+		assertThat(optionsMap).containsEntry("temperature", 1.2);
+		assertThat(optionsMap).containsEntry("top_k", 20);
+		assertThat(optionsMap).containsEntry("top_p", 0.5);
+		assertThat(optionsMap).containsEntry("max_new_tokens", 100);
+		assertThat(optionsMap).containsEntry("min_new_tokens", 20);
+		assertThat(optionsMap).containsEntry("stop_sequences", List.of("\n\n\n"));
+		assertThat(optionsMap).containsEntry("repetition_penalty", 1.1);
+		assertThat(optionsMap).containsEntry("random_seed", 4);
+		assertThat(optionsMap).containsEntry("hap", true);
+		assertThat(optionsMap).containsEntry("typical_p", 0.5);
+		assertThat(optionsMap).containsEntry("test_value", "test");
+	}
+
 
 	@Test
 	public void testFilterOut() {

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/watsonxai/WatsonxAiChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/watsonxai/WatsonxAiChatProperties.java
@@ -19,6 +19,8 @@ import org.springframework.ai.watsonx.WatsonxAiChatOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
+import java.util.List;
+
 /**
  * Chat properties for Watsonx.AI Chat.
  *
@@ -48,6 +50,7 @@ public class WatsonxAiChatProperties {
 		.withMaxNewTokens(20)
 		.withMinNewTokens(0)
 		.withRepetitionPenalty(1.0f)
+		.withStopSequences(List.of())
 		.build();
 
 	public boolean isEnabled() {


### PR DESCRIPTION
Some custom models may include extra parameters, so the idea is to define all the common parameters but add and additional attribute that will store all these custom configuration parameters. This will also help with its maintaniablitiy as if new parameters are added we can still use it while the options are not updated.

- Add "additional" attribute to WatsonxAiChatOptions