### PR TITLE
Support keep-alive and format options in Ollama chat requests

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatClient.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatClient.java
@@ -161,11 +161,20 @@ public class OllamaChatClient implements ChatClient, StreamingChatClient {
 		}
 
 		String model = mergedOptions.getModel();
-		return OllamaApi.ChatRequest.builder(model)
+		OllamaApi.ChatRequest.Builder requestBuilder = OllamaApi.ChatRequest.builder(model)
 			.withStream(stream)
 			.withMessages(ollamaMessages)
-			.withOptions(mergedOptions)
-			.build();
+			.withOptions(mergedOptions);
+
+		if (mergedOptions.getFormat() != null) {
+			requestBuilder.withFormat(mergedOptions.getFormat());
+		}
+
+		if (mergedOptions.getKeepAlive() != null) {
+			requestBuilder.withKeepAlive(mergedOptions.getKeepAlive());
+		}
+
+		return requestBuilder.build();
 	}
 
 	private String fromMediaData(Object mediaData) {

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -399,8 +399,9 @@ public class OllamaApi {
 	 * @param model The model to use for completion.
 	 * @param messages The list of messages to chat with.
 	 * @param stream Whether to stream the response.
-	 * @param format The format to return the response in. Currently the only accepted
+	 * @param format The format to return the response in. Currently, the only accepted
 	 * value is "json".
+	 * @param keepAlive The duration to keep the model loaded in ollama while idle. https://pkg.go.dev/time#ParseDuration
 	 * @param options Additional model parameters. You can use the {@link OllamaOptions} builder
 	 * to create the options then {@link OllamaOptions#toMap()} to convert the options into a
 	 * map.
@@ -411,6 +412,7 @@ public class OllamaApi {
 			@JsonProperty("messages") List<Message> messages,
 			@JsonProperty("stream") Boolean stream,
 			@JsonProperty("format") String format,
+			@JsonProperty("keep_alive") String keepAlive,
 			@JsonProperty("options") Map<String, Object> options) {
 
 		public static Builder builder(String model) {
@@ -423,6 +425,7 @@ public class OllamaApi {
 			private List<Message> messages = List.of();
 			private boolean stream = false;
 			private String format;
+			private String keepAlive;
 			private Map<String, Object> options = Map.of();
 
 			public Builder(String model) {
@@ -445,6 +448,11 @@ public class OllamaApi {
 				return this;
 			}
 
+			public Builder withKeepAlive(String keepAlive) {
+				this.keepAlive = keepAlive;
+				return this;
+			}
+
 			public Builder withOptions(Map<String, Object> options) {
 				Objects.requireNonNullElse(options, "The options can not be null.");
 
@@ -459,7 +467,7 @@ public class OllamaApi {
 			}
 
 			public ChatRequest build() {
-				return new ChatRequest(model, messages, stream, format, options);
+				return new ChatRequest(model, messages, stream, format, keepAlive, options);
 			}
 		}
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -441,8 +441,16 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 		return format;
 	}
 
+	public void setFormat(String format) {
+		this.format = format;
+	}
+
 	public String getKeepAlive() {
 		return keepAlive;
+	}
+
+	public void setKeepAlive(String keepAlive) {
+		this.keepAlive = keepAlive;
 	}
 
 	public Boolean getUseNUMA() {

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -45,7 +45,20 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 
 	public static final String DEFAULT_MODEL = OllamaModel.MISTRAL.id();
 
+	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "format", "keep_alive");
+
 	// @formatter:off
+	/**
+	 * Sets the desired format of output from the LLM. The only valid values are null or "json".
+	 */
+	@JsonProperty("format") private String format;
+
+	/**
+	 * Sets the length of time for Ollama to keep the model loaded. Valid values for this
+	 * setting are parsed by <a href="https://pkg.go.dev/time#ParseDuration">ParseDuration in Go</a>.
+	 */
+	@JsonProperty("keep_alive") private String keepAlive;
+
 	/**
 	 * useNUMA Whether to use NUMA.
 	 */
@@ -254,6 +267,16 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 		this.model = model;
 	}
 
+	public OllamaOptions withFormat(String format) {
+		this.format = format;
+		return this;
+	}
+
+	public OllamaOptions withKeepAlive(String keepAlive) {
+		this.keepAlive = keepAlive;
+		return this;
+	}
+
 	public OllamaOptions withUseNUMA(Boolean useNUMA) {
 		this.useNUMA = useNUMA;
 		return this;
@@ -412,6 +435,14 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 	public OllamaOptions withStop(List<String> stop) {
 		this.stop = stop;
 		return this;
+	}
+
+	public String getFormat() {
+		return format;
+	}
+
+	public String getKeepAlive() {
+		return keepAlive;
 	}
 
 	public Boolean getUseNUMA() {
@@ -694,13 +725,13 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 	}
 
 	/**
-	 * Filter out the non supported fields from the options.
+	 * Filter out the non-supported fields from the options.
 	 * @param options The options to filter.
 	 * @return The filtered options.
 	 */
 	public static Map<String, Object> filterNonSupportedFields(Map<String, Object> options) {
 		return options.entrySet().stream()
-			.filter(e -> !e.getKey().equals("model"))
+			.filter(e -> !NON_SUPPORTED_FIELDS.contains(e.getKey()))
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 


### PR DESCRIPTION
I added an `OllamaChatRequestOptions` class and wired it into `call()` and `stream()` in `OllamaChatClient`. It's optional and won't break existing code, but it provides a couple of new options that I find very convenient.

The **keep-alive** option will keep your model loaded in Ollama for the duration you specify.
The **format** option was there in part already, but not fully wired up. There was no way to actually use it from an application. It is a way to tell Ollama that you only want JSON output instead of chat.