### PR TITLE
Ollama: Remove unused option in chat completion

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatClient.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatClient.java
@@ -174,10 +174,6 @@ public class OllamaChatClient implements ChatClient, StreamingChatClient {
 			requestBuilder.withKeepAlive(mergedOptions.getKeepAlive());
 		}
 
-		if (mergedOptions.getTemplate() != null) {
-			requestBuilder.withTemplate(mergedOptions.getTemplate());
-		}
-
 		return requestBuilder.build();
 	}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -416,7 +416,6 @@ public class OllamaApi {
 	 * @param format The format to return the response in. Currently, the only accepted
 	 * value is "json".
 	 * @param keepAlive The duration to keep the model loaded in ollama while idle. https://pkg.go.dev/time#ParseDuration
-	 * @param template The prompt template (overrides what is defined in the Modelfile).
 	 * @param options Additional model parameters. You can use the {@link OllamaOptions} builder
 	 * to create the options then {@link OllamaOptions#toMap()} to convert the options into a
 	 * map.
@@ -428,7 +427,6 @@ public class OllamaApi {
 			@JsonProperty("stream") Boolean stream,
 			@JsonProperty("format") String format,
 			@JsonProperty("keep_alive") String keepAlive,
-			@JsonProperty("template") String template,
 			@JsonProperty("options") Map<String, Object> options) {
 
 		public static Builder builder(String model) {
@@ -442,7 +440,6 @@ public class OllamaApi {
 			private boolean stream = false;
 			private String format;
 			private String keepAlive;
-			private String template;
 			private Map<String, Object> options = Map.of();
 
 			public Builder(String model) {
@@ -470,11 +467,6 @@ public class OllamaApi {
 				return this;
 			}
 
-			public Builder withTemplate(String template) {
-				this.template = template;
-				return this;
-			}
-
 			public Builder withOptions(Map<String, Object> options) {
 				Objects.requireNonNull(options, "The options can not be null.");
 
@@ -489,7 +481,7 @@ public class OllamaApi {
 			}
 
 			public ChatRequest build() {
-				return new ChatRequest(model, messages, stream, format, keepAlive, template, options);
+				return new ChatRequest(model, messages, stream, format, keepAlive, options);
 			}
 		}
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -45,7 +45,7 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 
 	public static final String DEFAULT_MODEL = OllamaModel.MISTRAL.id();
 
-	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "format", "keep_alive", "template");
+	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "format", "keep_alive");
 
 	// @formatter:off
 	/**
@@ -256,13 +256,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 	@JsonProperty("keep_alive") private String keepAlive;
 
 	/**
-	 * The prompt template to use (overrides what is defined in the Modelfile).
-	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">advanced parameters</a>.
-	 */
-	@JsonProperty("template") private String template;
-
-
-	/**
 	 * @param model The ollama model names to use. See the {@link OllamaModel} for the common models.
 	 */
 	public OllamaOptions withModel(String model) {
@@ -285,11 +278,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 
 	public OllamaOptions withKeepAlive(String keepAlive) {
 		this.keepAlive = keepAlive;
-		return this;
-	}
-
-	public OllamaOptions withTemplate(String template) {
-		this.template = template;
 		return this;
 	}
 
@@ -467,14 +455,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 
 	public void setKeepAlive(String keepAlive) {
 		this.keepAlive = keepAlive;
-	}
-
-	public String getTemplate() {
-		return this.template;
-	}
-
-	public void setTemplate(String template) {
-		this.template = template;
 	}
 
 	public Boolean getUseNUMA() {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -65,7 +65,6 @@ Here are the advanced request parameter for the Ollama chat client:
 | spring.ai.ollama.chat.options.model  | The name of the https://github.com/ollama/ollama?tab=readme-ov-file#model-library[supported models] to use. | mistral
 | spring.ai.ollama.chat.options.format  | The format to return a response in. Currently the only accepted value is `json` | -
 | spring.ai.ollama.chat.options.keep_alive  | Controls how long the model will stay loaded into memory following the request | 5m
-| spring.ai.ollama.chat.options.template  | The prompt template to use (overrides what is defined in the Modelfile) | -
 |====
 
 The `options` properties are based on the link:https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values[Ollama Valid Parameters and Values] and link:https://github.com/jmorganca/ollama/blob/main/api/types.go[Ollama Types]. The default values are based on: link:https://github.com/ollama/ollama/blob/b538dc3858014f94b099730a592751a5454cab0a/api/types.go#L364[Ollama type defaults].


### PR DESCRIPTION
The Ollama documentation used to include a `template` parameter for the `chat completion` endpoint. However, that parameter only exists for the `generation` endpoint. It was probably a copy/paste mistake in the documentation. I have submitted a fix to the Ollama project which has now been merged (https://github.com/ollama/ollama/pull/3515).

This pull request is for removing the `template` parameter from the `ChatRequest` class and from the `OllamaOptions` class since it's not part of the Ollama API for Chat Completion. I have also updated the related documentation. The Ollama Server will not fail if the parameter is included, but it won't have any effect.
