### PR TITLE
Add ObjectMapper in FunctionCallbackWrapper constructor

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackWrapper.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackWrapper.java
@@ -35,9 +35,8 @@ public class FunctionCallbackWrapper<I, O> extends AbstractFunctionCallback<I, O
 	private final Function<I, O> function;
 
 	private FunctionCallbackWrapper(String name, String description, String inputTypeSchema, Class<I> inputType,
-			Function<O, String> responseConverter, Function<I, O> function) {
-		super(name, description, inputTypeSchema, inputType, responseConverter,
-				new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+			Function<O, String> responseConverter, ObjectMapper objectMapper, Function<I, O> function) {
+		super(name, description, inputTypeSchema, inputType, responseConverter, objectMapper);
 		Assert.notNull(function, "Function must not be null");
 		this.function = function;
 	}
@@ -148,7 +147,7 @@ public class FunctionCallbackWrapper<I, O> extends AbstractFunctionCallback<I, O
 			}
 
 			return new FunctionCallbackWrapper<>(this.name, this.description, this.inputTypeSchema, this.inputType,
-					this.responseConverter, this.function);
+					this.responseConverter, this.objectMapper, this.function);
 		}
 
 	}


### PR DESCRIPTION
`FunctionCallbackWrapper` has a `Builder` object to build `FunctionCallbackWrapper`s.  The `Builder` has a method `withObjectMapper` to pass in custom `ObjectMapper`s. However, this custom `ObjectMapper` is not used in the constructor of `FunctionCallbackWrapper`, so `FunctionCallbackWrapper` always uses the default `ObjectMapper`. 

```java
new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
```

This causes problems when using Kotlin data classes as the function types. For serialization/deserialization with Kotlin data classes, the `KotlinModule` should be registered to the `ObjectMapper`, which requires a custom `ObjectMapper`. The workaround is using records.

In this fix, I added the `ObjectMapper` to the constructor of `FunctionCallbackWrapper`. No null-check is required as this constructor is private and `Builder` is the only way to create new instances of `FunctionCallbackWrapper`. Null-check is already done in the `build` method of `Builder`. The default value of `ObjectMapper` is the same as before, which is also already defined in `Builder`.
