### PR TITLE
Update ollama-chat.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -268,7 +268,7 @@ Flux<ChatResponse> response = chatClient.stream(
 
 The `OllamaOptions` provides the configuration information for all chat requests.
 
-== Low-level OpenAiApi Client [[low-level-api]]
+== Low-level OllamaApi Client [[low-level-api]]
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java[OllamaApi] provides is lightweight Java client for Ollama Chat API link:https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion[Ollama Chat Completion API].
 


### PR DESCRIPTION
Fix typo in API class name: OpenAiApi -> OllamaApi

This commit fixes a typo in the API class name mentioned in the documentation. The previous sentence "Low-level OpenAiApi Client" now correctly reads "Low-level OllamaApi Client."
