### PR TITLE
Refactor filter expression for clarity and accuracy

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
@@ -145,7 +145,7 @@ vectorStore.similaritySearch(SearchRequest.defaults()
     .withTopK(TOP_K)
     .withSimilarityThreshold(SIMILARITY_THRESHOLD)
     .withFilterExpression(b.and(
-        b.in("john", "jill"),
+        b.in("author","john", "jill"),
         b.eq("article_type", "blog")).build()));
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mongodb.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mongodb.adoc
@@ -74,7 +74,7 @@ vectorStore.similaritySearch(SearchRequest.defaults()
                     .withTopK(TOP_K)
                     .withSimilarityThreshold(SIMILARITY_THRESHOLD)
                     .withFilterExpression(b.and(
-                            b.in("john", "jill"),
+                            b.in("author", "john", "jill"),
                             b.eq("article_type", "blog")).build()));
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
@@ -159,7 +159,7 @@ vectorStore.similaritySearch(SearchRequest.defaults()
                     .withTopK(TOP_K)
                     .withSimilarityThreshold(SIMILARITY_THRESHOLD)
                     .withFilterExpression(b.and(
-                            b.in("john", "jill"),
+                            b.in("author", "john", "jill"),
                             b.eq("article_type", "blog")).build()));
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/qdrant.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/qdrant.adoc
@@ -171,7 +171,7 @@ vectorStore.similaritySearch(SearchRequest.defaults()
     .withTopK(TOP_K)
     .withSimilarityThreshold(SIMILARITY_THRESHOLD)
     .withFilterExpression(b.and(
-        b.in("john", "jill"),
+        b.in("author", "john", "jill"),
         b.eq("article_type", "blog")).build()));
 ----
 


### PR DESCRIPTION
The filter expression within the document handling logic has been updated to enhance clarity and ensure accurate author filtering. Previously, the `in` function mistakenly included names as direct arguments, potentially leading to ambiguity in filter application. This has been corrected by explicitly specifying the `author` field, ensuring the filter accurately applies to author names only. This change improves the maintainability and readability of the code, particularly in sections dealing with article filtering based on authorship and type.

- Correct the filter expression by explicitly specifying the `author` field.
- Ensure accurate and unambiguous author filtering in article management.
