### PR TITLE
Enhancing Elasticsearch vector store implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
 		<pgvector.version>0.1.4</pgvector.version>
 		<sap.hanadb.version>2.20.11</sap.hanadb.version>
 		<postgresql.version>42.7.2</postgresql.version>
+		<elasticsearch-java.version>8.13.3</elasticsearch-java.version>
 		<milvus.version>2.3.4</milvus.version>
 		<pinecone.version>0.8.0</pinecone.version>
 		<fastjson.version>2.0.46</fastjson.version>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -134,10 +134,17 @@ Properties starting with the `spring.ai.vectorstore.elasticsearch.*` prefix are 
 
 |`spring.ai.vectorstore.elasticsearch.index-name` | The name of the index to store the vectors. | spring-ai-document-index
 |`spring.ai.vectorstore.elasticsearch.dimensions` | The number of dimensions in the vector. | 1536
-|`spring.ai.vectorstore.elasticsearch.dense-vector-indexing` | Whether to use dense vector indexing. | true
 |`spring.ai.vectorstore.elasticsearch.similarity` | The similarity function to use. | `cosine`
 |`spring.ai.vectorstore.elasticsearch.initialize-schema`| whether to initialize the required schema  | `false`
 |===
+
+The following similarity functions are available:
+
+* cosine
+* l2_norm
+* dot_product
+
+More details about each in the https://www.elastic.co/guide/en/elasticsearch/reference/master/dense-vector.html#dense-vector-params[Elasticsearch Documentation] on dense vectors.
 
 == Metadata Filtering
 
@@ -214,10 +221,11 @@ Read the link:https://www.elastic.co/guide/en/elasticsearch/client/java-api-clie
 ----
 @Bean
 public RestClient restClient() {
-    RestClientBuilder builder = RestClient.builder(new HttpHost("<host>", 9200, "http"));
-    Header[] defaultHeaders = new Header[] { new BasicHeader("Authorization", "Basic <encoded username and password>") };
-    builder.setDefaultHeaders(defaultHeaders);
-    return builder.build();
+    RestClient.builder(new HttpHost("<host>", 9200, "http"))
+        .setDefaultHeaders(new Header[]{
+            new BasicHeader("Authorization", "Basic <encoded username and password>")
+        })
+        .build();
 }
 ----
 

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -260,6 +260,7 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Elasticsearch Vector Store-->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-elasticsearch-store</artifactId>
@@ -279,6 +280,12 @@
 			<artifactId>spring-ai-zhipuai</artifactId>
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>co.elastic.clients</groupId>
+			<artifactId>elasticsearch-java</artifactId>
+			<version>${elasticsearch-java.version}</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
@@ -28,6 +28,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * @author Eddú Meléndez
  * @author Wei Jiang
@@ -52,10 +54,7 @@ class ElasticsearchVectorStoreAutoConfiguration {
 		if (properties.getDimensions() != null) {
 			elasticsearchVectorStoreOptions.setDimensions(properties.getDimensions());
 		}
-		if (properties.isDenseVectorIndexing() != null) {
-			elasticsearchVectorStoreOptions.setDenseVectorIndexing(properties.isDenseVectorIndexing());
-		}
-		if (StringUtils.hasText(properties.getSimilarity())) {
+		if (properties.getSimilarity() != null) {
 			elasticsearchVectorStoreOptions.setSimilarity(properties.getSimilarity());
 		}
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
@@ -28,8 +28,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.util.StringUtils;
 
-import java.util.Objects;
-
 /**
  * @author Eddú Meléndez
  * @author Wei Jiang

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreProperties.java
@@ -16,6 +16,7 @@
 package org.springframework.ai.autoconfigure.vectorstore.elasticsearch;
 
 import org.springframework.ai.autoconfigure.CommonVectorStoreProperties;
+import org.springframework.ai.vectorstore.SimilarityFunction;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -38,14 +39,9 @@ public class ElasticsearchVectorStoreProperties extends CommonVectorStorePropert
 	private Integer dimensions;
 
 	/**
-	 * Whether to use dense vector indexing.
-	 */
-	private Boolean denseVectorIndexing;
-
-	/**
 	 * The similarity function to use.
 	 */
-	private String similarity;
+	private SimilarityFunction similarity;
 
 	public String getIndexName() {
 		return this.indexName;
@@ -63,19 +59,11 @@ public class ElasticsearchVectorStoreProperties extends CommonVectorStorePropert
 		this.dimensions = dimensions;
 	}
 
-	public Boolean isDenseVectorIndexing() {
-		return denseVectorIndexing;
-	}
-
-	public void setDenseVectorIndexing(Boolean denseVectorIndexing) {
-		this.denseVectorIndexing = denseVectorIndexing;
-	}
-
-	public String getSimilarity() {
+	public SimilarityFunction getSimilarity() {
 		return similarity;
 	}
 
-	public void setSimilarity(String similarity) {
+	public void setSimilarity(SimilarityFunction similarity) {
 		this.similarity = similarity;
 	}
 

--- a/vector-stores/spring-ai-elasticsearch-store/pom.xml
+++ b/vector-stores/spring-ai-elasticsearch-store/pom.xml
@@ -35,6 +35,7 @@
 		<dependency>
 			<groupId>co.elastic.clients</groupId>
 			<artifactId>elasticsearch-java</artifactId>
+			<version>8.13.2</version>
 		</dependency>
 
 		<!-- TESTING -->

--- a/vector-stores/spring-ai-elasticsearch-store/pom.xml
+++ b/vector-stores/spring-ai-elasticsearch-store/pom.xml
@@ -45,7 +45,6 @@
 			<scope>test</scope>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>

--- a/vector-stores/spring-ai-elasticsearch-store/pom.xml
+++ b/vector-stores/spring-ai-elasticsearch-store/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>co.elastic.clients</groupId>
 			<artifactId>elasticsearch-java</artifactId>
-			<version>8.13.2</version>
+			<version>${elasticsearch-java.version}</version>
 		</dependency>
 
 		<!-- TESTING -->

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -48,6 +48,7 @@ import static org.springframework.ai.vectorstore.SimilarityFunction.l2_norm;
 /**
  * @author Jemin Huh
  * @author Wei Jiang
+ * @author Laura Trotta
  * @since 1.0.0
  */
 public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
@@ -61,8 +62,6 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 	private final ElasticsearchVectorStoreOptions options;
 
 	private final FilterExpressionConverter filterExpressionConverter;
-
-	private String similarityFunction;
 
 	private final boolean initializeSchema;
 
@@ -134,7 +133,7 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 				threshold = 1 - threshold;
 			}
 			final float finalThreshold = threshold;
-			List<Float> vectors = this.embeddingClient.embed(searchRequest.getQuery())
+			List<Float> vectors = this.embeddingModel.embed(searchRequest.getQuery())
 				.stream()
 				.map(Double::floatValue)
 				.toList();
@@ -151,7 +150,6 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 					Document.class);
 
 			return res.hits().hits().stream().map(this::toDocument).collect(Collectors.toList());
-
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -16,10 +16,12 @@
 package org.springframework.ai.vectorstore;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.elasticsearch._types.mapping.DenseVectorProperty;
+import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
@@ -43,6 +45,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.Math.sqrt;
+import static org.springframework.ai.vectorstore.SimilarityFunction.l2_norm;
 
 /**
  * @author Jemin Huh
@@ -58,8 +61,6 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 	private final ElasticsearchClient elasticsearchClient;
 
 	private final ElasticsearchVectorStoreOptions options;
-
-	private String similarityFunction = SIMILARITY_DEFAULT;
 
 	private final FilterExpressionConverter filterExpressionConverter;
 
@@ -85,18 +86,18 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 
 	@Override
 	public void add(List<Document> documents) {
-		BulkRequest.Builder builkRequestBuilder = new BulkRequest.Builder();
+		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
 
 		for (Document document : documents) {
 			if (Objects.isNull(document.getEmbedding()) || document.getEmbedding().isEmpty()) {
 				logger.debug("Calling EmbeddingModel for document id = " + document.getId());
 				document.setEmbedding(this.embeddingModel.embed(document));
 			}
-			builkRequestBuilder.operations(op -> op
+			bulkRequestBuilder.operations(op -> op
 				.index(idx -> idx.index(this.options.getIndexName()).id(document.getId()).document(document)));
 		}
 
-		BulkResponse bulkRequest = bulkRequest(builkRequestBuilder.build());
+		BulkResponse bulkRequest = bulkRequest(bulkRequestBuilder.build());
 
 		if (bulkRequest.errors()) {
 			List<BulkResponseItem> bulkResponseItems = bulkRequest.items();
@@ -110,10 +111,10 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 
 	@Override
 	public Optional<Boolean> delete(List<String> idList) {
-		BulkRequest.Builder builkRequestBuilder = new BulkRequest.Builder();
+		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
 		for (String id : idList)
-			builkRequestBuilder.operations(op -> op.delete(idx -> idx.index(this.options.getIndexName()).id(id)));
-		return Optional.of(bulkRequest(builkRequestBuilder.build()).errors());
+			bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(this.options.getIndexName()).id(id)));
+		return Optional.of(bulkRequest(bulkRequestBuilder.build()).errors());
 	}
 
 	private BulkResponse bulkRequest(BulkRequest bulkRequest) {
@@ -131,7 +132,7 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 		try {
 			float threshold = (float) searchRequest.getSimilarityThreshold();
 			// reverting l2_norm distance to its original value
-			if (similarityFunction.equals("l2_norm")) {
+			if (options.getSimilarity().equals(l2_norm)) {
 				threshold = 1 - threshold;
 			}
 			final float finalThreshold = threshold;
@@ -141,11 +142,11 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 				.toList();
 
 			SearchResponse<Document> res = elasticsearchClient.search(
-					sr -> sr.index(this.index)
+					sr -> sr.index(options.getIndexName())
 						.knn(knn -> knn.queryVector(vectors)
 							.similarity(finalThreshold)
 							.k(searchRequest.getTopK())
-							.field(EMBEDDING)
+							.field("embedding")
 							.numCandidates((long) (1.5 * searchRequest.getTopK()))
 							.filter(fl -> fl.queryString(
 									qs -> qs.query(getElasticsearchQueryString(searchRequest.getFilterExpression()))))),
@@ -174,8 +175,8 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 	// more info on score/distance calculation
 	// https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#knn-similarity-search
 	private float calculateDistance(Float score) {
-		switch (similarityFunction) {
-			case "l2_norm":
+		switch (options.getSimilarity()) {
+			case l2_norm:
 				// the returned value of l2_norm is the opposite of the other functions
 				// (closest to zero means more accurate), so to make it consistent
 				// with the other functions the reverse is returned applying a "1-"
@@ -187,9 +188,9 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 		}
 	}
 
-	public boolean existsIndex() {
+	public boolean indexExists() {
 		try {
-			return this.elasticsearchClient.indices().exists(ex -> ex.index(this.index)).value();
+			return this.elasticsearchClient.indices().exists(ex -> ex.index(options.getIndexName())).value();
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);
@@ -199,18 +200,9 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 	private CreateIndexResponse createIndexMapping() {
 		try {
 			return this.elasticsearchClient.indices()
-				.create(createIndexBuilder -> createIndexBuilder.index(options.getIndexName())
-					.mappings(typeMappingBuilder -> {
-						typeMappingBuilder.properties("embedding",
-								new Property.Builder()
-									.denseVector(new DenseVectorProperty.Builder().dims(options.getDimensions())
-										.similarity(options.getSimilarity())
-										.index(options.isDenseVectorIndexing())
-										.build())
-									.build());
-
-						return typeMappingBuilder;
-					}));
+				.create(cr -> cr.index(options.getIndexName())
+					.mappings(map -> map.properties("embedding", p -> p.denseVector(
+							dv -> dv.similarity(options.getSimilarity().toString()).dims(options.getDimensions())))));
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -21,7 +21,6 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
-import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -16,8 +16,6 @@
 package org.springframework.ai.vectorstore;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.mapping.DenseVectorProperty;
-import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -145,7 +143,7 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 					sr -> sr.index(options.getIndexName())
 						.knn(knn -> knn.queryVector(vectors)
 							.similarity(finalThreshold)
-							.k(searchRequest.getTopK())
+							.k((long) searchRequest.getTopK())
 							.field("embedding")
 							.numCandidates((long) (1.5 * searchRequest.getTopK()))
 							.filter(fl -> fl.queryString(

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -128,15 +128,22 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 	@Override
 	public List<Document> similaritySearch(SearchRequest searchRequest) {
 		Assert.notNull(searchRequest, "The search request must not be null.");
-		return similaritySearch(this.embeddingModel.embed(searchRequest.getQuery()), searchRequest.getTopK(),
-				Double.valueOf(searchRequest.getSimilarityThreshold()).floatValue(),
-				searchRequest.getFilterExpression());
-	}
+		try {
+			float threshold = (float) searchRequest.getSimilarityThreshold();
+			// reverting l2_norm distance to its original value
+			if (similarityFunction.equals("l2_norm")) {
+				threshold = 1 - threshold;
+			}
+			final float finalThreshold = threshold;
+			List<Float> vectors = this.embeddingClient.embed(searchRequest.getQuery())
+				.stream()
+				.map(Double::floatValue)
+				.toList();
 
 			SearchResponse<Document> res = elasticsearchClient.search(
 					sr -> sr.index(this.index)
 						.knn(knn -> knn.queryVector(vectors)
-							.similarity((float) searchRequest.getSimilarityThreshold())
+							.similarity(finalThreshold)
 							.k(searchRequest.getTopK())
 							.field(EMBEDDING)
 							.numCandidates((long) (1.5 * searchRequest.getTopK()))
@@ -170,8 +177,10 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 		switch (similarityFunction) {
 			case "l2_norm":
 				// the returned value of l2_norm is the opposite of the other functions
-				// (closest to zero means more accurate)
-				return (float) (sqrt((1 / score) - 1));
+				// (closest to zero means more accurate), so to make it consistent
+				// with the other functions the reverse is returned applying a "1-"
+				// to the standard transformation
+				return (float) (1 - (sqrt((1 / score) - 1)));
 			// cosine and dot_product
 			default:
 				return (2 * score) - 1;

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreOptions.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreOptions.java
@@ -35,14 +35,9 @@ public class ElasticsearchVectorStoreOptions {
 	private int dimensions = 1536;
 
 	/**
-	 * Whether to use dense vector indexing.
-	 */
-	private boolean denseVectorIndexing = true;
-
-	/**
 	 * The similarity function to use.
 	 */
-	private String similarity = "cosine";
+	private SimilarityFunction similarity = SimilarityFunction.cosine;
 
 	public String getIndexName() {
 		return indexName;
@@ -60,19 +55,11 @@ public class ElasticsearchVectorStoreOptions {
 		this.dimensions = dims;
 	}
 
-	public boolean isDenseVectorIndexing() {
-		return denseVectorIndexing;
-	}
-
-	public void setDenseVectorIndexing(boolean denseVectorIndexing) {
-		this.denseVectorIndexing = denseVectorIndexing;
-	}
-
-	public String getSimilarity() {
+	public SimilarityFunction getSimilarity() {
 		return similarity;
 	}
 
-	public void setSimilarity(String similarity) {
+	public void setSimilarity(SimilarityFunction similarity) {
 		this.similarity = similarity;
 	}
 

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/SimilarityFunction.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/SimilarityFunction.java
@@ -1,0 +1,12 @@
+package org.springframework.ai.vectorstore;
+
+/*
+https://www.elastic.co/guide/en/elasticsearch/reference/master/dense-vector.html
+max_inner_product is currently not supported because the distance value is not
+normalized and would not comply with the requirement of being between 0 and 1
+*/
+public enum SimilarityFunction {
+
+	l2_norm, dot_product, cosine
+
+}

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/SimilarityFunction.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/SimilarityFunction.java
@@ -1,10 +1,13 @@
 package org.springframework.ai.vectorstore;
 
-/*
-https://www.elastic.co/guide/en/elasticsearch/reference/master/dense-vector.html
-max_inner_product is currently not supported because the distance value is not
-normalized and would not comply with the requirement of being between 0 and 1
-*/
+/**
+ * https://www.elastic.co/guide/en/elasticsearch/reference/master/dense-vector.html
+ * max_inner_product is currently not supported because the distance value is not
+ * normalized and would not comply with the requirement of being between 0 and 1
+ *
+ * @author Laura Trotta
+ * @since 1.0.0
+ */
 public enum SimilarityFunction {
 
 	l2_norm, dot_product, cosine

--- a/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
@@ -64,7 +64,7 @@ class ElasticsearchVectorStoreIT {
 
 	@Container
 	private static final ElasticsearchContainer elasticsearchContainer = new ElasticsearchContainer(
-			"docker.elastic.co/elasticsearch/elasticsearch:8.12.2")
+			"docker.elastic.co/elasticsearch/elasticsearch:8.13.3")
 		.withEnv("xpack.security.enabled", "false");
 
 	private final List<Document> documents = List.of(
@@ -338,24 +338,24 @@ class ElasticsearchVectorStoreIT {
 	public static class TestApplication {
 
 		@Bean("vectorStore_cosine")
-		public ElasticsearchVectorStore vectorStoreDefault(EmbeddingClient embeddingClient, RestClient restClient) {
-			return new ElasticsearchVectorStore(restClient, embeddingClient);
+		public ElasticsearchVectorStore vectorStoreDefault(EmbeddingModel embeddingModel, RestClient restClient) {
+			return new ElasticsearchVectorStore(restClient, embeddingModel, true);
 		}
 
 		@Bean("vectorStore_l2_norm")
-		public ElasticsearchVectorStore vectorStoreL2(EmbeddingClient embeddingClient, RestClient restClient) {
+		public ElasticsearchVectorStore vectorStoreL2(EmbeddingModel embeddingModel, RestClient restClient) {
 			ElasticsearchVectorStoreOptions options = new ElasticsearchVectorStoreOptions();
 			options.setIndexName("index_l2");
 			options.setSimilarity(SimilarityFunction.l2_norm);
-			return new ElasticsearchVectorStore(options, restClient, embeddingClient);
+			return new ElasticsearchVectorStore(options, restClient, embeddingModel,true);
 		}
 
 		@Bean("vectorStore_dot_product")
-		public ElasticsearchVectorStore vectorStoreDotProduct(EmbeddingClient embeddingClient, RestClient restClient) {
+		public ElasticsearchVectorStore vectorStoreDotProduct(EmbeddingModel embeddingModel, RestClient restClient) {
 			ElasticsearchVectorStoreOptions options = new ElasticsearchVectorStoreOptions();
 			options.setIndexName("index_dot_product");
 			options.setSimilarity(SimilarityFunction.dot_product);
-			return new ElasticsearchVectorStore(options, restClient, embeddingClient);
+			return new ElasticsearchVectorStore(options, restClient, embeddingModel,true);
 		}
 
 		@Bean

--- a/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
@@ -106,14 +106,6 @@ class ElasticsearchVectorStoreIT {
 		}
 	}
 
-	private double getThreshold(String similarity) {
-		// l2_norm works in reverse: accept all threshold = 1, accept none = 0
-		if (similarity.equals("l2_norm")) {
-			return 1.0;
-		}
-		return 0.0;
-	}
-
 	@BeforeEach
 	void cleanDatabase() {
 		getContextRunner().run(context -> {
@@ -139,15 +131,14 @@ class ElasticsearchVectorStoreIT {
 
 			vectorStore.add(documents);
 
-			double threshold = getThreshold(similarityFunction);
-
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(
-						SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(threshold)),
-						hasSize(1));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Great Depression")
+					.withTopK(1)
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(1));
 
-			List<Document> results = vectorStore.similaritySearch(
-					SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(threshold));
+			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Great Depression")
+				.withTopK(1)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -161,9 +152,9 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(
-						SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(threshold)),
-						hasSize(0));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Great Depression")
+					.withTopK(1)
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(0));
 		});
 	}
 
@@ -185,16 +176,14 @@ class ElasticsearchVectorStoreIT {
 
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
-			double threshold = getThreshold(similarityFunction);
-
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("The World").withTopK(5).withSimilarityThreshold(threshold)),
-						hasSize(3));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(3));
 
 			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression("country == 'NL'"));
 
 			assertThat(results).hasSize(1);
@@ -202,7 +191,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression("country == 'BG'"));
 
 			assertThat(results).hasSize(2);
@@ -211,7 +200,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression("country == 'BG' && year == 2020"));
 
 			assertThat(results).hasSize(1);
@@ -219,7 +208,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression("country in ['BG']"));
 
 			assertThat(results).hasSize(2);
@@ -228,14 +217,14 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression("country in ['BG','NL']"));
 
 			assertThat(results).hasSize(3);
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression("country not in ['BG']"));
 
 			assertThat(results).hasSize(1);
@@ -243,7 +232,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression("NOT(country not in ['BG'])"));
 
 			assertThat(results).hasSize(2);
@@ -252,7 +241,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
 				.withFilterExpression(
 						"activationDate > " + ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
 
@@ -280,15 +269,14 @@ class ElasticsearchVectorStoreIT {
 					Map.of("meta1", "meta1"));
 			vectorStore.add(List.of(document));
 
-			double threshold = getThreshold(similarityFunction);
-
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(threshold).withTopK(5)),
-						hasSize(1));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Spring")
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+					.withTopK(5)), hasSize(1));
 
-			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(threshold).withTopK(5));
+			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Spring")
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withTopK(5));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -303,7 +291,7 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.add(List.of(sameIdDocument));
 			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar")
 				.withTopK(5)
-				.withSimilarityThreshold(threshold);
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
 
 			Awaitility.await()
 				.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
@@ -336,11 +324,9 @@ class ElasticsearchVectorStoreIT {
 
 			vectorStore.add(documents);
 
-			double threshold = getThreshold(similarityFunction);
-
 			SearchRequest query = SearchRequest.query("Great Depression")
 				.withTopK(50)
-				.withSimilarityThreshold(threshold);
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
 
 			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
 
@@ -366,9 +352,9 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(
-						SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(threshold)),
-						hasSize(0));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Great Depression")
+					.withTopK(50)
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(0));
 		});
 	}
 

--- a/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
@@ -93,14 +93,13 @@ class ElasticsearchVectorStoreIT {
 		return new ApplicationContextRunner().withUserConfiguration(TestApplication.class);
 	}
 
-
 	@BeforeEach
 	void cleanDatabase() {
 		getContextRunner().run(context -> {
 			// deleting indices and data before following tests
 			ElasticsearchClient elasticsearchClient = context.getBean(ElasticsearchClient.class);
 			List indices = elasticsearchClient.cat().indices().valueBody().stream().map(IndicesRecord::index).toList();
-			if(!indices.isEmpty()) {
+			if (!indices.isEmpty()) {
 				elasticsearchClient.indices().delete(del -> del.index(indices));
 			}
 		});
@@ -112,7 +111,8 @@ class ElasticsearchVectorStoreIT {
 
 		getContextRunner().run(context -> {
 
-			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_"+similarityFunction, ElasticsearchVectorStore.class);
+			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					ElasticsearchVectorStore.class);
 
 			vectorStore.add(documents);
 
@@ -147,7 +147,8 @@ class ElasticsearchVectorStoreIT {
 	public void searchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_"+similarityFunction, ElasticsearchVectorStore.class);
+			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					ElasticsearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -243,7 +244,8 @@ class ElasticsearchVectorStoreIT {
 	public void documentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_"+similarityFunction, ElasticsearchVectorStore.class);
+			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					ElasticsearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
@@ -295,7 +297,8 @@ class ElasticsearchVectorStoreIT {
 	@ValueSource(strings = { "cosine", "l2_norm", "dot_product" })
 	public void searchThresholdTest(String similarityFunction) {
 		getContextRunner().run(context -> {
-			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_"+similarityFunction, ElasticsearchVectorStore.class);
+			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					ElasticsearchVectorStore.class);
 
 			vectorStore.add(documents);
 
@@ -344,7 +347,7 @@ class ElasticsearchVectorStoreIT {
 			ElasticsearchVectorStoreOptions options = new ElasticsearchVectorStoreOptions();
 			options.setIndexName("index_l2");
 			options.setSimilarity(SimilarityFunction.l2_norm);
-			return new ElasticsearchVectorStore(options,restClient, embeddingClient);
+			return new ElasticsearchVectorStore(options, restClient, embeddingClient);
 		}
 
 		@Bean("vectorStore_dot_product")
@@ -352,7 +355,7 @@ class ElasticsearchVectorStoreIT {
 			ElasticsearchVectorStoreOptions options = new ElasticsearchVectorStoreOptions();
 			options.setIndexName("index_dot_product");
 			options.setSimilarity(SimilarityFunction.dot_product);
-			return new ElasticsearchVectorStore(options,restClient, embeddingClient);
+			return new ElasticsearchVectorStore(options, restClient, embeddingClient);
 		}
 
 		@Bean
@@ -372,4 +375,5 @@ class ElasticsearchVectorStoreIT {
 		}
 
 	}
+
 }

--- a/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/ElasticsearchVectorStoreIT.java
@@ -132,13 +132,12 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.add(documents);
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Great Depression")
-					.withTopK(1)
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThresholdAll()),
+						hasSize(1));
 
-			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Great Depression")
-				.withTopK(1)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL));
+			List<Document> results = vectorStore
+				.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThresholdAll());
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -152,9 +151,9 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Great Depression")
-					.withTopK(1)
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(0));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThresholdAll()),
+						hasSize(0));
 		});
 	}
 
@@ -177,13 +176,13 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(3));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("The World").withTopK(5).withSimilarityThresholdAll()),
+						hasSize(3));
 
 			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression("country == 'NL'"));
 
 			assertThat(results).hasSize(1);
@@ -191,7 +190,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression("country == 'BG'"));
 
 			assertThat(results).hasSize(2);
@@ -200,7 +199,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression("country == 'BG' && year == 2020"));
 
 			assertThat(results).hasSize(1);
@@ -208,7 +207,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression("country in ['BG']"));
 
 			assertThat(results).hasSize(2);
@@ -217,14 +216,14 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression("country in ['BG','NL']"));
 
 			assertThat(results).hasSize(3);
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression("country not in ['BG']"));
 
 			assertThat(results).hasSize(1);
@@ -232,7 +231,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression("NOT(country not in ['BG'])"));
 
 			assertThat(results).hasSize(2);
@@ -241,7 +240,7 @@ class ElasticsearchVectorStoreIT {
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
 				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
+				.withSimilarityThresholdAll()
 				.withFilterExpression(
 						"activationDate > " + ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
 
@@ -270,13 +269,12 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.add(List.of(document));
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Spring")
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
-					.withTopK(5)), hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withSimilarityThresholdAll().withTopK(5)),
+						hasSize(1));
 
-			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Spring")
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)
-				.withTopK(5));
+			List<Document> results = vectorStore
+				.similaritySearch(SearchRequest.query("Spring").withSimilarityThresholdAll().withTopK(5));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -289,9 +287,7 @@ class ElasticsearchVectorStoreIT {
 					"The World is Big and Salvation Lurks Around the Corner", Map.of("meta2", "meta2"));
 
 			vectorStore.add(List.of(sameIdDocument));
-			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar")
-				.withTopK(5)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar").withTopK(5).withSimilarityThresholdAll();
 
 			Awaitility.await()
 				.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
@@ -324,9 +320,7 @@ class ElasticsearchVectorStoreIT {
 
 			vectorStore.add(documents);
 
-			SearchRequest query = SearchRequest.query("Great Depression")
-				.withTopK(50)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+			SearchRequest query = SearchRequest.query("Great Depression").withTopK(50).withSimilarityThresholdAll();
 
 			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
 
@@ -352,9 +346,8 @@ class ElasticsearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("Great Depression")
-					.withTopK(50)
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL)), hasSize(0));
+				.until(() -> vectorStore.similaritySearch(
+						SearchRequest.query("Great Depression").withTopK(50).withSimilarityThresholdAll()), hasSize(0));
 		});
 	}
 


### PR DESCRIPTION
This PR provides a more performant search function for the Elasticsearch vector store and removes the bean autoconfiguration.

## In depth

### Autoconfiguration

The current implementation of `afterPropertiesSet()` automatically creates a new index with a set of properties that only works with OpenAI, or any other model that works with vectors with a dimension of 1536; users adopting other models would currently have to manually delete the index. By default, Elasticsearch automatically creates the correct index settings when it receives the first PUT request for vectors, so in our opinion there's no need for such autoconfiguration. 

### Search

The function used now is [script_score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-score-query.html), which can be slow for large data samples since it does a brute force comparison with all vectors using the similarity function. This PR replaces it with the approximate [knn search](https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html), more performant because it only scans the closest neighbours. The similarity functions available for `knn` can be easily configured in the index mapping by setting the correct name. 

##

We would also like to contribute to the documentation, should that be done in a different PR?  

Thank you @JM-Lab for the original implementation, would you like to review these changes?

 (Disclosure: I work for Elastic)



