### PR TITLE
Fix bean name conflicts when using BedrockAnthropic and BedrockAnthropic3 at the same time.

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/anthropic3/BedrockAnthropic3ChatAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/anthropic3/BedrockAnthropic3ChatAutoConfiguration.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
  * Leverages the Spring Cloud AWS to resolve the {@link AwsCredentialsProvider}.
  *
  * @author Christian Tzolov
+ * @author Wei Jiang
  * @since 0.8.0
  */
 @AutoConfiguration
@@ -46,14 +47,14 @@ public class BedrockAnthropic3ChatAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Anthropic3ChatBedrockApi anthropicApi(AwsCredentialsProvider credentialsProvider,
+	public Anthropic3ChatBedrockApi anthropic3Api(AwsCredentialsProvider credentialsProvider,
 			BedrockAnthropic3ChatProperties properties, BedrockAwsConnectionProperties awsProperties) {
 		return new Anthropic3ChatBedrockApi(properties.getModel(), credentialsProvider, awsProperties.getRegion(),
 				new ObjectMapper(), awsProperties.getTimeout());
 	}
 
 	@Bean
-	public BedrockAnthropic3ChatClient anthropicChatClient(Anthropic3ChatBedrockApi anthropicApi,
+	public BedrockAnthropic3ChatClient anthropic3ChatClient(Anthropic3ChatBedrockApi anthropicApi,
 			BedrockAnthropic3ChatProperties properties) {
 		return new BedrockAnthropic3ChatClient(anthropicApi, properties.getOptions());
 	}


### PR DESCRIPTION
When enabling bedrock anthropic and anthropic3 at the same time, it will throw the bean name conflict exception.
```
spring:
  ai:
    bedrock:
      anthropic:
        chat:
          enabled: true
      anthropic3:
        chat:
          enabled: true

```

>
>The bean 'anthropicApi', defined in class path resource [org/springframework/ai/autoconfigure/bedrock/anthropic3/BedrockAnthropic3ChatAutoConfiguration.class], could not be registered. A bean with that name has already been defined in class path resource [org/springframework/ai/autoconfigure/bedrock/anthropic/BedrockAnthropicChatAutoConfiguration.class] and overriding is disabled.
>

So change the anthropic3 to a proper bean name to avoid this issue.