### PR TITLE
Bedrock AI models add usage information.

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/BedrockUsage.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/BedrockUsage.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.bedrock;
 
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetrics;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.util.Assert;
@@ -23,38 +24,45 @@ import org.springframework.util.Assert;
  * {@link Usage} implementation for Bedrock API.
  *
  * @author Christian Tzolov
+ * @author Wei Jiang
  * @since 0.8.0
  */
 public class BedrockUsage implements Usage {
 
 	public static BedrockUsage from(AmazonBedrockInvocationMetrics usage) {
-		return new BedrockUsage(usage);
+		Assert.notNull(usage, "Amazon Bedrock Usage must not be null");
+
+		return new BedrockUsage(usage.inputTokenCount().longValue(), usage.outputTokenCount().longValue());
 	}
 
-	private final AmazonBedrockInvocationMetrics usage;
+	public static BedrockUsage from(AmazonBedrockInvocationMetadata metadata) {
+		Assert.notNull(metadata, "Amazon Bedrock Invocation Metadata must not be null");
 
-	protected BedrockUsage(AmazonBedrockInvocationMetrics usage) {
-		Assert.notNull(usage, "OpenAI Usage must not be null");
-		this.usage = usage;
+		return new BedrockUsage(metadata.inputTokenCount(), metadata.outputTokenCount());
 	}
 
-	protected AmazonBedrockInvocationMetrics getUsage() {
-		return this.usage;
+	private Long promptTokens;
+
+	private Long generationTokens;
+
+	protected BedrockUsage(Long promptTokens, Long generationTokens) {
+		this.promptTokens = promptTokens;
+		this.generationTokens = generationTokens;
 	}
 
 	@Override
 	public Long getPromptTokens() {
-		return getUsage().inputTokenCount().longValue();
+		return this.promptTokens;
 	}
 
 	@Override
 	public Long getGenerationTokens() {
-		return getUsage().outputTokenCount().longValue();
+		return this.generationTokens;
 	}
 
 	@Override
 	public String toString() {
-		return getUsage().toString();
+		return "BedrockUsage [promptTokens=" + promptTokens + ", generationTokens=" + generationTokens + "]";
 	}
 
 }

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatClient.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatClient.java
@@ -27,6 +27,8 @@ import org.springframework.ai.bedrock.MessageToPromptConverter;
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi;
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatRequest;
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatResponse;
+import org.springframework.ai.bedrock.anthropic.metadata.BedrockAnthropicChatResponseMetadata;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
 import org.springframework.ai.chat.StreamingChatClient;
 import org.springframework.ai.chat.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -37,6 +39,7 @@ import org.springframework.ai.model.ModelOptionsUtils;
  * generative.
  *
  * @author Christian Tzolov
+ * @author Wei Jiang
  * @since 0.8.0
  */
 public class BedrockAnthropicChatClient implements ChatClient, StreamingChatClient {
@@ -65,9 +68,16 @@ public class BedrockAnthropicChatClient implements ChatClient, StreamingChatClie
 
 		AnthropicChatRequest request = createRequest(prompt);
 
-		AnthropicChatResponse response = this.anthropicChatApi.chatCompletion(request);
+		AmazonBedrockInvocationContext<AnthropicChatResponse> context = anthropicChatApi.chatCompletion(request);
 
-		return new ChatResponse(List.of(new Generation(response.completion())));
+		AnthropicChatResponse response = context.response();
+
+		List<Generation> generations = List.of(new Generation(response.completion()));
+
+		BedrockAnthropicChatResponseMetadata chatResponseMetadata = BedrockAnthropicChatResponseMetadata.from(response,
+				context.metadata());
+
+		return new ChatResponse(generations, chatResponseMetadata);
 	}
 
 	@Override

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApi.java
@@ -238,7 +238,7 @@ public class AnthropicChatBedrockApi extends
 	}
 
 	@Override
-	public AnthropicChatResponse chatCompletion(AnthropicChatRequest anthropicRequest) {
+	public AmazonBedrockInvocationContext<AnthropicChatResponse> chatCompletion(AnthropicChatRequest anthropicRequest) {
 		Assert.notNull(anthropicRequest, "'anthropicRequest' must not be null");
 		return this.internalInvocation(anthropicRequest, AnthropicChatResponse.class);
 	}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/metadata/BedrockAnthropicChatResponseMetadata.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/metadata/BedrockAnthropicChatResponseMetadata.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic.metadata;
+
+import org.springframework.ai.bedrock.BedrockUsage;
+import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatResponse;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ChatResponseMetadata} implementation for
+ * {@literal Amazon Bedrock Anthropic Chat Model}.
+ *
+ * @author Wei Jiang
+ * @see ChatResponseMetadata
+ * @since 0.8.1
+ */
+public class BedrockAnthropicChatResponseMetadata implements ChatResponseMetadata {
+
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, id: %2$s, latency: %3$s, usage: %4$s, rateLimit: %5$s }";
+
+	public static BedrockAnthropicChatResponseMetadata from(AnthropicChatResponse response,
+			AmazonBedrockInvocationMetadata invocationMetadata) {
+		Assert.notNull(invocationMetadata, "Bedrock invocation metadata must not be null");
+
+		BedrockUsage usage = BedrockUsage.from(invocationMetadata);
+
+		BedrockAnthropicChatResponseMetadata chatResponseMetadata = new BedrockAnthropicChatResponseMetadata(
+				invocationMetadata.awsRequestId(), invocationMetadata.invocationLatency(), usage);
+		return chatResponseMetadata;
+	}
+
+	private final String id;
+
+	private Long invocationLatency;
+
+	private final Usage usage;
+
+	protected BedrockAnthropicChatResponseMetadata(String id, Long invocationLatency, BedrockUsage usage) {
+		this.id = id;
+		this.invocationLatency = invocationLatency;
+		this.usage = usage;
+	}
+
+	public String getId() {
+		return this.id;
+	}
+
+	public Long getInvocationLatency() {
+		return this.invocationLatency;
+	}
+
+	@Override
+	public Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public PromptMetadata getPromptMetadata() {
+		return PromptMetadata.empty();
+	}
+
+	@Override
+	public String toString() {
+		return AI_METADATA_STRING.formatted(getClass().getTypeName(), getId(), getInvocationLatency(), getUsage(),
+				getRateLimit());
+	}
+
+}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatClient.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatClient.java
@@ -20,6 +20,8 @@ import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.An
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.AnthropicChatResponse;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.AnthropicChatStreamingResponse.StreamingType;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.MediaContent;
+import org.springframework.ai.bedrock.anthropic3.metadata.BedrockAnthropic3ChatResponseMetadata;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.ChatCompletionMessage;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.ChatCompletionMessage.Role;
 import org.springframework.ai.chat.ChatClient;
@@ -48,6 +50,7 @@ import java.util.stream.Collectors;
  *
  * @author Ben Middleton
  * @author Christian Tzolov
+ * @author Wei Jiang
  * @since 1.0.0
  */
 public class BedrockAnthropic3ChatClient implements ChatClient, StreamingChatClient {
@@ -76,9 +79,16 @@ public class BedrockAnthropic3ChatClient implements ChatClient, StreamingChatCli
 
 		AnthropicChatRequest request = createRequest(prompt);
 
-		AnthropicChatResponse response = this.anthropicChatApi.chatCompletion(request);
+		AmazonBedrockInvocationContext<AnthropicChatResponse> context = this.anthropicChatApi.chatCompletion(request);
 
-		return new ChatResponse(List.of(new Generation(response.content().get(0).text())));
+		AnthropicChatResponse response = context.response();
+
+		List<Generation> generations = List.of(new Generation(response.content().get(0).text()));
+
+		BedrockAnthropic3ChatResponseMetadata chatResponseMetadata = BedrockAnthropic3ChatResponseMetadata
+			.from(response, context.metadata());
+
+		return new ChatResponse(generations, chatResponseMetadata);
 	}
 
 	@Override

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/Anthropic3ChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/Anthropic3ChatBedrockApi.java
@@ -459,7 +459,7 @@ public class Anthropic3ChatBedrockApi extends
 	}
 
 	@Override
-	public AnthropicChatResponse chatCompletion(AnthropicChatRequest anthropicRequest) {
+	public AmazonBedrockInvocationContext<AnthropicChatResponse> chatCompletion(AnthropicChatRequest anthropicRequest) {
 		Assert.notNull(anthropicRequest, "'anthropicRequest' must not be null");
 		return this.internalInvocation(anthropicRequest, AnthropicChatResponse.class);
 	}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/metadata/BedrockAnthropic3ChatResponseMetadata.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/metadata/BedrockAnthropic3ChatResponseMetadata.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3.metadata;
+
+import org.springframework.ai.bedrock.BedrockUsage;
+import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.AnthropicChatResponse;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ChatResponseMetadata} implementation for
+ * {@literal Amazon Bedrock Anthropic Chat Model}.
+ *
+ * @author Wei Jiang
+ * @see ChatResponseMetadata
+ * @since 0.8.1
+ */
+public class BedrockAnthropic3ChatResponseMetadata implements ChatResponseMetadata {
+
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, id: %2$s, latency: %3$s, usage: %4$s, rateLimit: %5$s }";
+
+	public static BedrockAnthropic3ChatResponseMetadata from(AnthropicChatResponse response,
+			AmazonBedrockInvocationMetadata invocationMetadata) {
+		Assert.notNull(invocationMetadata, "Bedrock invocation metadata must not be null");
+
+		BedrockUsage usage = BedrockUsage.from(invocationMetadata);
+
+		BedrockAnthropic3ChatResponseMetadata chatResponseMetadata = new BedrockAnthropic3ChatResponseMetadata(
+				response.id(), invocationMetadata.invocationLatency(), usage);
+		return chatResponseMetadata;
+	}
+
+	private final String id;
+
+	private Long invocationLatency;
+
+	private final Usage usage;
+
+	protected BedrockAnthropic3ChatResponseMetadata(String id, Long invocationLatency, BedrockUsage usage) {
+		this.id = id;
+		this.invocationLatency = invocationLatency;
+		this.usage = usage;
+	}
+
+	public String getId() {
+		return this.id;
+	}
+
+	public Long getInvocationLatency() {
+		return this.invocationLatency;
+	}
+
+	@Override
+	public Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public PromptMetadata getPromptMetadata() {
+		return PromptMetadata.empty();
+	}
+
+	@Override
+	public String toString() {
+		return AI_METADATA_STRING.formatted(getClass().getTypeName(), getId(), getInvocationLatency(), getUsage(),
+				getRateLimit());
+	}
+
+}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingClient.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingClient.java
@@ -104,7 +104,7 @@ public class BedrockCohereEmbeddingClient extends AbstractEmbeddingClient {
 
 		var apiRequest = new CohereEmbeddingRequest(request.getInstructions(), optionsToUse.getInputType(),
 				optionsToUse.getTruncate());
-		CohereEmbeddingResponse apiResponse = this.embeddingApi.embedding(apiRequest);
+		CohereEmbeddingResponse apiResponse = this.embeddingApi.embedding(apiRequest).response();
 		var indexCounter = new AtomicInteger(0);
 		List<Embedding> embeddings = apiResponse.embeddings()
 			.stream()

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereChatBedrockApi.java
@@ -377,7 +377,7 @@ public class CohereChatBedrockApi extends
 	}
 
 	@Override
-	public CohereChatResponse chatCompletion(CohereChatRequest request) {
+	public AmazonBedrockInvocationContext<CohereChatResponse> chatCompletion(CohereChatRequest request) {
 		Assert.isTrue(!request.stream(), "The request must be configured to return the complete response!");
 		return this.internalInvocation(request, CohereChatResponse.class);
 	}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
@@ -202,7 +202,7 @@ public class CohereEmbeddingBedrockApi extends
 	}
 
 	@Override
-	public CohereEmbeddingResponse embedding(CohereEmbeddingRequest request) {
+	public AmazonBedrockInvocationContext<CohereEmbeddingResponse> embedding(CohereEmbeddingRequest request) {
 		return this.internalInvocation(request, CohereEmbeddingResponse.class);
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/metadata/CohereChatResponseMetadata.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/metadata/CohereChatResponseMetadata.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.cohere.metadata;
+
+import org.springframework.ai.bedrock.BedrockUsage;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
+import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatResponse;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ChatResponseMetadata} implementation for
+ * {@literal Amazon Bedrock Cohere chat model}.
+ *
+ * @author Wei Jiang
+ * @see ChatResponseMetadata
+ * @since 0.8.1
+ */
+public class CohereChatResponseMetadata implements ChatResponseMetadata {
+
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, id: %2$s, latency: %3$s, usage: %4$s, rateLimit: %5$s }";
+
+	public static CohereChatResponseMetadata from(CohereChatResponse response,
+			AmazonBedrockInvocationMetadata invocationMetadata) {
+		Assert.notNull(invocationMetadata, "Bedrock invocation metadata must not be null");
+
+		BedrockUsage usage = BedrockUsage.from(invocationMetadata);
+
+		CohereChatResponseMetadata chatResponseMetadata = new CohereChatResponseMetadata(response.id(),
+				invocationMetadata.invocationLatency(), usage);
+		return chatResponseMetadata;
+	}
+
+	private final String id;
+
+	private Long invocationLatency;
+
+	private final Usage usage;
+
+	protected CohereChatResponseMetadata(String id, Long invocationLatency, BedrockUsage usage) {
+		this.id = id;
+		this.invocationLatency = invocationLatency;
+		this.usage = usage;
+	}
+
+	public String getId() {
+		return this.id;
+	}
+
+	public Long getInvocationLatency() {
+		return this.invocationLatency;
+	}
+
+	@Override
+	public Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public PromptMetadata getPromptMetadata() {
+		return PromptMetadata.empty();
+	}
+
+	@Override
+	public String toString() {
+		return AI_METADATA_STRING.formatted(getClass().getTypeName(), getId(), getInvocationLatency(), getUsage(),
+				getRateLimit());
+	}
+
+}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/api/Ai21Jurassic2ChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/api/Ai21Jurassic2ChatBedrockApi.java
@@ -382,7 +382,7 @@ public class Ai21Jurassic2ChatBedrockApi extends
 	}
 
 	@Override
-	public Ai21Jurassic2ChatResponse chatCompletion(Ai21Jurassic2ChatRequest request) {
+	public AmazonBedrockInvocationContext<Ai21Jurassic2ChatResponse> chatCompletion(Ai21Jurassic2ChatRequest request) {
 		return this.internalInvocation(request, Ai21Jurassic2ChatResponse.class);
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/metadata/BedrockAi21Jurassic2ChatResponseMetadata.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/metadata/BedrockAi21Jurassic2ChatResponseMetadata.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.jurassic2.metadata;
+
+import org.springframework.ai.bedrock.BedrockUsage;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
+import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatResponse;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ChatResponseMetadata} implementation for
+ * {@literal Amazon Bedrock Ai21Jurassic2 chat model}.
+ *
+ * @author Wei Jiang
+ * @see ChatResponseMetadata
+ * @since 0.8.1
+ */
+public class BedrockAi21Jurassic2ChatResponseMetadata implements ChatResponseMetadata {
+
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, id: %2$s, latency: %3$s, usage: %4$s, rateLimit: %5$s }";
+
+	public static BedrockAi21Jurassic2ChatResponseMetadata from(Ai21Jurassic2ChatResponse response,
+			AmazonBedrockInvocationMetadata invocationMetadata) {
+		Assert.notNull(invocationMetadata, "Bedrock invocation metadata must not be null");
+
+		BedrockUsage usage = BedrockUsage.from(invocationMetadata);
+
+		BedrockAi21Jurassic2ChatResponseMetadata chatResponseMetadata = new BedrockAi21Jurassic2ChatResponseMetadata(
+				response.id(), invocationMetadata.invocationLatency(), usage);
+		return chatResponseMetadata;
+	}
+
+	private final String id;
+
+	private Long invocationLatency;
+
+	private final Usage usage;
+
+	protected BedrockAi21Jurassic2ChatResponseMetadata(String id, Long invocationLatency, BedrockUsage usage) {
+		this.id = id;
+		this.invocationLatency = invocationLatency;
+		this.usage = usage;
+	}
+
+	public String getId() {
+		return this.id;
+	}
+
+	public Long getInvocationLatency() {
+		return this.invocationLatency;
+	}
+
+	@Override
+	public Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public PromptMetadata getPromptMetadata() {
+		return PromptMetadata.empty();
+	}
+
+	@Override
+	public String toString() {
+		return AI_METADATA_STRING.formatted(getClass().getTypeName(), getId(), getInvocationLatency(), getUsage(),
+				getRateLimit());
+	}
+
+}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama2/api/Llama2ChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama2/api/Llama2ChatBedrockApi.java
@@ -215,7 +215,7 @@ public class Llama2ChatBedrockApi extends
 	}
 
 	@Override
-	public Llama2ChatResponse chatCompletion(Llama2ChatRequest request) {
+	public AmazonBedrockInvocationContext<Llama2ChatResponse> chatCompletion(Llama2ChatRequest request) {
 		return this.internalInvocation(request, Llama2ChatResponse.class);
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama2/metadata/BedrockLlama2ChatResponseMetadata.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama2/metadata/BedrockLlama2ChatResponseMetadata.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.llama2.metadata;
+
+import org.springframework.ai.bedrock.BedrockUsage;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
+import org.springframework.ai.bedrock.llama2.api.Llama2ChatBedrockApi.Llama2ChatResponse;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ChatResponseMetadata} implementation for
+ * {@literal Amazon Bedrock Llama2 chat model}.
+ *
+ * @author Wei Jiang
+ * @see ChatResponseMetadata
+ * @since 0.8.1
+ */
+public class BedrockLlama2ChatResponseMetadata implements ChatResponseMetadata {
+
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, id: %2$s, latency: %3$s, usage: %4$s, rateLimit: %5$s }";
+
+	public static BedrockLlama2ChatResponseMetadata from(Llama2ChatResponse response,
+			AmazonBedrockInvocationMetadata invocationMetadata) {
+		Assert.notNull(invocationMetadata, "Bedrock invocation metadata must not be null");
+
+		BedrockUsage usage = BedrockUsage.from(invocationMetadata);
+
+		BedrockLlama2ChatResponseMetadata chatResponseMetadata = new BedrockLlama2ChatResponseMetadata(
+				invocationMetadata.awsRequestId(), invocationMetadata.invocationLatency(), usage);
+		return chatResponseMetadata;
+	}
+
+	private final String id;
+
+	private Long invocationLatency;
+
+	private final Usage usage;
+
+	protected BedrockLlama2ChatResponseMetadata(String id, Long invocationLatency, BedrockUsage usage) {
+		this.id = id;
+		this.invocationLatency = invocationLatency;
+		this.usage = usage;
+	}
+
+	public String getId() {
+		return this.id;
+	}
+
+	public Long getInvocationLatency() {
+		return this.invocationLatency;
+	}
+
+	@Override
+	public Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public PromptMetadata getPromptMetadata() {
+		return PromptMetadata.empty();
+	}
+
+	@Override
+	public String toString() {
+		return AI_METADATA_STRING.formatted(getClass().getTypeName(), getId(), getInvocationLatency(), getUsage(),
+				getRateLimit());
+	}
+
+}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingClient.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingClient.java
@@ -90,7 +90,7 @@ public class BedrockTitanEmbeddingClient extends AbstractEmbeddingClient {
 			var apiRequest = (this.inputType == InputType.IMAGE)
 					? new TitanEmbeddingRequest.Builder().withInputImage(inputContent).build()
 					: new TitanEmbeddingRequest.Builder().withInputText(inputContent).build();
-			TitanEmbeddingResponse response = this.embeddingApi.embedding(apiRequest);
+			TitanEmbeddingResponse response = this.embeddingApi.embedding(apiRequest).response();
 			embeddingList.add(response.embedding());
 		}
 		var indexCounter = new AtomicInteger(0);

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanChatBedrockApi.java
@@ -38,6 +38,7 @@ import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatRes
  * https://docs.aws.amazon.com/bedrock/latest/userguide/titan-text-models.html
  *
  * @author Christian Tzolov
+ * @author Wei Jiang
  * @since 0.8.0
  */
 // @formatter:off
@@ -276,7 +277,7 @@ public class TitanChatBedrockApi extends
 	}
 
 	@Override
-	public TitanChatResponse chatCompletion(TitanChatRequest request) {
+	public AmazonBedrockInvocationContext<TitanChatResponse> chatCompletion(TitanChatRequest request) {
 		return this.internalInvocation(request, TitanChatResponse.class);
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
@@ -154,7 +154,7 @@ public class TitanEmbeddingBedrockApi extends
 	}
 
 	@Override
-	public TitanEmbeddingResponse embedding(TitanEmbeddingRequest request) {
+	public AmazonBedrockInvocationContext<TitanEmbeddingResponse> embedding(TitanEmbeddingRequest request) {
 		return this.internalInvocation(request, TitanEmbeddingResponse.class);
 	}
 }

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/metadata/BedrockTitanChatResponseMetadata.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/metadata/BedrockTitanChatResponseMetadata.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.titan.metadata;
+
+import org.springframework.ai.bedrock.BedrockUsage;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
+import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatResponse;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.util.Assert;
+
+/**
+ * {@link ChatResponseMetadata} implementation for
+ * {@literal Amazon Bedrock Titan chat model}.
+ *
+ * @author Wei Jiang
+ * @see ChatResponseMetadata
+ * @since 0.8.1
+ */
+public class BedrockTitanChatResponseMetadata implements ChatResponseMetadata {
+
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, id: %2$s, latency: %3$s, usage: %4$s, rateLimit: %5$s }";
+
+	public static BedrockTitanChatResponseMetadata from(TitanChatResponse response,
+			AmazonBedrockInvocationMetadata invocationMetadata) {
+		Assert.notNull(invocationMetadata, "Bedrock invocation metadata must not be null");
+
+		BedrockUsage usage = BedrockUsage.from(invocationMetadata);
+
+		BedrockTitanChatResponseMetadata chatResponseMetadata = new BedrockTitanChatResponseMetadata(
+				invocationMetadata.awsRequestId(), invocationMetadata.invocationLatency(), usage);
+		return chatResponseMetadata;
+	}
+
+	private final String id;
+
+	private Long invocationLatency;
+
+	private final Usage usage;
+
+	protected BedrockTitanChatResponseMetadata(String id, Long invocationLatency, BedrockUsage usage) {
+		this.id = id;
+		this.invocationLatency = invocationLatency;
+		this.usage = usage;
+	}
+
+	public String getId() {
+		return this.id;
+	}
+
+	public Long getInvocationLatency() {
+		return this.invocationLatency;
+	}
+
+	@Override
+	public Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public PromptMetadata getPromptMetadata() {
+		return PromptMetadata.empty();
+	}
+
+	@Override
+	public String toString() {
+		return AI_METADATA_STRING.formatted(getClass().getTypeName(), getId(), getInvocationLatency(), getUsage(),
+				getRateLimit());
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApiIT.java
@@ -30,6 +30,8 @@ import software.amazon.awssdk.regions.Region;
 
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatRequest;
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatResponse;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatModel;
 
 import static org.assertj.core.api.Assertions.assertThat;;
@@ -57,7 +59,14 @@ public class AnthropicChatBedrockApiIT {
 			.withTopK(10)
 			.build();
 
-		AnthropicChatResponse response = anthropicChatApi.chatCompletion(request);
+		AmazonBedrockInvocationContext<AnthropicChatResponse> context = anthropicChatApi.chatCompletion(request);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		AnthropicChatResponse response = context.response();
+		assertThat(response).isNotNull();
 
 		System.out.println(response.completion());
 		assertThat(response).isNotNull();

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/metadata/BedrockAnthropicChatResponseMetadataT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/metadata/BedrockAnthropicChatResponseMetadataT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.bedrock.anthropic.BedrockAnthropicChatClient;
+import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * @author Wei Jiang
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+public class BedrockAnthropicChatResponseMetadataT {
+
+	@Autowired
+	private BedrockAnthropicChatClient client;
+
+	@Test
+	public void chatCompletion() {
+		Prompt prompt = new Prompt("Can I fly like a bird?");
+
+		ChatResponse response = this.client.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getMetadata()).isNotNull();
+		assertThat(response.getMetadata()).isInstanceOf(BedrockAnthropicChatResponseMetadata.class);
+
+		BedrockAnthropicChatResponseMetadata metadata = (BedrockAnthropicChatResponseMetadata) response.getMetadata();
+		assertThat(metadata.getId()).isNotNull();
+		assertThat(metadata.getInvocationLatency()).isNotNull();
+
+		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getGenerationTokens()).isGreaterThan(0);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isGreaterThan(0);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public AnthropicChatBedrockApi anthropicApi() {
+			return new AnthropicChatBedrockApi(AnthropicChatBedrockApi.AnthropicChatModel.CLAUDE_V2.id(),
+					EnvironmentVariableCredentialsProvider.create(), Region.US_EAST_1.id(), new ObjectMapper(),
+					Duration.ofMinutes(2));
+		}
+
+		@Bean
+		public BedrockAnthropicChatClient anthropicChatClient(AnthropicChatBedrockApi anthropicApi) {
+			return new BedrockAnthropicChatClient(anthropicApi);
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/api/Anthropic3ChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/api/Anthropic3ChatBedrockApiIT.java
@@ -25,6 +25,8 @@ import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.An
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.AnthropicChatResponse;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.AnthropicChatStreamingResponse.StreamingType;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.MediaContent;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.ChatCompletionMessage;
 import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi.ChatCompletionMessage.Role;
 import reactor.core.publisher.Flux;
@@ -40,6 +42,7 @@ import static org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedroc
 
 /**
  * @author Ben Middleton
+ * @author Wei Jiang
  */
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
@@ -63,11 +66,17 @@ public class Anthropic3ChatBedrockApiIT {
 			.withAnthropicVersion(DEFAULT_ANTHROPIC_VERSION)
 			.build();
 
-		AnthropicChatResponse response = anthropicChatApi.chatCompletion(request);
+		AmazonBedrockInvocationContext<AnthropicChatResponse> context = anthropicChatApi.chatCompletion(request);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		AnthropicChatResponse response = context.response();
+		assertThat(response).isNotNull();
 
 		logger.info("" + response.content());
 
-		assertThat(response).isNotNull();
 		assertThat(response.content().get(0).text()).isNotEmpty();
 		assertThat(response.content().get(0).text()).contains("Blackbeard");
 		assertThat(response.stopReason()).isEqualTo("end_turn");
@@ -103,7 +112,14 @@ public class Anthropic3ChatBedrockApiIT {
 			.withAnthropicVersion(DEFAULT_ANTHROPIC_VERSION)
 			.build();
 
-		AnthropicChatResponse response = anthropicChatApi.chatCompletion(request);
+		AmazonBedrockInvocationContext<AnthropicChatResponse> context = anthropicChatApi.chatCompletion(request);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		AnthropicChatResponse response = context.response();
+		assertThat(response).isNotNull();
 
 		logger.info("" + response.content());
 		assertThat(response).isNotNull();

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/metadata/BedrockAnthropic3ChatResponseMetadataT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/metadata/BedrockAnthropic3ChatResponseMetadataT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.anthropic3.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.bedrock.anthropic3.BedrockAnthropic3ChatClient;
+import org.springframework.ai.bedrock.anthropic3.api.Anthropic3ChatBedrockApi;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * @author Wei Jiang
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+public class BedrockAnthropic3ChatResponseMetadataT {
+
+	@Autowired
+	private BedrockAnthropic3ChatClient client;
+
+	@Test
+	public void chatCompletion() {
+		Prompt prompt = new Prompt("Can I fly like a bird?");
+
+		ChatResponse response = this.client.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getMetadata()).isNotNull();
+		assertThat(response.getMetadata()).isInstanceOf(BedrockAnthropic3ChatResponseMetadata.class);
+
+		BedrockAnthropic3ChatResponseMetadata metadata = (BedrockAnthropic3ChatResponseMetadata) response.getMetadata();
+		assertThat(metadata.getId()).isNotNull();
+		assertThat(metadata.getInvocationLatency()).isNotNull();
+
+		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getGenerationTokens()).isGreaterThan(0);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isGreaterThan(0);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public Anthropic3ChatBedrockApi anthropicApi() {
+			return new Anthropic3ChatBedrockApi(Anthropic3ChatBedrockApi.AnthropicChatModel.CLAUDE_V3_SONNET.id(),
+					EnvironmentVariableCredentialsProvider.create(), Region.US_EAST_1.id(), new ObjectMapper(),
+					Duration.ofMinutes(5));
+		}
+
+		@Bean
+		public BedrockAnthropic3ChatClient anthropicChatClient(Anthropic3ChatBedrockApi anthropicApi) {
+			return new BedrockAnthropic3ChatClient(anthropicApi);
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereChatBedrockApiIT.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import reactor.core.publisher.Flux;
 import software.amazon.awssdk.regions.Region;
 
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatModel;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatRequest.Truncate;
@@ -83,7 +85,14 @@ public class CohereChatBedrockApiIT {
 			.withTruncate(Truncate.NONE)
 			.build();
 
-		CohereChatResponse response = cohereChatApi.chatCompletion(request);
+		AmazonBedrockInvocationContext<CohereChatResponse> context = cohereChatApi.chatCompletion(request);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		CohereChatResponse response = context.response();
+		assertThat(response).isNotNull();
 
 		assertThat(response).isNotNull();
 		assertThat(response.prompt()).isEqualTo(request.prompt());

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiIT.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingModel;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingResponse;
@@ -48,7 +50,14 @@ public class CohereEmbeddingBedrockApiIT {
 				List.of("I like to eat apples", "I like to eat oranges"),
 				CohereEmbeddingRequest.InputType.SEARCH_DOCUMENT, CohereEmbeddingRequest.Truncate.NONE);
 
-		CohereEmbeddingResponse response = api.embedding(request);
+		AmazonBedrockInvocationContext<CohereEmbeddingResponse> context = api.embedding(request);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		CohereEmbeddingResponse response = context.response();
+		assertThat(response).isNotNull();
 
 		assertThat(response).isNotNull();
 		assertThat(response.texts()).isEqualTo(request.texts());

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/metadata/BedrockCohereChatResponseMetadataT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/metadata/BedrockCohereChatResponseMetadataT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.cohere.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.bedrock.cohere.BedrockCohereChatClient;
+import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi;
+import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatModel;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * @author Wei Jiang
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+public class BedrockCohereChatResponseMetadataT {
+
+	@Autowired
+	private BedrockCohereChatClient client;
+
+	@Test
+	public void chatCompletion() {
+		Prompt prompt = new Prompt("Can I fly like a bird?");
+
+		ChatResponse response = this.client.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getMetadata()).isNotNull();
+		assertThat(response.getMetadata()).isInstanceOf(CohereChatResponseMetadata.class);
+
+		CohereChatResponseMetadata metadata = (CohereChatResponseMetadata) response.getMetadata();
+		assertThat(metadata.getId()).isNotNull();
+		assertThat(metadata.getInvocationLatency()).isNotNull();
+
+		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getGenerationTokens()).isGreaterThan(0);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isGreaterThan(0);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public CohereChatBedrockApi cohereApi() {
+			return new CohereChatBedrockApi(CohereChatModel.COHERE_COMMAND_V14.id(),
+					EnvironmentVariableCredentialsProvider.create(), Region.US_EAST_1.id(), new ObjectMapper(),
+					Duration.ofMinutes(2));
+		}
+
+		@Bean
+		public BedrockCohereChatClient cohereChatClient(CohereChatBedrockApi cohereApi) {
+			return new BedrockCohereChatClient(cohereApi);
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/api/Ai21Jurassic2ChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/api/Ai21Jurassic2ChatBedrockApiIT.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.regions.Region;
 
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatModel;
 import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatRequest;
 import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatResponse;
@@ -46,7 +48,14 @@ public class Ai21Jurassic2ChatBedrockApiIT {
 				new Ai21Jurassic2ChatRequest.FloatScalePenalty(0.5f, true, true, true, true, true),
 				new Ai21Jurassic2ChatRequest.IntegerScalePenalty(1, true, true, true, true, true));
 
-		Ai21Jurassic2ChatResponse response = api.chatCompletion(request);
+		AmazonBedrockInvocationContext<Ai21Jurassic2ChatResponse> context = api.chatCompletion(request);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		Ai21Jurassic2ChatResponse response = context.response();
+		assertThat(response).isNotNull();
 
 		assertThat(response).isNotNull();
 		assertThat(response.completions()).isNotEmpty();

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/metadata/BedrockAi21Jurassic2ChatResponseMetadataT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/metadata/BedrockAi21Jurassic2ChatResponseMetadataT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.jurassic2.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.bedrock.jurassic2.BedrockAi21Jurassic2ChatClient;
+import org.springframework.ai.bedrock.jurassic2.BedrockAi21Jurassic2ChatOptions;
+import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * @author Wei Jiang
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+public class BedrockAi21Jurassic2ChatResponseMetadataT {
+
+	@Autowired
+	private BedrockAi21Jurassic2ChatClient client;
+
+	@Test
+	public void chatCompletion() {
+		Prompt prompt = new Prompt("Can I fly like a bird?");
+
+		ChatResponse response = this.client.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getMetadata()).isNotNull();
+		assertThat(response.getMetadata()).isInstanceOf(BedrockAi21Jurassic2ChatResponseMetadata.class);
+
+		BedrockAi21Jurassic2ChatResponseMetadata metadata = (BedrockAi21Jurassic2ChatResponseMetadata) response
+			.getMetadata();
+		assertThat(metadata.getId()).isNotNull();
+		assertThat(metadata.getInvocationLatency()).isNotNull();
+
+		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getGenerationTokens()).isGreaterThan(0);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isGreaterThan(0);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public Ai21Jurassic2ChatBedrockApi jurassic2ChatBedrockApi() {
+			return new Ai21Jurassic2ChatBedrockApi(
+					Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatModel.AI21_J2_MID_V1.id(),
+					EnvironmentVariableCredentialsProvider.create(), Region.US_EAST_1.id(), new ObjectMapper(),
+					Duration.ofMinutes(2));
+		}
+
+		@Bean
+		public BedrockAi21Jurassic2ChatClient bedrockAi21Jurassic2ChatClient(
+				Ai21Jurassic2ChatBedrockApi jurassic2ChatBedrockApi) {
+			return new BedrockAi21Jurassic2ChatClient(jurassic2ChatBedrockApi,
+					BedrockAi21Jurassic2ChatOptions.builder()
+						.withTemperature(0.5f)
+						.withMaxTokens(100)
+						.withTopP(0.9f)
+						.build());
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/api/Llama2ChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/api/Llama2ChatBedrockApiIT.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import reactor.core.publisher.Flux;
 import software.amazon.awssdk.regions.Region;
 
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.llama2.api.Llama2ChatBedrockApi.Llama2ChatModel;
 import org.springframework.ai.bedrock.llama2.api.Llama2ChatBedrockApi.Llama2ChatRequest;
 import org.springframework.ai.bedrock.llama2.api.Llama2ChatBedrockApi.Llama2ChatResponse;
@@ -31,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Wei Jiang
  */
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
@@ -48,7 +51,14 @@ public class Llama2ChatBedrockApiIT {
 			.withMaxGenLen(20)
 			.build();
 
-		Llama2ChatResponse response = llama2ChatApi.chatCompletion(request);
+		AmazonBedrockInvocationContext<Llama2ChatResponse> context = llama2ChatApi.chatCompletion(request);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		Llama2ChatResponse response = context.response();
+		assertThat(response).isNotNull();
 
 		System.out.println(response.generation());
 		assertThat(response).isNotNull();

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/metadata/Llama2ChatResponseMetadataT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama2/metadata/Llama2ChatResponseMetadataT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.llama2.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.bedrock.llama2.BedrockLlama2ChatClient;
+import org.springframework.ai.bedrock.llama2.BedrockLlama2ChatOptions;
+import org.springframework.ai.bedrock.llama2.api.Llama2ChatBedrockApi;
+import org.springframework.ai.bedrock.llama2.api.Llama2ChatBedrockApi.Llama2ChatModel;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * @author Wei Jiang
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+public class Llama2ChatResponseMetadataT {
+
+	@Autowired
+	private BedrockLlama2ChatClient client;
+
+	@Test
+	public void chatCompletion() {
+		Prompt prompt = new Prompt("Can I fly like a bird?");
+
+		ChatResponse response = this.client.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getMetadata()).isNotNull();
+		assertThat(response.getMetadata()).isInstanceOf(BedrockLlama2ChatResponseMetadata.class);
+
+		BedrockLlama2ChatResponseMetadata metadata = (BedrockLlama2ChatResponseMetadata) response.getMetadata();
+		assertThat(metadata.getId()).isNotNull();
+		assertThat(metadata.getInvocationLatency()).isNotNull();
+
+		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getGenerationTokens()).isGreaterThan(0);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isGreaterThan(0);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public Llama2ChatBedrockApi llama2Api() {
+			return new Llama2ChatBedrockApi(Llama2ChatModel.LLAMA2_13B_CHAT_V1.id(),
+					EnvironmentVariableCredentialsProvider.create(), Region.US_EAST_1.id(), new ObjectMapper(),
+					Duration.ofMinutes(2));
+		}
+
+		@Bean
+		public BedrockLlama2ChatClient llama2ChatClient(Llama2ChatBedrockApi llama2Api) {
+			return new BedrockLlama2ChatClient(llama2Api,
+					BedrockLlama2ChatOptions.builder().withTemperature(0.5f).withMaxGenLen(100).withTopP(0.9f).build());
+		}
+
+	}
+
+}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanChatBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/api/TitanChatBedrockApiIT.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import reactor.core.publisher.Flux;
 import software.amazon.awssdk.regions.Region;
 
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationContext;
+import org.springframework.ai.bedrock.api.AbstractBedrockApi.AmazonBedrockInvocationMetadata;
 import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatModel;
 import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatRequest;
 import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatResponse;
@@ -33,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Wei Jiang
  */
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
@@ -50,7 +53,15 @@ public class TitanChatBedrockApiIT {
 
 	@Test
 	public void chatCompletion() {
-		TitanChatResponse response = titanBedrockApi.chatCompletion(titanChatRequest);
+		AmazonBedrockInvocationContext<TitanChatResponse> context = titanBedrockApi.chatCompletion(titanChatRequest);
+		assertThat(context).isNotNull();
+
+		AmazonBedrockInvocationMetadata metadata = context.metadata();
+		assertThat(metadata).isNotNull();
+
+		TitanChatResponse response = context.response();
+		assertThat(response).isNotNull();
+
 		assertThat(response.results()).hasSize(1);
 		assertThat(response.results().get(0).outputText()).contains("Blackbeard");
 	}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/metadata/BedrockTitanChatResponseMetadataT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/metadata/BedrockTitanChatResponseMetadataT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.titan.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.bedrock.titan.BedrockTitanChatClient;
+import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi;
+import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatModel;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * @author Wei Jiang
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
+public class BedrockTitanChatResponseMetadataT {
+
+	@Autowired
+	private BedrockTitanChatClient client;
+
+	@Test
+	public void chatCompletion() {
+		Prompt prompt = new Prompt("Can I fly like a bird?");
+
+		ChatResponse response = this.client.call(prompt);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getMetadata()).isNotNull();
+		assertThat(response.getMetadata()).isInstanceOf(BedrockTitanChatResponseMetadata.class);
+
+		BedrockTitanChatResponseMetadata metadata = (BedrockTitanChatResponseMetadata) response.getMetadata();
+		assertThat(metadata.getId()).isNotNull();
+		assertThat(metadata.getInvocationLatency()).isNotNull();
+
+		assertThat(response.getMetadata().getUsage()).isNotNull();
+		assertThat(response.getMetadata().getUsage().getGenerationTokens()).isGreaterThan(0);
+		assertThat(response.getMetadata().getUsage().getPromptTokens()).isGreaterThan(0);
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public TitanChatBedrockApi titanApi() {
+			return new TitanChatBedrockApi(TitanChatModel.TITAN_TEXT_EXPRESS_V1.id(),
+					EnvironmentVariableCredentialsProvider.create(), Region.US_EAST_1.id(), new ObjectMapper(),
+					Duration.ofMinutes(2));
+		}
+
+		@Bean
+		public BedrockTitanChatClient titanChatClient(TitanChatBedrockApi titanApi) {
+			return new BedrockTitanChatClient(titanApi);
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR closes: https://github.com/spring-projects/spring-ai/issues/600

When Bedrock invokes model API, Bedrock will return input, output token count, and latency information from the `SDKHttpResponse` header.

extract this information as `ChatResponseMetadata` to `ChatResponse`