### PR TITLE
Initial chatcall implementation

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatCallIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatCallIT.java
@@ -1,0 +1,147 @@
+package org.springframework.ai.openai.chat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.ai.chat.call.ChatCall;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.ChatOptionsBuilder;
+import org.springframework.ai.openai.OpenAiChatClient;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+@SpringBootTest(classes = OpenAiChatCallIT.Config.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+public class OpenAiChatCallIT {
+
+	private ChatClient chatClient;
+
+	private ChatCall chatCall;
+
+	@Autowired
+	public OpenAiChatCallIT(ChatClient chatClient, ChatCall chatCall) {
+		this.chatClient = chatClient;
+		this.chatCall = chatCall;
+	}
+
+	@Test
+	void userMessage() {
+		// The creation of ChatCall would usually be in a @Bean
+		ChatCall chatCall = ChatCall.builder(chatClient)
+			.withUserString("Tell me a {adjective} joke about {topic}")
+			.build();
+
+		String joke = chatCall.execute(Map.of("adjective", "silly", "topic", "cows"));
+		System.out.println(joke);
+	}
+
+	@Test
+	void testUserAndSystemMessage() {
+		// @Bean begin
+		String userString = """
+				Tell me about three famous {occupation} and what they did.
+				Write at least three sentences for each person.
+				""";
+		String systemString = """
+				 You are a helpful AI assistant.
+				 You are an AI assistant that helps people find information.
+				 Your name is {name}
+				 You should reply to the user's request with your name and also in the style of a {voice}.
+				""";
+
+		ChatCall chatCall = ChatCall.builder(chatClient)
+			.withUserString(userString)
+			.withSystemString(systemString)
+			.withSystemMap(Map.of("name", "Rick", "voice", "Rick Sanchez"))
+			.build();
+
+		System.out.println("Using default temperature");
+		Map<String, Object> userMap = Map.of("occupation", "scientists");
+		String answer = chatCall.execute(userMap);
+		System.out.println(answer);
+
+		ChatOptions chatOptions = ChatOptionsBuilder.builder().withTemperature(1.0f).build();
+		chatCall = ChatCall.builder(chatClient)
+			.withUserString(userString)
+			// .withMedia(List.of(mediaObject)) TODO
+			// .withFunctionName() TODO
+			.withSystemString(systemString)
+			.withChatOptions(chatOptions)
+			.build();
+
+		System.out.println("Using temperature 1.0");
+		answer = chatCall.execute(userMap, Map.of("name", "Rick", "voice", "Rick Sanchez"));
+		System.out.println(answer);
+	}
+
+	@Test
+	void objectMapping() {
+		String userString = "Generate the filmography for the actor {actor}";
+
+		ChatCall chatCall = ChatCall.builder(chatClient).withUserString(userString).build();
+
+		ActorsFilms actorsFilms = chatCall.execute(ActorsFilms.class, Map.of("actor", "Tom Hanks"));
+		System.out.println(actorsFilms);
+	}
+
+	public record ActorsFilms(String actor, List<String> movies) {
+
+	}
+
+	@Test
+	void simpleChain() {
+		Function<String, String> composedFunction = generateSynopsis.andThen(generateReview);
+		String result = composedFunction.apply("Tragedy at sunset on the beach");
+		System.out.println(result);
+	}
+
+	private Function<String, String> generateSynopsis = title -> {
+		String synopsisInput = """
+				You are a playwright. Given the title of play, it is your job to write a synopsis for that title.
+
+				Title: {title}
+				Playwright: This is a synopsis for the above play:
+				""";
+		return this.chatCall.execute(synopsisInput, Map.of("title", title));
+	};
+
+	private Function<String, String> generateReview = synopsis -> {
+		String synopsisInput = """
+				You are a play critic from the New York Times. Given the synopsis of play, it is your job to write a review for that play.
+
+				Play Synopsis:
+				{synopsis}
+				Review from a New York Times play critic of the above play:""";
+
+		return this.chatCall.execute(synopsisInput, Map.of("synopsis", synopsis));
+	};
+
+	@SpringBootConfiguration
+	static class Config {
+
+		@Bean
+		public OpenAiApi chatCompletionApi() {
+			return new OpenAiApi(System.getenv("OPENAI_API_KEY"));
+		}
+
+		@Bean
+		public ChatClient openAiClient(OpenAiApi openAiApi) {
+			return new OpenAiChatClient(openAiApi);
+		}
+
+		@Bean
+		public ChatCall chatCall(ChatClient chatClient) {
+			return ChatCall.builder(chatClient).build();
+		}
+
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/call/ChatCall.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/call/ChatCall.java
@@ -1,0 +1,310 @@
+package org.springframework.ai.chat.call;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.messages.Media;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.chat.prompt.SystemPromptTemplate;
+import org.springframework.ai.parser.BeanOutputParser;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+
+public class ChatCall implements ChatCallOperations {
+
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
+	private final ChatClient chatClient;
+
+	private final Optional<String> userString;
+
+	private final List<Media> mediaList;
+
+	private final Map<String, Object> userMap;
+
+	private final Optional<String> systemString;
+
+	private final Map<String, Object> systemMap;
+
+	private final Optional<ChatOptions> chatOptions;
+
+	public ChatCall(ChatClient chatClient, Optional<String> userString, Map<String, Object> userMap, List<Media> media,
+			Optional<String> systemString, Map<String, Object> systemMap, Optional<ChatOptions> chatOptions) {
+		Objects.requireNonNull(chatClient, "ChatClient cannot be null.");
+		this.chatClient = chatClient;
+		this.userString = userString;
+		this.userMap = userMap != null ? Collections.unmodifiableMap(new HashMap<>(userMap))
+				: Collections.unmodifiableMap(new HashMap<>());
+		this.mediaList = media != null ? media : new ArrayList<>();
+		this.systemString = systemString;
+		this.systemMap = systemMap != null ? Collections.unmodifiableMap(new HashMap<>(systemMap))
+				: Collections.unmodifiableMap(new HashMap<>());
+		this.chatOptions = chatOptions;
+	}
+
+	public static ChatCallBuilder builder(ChatClient chatClient) {
+		return new ChatCallBuilder(chatClient);
+	}
+
+	@Override
+	public String execute(Map<String, Object>... userMap) {
+		if (userMap.length == 0) {
+			return execute(Collections.emptyMap(), Collections.emptyMap());
+		}
+		else {
+			return execute(userMap[0], new HashMap<>());
+		}
+	}
+
+	@Override
+	public String execute(String userText, Map<String, Object>... userMap) {
+		if (userMap.length == 0) {
+			return execute(userText, Collections.emptyMap(), "", Collections.emptyMap());
+		}
+		else {
+			return execute(userText, userMap[0], "", Collections.emptyMap());
+		}
+	}
+
+	@Override
+	public String execute(UserMessage userMessage, Map<String, Object>... userMap) {
+		if (userMap.length == 0) {
+			return execute(userMessage, Collections.emptyMap(), "", Collections.emptyMap());
+		}
+		else {
+			return execute(userMessage, userMap[0], "", Collections.emptyMap());
+		}
+	}
+
+	// Execute Methods for user and system messages
+
+	@Override
+	public String execute(Map<String, Object> runtimeUserMap, Map<String, Object> runtimeSystemMap) {
+		return execute("", runtimeUserMap, "", runtimeSystemMap);
+	}
+
+	@Override
+	public String execute(String userText, Map<String, Object> runtimeUserMap, String systemText,
+			Map<String, Object> runtimeSystemMap) {
+		List<Message> messageList = new ArrayList<>();
+		doCreateUserMessage(userText, this.mediaList, runtimeUserMap, messageList);
+		doCreateSystemMessage(systemText, runtimeSystemMap, messageList);
+		Prompt prompt = doCreatePrompt(messageList);
+		ChatResponse chatResponse = doExecute(prompt);
+		String response = doCreateStringResponse(chatResponse);
+		return response;
+	}
+
+	@Override
+	public String execute(UserMessage userMessage, Map<String, Object> runtimeUserMap, String systemText,
+			Map<String, Object> runtimeSystemMap) {
+		List<Message> messageList = new ArrayList<>();
+
+		doCreateUserMessage(userMessage.getContent(), userMessage.getMedia(), runtimeUserMap, messageList);
+		doCreateSystemMessage(systemText, runtimeSystemMap, messageList);
+		Prompt prompt = doCreatePrompt(messageList);
+		ChatResponse chatResponse = doExecute(prompt);
+		String response = doCreateStringResponse(chatResponse);
+		return response;
+	}
+
+	// Execute Methods for user message that return a POJO
+
+	@Override
+	public <T> T execute(Class<T> returnType, Map<String, Object>... runtimeUserMap) {
+		var userMessage = new UserMessage(this.userString.get());
+		if (runtimeUserMap.length == 0) {
+			return execute(returnType, userMessage, Collections.emptyMap(), "", Collections.emptyMap());
+		}
+		else {
+			return execute(returnType, userMessage, runtimeUserMap[0], "", Collections.emptyMap());
+		}
+	}
+
+	@Override
+	public <T> T execute(Class<T> returnType, String userText, Map<String, Object>... runtimeUserMap) {
+		var userMessage = new UserMessage(userText);
+		if (runtimeUserMap.length == 0) {
+			return execute(returnType, userMessage, Collections.emptyMap(), "", Collections.emptyMap());
+		}
+		else {
+			return execute(returnType, userMessage, runtimeUserMap[0], "", Collections.emptyMap());
+		}
+	}
+
+	@Override
+	public <T> T execute(Class<T> returnType, UserMessage userMessage, Map<String, Object>... runtimeUserMap) {
+		if (runtimeUserMap.length == 0) {
+			return execute(returnType, userMessage, Collections.emptyMap(), "", Collections.emptyMap());
+		}
+		else {
+			return execute(returnType, userMessage, runtimeUserMap[0], "", Collections.emptyMap());
+		}
+	}
+
+	// Execute Methods for user and system message that return a POJO
+
+	@Override
+	public <T> T execute(Class<T> returnType, Map<String, Object> runtimeUserMap,
+			Map<String, Object> runtimeSystemMap) {
+		return execute(returnType, new UserMessage(this.userString.get()), runtimeUserMap, "", runtimeSystemMap);
+	}
+
+	@Override
+	public <T> T execute(Class<T> returnType, String userText, Map<String, Object> runtimeUserMap, String systemText,
+			Map<String, Object> runtimeSystemMap) {
+		return execute(returnType, new UserMessage(this.userString.get()), runtimeUserMap, "", runtimeSystemMap);
+	}
+
+	@Override
+	public <T> T execute(Class<T> returnType, UserMessage userMessage, Map<String, Object> runtimeUserMap,
+			String systemText, Map<String, Object> runtimeSystemMap) {
+		List<Message> messageList = new ArrayList<>();
+		String userTextToUse = userMessage.getContent() + System.lineSeparator() + "{format}";
+		var parser = new BeanOutputParser<>(returnType);
+		runtimeUserMap.put("format", parser.getFormat());
+		doCreateUserMessage(userTextToUse, userMessage.getMedia(), runtimeUserMap, messageList);
+		doCreateSystemMessage(systemText, runtimeSystemMap, messageList);
+
+		Prompt prompt = doCreatePrompt(messageList);
+		ChatResponse chatResponse = doExecute(prompt);
+		String stringResponse = doCreateStringResponse(chatResponse);
+		T parsedResponse = parser.parse(stringResponse);
+		return parsedResponse;
+	}
+
+	protected void doCreateUserMessage(String userText, List<Media> runtimeMedia, Map<String, Object> runtimeUserMap,
+			List<Message> messageList) {
+		PromptTemplate userPromptTemplate = null;
+
+		if (StringUtils.hasText(userText)) {
+			userPromptTemplate = new PromptTemplate(userText);
+		}
+		else if (this.userString.isPresent()) {
+			userPromptTemplate = new PromptTemplate(this.userString.get());
+		}
+
+		List<Media> mediaListToUse;
+		if (CollectionUtils.isEmpty(runtimeMedia)) {
+			mediaListToUse = this.mediaList;
+		}
+		else {
+			mediaListToUse = runtimeMedia;
+		}
+
+		if (userPromptTemplate != null) {
+			Map userMapToUse = new HashMap(this.userMap);
+			userMapToUse.putAll(runtimeUserMap);
+			messageList.add(userPromptTemplate.createMessage(userMapToUse, mediaListToUse));
+		}
+		else {
+			logger.warn("No user message set.");
+		}
+	}
+
+	protected void doCreateSystemMessage(String systemText, Map<String, Object> runtimeSystemMap,
+			List<Message> messageList) {
+		SystemPromptTemplate systemPromptTemplate = null;
+		if (StringUtils.hasText(systemText)) {
+			systemPromptTemplate = new SystemPromptTemplate(systemText);
+		}
+		else if (this.systemString.isPresent()) {
+			systemPromptTemplate = new SystemPromptTemplate(this.systemString.get());
+		}
+		if (systemPromptTemplate != null) {
+			Map systemMapToUse = new HashMap(this.systemMap);
+			systemMapToUse.putAll(runtimeSystemMap);
+			messageList.add(systemPromptTemplate.createMessage(systemMapToUse));
+		}
+		else {
+			logger.trace("No system message set");
+		}
+	}
+
+	protected Prompt doCreatePrompt(List<Message> messageList) {
+		Prompt prompt;
+		if (this.chatOptions.isPresent()) {
+			prompt = new Prompt(messageList, this.chatOptions.get());
+		}
+		else {
+			prompt = new Prompt(messageList);
+		}
+		logger.debug("Created Prompt: {}", prompt);
+		return prompt;
+	}
+
+	protected ChatResponse doExecute(Prompt prompt) {
+		ChatResponse chatResponse = this.chatClient.call(prompt);
+		return chatResponse;
+	}
+
+	protected static String doCreateStringResponse(ChatResponse chatResponse) {
+		return chatResponse.getResult().getOutput().getContent();
+	}
+
+	public static class ChatCallBuilder {
+
+		private final ChatClient chatClient;
+
+		private Optional<String> userString = Optional.empty();
+
+		private Map<String, Object> userMap = Collections.emptyMap();
+
+		private List<Media> mediaList = Collections.emptyList();
+
+		private Optional<String> systemString = Optional.empty();
+
+		private Map<String, Object> systemMap = Collections.emptyMap();
+
+		private Optional<ChatOptions> chatOptions = Optional.empty();
+
+		private ChatCallBuilder(ChatClient chatClient) {
+			Objects.requireNonNull(chatClient, "ChatClient cannot be null.");
+			this.chatClient = chatClient;
+		}
+
+		public ChatCallBuilder withSystemString(String systemString) {
+			this.systemString = Optional.ofNullable(systemString);
+			return this;
+		}
+
+		public ChatCallBuilder withSystemMap(Map<String, Object> systemMap) {
+			this.systemMap = systemMap;
+			return this;
+		}
+
+		public ChatCallBuilder withUserString(String userString) {
+			this.userString = Optional.ofNullable(userString);
+			return this;
+		}
+
+		public ChatCallBuilder withUserMap(Map<String, Object> userMap) {
+			this.userMap = userMap;
+			return this;
+		}
+
+		public ChatCallBuilder withMedia(List<Media> media) {
+			this.mediaList = media;
+			return this;
+		}
+
+		public ChatCallBuilder withChatOptions(ChatOptions chatOptions) {
+			this.chatOptions = Optional.ofNullable(chatOptions);
+			return this;
+		}
+
+		public ChatCall build() {
+			return new ChatCall(this.chatClient, this.userString, this.userMap, this.mediaList, this.systemString,
+					this.systemMap, this.chatOptions);
+		}
+
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/call/ChatCallOperations.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/call/ChatCallOperations.java
@@ -1,0 +1,71 @@
+package org.springframework.ai.chat.call;
+
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.Map;
+
+public interface ChatCallOperations {
+
+	// Execute Methods for user message
+
+	/**
+	 * Execute a call to the AI model given a map of key-value pairs to replace in user
+	 * text
+	 * @param userMap The map that replaces placeholders in the user text. Only the first
+	 * vararg entry will be used if present.
+	 * @return The String result of calling the AI Model
+	 */
+	String execute(Map<String, Object>... userMap);
+
+	/**
+	 * Execute a call to the AI model given a String fo user text and a map of key-value
+	 * pairs to replace in user text.
+	 * @param userText The user text to use
+	 * @param userMap An optional map that replaces placeholders in the user text. Only
+	 * the * first vararg entry will be used if present
+	 * @return The String result of calling the AI Model
+	 */
+	String execute(String userText, Map<String, Object>... userMap);
+
+	/**
+	 * Execute a call to the AI model given a UserMessage and a map of key-value pairs to
+	 * replace in user text. Note, that this overloaded method handles the case of passing
+	 * a List of Media objects in addition to user text
+	 * @param userMessage The user text to use
+	 * @param userMap An optional map that replaces placeholders in the user text. Only
+	 * the first vararg entry will be used if present
+	 * @return The String result of calling the AI Model
+	 */
+	String execute(UserMessage userMessage, Map<String, Object>... userMap);
+
+	// Execute Methods for user and system messages
+
+	String execute(Map<String, Object> userMap, Map<String, Object> systemMap);
+
+	String execute(String userText, Map<String, Object> userMap, String systemText, Map<String, Object> systemMap); // could
+	// make
+	// systemMap
+	// varargs
+
+	String execute(UserMessage userMessage, Map<String, Object> userMap, String systemText,
+			Map<String, Object> systemMap); // could make systemMap varargs
+
+	// Execute Methods for user text that return a POJO
+
+	<T> T execute(Class<T> returnType, Map<String, Object>... userMap);
+
+	<T> T execute(Class<T> returnType, String userText, Map<String, Object>... userMap);
+
+	<T> T execute(Class<T> returnType, UserMessage userMessage, Map<String, Object>... userMap);
+
+	// Execute Methods for user and messages that return a POJO
+
+	<T> T execute(Class<T> returnType, Map<String, Object> userMap, Map<String, Object> systemMap);
+
+	<T> T execute(Class<T> returnType, String userText, Map<String, Object> userMap, String systemText,
+			Map<String, Object> systemMap); // could make systemMap varargs
+
+	<T> T execute(Class<T> returnType, UserMessage userMessage, Map<String, Object> userMap, String systemText,
+			Map<String, Object> systemMap); // could make systemMap varargs
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
@@ -185,6 +185,11 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 	}
 
 	@Override
+	public Message createMessage(Map<String, Object> model, List<Media> mediaList) {
+		return new UserMessage(render(model), mediaList);
+	}
+
+	@Override
 	public Prompt create() {
 		return new Prompt(render(new HashMap<>()));
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplateMessageActions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplateMessageActions.java
@@ -29,4 +29,6 @@ public interface PromptTemplateMessageActions {
 
 	Message createMessage(Map<String, Object> model);
 
+	Message createMessage(Map<String, Object> model, List<Media> mediaList);
+
 }


### PR DESCRIPTION
`ChatCall` encapsulates the steps of using `ChatClient` into an object named `ChatCall`.  The `ChatCall` is created using a fluent-api, often registered as a Spring `@Bean` and then calling an `execute` method with some runtime parameters, such as the variables to substitute into the prompt.

Similar to Spring's `RdbmsOperation` interface, which models RDBMS operations as objects with the `SqlCall` implementation handling SQL-based calls like stored procedures or functions, and akin to `JdbcClient` offering a fluent API for JDBC operations, we introduce a helper class named `ChatCall`.

This class aims to streamline the process of gathering all necessary parameters for making calls to an AI model. It provides an easily shareable object encapsulating various options for calling an AI model and also helping to more easily chaining multiple calls to the model.


```java
ChatCall chatCall = new ChatCall.Builder().
                                    .withChatClient(chatClient)
                                    .withSystemMessage("you are a helpful assistant") // not likely to change
                                    .withSystemMap(Map.of)  // likely to change at runtime
                                    .withUserMessage("tell me a joke")  // not likely to change
                                    .withUserMap(Map.of)  // likely to change at runtime
)                                   .withChatResponseMapper(chatResponseMapper) // not likely to change
                                    .withChatOptions(chatOptions)  // only likely to change during development
                                    .build()

String result = chatCall.execute(Map.of)  //User map
String result = chatCall.execute(Map.of, Map.of)  //User and System map
String result = chatCall.execute("user message", Map.of);
String result = chatCall.execute("user message", Map.of, "system message", Map.of);
<T> T result  = chatCall.execute("user message", Map.of, Class<T> returnType)
<T> T result  = chatCall.execute("user message", Map.of, Class<T> returnType, "system message", Map.of)

ChatResponse chatResponse = chatOperation.call()
```


open issues

* Change execute signature to have `T...` as last parameter so don't have to specify `MyDomainObject.class`
* Ensure support for returning collections of objects, need to use `ParameterizedTypeReference` 