### PR TITLE
Bedrock Titan embedding client support dynamic embedding request types.

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/aot/BedrockRuntimeHints.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/aot/BedrockRuntimeHints.java
@@ -28,6 +28,7 @@ import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi;
 import org.springframework.ai.bedrock.llama.BedrockLlamaChatOptions;
 import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi;
 import org.springframework.ai.bedrock.titan.BedrockTitanChatOptions;
+import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingOptions;
 import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi;
 import org.springframework.aot.hint.MemberCategory;
@@ -43,6 +44,7 @@ import static org.springframework.ai.aot.AiRuntimeHints.findJsonAnnotatedClasses
  * @author Josh Long
  * @author Christian Tzolov
  * @author Mark Pollack
+ * @author Wei Jiang
  */
 public class BedrockRuntimeHints implements RuntimeHintsRegistrar {
 
@@ -71,6 +73,8 @@ public class BedrockRuntimeHints implements RuntimeHintsRegistrar {
 		for (var tr : findJsonAnnotatedClassesInPackage(TitanChatBedrockApi.class))
 			hints.reflection().registerType(tr, mcs);
 		for (var tr : findJsonAnnotatedClassesInPackage(BedrockTitanChatOptions.class))
+			hints.reflection().registerType(tr, mcs);
+		for (var tr : findJsonAnnotatedClassesInPackage(BedrockTitanEmbeddingOptions.class))
 			hints.reflection().registerType(tr, mcs);
 		for (var tr : findJsonAnnotatedClassesInPackage(TitanEmbeddingBedrockApi.class))
 			hints.reflection().registerType(tr, mcs);

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.bedrock.titan;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingClient.InputType;
+import org.springframework.ai.embedding.EmbeddingOptions;
+import org.springframework.util.Assert;
+
+/**
+ * @author Wei Jiang
+ */
+@JsonInclude(Include.NON_NULL)
+public class BedrockTitanEmbeddingOptions implements EmbeddingOptions {
+
+	/**
+	 * Titan Embedding API input types. Could be either text or image (encoded in base64).
+	 */
+	private InputType inputType;
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private BedrockTitanEmbeddingOptions options = new BedrockTitanEmbeddingOptions();
+
+		public Builder withInputType(InputType inputType) {
+			Assert.notNull(inputType, "input type can not be null.");
+
+			this.options.setInputType(inputType);
+			return this;
+		}
+
+		public BedrockTitanEmbeddingOptions build() {
+			return this.options;
+		}
+
+	}
+
+	public InputType getInputType() {
+		return this.inputType;
+	}
+
+	public void setInputType(InputType inputType) {
+		this.inputType = inputType;
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
@@ -81,6 +81,22 @@ The prefix `spring.ai.bedrock.titan.embedding` (defined in `BedrockTitanEmbeddin
 Supported values are: `amazon.titan-embed-image-v1` and `amazon.titan-embed-text-v1`.
 Model ID values can also be found in the https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids-arns.html[AWS Bedrock documentation for base model IDs].
 
+== Runtime Options [[embedding-options]]
+
+The https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java[BedrockTitanEmbeddingOptions.java] provides model configurations, such as `input-type`.
+On start-up, the default options can be configured with the `BedrockTitanEmbeddingClient(api).withInputType(type)` method or the `spring.ai.bedrock.titan.embedding.input-type` properties.
+
+At run-time you can override the default options by adding new, request specific, options to the `EmbeddingRequest` call.
+For example to override the default temperature for a specific request:
+
+[source,java]
+----
+EmbeddingResponse embeddingResponse = embeddingClient.call(
+    new EmbeddingRequest(List.of("Hello World", "World is big and salvation is near"),
+        BedrockTitanEmbeddingOptions.builder()
+        	.withInputType(InputType.TEXT)
+        .build()));
+----
 
 == Sample Controller
 
@@ -154,7 +170,7 @@ Next, create an https://github.com/spring-projects/spring-ai/blob/main/models/sp
 var titanEmbeddingApi = new TitanEmbeddingBedrockApi(
 	TitanEmbeddingModel.TITAN_EMBED_IMAGE_V1.id(), Region.US_EAST_1.id());
 
-var embeddingClient  new BedrockTitanEmbeddingClient(titanEmbeddingApi);
+var embeddingClient = new BedrockTitanEmbeddingClient(titanEmbeddingApi);
 
 EmbeddingResponse embeddingResponse = embeddingClient
 	.embedForResponse(List.of("Hello World")); // NOTE titan does not support batch embedding.


### PR DESCRIPTION
`BedrockTitanEmbeddingClient` only support configuration embedding type when startup in `BedrockTitanEmbeddingProperties.inputType` property. 

Add new `BedrockTitanEmbeddingOptions` to support dynamic embedding request types while runtime.

For example:
```
bedrockTitanEmbeddingClient.call(new EmbeddingRequest(List.of("hello world"),
              BedrockTitanEmbeddingOptions.builder().withInputType(InputType.TEXT).build()));
```