### PR TITLE
Fix erroneous references to OpenAI

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -176,9 +176,9 @@ where fruits are being displayed, possibly for convenience or aesthetic purposes
 
 == Sample Controller
 
-https://start.spring.io/[Create] a new Spring Boot project and add the `spring-ai-openai-spring-boot-starter` to your pom (or gradle) dependencies.
+https://start.spring.io/[Create] a new Spring Boot project and add the `spring-ai-ollama-spring-boot-starter` to your pom (or gradle) dependencies.
 
-Add a `application.properties` file, under the `src/main/resources` directory, to enable and configure the OpenAi Chat client:
+Add a `application.properties` file, under the `src/main/resources` directory, to enable and configure the Ollama Chat client:
 
 [source,application.properties]
 ----


### PR DESCRIPTION
This fixes what appear to be erroneous copy/paste references to OpenAI in the Ollama doc.
