### PR TITLE
Select text-generation-inferenc support LLMs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/huggingface.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/huggingface.adoc
@@ -6,6 +6,8 @@ HuggingFace Inference Endpoints allow you to deploy and serve machine learning m
 
 Further details on HuggingFace Inference Endpoints can be found link:https://huggingface.co/docs/inference-endpoints/index[here].
 
+TIP: Please select the LLMs link:https://huggingface.co/docs/text-generation-inference/index[text-generation-inference] support.
+
 == Prerequisites
 
 Add the `spring-ai-huggingface` dependency:


### PR DESCRIPTION
Now huggingface text-generation-inference only support Llama, Falcon, StarCoder, BLOOM, GPT-NeoX, and T5. If you select other LLMs, use HuggingfaceChatClient will get errors.

Yesterday, I use gpt2 model, and I use HuggingfaceChatClient get a lot of errors. So I think add a tip for novice will be friendly.