### PR TITLE
Fix Neo4jVectorStore max allowed dimension size to 4096

### DIFF
--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
@@ -149,8 +149,8 @@ public class Neo4jVectorStore implements VectorStore, InitializingBean {
 			 */
 			public Builder withEmbeddingDimension(int newEmbeddingDimension) {
 
-				Assert.isTrue(newEmbeddingDimension >= 1 && newEmbeddingDimension <= 2048,
-						"Dimension has to be withing the boundaries 1 and 2048 (inclusively)");
+				Assert.isTrue(newEmbeddingDimension >= 1 && newEmbeddingDimension <= 4096,
+						"Dimension has to be withing the boundaries 1 and 4096 (inclusively)");
 
 				this.embeddingDimension = newEmbeddingDimension;
 				return this;


### PR DESCRIPTION
The Neo4j "vector-2.0" index provider allows up to 4096 dimensions.

@pivotal-cla This is an Obvious Fix

Issue #644 
