### PR TITLE
Docs: Fix typos in embedding and function calling documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
@@ -12,7 +12,7 @@ Spring AI provides flexible and user-friendly ways to register and call custom f
 In general, the custom functions need to provide a function `name`,  `description`, and the function call `signature` (as JSON schema) to let the model know what arguments the function expects.
 The `description` helps the model to understand when to call the function.
 
-As a developer, you need to implement a functions that takes the function call arguments sent from the AI model, and respond with the result back to the model.
+As a developer, you need to implement a function that takes the function call arguments sent from the AI model, and respond with the result back to the model.
 Your function can in turn invoke other 3rd party services to provide the results.
 
 Spring AI makes this as easy as defining a `@Bean` definition that returns a `java.util.Function` and supplying the bean name as an option when invoking the `ChatClient`.
@@ -29,7 +29,7 @@ We can provide the AI model with metadata about our own functions that it can us
 For example, if during the processing of a prompt, the AI Model determines that it needs additional information about the temperature in a given location, it will start a server side generated request/response interaction.  The AI Model invokes a client side function.
 The AI Model provides method invocation details as JSON and it is the responsibility of the client to execute that function and return the response.
 
-Spring AI greatly simplifies code you need to write to support function invocation.
+Spring AI greatly simplifies the code you need to write to support function invocation.
 It brokers the function invocation conversation for you.
 You can simply provide your function definition as a `@Bean` and then provide the bean name of the function in your prompt options.
 You can also reference multiple function bean names in your prompt.
@@ -88,10 +88,10 @@ static class Config {
 }
 ----
 
-The `@Description` annotation is optional and provides a function description (2) that helps the model to understand when to call the function.
+The `@Description` annotation is optional and provides a function description (2) that helps the model understand when to call the function.
 It is an important property to set to help the AI model determine what client side function to invoke.
 
-Another option to provide the description of the function is to the `@JacksonDescription` annotation on the `MockWeatherService.Request` to provide the function description:
+Another option to provide the description of the function is to use the `@JsonClassDescription` annotation on the `MockWeatherService.Request` to provide the function description:
 
 [source,java]
 ----
@@ -110,14 +110,14 @@ static class Config {
 public record Request(String location, Unit unit) {}
 ----
 
-It is a best practice to annotate the request object with information such that the generates JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
+It is a best practice to annotate the request object with information such that the generated JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithFunctionBeanIT.java.java[FunctionCallWithFunctionBeanIT.java] demonstrates this approach.
 
 
 ==== FunctionCallback Wrapper
 
-Another way register a function is to create `FunctionCallbackWrapper` wrapper like this:
+Another way to register a function is to create a `FunctionCallbackWrapper` wrapper like this:
 
 [source,java]
 ----
@@ -136,7 +136,7 @@ static class Config {
 }
 ----
 
-It wraps the 3rd party, `MockWeatherService` function and registers it as a `CurrentWeather` function with the `AnthropicChatClient`.
+It wraps the 3rd party `MockWeatherService` function and registers it as a `CurrentWeather` function with the `AnthropicChatClient`.
 It also provides a description (2) and an optional response converter (3) to convert the response into a text as expected by the model.
 
 NOTE: By default, the response converter does a JSON serialization of the Response object.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/azure-open-ai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/azure-open-ai-chat-functions.adoc
@@ -13,7 +13,8 @@ The Azure OpenAI API does not call the function directly; instead, the model gen
 Spring AI provides flexible and user-friendly ways to register and call custom functions.
 In general, the custom functions need to provide a function `name`, `description`, and the function call `signature` (as JSON schema) to let the model know what arguments the function expects.  The `description` helps the model to understand when to call the function.
 
-As a developer, you need to implement a functions that takes the function call arguments sent from the AI model, and respond with the result back to the model.  Your function can in turn invoke other 3rd party services to provide the results.
+As a developer, you need to implement a function that takes the function call arguments sent from the AI model, and respond with the result back to the model.
+Your function can in turn invoke other 3rd party services to provide the results.
 
 Spring AI makes this as easy as defining a `@Bean` definition that returns a `java.util.Function` and supplying the bean name as an option when invoking the `ChatClient`.
 
@@ -29,7 +30,7 @@ We can provide the AI model with metadata about our own functions that it can us
 For example, if during the processing of a prompt, the AI Model determines that it needs additional information about the temperature in a given location, it will start a server side generated request/response interaction.  The AI Model invokes a client side function.
 The AI Model provides method invocation details as JSON and it is the responsibility of the client to execute that function and return the response.
 
-Spring AI greatly simplifies code you need to write to support function invocation.
+Spring AI greatly simplifies the code you need to write to support function invocation.
 It brokers the function invocation conversation for you.
 You can simply provide your function definition as a `@Bean` and then provide the bean name of the function in your prompt options.
 You can also reference multiple function bean names in your prompt.
@@ -87,9 +88,9 @@ static class Config {
 }
 ----
 
-The `@Description` annotation is optional and provides a function description (2) that helps the model to understand when to call the function.  It is an important property to set to help the AI model determine what client side function to invoke.
+The `@Description` annotation is optional and provides a function description (2) that helps the model understand when to call the function.  It is an important property to set to help the AI model determine what client side function to invoke.
 
-Another option to provide the description of the function is to the `@JacksonDescription` annotation on the `MockWeatherService.Request` to provide the function description:
+Another option to provide the description of the function is to use the `@JsonClassDescription` annotation on the `MockWeatherService.Request` to provide the function description:
 
 [source,java]
 ----
@@ -108,13 +109,13 @@ static class Config {
 public record Request(String location, Unit unit) {}
 ----
 
-It is a best practice to annotate the request object with information such that the generates JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
+It is a best practice to annotate the request object with information such that the generated JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionBeanIT.java[FunctionCallWithFunctionBeanIT.java] demonstrates this approach.
 
 ==== FunctionCallback Wrapper
 
-Another way register a function is to create `FunctionCallbackWrapper` wrapper like this:
+Another way to register a function is to create a `FunctionCallbackWrapper` wrapper like this:
 
 [source,java]
 ----
@@ -133,7 +134,7 @@ static class Config {
 }
 ----
 
-It wraps the 3rd party, `MockWeatherService` function and registers it as a `CurrentWeather` function with the `ChatClient` and provides a description (2).
+It wraps the 3rd party `MockWeatherService` function and registers it as a `CurrentWeather` function with the `AzureAiChatClient` and provides a description (2).
 
 NOTE: The default response converter does a JSON serialization of the Response object.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
@@ -2,17 +2,17 @@
 
 You can register custom Java functions with the `MistralAiChatClient` and have the Mistral AI models intelligently choose to output a JSON object containing arguments to call one or many of the registered functions.
 This allows you to connect the LLM capabilities with external tools and APIs.
-The `mistral_small_latest` and `mistral_large_latest` models are trained to detect when a function should be called and to respond with JSON that adheres to the function signature.
+The `open-mixtral-8x22b`, `mistral_small_latest`, and `mistral_large_latest` models are trained to detect when a function should be called and to respond with JSON that adheres to the function signature.
 
 The MistralAI API does not call the function directly; instead, the model generates JSON that you can use to call the function in your code and return the result back to the model to complete the conversation.
 
-NOTE: As of March 13, 2024, Mistral AI has integrated support for parallel function calling into their `mistral_large_latest`` model, a feature that was absent at the time of the first Spring AI Mistral AI.
+NOTE: As of March 13, 2024, Mistral AI has integrated support for parallel function calling into their `mistral_large_latest` model, a feature that was absent at the time of the first Spring AI Mistral AI.
 
 Spring AI provides flexible and user-friendly ways to register and call custom functions.
 In general, the custom functions need to provide a function `name`,  `description`, and the function call `signature` (as JSON schema) to let the model know what arguments the function expects.
 The `description` helps the model to understand when to call the function.
 
-As a developer, you need to implement a functions that takes the function call arguments sent from the AI model, and respond with the result back to the model.
+As a developer, you need to implement a function that takes the function call arguments sent from the AI model, and respond with the result back to the model.
 Your function can in turn invoke other 3rd party services to provide the results.
 
 Spring AI makes this as easy as defining a `@Bean` definition that returns a `java.util.Function` and supplying the bean name as an option when invoking the `ChatClient`.
@@ -29,7 +29,7 @@ We can provide the AI model with metadata about our own functions that it can us
 For example, if during the processing of a prompt, the AI Model determines that it needs additional information about the temperature in a given location, it will start a server side generated request/response interaction.  The AI Model invokes a client side function.
 The AI Model provides method invocation details as JSON and it is the responsibility of the client to execute that function and return the response.
 
-Spring AI greatly simplifies code you need to write to support function invocation.
+Spring AI greatly simplifies the code you need to write to support function invocation.
 It brokers the function invocation conversation for you.
 You can simply provide your function definition as a `@Bean` and then provide the bean name of the function in your prompt options.
 You can also reference multiple function bean names in your prompt.
@@ -41,7 +41,7 @@ To support the response of the chatbot, we will register our own function that t
 
 When the response to the prompt to the model needs to answer a question such as `"What’s the weather like in Boston?"` the AI model will invoke the client providing the location value as an argument to be passed to the function.  This RPC-like data is passed as JSON.
 
-Our function can some SaaS based weather service API and returns the weather response back to the model to complete the conversation.
+Our function calls some SaaS based weather service API and returns the weather response back to the model to complete the conversation.
 In this example we will use a simple implementation named `MockWeatherService` that hard codes the temperature for various locations.
 
 The following `MockWeatherService.java` represents the weather service API:
@@ -88,10 +88,10 @@ static class Config {
 }
 ----
 
-The `@Description` annotation is optional and provides a function description (2) that helps the model to understand when to call the function.
+The `@Description` annotation is optional and provides a function description (2) that helps the model understand when to call the function.
 It is an important property to set to help the AI model determine what client side function to invoke.
 
-Another option to provide the description of the function is to the `@JacksonDescription` annotation on the `MockWeatherService.Request` to provide the function description:
+Another option to provide the description of the function is the `@JsonClassDescription` annotation on the `MockWeatherService.Request` to provide the function description:
 
 [source,java]
 ----
@@ -110,7 +110,7 @@ static class Config {
 public record Request(String location, Unit unit) {}
 ----
 
-It is a best practice to annotate the request object with information such that the generates JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
+It is a best practice to annotate the request object with information such that the generated JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/PaymentStatusBeanIT.java[PaymentStatusBeanIT.java] demonstrates this approach.
 
@@ -120,7 +120,7 @@ MistralAI is almost identical to OpenAI in this regard.
 
 ==== FunctionCallback Wrapper
 
-Another way register a function is to create `FunctionCallbackWrapper` wrapper like this:
+Another way to register a function is to create `FunctionCallbackWrapper` wrapper like this:
 
 [source,java]
 ----
@@ -139,7 +139,7 @@ static class Config {
 }
 ----
 
-It wraps the 3rd party, `MockWeatherService` function and registers it as a `CurrentWeather` function with the `MistralAiChatClient`.
+It wraps the 3rd party `MockWeatherService` function and registers it as a `CurrentWeather` function with the `MistralAiChatClient`.
 It also provides a description (2) and an optional response converter (3) to convert the response into a text as expected by the model.
 
 NOTE: By default, the response converter does a JSON serialization of the Response object.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
@@ -30,7 +30,7 @@ The AI Model provides method invocation details as JSON and it is the responsibi
 
 The model-client interaction is illustrated in the <<spring-ai-function-calling-flow>> diagram.
 
-Spring AI greatly simplifies code you need to write to support function invocation.
+Spring AI greatly simplifies the code you need to write to support function invocation.
 It brokers the function invocation conversation for you.
 You can simply provide your function definition as a `@Bean` and then provide the bean name of the function in your prompt options.
 You can also reference multiple function bean names in your prompt.
@@ -89,9 +89,9 @@ static class Config {
 }
 ----
 
-The `@Description` annotation is optional and provides a function description (2) that helps the model to understand when to call the function.  It is an important property to set to help the AI model determine what client side function to invoke.
+The `@Description` annotation is optional and provides a function description (2) that helps the model understand when to call the function.  It is an important property to set to help the AI model determine what client side function to invoke.
 
-Another option to provide the description of the function is to the `@JacksonDescription` annotation on the `MockWeatherService.Request` to provide the function description:
+Another option to provide the description of the function is to use the `@JsonClassDescription` annotation on the `MockWeatherService.Request` to provide the function description:
 
 [source,java]
 ----
@@ -110,14 +110,14 @@ static class Config {
 public record Request(String location, Unit unit) {}
 ----
 
-It is a best practice to annotate the request object with information such that the generates JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
+It is a best practice to annotate the request object with information such that the generated JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java[FunctionCallbackWithPlainFunctionBeanIT.java] demonstrates this approach.
 
 
 ==== FunctionCallback Wrapper
 
-Another way register a function is to create `FunctionCallbackWrapper` wrapper like this:
+Another way to register a function is to create a `FunctionCallbackWrapper` wrapper like this:
 
 [source,java]
 ----
@@ -136,7 +136,7 @@ static class Config {
 }
 ----
 
-It wraps the 3rd party, `MockWeatherService` function and registers it as a `CurrentWeather` function with the `OpenAiChatClient`.
+It wraps the 3rd party `MockWeatherService` function and registers it as a `CurrentWeather` function with the `OpenAiChatClient`.
 It also provides a description (2) and an optional response converter (3) to convert the response into a text as expected by the model.
 
 NOTE: By default, the response converter does a JSON serialization of the Response object.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/vertexai-gemini-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/vertexai-gemini-chat-functions.adoc
@@ -11,7 +11,8 @@ The VertexAI Gemini API does not call the function directly; instead, the model 
 Spring AI provides flexible and user-friendly ways to register and call custom functions.
 In general, the custom functions need to provide a function `name`, `description`, and the function call `signature` (as Open API schema) to let the model know what arguments the function expects.  The `description` helps the model to understand when to call the function.
 
-As a developer, you need to implement a functions that takes the function call arguments sent from the AI model, and respond with the result back to the model.  Your function can in turn invoke other 3rd party services to provide the results.
+As a developer, you need to implement a function that takes the function call arguments sent from the AI model, and respond with the result back to the model.
+Your function can in turn invoke other 3rd party services to provide the results.
 
 Spring AI makes this as easy as defining a `@Bean` definition that returns a `java.util.Function` and supplying the bean name as an option when invoking the `ChatClient`.
 
@@ -29,7 +30,7 @@ We can provide the AI model with metadata about our own functions that it can us
 For example, if during the processing of a prompt, the AI Model determines that it needs additional information about the temperature in a given location, it will start a server side generated request/response interaction.  The AI Model invokes a client side function.
 The AI Model provides method invocation details as JSON and it is the responsibility of the client to execute that function and return the response.
 
-Spring AI greatly simplifies code you need to write to support function invocation.
+Spring AI greatly simplifies the code you need to write to support function invocation.
 It brokers the function invocation conversation for you.
 You can simply provide your function definition as a `@Bean` and then provide the bean name of the function in your prompt options.
 You can also reference multiple function bean names in your prompt.
@@ -87,9 +88,9 @@ static class Config {
 }
 ----
 
-The `@Description` annotation is optional and provides a function description (2) that helps the model to understand when to call the function.  It is an important property to set to help the AI model determine what client side function to invoke.
+The `@Description` annotation is optional and provides a function description (2) that helps the model understand when to call the function.  It is an important property to set to help the AI model determine what client side function to invoke.
 
-Another option to provide the description of the function is to the `@JacksonDescription` annotation on the `MockWeatherService.Request` to provide the function description:
+Another option to provide the description of the function is to use the `@JsonClassDescription` annotation on the `MockWeatherService.Request` to provide the function description:
 
 [source,java]
 ----
@@ -108,13 +109,13 @@ static class Config {
 public record Request(String location, Unit unit) {}
 ----
 
-It is a best practice to annotate the request object with information such that the generates JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
+It is a best practice to annotate the request object with information such that the generated JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/gemini/tool/FunctionCallWithFunctionBeanIT.java[FunctionCallWithFunctionBeanIT.java] demonstrates this approach.
 
 ==== FunctionCallback Wrapper
 
-Another way register a function is to create `FunctionCallbackWrapper` wrapper like this:
+Another way to register a function is to create a `FunctionCallbackWrapper` wrapper like this:
 
 [source,java]
 ----
@@ -134,7 +135,7 @@ static class Config {
 }
 ----
 
-It wraps the 3rd party, `MockWeatherService` function and registers it as a `CurrentWeather` function with the `VertexAiGeminiChatClient`.
+It wraps the 3rd party `MockWeatherService` function and registers it as a `CurrentWeather` function with the `VertexAiGeminiChatClient`.
 It also provides a description (2) and sets the Schema type to Open API type (3).
 
 NOTE: The default response converter does a JSON serialization of the Response object.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -140,7 +140,7 @@ Read more about xref:api/chat/functions/mistralai-chat-functions.adoc[Mistral AI
 
 == Sample Controller (Auto-configuration)
 
-https://start.spring.io/[Create] a new Spring Boot project and add the `spring-ai-mistralai-spring-boot-starter` to your pom (or gradle) dependencies.
+https://start.spring.io/[Create] a new Spring Boot project and add the `spring-ai-mistral-ai-spring-boot-starter` to your pom (or gradle) dependencies.
 
 Add a `application.properties` file, under the `src/main/resources` directory, to enable and configure the OpenAi Chat client:
 
@@ -185,13 +185,13 @@ public class ChatController {
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatClient.java[MistralAiChatClient] implements the `ChatClient` and `StreamingChatClient` and uses the <<low-level-api>> to connect to the MistralAI service.
 
-Add the `spring-ai-mistralai` dependency to your project's Maven `pom.xml` file:
+Add the `spring-ai-mistral-ai` dependency to your project's Maven `pom.xml` file:
 
 [source, xml]
 ----
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-mistralai</artifactId>
+    <artifactId>spring-ai-mistral-ai</artifactId>
 </dependency>
 ----
 
@@ -200,7 +200,7 @@ or to your Gradle `build.gradle` build file.
 [source,groovy]
 ----
 dependencies {
-    implementation 'org.springframework.ai:spring-ai-mistralai'
+    implementation 'org.springframework.ai:spring-ai-mistral-ai'
 }
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/mistralai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/mistralai-embeddings.adoc
@@ -155,12 +155,12 @@ public class EmbeddingController {
 == Manual Configuration
 
 If you are not using Spring Boot, you can manually configure the OpenAI Embedding Client.
-For this add the `spring-ai-mistralai` dependency to your project's Maven `pom.xml` file:
+For this add the `spring-ai-mistral-ai` dependency to your project's Maven `pom.xml` file:
 [source, xml]
 ----
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-mistralai</artifactId>
+    <artifactId>spring-ai-mistral-ai</artifactId>
 </dependency>
 ----
 
@@ -169,13 +169,13 @@ or to your Gradle `build.gradle` build file.
 [source,groovy]
 ----
 dependencies {
-    implementation 'org.springframework.ai:spring-ai-mistralai'
+    implementation 'org.springframework.ai:spring-ai-mistral-ai'
 }
 ----
 
 TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
 
-NOTE: The `spring-ai-mistralai` dependency provides access also to the `MistralAiChatClient`.
+NOTE: The `spring-ai-mistral-ai` dependency provides access also to the `MistralAiChatClient`.
 For more information about the `MistralAiChatClient` refer to the link:../chat/mistralai-chat.html[MistralAI Chat Client] section.
 
 Next, create an `MistralAiEmbeddingClient` instance and use it to compute the similarity between two input texts:

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/onnx.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/onnx.adoc
@@ -81,7 +81,7 @@ List<List<Double>> embeddings = embeddingClient.embed(List.of("Hello world", "Wo
 
 ----
 
-NOTE: that when created manually, you must call the `afterPropertiesSet()` after setting the properties and before using the client.
+NOTE: If you create an instance of `TransformersEmbeddingClient` manually, you must call the `afterPropertiesSet()` method after setting the properties and before using the client.
 
 The first `embed()` call downloads the large ONNX model and caches it on the local file system.
 Therefore, the first call might take longer than usual.


### PR DESCRIPTION
Fix typos in the function calling and embedding model documentation for specific models.

There are many duplicated sections across the different model docs. It might be worth looking into extracting those sections into AsciiDoc fragments to re-use them (and simplify the maintenance).
