### PR TITLE
Currently Vertex API uses one Tool per function definition, but tools can have multiple function inside

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatClient.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatClient.java
@@ -349,16 +349,19 @@ public class VertexAiGeminiChatClient
 
 	private List<Tool> getFunctionTools(Set<String> functionNames) {
 
-		return this.resolveFunctionCallbacks(functionNames).stream().map(functionCallback -> {
-			FunctionDeclaration functionDeclaration = FunctionDeclaration.newBuilder()
+		final var tool = Tool.newBuilder();
+
+		final var functionDeclarations = this.resolveFunctionCallbacks(functionNames)
+			.stream()
+			.map(functionCallback -> FunctionDeclaration.newBuilder()
 				.setName(functionCallback.getName())
 				.setDescription(functionCallback.getDescription())
 				.setParameters(jsonToSchema(functionCallback.getInputTypeSchema()))
 				// .setParameters(toOpenApiSchema(functionCallback.getInputTypeSchema()))
-				.build();
-
-			return Tool.newBuilder().addFunctionDeclarations(functionDeclaration).build();
-		}).toList();
+				.build())
+			.toList();
+		tool.addAllFunctionDeclarations(functionDeclarations);
+		return List.of(tool.build());
 	}
 
 	private static String structToJson(Struct struct) {


### PR DESCRIPTION
as described in issue #619 There are an API error with Gemini-Vertex API with multiple functions.

The "model" can admit multiple tools with multiple function inside. But if you specify two or more tools the Gemini API throw an 400 error.

Avoid this generating a single tool with all function inside.