### PR TITLE
[FEATURE] avoid second round trip for function call

### DIFF
--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/SpyingMockWeatherService.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/SpyingMockWeatherService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.azure.openai.function;
+
+import java.util.function.Function;
+
+public class SpyingMockWeatherService implements Function<MockWeatherService.Request, Void> {
+
+	private MockWeatherService.Request interceptedRequest = null;
+
+	@Override
+	public Void apply(MockWeatherService.Request request) {
+		interceptedRequest = request;
+		return null;
+	}
+
+	public MockWeatherService.Request getInterceptedRequest() {
+		return interceptedRequest;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractFunctionCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractFunctionCallSupport.java
@@ -60,19 +60,16 @@ public abstract class AbstractFunctionCallSupport<Msg, Req, Resp> {
 
 		if (options != null) {
 			if (!CollectionUtils.isEmpty(options.getFunctionCallbacks())) {
-				options.getFunctionCallbacks().stream().forEach(functionCallback -> {
-
+				options.getFunctionCallbacks().forEach(functionCallback -> {
 					// Register the tool callback.
 					if (isRuntimeCall) {
 						this.functionCallbackRegister.put(functionCallback.getName(), functionCallback);
+						// Automatically enable the function, usually from prompt
+						// callback.
+						functionToCall.add(functionCallback.getName());
 					}
 					else {
 						this.functionCallbackRegister.putIfAbsent(functionCallback.getName(), functionCallback);
-					}
-
-					// Automatically enable the function, usually from prompt callback.
-					if (isRuntimeCall) {
-						functionToCall.add(functionCallback.getName());
 					}
 				});
 			}
@@ -147,6 +144,9 @@ public abstract class AbstractFunctionCallSupport<Msg, Req, Resp> {
 
 		Req newRequest = this.doCreateToolResponseRequest(request, responseMessage, conversationHistory);
 
+		if (!this.hasReturningFunction(responseMessage)) {
+			return response;
+		}
 		return this.callWithFunctionSupport(newRequest);
 	}
 
@@ -179,6 +179,8 @@ public abstract class AbstractFunctionCallSupport<Msg, Req, Resp> {
 		});
 
 	}
+
+	abstract protected boolean hasReturningFunction(Msg responseMessage);
 
 	abstract protected Req doCreateToolResponseRequest(Req previousRequest, Msg responseMessage,
 			List<Msg> conversationHistory);

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
@@ -49,4 +49,9 @@ public interface FunctionCallback {
 	 */
 	public String call(String functionInput);
 
+	/**
+	 * @return This function return a value or not
+	 */
+	boolean returningFunction();
+
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
@@ -16,6 +16,7 @@
 package org.springframework.ai.model.function;
 
 import java.lang.reflect.Type;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
@@ -73,9 +74,10 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 					"Functional bean with name: " + beanName + " does not exist in the context.");
 		}
 
-		if (!Function.class.isAssignableFrom(FunctionTypeUtils.getRawType(beanType))) {
+		if (!Function.class.isAssignableFrom(FunctionTypeUtils.getRawType(beanType))
+				|| !Consumer.class.isAssignableFrom(FunctionTypeUtils.getRawType(beanType))) {
 			throw new IllegalArgumentException(
-					"Function call Bean must be of type Function. Found: " + beanType.getTypeName());
+					"Function call Bean must be of type Function or Consumer. Found: " + beanType.getTypeName());
 		}
 
 		Type functionInputType = TypeResolverHelper.getFunctionArgumentType(beanType, 0);
@@ -112,6 +114,14 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 
 		if (bean instanceof Function<?, ?> function) {
 			return FunctionCallbackWrapper.builder(function)
+				.withName(functionName)
+				.withSchemaType(this.schemaType)
+				.withDescription(functionDescription)
+				.withInputType(functionInputClass)
+				.build();
+		}
+		if (bean instanceof Consumer<?> consumer) {
+			return FunctionCallbackWrapper.builder(consumer)
 				.withName(functionName)
 				.withSchemaType(this.schemaType)
 				.withDescription(functionDescription)


### PR DESCRIPTION
Reefer issue #652 

For some use case after local function is called no need to pass the results to LLMs. (eg: data extraction from documents)
