### PR TITLE
fix #625： No serializer found for class org.springframework.ai.openai.metadata.OpenAiImageResponseMetadata

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiImageResponseMetadata.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/OpenAiImageResponseMetadata.java
@@ -35,7 +35,7 @@ public class OpenAiImageResponseMetadata implements ImageResponseMetadata {
 	}
 
 	@Override
-	public Long created() {
+	public Long getCreated() {
 		return this.created;
 	}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageClientIT.java
@@ -44,7 +44,7 @@ public class OpenAiImageClientIT extends AbstractIT {
 		assertThat(imageResponse.getResults()).hasSize(1);
 
 		ImageResponseMetadata imageResponseMetadata = imageResponse.getMetadata();
-		assertThat(imageResponseMetadata.created()).isPositive();
+		assertThat(imageResponseMetadata.getCreated()).isPositive();
 
 		var generation = imageResponse.getResult();
 		Image image = generation.getOutput();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageClientWithImageResponseMetadataTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageClientWithImageResponseMetadataTests.java
@@ -79,7 +79,7 @@ public class OpenAiImageClientWithImageResponseMetadataTests {
 
 		assertThat(imageResponseMetadata).isNotNull();
 
-		Long created = imageResponseMetadata.created();
+		Long created = imageResponseMetadata.getCreated();
 
 		assertThat(created).isNotNull();
 		assertThat(created).isEqualTo(1589478378);

--- a/spring-ai-core/src/main/java/org/springframework/ai/image/ImageResponseMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/image/ImageResponseMetadata.java
@@ -22,7 +22,7 @@ public interface ImageResponseMetadata extends ResponseMetadata {
 	ImageResponseMetadata NULL = new ImageResponseMetadata() {
 	};
 
-	default Long created() {
+	default Long getCreated() {
 		return System.currentTimeMillis();
 	}
 


### PR DESCRIPTION
The reason is that the OpenAiImageResponseMetadata class does not have standard getter methods.
