### PR TITLE
:adhesive_bandage: Add google search retrieval as builtin tool

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -15,10 +15,7 @@
  */
 package org.springframework.ai.vertexai.gemini;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -99,6 +96,12 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 	@JsonIgnore
 	private Set<String> functions = new HashSet<>();
 
+	/**
+	 * Use Google search Grounding feature
+	 */
+	@JsonIgnore
+	private boolean googleSearchRetrieval = false;
+
 	// @formatter:on
 
 	public static Builder builder() {
@@ -158,6 +161,11 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 		public Builder withFunction(String functionName) {
 			Assert.hasText(functionName, "Function name must not be empty");
 			this.options.functions.add(functionName);
+			return this;
+		}
+
+		public Builder withGoogleSearchRetrieval(boolean googleSearch) {
+			this.options.googleSearchRetrieval = googleSearch;
 			return this;
 		}
 
@@ -248,86 +256,32 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 		this.functions = functions;
 	}
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((stopSequences == null) ? 0 : stopSequences.hashCode());
-		result = prime * result + ((temperature == null) ? 0 : temperature.hashCode());
-		result = prime * result + ((topP == null) ? 0 : topP.hashCode());
-		result = prime * result + ((topK == null) ? 0 : topK.hashCode());
-		result = prime * result + ((candidateCount == null) ? 0 : candidateCount.hashCode());
-		result = prime * result + ((maxOutputTokens == null) ? 0 : maxOutputTokens.hashCode());
-		result = prime * result + ((model == null) ? 0 : model.hashCode());
-		result = prime * result + ((functionCallbacks == null) ? 0 : functionCallbacks.hashCode());
-		result = prime * result + ((functions == null) ? 0 : functions.hashCode());
-		return result;
+	public boolean getGoogleSearchRetrieval() {
+		return this.googleSearchRetrieval;
+	}
+
+	public void setGoogleSearchRetrieval(boolean googleSearchRetrieval) {
+		this.googleSearchRetrieval = googleSearchRetrieval;
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
+	public boolean equals(Object o) {
+		if (this == o)
 			return true;
-		if (obj == null)
+		if (!(o instanceof VertexAiGeminiChatOptions that))
 			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		VertexAiGeminiChatOptions other = (VertexAiGeminiChatOptions) obj;
-		if (stopSequences == null) {
-			if (other.stopSequences != null)
-				return false;
-		}
-		else if (!stopSequences.equals(other.stopSequences))
-			return false;
-		if (temperature == null) {
-			if (other.temperature != null)
-				return false;
-		}
-		else if (!temperature.equals(other.temperature))
-			return false;
-		if (topP == null) {
-			if (other.topP != null)
-				return false;
-		}
-		else if (!topP.equals(other.topP))
-			return false;
-		if (topK == null) {
-			if (other.topK != null)
-				return false;
-		}
-		else if (!topK.equals(other.topK))
-			return false;
-		if (candidateCount == null) {
-			if (other.candidateCount != null)
-				return false;
-		}
-		else if (!candidateCount.equals(other.candidateCount))
-			return false;
-		if (maxOutputTokens == null) {
-			if (other.maxOutputTokens != null)
-				return false;
-		}
-		else if (!maxOutputTokens.equals(other.maxOutputTokens))
-			return false;
-		if (model == null) {
-			if (other.model != null)
-				return false;
-		}
-		else if (!model.equals(other.model))
-			return false;
-		if (functionCallbacks == null) {
-			if (other.functionCallbacks != null)
-				return false;
-		}
-		else if (!functionCallbacks.equals(other.functionCallbacks))
-			return false;
-		if (functions == null) {
-			if (other.functions != null)
-				return false;
-		}
-		else if (!functions.equals(other.functions))
-			return false;
-		return true;
+		return googleSearchRetrieval == that.googleSearchRetrieval && Objects.equals(stopSequences, that.stopSequences)
+				&& Objects.equals(temperature, that.temperature) && Objects.equals(topP, that.topP)
+				&& Objects.equals(topK, that.topK) && Objects.equals(candidateCount, that.candidateCount)
+				&& Objects.equals(maxOutputTokens, that.maxOutputTokens) && Objects.equals(model, that.model)
+				&& Objects.equals(functionCallbacks, that.functionCallbacks)
+				&& Objects.equals(functions, that.functions);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(stopSequences, temperature, topP, topK, candidateCount, maxOutputTokens, model,
+				functionCallbacks, functions, googleSearchRetrieval);
 	}
 
 }


### PR DESCRIPTION
Added in Vertex client configuration the possibility to use GoogleSearchRetrieval as tool as grounding feature

https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/grounding

next up (on other PR) grounding support with "retrieval" tool, more studies needed.