### PR TITLE
Docs: Fix filter expression reference to Elasticsearch Query string query

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -160,7 +160,7 @@ vectorStore.similaritySearch(SearchRequest.defaults()
                 b.eq("article_type", "blog")).build()));
 ----
 
-NOTE: Those (portable) filter expressions get automatically converted into the proprietary Elasticsearch `WHERE` link:https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-syntax-select.html#sql-syntax-where[filter expressions].
+NOTE: Those (portable) filter expressions get automatically converted into the proprietary Elasticsearch link:https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html[Query string query].
 
 For example, this portable filter expression:
 


### PR DESCRIPTION
I fixed a mistake in our documentation that incorrectly mentioned SQL's WHERE. We actually use Elasticsearch's Query string query. This update makes sure our guide is right.