### PR TITLE
Add the autoconfigure property for the CassandraVectorStore option to return embeddings in documents from similarity searches

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStoreAutoConfiguration.java
@@ -57,6 +57,9 @@ public class CassandraVectorStoreAutoConfiguration {
 		if (properties.getDisallowSchemaCreation()) {
 			builder = builder.disallowSchemaChanges();
 		}
+		if (properties.getReturnEmbeddings()) {
+			builder = builder.returnEmbeddings();
+		}
 
 		return new CassandraVectorStore(builder.build(), embeddingClient);
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStoreProperties.java
@@ -41,6 +41,8 @@ public class CassandraVectorStoreProperties {
 
 	private boolean disallowSchemaChanges = false;
 
+	private boolean returnEmbeddings = false;
+
 	private int fixedThreadPoolExecutorSize = CassandraVectorStoreConfig.DEFAULT_ADD_CONCURRENCY;
 
 	public String getKeyspace() {
@@ -83,12 +85,20 @@ public class CassandraVectorStoreProperties {
 		this.embeddingColumnName = embeddingColumnName;
 	}
 
-	public Boolean getDisallowSchemaCreation() {
+	public boolean getDisallowSchemaCreation() {
 		return this.disallowSchemaChanges;
 	}
 
 	public void setDisallowSchemaCreation(boolean disallowSchemaCreation) {
 		this.disallowSchemaChanges = disallowSchemaCreation;
+	}
+
+	public boolean getReturnEmbeddings() {
+		return this.returnEmbeddings;
+	}
+
+	public void setReturnEmbeddings(boolean returnEmbeddings) {
+		this.returnEmbeddings = returnEmbeddings;
 	}
 
 	public int getFixedThreadPoolExecutorSize() {


### PR DESCRIPTION


 ref: https://github.com/spring-projects/spring-ai/pull/673
