### PR TITLE
Expose `QdrantClient` and `WeaviateClient` as beans

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfiguration.java
@@ -15,9 +15,10 @@
  */
 package org.springframework.ai.autoconfigure.vectorstore.qdrant;
 
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
 import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.ai.vectorstore.qdrant.QdrantVectorStore;
-import org.springframework.ai.vectorstore.qdrant.QdrantVectorStore.QdrantVectorStoreConfig;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -42,21 +43,25 @@ public class QdrantVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public QdrantVectorStore vectorStore(EmbeddingClient embeddingClient, QdrantVectorStoreProperties properties,
+	public QdrantClient qdrantClient(QdrantVectorStoreProperties properties,
 			QdrantConnectionDetails connectionDetails) {
+		QdrantGrpcClient.Builder grpcClientBuilder = QdrantGrpcClient.newBuilder(connectionDetails.getHost(),
+				connectionDetails.getPort(), properties.isUseTls());
 
-		var config = QdrantVectorStoreConfig.builder()
-			.withCollectionName(properties.getCollectionName())
-			.withHost(connectionDetails.getHost())
-			.withPort(connectionDetails.getPort())
-			.withTls(properties.isUseTls())
-			.withApiKey(properties.getApiKey())
-			.build();
-
-		return new QdrantVectorStore(config, embeddingClient);
+		if (properties.getApiKey() != null) {
+			grpcClientBuilder.withApiKey(properties.getApiKey());
+		}
+		return new QdrantClient(grpcClientBuilder.build());
 	}
 
-	private static class PropertiesQdrantConnectionDetails implements QdrantConnectionDetails {
+	@Bean
+	@ConditionalOnMissingBean
+	public QdrantVectorStore vectorStore(EmbeddingClient embeddingClient, QdrantVectorStoreProperties properties,
+			QdrantClient qdrantClient) {
+		return new QdrantVectorStore(qdrantClient, properties.getCollectionName(), embeddingClient);
+	}
+
+	static class PropertiesQdrantConnectionDetails implements QdrantConnectionDetails {
 
 		private final QdrantVectorStoreProperties properties;
 

--- a/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -34,7 +34,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
 
 import io.qdrant.client.QdrantClient;
-import io.qdrant.client.QdrantGrpcClient;
 import io.qdrant.client.grpc.Collections.Distance;
 import io.qdrant.client.grpc.Collections.VectorParams;
 import io.qdrant.client.grpc.JsonWithInt.Value;
@@ -51,6 +50,7 @@ import io.qdrant.client.grpc.Points.UpdateStatus;
  *
  * @author Anush Shetty
  * @author Christian Tzolov
+ * @author Eddú Meléndez
  * @since 0.8.1
  */
 public class QdrantVectorStore implements VectorStore, InitializingBean {
@@ -74,8 +74,6 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 
 		private final String collectionName;
 
-		private QdrantClient qdrantClient;
-
 		/*
 		 * Constructor using the builder.
 		 *
@@ -83,15 +81,6 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 		 */
 		private QdrantVectorStoreConfig(Builder builder) {
 			this.collectionName = builder.collectionName;
-
-			QdrantGrpcClient.Builder grpcClientBuilder = QdrantGrpcClient.newBuilder(builder.host, builder.port,
-					builder.useTls);
-
-			if (builder.apiKey != null) {
-				grpcClientBuilder.withApiKey(builder.apiKey);
-			}
-
-			this.qdrantClient = new QdrantClient(grpcClientBuilder.build());
 		}
 
 		/**
@@ -113,24 +102,7 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 
 			private String collectionName;
 
-			private String host = "localhost";
-
-			private int port = 6334;
-
-			private boolean useTls = false;
-
-			private String apiKey = null;
-
 			private Builder() {
-			}
-
-			/**
-			 * @param host The host of the Qdrant instance. Defaults to "localhost".
-			 */
-			public Builder withHost(String host) {
-				Assert.notNull(host, "host cannot be null");
-				this.host = host;
-				return this;
 			}
 
 			/**
@@ -138,32 +110,6 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 			 */
 			public Builder withCollectionName(String collectionName) {
 				this.collectionName = collectionName;
-				return this;
-			}
-
-			/**
-			 * @param port The GRPC port of the Qdrant instance. Defaults to 6334.
-			 * @return
-			 */
-			public Builder withPort(int port) {
-				this.port = port;
-				return this;
-			}
-
-			/**
-			 * @param useTls Whether to use TLS(HTTPS). Defaults to false.
-			 * @return
-			 */
-			public Builder withTls(boolean useTls) {
-				this.useTls = useTls;
-				return this;
-			}
-
-			/**
-			 * @param apiKey The Qdrant API key to authenticate with. Defaults to null.
-			 */
-			public Builder withApiKey(String apiKey) {
-				this.apiKey = apiKey;
 				return this;
 			}
 
@@ -184,8 +130,9 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 	 * @param config The configuration for the store.
 	 * @param embeddingClient The client for embedding operations.
 	 */
-	public QdrantVectorStore(QdrantVectorStoreConfig config, EmbeddingClient embeddingClient) {
-		this(config.qdrantClient, config.collectionName, embeddingClient);
+	public QdrantVectorStore(QdrantClient qdrantClient, QdrantVectorStoreConfig config,
+			EmbeddingClient embeddingClient) {
+		this(qdrantClient, config.collectionName, embeddingClient);
 	}
 
 	/**

--- a/vector-stores/spring-ai-weaviate/src/test/java/org/springframework/ai/vectorstore/WeaviateVectorStoreIT.java
+++ b/vector-stores/spring-ai-weaviate/src/test/java/org/springframework/ai/vectorstore/WeaviateVectorStoreIT.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -242,14 +244,15 @@ public class WeaviateVectorStoreIT {
 
 		@Bean
 		public VectorStore vectorStore(EmbeddingClient embeddingClient) {
+			WeaviateClient weaviateClient = new WeaviateClient(
+					new Config("http", weaviateContainer.getHttpHostAddress()));
+
 			WeaviateVectorStoreConfig config = WeaviateVectorStore.WeaviateVectorStoreConfig.builder()
-				.withScheme("http")
-				.withHost(weaviateContainer.getHttpHostAddress())
 				.withFilterableMetadataFields(List.of(MetadataField.text("country"), MetadataField.number("year")))
 				.withConsistencyLevel(WeaviateVectorStoreConfig.ConsistentLevel.ONE)
 				.build();
 
-			WeaviateVectorStore vectorStore = new WeaviateVectorStore(config, embeddingClient);
+			WeaviateVectorStore vectorStore = new WeaviateVectorStore(config, embeddingClient, weaviateClient);
 
 			return vectorStore;
 		}


### PR DESCRIPTION
Currently, `QdrantClient` and `WeaviateClient` are not exposed as beans. Having access to those would benefit to perform operations with an already configured client.

This would be great for having a actuator module with HealthContributor for each integration.

This is a breaking change but IMHO it is fine for 1.0.0.
