### PR TITLE
 Message Serialization: Enhance deserialization

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/AbstractMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/AbstractMessage.java
@@ -38,14 +38,18 @@ public abstract class AbstractMessage implements Message {
 
 	protected final MessageType messageType;
 
-	protected final String textContent;
+	protected final String content;
 
-	protected final List<Media> mediaData;
+	protected final List<Media> media;
 
 	/**
 	 * Additional options for the message to influence the response, not a generative map.
 	 */
 	protected final Map<String, Object> properties;
+
+	protected AbstractMessage(MessageType messageType) {
+		this(messageType, "");
+	}
 
 	protected AbstractMessage(MessageType messageType, String content) {
 		this(messageType, content, Map.of());
@@ -54,25 +58,25 @@ public abstract class AbstractMessage implements Message {
 	protected AbstractMessage(MessageType messageType, String content, Map<String, Object> messageProperties) {
 		Assert.notNull(messageType, "Message type must not be null");
 		this.messageType = messageType;
-		this.textContent = content;
-		this.mediaData = new ArrayList<>();
+		this.content = content;
+		this.media = new ArrayList<>();
 		this.properties = messageProperties;
 	}
 
-	protected AbstractMessage(MessageType messageType, String textContent, List<Media> mediaData) {
-		this(messageType, textContent, mediaData, Map.of());
+	protected AbstractMessage(MessageType messageType, String content, List<Media> media) {
+		this(messageType, content, media, Map.of());
 	}
 
-	protected AbstractMessage(MessageType messageType, String textContent, List<Media> mediaData,
-			Map<String, Object> messageProperties) {
+	protected AbstractMessage(MessageType messageType, String content, List<Media> media,
+							  Map<String, Object> messageProperties) {
 
 		Assert.notNull(messageType, "Message type must not be null");
-		Assert.notNull(textContent, "Content must not be null");
-		Assert.notNull(mediaData, "media data must not be null");
+		Assert.notNull(content, "Content must not be null");
+		Assert.notNull(media, "media data must not be null");
 
 		this.messageType = messageType;
-		this.textContent = textContent;
-		this.mediaData = new ArrayList<>(mediaData);
+		this.content = content;
+		this.media = new ArrayList<>(media);
 		this.properties = messageProperties;
 	}
 
@@ -87,10 +91,10 @@ public abstract class AbstractMessage implements Message {
 
 		this.messageType = messageType;
 		this.properties = messageProperties;
-		this.mediaData = new ArrayList<>();
+		this.media = new ArrayList<>();
 
 		try (InputStream inputStream = resource.getInputStream()) {
-			this.textContent = StreamUtils.copyToString(inputStream, Charset.defaultCharset());
+			this.content = StreamUtils.copyToString(inputStream, Charset.defaultCharset());
 		}
 		catch (IOException ex) {
 			throw new RuntimeException("Failed to read resource", ex);
@@ -99,12 +103,12 @@ public abstract class AbstractMessage implements Message {
 
 	@Override
 	public String getContent() {
-		return this.textContent;
+		return this.content;
 	}
 
 	@Override
 	public List<Media> getMedia() {
-		return this.mediaData;
+		return this.media;
 	}
 
 	@Override
@@ -121,7 +125,7 @@ public abstract class AbstractMessage implements Message {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((mediaData == null) ? 0 : mediaData.hashCode());
+		result = prime * result + ((media == null) ? 0 : media.hashCode());
 		result = prime * result + ((properties == null) ? 0 : properties.hashCode());
 		result = prime * result + ((messageType == null) ? 0 : messageType.hashCode());
 		return result;
@@ -136,11 +140,11 @@ public abstract class AbstractMessage implements Message {
 		if (getClass() != obj.getClass())
 			return false;
 		AbstractMessage other = (AbstractMessage) obj;
-		if (mediaData == null) {
-			if (other.mediaData != null)
+		if (media == null) {
+			if (other.media != null)
 				return false;
 		}
-		else if (!mediaData.equals(other.mediaData))
+		else if (!media.equals(other.media))
 			return false;
 		if (properties == null) {
 			if (other.properties != null)

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
@@ -25,6 +25,10 @@ import java.util.Map;
  */
 public class AssistantMessage extends AbstractMessage {
 
+	public AssistantMessage() {
+        super(MessageType.ASSISTANT);
+    }
+
 	public AssistantMessage(String content) {
 		super(MessageType.ASSISTANT, content);
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/FunctionMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/FunctionMessage.java
@@ -23,6 +23,10 @@ import java.util.Map;
  */
 public class FunctionMessage extends AbstractMessage {
 
+	public FunctionMessage() {
+		super(MessageType.FUNCTION);
+	}
+
 	public FunctionMessage(String content) {
 		super(MessageType.FUNCTION, content);
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/SystemMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/SystemMessage.java
@@ -26,6 +26,10 @@ import org.springframework.core.io.Resource;
  */
 public class SystemMessage extends AbstractMessage {
 
+	public SystemMessage() {
+		super(MessageType.SYSTEM);
+	}
+
 	public SystemMessage(String content) {
 		super(MessageType.SYSTEM, content);
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
@@ -27,6 +27,10 @@ import org.springframework.core.io.Resource;
  */
 public class UserMessage extends AbstractMessage {
 
+	public UserMessage() {
+		super(MessageType.USER);
+	}
+
 	public UserMessage(String message) {
 		super(MessageType.USER, message);
 	}


### PR DESCRIPTION
## Background

Hey there, while developing with Spring Boot, I encountered issues with Jackson deserialization when storing historical messages into the Redis client. After troubleshooting using the control variable method, I found that there is room for improvement in the classes under the Message package. I made two code modifications to accommodate the new version of Jackson's deserialization process.

## Solution

1. I added no-argument constructors to `UserMessage`, `SystemMessage`, `FunctionMessage`, and `AssistMessage`, and modified `AbstractMessage` to include a single-argument constructor. This resolves the following serialization error:

```java
org.springframework.data.redis.serializer.SerializationException: Could not read JSON: Cannot construct instance of `org.springframework.ai.chat.messages.SystemMessage` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)
```

2. I renamed `textContent` and `mediaData` in `AbstractMessage` to `content` and `media` to align with the methods exposed by the message. This change can resolve the following error:

```java
org.springframework.data.redis.serializer.SerializationException: Could not read JSON: Problem deserializing 'setterless' property ("media"): no way to handle typed deser with setterless yet
```

## PS: Additional Information

Version Information: Spring Boot 3.2.4, spring-boot-starter-data-redis 3.2.4, SpringAI 1.0.0-SNAPSHOT

RedisTemplateConfig.java:

```java
@Configuration
public class RedisConfig {
    @Bean
    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
        RedisSerializer<Object> serializer = redisSerializer();
        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
        redisTemplate.setConnectionFactory(redisConnectionFactory);

        redisTemplate.setKeySerializer(new StringRedisSerializer());
        redisTemplate.setValueSerializer(serializer);
        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
        redisTemplate.setHashValueSerializer(serializer);
        redisTemplate.afterPropertiesSet();
        return redisTemplate;
    }

    @Bean
    public RedisSerializer<Object> redisSerializer() {
        ObjectMapper objectMapper = new ObjectMapper();
        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
        objectMapper.activateDefaultTyping(LaissezFaireSubTypeValidator.instance, ObjectMapper.DefaultTyping.NON_FINAL);

        return new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
    }
}
```

