### PR TITLE
Fix AWS Bedrock Cohere embedding truncate type error.

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
@@ -162,11 +162,11 @@ public class CohereEmbeddingBedrockApi extends
 			/**
 			 * Discard the start of the input.
 			 */
-			LEFT,
+			START,
 			/**
 			 * Discards the end of the input.
 			 */
-			RIGHT
+			END
 		}
 	}
 

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiIT.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Wei Jiang
  */
 @EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".*")
 @EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".*")
@@ -49,6 +50,31 @@ public class CohereEmbeddingBedrockApiIT {
 				CohereEmbeddingRequest.InputType.SEARCH_DOCUMENT, CohereEmbeddingRequest.Truncate.NONE);
 
 		CohereEmbeddingResponse response = api.embedding(request);
+
+		assertThat(response).isNotNull();
+		assertThat(response.texts()).isEqualTo(request.texts());
+		assertThat(response.embeddings()).hasSize(2);
+		assertThat(response.embeddings().get(0)).hasSize(1024);
+	}
+
+	@Test
+	public void embedTextWithTruncate() {
+
+		CohereEmbeddingRequest request = new CohereEmbeddingRequest(
+				List.of("I like to eat apples", "I like to eat oranges"),
+				CohereEmbeddingRequest.InputType.SEARCH_DOCUMENT, CohereEmbeddingRequest.Truncate.START);
+
+		CohereEmbeddingResponse response = api.embedding(request);
+
+		assertThat(response).isNotNull();
+		assertThat(response.texts()).isEqualTo(request.texts());
+		assertThat(response.embeddings()).hasSize(2);
+		assertThat(response.embeddings().get(0)).hasSize(1024);
+
+		request = new CohereEmbeddingRequest(List.of("I like to eat apples", "I like to eat oranges"),
+				CohereEmbeddingRequest.InputType.SEARCH_DOCUMENT, CohereEmbeddingRequest.Truncate.END);
+
+		response = api.embedding(request);
 
 		assertThat(response).isNotNull();
 		assertThat(response.texts()).isEqualTo(request.texts());


### PR DESCRIPTION
According to the AWS Bedrock cohere embedding document: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed.html

The request parameter `truncate` should have the following values:
```
truncate – Specifies how the API handles inputs longer than the maximum token length. Use one of the following:

NONE – (Default) Returns an error when the input exceeds the maximum input token length.

START – Discards the start of the input.

END – Discards the end of the input.

If you specify START or END, the model discards the input until the remaining input is exactly the maximum input token length for the model.
```

But currently we have `LEFT` and `RIGHT` values. It will be throw the exception below:

```
Caused by: software.amazon.awssdk.services.bedrockruntime.model.ValidationException: Malformed input request: #/truncate: LEFT is not a valid enum value, please reformat your input and try again. (Service: BedrockRuntime, Status Code: 400
```