### PR TITLE
Fix ChromaDB basic authentication

### DIFF
--- a/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/chroma/ChromaApi.java
+++ b/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/chroma/ChromaApi.java
@@ -82,7 +82,7 @@ public class ChromaApi {
 	 * @param password Credentials password.
 	 */
 	public ChromaApi withBasicAuthCredentials(String username, String password) {
-		this.restTemplate.getInterceptors().add(new BasicAuthenticationInterceptor(username, username));
+		this.restTemplate.getInterceptors().add(new BasicAuthenticationInterceptor(username, password));
 		return this;
 	}
 

--- a/vector-stores/spring-ai-chroma/src/test/java/org/springframework/ai/vectorstore/BasicAuthChromaWhereIT.java
+++ b/vector-stores/spring-ai-chroma/src/test/java/org/springframework/ai/vectorstore/BasicAuthChromaWhereIT.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.testcontainers.chromadb.ChromaDBContainer;
-import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -28,12 +27,12 @@ import org.springframework.ai.chroma.ChromaApi;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.ai.vectorstore.ChromaVectorStore;
 import org.springframework.ai.openai.OpenAiEmbeddingClient;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
+import org.testcontainers.utility.MountableFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,11 +55,11 @@ public class BasicAuthChromaWhereIT {
 	 */
 	@Container
 	static ChromaDBContainer chromaContainer = new ChromaDBContainer("ghcr.io/chroma-core/chroma:0.4.22")
-		.withEnv("CHROMA_SERVER_AUTH_CREDENTIALS_FILE", "server.htpasswd")
+		.withEnv("CHROMA_SERVER_AUTH_CREDENTIALS_FILE", "/chroma/server.htpasswd")
 		.withEnv("CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER",
 				"chromadb.auth.providers.HtpasswdFileServerAuthCredentialsProvider")
 		.withEnv("CHROMA_SERVER_AUTH_PROVIDER", "chromadb.auth.basic.BasicAuthServerProvider")
-		.withCopyToContainer(Transferable.of("src/test/resources/server.htpasswd"), "server.htpasswd");
+		.withCopyToContainer(MountableFile.forClasspathResource("server.htpasswd"), "/chroma/server.htpasswd");
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withUserConfiguration(TestApplication.class)
@@ -103,7 +102,7 @@ public class BasicAuthChromaWhereIT {
 		@Bean
 		public ChromaApi chromaApi(RestTemplate restTemplate) {
 			return new ChromaApi(chromaContainer.getEndpoint(), restTemplate).withBasicAuthCredentials("admin",
-					"admin");
+					"password");
 		}
 
 		@Bean

--- a/vector-stores/spring-ai-chroma/src/test/java/org/springframework/ai/vectorstore/TokenSecuredChromaWhereIT.java
+++ b/vector-stores/spring-ai-chroma/src/test/java/org/springframework/ai/vectorstore/TokenSecuredChromaWhereIT.java
@@ -27,7 +27,6 @@ import org.springframework.ai.chroma.ChromaApi;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.ai.vectorstore.ChromaVectorStore;
 import org.springframework.ai.openai.OpenAiEmbeddingClient;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/vector-stores/spring-ai-chroma/src/test/resources/server.htpasswd
+++ b/vector-stores/spring-ai-chroma/src/test/resources/server.htpasswd
@@ -1,2 +1,2 @@
-admin:$2y$05$fM.6b629s3L6L8RcA.kqg.BmxEzwB9t4MpGux62MEXNMJ9M7w8CY2
+admin:$2y$05$qSmQb0YJmaLRIhbT7MRBRu6bPK267dxkzLikr6WA/7JfGERc7dKkW
 


### PR DESCRIPTION
Currently, `username` is added as a password in `BasicAuthenticationInterceptor`. This commit fixes the issue and also make sure the integration test setup is correct.
