### PR TITLE
Add default collection name to Qdrant

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreProperties.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.autoconfigure.vectorstore.qdrant;
 
+import org.springframework.ai.vectorstore.qdrant.QdrantVectorStore;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -29,7 +30,7 @@ public class QdrantVectorStoreProperties {
 	/**
 	 * The name of the collection to use in Qdrant.
 	 */
-	private String collectionName;
+	private String collectionName = QdrantVectorStore.DEFAULT_COLLECTION_NAME;
 
 	/**
 	 * The host of the Qdrant server.

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfigurationIT.java
@@ -40,12 +40,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Eddú Meléndez
  * @since 0.8.1
  */
 @Testcontainers
 public class QdrantVectorStoreAutoConfigurationIT {
-
-	private static final String COLLECTION_NAME = "test_collection";
 
 	private static final int QDRANT_GRPC_PORT = 6334;
 
@@ -61,8 +60,7 @@ public class QdrantVectorStoreAutoConfigurationIT {
 		.withConfiguration(AutoConfigurations.of(QdrantVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.qdrant.port=" + qdrantContainer.getMappedPort(QDRANT_GRPC_PORT),
-				"spring.ai.vectorstore.qdrant.host=" + qdrantContainer.getHost(),
-				"spring.ai.vectorstore.qdrant.collectionName=" + COLLECTION_NAME);
+				"spring.ai.vectorstore.qdrant.host=" + qdrantContainer.getHost());
 
 	@Test
 	public void addAndSearch() {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStorePropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStorePropertiesTests.java
@@ -16,11 +16,13 @@
 package org.springframework.ai.autoconfigure.vectorstore.qdrant;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.vectorstore.qdrant.QdrantVectorStore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Eddú Meléndez
  */
 public class QdrantVectorStorePropertiesTests {
 
@@ -28,7 +30,7 @@ public class QdrantVectorStorePropertiesTests {
 	public void defaultValues() {
 		var props = new QdrantVectorStoreProperties();
 
-		assertThat(props.getCollectionName()).isNull();
+		assertThat(props.getCollectionName()).isEqualTo(QdrantVectorStore.DEFAULT_COLLECTION_NAME);
 		assertThat(props.getHost()).isEqualTo("localhost");
 		assertThat(props.getPort()).isEqualTo(6334);
 		assertThat(props.isUseTls()).isFalse();

--- a/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -59,6 +59,8 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 
 	private static final String DISTANCE_FIELD_NAME = "distance";
 
+	public static final String DEFAULT_COLLECTION_NAME = "vector_store";
+
 	private final EmbeddingClient embeddingClient;
 
 	private final QdrantClient qdrantClient;


### PR DESCRIPTION
Add a default collection name similar to other vector store implementations. Currently, when using starters, qdrant requires a collection name. Otherwise, it fails.
