### PR TITLE
Optimize Request for Embedding in Vector Store

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.core.io.Resource;
+import org.springframework.util.CollectionUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -71,9 +72,10 @@ public class SimpleVectorStore implements VectorStore {
 	@Override
 	public void add(List<Document> documents) {
 		for (Document document : documents) {
-			logger.info("Calling EmbeddingClient for document id = {}", document.getId());
-			List<Double> embedding = this.embeddingClient.embed(document);
-			document.setEmbedding(embedding);
+			if (CollectionUtils.isEmpty(document.getEmbedding())) {
+				logger.info("Calling EmbeddingClient for document id = {}", document.getId());
+				document.setEmbedding(this.embeddingClient.embed(document));
+			}
 			this.store.put(document.getId(), document);
 		}
 	}

--- a/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -211,7 +211,8 @@ public class AzureVectorStore implements VectorStore, InitializingBean {
 		}
 
 		final var searchDocuments = documents.stream().map(document -> {
-			final var embeddings = this.embeddingClient.embed(document);
+			final var embeddings = CollectionUtils.isEmpty(document.getEmbedding())
+					? this.embeddingClient.embed(document) : document.getEmbedding();
 			SearchDocument searchDocument = new SearchDocument();
 			searchDocument.put(ID_FIELD_NAME, document.getId());
 			searchDocument.put(EMBEDDING_FIELD_NAME, embeddings);

--- a/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
@@ -93,7 +93,9 @@ public class ChromaVectorStore implements VectorStore, InitializingBean {
 			ids.add(document.getId());
 			metadatas.add(document.getMetadata());
 			contents.add(document.getContent());
-			document.setEmbedding(this.embeddingClient.embed(document));
+			if (CollectionUtils.isEmpty(document.getEmbedding())) {
+				document.setEmbedding(this.embeddingClient.embed(document));
+			}
 			embeddings.add(JsonUtils.toFloatArray(document.getEmbedding()));
 		}
 

--- a/vector-stores/spring-ai-gemfire/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
@@ -35,6 +35,7 @@ import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
@@ -417,7 +418,9 @@ public class GemFireVectorStore implements VectorStore {
 	public void add(List<Document> documents) {
 		UploadRequest upload = new UploadRequest(documents.stream().map(document -> {
 			// Compute and assign an embedding to the document.
-			document.setEmbedding(this.embeddingClient.embed(document));
+			if (CollectionUtils.isEmpty(document.getEmbedding())) {
+				document.setEmbedding(this.embeddingClient.embed(document));
+			}
 			List<Float> floatVector = document.getEmbedding().stream().map(Double::floatValue).toList();
 			return new UploadRequest.Embedding(document.getId(), floatVector, documentField, document.getContent(),
 					document.getMetadata());

--- a/vector-stores/spring-ai-hanadb-store/src/main/java/org/springframework/ai/vectorstore/HanaCloudVectorStore.java
+++ b/vector-stores/spring-ai-hanadb-store/src/main/java/org/springframework/ai/vectorstore/HanaCloudVectorStore.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingClient;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -137,9 +138,10 @@ public class HanaCloudVectorStore implements VectorStore {
 	}
 
 	private String getEmbedding(Document document) {
-		return "["
-				+ this.embeddingClient.embed(document).stream().map(String::valueOf).collect(Collectors.joining(", "))
-				+ "]";
+		if (CollectionUtils.isEmpty(document.getEmbedding())) {
+			document.setEmbedding(this.embeddingClient.embed(document));
+		}
+		return "[" + document.getEmbedding().stream().map(String::valueOf).collect(Collectors.joining(", ")) + "]";
 	}
 
 }

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -268,7 +268,8 @@ public class MilvusVectorStore implements VectorStore, InitializingBean {
 		List<List<Float>> embeddingArray = new ArrayList<>();
 
 		for (Document document : documents) {
-			List<Double> embedding = this.embeddingClient.embed(document);
+			List<Double> embedding = document.getEmbedding().isEmpty() ? this.embeddingClient.embed(document)
+					: document.getEmbedding();
 
 			docIdArray.add(document.getId());
 			// Use a (future) DocumentTextLayoutFormatter instance to extract

--- a/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/MongoDBAtlasVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/MongoDBAtlasVectorStore.java
@@ -129,8 +129,9 @@ public class MongoDBAtlasVectorStore implements VectorStore, InitializingBean {
 	@Override
 	public void add(List<Document> documents) {
 		for (Document document : documents) {
-			List<Double> embedding = this.embeddingClient.embed(document);
-			document.setEmbedding(embedding);
+			if (document.getEmbedding().isEmpty()) {
+				document.setEmbedding(this.embeddingClient.embed(document));
+			}
 			this.mongoTemplate.save(document, this.config.collectionName);
 		}
 	}

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
@@ -24,6 +24,7 @@ import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.ai.vectorstore.filter.Neo4jVectorFilterExpressionConverter;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -372,8 +373,9 @@ public class Neo4jVectorStore implements VectorStore, InitializingBean {
 	}
 
 	private Map<String, Object> documentToRecord(Document document) {
-		var embedding = this.embeddingClient.embed(document);
-		document.setEmbedding(embedding);
+		if (CollectionUtils.isEmpty(document.getEmbedding())) {
+			document.setEmbedding(this.embeddingClient.embed(document));
+		}
 
 		var row = new HashMap<String, Object>();
 
@@ -385,7 +387,7 @@ public class Neo4jVectorStore implements VectorStore, InitializingBean {
 		document.getMetadata().forEach((k, v) -> properties.put("metadata." + k, Values.value(v)));
 		row.put("properties", properties);
 
-		row.put(this.config.embeddingProperty, Values.value(toFloatArray(embedding)));
+		row.put(this.config.embeddingProperty, Values.value(toFloatArray(document.getEmbedding())));
 		return row;
 	}
 

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
@@ -42,6 +42,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SqlTypeValue;
 import org.springframework.jdbc.core.StatementCreatorUtils;
 import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -237,7 +238,9 @@ public class PgVectorStore implements VectorStore, InitializingBean {
 						var document = documents.get(i);
 						var content = document.getContent();
 						var json = toJson(document.getMetadata());
-						var pGvector = new PGvector(toFloatArray(embeddingClient.embed(document)));
+						var embedding = CollectionUtils.isEmpty(document.getEmbedding())
+								? embeddingClient.embed(document) : document.getEmbedding();
+						var pGvector = new PGvector(toFloatArray(embedding));
 
 						StatementCreatorUtils.setParameterValue(ps, 1, SqlTypeValue.TYPE_UNKNOWN,
 								UUID.fromString(document.getId()));

--- a/vector-stores/spring-ai-pinecone/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
@@ -39,6 +39,7 @@ import org.springframework.ai.embedding.EmbeddingClient;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
 import org.springframework.ai.vectorstore.filter.converter.PineconeFilterExpressionConverter;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -232,7 +233,9 @@ public class PineconeVectorStore implements VectorStore {
 
 		List<Vector> upsertVectors = documents.stream().map(document -> {
 			// Compute and assign an embedding to the document.
-			document.setEmbedding(this.embeddingClient.embed(document));
+			if (CollectionUtils.isEmpty(document.getEmbedding())) {
+				document.setEmbedding(this.embeddingClient.embed(document));
+			}
 
 			return Vector.newBuilder()
 				.setId(document.getId())

--- a/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -43,6 +43,7 @@ import io.qdrant.client.grpc.Points.PointStruct;
 import io.qdrant.client.grpc.Points.ScoredPoint;
 import io.qdrant.client.grpc.Points.SearchPoints;
 import io.qdrant.client.grpc.Points.UpdateStatus;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Qdrant vectorStore implementation. This store supports creating, updating, deleting,
@@ -165,7 +166,9 @@ public class QdrantVectorStore implements VectorStore, InitializingBean {
 		try {
 			List<PointStruct> points = documents.stream().map(document -> {
 				// Compute and assign an embedding to the document.
-				document.setEmbedding(this.embeddingClient.embed(document));
+				if (CollectionUtils.isEmpty(document.getEmbedding())) {
+					document.setEmbedding(this.embeddingClient.embed(document));
+				}
 
 				return PointStruct.newBuilder()
 					.setId(id(UUID.fromString(document.getId())))

--- a/vector-stores/spring-ai-redis/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
@@ -305,11 +305,12 @@ public class RedisVectorStore implements VectorStore, InitializingBean {
 	public void add(List<Document> documents) {
 		try (Pipeline pipeline = this.jedis.pipelined()) {
 			for (Document document : documents) {
-				var embedding = this.embeddingClient.embed(document);
-				document.setEmbedding(embedding);
+				if (CollectionUtils.isEmpty(document.getEmbedding())) {
+					document.setEmbedding(this.embeddingClient.embed(document));
+				}
 
 				var fields = new HashMap<String, Object>();
-				fields.put(this.config.embeddingFieldName, embedding);
+				fields.put(this.config.embeddingFieldName, document.getEmbedding());
 				fields.put(this.config.contentFieldName, document.getContent());
 				fields.putAll(document.getMetadata());
 				pipeline.jsonSetWithEscape(key(document.getId()), JSON_SET_PATH, fields);


### PR DESCRIPTION
Currently, vector store automatically calls the embedding client to generate the document embedding without checking whether the document already had an embedding.

In this PR, I first check if the document doesn't already have an embedding before calling the client to generate an embedding. This prevents too many calls to generate an embedding.

- Tests are green for impacted vector stores