### PR TITLE
OpenAI: Add gpt-4o to chat model enum

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -109,10 +109,17 @@ public class OpenAiApi {
 
 	/**
 	 * OpenAI Chat Completion Models:
-	 * <a href="https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo">GPT-4 and GPT-4 Turbo</a> and
-	 * <a href="https://platform.openai.com/docs/models/gpt-3-5-turbo">GPT-3.5 Turbo</a>.
+	 * - <a href="https://platform.openai.com/docs/models/gpt-4o">GPT-4o</a>
+	 * - <a href="https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo">GPT-4 and GPT-4 Turbo</a>
+	 * - <a href="https://platform.openai.com/docs/models/gpt-3-5-turbo">GPT-3.5 Turbo</a>.
 	 */
 	public enum ChatModel {
+		/**
+		 * Multimodal flagship model that’s cheaper and faster than GPT-4 Turbo.
+		 * Currently points to gpt-4o-2024-05-13.
+		 */
+		GPT_4_O("gpt-4o"),
+
 		/**
 		 * (New) GPT-4 Turbo - latest GPT-4 model intended to reduce cases
 		 * of “laziness” where the model doesn’t complete a task.


### PR DESCRIPTION
Add gpt-4o to OpenAI chat models enum and update JavaDoc
