### PR TITLE
Add getContent() method to ChatResponse

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/ChatResponse.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/ChatResponse.java
@@ -79,6 +79,15 @@ public class ChatResponse implements ModelResponse<Generation> {
 	}
 
 	/**
+	 * Convenience method equivalent to {@code getResult().getOutput().getContent()}.
+	 * @return The content from the output of the first {@link Generation} in the
+	 * generations list.
+	 */
+	public String getContent() {
+		return getResult().getOutput().getContent();
+	}
+
+	/**
 	 * @return Returns {@link ChatResponseMetadata} containing information about the use
 	 * of the AI provider's API.
 	 */


### PR DESCRIPTION
Simple convenience method on `ChatRespoonse` to return the content of the first generation.

Although `ChatResponse` has many useful bits of information carried in it, the most common thing needed by all applications is the content of the first generation. E.g.

```
String content = chatResponse.getResult().getOuptut().getContent();
```

Because it's the most commonly needed information from a `ChatResponse`, it would be helpful if there were a convenience method that returns the content directly instead of having to navigate through a few other properties. That's what this PR provides. The above code can then be replaced with:

```
String content = chatResponse.getContent();
```