### PR TITLE
Add spring-ai-retry dependency to Ollama model pom.xml

### DIFF
--- a/models/spring-ai-ollama/pom.xml
+++ b/models/spring-ai-ollama/pom.xml
@@ -34,6 +34,12 @@
         </dependency>
 
         <dependency>
+    			<groupId>org.springframework.ai</groupId>
+    			<artifactId>spring-ai-retry</artifactId>
+    			<version>${project.parent.version}</version>
+    		</dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
         </dependency>


### PR DESCRIPTION
Fixes #546 

In short: I'm getting a `ClassNotFoundException` for `NonTransientAiException` when trying to use the Ollama model dependency. It works if I explicitly add it to my build. Meanwhile I don't need to do that for OpenAI because it's already in that module's build.
