### PR TITLE
fix: wrong operator in neo4j vector store filter expression

### DIFF
--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/filter/Neo4jVectorFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/filter/Neo4jVectorFilterExpressionConverter.java
@@ -46,7 +46,7 @@ public class Neo4jVectorFilterExpressionConverter extends AbstractFilterExpressi
 			case AND -> " AND ";
 			case OR -> " OR ";
 			case EQ -> " = ";
-			case NE -> " != ";
+			case NE -> " <> ";
 			case LT -> " < ";
 			case LTE -> " <= ";
 			case GT -> " > ";

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/filter/Neo4jVectorFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/filter/Neo4jVectorFilterExpressionConverterTests.java
@@ -76,13 +76,13 @@ public class Neo4jVectorFilterExpressionConverterTests {
 
 	@Test
 	public void testNe() {
-		// year >= 2020 OR country = "BG" AND city != "Sofia"
+		// year >= 2020 OR country = "BG" AND city <> "Sofia"
 		String vectorExpr = converter
 			.convertExpression(new Expression(OR, new Expression(GTE, new Key("year"), new Value(2020)),
 					new Expression(AND, new Expression(EQ, new Key("country"), new Value("BG")),
 							new Expression(NE, new Key("city"), new Value("Sofia")))));
 		assertThat(vectorExpr).isEqualTo(
-				"node.`metadata.year` >= 2020 OR node.`metadata.country` = \"BG\" AND node.`metadata.city` != \"Sofia\"");
+				"node.`metadata.year` >= 2020 OR node.`metadata.country` = \"BG\" AND node.`metadata.city` <> \"Sofia\"");
 	}
 
 	@Test


### PR DESCRIPTION
Hello, 

this PR fixes an issue with the neo4j vector store. Currently it is not possible to use the "Not equals" filter expression since the used operator (`!=`) is not valid. In Neo4j/Cypher inequality is checked with the `<>`-operator.

See also: [Cypher Manual - Equality](https://neo4j.com/docs/cypher-manual/current/syntax/operators/?utm_source=Google&utm_medium=PaidSearch&utm_campaign=Evergreen&utm_content=EMEA-Search-SEMCE-DSA-None-SEM-SEM-NonABM&utm_term=&utm_adgroup=DSA&gad_source=1&gclid=Cj0KCQjw6auyBhDzARIsALIo6v9oEVwWHnJDVZu9VEnDpFoeU7SWis-MvfiHRi1bq8pyngiDX503lgQaAjr9EALw_wcB#cypher-comparison) 
