### PR TITLE
[Azure OpenAI] added support for response format in chat options

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -32,6 +32,9 @@ import com.azure.ai.openai.models.CompletionsFinishReason;
 import com.azure.ai.openai.models.ContentFilterResultsForPrompt;
 import com.azure.ai.openai.models.FunctionCall;
 import com.azure.ai.openai.models.FunctionDefinition;
+import com.azure.ai.openai.models.ChatCompletionsJsonResponseFormat;
+import com.azure.ai.openai.models.ChatCompletionsTextResponseFormat;
+import com.azure.ai.openai.models.ChatCompletionsResponseFormat;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.IterableStream;
 import org.slf4j.Logger;
@@ -349,6 +352,11 @@ public class AzureOpenAiChatModel
 			mergedAzureOptions.setPresencePenalty(toSpringAiOptions.getPresencePenalty().doubleValue());
 		}
 
+		mergedAzureOptions.setResponseFormat(fromAzureOptions.getResponseFormat());
+		if (mergedAzureOptions.getResponseFormat() == null && toSpringAiOptions.getResponseFormat() != null) {
+			mergedAzureOptions.setResponseFormat(toAzureResponseFormat(toSpringAiOptions.getResponseFormat()));
+		}
+
 		mergedAzureOptions.setN(fromAzureOptions.getN() != null ? fromAzureOptions.getN() : toSpringAiOptions.getN());
 
 		mergedAzureOptions
@@ -417,6 +425,10 @@ public class AzureOpenAiChatModel
 			mergedAzureOptions.setModel(fromSpringAiOptions.getDeploymentName());
 		}
 
+		if (fromSpringAiOptions.getResponseFormat() != null) {
+			mergedAzureOptions.setResponseFormat(toAzureResponseFormat(fromSpringAiOptions.getResponseFormat()));
+		}
+
 		return mergedAzureOptions;
 	}
 
@@ -465,6 +477,9 @@ public class AzureOpenAiChatModel
 		if (fromOptions.getModel() != null) {
 			mergedOptions.setModel(fromOptions.getModel());
 		}
+		if (fromOptions.getResponseFormat() != null) {
+			mergedOptions.setResponseFormat(fromOptions.getResponseFormat());
+		}
 
 		return mergedOptions;
 	}
@@ -508,6 +523,9 @@ public class AzureOpenAiChatModel
 		}
 		if (fromOptions.getModel() != null) {
 			copyOptions.setModel(fromOptions.getModel());
+		}
+		if (fromOptions.getResponseFormat() != null) {
+			copyOptions.setResponseFormat(fromOptions.getResponseFormat());
 		}
 
 		return copyOptions;
@@ -588,6 +606,18 @@ public class AzureOpenAiChatModel
 		}
 
 		return choice.getFinishReason() == CompletionsFinishReason.TOOL_CALLS;
+	}
+
+	/**
+	 * Maps the SpringAI response format to the Azure response format
+	 * @param responseFormat SpringAI response format
+	 * @return Azure response format
+	 */
+	private ChatCompletionsResponseFormat toAzureResponseFormat(AzureOpenAiResponseFormat responseFormat) {
+		if (responseFormat == AzureOpenAiResponseFormat.JSON) {
+			return new ChatCompletionsJsonResponseFormat();
+		}
+		return new ChatCompletionsTextResponseFormat();
 	}
 
 }

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -127,6 +127,14 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions, ChatOptio
 	private String deploymentName;
 
 	/**
+	 * The response format expected from the Azure OpenAI model
+	 * @see org.springframework.ai.azure.openai.AzureOpenAiResponseFormat for supported
+	 * formats
+	 */
+	@JsonProperty("response_format")
+	private AzureOpenAiResponseFormat responseFormat;
+
+	/**
 	 * OpenAI Tool Function Callbacks to register with the ChatModel. For Prompt Options
 	 * the functionCallbacks are automatically enabled for the duration of the prompt
 	 * execution. For Default Options the functionCallbacks are registered but disabled by
@@ -236,6 +244,12 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions, ChatOptio
 		public Builder withFunction(String functionName) {
 			Assert.hasText(functionName, "Function name must not be empty");
 			this.options.functions.add(functionName);
+			return this;
+		}
+
+		public Builder withResponseFormat(AzureOpenAiResponseFormat responseFormat) {
+			Assert.notNull(responseFormat, "responseFormat must not be null");
+			this.options.responseFormat = responseFormat;
 			return this;
 		}
 
@@ -354,6 +368,14 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions, ChatOptio
 
 	public void setFunctions(Set<String> functions) {
 		this.functions = functions;
+	}
+
+	public AzureOpenAiResponseFormat getResponseFormat() {
+		return this.responseFormat;
+	}
+
+	public void setResponseFormat(AzureOpenAiResponseFormat responseFormat) {
+		this.responseFormat = responseFormat;
 	}
 
 	public static AzureOpenAiChatOptions fromOptions(AzureOpenAiChatOptions fromOptions) {

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiResponseFormat.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiResponseFormat.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.azure.openai;
+
+/**
+ * Utility enumeration for representing the response format that may be requested from the
+ * Azure OpenAI model. Please check <a href=
+ * "https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format">OpenAI
+ * API documentation</a> for more details.
+ */
+public enum AzureOpenAiResponseFormat {
+
+	// default value used by OpenAI
+	TEXT,
+	/*
+	 * From the OpenAI API documentation: Compatability: Compatible with GPT-4 Turbo and
+	 * all GPT-3.5 Turbo models newer than gpt-3.5-turbo-1106. Caveats: This enables JSON
+	 * mode, which guarantees the message the model generates is valid JSON. Important:
+	 * when using JSON mode, you must also instruct the model to produce JSON yourself via
+	 * a system or user message. Without this, the model may generate an unending stream
+	 * of whitespace until the generation reaches the token limit, resulting in a
+	 * long-running and seemingly "stuck" request. Also note that the message content may
+	 * be partially cut off if finish_reason="length", which indicates the generation
+	 * exceeded max_tokens or the conversation exceeded the max context length.
+	 */
+	JSON
+
+}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
@@ -16,6 +16,8 @@
 package org.springframework.ai.azure.openai;
 
 import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.models.ChatCompletionsJsonResponseFormat;
+import com.azure.ai.openai.models.ChatCompletionsTextResponseFormat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -51,6 +53,7 @@ public class AzureChatCompletionsOptionsTests {
 			.withStop(List.of("foo", "bar"))
 			.withTopP(0.69f)
 			.withUser("user")
+			.withResponseFormat(AzureOpenAiResponseFormat.TEXT)
 			.build();
 
 		var client = new AzureOpenAiChatModel(mockClient, defaultOptions);
@@ -69,6 +72,7 @@ public class AzureChatCompletionsOptionsTests {
 		assertThat(requestOptions.getStop()).isEqualTo(List.of("foo", "bar"));
 		assertThat(requestOptions.getTopP()).isEqualTo(0.69f);
 		assertThat(requestOptions.getUser()).isEqualTo("user");
+		assertThat(requestOptions.getResponseFormat()).isInstanceOf(ChatCompletionsTextResponseFormat.class);
 
 		var runtimeOptions = AzureOpenAiChatOptions.builder()
 			.withDeploymentName("PROMPT_MODEL")
@@ -81,6 +85,7 @@ public class AzureChatCompletionsOptionsTests {
 			.withStop(List.of("foo", "bar"))
 			.withTopP(0.111f)
 			.withUser("user2")
+			.withResponseFormat(AzureOpenAiResponseFormat.JSON)
 			.build();
 
 		requestOptions = client.toAzureChatCompletionsOptions(new Prompt("Test message content", runtimeOptions));
@@ -97,6 +102,7 @@ public class AzureChatCompletionsOptionsTests {
 		assertThat(requestOptions.getStop()).isEqualTo(List.of("foo", "bar"));
 		assertThat(requestOptions.getTopP()).isEqualTo(0.111f);
 		assertThat(requestOptions.getUser()).isEqualTo("user2");
+		assertThat(requestOptions.getResponseFormat()).isInstanceOf(ChatCompletionsJsonResponseFormat.class);
 	}
 
 	private static Stream<Arguments> providePresencePenaltyAndFrequencyPenaltyTest() {


### PR DESCRIPTION
This pull request adds support for the response format option that enforces a specific format from Azure OpenAI chat models.
Details of the pull request:

- Added new enum class AzureOpenAiResponseFormat
- Modified merge methods in AzureOpenAiChatModel to use new parameter
- Modfied AzureOpenAiChatOptions to include the responseFormat parameter
- Modified Azure ChatCompletionsOptionsTests to verify that new parameter is working as expected