### PR TITLE
Fix BedrockAnthropic3ChatModel out of bounds exception

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -18,6 +18,7 @@ package org.springframework.ai.bedrock.anthropic3;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -48,6 +49,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Ben Middleton
  * @author Christian Tzolov
+ * @author Wei Jiang
  * @since 1.0.0
  */
 public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel {
@@ -78,7 +80,12 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 
 		AnthropicChatResponse response = this.anthropicChatApi.chatCompletion(request);
 
-		return new ChatResponse(List.of(new Generation(response.content().get(0).text())));
+		List<Generation> generations = response.content().stream().map(content -> {
+			return new Generation(content.text(), Map.of())
+				.withGenerationMetadata(ChatGenerationMetadata.from(response.stopReason(), null));
+		}).toList();
+
+		return new ChatResponse(generations);
 	}
 
 	@Override

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModelIT.java
@@ -217,6 +217,17 @@ class BedrockAnthropic3ChatModelIT {
 		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple", "basket");
 	}
 
+	@Test
+	void stopSequencesWithEmptyContents() {
+		Anthropic3ChatOptions chatOptions = new Anthropic3ChatOptions();
+		chatOptions.setStopSequences(List.of("Hello"));
+
+		var response = chatModel.call(new Prompt("hi", chatOptions));
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).isEmpty();
+	}
+
 	@SpringBootConfiguration
 	public static class TestConfiguration {
 


### PR DESCRIPTION
Fix BedrockAnthropic3ChatModel handle AnthropicChatResponse out of bounds exception when response content is empty.


see: https://github.com/spring-projects/spring-ai/issues/757