### PR TITLE
Add ChatClient plugable advisors support

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/AdvisedRequest.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/AdvisedRequest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.ai.chat.messages.Media;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.model.function.FunctionCallback;
+
+/**
+ * @author Christian Tzolov
+ */
+public record AdvisedRequest(ChatModel chatModel, String userText, String systemText, ChatOptions chatOptions,
+		List<Media> media, List<String> functionNames, List<FunctionCallback> functionCallbacks, List<Message> messages,
+		Map<String, Object> userParams, Map<String, Object> systemParams, List<RequestResponseAdvisor> advisors) {
+
+	public static Builder from(AdvisedRequest from) {
+		Builder builder = new Builder();
+		builder.chatModel = from.chatModel;
+		builder.userText = from.userText;
+		builder.systemText = from.systemText;
+		builder.chatOptions = from.chatOptions;
+		builder.media = from.media;
+		builder.functionNames = from.functionNames;
+		builder.functionCallbacks = from.functionCallbacks;
+		builder.messages = from.messages;
+		builder.userParams = from.userParams;
+		builder.systemParams = from.systemParams;
+		builder.advisors = from.advisors;
+		return builder;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private ChatModel chatModel;
+
+		private String userText = "";
+
+		private String systemText = "";
+
+		private ChatOptions chatOptions = null;
+
+		private List<Media> media = List.of();
+
+		private List<String> functionNames = List.of();
+
+		private List<FunctionCallback> functionCallbacks = List.of();
+
+		private List<Message> messages = List.of();
+
+		private Map<String, Object> userParams = Map.of();
+
+		private Map<String, Object> systemParams = Map.of();
+
+		private List<RequestResponseAdvisor> advisors = List.of();
+
+		public Builder withChatModel(ChatModel chatModel) {
+			this.chatModel = chatModel;
+			return this;
+		}
+
+		public Builder withUserText(String userText) {
+			this.userText = userText;
+			return this;
+		}
+
+		public Builder withSystemText(String systemText) {
+			this.systemText = systemText;
+			return this;
+		}
+
+		public Builder withChatOptions(ChatOptions chatOptions) {
+			this.chatOptions = chatOptions;
+			return this;
+		}
+
+		public Builder withMedia(List<Media> media) {
+			this.media = media;
+			return this;
+		}
+
+		public Builder withFunctionNames(List<String> functionNames) {
+			this.functionNames = functionNames;
+			return this;
+		}
+
+		public Builder withFunctionCallbacks(List<FunctionCallback> functionCallbacks) {
+			this.functionCallbacks = functionCallbacks;
+			return this;
+		}
+
+		public Builder withMessages(List<Message> messages) {
+			this.messages = messages;
+			return this;
+		}
+
+		public Builder withUserParams(Map<String, Object> userParams) {
+			this.userParams = userParams;
+			return this;
+		}
+
+		public Builder withSystemParams(Map<String, Object> systemParams) {
+			this.systemParams = systemParams;
+			return this;
+		}
+
+		public Builder withAdvisors(List<RequestResponseAdvisor> advisors) {
+			this.advisors = advisors;
+			return this;
+		}
+
+		public AdvisedRequest build() {
+			return new AdvisedRequest(chatModel, this.userText, this.systemText, this.chatOptions, this.media,
+					this.functionNames, this.functionCallbacks, this.messages, this.userParams, this.systemParams,
+					this.advisors);
+		}
+
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/AdvisedRequest.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/AdvisedRequest.java
@@ -30,7 +30,8 @@ import org.springframework.ai.model.function.FunctionCallback;
  */
 public record AdvisedRequest(ChatModel chatModel, String userText, String systemText, ChatOptions chatOptions,
 		List<Media> media, List<String> functionNames, List<FunctionCallback> functionCallbacks, List<Message> messages,
-		Map<String, Object> userParams, Map<String, Object> systemParams, List<RequestResponseAdvisor> advisors) {
+		Map<String, Object> userParams, Map<String, Object> systemParams, List<RequestResponseAdvisor> advisors,
+		Map<String, Object> advisorParams) {
 
 	public static Builder from(AdvisedRequest from) {
 		Builder builder = new Builder();
@@ -45,6 +46,7 @@ public record AdvisedRequest(ChatModel chatModel, String userText, String system
 		builder.userParams = from.userParams;
 		builder.systemParams = from.systemParams;
 		builder.advisors = from.advisors;
+		builder.advisorParams = from.advisorParams;
 		return builder;
 	}
 
@@ -75,6 +77,8 @@ public record AdvisedRequest(ChatModel chatModel, String userText, String system
 		private Map<String, Object> systemParams = Map.of();
 
 		private List<RequestResponseAdvisor> advisors = List.of();
+
+		private Map<String, Object> advisorParams = Map.of();
 
 		public Builder withChatModel(ChatModel chatModel) {
 			this.chatModel = chatModel;
@@ -131,10 +135,15 @@ public record AdvisedRequest(ChatModel chatModel, String userText, String system
 			return this;
 		}
 
+		public Builder withAdvisorParams(Map<String, Object> advisorParams) {
+			this.advisorParams = advisorParams;
+			return this;
+		}
+
 		public AdvisedRequest build() {
 			return new AdvisedRequest(chatModel, this.userText, this.systemText, this.chatOptions, this.media,
 					this.functionNames, this.functionCallbacks, this.messages, this.userParams, this.systemParams,
-					this.advisors);
+					this.advisors, this.advisorParams);
 		}
 
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -230,6 +230,34 @@ public interface ChatClient {
 
 		private final Map<String, Object> systemParams = new HashMap<>();
 
+		private List<RequestResponseAdvisor> advisors = new ArrayList<>();
+
+		/* copy constructor */
+		ChatClientRequest(ChatClientRequest ccr) {
+			this(ccr.chatModel, ccr.userText, ccr.userParams, ccr.systemText, ccr.systemParams, ccr.functionCallbacks,
+					ccr.messages, ccr.functionNames, ccr.media, ccr.chatOptions, ccr.advisors);
+		}
+
+		public ChatClientRequest(ChatModel chatModel, String userText, Map<String, Object> userParams,
+				String systemText, Map<String, Object> systemParams, List<FunctionCallback> functionCallbacks,
+				List<Message> messages, List<String> functionNames, List<Media> media, ChatOptions chatOptions,
+				List<RequestResponseAdvisor> advisors) {
+
+			this.chatModel = chatModel;
+			this.chatOptions = chatOptions != null ? chatOptions : chatModel.getDefaultOptions();
+
+			this.userText = userText;
+			this.userParams.putAll(userParams);
+			this.systemText = systemText;
+			this.systemParams.putAll(systemParams);
+
+			this.functionNames.addAll(functionNames);
+			this.functionCallbacks.addAll(functionCallbacks);
+			this.messages.addAll(messages);
+			this.media.addAll(media);
+			this.advisors.addAll(advisors);
+		}
+
 		/**
 		 * Return a {@code ChatClient.Builder} to create a new {@code ChatClient} whose
 		 * settings are replicated from this {@code ChatClientRequest}.
@@ -250,46 +278,49 @@ public interface ChatClient {
 			return builder;
 		}
 
-		/* copy constructor */
-		ChatClientRequest(ChatClientRequest ccr) {
-			this(ccr.chatModel, ccr.userText, ccr.userParams, ccr.systemText, ccr.systemParams, ccr.functionCallbacks,
-					ccr.functionNames, ccr.media, ccr.chatOptions);
+		public ChatClientRequest advisor(RequestResponseAdvisor advisor) {
+			Assert.notNull(advisor, "the advisor must be non-null");
+			this.advisors.add(advisor);
+			return this;
 		}
 
-		public ChatClientRequest(ChatModel chatModel, String userText, Map<String, Object> userParams,
-				String systemText, Map<String, Object> systemParams, List<FunctionCallback> functionCallbacks,
-				List<String> functionNames, List<Media> media, ChatOptions chatOptions) {
+		public ChatClientRequest advisor(RequestResponseAdvisor... advisors) {
+			Assert.notNull(advisors, "the advisors must be non-null");
+			this.advisors.addAll(List.of(advisors));
+			return this;
+		}
 
-			this.chatModel = chatModel;
-			this.chatOptions = chatOptions != null ? chatOptions : chatModel.getDefaultOptions();
-
-			this.userText = userText;
-			this.userParams.putAll(userParams);
-			this.systemText = systemText;
-			this.systemParams.putAll(systemParams);
-
-			this.functionNames.addAll(functionNames);
-			this.functionCallbacks.addAll(functionCallbacks);
-			this.media.addAll(media);
+		public ChatClientRequest advisor(List<RequestResponseAdvisor> advisors) {
+			Assert.notNull(advisors, "the advisors must be non-null");
+			this.advisors.addAll(advisors);
+			return this;
 		}
 
 		public ChatClientRequest messages(Message... messages) {
+			Assert.notNull(messages, "the messages must be non-null");
 			this.messages.addAll(List.of(messages));
 			return this;
 		}
 
 		public ChatClientRequest messages(List<Message> messages) {
+			Assert.notNull(messages, "the messages must be non-null");
 			this.messages.addAll(messages);
 			return this;
 		}
 
 		public <T extends ChatOptions> ChatClientRequest options(T options) {
+			Assert.notNull(options, "the options must be non-null");
 			this.chatOptions = options;
 			return this;
 		}
 
 		public <I, O> ChatClientRequest function(String name, String description,
 				java.util.function.Function<I, O> function) {
+
+			Assert.hasText(name, "the name must be non-null and non-empty");
+			Assert.hasText(description, "the description must be non-null and non-empty");
+			Assert.notNull(function, "the function must be non-null");
+
 			var fcw = FunctionCallbackWrapper.builder(function)
 				.withDescription(description)
 				.withName(name)
@@ -300,18 +331,24 @@ public interface ChatClient {
 		}
 
 		public ChatClientRequest functions(String... functionBeanNames) {
+			Assert.notNull(functionBeanNames, "the functionBeanNames must be non-null");
 			this.functionNames.addAll(List.of(functionBeanNames));
 			return this;
 		}
 
 		public ChatClientRequest system(String text) {
+			Assert.notNull(text, "the text must be non-null");
 			this.systemText = text;
 			return this;
 		}
 
-		public ChatClientRequest system(Resource text, Charset charset) {
+		public ChatClientRequest system(Resource textResource, Charset charset) {
+
+			Assert.notNull(textResource, "the text resource must be non-null");
+			Assert.notNull(charset, "the charset must be non-null");
+
 			try {
-				this.systemText = text.getContentAsString(charset);
+				this.systemText = textResource.getContentAsString(charset);
 			}
 			catch (IOException e) {
 				throw new RuntimeException(e);
@@ -320,10 +357,14 @@ public interface ChatClient {
 		}
 
 		public ChatClientRequest system(Resource text) {
+			Assert.notNull(text, "the text resource must be non-null");
 			return this.system(text, Charset.defaultCharset());
 		}
 
 		public ChatClientRequest system(Consumer<SystemSpec> consumer) {
+
+			Assert.notNull(consumer, "the consumer must be non-null");
+
 			var ss = new SystemSpec();
 			consumer.accept(ss);
 			this.systemText = StringUtils.hasText(ss.text()) ? ss.text() : this.systemText;
@@ -333,11 +374,16 @@ public interface ChatClient {
 		}
 
 		public ChatClientRequest user(String text) {
+			Assert.notNull(text, "the text must be non-null");
 			this.userText = text;
 			return this;
 		}
 
 		public ChatClientRequest user(Resource text, Charset charset) {
+
+			Assert.notNull(text, "the text resource must be non-null");
+			Assert.notNull(charset, "the charset must be non-null");
+
 			try {
 				this.userText = text.getContentAsString(charset);
 			}
@@ -348,10 +394,13 @@ public interface ChatClient {
 		}
 
 		public ChatClientRequest user(Resource text) {
+			Assert.notNull(text, "the text resource must be non-null");
 			return this.user(text, Charset.defaultCharset());
 		}
 
 		public ChatClientRequest user(Consumer<UserSpec> consumer) {
+			Assert.notNull(consumer, "the consumer must be non-null");
+
 			var us = new UserSpec();
 			consumer.accept(us);
 			this.userText = StringUtils.hasText(us.text()) ? us.text() : this.userText;
@@ -423,6 +472,32 @@ public interface ChatClient {
 
 		}
 
+		private static ChatClientRequest adviseOnRequest(ChatClientRequest inputRequest) {
+
+			ChatClientRequest advisedRequest = inputRequest;
+
+			if (!CollectionUtils.isEmpty(inputRequest.advisors)) {
+				AdvisedRequest adviseRequest = new AdvisedRequest(inputRequest.chatModel, inputRequest.userText,
+						inputRequest.systemText, inputRequest.chatOptions, inputRequest.media,
+						inputRequest.functionNames, inputRequest.functionCallbacks, inputRequest.messages,
+						inputRequest.userParams, inputRequest.systemParams, inputRequest.advisors);
+
+				// apply the advisors onRequest
+
+				var currentAdvisors = new ArrayList<>(inputRequest.advisors);
+				for (RequestResponseAdvisor advisor : currentAdvisors) {
+					adviseRequest = advisor.adviseRequest(adviseRequest);
+				}
+
+				advisedRequest = new ChatClientRequest(adviseRequest.chatModel(), adviseRequest.userText(),
+						adviseRequest.userParams(), adviseRequest.systemText(), adviseRequest.systemParams(),
+						adviseRequest.functionCallbacks(), adviseRequest.messages(), adviseRequest.functionNames(),
+						adviseRequest.media(), adviseRequest.chatOptions(), adviseRequest.advisors());
+			}
+
+			return advisedRequest;
+		}
+
 		public static class CallResponseSpec {
 
 			private final ChatClientRequest request;
@@ -443,7 +518,7 @@ public interface ChatClient {
 			}
 
 			private <T> T doSingleWithBeanOutputConverter(StructuredOutputConverter<T> boc) {
-				var chatResponse = doGetChatResponse(boc.getFormat());
+				var chatResponse = doGetChatResponse(this.request, boc.getFormat());
 				var stringResponse = chatResponse.getResult().getOutput().getContent();
 				return boc.convert(stringResponse);
 			}
@@ -455,48 +530,62 @@ public interface ChatClient {
 			}
 
 			private ChatResponse doGetChatResponse() {
-				return this.doGetChatResponse("");
+				return this.doGetChatResponse(this.request, "");
 			}
 
-			private ChatResponse doGetChatResponse(String formatParam) {
+			private ChatResponse doGetChatResponse(ChatClientRequest inputRequest, String formatParam) {
+
+				ChatClientRequest advisedRequest = adviseOnRequest(inputRequest);
 
 				var processedUserText = StringUtils.hasText(formatParam)
-						? this.request.userText + System.lineSeparator() + "{format}" : this.request.userText;
+						? advisedRequest.userText + System.lineSeparator() + "{format}" : advisedRequest.userText;
 
-				Map<String, Object> userParams = new HashMap<>(this.request.userParams);
+				Map<String, Object> userParams = new HashMap<>(advisedRequest.userParams);
 				if (StringUtils.hasText(formatParam)) {
 					userParams.put("format", formatParam);
 				}
 
-				var messages = new ArrayList<Message>(this.request.messages);
+				var messages = new ArrayList<Message>(advisedRequest.messages);
 				var textsAreValid = (StringUtils.hasText(processedUserText)
-						|| StringUtils.hasText(this.request.systemText));
+						|| StringUtils.hasText(advisedRequest.systemText));
 				if (textsAreValid) {
-					if (StringUtils.hasText(this.request.systemText) || !this.request.systemParams.isEmpty()) {
+					if (StringUtils.hasText(advisedRequest.systemText) || !advisedRequest.systemParams.isEmpty()) {
 						var systemMessage = new SystemMessage(
-								new PromptTemplate(this.request.systemText, this.request.systemParams).render());
+								new PromptTemplate(advisedRequest.systemText, advisedRequest.systemParams).render());
 						messages.add(systemMessage);
 					}
 					UserMessage userMessage = null;
 					if (!CollectionUtils.isEmpty(userParams)) {
 						userMessage = new UserMessage(new PromptTemplate(processedUserText, userParams).render(),
-								this.request.media);
+								advisedRequest.media);
 					}
 					else {
-						userMessage = new UserMessage(processedUserText, this.request.media);
+						userMessage = new UserMessage(processedUserText, advisedRequest.media);
 					}
 					messages.add(userMessage);
 				}
-				if (this.request.chatOptions instanceof FunctionCallingOptions functionCallingOptions) {
-					if (!this.request.functionNames.isEmpty()) {
-						functionCallingOptions.setFunctions(new HashSet<>(this.request.functionNames));
+
+				if (advisedRequest.chatOptions instanceof FunctionCallingOptions functionCallingOptions) {
+					if (!advisedRequest.functionNames.isEmpty()) {
+						functionCallingOptions.setFunctions(new HashSet<>(advisedRequest.functionNames));
 					}
-					if (!this.request.functionCallbacks.isEmpty()) {
-						functionCallingOptions.setFunctionCallbacks(this.request.functionCallbacks);
+					if (!advisedRequest.functionCallbacks.isEmpty()) {
+						functionCallingOptions.setFunctionCallbacks(advisedRequest.functionCallbacks);
 					}
 				}
-				var prompt = new Prompt(messages, this.request.chatOptions);
-				return this.chatModel.call(prompt);
+				var prompt = new Prompt(messages, advisedRequest.chatOptions);
+				var chatResponse = this.chatModel.call(prompt);
+
+				ChatResponse advisedResponse = chatResponse;
+				// apply the advisors on response
+				if (!CollectionUtils.isEmpty(inputRequest.advisors)) {
+					var currentAdvisors = new ArrayList<>(inputRequest.advisors);
+					for (RequestResponseAdvisor advisor : currentAdvisors) {
+						advisedResponse = advisor.adviseResponse(advisedResponse);
+					}
+				}
+
+				return advisedResponse;
 			}
 
 			public ChatResponse chatResponse() {
@@ -520,55 +609,65 @@ public interface ChatClient {
 				this.request = request;
 			}
 
-			private Flux<ChatResponse> doGetFluxChatResponse(String processedUserText) {
-				Map<String, Object> userParams = new HashMap<>(this.request.userParams);
+			private Flux<ChatResponse> doGetFluxChatResponse(ChatClientRequest inputRequest) {
 
-				var messages = new ArrayList<Message>();
+				ChatClientRequest advisedRequest = adviseOnRequest(inputRequest);
+
+				String processedUserText = advisedRequest.userText;
+				Map<String, Object> userParams = new HashMap<>(advisedRequest.userParams);
+
+				var messages = new ArrayList<Message>(advisedRequest.messages);
 				var textsAreValid = (StringUtils.hasText(processedUserText)
-						|| StringUtils.hasText(this.request.systemText));
-				var messagesAreValid = !this.request.messages.isEmpty();
-				Assert.state(!(messagesAreValid && textsAreValid), "you must specify either " + Message.class.getName()
-						+ " instances or user/system texts, but not both");
+						|| StringUtils.hasText(advisedRequest.systemText));
 				if (textsAreValid) {
 					UserMessage userMessage = null;
 					if (!CollectionUtils.isEmpty(userParams)) {
 						userMessage = new UserMessage(new PromptTemplate(processedUserText, userParams).render(),
-								this.request.media);
+								advisedRequest.media);
 					}
 					else {
-						userMessage = new UserMessage(processedUserText, this.request.media);
+						userMessage = new UserMessage(processedUserText, advisedRequest.media);
 					}
-					if (StringUtils.hasText(this.request.systemText) || !this.request.systemParams.isEmpty()) {
+					if (StringUtils.hasText(advisedRequest.systemText) || !advisedRequest.systemParams.isEmpty()) {
 						var systemMessage = new SystemMessage(
-								new PromptTemplate(this.request.systemText, this.request.systemParams).render());
+								new PromptTemplate(advisedRequest.systemText, advisedRequest.systemParams).render());
 						messages.add(systemMessage);
 					}
 					messages.add(userMessage);
 				}
-				else {
-					messages.addAll(this.request.messages);
-				}
-				if (this.request.chatOptions instanceof FunctionCallingOptions functionCallingOptions) {
-					// if (this.request.chatOptions instanceof
-					// FunctionCallingOptionsBuilder.PortableFunctionCallingOptions
-					// functionCallingOptions) {
-					if (!this.request.functionNames.isEmpty()) {
-						functionCallingOptions.setFunctions(new HashSet<>(this.request.functionNames));
+
+				if (advisedRequest.chatOptions instanceof
+
+				FunctionCallingOptions functionCallingOptions) {
+					if (!advisedRequest.functionNames.isEmpty()) {
+						functionCallingOptions.setFunctions(new HashSet<>(advisedRequest.functionNames));
 					}
-					if (!this.request.functionCallbacks.isEmpty()) {
-						functionCallingOptions.setFunctionCallbacks(this.request.functionCallbacks);
+					if (!advisedRequest.functionCallbacks.isEmpty()) {
+						functionCallingOptions.setFunctionCallbacks(advisedRequest.functionCallbacks);
 					}
 				}
-				var prompt = new Prompt(messages, this.request.chatOptions);
-				return this.chatModel.stream(prompt);
+				var prompt = new Prompt(messages, advisedRequest.chatOptions);
+
+				var fluxChatResponse = this.chatModel.stream(prompt);
+
+				Flux<ChatResponse> advisedResponse = fluxChatResponse;
+				// apply the advisors on response
+				if (!CollectionUtils.isEmpty(inputRequest.advisors)) {
+					var currentAdvisors = new ArrayList<>(inputRequest.advisors);
+					for (RequestResponseAdvisor advisor : currentAdvisors) {
+						advisedResponse = advisor.adviseResponse(advisedResponse);
+					}
+				}
+
+				return advisedResponse;
 			}
 
 			public Flux<ChatResponse> chatResponse() {
-				return doGetFluxChatResponse(this.request.userText);
+				return doGetFluxChatResponse(this.request);
 			}
 
 			public Flux<String> content() {
-				return doGetFluxChatResponse(this.request.userText).map(r -> {
+				return doGetFluxChatResponse(this.request).map(r -> {
 					if (r.getResult() == null || r.getResult().getOutput() == null
 							|| r.getResult().getOutput().getContent() == null) {
 						return "";
@@ -599,7 +698,22 @@ public interface ChatClient {
 			Assert.notNull(chatModel, "the " + ChatModel.class.getName() + " must be non-null");
 			this.chatModel = chatModel;
 			this.defaultRequest = new ChatClientRequest(chatModel, "", Map.of(), "", Map.of(), List.of(), List.of(),
-					List.of(), null);
+					List.of(), List.of(), null, List.of());
+		}
+
+		public Builder defaultAdvisor(RequestResponseAdvisor advisor) {
+			this.defaultRequest.advisor(advisor);
+			return this;
+		}
+
+		public Builder defaultAdvisor(RequestResponseAdvisor... advisors) {
+			this.defaultRequest.advisor(advisors);
+			return this;
+		}
+
+		public Builder defaultAdvisor(List<RequestResponseAdvisor> advisors) {
+			this.defaultRequest.advisor(advisors);
+			return this;
 		}
 
 		public ChatClient build() {

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import reactor.core.publisher.Flux;
@@ -483,10 +484,10 @@ public interface ChatClient {
 						inputRequest.userParams, inputRequest.systemParams, inputRequest.advisors);
 
 				// apply the advisors onRequest
-
+				Map<String, Object> context = new ConcurrentHashMap<>();
 				var currentAdvisors = new ArrayList<>(inputRequest.advisors);
 				for (RequestResponseAdvisor advisor : currentAdvisors) {
-					adviseRequest = advisor.adviseRequest(adviseRequest);
+					adviseRequest = advisor.adviseRequest(adviseRequest, context);
 				}
 
 				advisedRequest = new ChatClientRequest(adviseRequest.chatModel(), adviseRequest.userText(),
@@ -578,10 +579,11 @@ public interface ChatClient {
 
 				ChatResponse advisedResponse = chatResponse;
 				// apply the advisors on response
+				Map<String, Object> context = new ConcurrentHashMap<>();
 				if (!CollectionUtils.isEmpty(inputRequest.advisors)) {
 					var currentAdvisors = new ArrayList<>(inputRequest.advisors);
 					for (RequestResponseAdvisor advisor : currentAdvisors) {
-						advisedResponse = advisor.adviseResponse(advisedResponse);
+						advisedResponse = advisor.adviseResponse(advisedResponse, context);
 					}
 				}
 
@@ -652,10 +654,11 @@ public interface ChatClient {
 
 				Flux<ChatResponse> advisedResponse = fluxChatResponse;
 				// apply the advisors on response
+				Map<String, Object> context = new ConcurrentHashMap<>();
 				if (!CollectionUtils.isEmpty(inputRequest.advisors)) {
 					var currentAdvisors = new ArrayList<>(inputRequest.advisors);
 					for (RequestResponseAdvisor advisor : currentAdvisors) {
-						advisedResponse = advisor.adviseResponse(advisedResponse);
+						advisedResponse = advisor.adviseResponse(advisedResponse, context);
 					}
 				}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -285,13 +285,13 @@ public interface ChatClient {
 			return this;
 		}
 
-		public ChatClientRequest advisor(RequestResponseAdvisor... advisors) {
+		public ChatClientRequest advisors(RequestResponseAdvisor... advisors) {
 			Assert.notNull(advisors, "the advisors must be non-null");
 			this.advisors.addAll(List.of(advisors));
 			return this;
 		}
 
-		public ChatClientRequest advisor(List<RequestResponseAdvisor> advisors) {
+		public ChatClientRequest advisors(List<RequestResponseAdvisor> advisors) {
 			Assert.notNull(advisors, "the advisors must be non-null");
 			this.advisors.addAll(advisors);
 			return this;
@@ -709,13 +709,13 @@ public interface ChatClient {
 			return this;
 		}
 
-		public Builder defaultAdvisor(RequestResponseAdvisor... advisors) {
-			this.defaultRequest.advisor(advisors);
+		public Builder defaultAdvisors(RequestResponseAdvisor... advisors) {
+			this.defaultRequest.advisors(advisors);
 			return this;
 		}
 
-		public Builder defaultAdvisor(List<RequestResponseAdvisor> advisors) {
-			this.defaultRequest.advisor(advisors);
+		public Builder defaultAdvisors(List<RequestResponseAdvisor> advisors) {
+			this.defaultRequest.advisors(advisors);
 			return this;
 		}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/RequestResponseAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/RequestResponseAdvisor.java
@@ -22,26 +22,50 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient.ChatClientRequest;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
 
 /**
- * A before and after advisor called before the {@link ChatClientRequest} is sealed into a
- * {@link Prompt} and send and after the {@link ChatResponse} (or it Flux variant) is
- * received.
+ * Advisor called before and after the {@link ChatModel#call(Prompt)} and
+ * {@link ChatModel#stream(Prompt)} methods calls. The {@link ChatClient} maintains a
+ * chain of advisors with chared execution context.
  *
  * @author Christian Tzolov
  * @since 1.0.0 M1
  */
 public interface RequestResponseAdvisor {
 
+	/**
+	 * @param request the {@link AdvisedRequest} data to be advised. Represents the row
+	 * {@link ChatClientRequest} data before sealed into a {@link Prompt}.
+	 * @param context the shared data between the advisors in the chain. It is shared
+	 * between all request and response advising points of all advisors in the chain.
+	 * @return the advised {@link AdvisedRequest}.
+	 */
 	default AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
 		return request;
 	}
 
+	/**
+	 * @param response the {@link ChatResponse} data to be advised. Represents the row
+	 * {@link ChatResponse} data after the {@link ChatModel#call(Prompt)} method is
+	 * called.
+	 * @param context the shared data between the advisors in the chain. It is shared
+	 * between all request and response advising points of all advisors in the chain.
+	 * @return the advised {@link ChatResponse}.
+	 */
 	default ChatResponse adviseResponse(ChatResponse response, Map<String, Object> context) {
 		return response;
 	}
 
+	/**
+	 * @param fluxResponse the streaming {@link ChatResponse} data to be advised.
+	 * Represents the row {@link ChatResponse} stream data after the
+	 * {@link ChatModel#stream(Prompt)} method is called.
+	 * @param context the shared data between the advisors in the chain. It is shared
+	 * between all request and response advising points of all advisors in the chain.
+	 * @return the advised {@link ChatResponse} flux.
+	 */
 	default Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxResponse, Map<String, Object> context) {
 		return fluxResponse;
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/RequestResponseAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/RequestResponseAdvisor.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.chat.client;
 
+import java.util.Map;
+
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient.ChatClientRequest;
@@ -32,15 +34,15 @@ import org.springframework.ai.chat.prompt.Prompt;
  */
 public interface RequestResponseAdvisor {
 
-	default AdvisedRequest adviseRequest(AdvisedRequest request) {
+	default AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
 		return request;
 	}
 
-	default ChatResponse adviseResponse(ChatResponse response) {
+	default ChatResponse adviseResponse(ChatResponse response, Map<String, Object> context) {
 		return response;
 	}
 
-	default Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxResponse) {
+	default Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxResponse, Map<String, Object> context) {
 		return fluxResponse;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/RequestResponseAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/RequestResponseAdvisor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClient.ChatClientRequest;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+
+/**
+ * A before and after advisor called before the {@link ChatClientRequest} is sealed into a
+ * {@link Prompt} and send and after the {@link ChatResponse} (or it Flux variant) is
+ * received.
+ *
+ * @author Christian Tzolov
+ * @since 1.0.0 M1
+ */
+public interface RequestResponseAdvisor {
+
+	default AdvisedRequest adviseRequest(AdvisedRequest request) {
+		return request;
+	}
+
+	default ChatResponse adviseResponse(ChatResponse response) {
+		return response;
+	}
+
+	default Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxResponse) {
+		return fluxResponse;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/AbstractChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/AbstractChatMemoryAdvisor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.Map;
+
+import org.springframework.ai.chat.client.RequestResponseAdvisor;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ */
+public abstract class AbstractChatMemoryAdvisor<T> implements RequestResponseAdvisor {
+
+	public static final String CHAT_MEMORY_CONVERSATION_ID_KEY = "chat.memory.conversation.id";
+
+	public static final String CHAT_MEMORY_RETRIEVE_SIZE_KEY = "chat.memory.response.size";
+
+	public static final String DEFAULT_CHAT_MEMORY_CONVERSATION_ID = "default";
+
+	public static final int DEFAULT_CHAT_MEMORY_RESPONSE_SIZE = 100;
+
+	protected final T chatMemoryStore;
+
+	protected final String defaultConversationId;
+
+	protected final int defaultChatMemoryRetrieveSize;
+
+	public AbstractChatMemoryAdvisor(T chatMemory) {
+		this(chatMemory, DEFAULT_CHAT_MEMORY_CONVERSATION_ID, DEFAULT_CHAT_MEMORY_RESPONSE_SIZE);
+	}
+
+	public AbstractChatMemoryAdvisor(T chatMemory, String defaultConversationId, int defaultChatMemoryRetrieveSize) {
+
+		Assert.notNull(chatMemory, "The chatMemory must not be null!");
+		Assert.hasText(defaultConversationId, "The conversationId must not be empty!");
+		Assert.isTrue(defaultChatMemoryRetrieveSize > 0, "The defaultChatMemoryRetrieveSize must be greater than 0!");
+
+		this.chatMemoryStore = chatMemory;
+		this.defaultConversationId = defaultConversationId;
+		this.defaultChatMemoryRetrieveSize = defaultChatMemoryRetrieveSize;
+	}
+
+	protected T getChatMemoryStore() {
+		return this.chatMemoryStore;
+	}
+
+	protected String doGetConversationId(Map<String, Object> context) {
+
+		return context.containsKey(CHAT_MEMORY_CONVERSATION_ID_KEY)
+				? context.get(CHAT_MEMORY_CONVERSATION_ID_KEY).toString() : this.defaultConversationId;
+	}
+
+	protected int doGetChatMemoryRetrieveSize(Map<String, Object> context) {
+		return context.containsKey(CHAT_MEMORY_RETRIEVE_SIZE_KEY)
+				? Integer.parseInt(context.get(CHAT_MEMORY_RETRIEVE_SIZE_KEY).toString())
+				: this.defaultChatMemoryRetrieveSize;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/LastMaxTokenSizeContentPurger.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/LastMaxTokenSizeContentPurger.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.ai.model.Content;
+import org.springframework.ai.tokenizer.TokenCountEstimator;
+
+/**
+ * Returns a new list of content (e.g list of messages of list of documents) that is a
+ * subset of the input list of contents and complies with the max token size constraint.
+ *
+ * The token estimator is used to estimate the token count of the datum.
+ *
+ * @author Christian Tzolov
+ * @since 1.0.0 M1
+ */
+public class LastMaxTokenSizeContentPurger {
+
+	protected final TokenCountEstimator tokenCountEstimator;
+
+	protected final int maxTokenSize;
+
+	public LastMaxTokenSizeContentPurger(TokenCountEstimator tokenCountEstimator, int maxTokenSize) {
+		this.tokenCountEstimator = tokenCountEstimator;
+		this.maxTokenSize = maxTokenSize;
+	}
+
+	public List<Content> purgeExcess(List<Content> datum, int totalSize) {
+
+		int index = 0;
+		List<Content> newList = new ArrayList<>();
+
+		while (index < datum.size() && totalSize > this.maxTokenSize) {
+			Content oldDatum = datum.get(index++);
+			int oldMessageTokenSize = this.doEstimateTokenCount(oldDatum);
+			totalSize = totalSize - oldMessageTokenSize;
+		}
+
+		if (index >= datum.size()) {
+			return List.of();
+		}
+
+		// add the rest of the messages.
+		newList.addAll(datum.subList(index, datum.size()));
+
+		return newList;
+	}
+
+	protected int doEstimateTokenCount(Content datum) {
+		return this.tokenCountEstimator.estimate(datum);
+	}
+
+	protected int doEstimateTokenCount(List<Content> datum) {
+		return datum.stream().mapToInt(this::doEstimateTokenCount).sum();
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client.advisor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import reactor.core.publisher.Flux;
 
@@ -59,7 +60,7 @@ public class MessageChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
 
 		// 1. Retrieve the chat memory for the current conversation.
 		List<Message> memoryMessages = this.chatMemory.get(this.conversationId, this.chatHistoryWindowSize);
@@ -79,7 +80,7 @@ public class MessageChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public ChatResponse adviseResponse(ChatResponse chatResponse) {
+	public ChatResponse adviseResponse(ChatResponse chatResponse, Map<String, Object> context) {
 
 		List<Message> assistantMessages = chatResponse.getResults().stream().map(g -> (Message) g.getOutput()).toList();
 
@@ -89,7 +90,7 @@ public class MessageChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse) {
+	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse, Map<String, Object> context) {
 
 		return new MessageAggregator().aggregate(fluxChatResponse, chatResponse -> {
 			List<Message> assistantMessages = chatResponse.getResults()

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.AdvisedRequest;
+import org.springframework.ai.chat.client.RequestResponseAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0 M1
+ */
+public class MessageChatMemoryAdvisor implements RequestResponseAdvisor {
+
+	private static final int CHAT_HISTORY_WINDOW_SIZE = 40;
+
+	private final String conversationId;
+
+	private final ChatMemory chatMemory;
+
+	private final int chatHistoryWindowSize;
+
+	public MessageChatMemoryAdvisor(String conversationId, ChatMemory chatMemory) {
+		this(conversationId, chatMemory, CHAT_HISTORY_WINDOW_SIZE);
+	}
+
+	public MessageChatMemoryAdvisor(String conversationId, ChatMemory chatMemory, int chatHistoryWindowSize) {
+		Assert.hasText(conversationId, "The conversationId must not be empty!");
+		Assert.notNull(chatMemory, "The chatMemory must not be null!");
+		Assert.isTrue(chatHistoryWindowSize > 0, "The chatHistoryWindowSize must be greater than 0!");
+
+		this.conversationId = conversationId;
+		this.chatMemory = chatMemory;
+		this.chatHistoryWindowSize = chatHistoryWindowSize;
+	}
+
+	@Override
+	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+
+		// 1. Retrieve the chat memory for the current conversation.
+		List<Message> memoryMessages = this.chatMemory.get(this.conversationId, this.chatHistoryWindowSize);
+
+		// 2. Advise the request messages list.
+		List<Message> advisedMessages = new ArrayList<>(request.messages());
+		advisedMessages.addAll(memoryMessages);
+
+		// 3. Create a new request with the advised messages.
+		AdvisedRequest advisedRequest = AdvisedRequest.from(request).withMessages(advisedMessages).build();
+
+		// 4. Add the new user input to the conversation memory.
+		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		this.chatMemory.add(this.conversationId, userMessage);
+
+		return advisedRequest;
+	}
+
+	@Override
+	public ChatResponse adviseResponse(ChatResponse chatResponse) {
+
+		List<Message> assistantMessages = chatResponse.getResults().stream().map(g -> (Message) g.getOutput()).toList();
+
+		this.chatMemory.add(this.conversationId, assistantMessages);
+
+		return chatResponse;
+	}
+
+	@Override
+	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse) {
+
+		return new MessageAggregator().aggregate(fluxChatResponse, chatResponse -> {
+			List<Message> assistantMessages = chatResponse.getResults()
+				.stream()
+				.map(g -> (Message) g.getOutput())
+				.toList();
+
+			this.chatMemory.add(this.conversationId, assistantMessages);
+		});
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
@@ -78,7 +78,7 @@ public class PromptChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
 
 		// 1. Advise system parameters.
 		List<Message> memoryMessages = this.chatMemory.get(this.conversationId, this.chatHistoryWindowSize);
@@ -108,7 +108,7 @@ public class PromptChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public ChatResponse adviseResponse(ChatResponse chatResponse) {
+	public ChatResponse adviseResponse(ChatResponse chatResponse, Map<String, Object> context) {
 
 		List<Message> assistantMessages = chatResponse.getResults().stream().map(g -> (Message) g.getOutput()).toList();
 
@@ -118,7 +118,7 @@ public class PromptChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse) {
+	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse, Map<String, Object> context) {
 
 		return new MessageAggregator().aggregate(fluxChatResponse, chatResponse -> {
 			List<Message> assistantMessages = chatResponse.getResults()

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.AdvisedRequest;
+import org.springframework.ai.chat.client.RequestResponseAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0 M1
+ */
+public class PromptChatMemoryAdvisor implements RequestResponseAdvisor {
+
+	private static final int CHAT_HISTORY_WINDOW_SIZE = 40;
+
+	private static final String DEFAULT_SYSTEM_TEXT_ADVISE = """
+
+			Use the conversation memory from the MEMORY section to provide accurate answers.
+
+			---------------------
+			MEMORY:
+			{memory}
+			---------------------
+
+			""";
+
+	private final String systemTextAdvise;
+
+	private final String conversationId;
+
+	private final ChatMemory chatMemory;
+
+	private final int chatHistoryWindowSize;
+
+	public PromptChatMemoryAdvisor(String conversationId, ChatMemory chatMemory) {
+		this(conversationId, chatMemory, DEFAULT_SYSTEM_TEXT_ADVISE, CHAT_HISTORY_WINDOW_SIZE);
+	}
+
+	public PromptChatMemoryAdvisor(String conversationId, ChatMemory chatMemory, String systemTextAdvise,
+			int chatHistoryWindowSize) {
+		Assert.hasText(conversationId, "The conversationId must not be empty!");
+		Assert.notNull(chatMemory, "The chatMemory must not be null!");
+		Assert.hasText(systemTextAdvise, "The systemTextAdvise must not be empty!");
+		Assert.isTrue(chatHistoryWindowSize > 0, "The chatHistoryWindowSize must be greater than 0!");
+
+		this.conversationId = conversationId;
+		this.chatMemory = chatMemory;
+		this.systemTextAdvise = systemTextAdvise;
+		this.chatHistoryWindowSize = chatHistoryWindowSize;
+	}
+
+	@Override
+	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+
+		// 1. Advise system parameters.
+		List<Message> memoryMessages = this.chatMemory.get(this.conversationId, this.chatHistoryWindowSize);
+
+		String memory = (memoryMessages != null) ? memoryMessages.stream()
+			.filter(m -> m.getMessageType() != MessageType.SYSTEM)
+			.map(m -> m.getMessageType() + ":" + m.getContent())
+			.collect(Collectors.joining(System.lineSeparator())) : "";
+
+		Map<String, Object> advisedSystemParams = new HashMap<>(request.systemParams());
+		advisedSystemParams.put("memory", memory);
+
+		// 2. Advise the system text.
+		String advisedSystemText = request.systemText() + System.lineSeparator() + this.systemTextAdvise;
+
+		// 3. Create a new request with the advised system text and parameters.
+		AdvisedRequest advisedRequest = AdvisedRequest.from(request)
+			.withSystemText(advisedSystemText)
+			.withSystemParams(advisedSystemParams)
+			.build();
+
+		// 4. Add the new user input to the conversation memory.
+		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		this.chatMemory.add(this.conversationId, userMessage);
+
+		return advisedRequest;
+	}
+
+	@Override
+	public ChatResponse adviseResponse(ChatResponse chatResponse) {
+
+		List<Message> assistantMessages = chatResponse.getResults().stream().map(g -> (Message) g.getOutput()).toList();
+
+		this.chatMemory.add(this.conversationId, assistantMessages);
+
+		return chatResponse;
+	}
+
+	@Override
+	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse) {
+
+		return new MessageAggregator().aggregate(fluxChatResponse, chatResponse -> {
+			List<Message> assistantMessages = chatResponse.getResults()
+				.stream()
+				.map(g -> (Message) g.getOutput())
+				.toList();
+
+			this.chatMemory.add(this.conversationId, assistantMessages);
+		});
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
@@ -67,7 +67,7 @@ public class QuestionAnswerAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
 
 		// 1. Advise the system text.
 		String advisedUserText = request.userText() + System.lineSeparator() + this.userTextAdvise;
@@ -76,13 +76,13 @@ public class QuestionAnswerAdvisor implements RequestResponseAdvisor {
 		List<Document> documents = vectorStore.similaritySearch(searchRequest.withQuery(request.userText()));
 
 		// 3. Create the context from the documents.
-		String context = documents.stream()
+		String documentContext = documents.stream()
 			.map(Content::getContent)
 			.collect(Collectors.joining(System.lineSeparator()));
 
 		// 4. Advise the user parameters.
 		Map<String, Object> advisedUserParams = new HashMap<>(request.userParams());
-		advisedUserParams.put("context", context);
+		advisedUserParams.put("context", documentContext);
 
 		AdvisedRequest advisedRequest = AdvisedRequest.from(request)
 			.withUserText(advisedUserText)

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.ai.chat.client.AdvisedRequest;
+import org.springframework.ai.chat.client.RequestResponseAdvisor;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.model.Content;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0 M1
+ */
+public class QuestionAnswerAdvisor implements RequestResponseAdvisor {
+
+	private static final String DEFAULT_USER_TEXT_ADVISE = """
+			Context information is below.
+			---------------------
+			{context}
+			---------------------
+			Given the context and provided history information and not prior knowledge,
+			reply to the user comment. If the answer is not in the context, inform
+			the user that you can't answer the question.
+			""";
+
+	private final VectorStore vectorStore;
+
+	private final String userTextAdvise;
+
+	private final SearchRequest searchRequest;
+
+	public QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest) {
+		this(vectorStore, searchRequest, DEFAULT_USER_TEXT_ADVISE);
+	}
+
+	public QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest, String userTextAdvise) {
+
+		Assert.notNull(vectorStore, "The vectorStore must not be null!");
+		Assert.notNull(searchRequest, "The searchRequest must not be null!");
+		Assert.hasText(userTextAdvise, "The userTextAdvise must not be empty!");
+
+		this.vectorStore = vectorStore;
+		this.searchRequest = searchRequest;
+		this.userTextAdvise = userTextAdvise;
+	}
+
+	@Override
+	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+
+		// 1. Advise the system text.
+		String advisedUserText = request.userText() + System.lineSeparator() + this.userTextAdvise;
+
+		// 2. Search for similar documents in the vector store.
+		List<Document> documents = vectorStore.similaritySearch(searchRequest.withQuery(request.userText()));
+
+		// 3. Create the context from the documents.
+		String context = documents.stream()
+			.map(Content::getContent)
+			.collect(Collectors.joining(System.lineSeparator()));
+
+		// 4. Advise the user parameters.
+		Map<String, Object> advisedUserParams = new HashMap<>(request.userParams());
+		advisedUserParams.put("context", context);
+
+		AdvisedRequest advisedRequest = AdvisedRequest.from(request)
+			.withUserText(advisedUserText)
+			.withUserParams(advisedUserParams)
+			.build();
+
+		return advisedRequest;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.AdvisedRequest;
+import org.springframework.ai.chat.client.RequestResponseAdvisor;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.model.Content;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0 M1
+ */
+public class VectorStoreChatMemoryAdvisor implements RequestResponseAdvisor {
+
+	private static final String DEFAULT_SYSTEM_TEXT_ADVISE = """
+
+			Use the long term conversation memory from the LONG_TERM_MEMORY section to provide accurate answers.
+
+			---------------------
+			LONG_TERM_MEMORY:
+			{long_term_memory}
+			---------------------
+
+			""";
+
+	public static final String CONVERSATION_ID = "conversationId";
+
+	private final VectorStore vectorStore;
+
+	private final int topK;
+
+	private final String conversationId;
+
+	private String systemTextAdvise = DEFAULT_SYSTEM_TEXT_ADVISE;
+
+	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String conversationId) {
+		this(vectorStore, conversationId, 5);
+	}
+
+	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String conversationId, int topK) {
+		this.vectorStore = vectorStore;
+		this.conversationId = conversationId;
+		this.topK = topK;
+	}
+
+	@Override
+	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+
+		String advisedSystemText = request.systemText() + System.lineSeparator() + this.systemTextAdvise;
+
+		var searchRequest = SearchRequest.query(request.userText())
+			.withTopK(this.topK)
+			.withFilterExpression(CONVERSATION_ID + "=='" + this.conversationId + "'");
+
+		List<Document> documents = this.vectorStore.similaritySearch(searchRequest);
+
+		String longTermMemory = documents.stream()
+			.map(Content::getContent)
+			.collect(Collectors.joining(System.lineSeparator()));
+
+		Map<String, Object> advisedSystemParams = new HashMap<>(request.systemParams());
+		advisedSystemParams.put("long_term_memory", longTermMemory);
+
+		AdvisedRequest advisedRequest = AdvisedRequest.from(request)
+			.withSystemText(advisedSystemText)
+			.withSystemParams(advisedSystemParams)
+			.build();
+
+		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		this.vectorStore.write(toDocuments(List.of(userMessage), this.conversationId));
+
+		return advisedRequest;
+	}
+
+	@Override
+	public ChatResponse adviseResponse(ChatResponse chatResponse) {
+
+		List<Message> assistantMessages = chatResponse.getResults().stream().map(g -> (Message) g.getOutput()).toList();
+
+		this.vectorStore.write(toDocuments(assistantMessages, this.conversationId));
+
+		return chatResponse;
+	}
+
+	@Override
+	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse) {
+
+		return new MessageAggregator().aggregate(fluxChatResponse, chatResponse -> {
+			List<Message> assistantMessages = chatResponse.getResults()
+				.stream()
+				.map(g -> (Message) g.getOutput())
+				.toList();
+
+			this.vectorStore.write(toDocuments(assistantMessages, this.conversationId));
+		});
+	}
+
+	private List<Document> toDocuments(List<Message> messages, String conversationId) {
+
+		List<Document> docs = messages.stream()
+			.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
+			.map(message -> {
+				var metadata = new HashMap<>(message.getMetadata() != null ? message.getMetadata() : new HashMap<>());
+				metadata.put(CONVERSATION_ID, conversationId);
+				metadata.put("messageType", message.getMessageType().name());
+				var doc = new Document(message.getContent(), metadata);
+				return doc;
+			})
+			.toList();
+
+		return docs;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
@@ -73,7 +73,7 @@ public class VectorStoreChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public AdvisedRequest adviseRequest(AdvisedRequest request) {
+	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
 
 		String advisedSystemText = request.systemText() + System.lineSeparator() + this.systemTextAdvise;
 
@@ -102,7 +102,7 @@ public class VectorStoreChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public ChatResponse adviseResponse(ChatResponse chatResponse) {
+	public ChatResponse adviseResponse(ChatResponse chatResponse, Map<String, Object> context) {
 
 		List<Message> assistantMessages = chatResponse.getResults().stream().map(g -> (Message) g.getOutput()).toList();
 
@@ -112,7 +112,7 @@ public class VectorStoreChatMemoryAdvisor implements RequestResponseAdvisor {
 	}
 
 	@Override
-	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse) {
+	public Flux<ChatResponse> adviseResponse(Flux<ChatResponse> fluxChatResponse, Map<String, Object> context) {
 
 		return new MessageAggregator().aggregate(fluxChatResponse, chatResponse -> {
 			List<Message> assistantMessages = chatResponse.getResults()

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/ChatMemoryChatServiceListener.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/ChatMemoryChatServiceListener.java
@@ -20,14 +20,19 @@ import java.util.List;
 
 import org.springframework.ai.chat.service.ChatServiceResponse;
 import org.springframework.ai.chat.service.ChatServiceListener;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.prompt.transformer.ChatServiceContext;
 import org.springframework.ai.chat.prompt.transformer.TransformerContentType;
 
 /**
+ * @deprecated Use the {@link MessageChatMemoryAdvisor} or {@link PromptChatMemoryAdvisor}
+ * instead.
  * @author Christian Tzolov
  */
+@Deprecated
 public class ChatMemoryChatServiceListener implements ChatServiceListener {
 
 	private final ChatMemory chatHistory;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/LastMaxTokenSizeContentTransformer.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/LastMaxTokenSizeContentTransformer.java
@@ -20,19 +20,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.ai.chat.client.advisor.LastMaxTokenSizeContentPurger;
 import org.springframework.ai.chat.prompt.transformer.AbstractPromptTransformer;
 import org.springframework.ai.chat.prompt.transformer.ChatServiceContext;
 import org.springframework.ai.model.Content;
 import org.springframework.ai.tokenizer.TokenCountEstimator;
 
 /**
+ *
  * Returns a new list of content (e.g list of messages of list of documents) that is a
  * subset of the input list of contents and complies with the max token size constraint.
  *
  * The token estimator is used to estimate the token count of the datum.
  *
+ * @deprecated Use the {@link LastMaxTokenSizeContentPurger} instead.
  * @author Christian Tzolov
  */
+@Deprecated
 public class LastMaxTokenSizeContentTransformer extends AbstractPromptTransformer {
 
 	protected final TokenCountEstimator tokenCountEstimator;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/MessageChatMemoryAugmentor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/MessageChatMemoryAugmentor.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.memory;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.messages.AbstractMessage;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -32,8 +33,10 @@ import org.springframework.ai.chat.prompt.transformer.PromptChange;
 import org.springframework.ai.chat.prompt.transformer.TransformerContentType;
 
 /**
+ * @deprecated Use the {@link MessageChatMemoryAdvisor} instead.
  * @author Christian Tzolov
  */
+@Deprecated
 public class MessageChatMemoryAugmentor extends AbstractPromptTransformer {
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/SystemPromptChatMemoryAugmentor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/SystemPromptChatMemoryAugmentor.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
 import org.springframework.ai.chat.messages.AbstractMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
@@ -35,8 +36,10 @@ import org.springframework.ai.chat.prompt.transformer.TransformerContentType;
 import org.springframework.util.Assert;
 
 /**
+ * @deprecated Use the {@link PromptChatMemoryAdvisor} instead.
  * @author Christian Tzolov
  */
+@Deprecated
 public class SystemPromptChatMemoryAugmentor extends AbstractPromptTransformer {
 
 	public static final String DEFAULT_HISTORY_PROMPT = """

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/VectorStoreChatMemoryChatServiceListener.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/VectorStoreChatMemoryChatServiceListener.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.springframework.ai.chat.service.ChatServiceListener;
 import org.springframework.ai.chat.service.ChatServiceResponse;
+import org.springframework.ai.chat.client.advisor.VectorStoreChatMemoryAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.prompt.transformer.TransformerContentType;
@@ -31,8 +32,10 @@ import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.util.CollectionUtils;
 
 /**
+ * @deprecated Use the {@link VectorStoreChatMemoryAdvisor} instead.
  * @author Christian Tzolov
  */
+@Deprecated
 public class VectorStoreChatMemoryChatServiceListener implements ChatServiceListener {
 
 	private final VectorStore vectorStore;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/VectorStoreChatMemoryRetriever.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/memory/VectorStoreChatMemoryRetriever.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.ai.chat.client.advisor.VectorStoreChatMemoryAdvisor;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.prompt.transformer.AbstractPromptTransformer;
 import org.springframework.ai.chat.prompt.transformer.ChatServiceContext;
@@ -32,8 +33,10 @@ import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.util.CollectionUtils;
 
 /**
+ * @deprecated Use the {@link VectorStoreChatMemoryAdvisor} instead.
  * @author Christian Tzolov
  */
+@Deprecated
 public class VectorStoreChatMemoryRetriever extends AbstractPromptTransformer {
 
 	private final VectorStore vectorStore;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ChatModel.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ChatModel.java
@@ -20,11 +20,13 @@ import org.springframework.ai.chat.prompt.Prompt;
 
 import java.util.Arrays;
 
+import reactor.core.publisher.Flux;
+
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.model.Model;
 
-public interface ChatModel extends Model<Prompt, ChatResponse> {
+public interface ChatModel extends Model<Prompt, ChatResponse>, StreamingChatModel {
 
 	default String call(String message) {
 		Prompt prompt = new Prompt(new UserMessage(message));
@@ -42,5 +44,9 @@ public interface ChatModel extends Model<Prompt, ChatResponse> {
 	ChatResponse call(Prompt prompt);
 
 	ChatOptions getDefaultOptions();
+
+	default Flux<ChatResponse> stream(Prompt prompt) {
+		throw new UnsupportedOperationException("streaming is not supported");
+	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.chat.service;
+package org.springframework.ai.chat.model;
 
 import java.util.HashMap;
 import java.util.List;
@@ -25,9 +25,6 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-
-import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.chat.model.Generation;
 
 /**
  * Helper that for streaming chat responses, aggregate the chat response messages into a

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/service/StreamingPromptTransformingChatService.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/service/StreamingPromptTransformingChatService.java
@@ -23,6 +23,7 @@ import org.springframework.ai.chat.prompt.transformer.ChatServiceContext;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.prompt.transformer.PromptTransformer;
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientAdviseTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientAdviseTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.advisor.PromptChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.InMemoryChatMemory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Christian Tzolov
+ */
+@ExtendWith(MockitoExtension.class)
+public class ChatClientAdviseTest {
+
+	@Mock
+	ChatModel chatModel;
+
+	@Captor
+	ArgumentCaptor<Prompt> promptCaptor;
+
+	private String join(Flux<String> fluxContent) {
+		return fluxContent.collectList().block().stream().collect(Collectors.joining());
+	}
+
+	@Test
+	public void promptChatMemory() {
+
+		when(chatModel.call(promptCaptor.capture()))
+				.thenReturn(new ChatResponse(List.of(new Generation("Hello John"))))
+				.thenReturn(new ChatResponse(List.of(new Generation("Your name is John"))));
+
+		ChatMemory chatMemory = new InMemoryChatMemory();
+
+		var chatClient = ChatClient.builder(chatModel)
+				.defaultSystem("Default system text.")
+				.defaultAdvisor(new PromptChatMemoryAdvisor("default", chatMemory))
+				.build();
+
+		var content = chatClient.prompt()
+				.user("my name is John")
+				.call().content();
+
+		assertThat(content).isEqualTo("Hello John");
+
+		Message systemMessage = promptCaptor.getValue().getInstructions().get(0);
+		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+				Default system text.
+
+				Use the conversation memory from the MEMORY section to provide accurate answers.
+
+				---------------------
+				MEMORY:
+				---------------------
+				""");
+		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
+
+		Message userMessage = promptCaptor.getValue().getInstructions().get(1);
+		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("my name is John");
+
+		content = chatClient.prompt()
+				.user("What is my name?")
+				.call().content();
+
+		assertThat(content).isEqualTo("Your name is John");
+
+		systemMessage = promptCaptor.getValue().getInstructions().get(0);
+		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+				Default system text.
+
+				Use the conversation memory from the MEMORY section to provide accurate answers.
+
+				---------------------
+				MEMORY:
+				USER:my name is John
+				ASSISTANT:Hello John
+				---------------------
+				""");
+		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
+
+		userMessage = promptCaptor.getValue().getInstructions().get(1);
+		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("What is my name?");
+	}
+
+	@Test
+	public void streamingPromptChatMemory() {
+
+		when(chatModel.stream(promptCaptor.capture()))
+				.thenReturn(
+						Flux.generate(() -> new ChatResponse(List.of(new Generation("Hello John"))), (state, sink) -> {
+							sink.next(state);
+							sink.complete();
+							return state;
+						}))
+				.thenReturn(
+						Flux.generate(() -> new ChatResponse(List.of(new Generation("Your name is John"))), (state, sink) -> {
+							sink.next(state);
+							sink.complete();
+							return state;
+						}));
+
+		ChatMemory chatMemory = new InMemoryChatMemory();
+
+		var chatClient = ChatClient.builder(chatModel)
+				.defaultSystem("Default system text.")
+				.defaultAdvisor(new PromptChatMemoryAdvisor("default", chatMemory))
+				.build();
+
+		var content = join(chatClient.prompt()
+				.user("my name is John")
+				.stream().content());
+
+		assertThat(content).isEqualTo("Hello John");
+
+		Message systemMessage = promptCaptor.getValue().getInstructions().get(0);
+		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+				Default system text.
+
+				Use the conversation memory from the MEMORY section to provide accurate answers.
+
+				---------------------
+				MEMORY:
+				---------------------
+				""");
+		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
+
+		Message userMessage = promptCaptor.getValue().getInstructions().get(1);
+		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("my name is John");
+
+		content = join(chatClient.prompt()
+				.user("What is my name?")
+				.stream().content());
+
+		assertThat(content).isEqualTo("Your name is John");
+
+		systemMessage = promptCaptor.getValue().getInstructions().get(0);
+		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+				Default system text.
+
+				Use the conversation memory from the MEMORY section to provide accurate answers.
+
+				---------------------
+				MEMORY:
+				USER:my name is John
+				ASSISTANT:Hello John
+				---------------------
+				""");
+		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
+
+		userMessage = promptCaptor.getValue().getInstructions().get(1);
+		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("What is my name?");
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
@@ -30,13 +30,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 
-import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.function.FunctionCallingOptions;
 import org.springframework.ai.model.function.FunctionCallingOptionsBuilder;
@@ -53,12 +52,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class ChatClientTest {
 
-	public static interface MixChatModel extends ChatModel, StreamingChatModel {
-
-	}
-
 	@Mock
-	MixChatModel chatModel;
+	ChatModel chatModel;
 
 	@Captor
 	ArgumentCaptor<Prompt> promptCaptor;


### PR DESCRIPTION
  - Add RequestResponseAdvisor interface with adviseReqeust and adviseResponse methods. The adviseRequest method takes and returns AdvisedRequest. The adviseResponse method takes and returns ChatRequest.
  - Add ChatClient#ChatClientRequets advisor(...) methods to register advisros. ChatClient call the registered advisors in order before sealing the ChatClientRequest into a Prompt and call the model and after the model response.
  - Implement PromptChatMemoryAdvisor that uses the ChatMemory and the systemem prompt.
  - Implement MessageChatMemoryAdvisor that usees the ChatMemory and the prompt messages.
  - Implement VectorStoreChatMemoryAdvisor that uses VecrStore for long term message history.
  - Add tests.