### PR TITLE
Fix improper streaming behavior in data handling

### DIFF
--- a/models/spring-ai-azure-openai/pom.xml
+++ b/models/spring-ai-azure-openai/pom.xml
@@ -58,6 +58,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
Fix improper streaming behavior in data handling

Resolved an issue where data was not being streamed correctly due to improper use of the reduce function in the stream(Prompt prompt) method. This was causing data to be processed in a blocking manner, contrary to the expected reactive streaming behavior.

Changes made:
- Removed the reduce operation which aggregated all data into one chunk, thus blocking the streaming.
- Replaced the reduce with a direct handling of each individual item within the window to maintain continuous stream flow.
- Added comprehensive tests to ensure streaming is performed as intended, and to verify the non-blocking behavior with multiple emitted items.

Resolves: #764
