### PR TITLE
Overload QuestionAnswerAdvisor to use SearchRequest.defaults()

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
@@ -58,6 +58,10 @@ public class QuestionAnswerAdvisor implements RequestResponseAdvisor {
 
 	public static String RETRIEVED_DOCUMENTS = "qa_retrieved_documents";
 
+	public QuestionAnswerAdvisor(VectorStore vectorStore) {
+		this(vectorStore, SearchRequest.defaults(), DEFAULT_USER_TEXT_ADVISE);
+	}
+
 	public QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest) {
 		this(vectorStore, searchRequest, DEFAULT_USER_TEXT_ADVISE);
 	}


### PR DESCRIPTION
Although it's helpful to be able to customize the `SearchRequest` given to `QuestionAnswerAdvisor`, it's not uncommon to just rely on `SearchRequest.defaults()`. Therefore, this PR overloads the constructor with a version that only requires a `VectorStore` and uses `SearchRequest.defaults()`...in the interest of simplifying the application code a little.
