### PR TITLE
Use List.of instead of Arrays.asList In the SEARCH_OUTPUT_FIELDS field.

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -16,7 +16,6 @@
 package org.springframework.ai.vectorstore;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -85,7 +84,7 @@ public class MilvusVectorStore implements VectorStore, InitializingBean {
 	// Metadata, automatically assigned by Milvus.
 	public static final String DISTANCE_FIELD_NAME = "distance";
 
-	public static final List<String> SEARCH_OUTPUT_FIELDS = Arrays.asList(DOC_ID_FIELD_NAME, CONTENT_FIELD_NAME,
+	public static final List<String> SEARCH_OUTPUT_FIELDS = List.of(DOC_ID_FIELD_NAME, CONTENT_FIELD_NAME,
 			METADATA_FIELD_NAME);
 
 	public final FilterExpressionConverter filterExpressionConverter = new MilvusFilterExpressionConverter();


### PR DESCRIPTION
Use List.of instead of Arrays.asList In the SEARCH_OUTPUT_FIELDS field.

The Arrays.asList method can change elements. SEARCH_OUTPUT_FIELDS is an immutable field, so it has been improved to util List.of.