### PR TITLE
Add YiAi model client 

### DIFF
--- a/models/spring-ai-yi/README.md
+++ b/models/spring-ai-yi/README.md
@@ -1,0 +1,1 @@
+[ZhiPu AI Chat Documentation](https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/chat/yi-chat.html)

--- a/models/spring-ai-yi/pom.xml
+++ b/models/spring-ai-yi/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>spring-ai-yi</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Model - Yi AI</name>
+    <description>Yi AI models support</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+
+        <!-- production dependencies -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+        <!-- Spring Framework -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/YiAiChatModel.java
+++ b/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/YiAiChatModel.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.yi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.function.AbstractFunctionCallSupport;
+import org.springframework.ai.model.function.FunctionCallbackContext;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.yi.api.YiAiApi;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletion;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletion.Choice;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionFinishReason;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage.MediaContent;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage.ToolCall;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.MimeType;
+import reactor.core.publisher.Flux;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.springframework.ai.yi.api.YiAiApi.DEFAULT_CHAT_MODEL;
+
+/**
+ * {@link ChatModel} and {@link StreamingChatModel} implementation for {@literal YiAi}
+ * backed by {@link YiAiApi}.
+ */
+public class YiAiChatModel extends
+		AbstractFunctionCallSupport<ChatCompletionMessage, ChatCompletionRequest, ResponseEntity<ChatCompletion>>
+		implements ChatModel, StreamingChatModel {
+
+	private static final Logger logger = LoggerFactory.getLogger(YiAiChatModel.class);
+
+	/**
+	 * The default options used for the chat completion requests.
+	 */
+	private YiAiChatOptions defaultOptions;
+
+	/**
+	 * The retry template used to retry the YiAi API calls.
+	 */
+	public final RetryTemplate retryTemplate;
+
+	/**
+	 * Low-level access to the YiAi API.
+	 */
+	private final YiAiApi YiAiApi;
+
+	/**
+	 * Creates an instance of the YiAiChatModel.
+	 * @param yiAiApi The YiAiApi instance to be used for interacting with the YiAi Chat
+	 * API.
+	 * @throws IllegalArgumentException if YiAiApi is null
+	 */
+	public YiAiChatModel(YiAiApi yiAiApi) {
+		this(yiAiApi, YiAiChatOptions.builder().withModel(DEFAULT_CHAT_MODEL).withTemperature(0.7f).build());
+	}
+
+	/**
+	 * Initializes an instance of the YiAiChatModel.
+	 * @param yiAiApi The YiAiApi instance to be used for interacting with the YiAi Chat
+	 * API.
+	 * @param options The YiAiChatOptions to configure the chat model.
+	 */
+	public YiAiChatModel(YiAiApi yiAiApi, YiAiChatOptions options) {
+		this(yiAiApi, options, null, RetryUtils.DEFAULT_RETRY_TEMPLATE);
+	}
+
+	/**
+	 * Initializes a new instance of the YiAiChatModel.
+	 * @param yiAiApi The YiAiApi instance to be used for interacting with the YiAi Chat
+	 * API.
+	 * @param options The YiAiChatOptions to configure the chat model.
+	 * @param functionCallbackContext The function callback context.
+	 * @param retryTemplate The retry template.
+	 */
+	public YiAiChatModel(YiAiApi yiAiApi, YiAiChatOptions options, FunctionCallbackContext functionCallbackContext,
+			RetryTemplate retryTemplate) {
+		super(functionCallbackContext);
+		Assert.notNull(yiAiApi, "yiAiApi must not be null");
+		Assert.notNull(options, "Options must not be null");
+		Assert.notNull(retryTemplate, "RetryTemplate must not be null");
+		this.YiAiApi = yiAiApi;
+		this.defaultOptions = options;
+		this.retryTemplate = retryTemplate;
+	}
+
+	@Override
+	public ChatResponse call(Prompt prompt) {
+		ChatCompletionRequest request = createRequest(prompt, false);
+		return this.retryTemplate.execute(ctx -> {
+			ResponseEntity<ChatCompletion> completionEntity = this.callWithFunctionSupport(request);
+
+			var chatCompletion = completionEntity.getBody();
+			if (chatCompletion == null) {
+				logger.warn("No chat completion returned for prompt: {}", prompt);
+				return new ChatResponse(List.of());
+			}
+
+			List<Generation> generations = chatCompletion.choices()
+				.stream()
+				.map(choice -> new Generation(choice.message().content(), toMap(chatCompletion.id(), choice))
+					.withGenerationMetadata(ChatGenerationMetadata.from(choice.finishReason().name(), null)))
+				.toList();
+
+			return new ChatResponse(generations);
+		});
+	}
+
+	private Map<String, Object> toMap(String id, Choice choice) {
+		Map<String, Object> map = new HashMap<>();
+		var message = choice.message();
+		if (message.role() != null) {
+			map.put("role", message.role().name());
+		}
+		if (choice.finishReason() != null) {
+			map.put("finishReason", choice.finishReason().name());
+		}
+		map.put("id", id);
+		return map;
+	}
+
+	@Override
+	public Flux<ChatResponse> stream(Prompt prompt) {
+		ChatCompletionRequest request = createRequest(prompt, true);
+		return this.retryTemplate.execute(ctx -> {
+			Flux<YiAiApi.ChatCompletionChunk> completionChunks = this.YiAiApi.chatCompletionStream(request);
+
+			// For chunked responses, only the first chunk contains the choice role.
+			// The rest of the chunks with same ID share the same role.
+			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
+
+			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
+			// the function call handling logic.
+			return completionChunks.map(this::chunkToChatCompletion).map(chatCompletion -> {
+				try {
+					chatCompletion = handleFunctionCallOrReturn(request, ResponseEntity.of(Optional.of(chatCompletion)))
+						.getBody();
+
+					String id = chatCompletion.id();
+
+					List<Generation> generations = chatCompletion.choices().stream().map(choice -> {
+						if (choice.message().role() != null) {
+							roleMap.putIfAbsent(id, choice.message().role().name());
+						}
+						String finish = (choice.finishReason() != null ? choice.finishReason().name() : "");
+						var generation = new Generation(choice.message().content(),
+								Map.of("id", id, "role", roleMap.get(id), "finishReason", finish));
+						if (choice.finishReason() != null) {
+							generation = generation.withGenerationMetadata(
+									ChatGenerationMetadata.from(choice.finishReason().name(), null));
+						}
+						return generation;
+					}).toList();
+
+					return new ChatResponse(generations);
+				}
+				catch (Exception e) {
+					logger.error("Error processing chat completion", e);
+					return new ChatResponse(List.of());
+				}
+
+			});
+		});
+	}
+
+	/**
+	 * Convert the ChatCompletionChunk into a ChatCompletion. The Usage is set to null.
+	 * @param chunk the ChatCompletionChunk to convert
+	 * @return the ChatCompletion
+	 */
+	private ChatCompletion chunkToChatCompletion(YiAiApi.ChatCompletionChunk chunk) {
+		List<Choice> choices = chunk.choices()
+			.stream()
+			.map(cc -> new Choice(cc.finishReason(), cc.index(), cc.delta(), cc.logprobs()))
+			.toList();
+		return new ChatCompletion(chunk.id(), choices, chunk.created(), chunk.model(), chunk.systemFingerprint(),
+				"chat.completion", null);
+	}
+
+	/**
+	 * Accessible for testing.
+	 */
+	ChatCompletionRequest createRequest(Prompt prompt, boolean stream) {
+		Set<String> functionsForThisRequest = new HashSet<>();
+		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(m -> {
+			// Add text content.
+			List<MediaContent> contents = new ArrayList<>(List.of(new MediaContent(m.getContent())));
+			if (!CollectionUtils.isEmpty(m.getMedia())) {
+				// Add media content.
+				contents.addAll(m.getMedia()
+					.stream()
+					.map(media -> new MediaContent(
+							new MediaContent.ImageUrl(this.fromMediaData(media.getMimeType(), media.getData()))))
+					.toList());
+			}
+
+			return new ChatCompletionMessage(contents, Role.valueOf(m.getMessageType().name()));
+		}).toList();
+
+		ChatCompletionRequest request = new ChatCompletionRequest(chatCompletionMessages, stream);
+
+		if (prompt.getOptions() != null) {
+			if (prompt.getOptions() instanceof ChatOptions runtimeOptions) {
+				YiAiChatOptions updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(runtimeOptions,
+						ChatOptions.class, YiAiChatOptions.class);
+				Set<String> promptEnabledFunctions = this.handleFunctionCallbackConfigurations(updatedRuntimeOptions,
+						IS_RUNTIME_CALL);
+				functionsForThisRequest.addAll(promptEnabledFunctions);
+				request = ModelOptionsUtils.merge(updatedRuntimeOptions, request, ChatCompletionRequest.class);
+			}
+			else {
+				throw new IllegalArgumentException("Prompt options are not of type ChatOptions: "
+						+ prompt.getOptions().getClass().getSimpleName());
+			}
+		}
+
+		if (this.defaultOptions != null) {
+			Set<String> defaultEnabledFunctions = this.handleFunctionCallbackConfigurations(this.defaultOptions,
+					!IS_RUNTIME_CALL);
+			functionsForThisRequest.addAll(defaultEnabledFunctions);
+			request = ModelOptionsUtils.merge(request, this.defaultOptions, ChatCompletionRequest.class);
+		}
+
+		return request;
+	}
+
+	private String fromMediaData(MimeType mimeType, Object mediaContentData) {
+		if (mediaContentData instanceof byte[] bytes) {
+			// Assume the bytes are an image. So, convert the bytes to a base64 encoded
+			// following the prefix pattern.
+			return String.format("data:%s;base64,%s", mimeType.toString(), Base64.getEncoder().encodeToString(bytes));
+		}
+		else if (mediaContentData instanceof String text) {
+			// Assume the text is a URLs or a base64 encoded image prefixed by the user.
+			return text;
+		}
+		else {
+			throw new IllegalArgumentException(
+					"Unsupported media data type: " + mediaContentData.getClass().getSimpleName());
+		}
+	}
+
+	@Override
+	protected ChatCompletionRequest doCreateToolResponseRequest(ChatCompletionRequest previousRequest,
+			ChatCompletionMessage responseMessage, List<ChatCompletionMessage> conversationHistory) {
+		// Every tool-call item requires a separate function call and a response (TOOL)
+		// message.
+		for (ToolCall toolCall : responseMessage.toolCalls()) {
+
+			var functionName = toolCall.function().name();
+			String functionArguments = toolCall.function().arguments();
+
+			if (!this.functionCallbackRegister.containsKey(functionName)) {
+				throw new IllegalStateException("No function callback found for function name: " + functionName);
+			}
+
+			String functionResponse = this.functionCallbackRegister.get(functionName).call(functionArguments);
+
+			// Add the function response to the conversation.
+			conversationHistory
+				.add(new ChatCompletionMessage(functionResponse, Role.TOOL, functionName, toolCall.id(), null));
+		}
+
+		// Recursively call chatCompletionWithTools until the model doesn't call a
+		// functions anymore.
+		ChatCompletionRequest newRequest = new ChatCompletionRequest(conversationHistory, false);
+		newRequest = ModelOptionsUtils.merge(newRequest, previousRequest, ChatCompletionRequest.class);
+
+		return newRequest;
+	}
+
+	@Override
+	protected List<ChatCompletionMessage> doGetUserMessages(ChatCompletionRequest request) {
+		return request.messages();
+	}
+
+	@Override
+	protected ChatCompletionMessage doGetToolResponseMessage(ResponseEntity<ChatCompletion> chatCompletion) {
+		return chatCompletion.getBody().choices().iterator().next().message();
+	}
+
+	@Override
+	protected ResponseEntity<ChatCompletion> doChatCompletion(ChatCompletionRequest request) {
+		return this.YiAiApi.chatCompletionEntity(request);
+	}
+
+	@Override
+	protected Flux<ResponseEntity<ChatCompletion>> doChatCompletionStream(ChatCompletionRequest request) {
+		return this.YiAiApi.chatCompletionStream(request)
+			.map(this::chunkToChatCompletion)
+			.map(Optional::ofNullable)
+			.map(ResponseEntity::of);
+	}
+
+	@Override
+	protected boolean isToolFunctionCall(ResponseEntity<ChatCompletion> chatCompletion) {
+		var body = chatCompletion.getBody();
+		if (body == null) {
+			return false;
+		}
+
+		var choices = body.choices();
+		if (CollectionUtils.isEmpty(choices)) {
+			return false;
+		}
+
+		var choice = choices.get(0);
+		return !CollectionUtils.isEmpty(choice.message().toolCalls())
+				&& choice.finishReason() == ChatCompletionFinishReason.TOOL_CALLS;
+	}
+
+	@Override
+	public ChatOptions getDefaultOptions() {
+		return YiAiChatOptions.fromOptions(this.defaultOptions);
+	}
+
+}

--- a/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/YiAiChatOptions.java
+++ b/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/YiAiChatOptions.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.yi;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.model.function.FunctionCallingOptions;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * YiAiChatOptions represents the options for the YiAiChat model.
+ *
+ * @author Geng Rong
+ * @since 1.0.0 M1
+ */
+@JsonInclude(Include.NON_NULL)
+public class YiAiChatOptions implements FunctionCallingOptions, ChatOptions {
+
+	/**
+	 * ID of the model to use.
+	 */
+	private @JsonProperty("model") String model;
+
+	/**
+	 * Specify the maximum number of tokens for the model when generating content. This
+	 * defines the upper limit for generation, but does not guarantee that this number
+	 * will be generated each time.
+	 */
+	private @JsonProperty("max_tokens") Integer maxTokens;
+
+	/**
+	 * Controls the divergence and centralization of the generated results. The smaller
+	 * the value, the more centralized; the larger the value, the more divergent. Default
+	 * value: 0.3. Range of values: between 0 and 2.
+	 */
+	private @JsonProperty("temperature") Float temperature;
+
+	/**
+	 * Control the randomness of the generated results. The smaller the value, the weaker
+	 * the randomness; the larger the value, the stronger the randomness. Default value:
+	 * 0.9. Value range: between 0 and 1.
+	 */
+	private @JsonProperty("top_p") Float topP;
+
+	/**
+	 * Tool Function Callbacks to register with the ChatModel. For Prompt Options the
+	 * functionCallbacks are automatically enabled for the duration of the prompt
+	 * execution. For Default Options the functionCallbacks are registered but disabled by
+	 * default. Use the enableFunctions to set the functions from the registry to be used
+	 * by the ChatModel chat completion requests.
+	 */
+	@NestedConfigurationProperty
+	@JsonIgnore
+	private List<FunctionCallback> functionCallbacks = new ArrayList<>();
+
+	/**
+	 * List of functions, identified by their names, to configure for function calling in
+	 * the chat completion requests. Functions with those names must exist in the
+	 * functionCallbacks registry. The {@link #functionCallbacks} from the PromptOptions
+	 * are automatically enabled for the duration of the prompt execution.
+	 * <p>
+	 * Note that function enabled with the default options are enabled for all chat
+	 * completion requests. This could impact the token count and the billing. If the
+	 * functions is set in a prompt options, then the enabled functions are only active
+	 * for the duration of this prompt execution.
+	 */
+	@NestedConfigurationProperty
+	@JsonIgnore
+	private Set<String> functions = new HashSet<>();
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		protected YiAiChatOptions options;
+
+		public Builder() {
+			this.options = new YiAiChatOptions();
+		}
+
+		public Builder(YiAiChatOptions options) {
+			this.options = options;
+		}
+
+		public Builder withModel(String model) {
+			this.options.model = model;
+			return this;
+		}
+
+		public Builder withMaxTokens(Integer maxTokens) {
+			this.options.maxTokens = maxTokens;
+			return this;
+		}
+
+		public Builder withTemperature(Float temperature) {
+			this.options.temperature = temperature;
+			return this;
+		}
+
+		public Builder withTopP(Float topP) {
+			this.options.topP = topP;
+			return this;
+		}
+
+		public YiAiChatOptions build() {
+			return this.options;
+		}
+
+		public Builder withFunctionCallbacks(List<FunctionCallback> functionCallbacks) {
+			this.options.functionCallbacks = functionCallbacks;
+			return this;
+		}
+
+		public Builder withFunctions(Set<String> functionNames) {
+			Assert.notNull(functionNames, "Function names must not be null");
+			this.options.functions = functionNames;
+			return this;
+		}
+
+		public Builder withFunction(String functionName) {
+			Assert.hasText(functionName, "Function name must not be empty");
+			this.options.functions.add(functionName);
+			return this;
+		}
+
+	}
+
+	public String getModel() {
+		return this.model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	public Integer getMaxTokens() {
+		return this.maxTokens;
+	}
+
+	public void setMaxTokens(Integer maxTokens) {
+		this.maxTokens = maxTokens;
+	}
+
+	@Override
+	public Float getTemperature() {
+		return this.temperature;
+	}
+
+	public void setTemperature(Float temperature) {
+		this.temperature = temperature;
+	}
+
+	@Override
+	public Float getTopP() {
+		return this.topP;
+	}
+
+	public void setTopP(Float topP) {
+		this.topP = topP;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((model == null) ? 0 : model.hashCode());
+		result = prime * result + ((maxTokens == null) ? 0 : maxTokens.hashCode());
+		result = prime * result + ((temperature == null) ? 0 : temperature.hashCode());
+		result = prime * result + ((topP == null) ? 0 : topP.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		YiAiChatOptions other = (YiAiChatOptions) obj;
+		if (this.model == null) {
+			if (other.model != null)
+				return false;
+		}
+		else if (!model.equals(other.model))
+			return false;
+		if (this.maxTokens == null) {
+			if (other.maxTokens != null)
+				return false;
+		}
+		else if (!this.maxTokens.equals(other.maxTokens))
+			return false;
+		else if (!this.temperature.equals(other.temperature))
+			return false;
+		if (this.topP == null) {
+			if (other.topP != null)
+				return false;
+		}
+		else if (!topP.equals(other.topP))
+			return false;
+		return true;
+	}
+
+	@Override
+	@JsonIgnore
+	public Integer getTopK() {
+		throw new UnsupportedOperationException("Unimplemented method 'getTopK'");
+	}
+
+	@JsonIgnore
+	public void setTopK(Integer topK) {
+		throw new UnsupportedOperationException("Unimplemented method 'setTopK'");
+	}
+
+	@Override
+	public List<FunctionCallback> getFunctionCallbacks() {
+		return this.functionCallbacks;
+	}
+
+	@Override
+	public void setFunctionCallbacks(List<FunctionCallback> functionCallbacks) {
+		this.functionCallbacks = functionCallbacks;
+	}
+
+	@Override
+	public Set<String> getFunctions() {
+		return this.functions;
+	}
+
+	@Override
+	public void setFunctions(Set<String> functions) {
+		this.functions = functions;
+	}
+
+	public static YiAiChatOptions fromOptions(YiAiChatOptions fromOptions) {
+		// @formatter:off
+        return YiAiChatOptions.builder()
+                .withModel(fromOptions.getModel())
+                .withMaxTokens(fromOptions.getMaxTokens())
+                .withTemperature(fromOptions.getTemperature())
+                .withTopP(fromOptions.getTopP())
+                .withFunctionCallbacks(fromOptions.getFunctionCallbacks())
+                .withFunctions(fromOptions.getFunctions()).build();
+        // @formatter:on
+	}
+
+}

--- a/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/aot/YiAiRuntimeHints.java
+++ b/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/aot/YiAiRuntimeHints.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.yi.aot;
+
+import org.springframework.ai.yi.api.YiAiApi;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import static org.springframework.ai.aot.AiRuntimeHints.findJsonAnnotatedClassesInPackage;
+
+/**
+ * The ZhiPuAiRuntimeHints class is responsible for registering runtime hints for ZhiPu AI
+ * API classes.
+ *
+ * @author Geng Rong
+ * @since 1.0.0 M1
+ */
+public class YiAiRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(@NonNull RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		var mcs = MemberCategory.values();
+		for (var tr : findJsonAnnotatedClassesInPackage(YiAiApi.class))
+			hints.reflection().registerType(tr, mcs);
+	}
+
+}

--- a/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/ApiUtils.java
+++ b/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/ApiUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.yi.api;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Geng Rong
+ */
+public class ApiUtils {
+
+	// Default base API URL
+	public static final String DEFAULT_BASE_URL = "https://api.lingyiwanwu.com";
+
+	/**
+	 * Returns a Consumer that sets JSON content type and API key in HttpHeaders.
+	 * @param apiKey The key used for API authentication.
+	 * @return A Consumer function to apply on HttpHeaders instances, setting the
+	 * authentication and content type.
+	 */
+	public static Consumer<HttpHeaders> getJsonContentHeaders(String apiKey) {
+		return (headers) -> {
+			headers.setBearerAuth(apiKey); // Set Bearer authentication
+			headers.setContentType(MediaType.APPLICATION_JSON); // Set content type to
+																// JSON
+		};
+	}
+
+}

--- a/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/YiAiApi.java
+++ b/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/YiAiApi.java
@@ -1,0 +1,575 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.yi.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.ai.model.ModelDescription;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+/**
+ * Single class implementation of the YiAI Chat Completion API:
+ * https://platform.lingyiwanwu.com/docs#create-chat-completion
+ *
+ * @author Geng Rong
+ * @since 1.0.0 M1
+ */
+public class YiAiApi {
+
+	public static final String DEFAULT_CHAT_MODEL = ChatModel.YI_LARGE.getValue();
+
+	private static final Predicate<String> SSE_DONE_PREDICATE = "[DONE]"::equals;
+
+	private final RestClient restClient;
+
+	private final WebClient webClient;
+
+	/**
+	 * Create a new chat completion api with default base URL.
+	 * @param apiKey YiAI apiKey.
+	 */
+	public YiAiApi(String apiKey) {
+		this(ApiUtils.DEFAULT_BASE_URL, apiKey);
+	}
+
+	/**
+	 * Create a new chat completion api.
+	 * @param baseUrl api base URL.
+	 * @param apiKey YiAI apiKey.
+	 */
+	public YiAiApi(String baseUrl, String apiKey) {
+		this(baseUrl, apiKey, RestClient.builder());
+	}
+
+	/**
+	 * Create a new chat completion api.
+	 * @param baseUrl api base URL.
+	 * @param apiKey YiAI apiKey.
+	 * @param restClientBuilder RestClient builder.
+	 */
+	public YiAiApi(String baseUrl, String apiKey, RestClient.Builder restClientBuilder) {
+		this(baseUrl, apiKey, restClientBuilder, RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER);
+	}
+
+	/**
+	 * Create a new chat completion api.
+	 * @param baseUrl api base URL.
+	 * @param apiKey YiAI apiKey.
+	 * @param restClientBuilder RestClient builder.
+	 * @param responseErrorHandler Response error handler.
+	 */
+	public YiAiApi(String baseUrl, String apiKey, RestClient.Builder restClientBuilder,
+			ResponseErrorHandler responseErrorHandler) {
+
+		this.restClient = restClientBuilder.baseUrl(baseUrl)
+			.defaultHeaders(ApiUtils.getJsonContentHeaders(apiKey))
+			.defaultStatusHandler(responseErrorHandler)
+			.build();
+
+		this.webClient = WebClient.builder()
+			.baseUrl(baseUrl)
+			.defaultHeaders(ApiUtils.getJsonContentHeaders(apiKey))
+			.build();
+	}
+
+	/**
+	 * Yi Chat Completion Models:
+	 * <a href="https://platform.lingyiwanwu.com/docs#%E6%A8%A1%E5%9E%8B">YiAI Model</a>.
+	 */
+	public enum ChatModel implements ModelDescription {
+
+		YI_LARGE("yi-large"), YI_MEDIUM("yi-medium"), YI_VISION("yi-vision"), YI_MEDIUM_200K("yi-medium-200k"),
+		YI_SPARK("yi-spark"), YI_LARGE_RAG("yi-large-rag"), YI_LARGE_TURBO("yi-large-turbo");
+
+		public final String value;
+
+		ChatModel(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		@Override
+		public String getModelName() {
+			return this.value;
+		}
+
+	}
+
+	/**
+	 * Creates a model response for the given chat conversation.
+	 *
+	 * @param messages A list of messages comprising the conversation so far.
+	 * @param model ID of the model to use.
+	 * @param maxTokens The maximum number of tokens to generate in the chat completion.
+	 * The total length of input tokens and generated tokens is limited by the model's
+	 * context length.
+	 * @param stream If set, partial message deltas will be sent.Tokens will be sent as
+	 * data-only server-sent events as they become available, with the stream terminated
+	 * by a data: [DONE] message.
+	 * @param temperature What sampling temperature to use, between 0 and 1. Higher values
+	 * like 0.8 will make the output more random, while lower values like 0.2 will make it
+	 * more focused and deterministic. We generally recommend altering this or top_p but
+	 * not both.
+	 * @param topP An alternative to sampling with temperature, called nucleus sampling,
+	 * where the model considers the results of the tokens with top_p probability mass. So
+	 * 0.1 means only the tokens comprising the top 10% probability mass are considered.
+	 * We generally recommend altering this or temperature but not both.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record ChatCompletionRequest(@JsonProperty("messages") List<ChatCompletionMessage> messages,
+			@JsonProperty("model") String model, @JsonProperty("max_tokens") Integer maxTokens,
+			@JsonProperty("stream") Boolean stream, @JsonProperty("temperature") Float temperature,
+			@JsonProperty("top_p") Float topP) {
+
+		/**
+		 * Shortcut constructor for a chat completion request with the given messages and
+		 * model.
+		 * @param messages A list of messages comprising the conversation so far.
+		 * @param model ID of the model to use.
+		 * @param temperature What sampling temperature to use, between 0 and 1.
+		 */
+		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Float temperature) {
+			this(messages, model, null, false, temperature, null);
+		}
+
+		/**
+		 * Shortcut constructor for a chat completion request with the given messages,
+		 * model and control for streaming.
+		 * @param messages A list of messages comprising the conversation so far.
+		 * @param model ID of the model to use.
+		 * @param temperature What sampling temperature to use, between 0 and 1.
+		 * @param stream If set, partial message deltas will be sent.Tokens will be sent
+		 * as data-only server-sent events as they become available, with the stream
+		 * terminated by a data: [DONE] message.
+		 */
+		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Float temperature,
+				boolean stream) {
+			this(messages, model, null, stream, temperature, null);
+		}
+
+		/**
+		 * Shortcut constructor for a chat completion request with the given messages,
+		 * model, tools and tool choice. Streaming is set to false, temperature to 0.8 and
+		 * all other parameters are null.
+		 * @param messages A list of messages comprising the conversation so far.
+		 * @param stream If set, partial message deltas will be sent.Tokens will be sent
+		 * as data-only server-sent events as they become available, with the stream
+		 * terminated by a data: [DONE] message.
+		 */
+		public ChatCompletionRequest(List<ChatCompletionMessage> messages, Boolean stream) {
+			this(messages, null, null, stream, null, null);
+		}
+	}
+
+	/**
+	 * Message comprising the conversation.
+	 *
+	 * @param rawContent The contents of the message. Can be either a {@link MediaContent}
+	 * or a {@link String}. The response message content is always a {@link String}.
+	 * @param role The role of the messages author. Could be one of the {@link Role}
+	 * types.
+	 * @param name An optional name for the participant. Provides the model information to
+	 * differentiate between participants of the same role. In case of Function calling,
+	 * the name is the function name that the message is responding to.
+	 * @param toolCallId Tool call that this message is responding to. Only applicable for
+	 * the {@link Role#TOOL} role and null otherwise.
+	 * @param toolCalls The tool calls generated by the model, such as function calls.
+	 * Applicable only for {@link Role#ASSISTANT} role and null otherwise.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record ChatCompletionMessage(@JsonProperty("content") Object rawContent, @JsonProperty("role") Role role,
+			@JsonProperty("name") String name, @JsonProperty("tool_call_id") String toolCallId,
+			@JsonProperty("tool_calls") List<ToolCall> toolCalls) {
+
+		/**
+		 * Get message content as String.
+		 */
+		public String content() {
+			if (this.rawContent == null) {
+				return null;
+			}
+			if (this.rawContent instanceof String text) {
+				return text;
+			}
+			if (this.rawContent instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof MediaContent) {
+				return ((List<MediaContent>) list).stream()
+					.filter(c -> false)
+					.map(ChatCompletionMessage.MediaContent::text)
+					.reduce("", (a, b) -> a + b);
+			}
+			throw new IllegalStateException("The content is not a string or a image format!");
+		}
+
+		/**
+		 * Create a chat completion message with the given content and role. All other
+		 * fields are null.
+		 * @param content The contents of the message.
+		 * @param role The role of the author of this message.
+		 */
+		public ChatCompletionMessage(Object content, Role role) {
+			this(content, role, null, null, null);
+		}
+
+		/**
+		 * The role of the author of this message.
+		 */
+		public enum Role {
+
+			/**
+			 * System message.
+			 */
+			@JsonProperty("system")
+			SYSTEM,
+			/**
+			 * User message.
+			 */
+			@JsonProperty("user")
+			USER,
+			/**
+			 * Assistant message.
+			 */
+			@JsonProperty("assistant")
+			ASSISTANT,
+			/**
+			 * Tool message.
+			 */
+			@JsonProperty("tool")
+			TOOL
+
+		}
+
+		/**
+		 * An array of content parts with a defined type. Each MediaContent can be of
+		 * either "text" or "image_url" type. Not both.
+		 *
+		 * @param type Content type, each can be of type text or image_url.
+		 * @param text The text content of the message.
+		 * @param imageUrl The image content of the message. You can pass multiple images
+		 * by adding multiple image_url content parts. Image input is only supported when
+		 * using the glm-4v model.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record MediaContent(@JsonProperty("type") String type, @JsonProperty("text") String text,
+				@JsonProperty("image_url") ImageUrl imageUrl) {
+
+			/**
+			 * @param url Either a URL of the image or the base64 encoded image data. The
+			 * base64 encoded image data must have a special prefix in the following
+			 * format: "data:{mimetype};base64,{base64-encoded-image-data}".
+			 * @param detail Specifies the detail level of the image.
+			 */
+			@JsonInclude(Include.NON_NULL)
+			public record ImageUrl(@JsonProperty("url") String url, @JsonProperty("detail") String detail) {
+
+				public ImageUrl(String url) {
+					this(url, null);
+				}
+			}
+
+			/**
+			 * Shortcut constructor for a text content.
+			 * @param text The text content of the message.
+			 */
+			public MediaContent(String text) {
+				this("text", text, null);
+			}
+
+			/**
+			 * Shortcut constructor for an image content.
+			 * @param imageUrl The image content of the message.
+			 */
+			public MediaContent(ImageUrl imageUrl) {
+				this("image_url", null, imageUrl);
+			}
+		}
+
+		/**
+		 * The relevant tool call.
+		 *
+		 * @param id The ID of the tool call. This ID must be referenced when you submit
+		 * the tool outputs in using the Submit tool outputs to run endpoint.
+		 * @param type The type of tool call the output is required for. For now, this is
+		 * always function.
+		 * @param function The function definition.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record ToolCall(@JsonProperty("id") String id, @JsonProperty("type") String type,
+				@JsonProperty("function") ChatCompletionFunction function) {
+		}
+
+		/**
+		 * The function definition.
+		 *
+		 * @param name The name of the function.
+		 * @param arguments The arguments that the model expects you to pass to the
+		 * function.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record ChatCompletionFunction(@JsonProperty("name") String name,
+				@JsonProperty("arguments") String arguments) {
+		}
+	}
+
+	/**
+	 * The reason the model stopped generating tokens.
+	 */
+	public enum ChatCompletionFinishReason {
+
+		/**
+		 * The model hit a natural stop point or a provided stop sequence.
+		 */
+		@JsonProperty("stop")
+		STOP,
+		/**
+		 * The maximum number of tokens specified in the request was reached.
+		 */
+		@JsonProperty("length")
+		LENGTH,
+		/**
+		 * The content was omitted due to a flag from our content filters.
+		 */
+		@JsonProperty("content_filter")
+		CONTENT_FILTER,
+		/**
+		 * The model called a tool.
+		 */
+		@JsonProperty("tool_calls")
+		TOOL_CALLS,
+		/**
+		 * (deprecated) The model called a function.
+		 */
+		@JsonProperty("function_call")
+		FUNCTION_CALL,
+		/**
+		 * Only for compatibility with Mistral AI API.
+		 */
+		@JsonProperty("tool_call")
+		TOOL_CALL
+
+	}
+
+	/**
+	 * Represents a chat completion response returned by model, based on the provided
+	 * input.
+	 *
+	 * @param id A unique identifier for the chat completion.
+	 * @param choices A list of chat completion choices. Can be more than one if n is
+	 * greater than 1.
+	 * @param created The Unix timestamp (in seconds) of when the chat completion was
+	 * created.
+	 * @param model The model used for the chat completion.
+	 * @param systemFingerprint This fingerprint represents the backend configuration that
+	 * the model runs with. Can be used in conjunction with the seed request parameter to
+	 * understand when backend changes have been made that might impact determinism.
+	 * @param object The object type, which is always chat.completion.
+	 * @param usage Usage statistics for the completion request.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record ChatCompletion(@JsonProperty("id") String id, @JsonProperty("choices") List<Choice> choices,
+			@JsonProperty("created") Long created, @JsonProperty("model") String model,
+			@JsonProperty("system_fingerprint") String systemFingerprint, @JsonProperty("object") String object,
+			@JsonProperty("usage") Usage usage) {
+
+		/**
+		 * Chat completion choice.
+		 *
+		 * @param finishReason The reason the model stopped generating tokens.
+		 * @param index The index of the choice in the list of choices.
+		 * @param message A chat completion message generated by the model.
+		 * @param logprobs Log probability information for the choice.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record Choice(@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
+				@JsonProperty("index") Integer index, @JsonProperty("message") ChatCompletionMessage message,
+				@JsonProperty("logprobs") LogProbs logprobs) {
+
+		}
+	}
+
+	/**
+	 * Log probability information for the choice.
+	 *
+	 * @param content A list of message content tokens with log probability information.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record LogProbs(@JsonProperty("content") List<Content> content) {
+
+		/**
+		 * Message content tokens with log probability information.
+		 *
+		 * @param token The token.
+		 * @param logprob The log probability of the token.
+		 * @param probBytes A list of integers representing the UTF-8 bytes representation
+		 * of the token. Useful in instances where characters are represented by multiple
+		 * tokens and their byte representations must be combined to generate the correct
+		 * text representation. Can be null if there is no bytes representation for the
+		 * token.
+		 * @param topLogprobs List of the most likely tokens and their log probability, at
+		 * this token position. In rare cases, there may be fewer than the number of
+		 * requested top_logprobs returned.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record Content(@JsonProperty("token") String token, @JsonProperty("logprob") Float logprob,
+				@JsonProperty("bytes") List<Integer> probBytes,
+				@JsonProperty("top_logprobs") List<TopLogProbs> topLogprobs) {
+
+			/**
+			 * The most likely tokens and their log probability, at this token position.
+			 *
+			 * @param token The token.
+			 * @param logprob The log probability of the token.
+			 * @param probBytes A list of integers representing the UTF-8 bytes
+			 * representation of the token. Useful in instances where characters are
+			 * represented by multiple tokens and their byte representations must be
+			 * combined to generate the correct text representation. Can be null if there
+			 * is no bytes representation for the token.
+			 */
+			@JsonInclude(Include.NON_NULL)
+			public record TopLogProbs(@JsonProperty("token") String token, @JsonProperty("logprob") Float logprob,
+					@JsonProperty("bytes") List<Integer> probBytes) {
+			}
+		}
+	}
+
+	/**
+	 * Usage statistics for the completion request.
+	 *
+	 * @param completionTokens Number of tokens in the generated completion. Only
+	 * applicable for completion requests.
+	 * @param promptTokens Number of tokens in the prompt.
+	 * @param totalTokens Total number of tokens used in the request (prompt +
+	 * completion).
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record Usage(@JsonProperty("completion_tokens") Integer completionTokens,
+			@JsonProperty("prompt_tokens") Integer promptTokens, @JsonProperty("total_tokens") Integer totalTokens) {
+
+	}
+
+	/**
+	 * Represents a streamed chunk of a chat completion response returned by model, based
+	 * on the provided input.
+	 *
+	 * @param id A unique identifier for the chat completion. Each chunk has the same ID.
+	 * @param choices A list of chat completion choices. Can be more than one if n is
+	 * greater than 1.
+	 * @param created The Unix timestamp (in seconds) of when the chat completion was
+	 * created. Each chunk has the same timestamp.
+	 * @param model The model used for the chat completion.
+	 * @param systemFingerprint This fingerprint represents the backend configuration that
+	 * the model runs with. Can be used in conjunction with the seed request parameter to
+	 * understand when backend changes have been made that might impact determinism.
+	 * @param object The object type, which is always 'chat.completion.chunk'.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record ChatCompletionChunk(@JsonProperty("id") String id, @JsonProperty("choices") List<ChunkChoice> choices,
+			@JsonProperty("created") Long created, @JsonProperty("model") String model,
+			@JsonProperty("system_fingerprint") String systemFingerprint, @JsonProperty("object") String object) {
+
+		/**
+		 * Chat completion choice.
+		 *
+		 * @param finishReason The reason the model stopped generating tokens.
+		 * @param index The index of the choice in the list of choices.
+		 * @param delta A chat completion delta generated by streamed model responses.
+		 * @param logprobs Log probability information for the choice.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		public record ChunkChoice(@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
+				@JsonProperty("index") Integer index, @JsonProperty("delta") ChatCompletionMessage delta,
+				@JsonProperty("logprobs") LogProbs logprobs) {
+		}
+	}
+
+	/**
+	 * Creates a model response for the given chat conversation.
+	 * @param chatRequest The chat completion request.
+	 * @return Entity response with {@link ChatCompletion} as a body and HTTP status code
+	 * and headers.
+	 */
+	public ResponseEntity<ChatCompletion> chatCompletionEntity(ChatCompletionRequest chatRequest) {
+
+		Assert.notNull(chatRequest, "The request body can not be null.");
+		Assert.isTrue(!chatRequest.stream(), "Request must set the steam property to false.");
+
+		return this.restClient.post()
+			.uri("/v1/chat/completions")
+			.body(chatRequest)
+			.retrieve()
+			.toEntity(ChatCompletion.class);
+	}
+
+	private final YiAiStreamFunctionCallingHelper chunkMerger = new YiAiStreamFunctionCallingHelper();
+
+	/**
+	 * Creates a streaming chat response for the given chat conversation.
+	 * @param chatRequest The chat completion request. Must have the stream property set
+	 * to true.
+	 * @return Returns a {@link Flux} stream from chat completion chunks.
+	 */
+	public Flux<ChatCompletionChunk> chatCompletionStream(ChatCompletionRequest chatRequest) {
+
+		Assert.notNull(chatRequest, "The request body can not be null.");
+		Assert.isTrue(chatRequest.stream(), "Request must set the steam property to true.");
+
+		AtomicBoolean isInsideTool = new AtomicBoolean(false);
+
+		return this.webClient.post()
+			.uri("/v1/chat/completions")
+			.body(Mono.just(chatRequest), ChatCompletionRequest.class)
+			.retrieve()
+			.bodyToFlux(String.class)
+			.takeUntil(SSE_DONE_PREDICATE)
+			.filter(SSE_DONE_PREDICATE.negate())
+			.map(content -> ModelOptionsUtils.jsonToObject(content, ChatCompletionChunk.class))
+			.map(chunk -> {
+				if (this.chunkMerger.isStreamingToolFunctionCall(chunk)) {
+					isInsideTool.set(true);
+				}
+				return chunk;
+			})
+			.windowUntil(chunk -> {
+				if (isInsideTool.get() && this.chunkMerger.isStreamingToolFunctionCallFinish(chunk)) {
+					isInsideTool.set(false);
+					return true;
+				}
+				return !isInsideTool.get();
+			})
+			.concatMapIterable(window -> {
+				Mono<ChatCompletionChunk> monoChunk = window
+					.reduce(new ChatCompletionChunk(null, null, null, null, null, null), this.chunkMerger::merge);
+				return List.of(monoChunk);
+			})
+			.flatMap(mono -> mono);
+	}
+
+}

--- a/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/YiAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/YiAiStreamFunctionCallingHelper.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.yi.api;
+
+import org.springframework.ai.yi.api.YiAiApi.*;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletion.Choice;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage.ChatCompletionFunction;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage.ToolCall;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class to support Streaming function calling. It can merge the streamed
+ * ChatCompletionChunk in case of function calling message.
+ */
+public class YiAiStreamFunctionCallingHelper {
+
+	/**
+	 * Merge the previous and current ChatCompletionChunk into a single one.
+	 * @param previous the previous ChatCompletionChunk
+	 * @param current the current ChatCompletionChunk
+	 * @return the merged ChatCompletionChunk
+	 */
+	public ChatCompletionChunk merge(ChatCompletionChunk previous, ChatCompletionChunk current) {
+
+		if (previous == null) {
+			return current;
+		}
+
+		String id = (current.id() != null ? current.id() : previous.id());
+		Long created = (current.created() != null ? current.created() : previous.created());
+		String model = (current.model() != null ? current.model() : previous.model());
+		String systemFingerprint = (current.systemFingerprint() != null ? current.systemFingerprint()
+				: previous.systemFingerprint());
+		String object = (current.object() != null ? current.object() : previous.object());
+
+		ChunkChoice previousChoice0 = (CollectionUtils.isEmpty(previous.choices()) ? null : previous.choices().get(0));
+		ChunkChoice currentChoice0 = (CollectionUtils.isEmpty(current.choices()) ? null : current.choices().get(0));
+
+		ChunkChoice choice = merge(previousChoice0, currentChoice0);
+		List<ChunkChoice> chunkChoices = choice == null ? List.of() : List.of(choice);
+		return new ChatCompletionChunk(id, chunkChoices, created, model, systemFingerprint, object);
+	}
+
+	private ChunkChoice merge(ChunkChoice previous, ChunkChoice current) {
+		if (previous == null) {
+			return current;
+		}
+
+		ChatCompletionFinishReason finishReason = (current.finishReason() != null ? current.finishReason()
+				: previous.finishReason());
+		Integer index = (current.index() != null ? current.index() : previous.index());
+
+		ChatCompletionMessage message = merge(previous.delta(), current.delta());
+
+		LogProbs logprobs = (current.logprobs() != null ? current.logprobs() : previous.logprobs());
+		return new ChunkChoice(finishReason, index, message, logprobs);
+	}
+
+	private ChatCompletionMessage merge(ChatCompletionMessage previous, ChatCompletionMessage current) {
+		String content = (current.content() != null ? current.content()
+				: (previous.content() != null) ? previous.content() : "");
+		Role role = (current.role() != null ? current.role() : previous.role());
+		role = (role != null ? role : Role.ASSISTANT); // default to ASSISTANT (if null
+		String name = (current.name() != null ? current.name() : previous.name());
+		String toolCallId = (current.toolCallId() != null ? current.toolCallId() : previous.toolCallId());
+
+		List<ToolCall> toolCalls = new ArrayList<>();
+		ToolCall lastPreviousTooCall = null;
+		if (previous.toolCalls() != null) {
+			lastPreviousTooCall = previous.toolCalls().get(previous.toolCalls().size() - 1);
+			if (previous.toolCalls().size() > 1) {
+				toolCalls.addAll(previous.toolCalls().subList(0, previous.toolCalls().size() - 1));
+			}
+		}
+		if (current.toolCalls() != null) {
+			if (current.toolCalls().size() > 1) {
+				throw new IllegalStateException("Currently only one tool call is supported per message!");
+			}
+			var currentToolCall = current.toolCalls().iterator().next();
+			if (currentToolCall.id() != null) {
+				if (lastPreviousTooCall != null) {
+					toolCalls.add(lastPreviousTooCall);
+				}
+				toolCalls.add(currentToolCall);
+			}
+			else {
+				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
+			}
+		}
+		else {
+			if (lastPreviousTooCall != null) {
+				toolCalls.add(lastPreviousTooCall);
+			}
+		}
+		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls);
+	}
+
+	private ToolCall merge(ToolCall previous, ToolCall current) {
+		if (previous == null) {
+			return current;
+		}
+		String id = (current.id() != null ? current.id() : previous.id());
+		String type = (current.type() != null ? current.type() : previous.type());
+		ChatCompletionFunction function = merge(previous.function(), current.function());
+		return new ToolCall(id, type, function);
+	}
+
+	private ChatCompletionFunction merge(ChatCompletionFunction previous, ChatCompletionFunction current) {
+		if (previous == null) {
+			return current;
+		}
+		String name = (current.name() != null ? current.name() : previous.name());
+		StringBuilder arguments = new StringBuilder();
+		if (previous.arguments() != null) {
+			arguments.append(previous.arguments());
+		}
+		if (current.arguments() != null) {
+			arguments.append(current.arguments());
+		}
+		return new ChatCompletionFunction(name, arguments.toString());
+	}
+
+	/**
+	 * @param chatCompletion the ChatCompletionChunk to check
+	 * @return true if the ChatCompletionChunk is a streaming tool function call.
+	 */
+	public boolean isStreamingToolFunctionCall(ChatCompletionChunk chatCompletion) {
+
+		if (chatCompletion == null || CollectionUtils.isEmpty(chatCompletion.choices())) {
+			return false;
+		}
+
+		var choice = chatCompletion.choices().get(0);
+		if (choice == null || choice.delta() == null) {
+			return false;
+		}
+		return !CollectionUtils.isEmpty(choice.delta().toolCalls());
+	}
+
+	/**
+	 * @param chatCompletion the ChatCompletionChunk to check
+	 * @return true if the ChatCompletionChunk is a streaming tool function call and it is
+	 * the last one.
+	 */
+	public boolean isStreamingToolFunctionCallFinish(ChatCompletionChunk chatCompletion) {
+
+		if (chatCompletion == null || CollectionUtils.isEmpty(chatCompletion.choices())) {
+			return false;
+		}
+
+		var choice = chatCompletion.choices().get(0);
+		if (choice == null || choice.delta() == null) {
+			return false;
+		}
+		return choice.finishReason() == ChatCompletionFinishReason.TOOL_CALLS;
+	}
+
+	/**
+	 * Convert the ChatCompletionChunk into a ChatCompletion. The Usage is set to null.
+	 * @param chunk the ChatCompletionChunk to convert
+	 * @return the ChatCompletion
+	 */
+	public ChatCompletion chunkToChatCompletion(ChatCompletionChunk chunk) {
+		List<Choice> choices = chunk.choices()
+			.stream()
+			.map(chunkChoice -> new Choice(chunkChoice.finishReason(), chunkChoice.index(), chunkChoice.delta(),
+					chunkChoice.logprobs()))
+			.toList();
+
+		return new ChatCompletion(chunk.id(), choices, chunk.created(), chunk.model(), chunk.systemFingerprint(),
+				"chat.completion", null);
+	}
+
+}

--- a/models/spring-ai-yi/src/main/resources/META-INF/spring/aot.factories
+++ b/models/spring-ai-yi/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+	org.springframework.ai.yi.aot.YiAiRuntimeHints

--- a/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/ChatCompletionRequestTests.java
+++ b/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/ChatCompletionRequestTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.yi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.yi.api.YiAiApi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChatCompletionRequestTests {
+
+	@Test
+	public void createRequestWithChatOptions() {
+
+		var client = new YiAiChatModel(new YiAiApi("TEST"),
+				YiAiChatOptions.builder().withModel("DEFAULT_MODEL").withTemperature(66.6f).build());
+
+		var request = client.createRequest(new Prompt("Test message content"), false);
+
+		assertThat(request.messages()).hasSize(1);
+		assertThat(request.stream()).isFalse();
+
+		assertThat(request.model()).isEqualTo("DEFAULT_MODEL");
+		assertThat(request.temperature()).isEqualTo(66.6f);
+
+		request = client.createRequest(new Prompt("Test message content",
+				YiAiChatOptions.builder().withModel("PROMPT_MODEL").withTemperature(99.9f).build()), true);
+
+		assertThat(request.messages()).hasSize(1);
+		assertThat(request.stream()).isTrue();
+
+		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
+		assertThat(request.temperature()).isEqualTo(99.9f);
+	}
+
+}

--- a/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/YiAiTestConfiguration.java
+++ b/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/YiAiTestConfiguration.java
@@ -1,0 +1,30 @@
+package org.springframework.ai.yi;
+
+import org.springframework.ai.yi.api.YiAiApi;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.StringUtils;
+
+@SpringBootConfiguration
+public class YiAiTestConfiguration {
+
+	@Bean
+	public YiAiApi yiAiApi() {
+		return new YiAiApi(getApiKey());
+	}
+
+	private String getApiKey() {
+		String apiKey = System.getenv("YI_AI_API_KEY");
+		if (!StringUtils.hasText(apiKey)) {
+			throw new IllegalArgumentException(
+					"You must provide an API key.  Put it in an environment variable under the name ZHIPU_AI_API_KEY");
+		}
+		return apiKey;
+	}
+
+	@Bean
+	public YiAiChatModel yiAiChatModel(YiAiApi api) {
+		return new YiAiChatModel(api);
+	}
+
+}

--- a/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/api/YiAiApiIT.java
+++ b/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/api/YiAiApiIT.java
@@ -1,0 +1,41 @@
+package org.springframework.ai.yi.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionChunk;
+import org.springframework.ai.yi.api.YiAiApi.ChatCompletionMessage;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfEnvironmentVariable(named = "YI_AI_API_KEY", matches = ".+")
+public class YiAiApiIT {
+
+	YiAiApi yiAiApi = new YiAiApi("c4e46efcf54747ccad35ce86a253f980");
+
+	@Test
+	void chatCompletionEntity() {
+		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world",
+				ChatCompletionMessage.Role.USER);
+		ResponseEntity<YiAiApi.ChatCompletion> response = yiAiApi.chatCompletionEntity(
+				new YiAiApi.ChatCompletionRequest(List.of(chatCompletionMessage), "yi-large", 0.3f, false));
+
+		assertThat(response).isNotNull();
+		assertThat(response.getBody()).isNotNull();
+	}
+
+	@Test
+	void chatCompletionStream() {
+		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world",
+				ChatCompletionMessage.Role.USER);
+		Flux<ChatCompletionChunk> response = yiAiApi.chatCompletionStream(
+				new YiAiApi.ChatCompletionRequest(List.of(chatCompletionMessage), "yi-large", 0.3f, true));
+
+		assertThat(response).isNotNull();
+		assertThat(response.collectList().block()).isNotNull();
+	}
+
+}

--- a/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/api/YiAiApiIT.java
+++ b/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/api/YiAiApiIT.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "YI_AI_API_KEY", matches = ".+")
 public class YiAiApiIT {
 
-	YiAiApi yiAiApi = new YiAiApi("c4e46efcf54747ccad35ce86a253f980");
+	YiAiApi yiAiApi = new YiAiApi(System.getenv("YI_AI_API_KEY"));
 
 	@Test
 	void chatCompletionEntity() {

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
 		<module>models/spring-ai-vertex-ai-palm2</module>
 		<module>models/spring-ai-watsonx-ai</module>
 		<module>models/spring-ai-zhipuai</module>
+		<module>models/spring-ai-yi</module>
 
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-anthropic</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-azure-openai</module>
@@ -85,6 +86,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-vertex-ai-palm2</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-watsonx-ai</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-zhipuai</module>
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-yi</module>
 	</modules>
 
 	<organization>

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -316,6 +316,12 @@
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-yi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-pinecone-store-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -406,6 +412,12 @@
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-zhipuai-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-yi-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -24,6 +24,7 @@
 *** xref:api/chat/mistralai-chat.adoc[Mistral AI]
 **** xref:api/chat/functions/mistralai-chat-functions.adoc[Function Calling]
 *** xref:api/chat/zhipuai-chat.adoc[ZhiPu AI]
+*** xref:api/chat/yiai-chat.adoc[Yi AI]
 **** xref:api/chat/functions/zhipuai-chat-functions.adoc[Function Calling]
 *** xref:api/chat/anthropic-chat.adoc[Anthropic 3]
 **** xref:api/chat/functions/anthropic-chat-functions.adoc[Function Calling]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/yiai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/yiai-chat.adoc
@@ -91,10 +91,9 @@ The prefix `spring.ai.yi.chat` is the property prefix that lets you configure th
 | spring.ai.yi.chat.base-url | Optional overrides the spring.ai.yi.base-url to provide chat specific url |  https://api.lingyiwanwu.com
 | spring.ai.yi.chat.api-key | Optional overrides the spring.ai.yi.api-key to provide chat specific api-key |  -
 | spring.ai.yi.chat.options.model | This is the YiAI Chat model to use | `YI_LARGE` (the `YI_LARGE`, `YI_MEDIUM`, `YI_MEDIUM`, `YI_VISION`, `YI_SPARK`, `YI_LARGE_RAG`, and `YI_LARGE_TURBO` point to the latest model versions)
-| spring.ai.yi.chat.options.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
-| spring.ai.yi.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.9
-| spring.ai.yi.chat.options.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both. | 0.3
-| spring.ai.yi.chat.options.user | A unique identifier representing your end-user, which can help YiAI to monitor and detect abuse. | -
+| spring.ai.yi.chat.options.maxTokens | Specify the maximum number of tokens for the model when generating content. This defines the upper limit for generation, but does not guarantee that this number will be generated each time. | -
+| spring.ai.yi.chat.options.temperature | Controls the divergence and centralization of the generated results. The smaller the value, the more centralized; the larger the value, the more divergent. Range of values: between 0 and 2. | 0.9
+| spring.ai.yi.chat.options.topP | Control the randomness of the generated results. The smaller the value, the weaker the randomness; the larger the value, the stronger the randomness. Value range: between 0 and 1. | 0.3
 |====
 
 NOTE: You can override the common `spring.ai.yi.base-url` and `spring.ai.yi.api-key` for the `ChatModel` implementations.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/yiai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/yiai-chat.adoc
@@ -1,0 +1,246 @@
+= Yi AI Chat
+
+Spring AI supports the various AI language models from Yi AI. You can interact with Yi AI language models and create a multilingual conversational assistant based on YiAI models.
+
+== Prerequisites
+
+You will need to create an API with YiAI to access Yi AI language models.
+
+Create an account at https://platform.lingyiwanwu.com/login[Yi AI registration page] and generate the token on the https://platform.lingyiwanwu.com/apikeys[API Keys page].
+The Spring AI project defines a configuration property named `spring.ai.yi.api-key` that you should set to the value of the `API Key` obtained from https://platform.lingyiwanwu.com/apikeys[API Keys page].
+Exporting an environment variable is one way to set that configuration property:
+
+[source,shell]
+----
+export SPRING_AI_YI_AI_API_KEY=<INSERT KEY HERE>
+----
+
+=== Add Repositories and BOM
+
+Spring AI artifacts are published in Spring Milestone and Snapshot repositories.
+Refer to the xref:getting-started.adoc#repositories[Repositories] section to add these repositories to your build system.
+
+To help with dependency management, Spring AI provides a BOM (bill of materials) to ensure that a consistent version of Spring AI is used throughout the entire project. Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build system.
+
+
+
+== Auto-configuration
+
+Spring AI provides Spring Boot auto-configuration for the YiAI Chat Client.
+To enable it add the following dependency to your project's Maven `pom.xml` file:
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-yi-spring-boot-starter</artifactId>
+</dependency>
+----
+
+or to your Gradle `build.gradle` build file.
+
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-yi-spring-boot-starter'
+}
+----
+
+TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
+
+=== Chat Properties
+
+==== Retry Properties
+
+The prefix `spring.ai.retry` is used as the property prefix that lets you configure the retry mechanism for the Yi AI chat model.
+
+[cols="3,5,1"]
+|====
+| Property | Description | Default
+
+| spring.ai.retry.max-attempts   | Maximum number of retry attempts. |  10
+| spring.ai.retry.backoff.initial-interval | Initial sleep duration for the exponential backoff policy. |  2 sec.
+| spring.ai.retry.backoff.multiplier | Backoff interval multiplier. |  5
+| spring.ai.retry.backoff.max-interval | Maximum backoff duration. |  3 min.
+| spring.ai.retry.on-client-errors | If false, throw a NonTransientAiException, and do not attempt retry for `4xx` client error codes | false
+| spring.ai.retry.exclude-on-http-codes | List of HTTP status codes that should not trigger a retry (e.g. to throw NonTransientAiException). | empty
+| spring.ai.retry.on-http-codes | List of HTTP status codes that should trigger a retry (e.g. to throw TransientAiException). | empty
+|====
+
+==== Connection Properties
+
+The prefix `spring.ai.yi` is used as the property prefix that lets you connect to YiAI.
+
+[cols="3,5,1"]
+|====
+| Property | Description | Default
+
+| spring.ai.yi.base-url   | The URL to connect to |  https://api.lingyiwanwu.com
+| spring.ai.yi.api-key    | The API Key           |  -
+|====
+
+==== Configuration Properties
+
+The prefix `spring.ai.yi.chat` is the property prefix that lets you configure the chat model implementation for YiAI.
+
+[cols="3,5,1"]
+|====
+| Property | Description | Default
+
+| spring.ai.yi.chat.enabled | Enable YiAI chat model.  | true
+| spring.ai.yi.chat.base-url | Optional overrides the spring.ai.yi.base-url to provide chat specific url |  https://api.lingyiwanwu.com
+| spring.ai.yi.chat.api-key | Optional overrides the spring.ai.yi.api-key to provide chat specific api-key |  -
+| spring.ai.yi.chat.options.model | This is the YiAI Chat model to use | `YI_LARGE` (the `YI_LARGE`, `YI_MEDIUM`, `YI_MEDIUM`, `YI_VISION`, `YI_SPARK`, `YI_LARGE_RAG`, and `YI_LARGE_TURBO` point to the latest model versions)
+| spring.ai.yi.chat.options.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
+| spring.ai.yi.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.9
+| spring.ai.yi.chat.options.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both. | 0.3
+| spring.ai.yi.chat.options.user | A unique identifier representing your end-user, which can help YiAI to monitor and detect abuse. | -
+|====
+
+NOTE: You can override the common `spring.ai.yi.base-url` and `spring.ai.yi.api-key` for the `ChatModel` implementations.
+The `spring.ai.yi.chat.base-url` and `spring.ai.yi.chat.api-key` properties if set take precedence over the common properties.
+This is useful if you want to use different YiAI accounts for different models and different model endpoints.
+
+TIP: All properties prefixed with `spring.ai.yi.chat.options` can be overridden at runtime by adding a request specific <<chat-options>> to the `Prompt` call.
+
+== Runtime Options [[chat-options]]
+
+The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/YiAiChatOptions.java[YiAiChatOptions.java] provides model configurations, such as the model to use, the temperature, the frequency penalty, etc.
+
+On start-up, the default options can be configured with the `YiAiChatModel(api, options)` constructor or the `spring.ai.yi.chat.options.*` properties.
+
+At run-time you can override the default options by adding new, request specific, options to the `Prompt` call.
+For example to override the default model and temperature for a specific request:
+
+[source,java]
+----
+ChatResponse response = chatModel.call(
+    new Prompt(
+        "Generate the names of 5 famous pirates.",
+        YiAiChatOptions.builder()
+            .withModel(YiAiApi.ChatModel.YI_LARGE.getValue())
+            .withTemperature(0.9f)
+        .build()
+    ));
+----
+
+TIP: In addition to the model specific link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/YiAiChatOptions.java[YiAiChatOptions] you can use a portable https://github.com/spring-projects/spring-ai/blob/main/spring-ai-core/src/main/java/org/springframework/ai/chat/ChatOptions.java[ChatOptions] instance, created with the https://github.com/spring-projects/spring-ai/blob/main/spring-ai-core/src/main/java/org/springframework/ai/chat/ChatOptionsBuilder.java[ChatOptionsBuilder#builder()].
+
+== Sample Controller
+
+https://start.spring.io/[Create] a new Spring Boot project and add the `spring-ai-yi-spring-boot-starter` to your pom (or gradle) dependencies.
+
+Add a `application.properties` file, under the `src/main/resources` directory, to enable and configure the YiAi chat model:
+
+[source,application.properties]
+----
+spring.ai.yi.api-key=YOUR_API_KEY
+spring.ai.yi.chat.options.model=yi-large
+spring.ai.yi.chat.options.temperature=0.9
+----
+
+TIP: replace the `api-key` with your YiAI credentials.
+
+This will create a `YiAiChatModel` implementation that you can inject into your class.
+Here is an example of a simple `@Controller` class that uses the chat model for text generations.
+
+[source,java]
+----
+@RestController
+public class ChatController {
+
+    private final YiAiChatModel chatModel;
+
+    @Autowired
+    public ChatController(YiAiChatModel chatModel) {
+        this.chatModel = chatModel;
+    }
+
+    @GetMapping("/ai/generate")
+    public Map generate(@RequestParam(value = "message", defaultValue = "Tell me a joke") String message) {
+        return Map.of("generation", chatModel.call(message));
+    }
+
+    @GetMapping("/ai/generateStream")
+	public Flux<ChatResponse> generateStream(@RequestParam(value = "message", defaultValue = "Tell me a joke") String message) {
+        var prompt = new Prompt(new UserMessage(message));
+        return chatModel.stream(prompt);
+    }
+}
+----
+
+== Manual Configuration
+
+The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/YiAiChatModel.java[YiAiChatModel] implements the `ChatModel` and `StreamingChatModel` and uses the <<low-level-api>> to connect to the YiAI service.
+
+Add the `spring-ai-yi` dependency to your project's Maven `pom.xml` file:
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-yi</artifactId>
+</dependency>
+----
+
+or to your Gradle `build.gradle` build file.
+
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-yi'
+}
+----
+
+TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
+
+Next, create a `YiAiChatModel` and use it for text generations:
+
+[source,java]
+----
+var yiAiApi = new YiAiApi(System.getenv("YI_AI_API_KEY"));
+
+var chatModel = new YiAiChatModel(yiAiApi, YiAiChatOptions.builder()
+                .withModel(yiAiApi.ChatModel.YI_LARGE.getValue())
+                .withTemperature(0.9f)
+                .withMaxTokens(100)
+                .build());
+
+ChatResponse response = chatModel.call(
+    new Prompt("Generate the names of 5 famous pirates."));
+
+// Or with streaming responses
+Flux<ChatResponse> streamResponse = chatModel.stream(
+    new Prompt("Generate the names of 5 famous pirates."));
+----
+
+The `YiAiChatOptions` provides the configuration information for the chat requests.
+The `YiAiChatOptions.Builder` is fluent options builder.
+
+=== Low-level YiAiApi Client [[low-level-api]]
+
+The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/YiAiApi.java[YiAiApi] provides is lightweight Java client for link:https://platform.lingyiwanwu.com/docs#create-chat-completion[Yi AI API].
+
+Here is a simple snippet how to use the api programmatically:
+
+[source,java]
+----
+YiAiApi yiAiApi =
+    new YiAiApi(System.getenv("YI_AI_API_KEY"));
+
+ChatCompletionMessage chatCompletionMessage =
+    new ChatCompletionMessage("Hello world", Role.USER);
+
+// Sync request
+ResponseEntity<ChatCompletion> response = yiAiApi.chatCompletionEntity(
+    new ChatCompletionRequest(List.of(chatCompletionMessage), yiAiApi.ChatModel.YI_LARGE.getValue(), 0.9f, false));
+
+// Streaming request
+Flux<ChatCompletionChunk> streamResponse = zhiPyiAiApiuAiApi.chatCompletionStream(
+        new ChatCompletionRequest(List.of(chatCompletionMessage), yiAiApi.ChatModel.YI_LARGE.getValue(), 0.9f, true));
+----
+
+Follow the https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-yi/src/main/java/org/springframework/ai/yi/api/YiAiApi.java[YiAiApi.java]'s JavaDoc for further information.
+
+==== YiAiApi Samples
+* The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-yi/src/test/java/org/springframework/ai/yi/api/YiAiApiIT.java[YiAiApiIT.java] test provides some general examples how to use the lightweight library.

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -281,6 +281,13 @@
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-yi</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiAutoConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.yi;
+
+import org.springframework.ai.autoconfigure.retry.SpringAiRetryAutoConfiguration;
+import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.model.function.FunctionCallbackContext;
+import org.springframework.ai.yi.YiAiChatModel;
+import org.springframework.ai.yi.api.YiAiApi;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+/**
+ * @author Geng Rong
+ */
+@AutoConfiguration(after = { RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class })
+@ConditionalOnClass(YiAiApi.class)
+@EnableConfigurationProperties({ YiAiConnectionProperties.class, YiAiChatProperties.class })
+public class YiAiAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = YiAiChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+			matchIfMissing = true)
+	public YiAiChatModel yiAiChatModel(YiAiConnectionProperties commonProperties, YiAiChatProperties chatProperties,
+			RestClient.Builder restClientBuilder, List<FunctionCallback> toolFunctionCallbacks,
+			FunctionCallbackContext functionCallbackContext, RetryTemplate retryTemplate,
+			ResponseErrorHandler responseErrorHandler) {
+
+		var yiAiApi = yiAiApi(chatProperties.getBaseUrl(), commonProperties.getBaseUrl(), chatProperties.getApiKey(),
+				commonProperties.getApiKey(), restClientBuilder, responseErrorHandler);
+
+		if (!CollectionUtils.isEmpty(toolFunctionCallbacks)) {
+			chatProperties.getOptions().getFunctionCallbacks().addAll(toolFunctionCallbacks);
+		}
+
+		return new YiAiChatModel(yiAiApi, chatProperties.getOptions(), functionCallbackContext, retryTemplate);
+	}
+
+	private YiAiApi yiAiApi(String baseUrl, String commonBaseUrl, String apiKey, String commonApiKey,
+			RestClient.Builder restClientBuilder, ResponseErrorHandler responseErrorHandler) {
+
+		String resolvedBaseUrl = StringUtils.hasText(baseUrl) ? baseUrl : commonBaseUrl;
+		Assert.hasText(resolvedBaseUrl, "YiAI base URL must be set");
+
+		String resolvedApiKey = StringUtils.hasText(apiKey) ? apiKey : commonApiKey;
+		Assert.hasText(resolvedApiKey, "YiAI API key must be set");
+
+		return new YiAiApi(resolvedBaseUrl, resolvedApiKey, restClientBuilder, responseErrorHandler);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public FunctionCallbackContext springAiFunctionManager(ApplicationContext context) {
+		FunctionCallbackContext manager = new FunctionCallbackContext();
+		manager.setApplicationContext(context);
+		return manager;
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiChatProperties.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.yi;
+
+import org.springframework.ai.autoconfigure.yi.YiAiParentProperties;
+import org.springframework.ai.yi.YiAiChatOptions;
+import org.springframework.ai.yi.api.YiAiApi;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * @author Geng Rong
+ */
+@ConfigurationProperties(YiAiChatProperties.CONFIG_PREFIX)
+public class YiAiChatProperties extends YiAiParentProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.yi.chat";
+
+	public static final String DEFAULT_CHAT_MODEL = YiAiApi.ChatModel.YI_LARGE.value;
+
+	private static final Double DEFAULT_TEMPERATURE = 0.7;
+
+	/**
+	 * Enable YiAi chat model.
+	 */
+	private boolean enabled = true;
+
+	@NestedConfigurationProperty
+	private YiAiChatOptions options = YiAiChatOptions.builder()
+		.withModel(DEFAULT_CHAT_MODEL)
+		.withTemperature(DEFAULT_TEMPERATURE.floatValue())
+		.build();
+
+	public YiAiChatOptions getOptions() {
+		return options;
+	}
+
+	public void setOptions(YiAiChatOptions options) {
+		this.options = options;
+	}
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiConnectionProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiConnectionProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.yi;
+
+import org.springframework.ai.autoconfigure.yi.YiAiParentProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(YiAiConnectionProperties.CONFIG_PREFIX)
+public class YiAiConnectionProperties extends YiAiParentProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.yi";
+
+	public static final String DEFAULT_BASE_URL = "https://api.lingyiwanwu.com";
+
+	public YiAiConnectionProperties() {
+		super.setBaseUrl(DEFAULT_BASE_URL);
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiParentProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/yi/YiAiParentProperties.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.autoconfigure.yi;
+
+/**
+ * @author Geng Rong
+ */
+class YiAiParentProperties {
+
+	private String apiKey;
+
+	private String baseUrl;
+
+	public String getApiKey() {
+		return apiKey;
+	}
+
+	public void setApiKey(String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+}

--- a/spring-ai-spring-boot-starters/spring-ai-starter-yi/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-yi/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-yi-spring-boot-starter</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Starter - YiAI</name>
+	<description>Spring AI YiAI Auto Configuration</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-spring-boot-autoconfigure</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-yi</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>


### PR DESCRIPTION
this PR is add YiAi model client and has passed unit testing.

I can provide my api_key if needed for testing

the PR content:

chat client
spring starter
unit test
chat client documents
For some reasons, products from OpenAI and others can't be directly used in Chinese Mainland.

YiAi is a big model platform, A variety of models are offered, among which [Yi-1.5](https://github.com/01-ai/Yi-1.5) are fully free. Although their API design is quite strange.

the link: [YiAI](https://platform.lingyiwanwu.com/)

