### PR TITLE
fixe the wrong word 'builderh' to 'builder' in chatclient.adoc file

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -376,7 +376,7 @@ public class CustomerSupportAssistant {
 
     public CustomerSupportAssistant(ChatClient.Builder builder, VectorStore vectorStore, ChatMemory chatMemory) {
 
-    this.chatClient = builderh
+    this.chatClient = builder
             .defaultSystem("""
                     You are a customer chat support agent of an airline named "Funnair".", Respond in a friendly,
                     helpful, and joyful manner.


### PR DESCRIPTION
There is a wrong word 'builderh' in chatclient.adoc file, it should be 'builder'.