### PR TITLE
Upgrade Apache Tika to version 2.9.2 to address security vulnerabilities

### DIFF
--- a/document-readers/tika-reader/pom.xml
+++ b/document-readers/tika-reader/pom.xml
@@ -21,7 +21,7 @@
 	</scm>
 
 	<properties>
-		<tika.version>2.9.0</tika.version>
+		<tika.version>2.9.2</tika.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
# Upgrade Apache Tika to version 2.9.2 to address security vulnerabilities  
  
## Description  
this PR upgrades Apache Tika from version 2.9.0 to 2.9.2 to address the following security vulnerabilities:  
  
- CVE-2024-26308  
- CVE-2024-25710  
- CVE-2023-42503  
- CVE-2024-21742  
  
The current version of Apache Tika (2.9.0) includes dependencies on Apache Commons Compress 1.23.0 and apache-mime4j 0.8.9, which are affected by the aforementioned vulnerabilities.   
Upgrading to Apache Tika 2.9.2 will automatically resolve these issues as the newer version includes updated dependencies that address the vulnerabilities.  
  
## Additional Information  
  
- [Apache Commons Compress CVEs](https://commons.apache.org/proper/commons-compress/security.html)  
- [Apache MIME4J CVEs](https://james.apache.org/james/update/2024/01/08/mime4j-0.8.10.html)  
