### PR TITLE
Introduce .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*.{adoc,bat,groovy,html,java,js,jsp,kt,kts,md,properties,py,rb,sh,sql,svg,txt,xml,xsd}]
+charset = utf-8
+
+[*.{groovy,java,kt,kts,xml,xsd}]
+indent_style = tab
+indent_size = 4
+continuation_indent_size = 8
+end_of_line = lf


### PR DESCRIPTION
To help the rest of us who are not using tabs for indentation.

Taken from https://github.com/spring-projects/spring-framework/blob/main/.editorconfig