### PR TITLE
Update mistralai-chat.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -215,7 +215,7 @@ var mistralAiApi = new MistralAiApi(System.getenv("MISTRAL_AI_API_KEY"));
 var chatModel = new MistralAiChatModel(mistralAiApi, MistralAiChatOptions.builder()
                 .withModel(MistralAiApi.ChatModel.LARGE.getValue())
                 .withTemperature(0.4f)
-                .withMaxToken(200)
+                .withMaxTokens(200)
                 .build());
 
 ChatResponse response = chatModel.call(


### PR DESCRIPTION
In the manual configuration section of MistralAI SpringAI documentation is used a `withMaxToken` method that doesn't exist in the current version of the API.

Replaced with correct `withMaxTokens` method name.
