### PR TITLE
Add enabled property for openai audio and transcription model

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAudioSpeechProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAudioSpeechProperties.java
@@ -42,6 +42,11 @@ public class OpenAiAudioSpeechProperties extends OpenAiParentProperties {
 
 	private static final OpenAiAudioApi.SpeechRequest.AudioResponseFormat DEFAULT_RESPONSE_FORMAT = OpenAiAudioApi.SpeechRequest.AudioResponseFormat.MP3;
 
+	/**
+	 * Enable OpenAI audio speech model.
+	 */
+	private boolean enabled = true;
+
 	@NestedConfigurationProperty
 	private OpenAiAudioSpeechOptions options = OpenAiAudioSpeechOptions.builder()
 		.withModel(DEFAULT_SPEECH_MODEL)
@@ -56,6 +61,14 @@ public class OpenAiAudioSpeechProperties extends OpenAiParentProperties {
 
 	public void setOptions(OpenAiAudioSpeechOptions options) {
 		this.options = options;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAudioTranscriptionProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAudioTranscriptionProperties.java
@@ -31,6 +31,11 @@ public class OpenAiAudioTranscriptionProperties extends OpenAiParentProperties {
 
 	private static final OpenAiAudioApi.TranscriptResponseFormat DEFAULT_RESPONSE_FORMAT = OpenAiAudioApi.TranscriptResponseFormat.TEXT;
 
+	/**
+	 * Enable OpenAI audio transcription model.
+	 */
+	private boolean enabled = true;
+
 	@NestedConfigurationProperty
 	private OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
 		.withModel(DEFAULT_TRANSCRIPTION_MODEL)
@@ -44,6 +49,14 @@ public class OpenAiAudioTranscriptionProperties extends OpenAiParentProperties {
 
 	public void setOptions(OpenAiAudioTranscriptionOptions options) {
 		this.options = options;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
@@ -132,6 +132,8 @@ public class OpenAiAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = OpenAiAudioTranscriptionProperties.CONFIG_PREFIX, name = "enabled",
+			havingValue = "true", matchIfMissing = true)
 	public OpenAiAudioTranscriptionModel openAiAudioTranscriptionModel(OpenAiConnectionProperties commonProperties,
 			OpenAiAudioTranscriptionProperties transcriptionProperties, RetryTemplate retryTemplate,
 			RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder,
@@ -157,6 +159,8 @@ public class OpenAiAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = OpenAiAudioSpeechProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+			matchIfMissing = true)
 	public OpenAiAudioSpeechModel openAiAudioSpeechClient(OpenAiConnectionProperties commonProperties,
 			OpenAiAudioSpeechProperties speechProperties, RestClient.Builder restClientBuilder,
 			WebClient.Builder webClientBuilder, ResponseErrorHandler responseErrorHandler) {


### PR DESCRIPTION
Enhance property classes of both models to allow disabling autoconfiguration for the OpenAI audio and transcription models. This makes the settings consistent across the different OpenAI client properties.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
