### PR TITLE
Fix potential NPE in AzureOpenAiChatModel

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -143,8 +143,7 @@ public class AzureOpenAiChatModel
 		ChatCompletions chatCompletions = this.callWithFunctionSupport(options);
 		logger.trace("Azure ChatCompletions: {}", chatCompletions);
 
-		List<Generation> generations = chatCompletions.getChoices()
-			.stream()
+		List<Generation> generations = nullSafeList(chatCompletions.getChoices()).stream()
 			.map(choice -> new Generation(choice.getMessage().getContent())
 				.withGenerationMetadata(generateChoiceMetadata(choice)))
 			.toList();


### PR DESCRIPTION
Fix #827 

Wrap `chatCompletions.getChoices()` using `nullSafeList` to avoid potential NPE