### PR TITLE
Improve compatibility with NOT fully compliant OpenAI APIs

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -253,18 +253,23 @@ public class OpenAiChatModel extends
 		Set<String> functionsForThisRequest = new HashSet<>();
 
 		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(m -> {
-			// Add text content.
-			List<MediaContent> contents = new ArrayList<>(List.of(new MediaContent(m.getContent())));
-			if (!CollectionUtils.isEmpty(m.getMedia())) {
-				// Add media content.
-				contents.addAll(m.getMedia()
+			Object content;
+			if (CollectionUtils.isEmpty(m.getMedia())) {
+				content = m.getContent();
+			}
+			else {
+				List<MediaContent> contentList = new ArrayList<>(List.of(new MediaContent(m.getContent())));
+
+				contentList.addAll(m.getMedia()
 					.stream()
 					.map(media -> new MediaContent(
 							new MediaContent.ImageUrl(this.fromMediaData(media.getMimeType(), media.getData()))))
 					.toList());
+
+				content = contentList;
 			}
 
-			return new ChatCompletionMessage(contents, ChatCompletionMessage.Role.valueOf(m.getMessageType().name()));
+			return new ChatCompletionMessage(content, ChatCompletionMessage.Role.valueOf(m.getMessageType().name()));
 		}).toList();
 
 		ChatCompletionRequest request = new ChatCompletionRequest(chatCompletionMessages, stream);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiCompatibleChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiCompatibleChatModelIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.openai.chat;
+
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+public class OpenAiCompatibleChatModelIT {
+
+	List<Message> conversation = List.of(new SystemMessage("You are a helpful assistant."),
+			new UserMessage("Are you familiar with pirates from the Golden Age of Piracy?"),
+			new AssistantMessage("Aye, I be well-versed in the legends of the Golden Age of Piracy!"),
+			new UserMessage("Tell me about 3 most famous ones."));
+
+	static OpenAiChatOptions forModelName(String modelName) {
+		return OpenAiChatOptions.builder().withModel(modelName).build();
+	};
+
+	static Stream<ChatModel> openAiCompatibleApis() {
+		Stream.Builder<ChatModel> builder = Stream.builder();
+
+		builder.add(new OpenAiChatModel(new OpenAiApi(System.getenv("OPENAI_API_KEY")), forModelName("gpt-3.5-turbo")));
+
+		if (System.getenv("GROQ_API_KEY") != null) {
+			builder.add(new OpenAiChatModel(new OpenAiApi("https://api.groq.com/openai", System.getenv("GROQ_API_KEY")),
+					forModelName("llama3-8b-8192")));
+		}
+
+		if (System.getenv("OPEN_ROUTER_API_KEY") != null) {
+			builder.add(new OpenAiChatModel(
+					new OpenAiApi("https://openrouter.ai/api", System.getenv("OPEN_ROUTER_API_KEY")),
+					forModelName("meta-llama/llama-3-8b-instruct")));
+		}
+
+		return builder.build();
+	}
+
+	@ParameterizedTest
+	@MethodSource("openAiCompatibleApis")
+	void chatCompletion(ChatModel chatModel) {
+		Prompt prompt = new Prompt(conversation);
+		ChatResponse response = chatModel.call(prompt);
+
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+	}
+
+	@ParameterizedTest
+	@MethodSource("openAiCompatibleApis")
+	void streamCompletion(StreamingChatModel streamingChatModel) {
+		Prompt prompt = new Prompt(conversation);
+		Flux<ChatResponse> flux = streamingChatModel.stream(prompt);
+
+		List<ChatResponse> responses = flux.collectList().block();
+		assertThat(responses).hasSizeGreaterThan(1);
+
+		String stitchedResponseContent = responses.stream()
+			.map(ChatResponse::getResults)
+			.flatMap(List::stream)
+			.map(Generation::getOutput)
+			.map(AssistantMessage::getContent)
+			.collect(Collectors.joining());
+
+		assertThat(stitchedResponseContent).contains("Blackbeard");
+	}
+
+}


### PR DESCRIPTION
Some LLM providers marketed as compatible with OpenAI API (e.g., Groq, OpenRouter), are in fact NOT fully compliant with the OpenAI API. 

For example, sometime, they don't implement the`user` specification for the [Chat Create Completion API](https://platform.openai.com/docs/api-reference/chat/create) and and as a result won't support user message contents like:

```
{
 "role": "user",
 "content": [
   {
     "type": "text",
     "text": "You are a helpful assistant."
   }
 ]
}
```

or like:

```
 "role": "user",
    "content": [
      {
        "type": "text",
        "text": "What'\''s in this image?"
      },
      {
        "type": "image_url",
        "image_url": {
          "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
        }
      }
    ]
```
In other words those provides won't be able to serve and support multimodal models (as a reference Ollama does).

instead they support only the outdated (but still valid) shortcut text expression:

```
{
 "role": "user",
 "content": "You are a helpful assistant."
}
```

The goal of this PR is to support, such not fully compliant providers.

I'm also introducing a very simple integration test testing Groq and OpenRoter API basic compatibility.

This PR fixes #856 and #621.