### PR TITLE
Update FunctionCallbackWrapper docs for Anthropic, Mistral, ZhiPu, MiniMax, and OpenAI

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
@@ -127,10 +127,10 @@ static class Config {
 	@Bean
 	public FunctionCallback weatherFunctionInfo() {
 
-		return new FunctionCallbackWrapper<>("CurrentWeather", // (1) function name
-				"Get the weather in location", // (2) function description
-				(response) -> "" + response.temp() + response.unit(), // (3) Response Converter
-				new MockWeatherService()); // function code
+    return FunctionCallbackWrapper.builder(new MockWeatherService())
+        .withName("CurrentWeather") // (1) function name
+        .withDescription("Get the weather in location") // (2) function description
+        .build();
 	}
 	...
 }
@@ -188,4 +188,3 @@ NOTE: The in-prompt registered functions are enabled by default for the duration
 This approach allows to dynamically chose different functions to be called based on the user input.
 
 The https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithPromptFunctionIT.java[FunctionCallWithPromptFunctionIT.java] integration test provides a complete example of how to register a function with the `AnthropicChatModel` and use it in a prompt request.
-

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/minimax-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/minimax-chat-functions.adoc
@@ -127,10 +127,10 @@ static class Config {
 	@Bean
 	public FunctionCallback weatherFunctionInfo() {
 
-		return new FunctionCallbackWrapper<>("CurrentWeather", // (1) function name
-				"Get the weather in location", // (2) function description
-				(response) -> "" + response.temp() + response.unit(), // (3) Response Converter
-				new MockWeatherService()); // function code
+    return FunctionCallbackWrapper.builder(new MockWeatherService())
+        .withName("CurrentWeather") // (1) function name
+        .withDescription("Get the weather in location") // (2) function description
+        .build();
 	}
 	...
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
@@ -2,7 +2,7 @@
 
 You can register custom Java functions with the `MistralAiChatModel` and have the Mistral AI models intelligently choose to output a JSON object containing arguments to call one or many of the registered functions.
 This allows you to connect the LLM capabilities with external tools and APIs.
-The `open-mixtral-8x22b`, `mistral_small_latest`, and `mistral-large-latest` models are trained to detect when a function should be called and to respond with JSON that adheres to the function signature.
+The `open-mixtral-8x22b`, `mistral-small-latest`, and `mistral-large-latest` models are trained to detect when a function should be called and to respond with JSON that adheres to the function signature.
 
 The MistralAI API does not call the function directly; instead, the model generates JSON that you can use to call the function in your code and return the result back to the model to complete the conversation.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
@@ -2,11 +2,11 @@
 
 You can register custom Java functions with the `MistralAiChatModel` and have the Mistral AI models intelligently choose to output a JSON object containing arguments to call one or many of the registered functions.
 This allows you to connect the LLM capabilities with external tools and APIs.
-The `open-mixtral-8x22b`, `mistral_small_latest`, and `mistral_large_latest` models are trained to detect when a function should be called and to respond with JSON that adheres to the function signature.
+The `open-mixtral-8x22b`, `mistral_small_latest`, and `mistral-large-latest` models are trained to detect when a function should be called and to respond with JSON that adheres to the function signature.
 
 The MistralAI API does not call the function directly; instead, the model generates JSON that you can use to call the function in your code and return the result back to the model to complete the conversation.
 
-NOTE: As of March 13, 2024, Mistral AI has integrated support for parallel function calling into their `mistral_large_latest` model, a feature that was absent at the time of the first Spring AI Mistral AI.
+NOTE: As of March 13, 2024, Mistral AI has integrated support for parallel function calling into their `mistral-large-latest` model, a feature that was absent at the time of the first Spring AI Mistral AI.
 
 Spring AI provides flexible and user-friendly ways to register and call custom functions.
 In general, the custom functions need to provide a function `name`,  `description`, and the function call `signature` (as JSON schema) to let the model know what arguments the function expects.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/mistralai-chat-functions.adoc
@@ -130,10 +130,10 @@ static class Config {
 	@Bean
 	public FunctionCallback weatherFunctionInfo() {
 
-		return new FunctionCallbackWrapper<>("CurrentWeather", // (1) function name
-				"Get the weather in location", // (2) function description
-				(response) -> "" + response.temp() + response.unit(), // (3) Response Converter
-				new MockWeatherService()); // function code
+    return FunctionCallbackWrapper.builder(new MockWeatherService())
+        .withName("CurrentWeather") // (1) function name
+        .withDescription("Get the weather in location") // (2) function description
+        .build();
 	}
 	...
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
@@ -127,10 +127,10 @@ static class Config {
 	@Bean
 	public FunctionCallback weatherFunctionInfo() {
 
-		return new FunctionCallbackWrapper<>("CurrentWeather", // (1) function name
-				"Get the weather in location", // (2) function description
-				(response) -> "" + response.temp() + response.unit(), // (3) Response Converter
-				new MockWeatherService()); // function code
+    return FunctionCallbackWrapper.builder(new MockWeatherService())
+        .withName("CurrentWeather") // (1) function name
+        .withDescription("Get the weather in location") // (2) function description
+        .build();
 	}
 	...
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/zhipuai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/zhipuai-chat-functions.adoc
@@ -127,10 +127,10 @@ static class Config {
 	@Bean
 	public FunctionCallback weatherFunctionInfo() {
 
-		return new FunctionCallbackWrapper<>("CurrentWeather", // (1) function name
-				"Get the weather in location", // (2) function description
-				(response) -> "" + response.temp() + response.unit(), // (3) Response Converter
-				new MockWeatherService()); // function code
+    return FunctionCallbackWrapper.builder(new MockWeatherService())
+        .withName("CurrentWeather") // (1) function name
+        .withDescription("Get the weather in location") // (2) function description
+        .build();
 	}
 	...
 }


### PR DESCRIPTION
I updated the documents for Anthropic, Mistral, ZhuPu, MiniMax, and OpenAI to match up with what is in the docs for Azure OpenAI to use the FunctionCallbackWrapper builder. In doing so the call to set to response converter was lost, although it could have been specified...it just wasn't in the Azure example.

I also noticed that the Gemini document also sets the schema type, as it's required for Gemini. I confirmed that it's not required for OpenAI, Anthropic, or Mistral. But while confirming, I discovered that the documentation for Mistral functions refers to "mistral_large_latest", but it should be "mistral-large-latest". The same fix was also needed for "mistral_small_latest" -> "mistral-small-latest".
