### PR TITLE
Remove `testcontainers.version` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,6 @@
 		<typesense.version>0.5.0</typesense.version>
 
 		<!-- testing dependencies -->
-		<testcontainers.version>1.19.7</testcontainers.version>
 
 		<!-- documentation dependencies -->
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -421,21 +421,18 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>qdrant</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>elasticsearch</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>weaviate</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Spring AI relies on spring boot 3.3.0 (providing Testcontainers 1.19.8).
The property is downgrading the version.
