### PR TITLE
Feat: Transfer the query when to call the vector store

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QueryTransformerQuestionAnswerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QueryTransformerQuestionAnswerAdvisor.java
@@ -1,0 +1,79 @@
+package org.springframework.ai.chat.client.advisor;
+
+import org.springframework.ai.chat.client.AdvisedRequest;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+/**
+ * Context for the question is retrieved from a Vector Store with Query Transformer and
+ * added to the prompt's user text.
+ *
+ * @author Zhiyong Li
+ * @since 1.0.0
+ */
+public class QueryTransformerQuestionAnswerAdvisor extends QuestionAnswerAdvisor {
+
+	private static final String QUERY_TRANSFER = """
+			Genereate 1 query according to customer input,it will be used to retrieve relevant documents.
+			The query should follow the below requirements:
+			{query_requirement}
+			Without enumerations, hyphens, or any additional formatting!
+			""";
+
+	private static final String QUERY_REQUIREMENT = "query_requirement";
+
+	protected ChatModel chatModel;
+
+	protected String queryPrompt;
+
+	public QueryTransformerQuestionAnswerAdvisor(VectorStore vectorStore, ChatModel chatModel,
+			String queryRequirement) {
+		super(vectorStore);
+		this.chatModel = chatModel;
+		if (StringUtils.hasLength(queryRequirement)) {
+			this.queryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
+		}
+	}
+
+	public QueryTransformerQuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest,
+			ChatModel chatModel, String queryRequirement) {
+		super(vectorStore, searchRequest);
+		this.chatModel = chatModel;
+		if (StringUtils.hasLength(queryRequirement)) {
+			this.queryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
+		}
+	}
+
+	public QueryTransformerQuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest,
+			String userTextAdvise, ChatModel chatModel, String queryRequirement) {
+		super(vectorStore, searchRequest, userTextAdvise);
+		this.chatModel = chatModel;
+		if (StringUtils.hasLength(queryRequirement)) {
+			this.queryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
+		}
+	}
+
+	@Override
+	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
+		String originalUserText = request.userText();
+		String queryRequirement = (String) context.get(QUERY_REQUIREMENT);
+		if (StringUtils.hasLength(queryRequirement)) {
+			queryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
+		}
+		if (StringUtils.hasLength(queryPrompt)) {
+			String processedMessage = chatModel.call(queryPrompt);
+			AdvisedRequest processedRequest = AdvisedRequest.from(request).withUserText(processedMessage).build();
+			request = super.adviseRequest(processedRequest, context);
+			return AdvisedRequest.from(request).withUserText(originalUserText).build();
+		}
+		else {
+			return request;
+		}
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QueryTransformerQuestionAnswerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QueryTransformerQuestionAnswerAdvisor.java
@@ -25,18 +25,18 @@ public class QueryTransformerQuestionAnswerAdvisor extends QuestionAnswerAdvisor
 			Without enumerations, hyphens, or any additional formatting!
 			""";
 
-	private static final String QUERY_REQUIREMENT = "query_requirement";
+	public static final String QUERY_REQUIREMENT = "query_requirement";
 
 	protected ChatModel chatModel;
 
-	protected String queryPrompt;
+	protected String clientQueryPrompt;
 
 	public QueryTransformerQuestionAnswerAdvisor(VectorStore vectorStore, ChatModel chatModel,
 			String queryRequirement) {
 		super(vectorStore);
 		this.chatModel = chatModel;
 		if (StringUtils.hasLength(queryRequirement)) {
-			this.queryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
+			this.clientQueryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
 		}
 	}
 
@@ -45,7 +45,7 @@ public class QueryTransformerQuestionAnswerAdvisor extends QuestionAnswerAdvisor
 		super(vectorStore, searchRequest);
 		this.chatModel = chatModel;
 		if (StringUtils.hasLength(queryRequirement)) {
-			this.queryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
+			this.clientQueryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
 		}
 	}
 
@@ -54,12 +54,13 @@ public class QueryTransformerQuestionAnswerAdvisor extends QuestionAnswerAdvisor
 		super(vectorStore, searchRequest, userTextAdvise);
 		this.chatModel = chatModel;
 		if (StringUtils.hasLength(queryRequirement)) {
-			this.queryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
+			this.clientQueryPrompt = new PromptTemplate(QUERY_TRANSFER).render(Map.of(QUERY_REQUIREMENT, queryRequirement));
 		}
 	}
 
 	@Override
 	public AdvisedRequest adviseRequest(AdvisedRequest request, Map<String, Object> context) {
+		String queryPrompt = clientQueryPrompt;
 		String originalUserText = request.userText();
 		String queryRequirement = (String) context.get(QUERY_REQUIREMENT);
 		if (StringUtils.hasLength(queryRequirement)) {


### PR DESCRIPTION
This PR is to provide the feature https://github.com/spring-projects/spring-ai/issues/880

Change:
1) New class QueryTransformerQuestionAnswerAdvisor extends QuestionAnswerAdvisor
2) Call the AI model to transfer the query before call the vector search


Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:


* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
 Done
* Rebase your changes on the latest `main` branch and squash your commits
Done
* Add/Update unit tests as needed
Done
* Run a build and make sure all tests pass prior to submission
Done
