### PR TITLE
Fix:base-url Error in openai-embeddings.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
@@ -75,7 +75,7 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 |====
 | Property | Description | Default
 
-| spring.ai.openai.base-url   | The URL to connect to |  https://api.openai.com
+| spring.ai.openai.base-url   | The URL to connect to |  +https://api.openai.com+
 | spring.ai.openai.api-key    | The API Key           |  -
 |====
 


### PR DESCRIPTION
- fix base-url error in openai-embeddings.adoc
- When I set `spring.ai.openai.base-url=api.openai.com` as the document, I meet the Error `URI is not absolute`
- It is necessary to set the base-url with `https`(`spring.ai.openai.base-url=https://api.openai.com` )

![image](https://github.com/spring-projects/spring-ai/assets/3973419/671f7185-5a54-4082-85f7-9903228882e9)

![image](https://github.com/spring-projects/spring-ai/assets/3973419/c2d6e259-a4bd-4391-84af-8e93cfe674ad)
