### PR TITLE
Support Qdrant's Api Key in Docker Compose and Testcontainers

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantConnectionDetails.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantConnectionDetails.java
@@ -26,4 +26,6 @@ public interface QdrantConnectionDetails extends ConnectionDetails {
 
 	int getPort();
 
+	String getApiKey();
+
 }

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfiguration.java
@@ -48,8 +48,8 @@ public class QdrantVectorStoreAutoConfiguration {
 		QdrantGrpcClient.Builder grpcClientBuilder = QdrantGrpcClient.newBuilder(connectionDetails.getHost(),
 				connectionDetails.getPort(), properties.isUseTls());
 
-		if (properties.getApiKey() != null) {
-			grpcClientBuilder.withApiKey(properties.getApiKey());
+		if (connectionDetails.getApiKey() != null) {
+			grpcClientBuilder.withApiKey(connectionDetails.getApiKey());
 		}
 		return new QdrantClient(grpcClientBuilder.build());
 	}
@@ -78,6 +78,11 @@ public class QdrantVectorStoreAutoConfiguration {
 		@Override
 		public int getPort() {
 			return this.properties.getPort();
+		}
+
+		@Override
+		public String getApiKey() {
+			return this.properties.getApiKey();
 		}
 
 	}

--- a/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/qdrant/QdrantDockerComposeConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/qdrant/QdrantDockerComposeConnectionDetailsFactory.java
@@ -43,12 +43,15 @@ public class QdrantDockerComposeConnectionDetailsFactory
 	static class QdrantDockerComposeConnectionDetails extends DockerComposeConnectionDetails
 			implements QdrantConnectionDetails {
 
+		private final QdrantEnvironment environment;
+
 		private final String host;
 
 		private final int port;
 
 		QdrantDockerComposeConnectionDetails(RunningService service) {
 			super(service);
+			this.environment = new QdrantEnvironment(service.env());
 			this.host = service.host();
 			this.port = service.ports().get(QDRANT_GRPC_PORT);
 		}
@@ -61,6 +64,11 @@ public class QdrantDockerComposeConnectionDetailsFactory
 		@Override
 		public int getPort() {
 			return this.port;
+		}
+
+		@Override
+		public String getApiKey() {
+			return this.environment.getApiKey();
 		}
 
 	}

--- a/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/qdrant/QdrantEnvironment.java
+++ b/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/qdrant/QdrantEnvironment.java
@@ -1,0 +1,17 @@
+package org.springframework.ai.docker.compose.service.connection.qdrant;
+
+import java.util.Map;
+
+class QdrantEnvironment {
+
+	private final String apiKey;
+
+	QdrantEnvironment(Map<String, String> env) {
+		this.apiKey = env.get("QDRANT__SERVICE__API_KEY");
+	}
+
+	public String getApiKey() {
+		return this.apiKey;
+	}
+
+}

--- a/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/ai/docker/compose/service/connection/qdrant/QdrantDockerComposeConnectionDetailsFactoryTests.java
+++ b/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/ai/docker/compose/service/connection/qdrant/QdrantDockerComposeConnectionDetailsFactoryTests.java
@@ -33,6 +33,7 @@ class QdrantDockerComposeConnectionDetailsFactoryTests extends AbstractDockerCom
 		QdrantConnectionDetails connectionDetails = run(QdrantConnectionDetails.class);
 		assertThat(connectionDetails.getHost()).isNotNull();
 		assertThat(connectionDetails.getPort()).isGreaterThan(0);
+		assertThat(connectionDetails.getApiKey()).isEqualTo("springai");
 	}
 
 }

--- a/spring-ai-spring-boot-docker-compose/src/test/resources/org/springframework/ai/docker/compose/service/connection/qdrant/qdrant-compose.yaml
+++ b/spring-ai-spring-boot-docker-compose/src/test/resources/org/springframework/ai/docker/compose/service/connection/qdrant/qdrant-compose.yaml
@@ -3,3 +3,5 @@ services:
     image: '{imageName}'
     ports:
       - '6334'
+    environment:
+      - QDRANT__SERVICE__API_KEY=springai

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerConnectionDetailsFactory.java
@@ -51,6 +51,11 @@ class QdrantContainerConnectionDetailsFactory
 			return getContainer().getMappedPort(6334);
 		}
 
+		@Override
+		public String getApiKey() {
+			return getContainer().getEnvMap().get("QDRANT__SERVICE__API_KEY");
+		}
+
 	}
 
 }

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerWithApiKeyConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/qdrant/QdrantContainerWithApiKeyConnectionDetailsFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.testcontainers.service.connection.qdrant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.vectorstore.qdrant.QdrantVectorStoreAutoConfiguration;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.transformers.TransformersEmbeddingModel;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.qdrant.QdrantContainer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig
+@Testcontainers
+@TestPropertySource(properties = "spring.ai.vectorstore.qdrant.collectionName=test_collection")
+public class QdrantContainerWithApiKeyConnectionDetailsFactoryTest {
+
+	@Container
+	@ServiceConnection
+	static QdrantContainer qdrantContainer = new QdrantContainer("qdrant/qdrant:v1.9.2").withApiKey("test_api_key");
+
+	List<Document> documents = List.of(
+			new Document(getText("classpath:/test/data/spring.ai.txt"), Map.of("spring", "great")),
+			new Document(getText("classpath:/test/data/time.shelter.txt")),
+			new Document(getText("classpath:/test/data/great.depression.txt"), Map.of("depression", "bad")));
+
+	@Autowired
+	private VectorStore vectorStore;
+
+	@Test
+	public void addAndSearch() {
+		vectorStore.add(documents);
+
+		List<Document> results = vectorStore
+			.similaritySearch(SearchRequest.query("What is Great Depression?").withTopK(1));
+
+		assertThat(results).hasSize(1);
+		Document resultDoc = results.get(0);
+		assertThat(resultDoc.getId()).isEqualTo(documents.get(2).getId());
+		assertThat(resultDoc.getMetadata()).containsKeys("depression", "distance");
+
+		// Remove all documents from the store
+		vectorStore.delete(documents.stream().map(doc -> doc.getId()).toList());
+		results = vectorStore.similaritySearch(SearchRequest.query("Great Depression").withTopK(1));
+		assertThat(results).hasSize(0);
+	}
+
+	public static String getText(String uri) {
+		var resource = new DefaultResourceLoader().getResource(uri);
+		try {
+			return resource.getContentAsString(StandardCharsets.UTF_8);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ImportAutoConfiguration(QdrantVectorStoreAutoConfiguration.class)
+	static class Config {
+
+		@Bean
+		public EmbeddingModel embeddingModel() {
+			return new TransformersEmbeddingModel();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Read `QDRANT__SERVICE__API_KEY` env var from compose file and Testcontainers definition to configure the connection details for Qdrant.
