### PR TITLE
Add support for redis/redis-stack image in Docker Compose

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/docker-compose.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/docker-compose.adoc
@@ -41,7 +41,7 @@ The following service connection factories are provided in the `spring-ai-spring
 | Containers named `qdrant/qdrant`
 
 | `RedisConnectionDetails`
-| Containers named `redis/redis-stack-server`
+| Containers named `redis/redis-stack-server`, `redis/redis-stack`
 
 | `WeaviateConnectionDetails`
 | Containers named `semitechnologies/weaviate`, `cr.weaviate.io/semitechnologies/weaviate`

--- a/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/redis/RedisDockerComposeConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/redis/RedisDockerComposeConnectionDetailsFactory.java
@@ -26,10 +26,12 @@ import org.springframework.boot.docker.compose.service.connection.DockerComposeC
 public class RedisDockerComposeConnectionDetailsFactory
 		extends DockerComposeConnectionDetailsFactory<RedisConnectionDetails> {
 
+	private static final String[] REDIS_IMAGE_NAMES = { "redis/redis-stack", "redis/redis-stack-server" };
+
 	private static final int REDIS_PORT = 6379;
 
 	protected RedisDockerComposeConnectionDetailsFactory() {
-		super("redis/redis-stack-server");
+		super(REDIS_IMAGE_NAMES);
 	}
 
 	@Override

--- a/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/ai/docker/compose/service/connection/redis/RedisStackDockerComposeConnectionDetailsFactoryTests.java
+++ b/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/ai/docker/compose/service/connection/redis/RedisStackDockerComposeConnectionDetailsFactoryTests.java
@@ -22,10 +22,10 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class RedisDockerComposeConnectionDetailsFactoryTests extends AbstractDockerComposeIntegrationTests {
+class RedisStackDockerComposeConnectionDetailsFactoryTests extends AbstractDockerComposeIntegrationTests {
 
-	RedisDockerComposeConnectionDetailsFactoryTests() {
-		super("redis-compose.yaml", DockerImageName.parse("redis/redis-stack-server"));
+	RedisStackDockerComposeConnectionDetailsFactoryTests() {
+		super("redis-compose.yaml", DockerImageName.parse("redis/redis-stack"));
 	}
 
 	@Test

--- a/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/ai/docker/compose/service/connection/redis/RedisStackServerDockerComposeConnectionDetailsFactoryTests.java
+++ b/spring-ai-spring-boot-docker-compose/src/test/java/org/springframework/ai/docker/compose/service/connection/redis/RedisStackServerDockerComposeConnectionDetailsFactoryTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.docker.compose.service.connection.redis;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.autoconfigure.vectorstore.redis.RedisConnectionDetails;
+import org.springframework.boot.docker.compose.service.connection.test.AbstractDockerComposeIntegrationTests;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisStackServerDockerComposeConnectionDetailsFactoryTests extends AbstractDockerComposeIntegrationTests {
+
+	RedisStackServerDockerComposeConnectionDetailsFactoryTests() {
+		super("redis-compose.yaml", DockerImageName.parse("redis/redis-stack-server"));
+	}
+
+	@Test
+	void runCreatesConnectionDetails() {
+		RedisConnectionDetails connectionDetails = run(RedisConnectionDetails.class);
+		assertThat(connectionDetails.getUri()).startsWith("redis://");
+	}
+
+}


### PR DESCRIPTION
Currently, `redis/redis-stack-server` image is supported. This commit introduces support for `redis/redis-stack`, which also contains Redis Insight.
