### PR TITLE
Add more models and change default model for MiniMax

### DIFF
--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -49,7 +49,7 @@ import java.util.function.Predicate;
  */
 public class MiniMaxApi {
 
-	public static final String DEFAULT_CHAT_MODEL = ChatModel.ABAB_5_5_Chat.getValue();
+	public static final String DEFAULT_CHAT_MODEL = ChatModel.ABAB_6_5_G_Chat.getValue();
 	public static final String DEFAULT_EMBEDDING_MODEL = EmbeddingModel.Embo_01.getValue();
 	private static final Predicate<String> SSE_DONE_PREDICATE = "[DONE]"::equals;
 
@@ -114,9 +114,15 @@ public class MiniMaxApi {
 	 * <a href="https://www.minimaxi.com/document/algorithm-concept">MiniMax Model</a>.
 	 */
 	public enum ChatModel implements ModelDescription {
-		ABAB_6_Chat("abab6-chat"),
+		ABAB_6_5_Chat("abab6.5-chat"),
+		ABAB_6_5_S_Chat("abab6.5s-chat"),
+		ABAB_6_5_T_Chat("abab6.5t-chat"),
+		ABAB_6_5_G_Chat("abab6.5g-chat"),
 		ABAB_5_5_Chat("abab5.5-chat"),
-		ABAB_5_5_S_Chat("abab5.5s-chat");
+		ABAB_5_5_S_Chat("abab5.5s-chat"),
+
+		@Deprecated(since = "1.0.0-M1", forRemoval = true) // Replaced by ABAB_6_5_S_Chat
+		ABAB_6_Chat("abab6-chat");
 
 		public final String  value;
 
@@ -408,8 +414,7 @@ public class MiniMaxApi {
 		 * @param type Content  type, each can be of type text or image_url.
 		 * @param text The text content of the message.
 		 * @param imageUrl The image content of the message. You can pass multiple
-		 * images by adding multiple image_url content parts. Image input is only
-		 * supported when using the glm-4v model.
+		 * images by adding multiple image_url content parts.
 		 */
 		@JsonInclude(Include.NON_NULL)
 		public record MediaContent(

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/EmbeddingIT.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/EmbeddingIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.minimax;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Geng Rong
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
+class EmbeddingIT {
+
+	@Autowired
+	private MiniMaxEmbeddingModel embeddingModel;
+
+	@Test
+	void defaultEmbedding() {
+		assertThat(embeddingModel).isNotNull();
+
+		EmbeddingResponse embeddingResponse = embeddingModel.embedForResponse(List.of("Hello World"));
+		assertThat(embeddingResponse.getResults()).hasSize(1);
+		assertThat(embeddingResponse.getResults().get(0)).isNotNull();
+		assertThat(embeddingResponse.getResults().get(0).getOutput()).hasSize(1536);
+
+		assertThat(embeddingModel.dimensions()).isEqualTo(1536);
+	}
+
+	@Test
+	void batchEmbedding() {
+		assertThat(embeddingModel).isNotNull();
+		EmbeddingResponse embeddingResponse = embeddingModel.embedForResponse(List.of("Hello World", "HI"));
+		assertThat(embeddingResponse.getResults()).hasSize(2);
+		assertThat(embeddingResponse.getResults().get(0)).isNotNull();
+		assertThat(embeddingResponse.getResults().get(0).getOutput()).hasSize(1536);
+		assertThat(embeddingResponse.getResults().get(1)).isNotNull();
+		assertThat(embeddingResponse.getResults().get(1).getOutput()).hasSize(1536);
+
+		assertThat(embeddingModel.dimensions()).isEqualTo(1536);
+	}
+
+}

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxApiIT.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxApiIT.java
@@ -17,7 +17,6 @@ package org.springframework.ai.minimax.api;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletion;
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionChunk;
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage;
@@ -43,8 +42,8 @@ public class MiniMaxApiIT {
 	@Test
 	void chatCompletionEntity() {
 		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world", Role.USER);
-		ResponseEntity<ChatCompletion> response = miniMaxApi.chatCompletionEntity(
-				new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-3-turbo", 0.7f, false));
+		ResponseEntity<ChatCompletion> response = miniMaxApi
+			.chatCompletionEntity(new ChatCompletionRequest(List.of(chatCompletionMessage), "abab6.5g", 0.7f, false));
 
 		assertThat(response).isNotNull();
 		assertThat(response.getBody()).isNotNull();
@@ -54,7 +53,7 @@ public class MiniMaxApiIT {
 	void chatCompletionStream() {
 		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world", Role.USER);
 		Flux<ChatCompletionChunk> response = miniMaxApi
-			.chatCompletionStream(new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-3-turbo", 0.7f, true));
+			.chatCompletionStream(new ChatCompletionRequest(List.of(chatCompletionMessage), "abab6.5g", 0.7f, true));
 
 		assertThat(response).isNotNull();
 		assertThat(response.collectList().block()).isNotNull();

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxApiToolFunctionCallIT.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxApiToolFunctionCallIT.java
@@ -85,7 +85,7 @@ public class MiniMaxApiToolFunctionCallIT {
 		List<ChatCompletionMessage> messages = new ArrayList<>(List.of(message));
 
 		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(messages,
-				org.springframework.ai.minimax.api.MiniMaxApi.ChatModel.ABAB_6_Chat.getValue(), List.of(functionTool),
+				org.springframework.ai.minimax.api.MiniMaxApi.ChatModel.ABAB_6_5_Chat.getValue(), List.of(functionTool),
 				ToolChoiceBuilder.AUTO);
 
 		ResponseEntity<ChatCompletion> chatCompletion = miniMaxApi.chatCompletionEntity(chatCompletionRequest);
@@ -116,7 +116,7 @@ public class MiniMaxApiToolFunctionCallIT {
 		}
 
 		var functionResponseRequest = new ChatCompletionRequest(messages,
-				org.springframework.ai.minimax.api.MiniMaxApi.ChatModel.ABAB_6_Chat.getValue(), 0.5F);
+				org.springframework.ai.minimax.api.MiniMaxApi.ChatModel.ABAB_6_5_Chat.getValue(), 0.5F);
 
 		ResponseEntity<ChatCompletion> chatCompletion2 = miniMaxApi.chatCompletionEntity(functionResponseRequest);
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/minimax-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/minimax-chat.adoc
@@ -90,7 +90,7 @@ The prefix `spring.ai.minimax.chat` is the property prefix that lets you configu
 | spring.ai.minimax.chat.enabled | Enable MiniMax chat model.  | true
 | spring.ai.minimax.chat.base-url | Optional overrides the spring.ai.minimax.base-url to provide chat specific url |  https://api.minimax.chat
 | spring.ai.minimax.chat.api-key | Optional overrides the spring.ai.minimax.api-key to provide chat specific api-key |  -
-| spring.ai.minimax.chat.options.model | This is the MiniMax Chat model to use | `abab5.5-chat` (the `abab5.5s-chat`, `abab5.5-chat`, and `abab6-chat` point to the latest model versions)
+| spring.ai.minimax.chat.options.model | This is the MiniMax Chat model to use | `abab6.5g-chat` (the `abab5.5-chat`, `abab5.5s-chat`, `abab6.5-chat`, `abab6.5g-chat`, `abab6.5t-chat` and `abab6.5s-chat` point to the latest model versions)
 | spring.ai.minimax.chat.options.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
 | spring.ai.minimax.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.7
 | spring.ai.minimax.chat.options.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both. | 1.0
@@ -121,7 +121,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         MiniMaxChatOptions.builder()
-            .withModel(MiniMaxApi.ChatModel.GLM_3_Turbo.getValue())
+            .withModel(MiniMaxApi.ChatModel.ABAB_5_5_Chat.getValue())
             .withTemperature(0.5f)
         .build()
     ));
@@ -138,7 +138,7 @@ Add a `application.properties` file, under the `src/main/resources` directory, t
 [source,application.properties]
 ----
 spring.ai.minimax.api-key=YOUR_API_KEY
-spring.ai.minimax.chat.options.model=glm-3-turbo
+spring.ai.minimax.chat.options.model=abab6.5g-chat
 spring.ai.minimax.chat.options.temperature=0.7
 ----
 
@@ -204,7 +204,7 @@ Next, create a `MiniMaxChatModel` and use it for text generations:
 var miniMaxApi = new MiniMaxApi(System.getenv("MINIMAX_API_KEY"));
 
 var chatModel = new MiniMaxChatModel(miniMaxApi, MiniMaxChatOptions.builder()
-                .withModel(MiniMaxApi.ChatModel.GLM_3_Turbo.getValue())
+                .withModel(MiniMaxApi.ChatModel.ABAB_5_5_Chat.getValue())
                 .withTemperature(0.4f)
                 .withMaxTokens(200)
                 .build());
@@ -236,11 +236,11 @@ ChatCompletionMessage chatCompletionMessage =
 
 // Sync request
 ResponseEntity<ChatCompletion> response = miniMaxApi.chatCompletionEntity(
-    new ChatCompletionRequest(List.of(chatCompletionMessage), MiniMaxApi.ChatModel.GLM_3_Turbo.getValue(), 0.7f, false));
+    new ChatCompletionRequest(List.of(chatCompletionMessage), MiniMaxApi.ChatModel.ABAB_5_5_Chat.getValue(), 0.7f, false));
 
 // Streaming request
 Flux<ChatCompletionChunk> streamResponse = miniMaxApi.chatCompletionStream(
-        new ChatCompletionRequest(List.of(chatCompletionMessage), MiniMaxApi.ChatModel.GLM_3_Turbo.getValue(), 0.7f, true));
+        new ChatCompletionRequest(List.of(chatCompletionMessage), MiniMaxApi.ChatModel.ABAB_5_5_Chat.getValue(), 0.7f, true));
 ----
 
 Follow the https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java[MiniMaxApi.java]'s JavaDoc for further information.


### PR DESCRIPTION
PR content:

1. supports `MiniMax` more new models
2. change default chat model to `abab6.5g-chat`, stronger reasoning ability and the same price as `abab5.5-chat`
3. more unit tests, including embedding test
4. update documents