### PR TITLE
GH-907: Change vector store schema init default

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -5,6 +5,11 @@
 
 * The configuration prefix for the Chroma Vector Store has been changes from `spring.ai.vectorstore.chroma.store` to `spring.ai.vectorstore.chroma` in order to align with the naming conventions of other vector stores.
 
+* The default value of the `initialize-schema` property on vector stores capable of initializing a schema is now set to `false`.
+This implies that the applications now need to explicitly opt-in for schema initialization on supported vector stores, if the schema is expected to be created at application startup.
+Not all vector stores support this property.
+See the corresponding vector store documentation for more details.
+
 == Upgrading to 1.0.0.M1
 
 On our march to release 1.0.0 M1 we have made several breaking changes.  Apologies, it is for the best!

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -9,6 +9,13 @@
 This implies that the applications now need to explicitly opt-in for schema initialization on supported vector stores, if the schema is expected to be created at application startup.
 Not all vector stores support this property.
 See the corresponding vector store documentation for more details.
+The following are the vector stores that currently don't support the `initialize-schema` property.
+
+1. Cassandra
+2. Gemfire
+3. Hana
+4. Pinecone
+5. Weaviate
 
 == Upgrading to 1.0.0.M1
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/CommonVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/CommonVectorStoreProperties.java
@@ -1,11 +1,33 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.ai.autoconfigure;
 
 /**
  * @author Josh Long
+ * @author Soby Chacko
  */
 public class CommonVectorStoreProperties {
 
-	private boolean initializeSchema = true;
+	/**
+	 * Vector stores do not initialize schema by default on application startup. The
+	 * applications explicitly need to opt-in for initializing the schema on startup. The
+	 * recommended way to initialize the schema on startup is to set the initialize-schema
+	 * property on the vector store. See {@link #setInitializeSchema(boolean)}.
+	 */
+	private boolean initializeSchema = false;
 
 	public boolean isInitializeSchema() {
 		return initializeSchema;

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
@@ -61,7 +61,8 @@ public class OpenSearchVectorStoreAutoConfiguration {
 		var indexName = Optional.ofNullable(properties.getIndexName()).orElse(OpenSearchVectorStore.DEFAULT_INDEX_NAME);
 		var mappingJson = Optional.ofNullable(properties.getMappingJson())
 			.orElse(OpenSearchVectorStore.DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536);
-		return new OpenSearchVectorStore(indexName, openSearchClient, embeddingModel, mappingJson);
+		return new OpenSearchVectorStore(indexName, openSearchClient, embeddingModel, mappingJson,
+				properties.isInitializeSchema());
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.ai.autoconfigure.vectorstore.opensearch;
 
+import org.springframework.ai.autoconfigure.CommonVectorStoreProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
 
 @ConfigurationProperties(prefix = OpenSearchVectorStoreProperties.CONFIG_PREFIX)
-public class OpenSearchVectorStoreProperties {
+public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.opensearch";
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseServiceClientProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseServiceClientProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.autoconfigure.vectorstore.typesense;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseVectorStoreAutoConfiguration.java
@@ -57,7 +57,7 @@ public class TypesenseVectorStoreAutoConfiguration {
 			.withEmbeddingDimension(properties.getEmbeddingDimension())
 			.build();
 
-		return new TypesenseVectorStore(typesenseClient, embeddingModel, config);
+		return new TypesenseVectorStore(typesenseClient, embeddingModel, config, properties.isInitializeSchema());
 	}
 
 	@Bean

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseVectorStoreProperties.java
@@ -1,13 +1,31 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.autoconfigure.vectorstore.typesense;
 
+import org.springframework.ai.autoconfigure.CommonVectorStoreProperties;
 import org.springframework.ai.vectorstore.TypesenseVectorStore;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Pablo Sanchidrian Herrera
+ * @author Soby Chacko
  */
 @ConfigurationProperties(TypesenseVectorStoreProperties.CONFIG_PREFIX)
-public class TypesenseVectorStoreProperties {
+public class TypesenseVectorStoreProperties extends CommonVectorStoreProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.typesense";
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.Bean;
 /**
  * @author Christian Tzolov
  * @author Eddú Meléndez
+ * @author Soby Chacko
  */
 @AutoConfiguration
 @ConditionalOnClass({ EmbeddingModel.class, WeaviateVectorStore.class })
@@ -72,8 +73,7 @@ public class WeaviateVectorStoreAutoConfiguration {
 				.toList())
 			.withConsistencyLevel(properties.getConsistencyLevel());
 
-		return new WeaviateVectorStore(configBuilder.build(), embeddingModel, weaviateClient,
-				properties.isInitializeSchema());
+		return new WeaviateVectorStore(configBuilder.build(), embeddingModel, weaviateClient);
 	}
 
 	static class PropertiesWeaviateConnectionDetails implements WeaviateConnectionDetails {

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreProperties.java
@@ -27,7 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Christian Tzolov
  */
 @ConfigurationProperties(WeaviateVectorStoreProperties.CONFIG_PREFIX)
-public class WeaviateVectorStoreProperties extends CommonVectorStoreProperties {
+public class WeaviateVectorStoreProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.weaviate";
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/azure/AzureVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/azure/AzureVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author Christian Tzolov
+ * @author Soby Chacko
  */
 @EnabledIfEnvironmentVariable(named = "AZURE_AI_SEARCH_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_AI_SEARCH_ENDPOINT", matches = ".+")
@@ -81,8 +82,8 @@ public class AzureVectorStoreAutoConfigurationIT {
 	public void addAndSearchTest() {
 
 		contextRunner
-			.withPropertyValues("spring.ai.vectorstore.azure.indexName=my_test_index",
-					"spring.ai.vectorstore.azure.defaultTopK=6",
+			.withPropertyValues("spring.ai.vectorstore.azure.initializeSchema=true",
+					"spring.ai.vectorstore.azure.indexName=my_test_index", "spring.ai.vectorstore.azure.defaultTopK=6",
 					"spring.ai.vectorstore.azure.defaultSimilarityThreshold=0.75")
 			.run(context -> {
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Christian Tzolov
  * @author Eddú Meléndez
+ * @author Soby Chacko
  */
 @Testcontainers
 public class ChromaVectorStoreAutoConfigurationIT {
@@ -50,7 +51,8 @@ public class ChromaVectorStoreAutoConfigurationIT {
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.chroma.client.host=http://" + chroma.getHost(),
 				"spring.ai.vectorstore.chroma.client.port=" + chroma.getMappedPort(8000),
-				"spring.ai.vectorstore.chroma.collectionName=TestCollection");
+				"spring.ai.vectorstore.chroma.store.initializeSchema=true",
+				"spring.ai.vectorstore.chroma.store.collectionName=TestCollection");
 
 	@Test
 	public void addAndSearchWithFilters() {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
@@ -51,8 +51,8 @@ public class ChromaVectorStoreAutoConfigurationIT {
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.chroma.client.host=http://" + chroma.getHost(),
 				"spring.ai.vectorstore.chroma.client.port=" + chroma.getMappedPort(8000),
-				"spring.ai.vectorstore.chroma.store.initializeSchema=true",
-				"spring.ai.vectorstore.chroma.store.collectionName=TestCollection");
+				"spring.ai.vectorstore.chroma.initializeSchema=true",
+				"spring.ai.vectorstore.chroma.collectionName=TestCollection");
 
 	@Test
 	public void addAndSearchWithFilters() {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfigurationIT.java
@@ -60,6 +60,7 @@ class ElasticsearchVectorStoreAutoConfigurationIT {
 				ElasticsearchVectorStoreAutoConfiguration.class, RestClientAutoConfiguration.class,
 				SpringAiRetryAutoConfiguration.class, OpenAiAutoConfiguration.class))
 		.withPropertyValues("spring.elasticsearch.uris=" + elasticsearchContainer.getHttpHostAddress(),
+				"spring.ai.vectorstore.elasticsearch.initializeSchema=true",
 				"spring.ai.openai.api-key=" + System.getenv("OPENAI_API_KEY"));
 
 	// No parametrized test based on similarity function,

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Christian Tzolov
  * @author Eddú Meléndez
+ * @author Soby Chacko
  */
 @Testcontainers
 public class MilvusVectorStoreAutoConfigurationIT {
@@ -62,7 +63,7 @@ public class MilvusVectorStoreAutoConfigurationIT {
 					"spring.ai.vectorstore.milvus.indexType=IVF_FLAT",
 					"spring.ai.vectorstore.milvus.embeddingDimension=384",
 					"spring.ai.vectorstore.milvus.collectionName=myTestCollection",
-
+					"spring.ai.vectorstore.milvus.initializeSchema=true",
 					"spring.ai.vectorstore.milvus.client.host=" + milvus.getHost(),
 					"spring.ai.vectorstore.milvus.client.port=" + milvus.getMappedPort(19530))
 			.run(context -> {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Jingzhou Ou
+ * @author Soby Chacko
  */
 @Testcontainers
 public class Neo4jVectorStoreAutoConfigurationIT {
@@ -59,7 +60,7 @@ public class Neo4jVectorStoreAutoConfigurationIT {
 		.withConfiguration(AutoConfigurations.of(Neo4jAutoConfiguration.class, Neo4jVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.neo4j.uri=" + neo4jContainer.getBoltUrl(),
-				"spring.neo4j.authentication.username=" + "neo4j",
+				"spring.ai.vectorstore.neo4j.initializeSchema=true", "spring.neo4j.authentication.username=" + "neo4j",
 				"spring.neo4j.authentication.password=" + neo4jContainer.getAdminPassword());
 
 	@Test

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class OpenSearchVectorStoreAutoConfigurationIT {
 				SpringAiRetryAutoConfiguration.class))
 		.withClassLoader(new FilteredClassLoader(Region.class, ApacheHttpClient.class))
 		.withUserConfiguration(Config.class)
-		.withPropertyValues(
+		.withPropertyValues("spring.ai.vectorstore.opensearch.initializeSchema=true",
 				OpenSearchVectorStoreProperties.CONFIG_PREFIX + ".uris=" + opensearchContainer.getHttpHostAddress(),
 				OpenSearchVectorStoreProperties.CONFIG_PREFIX + ".indexName=" + DOCUMENT_INDEX,
 				OpenSearchVectorStoreProperties.CONFIG_PREFIX + ".mappingJson=" + """

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /**
  * @author Christian Tzolov
  * @author Muthukumaran Navaneethakrishnan
+ * @author Soby Chacko
  */
 @Testcontainers
 public class PgVectorStoreAutoConfigurationIT {
@@ -75,6 +76,7 @@ public class PgVectorStoreAutoConfigurationIT {
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.pgvector.distanceType=COSINE_DISTANCE",
 				"spring.ai.vectorstore.pgvector.initialize-schema=true",
+				// JdbcTemplate configuration
 				String.format("spring.datasource.url=jdbc:postgresql://%s:%d/%s", postgresContainer.getHost(),
 						postgresContainer.getMappedPort(5432), postgresContainer.getDatabaseName()),
 				"spring.datasource.username=" + postgresContainer.getUsername(),

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStoreAutoConfigurationIT.java
@@ -66,7 +66,6 @@ public class PineconeVectorStoreAutoConfigurationIT {
 		.withConfiguration(AutoConfigurations.of(PineconeVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.pinecone.apiKey=" + System.getenv("PINECONE_API_KEY"),
-				"spring.ai.vectorstore.pinecone.initializeSchema=true",
 				"spring.ai.vectorstore.pinecone.environment=gcp-starter",
 				"spring.ai.vectorstore.pinecone.projectId=814621f",
 				"spring.ai.vectorstore.pinecone.indexName=spring-ai-test-index",

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStoreAutoConfigurationIT.java
@@ -42,6 +42,7 @@ import org.springframework.core.io.DefaultResourceLoader;
 
 /**
  * @author Christian Tzolov
+ * @author Soby Chacko
  */
 @EnabledIfEnvironmentVariable(named = "PINECONE_API_KEY", matches = ".+")
 public class PineconeVectorStoreAutoConfigurationIT {
@@ -65,6 +66,7 @@ public class PineconeVectorStoreAutoConfigurationIT {
 		.withConfiguration(AutoConfigurations.of(PineconeVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.pinecone.apiKey=" + System.getenv("PINECONE_API_KEY"),
+				"spring.ai.vectorstore.pinecone.initializeSchema=true",
 				"spring.ai.vectorstore.pinecone.environment=gcp-starter",
 				"spring.ai.vectorstore.pinecone.projectId=814621f",
 				"spring.ai.vectorstore.pinecone.indexName=spring-ai-test-index",

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Christian Tzolov
  * @author Eddú Meléndez
+ * @author Soby Chacko
  * @since 0.8.1
  */
 @Testcontainers
@@ -58,6 +59,7 @@ public class QdrantVectorStoreAutoConfigurationIT {
 		.withConfiguration(AutoConfigurations.of(QdrantVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.qdrant.port=" + qdrantContainer.getGrpcPort(),
+				"spring.ai.vectorstore.qdrant.initializeSchema=true",
 				"spring.ai.vectorstore.qdrant.host=" + qdrantContainer.getHost());
 
 	@Test

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreCloudAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/qdrant/QdrantVectorStoreCloudAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test using a free tier Qdrant Cloud instance: https://cloud.qdrant.io
  *
  * @author Christian Tzolov
+ * @author Soby Chacko
  * @since 0.8.1
  */
 // NOTE: The free Qdrant Cluster and the QDRANT_API_KEY expire after 4 weeks of
@@ -98,7 +99,7 @@ public class QdrantVectorStoreCloudAutoConfigurationIT {
 				"spring.ai.vectorstore.qdrant.host=" + CLOUD_HOST,
 				"spring.ai.vectorstore.qdrant.api-key=" + CLOUD_API_KEY,
 				"spring.ai.vectorstore.qdrant.collection-name=" + COLLECTION_NAME,
-				"spring.ai.vectorstore.qdrant.use-tls=true");
+				"spring.ai.vectorstore.qdrant.initializeSchema=true", "spring.ai.vectorstore.qdrant.use-tls=true");
 
 	@Test
 	public void addAndSearch() {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/redis/RedisVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/redis/RedisVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import com.redis.testcontainers.RedisStackContainer;
 
 /**
  * @author Julien Ruaux
+ * @author Soby Chacko
  */
 @Testcontainers
 class RedisVectorStoreAutoConfigurationIT {
@@ -54,6 +55,7 @@ class RedisVectorStoreAutoConfigurationIT {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(RedisVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)
+		.withPropertyValues("spring.ai.vectorstore.redis.initializeSchema=true")
 		.withPropertyValues("spring.ai.vectorstore.redis.index=myIdx")
 		.withPropertyValues("spring.ai.vectorstore.redis.prefix=doc:");
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/typesense/TypesenseVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Pablo Sanchidrian Herrera
  * @author Eddú Meléndez
+ * @author Soby Chacko
  */
 @Testcontainers
 public class TypesenseVectorStoreAutoConfigurationIT {
@@ -63,6 +64,7 @@ public class TypesenseVectorStoreAutoConfigurationIT {
 		contextRunner
 			.withPropertyValues("spring.ai.vectorstore.typesense.embeddingDimension=384",
 					"spring.ai.vectorstore.typesense.collectionName=myTestCollection",
+					"spring.ai.vectorstore.typesense.initializeSchema=true",
 					"spring.ai.vectorstore.typesense.client.apiKey=xyz",
 					"spring.ai.vectorstore.typesense.client.protocol=http",
 					"spring.ai.vectorstore.typesense.client.host=" + typesenseContainer.getHost(),

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Christian Tzolov
  * @author Eddú Meléndez
+ * @author Soby Chacko
  */
 @Testcontainers
-public class WeaviateVectorStoreAutoConfigurationTests {
+public class WeaviateVectorStoreAutoConfigurationIT {
 
 	@Container
 	static WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.25.4")

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfigurationTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/weaviate/WeaviateVectorStoreAutoConfigurationTests.java
@@ -48,8 +48,6 @@ public class WeaviateVectorStoreAutoConfigurationTests {
 	static WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.25.4")
 		.waitingFor(Wait.forHttp("/v1/.well-known/ready").forPort(8080));
 
-	;
-
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(WeaviateVectorStoreAutoConfiguration.class))
 		.withUserConfiguration(Config.class)

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -99,10 +99,11 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 				document.setEmbedding(this.embeddingModel.embed(document));
 			}
 			// We call operations on BulkRequest.Builder only if the index exists.
-			// For the index to be present, either it must be pre-created or set the initializeSchema to true.
+			// For the index to be present, either it must be pre-created or set the
+			// initializeSchema to true.
 			if (indexExists()) {
 				bulkRequestBuilder.operations(op -> op
-						.index(idx -> idx.index(this.options.getIndexName()).id(document.getId()).document(document)));
+					.index(idx -> idx.index(this.options.getIndexName()).id(document.getId()).document(document)));
 			}
 		}
 		BulkResponse bulkRequest = bulkRequest(bulkRequestBuilder.build());
@@ -120,7 +121,8 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 	public Optional<Boolean> delete(List<String> idList) {
 		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
 		// We call operations on BulkRequest.Builder only if the index exists.
-		// For the index to be present, either it must be pre-created or set the initializeSchema to true.
+		// For the index to be present, either it must be pre-created or set the
+		// initializeSchema to true.
 		if (indexExists()) {
 			for (String id : idList) {
 				bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(this.options.getIndexName()).id(id)));

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.search.Hit;
-import co.elastic.clients.elasticsearch.indices.CreateIndexResponse;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -57,6 +56,7 @@ import static org.springframework.ai.vectorstore.SimilarityFunction.l2_norm;
  * @author Jemin Huh
  * @author Wei Jiang
  * @author Laura Trotta
+ * @author Soby Chacko
  * @since 1.0.0
  */
 public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
@@ -98,12 +98,14 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 				logger.debug("Calling EmbeddingModel for document id = " + document.getId());
 				document.setEmbedding(this.embeddingModel.embed(document));
 			}
-			bulkRequestBuilder.operations(op -> op
-				.index(idx -> idx.index(this.options.getIndexName()).id(document.getId()).document(document)));
+			// We call operations on BulkRequest.Builder only if the index exists.
+			// For the index to be present, either it must be pre-created or set the initializeSchema to true.
+			if (indexExists()) {
+				bulkRequestBuilder.operations(op -> op
+						.index(idx -> idx.index(this.options.getIndexName()).id(document.getId()).document(document)));
+			}
 		}
-
 		BulkResponse bulkRequest = bulkRequest(bulkRequestBuilder.build());
-
 		if (bulkRequest.errors()) {
 			List<BulkResponseItem> bulkResponseItems = bulkRequest.items();
 			for (BulkResponseItem bulkResponseItem : bulkResponseItems) {
@@ -117,8 +119,13 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 	@Override
 	public Optional<Boolean> delete(List<String> idList) {
 		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
-		for (String id : idList)
-			bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(this.options.getIndexName()).id(id)));
+		// We call operations on BulkRequest.Builder only if the index exists.
+		// For the index to be present, either it must be pre-created or set the initializeSchema to true.
+		if (indexExists()) {
+			for (String id : idList) {
+				bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(this.options.getIndexName()).id(id)));
+			}
+		}
 		return Optional.of(bulkRequest(bulkRequestBuilder.build()).errors());
 	}
 
@@ -201,9 +208,9 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 		}
 	}
 
-	private CreateIndexResponse createIndexMapping() {
+	private void createIndexMapping() {
 		try {
-			return this.elasticsearchClient.indices()
+			this.elasticsearchClient.indices()
 				.create(cr -> cr.index(options.getIndexName())
 					.mappings(map -> map.properties("embedding", p -> p.denseVector(
 							dv -> dv.similarity(options.getSimilarity().toString()).dims(options.getDimensions())))));
@@ -215,11 +222,9 @@ public class ElasticsearchVectorStore implements VectorStore, InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() {
-
 		if (!this.initializeSchema) {
 			return;
 		}
-
 		if (!indexExists()) {
 			createIndexMapping();
 		}

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+/**
+ * @author Jemin Huh
+ * @author Soby Chacko
+ * @since 1.0.0
+ */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenSearchVectorStoreIT {
@@ -346,7 +351,7 @@ class OpenSearchVectorStoreIT {
 			try {
 				return new OpenSearchVectorStore(new OpenSearchClient(ApacheHttpClient5TransportBuilder
 					.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
-					.build()), embeddingModel);
+					.build()), embeddingModel, true);
 			}
 			catch (URISyntaxException e) {
 				throw new RuntimeException(e);

--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.ai.vectorstore;
 
 import java.time.Duration;

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.vectorstore;
 
 import java.util.HashMap;
@@ -25,6 +41,7 @@ import org.typesense.model.MultiSearchSearchesParameter;
 
 /**
  * @author Pablo Sanchidrian Herrera
+ * @author Soby Chacko
  */
 public class TypesenseVectorStore implements VectorStore, InitializingBean {
 
@@ -55,6 +72,8 @@ public class TypesenseVectorStore implements VectorStore, InitializingBean {
 	private final TypesenseVectorStoreConfig config;
 
 	public final FilterExpressionConverter filterExpressionConverter = new TypesenseFilterExpressionConverter();
+
+	private final boolean initializeSchema;
 
 	public static class TypesenseVectorStoreConfig {
 
@@ -127,16 +146,18 @@ public class TypesenseVectorStore implements VectorStore, InitializingBean {
 	}
 
 	public TypesenseVectorStore(Client client, EmbeddingModel embeddingModel) {
-		this(client, embeddingModel, TypesenseVectorStoreConfig.defaultConfig());
+		this(client, embeddingModel, TypesenseVectorStoreConfig.defaultConfig(), false);
 	}
 
-	public TypesenseVectorStore(Client client, EmbeddingModel embeddingModel, TypesenseVectorStoreConfig config) {
+	public TypesenseVectorStore(Client client, EmbeddingModel embeddingModel, TypesenseVectorStoreConfig config,
+			boolean initializeSchema) {
 		Assert.notNull(client, "Typesense must not be null");
 		Assert.notNull(embeddingModel, "EmbeddingModel must not be null");
 
 		this.client = client;
 		this.embeddingModel = embeddingModel;
 		this.config = config;
+		this.initializeSchema = initializeSchema;
 	}
 
 	@Override
@@ -265,8 +286,10 @@ public class TypesenseVectorStore implements VectorStore, InitializingBean {
 	// Initialization
 	// ---------------------------------------------------------------------------------
 	@Override
-	public void afterPropertiesSet() throws Exception {
-		this.createCollection();
+	public void afterPropertiesSet() {
+		if (this.initializeSchema) {
+			this.createCollection();
+		}
 	}
 
 	private boolean hasCollection() {

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,9 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Eddú Meléndez
  * @author Josh Long
+ * @author Soby Chacko
  */
-public class WeaviateVectorStore implements VectorStore, InitializingBean {
+public class WeaviateVectorStore implements VectorStore {
 
 	public static final String DOCUMENT_METADATA_DISTANCE_KEY_NAME = "distance";
 
@@ -281,11 +282,10 @@ public class WeaviateVectorStore implements VectorStore, InitializingBean {
 	 * @param embeddingModel The client for embedding operations.
 	 */
 	public WeaviateVectorStore(WeaviateVectorStoreConfig vectorStoreConfig, EmbeddingModel embeddingModel,
-			WeaviateClient weaviateClient, boolean initializeSchema) {
+			WeaviateClient weaviateClient) {
 		Assert.notNull(vectorStoreConfig, "WeaviateVectorStoreConfig must not be null");
 		Assert.notNull(embeddingModel, "EmbeddingModel must not be null");
 
-		this.initializeSchema = initializeSchema;
 		this.embeddingModel = embeddingModel;
 		this.consistencyLevel = vectorStoreConfig.consistencyLevel;
 		this.weaviateObjectClass = vectorStoreConfig.weaviateObjectClass;
@@ -524,39 +524,6 @@ public class WeaviateVectorStore implements VectorStore, InitializingBean {
 	 */
 	private Float[] toFloatArray(List<Double> doubleList) {
 		return doubleList.stream().map(Number::floatValue).toList().toArray(new Float[0]);
-	}
-
-	private final boolean initializeSchema;
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-
-		if (!this.initializeSchema) {
-			return;
-		}
-
-		Map<String, Object> metadata = new HashMap<>();
-		if (!CollectionUtils.isEmpty(this.filterMetadataFields)) {
-			for (MetadataField mf : this.filterMetadataFields) {
-				switch (mf.type()) {
-					case TEXT:
-						metadata.put(mf.name(), "Hello");
-						break;
-					case NUMBER:
-						metadata.put(mf.name(), 3.14);
-						break;
-					case BOOLEAN:
-						metadata.put(mf.name(), true);
-						break;
-					default:
-						break;
-				}
-			}
-		}
-
-		var document = new Document("Hello world", metadata);
-		this.add(List.of(document));
-		this.delete(List.of(document.getId()));
 	}
 
 }

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/WeaviateVectorStoreIT.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/WeaviateVectorStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import io.weaviate.client.WeaviateClient;
 /**
  * @author Christian Tzolov
  * @author Eddú Meléndez
+ * @author Soby Chacko
  */
 @Testcontainers
 public class WeaviateVectorStoreIT {
@@ -256,7 +257,7 @@ public class WeaviateVectorStoreIT {
 				.withConsistencyLevel(WeaviateVectorStoreConfig.ConsistentLevel.ONE)
 				.build();
 
-			return new WeaviateVectorStore(config, embeddingModel, weaviateClient, true);
+			return new WeaviateVectorStore(config, embeddingModel, weaviateClient);
 
 		}
 


### PR DESCRIPTION
* Change default schema initialization of vector stores from `true` to `false.` Users need to explicitly opt-in for schema initialization by setting the `initialize-schema` property on the corresponding vector store.
* Update integration tests
* Update copyright years

Resolves https://github.com/spring-projects/spring-ai/issues/907