### PR TITLE
Consistent vector store property prefix for Chroma store

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
@@ -74,7 +74,7 @@ spring.ai.vectorstore.chroma.client.username=<your username (if configure)>
 spring.ai.vectorstore.chroma.client.password=<your password (if configure)>
 
 # Chroma Vector Store collection properties
-spring.ai.vectorstore.chroma.store.collection-name=<your collection name>
+spring.ai.vectorstore.chroma.collection-name=<your collection name>
 
 # Chroma Vector Store configuration properties
 
@@ -116,7 +116,7 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.chroma.client.key-token`| Access token (if configured) | -
 |`spring.ai.vectorstore.chroma.client.username`| Access username (if configured) | -
 |`spring.ai.vectorstore.chroma.client.password`| Access password (if configured) | -
-|`spring.ai.vectorstore.chroma.store.collection-name`| Collection name | `SpringAiCollection`
+|`spring.ai.vectorstore.chroma.collection-name`| Collection name | `SpringAiCollection`
 |===
 
 [NOTE]

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * @author Christian Tzolov
+ * @author Soby Chacko
  */
 @ConfigurationProperties(ChromaVectorStoreProperties.CONFIG_PREFIX)
 public class ChromaVectorStoreProperties extends CommonVectorStoreProperties {
 
-	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.chroma.store";
+	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.chroma";
 
 	private String collectionName = ChromaVectorStore.DEFAULT_COLLECTION_NAME;
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
@@ -50,7 +50,7 @@ public class ChromaVectorStoreAutoConfigurationIT {
 		.withUserConfiguration(Config.class)
 		.withPropertyValues("spring.ai.vectorstore.chroma.client.host=http://" + chroma.getHost(),
 				"spring.ai.vectorstore.chroma.client.port=" + chroma.getMappedPort(8000),
-				"spring.ai.vectorstore.chroma.store.collectionName=TestCollection");
+				"spring.ai.vectorstore.chroma.collectionName=TestCollection");
 
 	@Test
 	public void addAndSearchWithFilters() {


### PR DESCRIPTION
* The Chroma vector store config property prefix uses .store at the end, which is not consistent with the other vector stores—fixing this.

