### PR TITLE
Fix Anthropic token usage handling in streaming

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -192,6 +192,11 @@ public class AnthropicChatModel extends
 				ChatCompletion delta = ModelOptionsUtils.mapToClass(chunk.delta(), ChatCompletion.class);
 
 				chatCompletionReference.get().withType(chunk.type());
+				if (chunk.usage() != null) {
+					var totalUsage = new Usage(chatCompletionReference.get().usage.inputTokens(),
+							chunk.usage().outputTokens());
+					chatCompletionReference.get().withUsage(totalUsage);
+				}
 				if (delta.id() != null) {
 					chatCompletionReference.get().withId(delta.id());
 				}
@@ -200,9 +205,6 @@ public class AnthropicChatModel extends
 				}
 				if (delta.model() != null) {
 					chatCompletionReference.get().withModel(delta.model());
-				}
-				if (delta.usage() != null) {
-					chatCompletionReference.get().withUsage(delta.usage());
 				}
 				if (delta.content() != null) {
 					chatCompletionReference.get().withContent(delta.content());

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -522,6 +522,17 @@ public class AnthropicApi {
 	}
 
 	/**
+	 * Usage statistics with output only tokens for streamed completions.
+	 *
+	 * @param outputTokens The number of output tokens which were used in a completion.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	public record OutputUsage( // @formatter:off
+		@JsonProperty("output_tokens") Integer outputTokens) {
+		// @formatter:off
+	}
+
+	/**
 	 * The role of the author of this message.
 	 */
 	public enum Role { // @formatter:off
@@ -557,7 +568,8 @@ public class AnthropicApi {
 		@JsonProperty("index") Integer index,
 		@JsonProperty("message") ChatCompletion message,
 		@JsonProperty("content_block") MediaContent contentBlock,
-		@JsonProperty("delta") Map<String, Object> delta) {
+		@JsonProperty("delta") Map<String, Object> delta,
+		@JsonProperty("usage") OutputUsage usage) {
 		// @formatter:on
 	}
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelIT.java
@@ -95,6 +95,24 @@ class AnthropicChatModelIT {
 	}
 
 	@Test
+	void streamingWithTokenUsage() {
+		var promptOptions = AnthropicChatOptions.builder().withTemperature(0f).build();
+
+		var prompt = new Prompt("List two colors of the Polish flag. Be brief.", promptOptions);
+		var streamingTokenUsage = this.chatModel.stream(prompt).blockLast().getMetadata().getUsage();
+		var referenceTokenUsage = this.chatModel.call(prompt).getMetadata().getUsage();
+
+		assertThat(streamingTokenUsage.getPromptTokens()).isGreaterThan(0);
+		assertThat(streamingTokenUsage.getGenerationTokens()).isGreaterThan(0);
+		assertThat(streamingTokenUsage.getTotalTokens()).isGreaterThan(0);
+
+		assertThat(streamingTokenUsage.getPromptTokens()).isEqualTo(referenceTokenUsage.getPromptTokens());
+		assertThat(streamingTokenUsage.getGenerationTokens()).isEqualTo(referenceTokenUsage.getGenerationTokens());
+		assertThat(streamingTokenUsage.getTotalTokens()).isEqualTo(referenceTokenUsage.getTotalTokens());
+
+	}
+
+	@Test
 	void listOutputConverter() {
 		DefaultConversionService conversionService = new DefaultConversionService();
 		ListOutputConverter listOutputConverter = new ListOutputConverter(conversionService);


### PR DESCRIPTION
Fixing an error in getting token usage for the `spring-ai-anthropic` model when using streaming.

The token usage for the generated tokens arrives near the end of the generation with the `message_delta` event, but the current implementation incorrectly assumes that the `usage` property is on the `delta` object. It also seems to miss the fact that only `output_tokens` are present in this event.

```
event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence":null}, "usage": {"output_tokens": 15}}
```
