### PR TITLE
Bug fix: fix failed prompt template validation if a variable name contains hyphen(-)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 		<spring-cloud-function-context.version>4.1.1</spring-cloud-function-context.version>
 		<spring-boot.version>3.3.0</spring-boot.version>
 		<spring-framework.version>6.1.4</spring-framework.version>
-		<stringtemplate.version>4.0.2</stringtemplate.version>
+		<ST4.version>4.3.4</ST4.version>
 		<azure-open-ai-client.version>1.0.0-beta.8</azure-open-ai-client.version>
 		<jtokkit.version>1.0.0</jtokkit.version>
 		<victools.version>4.31.1</victools.version>

--- a/spring-ai-core/pom.xml
+++ b/spring-ai-core/pom.xml
@@ -46,8 +46,8 @@
 		<!-- production dependencies -->
 		<dependency>
 			<groupId>org.antlr</groupId>
-			<artifactId>stringtemplate</artifactId>
-			<version>${stringtemplate.version}</version>
+			<artifactId>ST4</artifactId>
+			<version>${ST4.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bug fix for #943 .

After some troubleshooting, I find that the bug was introduced by old-versioned StringTemplate4.
There is an issue about this: https://github.com/antlr/stringtemplate4/issues/94
I upgrade StringTemplate4 to the latest version and add a UT to cover this.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
