### PR TITLE
Accept String answer in BasicEvaluationTest instead of ChatResponse

### DIFF
--- a/spring-ai-test/src/main/java/org/springframework/ai/evaluation/BasicEvaluationTest.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/evaluation/BasicEvaluationTest.java
@@ -52,9 +52,8 @@ public class BasicEvaluationTest {
 	@Value("classpath:/prompts/spring/test/evaluation/user-evaluator-message.st")
 	protected Resource userEvaluatorResource;
 
-	protected void evaluateQuestionAndAnswer(String question, ChatResponse response, boolean factBased) {
-		assertThat(response).isNotNull();
-		String answer = response.getResult().getOutput().getContent();
+	protected void evaluateQuestionAndAnswer(String question, String answer, boolean factBased) {
+		assertThat(answer).isNotNull();
 		logger.info("Question: " + question);
 		logger.info("Answer:" + answer);
 		PromptTemplate userPromptTemplate = new PromptTemplate(userEvaluatorResource,


### PR DESCRIPTION
Per a discussion with @markpollack, perhaps the `evaluateQuestionAndAnswer()` method in `BasicEvaluationTest` should accept a `String` instead of a `ChatResponse`. 

By doing so, this enables tests to be written against services whose implementations are based on Spring AI (or potentially any AI/non-AI implementation) and use the evaluation test to evaluate the response, rather than requiring that the test work with a `ChatResponse`, which would require the service to expose how it's implemented.

This PR makes that change.