### PR TITLE
Fix Windows line separation.

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -200,7 +200,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 				Here is the JSON Schema instance your output must adhere to:
 				```%s```
 				""";
-		return String.format(template, this.jsonSchema).replaceAll("\r\n", "\n");
+		return String.format(template, this.jsonSchema);
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -200,7 +200,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 				Here is the JSON Schema instance your output must adhere to:
 				```%s```
 				""";
-		return String.format(template, this.jsonSchema);
+		return String.format(template, this.jsonSchema).replaceAll("\r\n", "\n");
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/assertj/TextBlockAssertion.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/assertj/TextBlockAssertion.java
@@ -1,9 +1,12 @@
 package org.springframework.ai.assertj;
 
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
 import org.assertj.core.api.Assertions;
 
-public class TextBlockAssertion extends AbstractAssert<TextBlockAssertion, String> {
+import java.util.Arrays;
+
+public class TextBlockAssertion extends AbstractCharSequenceAssert<TextBlockAssertion, String> {
 
 	protected TextBlockAssertion(String string) {
 		super(string, TextBlockAssertion.class);
@@ -15,8 +18,22 @@ public class TextBlockAssertion extends AbstractAssert<TextBlockAssertion, Strin
 
 	@Override
 	public TextBlockAssertion isEqualTo(Object expected) {
-		Assertions.assertThat(actual.replaceAll("\r\n", "\n")).isEqualTo(expected);
+		Assertions.assertThat(normalizedEOL(actual)).isEqualTo(normalizedEOL((String) expected));
 		return this;
+	}
+
+	@Override
+	public TextBlockAssertion contains(CharSequence... values) {
+		Assertions.assertThat(normalizedEOL(actual)).contains(normalizedEOL(values));
+		return this;
+	}
+
+	private String normalizedEOL(CharSequence... values) {
+		return Arrays.stream(values).map(CharSequence::toString).map(this::normalizedEOL).reduce("", (a, b) -> a + b);
+	}
+
+	private String normalizedEOL(String line) {
+		return line.replaceAll("\r\n|\r|\n", System.lineSeparator());
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/assertj/TextBlockAssertion.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/assertj/TextBlockAssertion.java
@@ -1,0 +1,22 @@
+package org.springframework.ai.assertj;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+public class TextBlockAssertion extends AbstractAssert<TextBlockAssertion, String> {
+
+	protected TextBlockAssertion(String string) {
+		super(string, TextBlockAssertion.class);
+	}
+
+	public static TextBlockAssertion assertThat(String actual) {
+		return new TextBlockAssertion(actual);
+	}
+
+	@Override
+	public TextBlockAssertion isEqualTo(Object expected) {
+		Assertions.assertThat(actual.replaceAll("\r\n", "\n")).isEqualTo(expected);
+		return this;
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.assertj.TextBlockAssertion;
 import org.springframework.core.ParameterizedTypeReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,78 +112,81 @@ class BeanOutputConverterTest {
 		@Test
 		public void formatClassType() {
 			var converter = new BeanOutputConverter<>(TestClass.class);
-			assertThat(converter.getFormat()).isEqualTo(
-					"""
-							Your response should be in JSON format.
-							Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
-							Do not include markdown code blocks in your response.
-							Remove the ```json markdown from the output.
-							Here is the JSON Schema instance your output must adhere to:
-							```{
-							  "$schema" : "https://json-schema.org/draft/2020-12/schema",
-							  "type" : "object",
-							  "properties" : {
-							    "someString" : {
-							      "type" : "string"
-							    }
-							  }
-							}```
-							""");
+			TextBlockAssertion.assertThat(converter.getFormat())
+				.isEqualTo(
+						"""
+								Your response should be in JSON format.
+								Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
+								Do not include markdown code blocks in your response.
+								Remove the ```json markdown from the output.
+								Here is the JSON Schema instance your output must adhere to:
+								```{
+								  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+								  "type" : "object",
+								  "properties" : {
+								    "someString" : {
+								      "type" : "string"
+								    }
+								  }
+								}```
+								""");
 		}
 
 		@Test
 		public void formatTypeReference() {
 			var converter = new BeanOutputConverter<>(new ParameterizedTypeReference<TestClass>() {
 			});
-			assertThat(converter.getFormat()).isEqualTo(
-					"""
-							Your response should be in JSON format.
-							Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
-							Do not include markdown code blocks in your response.
-							Remove the ```json markdown from the output.
-							Here is the JSON Schema instance your output must adhere to:
-							```{
-							  "$schema" : "https://json-schema.org/draft/2020-12/schema",
-							  "type" : "object",
-							  "properties" : {
-							    "someString" : {
-							      "type" : "string"
-							    }
-							  }
-							}```
-							""");
+			TextBlockAssertion.assertThat(converter.getFormat())
+				.isEqualTo(
+						"""
+								Your response should be in JSON format.
+								Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
+								Do not include markdown code blocks in your response.
+								Remove the ```json markdown from the output.
+								Here is the JSON Schema instance your output must adhere to:
+								```{
+								  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+								  "type" : "object",
+								  "properties" : {
+								    "someString" : {
+								      "type" : "string"
+								    }
+								  }
+								}```
+								""");
 		}
 
 		@Test
 		public void formatTypeReferenceArray() {
 			var converter = new BeanOutputConverter<>(new ParameterizedTypeReference<List<TestClass>>() {
 			});
-			assertThat(converter.getFormat()).isEqualTo(
-					"""
-							Your response should be in JSON format.
-							Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
-							Do not include markdown code blocks in your response.
-							Remove the ```json markdown from the output.
-							Here is the JSON Schema instance your output must adhere to:
-							```{
-							  "$schema" : "https://json-schema.org/draft/2020-12/schema",
-							  "type" : "array",
-							  "items" : {
-							    "type" : "object",
-							    "properties" : {
-							      "someString" : {
-							        "type" : "string"
-							      }
-							    }
-							  }
-							}```
-							""");
+			TextBlockAssertion.assertThat(converter.getFormat())
+				.isEqualTo(
+						"""
+								Your response should be in JSON format.
+								Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
+								Do not include markdown code blocks in your response.
+								Remove the ```json markdown from the output.
+								Here is the JSON Schema instance your output must adhere to:
+								```{
+								  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+								  "type" : "array",
+								  "items" : {
+								    "type" : "object",
+								    "properties" : {
+								      "someString" : {
+								        "type" : "string"
+								      }
+								    }
+								  }
+								}```
+								""");
 		}
 
 		@Test
 		public void formatClassTypeWithAnnotations() {
 			var converter = new BeanOutputConverter<>(TestClassWithJsonAnnotations.class);
-			assertThat(converter.getFormat()).contains("""
+			TextBlockAssertion.assertThat(converter.getFormat()).contains("""
 					```{
 					  "$schema" : "https://json-schema.org/draft/2020-12/schema",
 					  "type" : "object",
@@ -200,7 +204,7 @@ class BeanOutputConverterTest {
 		public void formatTypeReferenceWithAnnotations() {
 			var converter = new BeanOutputConverter<>(new ParameterizedTypeReference<TestClassWithJsonAnnotations>() {
 			});
-			assertThat(converter.getFormat()).contains("""
+			TextBlockAssertion.assertThat(converter.getFormat()).contains("""
 					```{
 					  "$schema" : "https://json-schema.org/draft/2020-12/schema",
 					  "type" : "object",
@@ -221,7 +225,7 @@ class BeanOutputConverterTest {
 			String formatOutput = converter.getFormat();
 
 			// validate that output contains \n line endings
-			assertThat(formatOutput).contains("\n").doesNotContain("\r\n").doesNotContain("\r");
+			TextBlockAssertion.assertThat(formatOutput).contains(System.lineSeparator());
 		}
 
 		@Test
@@ -232,7 +236,7 @@ class BeanOutputConverterTest {
 			String formatOutput = converter.getFormat();
 
 			// validate that output contains \n line endings
-			assertThat(formatOutput).contains("\n").doesNotContain("\r\n").doesNotContain("\r");
+			TextBlockAssertion.assertThat(formatOutput).contains(System.lineSeparator());
 		}
 
 	}

--- a/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
@@ -221,7 +221,7 @@ class BeanOutputConverterTest {
 			String formatOutput = converter.getFormat();
 
 			// validate that output contains \n line endings
-			assertThat(formatOutput).contains(System.lineSeparator()).doesNotContain("\r\n").doesNotContain("\r");
+			assertThat(formatOutput).contains("\n").doesNotContain("\r\n").doesNotContain("\r");
 		}
 
 		@Test
@@ -232,7 +232,7 @@ class BeanOutputConverterTest {
 			String formatOutput = converter.getFormat();
 
 			// validate that output contains \n line endings
-			assertThat(formatOutput).contains(System.lineSeparator()).doesNotContain("\r\n").doesNotContain("\r");
+			assertThat(formatOutput).contains("\n").doesNotContain("\r\n").doesNotContain("\r");
 		}
 
 	}

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.document;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.assertj.TextBlockAssertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,13 +46,14 @@ public class ContentFormatterTests {
 
 		DefaultContentFormatter defaultConfigFormatter = DefaultContentFormatter.defaultConfig();
 
-		assertThat(document.getFormattedContent(defaultConfigFormatter, MetadataMode.ALL)).isEqualTo("""
-				llmKey2: value4
-				embedKey1: value1
-				embedKey2: value2
-				embedKey3: value3
+		TextBlockAssertion.assertThat(document.getFormattedContent(defaultConfigFormatter, MetadataMode.ALL))
+			.isEqualTo("""
+					llmKey2: value4
+					embedKey1: value1
+					embedKey2: value2
+					embedKey3: value3
 
-				The World is Big and Salvation Lurks Around the Corner""");
+					The World is Big and Salvation Lurks Around the Corner""");
 
 		assertThat(document.getFormattedContent(defaultConfigFormatter, MetadataMode.ALL))
 			.isEqualTo(document.getFormattedContent());
@@ -70,7 +72,7 @@ public class ContentFormatterTests {
 			.withMetadataTemplate("Key/Value {key}={value}")
 			.build();
 
-		assertThat(document.getFormattedContent(textFormatter, MetadataMode.EMBED)).isEqualTo("""
+		TextBlockAssertion.assertThat(document.getFormattedContent(textFormatter, MetadataMode.EMBED)).isEqualTo("""
 				Metadata:
 				Key/Value llmKey2=value4
 				Key/Value embedKey1=value1

--- a/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
@@ -17,6 +17,7 @@ package org.springframework.ai.prompt;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.assertj.TextBlockAssertion;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.core.io.InputStreamResource;
@@ -49,7 +50,7 @@ public class PromptTemplateTest {
 		// don't normalize EOLs.
 		// It should be fine on Unix systems. In addition, Git will replace CRLF by LF by
 		// default.
-		assertEqualsWithNormalizedEOLs(expected, message.getContent());
+		TextBlockAssertion.assertThat(expected).isEqualTo(message.getContent());
 
 		PromptTemplate unfilledPromptTemplate = new PromptTemplate(templateString);
 		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(unfilledPromptTemplate::render)
@@ -145,11 +146,6 @@ public class PromptTemplateTest {
 
 		// Rendering the template with a missing key should throw an exception
 		assertThrows(IllegalStateException.class, promptTemplate::render);
-	}
-
-	private static void assertEqualsWithNormalizedEOLs(String expected, String actual) {
-		assertEquals(expected.replaceAll("\\r\\n|\\r|\\n", System.lineSeparator()),
-				actual.replaceAll("\\r\\n|\\r|\\n", System.lineSeparator()));
 	}
 
 }


### PR DESCRIPTION
Bug fix for #595 
* `BeanOutputConverter` - replace all Windows line separation with \n.
* `BeanOutputConverterTest` - explicitly check line separation using \n.
* Introduce `TextBlockAssertion` that asserts text blocks with line separation set to \n.
