### PR TITLE
Add Minimax auto-configuration

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-ai-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -40,3 +40,4 @@ org.springframework.ai.autoconfigure.vectorstore.typesense.TypesenseVectorStoreA
 org.springframework.ai.autoconfigure.vectorstore.opensearch.OpenSearchVectorStoreAutoConfiguration
 org.springframework.ai.autoconfigure.moonshot.MoonshotAutoConfiguration
 org.springframework.ai.autoconfigure.qianfan.QianFanAutoConfiguration
+org.springframework.ai.autoconfigure.minimax.MiniMaxAutoConfiguration


### PR DESCRIPTION
This PR added org.springframework.ai.autoconfigure.minimax.MiniMaxAutoConfiguration to the org.springframework.boot.autoconfigure.AutoConfiguration.imports file to ensure MinimaxService is properly auto-configured.