### PR TITLE
Update selective typo corrections in documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -241,7 +241,7 @@ dependencies {
 TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
 
 TIP: The `spring-ai-ollama` dependency provides access also to the `OllamaEmbeddingModel`.
-For more information about the `OllamaEmbeddingModel` refer to the link:../embeddings/ollama-embeddings.html[Ollama Embedding MOdel] section.
+For more information about the `OllamaEmbeddingModel` refer to the link:../embeddings/ollama-embeddings.html[Ollama Embedding Model] section.
 
 Next, create an `OllamaChatModel` instance and use it to text generations requests:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
@@ -24,7 +24,7 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
-Spring AI provides Spring Boot auto-configuration for the Azure Ollama Embedding Mpdel.
+Spring AI provides Spring Boot auto-configuration for the Azure Ollama Embedding Model.
 To enable it add the following dependency to your Maven `pom.xml` file:
 
 [source,xml]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
@@ -112,7 +112,7 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.pinecone.index-name`| Pinecone index name | -
 |`spring.ai.vectorstore.pinecone.namespace`| Pinecone namespace | -
 |`spring.ai.vectorstore.pinecone.namespace`| Pinecone namespace | -
-|`spring.ai.vectorstore.pinecone.content-field-name`| Pinecone metadata field name used to store the origina text content. | `document_content`
+|`spring.ai.vectorstore.pinecone.content-field-name`| Pinecone metadata field name used to store the original text content. | `document_content`
 |`spring.ai.vectorstore.pinecone.distance-metadata-field-name`| Pinecone metadata field name used to store the computed distance. | `distance`
 |`spring.ai.vectorstore.pinecone.server-side-timeout`|  | 20 sec.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/typesense.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/typesense.adoc
@@ -235,7 +235,7 @@ If all goes well, you should retrieve the document containing the text "Spring A
 
 [NOTE]
 ====
-If you are not retrieveing the documents in the expected order or the search results are not as expected, check the embedding model you are using.
+If you are not retrieving the documents in the expected order or the search results are not as expected, check the embedding model you are using.
 
 Embedding models can have a significant impact on the search results (i.e. make sure if your data is in Spanish to use a Spanish or multilingual embedding model).
 ====


### PR DESCRIPTION
Corrected typographical errors in key documents:
  - `pinecone.adoc` (origina -> original)
    <img width="345" alt="pinecone-docs-fix" src="https://github.com/spring-projects/spring-ai/assets/52046067/9b8ae46e-d9da-4e3e-b763-6943424082f7">
  - `typesense.adoc` (retrieveing -> retrieving)
    <img width="209" alt="typesense-docs-fix" src="https://github.com/spring-projects/spring-ai/assets/52046067/e9e61638-cce5-4896-9f38-371a5eca9588">
  - `ollama-chat.adoc` (revise capital case)
    <img width="415" alt="ollama-chat-docs-fix" src="https://github.com/spring-projects/spring-ai/assets/52046067/2e98c695-9630-491e-8d44-89d78238e149">
  - `ollama-embeddings.adoc` (Mpdel -> Model)
    <img width="442" alt="ollama-embeddings-docs-fix" src="https://github.com/spring-projects/spring-ai/assets/52046067/ff02c494-44fc-4e0a-92f7-f5dfba6935db">

revised #961.
Thanks for reviewing. 