### PR TITLE
Accept response as a String instead of ChatResponse in EvaluationRequest

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/evaluation/EvaluationRequest.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/evaluation/EvaluationRequest.java
@@ -1,6 +1,5 @@
 package org.springframework.ai.evaluation;
 
-import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.model.Content;
 
 import java.util.List;
@@ -20,12 +19,12 @@ public class EvaluationRequest {
 
 	private final List<Content> dataList;
 
-	private final ChatResponse chatResponse;
+	private final String responseContent;
 
-	public EvaluationRequest(String userText, List<Content> dataList, ChatResponse chatResponse) {
+	public EvaluationRequest(String userText, List<Content> dataList, String responseContent) {
 		this.userText = userText;
 		this.dataList = dataList;
-		this.chatResponse = chatResponse;
+		this.responseContent = responseContent;
 	}
 
 	public String getUserText() {
@@ -36,14 +35,14 @@ public class EvaluationRequest {
 		return dataList;
 	}
 
-	public ChatResponse getChatResponse() {
-		return chatResponse;
+	public String getResponseContent() {
+		return responseContent;
 	}
 
 	@Override
 	public String toString() {
 		return "EvaluationRequest{" + "userText='" + userText + '\'' + ", dataList=" + dataList + ", chatResponse="
-				+ chatResponse + '}';
+				+ responseContent + '}';
 	}
 
 	@Override
@@ -53,12 +52,12 @@ public class EvaluationRequest {
 		if (!(o instanceof EvaluationRequest that))
 			return false;
 		return Objects.equals(userText, that.userText) && Objects.equals(dataList, that.dataList)
-				&& Objects.equals(chatResponse, that.chatResponse);
+				&& Objects.equals(responseContent, that.responseContent);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(userText, dataList, chatResponse);
+		return Objects.hash(userText, dataList, responseContent);
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/evaluation/RelevancyEvaluator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/evaluation/RelevancyEvaluator.java
@@ -30,7 +30,7 @@ public class RelevancyEvaluator implements Evaluator {
 	@Override
 	public EvaluationResponse evaluate(EvaluationRequest evaluationRequest) {
 
-		var response = doGetResponse(evaluationRequest);
+		var response = evaluationRequest.getResponseContent();
 		var context = doGetSupportingData(evaluationRequest);
 
 		String evaluationResponse = this.chatClientBuilder.build()
@@ -50,10 +50,6 @@ public class RelevancyEvaluator implements Evaluator {
 		}
 
 		return new EvaluationResponse(passing, score, "", Collections.emptyMap());
-	}
-
-	protected String doGetResponse(EvaluationRequest evaluationRequest) {
-		return evaluationRequest.getChatResponse().getResult().getOutput().getContent();
 	}
 
 	protected String doGetSupportingData(EvaluationRequest evaluationRequest) {


### PR DESCRIPTION
This is similar to https://github.com/spring-projects/spring-ai/pull/948, but applied to `EvaluatorRequest`. Aside from being about to use the evaluator at runtime, this makes it possible to write a test like this:

```
@Test
public void testAsk() {
  String question = "Why is the sky blue?";
  Answer answer = askService.ask(new Question(question));

  RelevancyEvaluator evaluator = new RelevancyEvaluator(chatClientBuilder);
  EvaluationResponse response = evaluator.evaluate(
      new EvaluationRequest(
          question,
          List.of(),
          "Scattering of light causes the sky to be blue."));

  Assertions.assertThat(response.getScore()).isEqualTo(1.0f);
}
```
