### PR TITLE
Bump Tika to avoid PDFBox conflicts

### DIFF
--- a/document-readers/tika-reader/pom.xml
+++ b/document-readers/tika-reader/pom.xml
@@ -21,7 +21,7 @@
 	</scm>
 
 	<properties>
-		<tika.version>2.9.2</tika.version>
+		<tika.version>3.0.0-BETA</tika.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Apache tika 2.x.x wants old version of PDFBox 2.x, bump to tika 3.0.0-BETA that want PDFBox 3.x. With this we can use Tika as PDF reader.