### PR TITLE
Missed call to setEmbedding on specific VectorStore implementations

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -272,7 +272,7 @@ public class MilvusVectorStore implements VectorStore, InitializingBean {
 
 		for (Document document : documents) {
 			List<Double> embedding = this.embeddingModel.embed(document);
-
+			document.setEmbedding(embedding);
 			docIdArray.add(document.getId());
 			// Use a (future) DocumentTextLayoutFormatter instance to extract
 			// the content used to compute the embeddings

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
@@ -166,7 +166,9 @@ public class PgVectorStore implements VectorStore, InitializingBean {
 						var document = documents.get(i);
 						var content = document.getContent();
 						var json = toJson(document.getMetadata());
-						var pGvector = new PGvector(toFloatArray(embeddingModel.embed(document)));
+						var embedding = embeddingModel.embed(document);
+						document.setEmbedding(embedding);
+						var pGvector = new PGvector(toFloatArray(embedding));
 
 						StatementCreatorUtils.setParameterValue(ps, 1, SqlTypeValue.TYPE_UNKNOWN,
 								UUID.fromString(document.getId()));


### PR DESCRIPTION
During the use of spring-ai we detected that the `PgVectorStore` class didn't call the method `setEmbedding` for each document added to the store, we were using it to do some clustering work based on each document added to the store. After check the source code we detected the same problem on `MilvusStore`.

The unique change on this PR is adding the call to `setEmbedding` in each store implementation.

