### PR TITLE
Fix MilvusVectorStore max allowed dimension size to 32768

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -225,8 +225,8 @@ public class MilvusVectorStore implements VectorStore, InitializingBean {
 			 */
 			public Builder withEmbeddingDimension(int newEmbeddingDimension) {
 
-				Assert.isTrue(newEmbeddingDimension >= 1 && newEmbeddingDimension <= 2048,
-						"Dimension has to be withing the boundaries 1 and 2048 (inclusively)");
+				Assert.isTrue(newEmbeddingDimension >= 1 && newEmbeddingDimension <= 32768,
+						"Dimension has to be withing the boundaries 1 and 32768 (inclusively)");
 
 				this.embeddingDimension = newEmbeddingDimension;
 				return this;

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusEmbeddingDimensionsTests.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusEmbeddingDimensionsTests.java
@@ -16,8 +16,11 @@
 package org.springframework.ai.vectorstore;
 
 import io.milvus.client.MilvusServiceClient;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,6 +28,7 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.MilvusVectorStore.MilvusVectorStoreConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -32,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Christian Tzolov
+ * @author Jiwoo Kim
  */
 @ExtendWith(MockitoExtension.class)
 public class MilvusEmbeddingDimensionsTests {
@@ -84,4 +89,15 @@ public class MilvusEmbeddingDimensionsTests {
 		verify(embeddingModel, only()).dimensions();
 	}
 
+	@ParameterizedTest
+	@ValueSource(ints = {0, 32769})
+	public void invalidDimensionsThrowException(final int explicitDimensions) {
+		// when
+		ThrowableAssert.ThrowingCallable actual = () ->  MilvusVectorStoreConfig.builder()
+				.withEmbeddingDimension(explicitDimensions)
+				.build();
+
+		// then
+		assertThatThrownBy(actual).isInstanceOf(IllegalArgumentException.class);
+	}
 }

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusEmbeddingDimensionsTests.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusEmbeddingDimensionsTests.java
@@ -90,14 +90,15 @@ public class MilvusEmbeddingDimensionsTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {0, 32769})
+	@ValueSource(ints = { 0, 32769 })
 	public void invalidDimensionsThrowException(final int explicitDimensions) {
 		// when
-		ThrowableAssert.ThrowingCallable actual = () ->  MilvusVectorStoreConfig.builder()
-				.withEmbeddingDimension(explicitDimensions)
-				.build();
+		ThrowableAssert.ThrowingCallable actual = () -> MilvusVectorStoreConfig.builder()
+			.withEmbeddingDimension(explicitDimensions)
+			.build();
 
 		// then
 		assertThatThrownBy(actual).isInstanceOf(IllegalArgumentException.class);
 	}
+
 }


### PR DESCRIPTION
Milvus Vector store v2.x index provider allows up to 32768 dimensions. [link](https://milvus.io/docs/limitations.md#Dimensions-of-a-vector)
<img width="1199" alt="image" src="https://github.com/spring-projects/spring-ai/assets/60593969/0e1fea83-5f1a-47ca-9030-1715da05d6cc">

Fix that part and write a boundary test!

Issue #781
