### PR TITLE
Extend EmbeddingResponseMetadata with model and usage

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
@@ -22,10 +22,10 @@ import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.EmbeddingItem;
 import com.azure.ai.openai.models.Embeddings;
 import com.azure.ai.openai.models.EmbeddingsOptions;
-import com.azure.ai.openai.models.EmbeddingsUsage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.azure.openai.metadata.AzureOpenAiEmbeddingUsage;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
@@ -105,7 +105,8 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private EmbeddingResponse generateEmbeddingResponse(Embeddings embeddings) {
 		List<Embedding> data = generateEmbeddingList(embeddings.getData());
-		EmbeddingResponseMetadata metadata = generateMetadata(embeddings.getUsage());
+		EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata();
+		metadata.setUsage(AzureOpenAiEmbeddingUsage.from(embeddings.getUsage()));
 		return new EmbeddingResponse(data, metadata);
 	}
 
@@ -119,14 +120,6 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 			data.add(embedding);
 		}
 		return data;
-	}
-
-	private EmbeddingResponseMetadata generateMetadata(EmbeddingsUsage embeddingsUsage) {
-		EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata();
-		// metadata.put("model", model);
-		metadata.put("prompt-tokens", embeddingsUsage.getPromptTokens());
-		metadata.put("total-tokens", embeddingsUsage.getTotalTokens());
-		return metadata;
 	}
 
 	public AzureOpenAiEmbeddingOptions getDefaultOptions() {

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiEmbeddingUsage.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiEmbeddingUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,38 +15,31 @@
  */
 package org.springframework.ai.azure.openai.metadata;
 
-import com.azure.ai.openai.models.ChatCompletions;
-import com.azure.ai.openai.models.CompletionsUsage;
-
+import com.azure.ai.openai.models.EmbeddingsUsage;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.util.Assert;
 
 /**
- * {@link Usage} implementation for {@literal Microsoft Azure OpenAI Service} chat.
+ * {@link Usage} implementation for {@literal Microsoft Azure OpenAI Service} embedding.
  *
- * @author John Blum
- * @see com.azure.ai.openai.models.CompletionsUsage
- * @since 0.7.0
+ * @author Thomas Vitale
+ * @see EmbeddingsUsage
  */
-public class AzureOpenAiUsage implements Usage {
+public class AzureOpenAiEmbeddingUsage implements Usage {
 
-	public static AzureOpenAiUsage from(ChatCompletions chatCompletions) {
-		Assert.notNull(chatCompletions, "ChatCompletions must not be null");
-		return from(chatCompletions.getUsage());
+	public static AzureOpenAiEmbeddingUsage from(EmbeddingsUsage usage) {
+		Assert.notNull(usage, "EmbeddingsUsage must not be null");
+		return new AzureOpenAiEmbeddingUsage(usage);
 	}
 
-	public static AzureOpenAiUsage from(CompletionsUsage usage) {
-		return new AzureOpenAiUsage(usage);
-	}
+	private final EmbeddingsUsage usage;
 
-	private final CompletionsUsage usage;
-
-	public AzureOpenAiUsage(CompletionsUsage usage) {
-		Assert.notNull(usage, "CompletionsUsage must not be null");
+	public AzureOpenAiEmbeddingUsage(EmbeddingsUsage usage) {
+		Assert.notNull(usage, "EmbeddingsUsage must not be null");
 		this.usage = usage;
 	}
 
-	protected CompletionsUsage getUsage() {
+	protected EmbeddingsUsage getUsage() {
 		return this.usage;
 	}
 
@@ -57,7 +50,7 @@ public class AzureOpenAiUsage implements Usage {
 
 	@Override
 	public Long getGenerationTokens() {
-		return (long) getUsage().getCompletionTokens();
+		return 0L;
 	}
 
 	@Override

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
@@ -26,6 +26,7 @@ import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.embedding.EmbeddingResponseMetadata;
 import org.springframework.ai.minimax.api.MiniMaxApi;
+import org.springframework.ai.minimax.metadata.MiniMaxUsage;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.retry.support.RetryTemplate;
@@ -38,6 +39,7 @@ import java.util.List;
  * MiniMax Embedding Model implementation.
  *
  * @author Geng Rong
+ * @author Thomas Vitale
  * @since 1.0.0 M1
  */
 public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
@@ -130,7 +132,8 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 				return new EmbeddingResponse(List.of());
 			}
 
-			var metadata = generateResponseMetadata(apiEmbeddingResponse.model(), apiEmbeddingResponse.totalTokens());
+			var metadata = new EmbeddingResponseMetadata(apiEmbeddingResponse.model(),
+					MiniMaxUsage.from(new MiniMaxApi.Usage(0, 0, apiEmbeddingResponse.totalTokens())));
 
 			List<Embedding> embeddings = new ArrayList<>();
 			for (int i = 0; i < apiEmbeddingResponse.vectors().size(); i++) {
@@ -139,13 +142,6 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 			}
 			return new EmbeddingResponse(embeddings, metadata);
 		});
-	}
-
-	private EmbeddingResponseMetadata generateResponseMetadata(String model, Integer totalTokens) {
-		EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata();
-		metadata.put("model", model);
-		metadata.put("total-tokens", totalTokens);
-		return metadata;
 	}
 
 }

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/metadata/MiniMaxUsage.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/metadata/MiniMaxUsage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.minimax.metadata;
+
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.minimax.api.MiniMaxApi;
+import org.springframework.util.Assert;
+
+/**
+ * {@link Usage} implementation for {@literal MiniMax}.
+ *
+ * @author Thomas Vitale
+ */
+public class MiniMaxUsage implements Usage {
+
+	public static MiniMaxUsage from(MiniMaxApi.Usage usage) {
+		return new MiniMaxUsage(usage);
+	}
+
+	private final MiniMaxApi.Usage usage;
+
+	protected MiniMaxUsage(MiniMaxApi.Usage usage) {
+		Assert.notNull(usage, "MiniMax Usage must not be null");
+		this.usage = usage;
+	}
+
+	protected MiniMaxApi.Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public Long getPromptTokens() {
+		return getUsage().promptTokens().longValue();
+	}
+
+	@Override
+	public Long getGenerationTokens() {
+		return getUsage().completionTokens().longValue();
+	}
+
+	@Override
+	public Long getTotalTokens() {
+		return getUsage().totalTokens().longValue();
+	}
+
+	@Override
+	public String toString() {
+		return getUsage().toString();
+	}
+
+}

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
@@ -29,6 +29,7 @@ import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.embedding.EmbeddingResponseMetadata;
 import org.springframework.ai.mistralai.api.MistralAiApi;
+import org.springframework.ai.mistralai.metadata.MistralAiUsage;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.retry.support.RetryTemplate;
@@ -36,6 +37,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Ricken Bazolo
+ * @author Thomas Vitale
  * @since 0.8.1
  */
 public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
@@ -100,7 +102,8 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 				return new EmbeddingResponse(List.of());
 			}
 
-			var metadata = generateResponseMetadata(apiEmbeddingResponse.model(), apiEmbeddingResponse.usage());
+			var metadata = new EmbeddingResponseMetadata(apiEmbeddingResponse.model(),
+					MistralAiUsage.from(apiEmbeddingResponse.usage()));
 
 			var embeddings = apiEmbeddingResponse.data()
 				.stream()
@@ -116,14 +119,6 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 	public List<Double> embed(Document document) {
 		Assert.notNull(document, "Document must not be null");
 		return this.embed(document.getFormattedContent(this.metadataMode));
-	}
-
-	private EmbeddingResponseMetadata generateResponseMetadata(String model, MistralAiApi.Usage usage) {
-		var metadata = new EmbeddingResponseMetadata();
-		metadata.put("model", model);
-		metadata.put("prompt-tokens", usage.promptTokens());
-		metadata.put("total-tokens", usage.totalTokens());
-		return metadata;
 	}
 
 }

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -31,7 +31,7 @@ import org.springframework.ai.embedding.EmbeddingResponseMetadata;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.openai.api.OpenAiApi.EmbeddingList;
-import org.springframework.ai.openai.api.OpenAiApi.Usage;
+import org.springframework.ai.openai.metadata.OpenAiUsage;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  * Open AI Embedding Model implementation.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
@@ -134,7 +135,8 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 				return new EmbeddingResponse(List.of());
 			}
 
-			var metadata = generateResponseMetadata(apiEmbeddingResponse.model(), apiEmbeddingResponse.usage());
+			var metadata = new EmbeddingResponseMetadata(apiEmbeddingResponse.model(),
+					OpenAiUsage.from(apiEmbeddingResponse.usage()));
 
 			List<Embedding> embeddings = apiEmbeddingResponse.data()
 				.stream()
@@ -144,15 +146,6 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 			return new EmbeddingResponse(embeddings, metadata);
 
 		});
-	}
-
-	private EmbeddingResponseMetadata generateResponseMetadata(String model, Usage usage) {
-		EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata();
-		metadata.put("model", model);
-		metadata.put("prompt-tokens", usage.promptTokens());
-		metadata.put("completion-tokens", usage.completionTokens());
-		metadata.put("total-tokens", usage.totalTokens());
-		return metadata;
 	}
 
 }

--- a/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanEmbeddingModel.java
+++ b/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanEmbeddingModel.java
@@ -28,6 +28,7 @@ import org.springframework.ai.embedding.EmbeddingResponseMetadata;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.qianfan.api.QianFanApi;
 import org.springframework.ai.qianfan.api.QianFanApi.EmbeddingList;
+import org.springframework.ai.qianfan.metadata.QianFanUsage;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
@@ -38,6 +39,7 @@ import java.util.List;
  * QianFan Embedding Client implementation.
  *
  * @author Geng Rong
+ * @author Thomas Vitale
  * @since 1.0
  */
 public class QianFanEmbeddingModel extends AbstractEmbeddingModel {
@@ -135,7 +137,8 @@ public class QianFanEmbeddingModel extends AbstractEmbeddingModel {
 						+ ", message:" + apiEmbeddingResponse.errorNsg());
 			}
 
-			var metadata = generateResponseMetadata(apiEmbeddingResponse.model(), apiEmbeddingResponse.usage());
+			var metadata = new EmbeddingResponseMetadata(apiEmbeddingResponse.model(),
+					QianFanUsage.from(apiEmbeddingResponse.usage()));
 
 			List<Embedding> embeddings = apiEmbeddingResponse.data()
 				.stream()
@@ -144,14 +147,6 @@ public class QianFanEmbeddingModel extends AbstractEmbeddingModel {
 
 			return new EmbeddingResponse(embeddings, metadata);
 		});
-	}
-
-	private EmbeddingResponseMetadata generateResponseMetadata(String model, QianFanApi.Usage usage) {
-		EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata();
-		metadata.put("model", model);
-		metadata.put("prompt-tokens", usage.promptTokens());
-		metadata.put("total-tokens", usage.totalTokens());
-		return metadata;
 	}
 
 }

--- a/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/metadata/QianFanUsage.java
+++ b/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/metadata/QianFanUsage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.qianfan.metadata;
+
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.qianfan.api.QianFanApi;
+import org.springframework.util.Assert;
+
+/**
+ * {@link Usage} implementation for {@literal QianFan}.
+ *
+ * @author Thomas Vitale
+ */
+public class QianFanUsage implements Usage {
+
+	public static QianFanUsage from(QianFanApi.Usage usage) {
+		return new QianFanUsage(usage);
+	}
+
+	private final QianFanApi.Usage usage;
+
+	protected QianFanUsage(QianFanApi.Usage usage) {
+		Assert.notNull(usage, "QianFan Usage must not be null");
+		this.usage = usage;
+	}
+
+	protected QianFanApi.Usage getUsage() {
+		return this.usage;
+	}
+
+	@Override
+	public Long getPromptTokens() {
+		return getUsage().promptTokens().longValue();
+	}
+
+	@Override
+	public Long getGenerationTokens() {
+		return 0L;
+	}
+
+	@Override
+	public Long getTotalTokens() {
+		return getUsage().totalTokens().longValue();
+	}
+
+	@Override
+	public String toString() {
+		return getUsage().toString();
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/embedding/EmbeddingResponse.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/embedding/EmbeddingResponse.java
@@ -29,12 +29,12 @@ public class EmbeddingResponse implements ModelResponse<Embedding> {
 	/**
 	 * Embedding data.
 	 */
-	private List<Embedding> embeddings;
+	private final List<Embedding> embeddings;
 
 	/**
 	 * Embedding metadata.
 	 */
-	private EmbeddingResponseMetadata metadata = new EmbeddingResponseMetadata();
+	private final EmbeddingResponseMetadata metadata;
 
 	/**
 	 * Creates a new {@link EmbeddingResponse} instance with empty metadata.

--- a/spring-ai-core/src/main/java/org/springframework/ai/embedding/EmbeddingResponseMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/embedding/EmbeddingResponseMetadata.java
@@ -15,31 +15,72 @@
  */
 package org.springframework.ai.embedding;
 
+import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.ai.chat.metadata.EmptyUsage;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.model.ResponseMetadata;
 
 /**
+ * Common AI provider metadata returned in an embedding response.
+ *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 public class EmbeddingResponseMetadata extends HashMap<String, Object> implements ResponseMetadata {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
+
+	private String model;
+
+	private Usage usage;
 
 	public EmbeddingResponseMetadata() {
 	}
 
+	@Deprecated(since = "1.0.0-M2", forRemoval = true)
 	public EmbeddingResponseMetadata(int initialCapacity) {
 		super(initialCapacity);
 	}
 
+	@Deprecated(since = "1.0.0-M2", forRemoval = true)
 	public EmbeddingResponseMetadata(int initialCapacity, float loadFactor) {
 		super(initialCapacity, loadFactor);
 	}
 
+	public EmbeddingResponseMetadata(String model, Usage usage) {
+		this.model = model;
+		this.usage = usage;
+	}
+
 	public EmbeddingResponseMetadata(Map<String, ?> metadata) {
 		super(metadata);
+	}
+
+	/**
+	 * The model that handled the request.
+	 */
+	public String getModel() {
+		return this.model != null ? this.model : "";
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	/**
+	 * The AI provider specific metadata on API usage.
+	 * @see Usage
+	 */
+	public Usage getUsage() {
+		return this.usage != null ? this.usage : new EmptyUsage();
+	}
+
+	public void setUsage(Usage usage) {
+		this.usage = usage;
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/image/ImageResponseMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/image/ImageResponseMetadata.java
@@ -15,14 +15,13 @@
  */
 package org.springframework.ai.image;
 
-import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.model.ResponseMetadata;
 
 import java.util.HashMap;
 
 public interface ImageResponseMetadata extends ResponseMetadata {
 
-	static class DefaultImageResponseMetadata extends HashMap<String, Object> implements ImageResponseMetadata {
+	class DefaultImageResponseMetadata extends HashMap<String, Object> implements ImageResponseMetadata {
 
 	}
 


### PR DESCRIPTION
Model name and token usage are common response metadata that are currently passed as free-text key/value pairs. This change make them part of the interface so that they can be programmatically and safely used
for evaluation and observability purposes.

@tzolov This change enables a better solution for https://github.com/spring-projects/spring-ai/issues/953, in particular this part: https://github.com/ThomasVitale/spring-ai/blob/834679a42c089502e2db07419242e96cf8f6bb44/spring-ai-core/src/main/java/org/springframework/ai/embedding/observation/DefaultEmbeddingModelObservationConvention.java#L124

