### PR TITLE
Allow custom metadata in all document reader implementations

### DIFF
--- a/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
+++ b/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/PagePdfDocumentReader.java
@@ -17,8 +17,7 @@ package org.springframework.ai.reader.pdf;
 
 import java.awt.Rectangle;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.pdfbox.pdfparser.PDFParser;
@@ -56,6 +55,8 @@ public class PagePdfDocumentReader implements DocumentReader {
 
 	public static final String METADATA_FILE_NAME = "file_name";
 
+	private final Map<String, Object> customMetadata = new HashMap<>();
+
 	private final PDDocument document;
 
 	private PdfDocumentReaderConfig config;
@@ -88,6 +89,14 @@ public class PagePdfDocumentReader implements DocumentReader {
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	/**
+	 * Metadata associated with all documents created by the loader.
+	 * @return Metadata to be assigned to the output Documents.
+	 */
+	public Map<String, Object> getCustomMetadata() {
+		return this.customMetadata;
 	}
 
 	@Override
@@ -170,6 +179,8 @@ public class PagePdfDocumentReader implements DocumentReader {
 			doc.getMetadata().put(METADATA_END_PAGE_NUMBER, endPageNumber);
 		}
 		doc.getMetadata().put(METADATA_FILE_NAME, this.resourceFileName);
+
+		doc.getMetadata().putAll(customMetadata);
 
 		return doc;
 	}

--- a/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
+++ b/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/ParagraphPdfDocumentReader.java
@@ -16,9 +16,7 @@
 package org.springframework.ai.reader.pdf;
 
 import java.awt.Rectangle;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -60,6 +58,8 @@ public class ParagraphPdfDocumentReader implements DocumentReader {
 	private static final String METADATA_LEVEL = "level";
 
 	private static final String METADATA_FILE_NAME = "file_name";
+
+	private final Map<String, Object> customMetadata = new HashMap<>();
 
 	private final ParagraphManager paragraphTextExtractor;
 
@@ -121,6 +121,14 @@ public class ParagraphPdfDocumentReader implements DocumentReader {
 	}
 
 	/**
+	 * Metadata associated with all documents created by the loader.
+	 * @return Metadata to be assigned to the output Documents.
+	 */
+	public Map<String, Object> getCustomMetadata() {
+		return this.customMetadata;
+	}
+
+	/**
 	 * Reads and processes the PDF document to extract paragraphs.
 	 * @return A list of {@link Document} objects representing paragraphs.
 	 */
@@ -169,6 +177,8 @@ public class ParagraphPdfDocumentReader implements DocumentReader {
 		document.getMetadata().put(METADATA_END_PAGE, to.startPageNumber());
 		document.getMetadata().put(METADATA_LEVEL, from.level());
 		document.getMetadata().put(METADATA_FILE_NAME, this.resourceFileName);
+
+		document.getMetadata().putAll(customMetadata);
 
 		return document;
 	}

--- a/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
+++ b/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.ai.reader.pdf;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +25,8 @@ import org.springframework.ai.reader.ExtractedTextFormatter;
 import org.springframework.ai.reader.pdf.config.PdfDocumentReaderConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Christian Tzolov
@@ -46,14 +48,22 @@ public class PagePdfDocumentReaderTests {
 					.withPagesPerDocument(1)
 					.build());
 
+		pdfReader.getCustomMetadata().put("CUSTOM_METADATA_KEY", "CUSTOM_METADATA_VALUE");
+
 		List<Document> docs = pdfReader.get();
 
 		assertThat(docs).hasSize(4);
 
 		String allText = docs.stream().map(d -> d.getContent()).collect(Collectors.joining(System.lineSeparator()));
+		List<Map<String, Object>> metadataList = docs.stream().map(Document::getMetadata).toList();
 
 		assertThat(allText).doesNotContain(
 				List.of("Page  1 of 4", "Page  2 of 4", "Page  3 of 4", "Page  4 of 4", "PDF  Bookmark   Sample"));
+
+		for (Map<String, Object> metadata : metadataList) {
+			assertTrue(metadata.containsKey("CUSTOM_METADATA_KEY"));
+			assertEquals("CUSTOM_METADATA_VALUE", metadata.get("CUSTOM_METADATA_KEY"));
+		}
 	}
 
 }

--- a/document-readers/tika-reader/src/main/java/org/springframework/ai/reader/tika/TikaDocumentReader.java
+++ b/document-readers/tika-reader/src/main/java/org/springframework/ai/reader/tika/TikaDocumentReader.java
@@ -17,8 +17,7 @@ package org.springframework.ai.reader.tika;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.AutoDetectParser;
@@ -84,6 +83,8 @@ public class TikaDocumentReader implements DocumentReader {
 	 */
 	private final ExtractedTextFormatter textFormatter;
 
+	private final Map<String, Object> customMetadata = new HashMap<>();
+
 	/**
 	 * Constructor initializing the reader with a given resource URL.
 	 * @param resourceUrl URL to the resource
@@ -137,6 +138,14 @@ public class TikaDocumentReader implements DocumentReader {
 	}
 
 	/**
+	 * Metadata associated with all documents created by the loader.
+	 * @return Metadata to be assigned to the output Documents.
+	 */
+	public Map<String, Object> getCustomMetadata() {
+		return this.customMetadata;
+	}
+
+	/**
 	 * Extracts and returns the list of documents from the resource.
 	 * @return List of extracted {@link Document}
 	 */
@@ -161,6 +170,7 @@ public class TikaDocumentReader implements DocumentReader {
 		docText = this.textFormatter.format(docText);
 		Document doc = new Document(docText);
 		doc.getMetadata().put(METADATA_SOURCE, resourceName());
+		doc.getMetadata().putAll(customMetadata);
 		return doc;
 	}
 

--- a/document-readers/tika-reader/src/test/java/org/springframework/ai/reader/tika/TikaDocumentReaderTests.java
+++ b/document-readers/tika-reader/src/test/java/org/springframework/ai/reader/tika/TikaDocumentReaderTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author Christian Tzolov
@@ -43,6 +44,30 @@ public class TikaDocumentReaderTests {
 		assertThat(doc.getMetadata()).containsKeys(TikaDocumentReader.METADATA_SOURCE);
 		assertThat(doc.getMetadata().get(TikaDocumentReader.METADATA_SOURCE)).isEqualTo(resourceName);
 		assertThat(doc.getContent()).contains(contentSnipped);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"classpath:/word-sample.docx,word-sample.docx,Two kinds of links are possible, those that refer to an external website",
+			"classpath:/word-sample.doc,word-sample.doc,The limited permissions granted above are perpetual and will not be revoked by OASIS",
+			"classpath:/sample2.pdf,sample2.pdf,Consult doc/pdftex/manual.pdf from your tetex distribution for more",
+			"classpath:/sample.ppt,sample.ppt,Sed ipsum tortor, fringilla a consectetur eget, cursus posuere sem.",
+			"classpath:/sample.pptx,sample.pptx,Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			"https://github.com/spring-projects/spring-ai/,https://github.com/spring-projects/spring-ai/,An Application Framework for AI Engineering" })
+	public void testCustomMetadata(String resourceUri, String resourceName, String contentSnipped) {
+
+		var reader = new TikaDocumentReader(resourceUri);
+		reader.getCustomMetadata().put("CUSTOM_METADATA_KEY", "CUSTOM_METADATA_VALUE");
+
+		var docs = reader.get();
+
+		assertThat(docs).hasSize(1);
+
+		var doc = docs.get(0);
+
+		assertThat(doc.getMetadata()).containsKeys(TikaDocumentReader.METADATA_SOURCE);
+		assertThat(doc.getMetadata().get(TikaDocumentReader.METADATA_SOURCE)).isEqualTo(resourceName);
+		assertEquals("CUSTOM_METADATA_VALUE", doc.getMetadata().get("CUSTOM_METADATA_KEY"));
 	}
 
 }


### PR DESCRIPTION
Not all implementations of DocumentReader allow adding metadata to a document during the document loader step. Only TextReader and JsonReader allow it, using different methods.

I have added support for custom metadata in the following implementations, using the same structure as in the TextReader implementation:

- PagePdfDocumentReader
- ParagraphPdfDocumentReader
- TikaDocumentReader

I have updated the tests as well. However, the ParagraphPdfDocumentReader currently only checks for a negative case because I don't have any PDF with the correct license and structure to create a positive case.