### PR TITLE
Fix leaked dependencies in autoconfigure module

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -25,6 +25,7 @@
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
 			<version>${protobuf-java.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- production dependencies -->
@@ -91,6 +92,7 @@
 			<groupId>io.netty</groupId>
 			<artifactId>netty-codec-http2</artifactId>
 			<version>4.1.100.Final</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Milvus Vector Store -->
@@ -204,6 +206,7 @@
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
 			<version>5.1.0</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Vertex AI PaLM2 -->
@@ -370,15 +373,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<version>${postgresql.version}</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
The `spring-ai-spring-boot-autoconfigure` module had a few dependencies that were included in the final JAR instead of being marked as optional (it's the starter dependency that is supposed to include compile-scope dependencies when needed).

Also, the PostgreSQL dependency was duplicated.
