### PR TITLE
Improve new function calling strategy

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -35,7 +35,6 @@ import org.springframework.ai.model.function.FunctionCallbackContext;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletion;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletion.Choice;
-import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionFinishReason;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.ChatCompletionFunction;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.MediaContent;
@@ -79,7 +78,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see StreamingChatModel
  * @see OpenAiApi
  */
-public class OpenAiChatModel extends AbstractToolCallSupport<ChatCompletion> implements ChatModel {
+public class OpenAiChatModel extends AbstractToolCallSupport implements ChatModel {
 
 	private static final Logger logger = LoggerFactory.getLogger(OpenAiChatModel.class);
 
@@ -143,51 +142,45 @@ public class OpenAiChatModel extends AbstractToolCallSupport<ChatCompletion> imp
 
 		ChatCompletionRequest request = createRequest(prompt, false);
 
-		return this.retryTemplate.execute(ctx -> {
+		ResponseEntity<ChatCompletion> completionEntity = this.retryTemplate
+			.execute(ctx -> this.openAiApi.chatCompletionEntity(request));
 
-			ResponseEntity<ChatCompletion> completionEntity = this.openAiApi.chatCompletionEntity(request);
+		var chatCompletion = completionEntity.getBody();
 
-			var chatCompletion = completionEntity.getBody();
+		if (chatCompletion == null) {
+			logger.warn("No chat completion returned for prompt: {}", prompt);
+			return new ChatResponse(List.of());
+		}
 
-			if (chatCompletion == null) {
-				logger.warn("No chat completion returned for prompt: {}", prompt);
-				return new ChatResponse(List.of());
-			}
+		RateLimit rateLimits = OpenAiResponseHeaderExtractor.extractAiResponseHeaders(completionEntity);
 
-			if (isToolFunctionCall(chatCompletion)) {
-				List<Message> toolCallMessageConversation = this.handleToolCallRequests(prompt.getInstructions(),
-						chatCompletion);
-				// Recursively call the call method with the tool call message
-				// conversation that contains the call responses.
+		List<Choice> choices = chatCompletion.choices();
+		if (choices == null) {
+			logger.warn("No choices returned for prompt: {}", prompt);
+			return new ChatResponse(List.of());
+		}
 
-				return this.call(new Prompt(toolCallMessageConversation, prompt.getOptions()));
-			}
+		List<Generation> generations = choices.stream().map(choice -> {
+			// @formatter:off
+			Map<String, Object> metadata = Map.of(
+					"id", chatCompletion.id(),
+					"role", choice.message().role() != null ? choice.message().role().name() : "",
+					"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "");
+			// @formatter:on
+			return buildGeneration(choice, metadata);
+		}).toList();
 
-			// Non function calling.
-			RateLimit rateLimits = OpenAiResponseHeaderExtractor.extractAiResponseHeaders(completionEntity);
+		ChatResponse chatResponse = new ChatResponse(generations,
+				OpenAiChatResponseMetadata.from(completionEntity.getBody()).withRateLimit(rateLimits));
 
-			List<Choice> choices = chatCompletion.choices();
-			if (choices == null) {
-				logger.warn("No choices returned for prompt: {}", prompt);
-				return new ChatResponse(List.of());
-			}
+		if (isToolCall(chatResponse, OpenAiApi.ChatCompletionFinishReason.TOOL_CALLS.name())) {
+			var toolCallConversation = handleToolCalls(prompt, chatResponse);
+			// Recursively call the call method with the tool call message
+			// conversation that contains the call responses.
+			return this.call(new Prompt(toolCallConversation, prompt.getOptions()));
+		}
 
-			List<Generation> generations = choices.stream().map(choice -> {
-				Map<String, Object> metadata = Map.of("id", chatCompletion.id(), "role",
-						choice.message().role() != null ? choice.message().role().name() : "", "finishReason",
-						choice.finishReason() != null ? choice.finishReason().name() : "");
-				var generation = new Generation(choice.message().content(), metadata);
-				if (choice.finishReason() != null) {
-					generation = generation
-						.withGenerationMetadata(ChatGenerationMetadata.from(choice.finishReason().name(), null));
-				}
-				return generation;
-
-			}).toList();
-
-			return new ChatResponse(generations,
-					OpenAiChatResponseMetadata.from(completionEntity.getBody()).withRateLimit(rateLimits));
-		});
+		return chatResponse;
 	}
 
 	@Override
@@ -195,83 +188,88 @@ public class OpenAiChatModel extends AbstractToolCallSupport<ChatCompletion> imp
 
 		ChatCompletionRequest request = createRequest(prompt, true);
 
-		return this.retryTemplate.execute(ctx -> {
+		Flux<OpenAiApi.ChatCompletionChunk> completionChunks = this.retryTemplate
+			.execute(ctx -> this.openAiApi.chatCompletionStream(request));
 
-			Flux<OpenAiApi.ChatCompletionChunk> completionChunks = this.openAiApi.chatCompletionStream(request);
+		// For chunked responses, only the first chunk contains the choice role.
+		// The rest of the chunks with same ID share the same role.
+		ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
 
-			// For chunked responses, only the first chunk contains the choice role.
-			// The rest of the chunks with same ID share the same role.
-			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
+		// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
+		// the function call handling logic.
+		Flux<ChatResponse> chatResponse = completionChunks.map(this::chunkToChatCompletion)
+			.switchMap(chatCompletion -> Mono.just(chatCompletion).map(chatCompletion2 -> {
+				try {
+					@SuppressWarnings("null")
+					String id = chatCompletion2.id();
 
-			// Convert the ChatCompletionChunk into a ChatCompletion to be able to reuse
-			// the function call handling logic.
-			return completionChunks.map(this::chunkToChatCompletion).switchMap(chatCompletion -> {
+					List<Generation> generations = chatCompletion2.choices().stream().map(choice -> {
+						if (choice.message().role() != null) {
+							roleMap.putIfAbsent(id, choice.message().role().name());
+						}
+			// @formatter:off
+						Map<String, Object> metadata = Map.of(
+								"id", chatCompletion2.id(),
+								"role", roleMap.getOrDefault(id, ""),
+								"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "");
+						// @formatter:on
+						return buildGeneration(choice, metadata);
+					}).toList();
 
-				if (this.isToolFunctionCall(chatCompletion)) {
-					var toolCallMessageConversation = this.handleToolCallRequests(prompt.getInstructions(),
-							chatCompletion);
-					// Recursively call the stream method with the tool call message
-					// conversation that contains the call responses.
-					return this.stream(new Prompt(toolCallMessageConversation, prompt.getOptions()));
+					if (chatCompletion2.usage() != null) {
+						return new ChatResponse(generations, OpenAiChatResponseMetadata.from(chatCompletion2));
+					}
+					else {
+						return new ChatResponse(generations);
+					}
+				}
+				catch (Exception e) {
+					logger.error("Error processing chat completion", e);
+					return new ChatResponse(List.of());
 				}
 
-				// Non function calling.
-				return Mono.just(chatCompletion).map(chatCompletion2 -> {
-					try {
-						@SuppressWarnings("null")
-						String id = chatCompletion2.id();
+			}));
 
-						List<Generation> generations = chatCompletion2.choices().stream().map(choice -> {
-							if (choice.message().role() != null) {
-								roleMap.putIfAbsent(id, choice.message().role().name());
-							}
-							String finish = (choice.finishReason() != null ? choice.finishReason().name() : "");
-							var generation = new Generation(choice.message().content(),
-									Map.of("id", id, "role", roleMap.getOrDefault(id, ""), "finishReason", finish));
-							if (choice.finishReason() != null) {
-								generation = generation.withGenerationMetadata(
-										ChatGenerationMetadata.from(choice.finishReason().name(), null));
-							}
-							return generation;
-						}).toList();
-
-						if (chatCompletion2.usage() != null) {
-							return new ChatResponse(generations, OpenAiChatResponseMetadata.from(chatCompletion2));
-						}
-						else {
-							return new ChatResponse(generations);
-						}
-					}
-					catch (Exception e) {
-						logger.error("Error processing chat completion", e);
-						return new ChatResponse(List.of());
-					}
-
-				});
-			});
+		return chatResponse.flatMap(response -> {
+			if (isToolCall(response, OpenAiApi.ChatCompletionFinishReason.TOOL_CALLS.name())) {
+				var toolCallConversation = handleToolCalls(prompt, response);
+				// Recursively call the stream method with the tool call message
+				// conversation that contains the call responses.
+				return this.stream(new Prompt(toolCallConversation, prompt.getOptions()));
+			}
+			else {
+				return Flux.just(response);
+			}
 		});
 	}
 
-	private List<Message> handleToolCallRequests(List<Message> previousMessages, ChatCompletion chatCompletion) {
+	private static Generation buildGeneration(Choice choice, Map<String, Object> metadata) {
+		List<AssistantMessage.ToolCall> toolCalls = choice.message().toolCalls() == null ? List.of()
+				: choice.message()
+					.toolCalls()
+					.stream()
+					.map(toolCall -> new AssistantMessage.ToolCall(toolCall.id(), "function",
+							toolCall.function().name(), toolCall.function().arguments()))
+					.toList();
+		var generation = new Generation(choice.message().content(), metadata, toolCalls);
+		if (choice.finishReason() != null) {
+			generation = generation
+				.withGenerationMetadata(ChatGenerationMetadata.from(choice.finishReason().name(), null));
+		}
+		return generation;
+	}
 
-		ChatCompletionMessage nativeAssistantMessage = this.extractAssistantMessage(chatCompletion);
+	private List<Message> handleToolCalls(Prompt prompt, ChatResponse response) {
+		var assistantMessage = response.getResult().getOutput();
+		var toolMessageResponses = this.executeFunctions(assistantMessage);
+		return this.buildToolCallConversation(prompt.getInstructions(), assistantMessage, toolMessageResponses);
+	}
 
-		List<AssistantMessage.ToolCall> assistantToolCalls = nativeAssistantMessage.toolCalls()
-			.stream()
-			.map(toolCall -> new AssistantMessage.ToolCall(toolCall.id(), "function", toolCall.function().name(),
-					toolCall.function().arguments()))
-			.toList();
-
-		AssistantMessage assistantMessage = new AssistantMessage(nativeAssistantMessage.content(), Map.of(),
-				assistantToolCalls);
-
-		List<ToolResponseMessage> toolResponseMessages = this.executeFuncitons(assistantMessage);
-
-		// History
+	private List<Message> buildToolCallConversation(List<Message> previousMessages, AssistantMessage assistantMessage,
+			List<ToolResponseMessage> toolResponseMessages) {
 		List<Message> messages = new ArrayList<>(previousMessages);
 		messages.add(assistantMessage);
 		messages.addAll(toolResponseMessages);
-
 		return messages;
 	}
 
@@ -407,22 +405,6 @@ public class OpenAiChatModel extends AbstractToolCallSupport<ChatCompletion> imp
 					functionCallback.getName(), functionCallback.getInputTypeSchema());
 			return new OpenAiApi.FunctionTool(function);
 		}).toList();
-	}
-
-	@Override
-	protected boolean isToolFunctionCall(ChatCompletion chatCompletion) {
-		if (chatCompletion == null) {
-			return false;
-		}
-
-		var choices = chatCompletion.choices();
-		if (CollectionUtils.isEmpty(choices)) {
-			return false;
-		}
-
-		var choice = choices.get(0);
-		return !CollectionUtils.isEmpty(choice.message().toolCalls())
-				&& choice.finishReason() == ChatCompletionFinishReason.TOOL_CALLS;
 	}
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/ToolResponseMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/ToolResponseMessage.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * The FunctionMessage class represents a message with a function content in a chat
+ * The ToolResponseMessage class represents a message with a function content in a chat
  * application.
  *
  * @author Christian Tzolov
@@ -70,7 +70,7 @@ public class ToolResponseMessage extends AbstractMessage {
 
 	@Override
 	public String toString() {
-		return "FunctionMessage [id=" + id + ", name=" + name + ", messageType=" + messageType + ", textContent="
+		return "ToolResponseMessage [id=" + id + ", name=" + name + ", messageType=" + messageType + ", textContent="
 				+ textContent + "]";
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/Generation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/Generation.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.chat.model;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -22,6 +23,7 @@ import org.springframework.ai.model.ModelResult;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Represents a response returned by the AI.
@@ -37,7 +39,14 @@ public class Generation implements ModelResult<AssistantMessage> {
 	}
 
 	public Generation(String text, Map<String, Object> properties) {
-		this.assistantMessage = new AssistantMessage(text, properties);
+		this(text, properties, List.of());
+	}
+
+	public Generation(String text, Map<String, Object> properties, List<AssistantMessage.ToolCall> toolCalls) {
+		if (CollectionUtils.isEmpty(toolCalls)) {
+			this.assistantMessage = new AssistantMessage(text, properties);
+		}
+		this.assistantMessage = new AssistantMessage(text, properties, toolCalls);
 	}
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractToolCallSupport.java
@@ -24,18 +24,20 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
 /**
  * Abstract base class for tool call support. Provides functionality for handling function
  * callbacks and executing functions.
  *
- * @param <TRes> The response type of the tool call.
  * @author Christian Tzolov
  * @author Grogdunn
+ * @author Thomas Vitale
  * @since 1.0.0
  */
-public abstract class AbstractToolCallSupport<TRes> {
+public abstract class AbstractToolCallSupport {
 
 	protected final static boolean IS_RUNTIME_CALL = true;
 
@@ -127,7 +129,7 @@ public abstract class AbstractToolCallSupport<TRes> {
 		return retrievedFunctionCallbacks;
 	}
 
-	protected List<ToolResponseMessage> executeFuncitons(AssistantMessage assistantMessage) {
+	protected List<ToolResponseMessage> executeFunctions(AssistantMessage assistantMessage) {
 
 		List<ToolResponseMessage> toolResponseMessages = new ArrayList<>();
 
@@ -149,6 +151,21 @@ public abstract class AbstractToolCallSupport<TRes> {
 
 	}
 
-	abstract protected boolean isToolFunctionCall(TRes response);
+	protected boolean isToolCall(ChatResponse chatResponse, String toolCallFinishReason) {
+		Assert.hasText(toolCallFinishReason, "toolCallFinishReason cannot be null or empty");
+
+		if (chatResponse == null) {
+			return false;
+		}
+
+		var generations = chatResponse.getResults();
+		if (CollectionUtils.isEmpty(generations)) {
+			return false;
+		}
+
+		var generation = generations.get(0);
+		return !CollectionUtils.isEmpty(generation.getOutput().getToolCalls())
+				&& toolCallFinishReason.equalsIgnoreCase(generation.getMetadata().getFinishReason());
+	}
 
 }


### PR DESCRIPTION
Small implementation changes to the function calling mechanism. Right now, in case there is a “tool call” request from a model, we directly do the recursive call. What I suggest in the PR is actually building the final `ChatResponse` object first. Then, we can return it directly if there’s no tool call. If there is, we trigger the recursive call.

With this change, we can correctly handle the observation scopes, making sure each observation contains the correct request/response pair in the context.

We can also generalize a bit more the function calling logic. Working directly with a `ChatResponse` object, I managed to remove the need for making the abstract class generic, moving even more logic up and reducing the amount of code that is provider-specific.

One more thing I changed is wrapping only the call to OpenAI within `RetryTemplate`. Right now, it wraps the entire implementation, catching many different exceptions not related to the HTTP call, and retrying even though it shouldn’t (impacting both runtime code but also tests). I would suggest progressively making this change for all implementations. Besides reaching a more predictable behaviour in terms of retries, it helps making the code more readable without unnecessary nesting, especially after delivering the observability changes (which would add one more nested level).