### PR TITLE
Fix not-null assertion in PdfDocumentReaderConfig

### DIFF
--- a/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/config/PdfDocumentReaderConfig.java
+++ b/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/config/PdfDocumentReaderConfig.java
@@ -86,7 +86,7 @@ public class PdfDocumentReaderConfig {
 		 */
 		public PdfDocumentReaderConfig.Builder withPageExtractedTextFormatter(
 				ExtractedTextFormatter pageExtractedTextFormatter) {
-			Assert.notNull(pagesPerDocument >= 0, "PageExtractedTextFormatter must not be null.");
+			Assert.notNull(pageExtractedTextFormatter, "PageExtractedTextFormatter must not be null.");
 			this.pageExtractedTextFormatter = pageExtractedTextFormatter;
 			return this;
 		}


### PR DESCRIPTION

This appears to be a copy-and-paste issue.