### PR TITLE
Support actual streaming for AzureAI 

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -44,7 +44,9 @@ import com.azure.core.util.IterableStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.azure.openai.metadata.AzureOpenAiChatResponseMetadata;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.PromptMetadata;
 import org.springframework.ai.chat.metadata.PromptMetadata.PromptFilterMetadata;
@@ -59,13 +61,9 @@ import org.springframework.ai.model.function.FunctionCallbackContext;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -104,9 +102,9 @@ public class AzureOpenAiChatModel extends
 	public AzureOpenAiChatModel(OpenAIClient microsoftOpenAiClient) {
 		this(microsoftOpenAiClient,
 				AzureOpenAiChatOptions.builder()
-					.withDeploymentName(DEFAULT_DEPLOYMENT_NAME)
-					.withTemperature(DEFAULT_TEMPERATURE)
-					.build());
+						.withDeploymentName(DEFAULT_DEPLOYMENT_NAME)
+						.withTemperature(DEFAULT_TEMPERATURE)
+						.build());
 	}
 
 	public AzureOpenAiChatModel(OpenAIClient microsoftOpenAiClient, AzureOpenAiChatOptions options) {
@@ -114,7 +112,7 @@ public class AzureOpenAiChatModel extends
 	}
 
 	public AzureOpenAiChatModel(OpenAIClient microsoftOpenAiClient, AzureOpenAiChatOptions options,
-			FunctionCallbackContext functionCallbackContext) {
+								FunctionCallbackContext functionCallbackContext) {
 		super(functionCallbackContext);
 		Assert.notNull(microsoftOpenAiClient, "com.azure.ai.openai.OpenAIClient must not be null");
 		Assert.notNull(options, "AzureOpenAiChatOptions must not be null");
@@ -148,9 +146,9 @@ public class AzureOpenAiChatModel extends
 		logger.trace("Azure ChatCompletions: {}", chatCompletions);
 
 		List<Generation> generations = nullSafeList(chatCompletions.getChoices()).stream()
-			.map(choice -> new Generation(choice.getMessage().getContent())
-				.withGenerationMetadata(generateChoiceMetadata(choice)))
-			.toList();
+				.map(choice -> new Generation(choice.getMessage().getContent())
+						.withGenerationMetadata(generateChoiceMetadata(choice)))
+				.toList();
 
 		PromptMetadata promptFilterMetadata = generatePromptMetadata(chatCompletions);
 
@@ -160,49 +158,79 @@ public class AzureOpenAiChatModel extends
 
 	@Override
 	public Flux<ChatResponse> stream(Prompt prompt) {
-
 		ChatCompletionsOptions options = toAzureChatCompletionsOptions(prompt);
+
+		// we have to map with a custom function to handle the tool call requests
+		// due to the existing bugs in the azure api (see comments in streamWithAzureApi)
+		// we have to recursively call this specific method for tool calls instead of using the one from the AbstractFunctionCallSupport
+		return streamWithAzureOpenAi(options).flatMapIterable(ChatCompletions::getChoices)
+				.map(choice -> {
+					var content = Optional.ofNullable(choice.getMessage()).orElse(choice.getDelta()).getContent();
+					var generation = new Generation(content).withGenerationMetadata(generateChoiceMetadata(choice));
+					return new ChatResponse(List.of(generation));
+				});
+	}
+
+	private Flux<ChatCompletions> streamWithAzureOpenAi(ChatCompletionsOptions options) {
 		options.setStream(true);
 
 		IterableStream<ChatCompletions> chatCompletionsStream = this.openAIClient
-			.getChatCompletionsStream(options.getModel(), options);
+				.getChatCompletionsStream(options.getModel(), options);
 
 		Flux<ChatCompletions> chatCompletionsFlux = Flux.fromIterable(chatCompletionsStream);
 
 		final var isFunctionCall = new AtomicBoolean(false);
 		final var accessibleChatCompletionsFlux = chatCompletionsFlux
-			// Note: the first chat completions can be ignored when using Azure OpenAI
-			// service which is a known service bug.
-			.skip(1)
-			.map(chatCompletions -> {
-				final var toolCalls = chatCompletions.getChoices().get(0).getDelta().getToolCalls();
-				isFunctionCall.set(toolCalls != null && !toolCalls.isEmpty());
-				return chatCompletions;
-			})
-			.windowUntil(chatCompletions -> {
-				if (isFunctionCall.get() && chatCompletions.getChoices()
-					.get(0)
-					.getFinishReason() == CompletionsFinishReason.TOOL_CALLS) {
-					isFunctionCall.set(false);
-					return true;
-				}
-				return !isFunctionCall.get();
-			})
-			.concatMapIterable(window -> {
-				final var reduce = window.reduce(MergeUtils.emptyChatCompletions(), MergeUtils::mergeChatCompletions);
-				return List.of(reduce);
-			})
-			.flatMap(mono -> mono);
+				// Note: the first chat completions can be ignored when using Azure OpenAI
+				// service which is a known service bug.
+				.skip(1)
+				.map(chatCompletions -> {
+					final var toolCalls = chatCompletions.getChoices().get(0).getDelta().getToolCalls();
+					isFunctionCall.set(toolCalls != null && !toolCalls.isEmpty());
+					return chatCompletions;
+				})
+				.windowUntil(chatCompletions -> {
+					if (isFunctionCall.get() && chatCompletions.getChoices()
+							.get(0)
+							.getFinishReason() == CompletionsFinishReason.TOOL_CALLS) {
+						isFunctionCall.set(false);
+						return true;
+					}
+					return !isFunctionCall.get();
+				})
+				.concatMapIterable(window -> {
+					final var reduce = window.reduce(MergeUtils.emptyChatCompletions(), MergeUtils::mergeChatCompletions);
+					return List.of(reduce);
+				})
+				.flatMap(mono -> mono);
 		return accessibleChatCompletionsFlux
-			.switchMap(accessibleChatCompletions -> handleFunctionCallOrReturnStream(options,
-					Flux.just(accessibleChatCompletions)))
-			.flatMapIterable(ChatCompletions::getChoices)
-			.map(choice -> {
-				var content = Optional.ofNullable(choice.getMessage()).orElse(choice.getDelta()).getContent();
-				var generation = new Generation(content).withGenerationMetadata(generateChoiceMetadata(choice));
-				return new ChatResponse(List.of(generation));
-			});
+				.switchMap(accessibleChatCompletions -> handleToolCallRequests(options,
+						Flux.just(accessibleChatCompletions)));
 
+	}
+
+	private Flux<ChatCompletions> handleToolCallRequests(ChatCompletionsOptions request, Flux<ChatCompletions> response) {
+		return response.switchMap(resp -> {
+			if (!this.isToolFunctionCall(resp)) {
+				return Mono.just(resp);
+			}
+
+			// The chat completion tool call requires the complete conversation
+			// history. Including the initial user message.
+			List<ChatRequestMessage> conversationHistory = new ArrayList<>();
+
+			conversationHistory.addAll(this.doGetUserMessages(request));
+
+			ChatRequestMessage responseMessage = this.doGetToolResponseMessage(resp);
+
+			// Add the assistant response to the message conversation history.
+			conversationHistory.add(responseMessage);
+
+			ChatCompletionsOptions newRequest = this.doCreateToolResponseRequest(request, responseMessage, conversationHistory);
+
+			// recursively go backwards and call our stream again (including all bug fixes / workarounds for the azure api)
+			return this.streamWithAzureOpenAi(newRequest);
+		});
 	}
 
 	/**
@@ -213,9 +241,9 @@ public class AzureOpenAiChatModel extends
 		Set<String> functionsForThisRequest = new HashSet<>();
 
 		List<ChatRequestMessage> azureMessages = prompt.getInstructions()
-			.stream()
-			.map(this::fromSpringAiMessage)
-			.toList();
+				.stream()
+				.map(this::fromSpringAiMessage)
+				.toList();
 
 		ChatCompletionsOptions options = new ChatCompletionsOptions(azureMessages);
 
@@ -250,8 +278,8 @@ public class AzureOpenAiChatModel extends
 		if (!CollectionUtils.isEmpty(functionsForThisRequest)) {
 			List<ChatCompletionsFunctionToolDefinition> tools = this.getFunctionTools(functionsForThisRequest);
 			List<ChatCompletionsToolDefinition> tools2 = tools.stream()
-				.map(t -> ((ChatCompletionsToolDefinition) t))
-				.toList();
+					.map(t -> ((ChatCompletionsToolDefinition) t))
+					.toList();
 			options.setTools(tools2);
 		}
 
@@ -264,7 +292,7 @@ public class AzureOpenAiChatModel extends
 			FunctionDefinition functionDefinition = new FunctionDefinition(functionCallback.getName());
 			functionDefinition.setDescription(functionCallback.getDescription());
 			BinaryData parameters = BinaryData
-				.fromObject(ModelOptionsUtils.jsonToMap(functionCallback.getInputTypeSchema()));
+					.fromObject(ModelOptionsUtils.jsonToMap(functionCallback.getInputTypeSchema()));
 			functionDefinition.setParameters(parameters);
 			return new ChatCompletionsFunctionToolDefinition(functionDefinition);
 		}).toList();
@@ -279,10 +307,10 @@ public class AzureOpenAiChatModel extends
 				items.add(new ChatMessageTextContentItem(message.getContent()));
 				if (!CollectionUtils.isEmpty(message.getMedia())) {
 					items.addAll(message.getMedia()
-						.stream()
-						.map(media -> new ChatMessageImageContentItem(
-								new ChatMessageImageUrl(media.getData().toString())))
-						.toList());
+							.stream()
+							.map(media -> new ChatMessageImageContentItem(
+									new ChatMessageImageUrl(media.getData().toString())))
+							.toList());
 				}
 				return new ChatRequestUserMessage(items);
 			case SYSTEM:
@@ -305,9 +333,9 @@ public class AzureOpenAiChatModel extends
 				chatCompletions.getPromptFilterResults());
 
 		return PromptMetadata.of(promptFilterResults.stream()
-			.map(promptFilterResult -> PromptFilterMetadata.from(promptFilterResult.getPromptIndex(),
-					promptFilterResult.getContentFilterResults()))
-			.toList());
+				.map(promptFilterResult -> PromptFilterMetadata.from(promptFilterResult.getPromptIndex(),
+						promptFilterResult.getContentFilterResults()))
+				.toList());
 	}
 
 	private <T> List<T> nullSafeList(List<T> list) {
@@ -320,7 +348,7 @@ public class AzureOpenAiChatModel extends
 	 * {@link ChatCompletionsOptions} instance.
 	 */
 	private ChatCompletionsOptions merge(ChatCompletionsOptions fromAzureOptions,
-			AzureOpenAiChatOptions toSpringAiOptions) {
+										 AzureOpenAiChatOptions toSpringAiOptions) {
 
 		if (toSpringAiOptions == null) {
 			return fromAzureOptions;
@@ -336,7 +364,7 @@ public class AzureOpenAiChatModel extends
 				: toSpringAiOptions.getLogitBias());
 
 		mergedAzureOptions
-			.setStop(fromAzureOptions.getStop() != null ? fromAzureOptions.getStop() : toSpringAiOptions.getStop());
+				.setStop(fromAzureOptions.getStop() != null ? fromAzureOptions.getStop() : toSpringAiOptions.getStop());
 
 		mergedAzureOptions.setTemperature(fromAzureOptions.getTemperature());
 		if (mergedAzureOptions.getTemperature() == null && toSpringAiOptions.getTemperature() != null) {
@@ -366,7 +394,7 @@ public class AzureOpenAiChatModel extends
 		mergedAzureOptions.setN(fromAzureOptions.getN() != null ? fromAzureOptions.getN() : toSpringAiOptions.getN());
 
 		mergedAzureOptions
-			.setUser(fromAzureOptions.getUser() != null ? fromAzureOptions.getUser() : toSpringAiOptions.getUser());
+				.setUser(fromAzureOptions.getUser() != null ? fromAzureOptions.getUser() : toSpringAiOptions.getUser());
 
 		mergedAzureOptions.setModel(fromAzureOptions.getModel() != null ? fromAzureOptions.getModel()
 				: toSpringAiOptions.getDeploymentName());
@@ -383,7 +411,7 @@ public class AzureOpenAiChatModel extends
 	 * @return a new {@link ChatCompletionsOptions} instance.
 	 */
 	private ChatCompletionsOptions merge(AzureOpenAiChatOptions fromSpringAiOptions,
-			ChatCompletionsOptions toAzureOptions) {
+										 ChatCompletionsOptions toAzureOptions) {
 
 		if (fromSpringAiOptions == null) {
 			return toAzureOptions;
@@ -542,7 +570,7 @@ public class AzureOpenAiChatModel extends
 
 	@Override
 	protected ChatCompletionsOptions doCreateToolResponseRequest(ChatCompletionsOptions previousRequest,
-			ChatRequestMessage responseMessage, List<ChatRequestMessage> conversationHistory) {
+																 ChatRequestMessage responseMessage, List<ChatRequestMessage> conversationHistory) {
 
 		// Every tool-call item requires a separate function call and a response (TOOL)
 		// message.
@@ -579,7 +607,7 @@ public class AzureOpenAiChatModel extends
 	protected ChatRequestMessage doGetToolResponseMessage(ChatCompletions response) {
 		final var accessibleChatChoice = response.getChoices().get(0);
 		var responseMessage = Optional.ofNullable(accessibleChatChoice.getMessage())
-			.orElse(accessibleChatChoice.getDelta());
+				.orElse(accessibleChatChoice.getDelta());
 		ChatRequestAssistantMessage assistantMessage = new ChatRequestAssistantMessage("");
 		final var toolCalls = responseMessage.getToolCalls();
 		assistantMessage.setToolCalls(toolCalls.stream().map(tc -> {

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -486,6 +486,9 @@ public class AzureOpenAiChatModel extends
 		if (fromOptions.getResponseFormat() != null) {
 			mergedOptions.setResponseFormat(fromOptions.getResponseFormat());
 		}
+		if (fromOptions.getTools() != null) {
+			mergedOptions.setTools(fromOptions.getTools());
+		}
 
 		return mergedOptions;
 	}

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.azure.openai;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.EmbeddingItem;
 import com.azure.ai.openai.models.Embeddings;
@@ -38,22 +39,22 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private static final Logger logger = LoggerFactory.getLogger(AzureOpenAiEmbeddingModel.class);
 
-	private final OpenAIClient azureOpenAiClient;
+	private final OpenAIAsyncClient azureOpenAiClient;
 
 	private final AzureOpenAiEmbeddingOptions defaultOptions;
 
 	private final MetadataMode metadataMode;
 
-	public AzureOpenAiEmbeddingModel(OpenAIClient azureOpenAiClient) {
+	public AzureOpenAiEmbeddingModel(OpenAIAsyncClient azureOpenAiClient) {
 		this(azureOpenAiClient, MetadataMode.EMBED);
 	}
 
-	public AzureOpenAiEmbeddingModel(OpenAIClient azureOpenAiClient, MetadataMode metadataMode) {
+	public AzureOpenAiEmbeddingModel(OpenAIAsyncClient azureOpenAiClient, MetadataMode metadataMode) {
 		this(azureOpenAiClient, metadataMode,
 				AzureOpenAiEmbeddingOptions.builder().withDeploymentName("text-embedding-ada-002").build());
 	}
 
-	public AzureOpenAiEmbeddingModel(OpenAIClient azureOpenAiClient, MetadataMode metadataMode,
+	public AzureOpenAiEmbeddingModel(OpenAIAsyncClient azureOpenAiClient, MetadataMode metadataMode,
 			AzureOpenAiEmbeddingOptions options) {
 		Assert.notNull(azureOpenAiClient, "com.azure.ai.openai.OpenAIClient must not be null");
 		Assert.notNull(metadataMode, "Metadata mode must not be null");
@@ -78,7 +79,7 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 		logger.debug("Retrieving embeddings");
 
 		EmbeddingsOptions azureOptions = toEmbeddingOptions(embeddingRequest);
-		Embeddings embeddings = this.azureOpenAiClient.getEmbeddings(azureOptions.getModel(), azureOptions);
+		Embeddings embeddings = this.azureOpenAiClient.getEmbeddings(azureOptions.getModel(), azureOptions).block();
 
 		logger.debug("Embeddings retrieved");
 		return generateEmbeddingResponse(embeddings);

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageModel.java
@@ -1,5 +1,6 @@
 package org.springframework.ai.azure.openai;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ImageGenerationOptions;
 import com.azure.ai.openai.models.ImageGenerationQuality;
@@ -45,15 +46,15 @@ public class AzureOpenAiImageModel implements ImageModel {
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Autowired
-	private final OpenAIClient openAIClient;
+	private final OpenAIAsyncClient openAIClient;
 
 	private final AzureOpenAiImageOptions defaultOptions;
 
-	public AzureOpenAiImageModel(OpenAIClient openAIClient) {
+	public AzureOpenAiImageModel(OpenAIAsyncClient openAIClient) {
 		this(openAIClient, AzureOpenAiImageOptions.builder().withDeploymentName(DEFAULT_DEPLOYMENT_NAME).build());
 	}
 
-	public AzureOpenAiImageModel(OpenAIClient microsoftOpenAiClient, AzureOpenAiImageOptions options) {
+	public AzureOpenAiImageModel(OpenAIAsyncClient microsoftOpenAiClient, AzureOpenAiImageOptions options) {
 		Assert.notNull(microsoftOpenAiClient, "com.azure.ai.openai.OpenAIClient must not be null");
 		Assert.notNull(options, "AzureOpenAiChatOptions must not be null");
 		this.openAIClient = microsoftOpenAiClient;
@@ -73,7 +74,7 @@ public class AzureOpenAiImageModel implements ImageModel {
 					toPrettyJson(imageGenerationOptions));
 		}
 
-		var images = openAIClient.getImageGenerations(deploymentOrModelName, imageGenerationOptions);
+		var images = openAIClient.getImageGenerations(deploymentOrModelName, imageGenerationOptions).block();
 
 		if (logger.isTraceEnabled()) {
 			logger.trace("Azure ImageGenerations: {}", toPrettyJson(images));

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.azure.openai;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.models.ChatCompletionsJsonResponseFormat;
 import com.azure.ai.openai.models.ChatCompletionsTextResponseFormat;
@@ -40,7 +41,7 @@ public class AzureChatCompletionsOptionsTests {
 	@Test
 	public void createRequestWithChatOptions() {
 
-		OpenAIClient mockClient = Mockito.mock(OpenAIClient.class);
+		OpenAIAsyncClient mockClient = Mockito.mock(OpenAIAsyncClient.class);
 
 		var defaultOptions = AzureOpenAiChatOptions.builder()
 			.withDeploymentName("DEFAULT_MODEL")

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureEmbeddingsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureEmbeddingsOptionsTests.java
@@ -17,6 +17,7 @@ package org.springframework.ai.azure.openai;
 
 import java.util.List;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,7 +36,7 @@ public class AzureEmbeddingsOptionsTests {
 	@Test
 	public void createRequestWithChatOptions() {
 
-		OpenAIClient mockClient = Mockito.mock(OpenAIClient.class);
+		OpenAIAsyncClient mockClient = Mockito.mock(OpenAIAsyncClient.class);
 		var client = new AzureOpenAiEmbeddingModel(mockClient, MetadataMode.EMBED,
 				AzureOpenAiEmbeddingOptions.builder()
 					.withDeploymentName("DEFAULT_MODEL")

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
@@ -214,14 +215,14 @@ class AzureOpenAiChatModelIT {
 	public static class TestConfiguration {
 
 		@Bean
-		public OpenAIClient openAIClient() {
+		public OpenAIAsyncClient openAIClient() {
 			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
 				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-				.buildClient();
+				.buildAsyncClient();
 		}
 
 		@Bean
-		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClient openAIClient) {
+		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIAsyncClient openAIClient) {
 			return new AzureOpenAiChatModel(openAIClient,
 					AzureOpenAiChatOptions.builder().withDeploymentName("gpt-35-turbo").withMaxTokens(200).build());
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModelIT.java
@@ -17,6 +17,7 @@ package org.springframework.ai.azure.openai;
 
 import java.util.List;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
@@ -67,14 +68,14 @@ class AzureOpenAiEmbeddingModelIT {
 	public static class TestConfiguration {
 
 		@Bean
-		public OpenAIClient openAIClient() {
+		public OpenAIAsyncClient openAIClient() {
 			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
 				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-				.buildClient();
+				.buildAsyncClient();
 		}
 
 		@Bean
-		public AzureOpenAiEmbeddingModel azureEmbeddingModel(OpenAIClient openAIClient) {
+		public AzureOpenAiEmbeddingModel azureEmbeddingModel(OpenAIAsyncClient openAIClient) {
 			return new AzureOpenAiEmbeddingModel(openAIClient);
 		}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/MockAzureOpenAiTestConfiguration.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/MockAzureOpenAiTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.azure.openai;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 
@@ -51,15 +52,15 @@ import okhttp3.mockwebserver.MockWebServer;
 public class MockAzureOpenAiTestConfiguration {
 
 	@Bean
-	OpenAIClient microsoftAzureOpenAiClient(MockWebServer webServer) {
+	OpenAIAsyncClient microsoftAzureOpenAiClient(MockWebServer webServer) {
 
 		HttpUrl baseUrl = webServer.url(MockAiTestConfiguration.SPRING_AI_API_PATH);
 
-		return new OpenAIClientBuilder().endpoint(baseUrl.toString()).buildClient();
+		return new OpenAIClientBuilder().endpoint(baseUrl.toString()).buildAsyncClient();
 	}
 
 	@Bean
-	AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClient microsoftAzureOpenAiClient) {
+	AzureOpenAiChatModel azureOpenAiChatModel(OpenAIAsyncClient microsoftAzureOpenAiClient) {
 		return new AzureOpenAiChatModel(microsoftAzureOpenAiClient);
 	}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -85,22 +85,22 @@ class AzureOpenAiChatModelFunctionCallIT {
 		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15.0", "15");
 	}
 
-
 	@Test
 	void functionCallSequentialTest() {
 
-		UserMessage userMessage = new UserMessage("What's the weather like in San Francisco? If the weather is above 25 degrees, please check the weather in Tokyo and Paris.");
+		UserMessage userMessage = new UserMessage(
+				"What's the weather like in San Francisco? If the weather is above 25 degrees, please check the weather in Tokyo and Paris.");
 
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-				.withDeploymentName(selectedModel)
-				.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
-						.withName("getCurrentWeather")
-						.withDescription("Get the current weather in a given location")
-						.withResponseConverter((response) -> "" + response.temp() + response.unit())
-						.build()))
-				.build();
+			.withDeploymentName(selectedModel)
+			.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
+				.withName("getCurrentWeather")
+				.withDescription("Get the current weather in a given location")
+				.withResponseConverter((response) -> "" + response.temp() + response.unit())
+				.build()))
+			.build();
 
 		ChatResponse response = chatModel.call(new Prompt(messages, promptOptions));
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -85,6 +85,32 @@ class AzureOpenAiChatModelFunctionCallIT {
 		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15.0", "15");
 	}
 
+
+	@Test
+	void functionCallSequentialTest() {
+
+		UserMessage userMessage = new UserMessage("What's the weather like in San Francisco? If the weather is above 25 degrees, please check the weather in Tokyo and Paris.");
+
+		List<Message> messages = new ArrayList<>(List.of(userMessage));
+
+		var promptOptions = AzureOpenAiChatOptions.builder()
+				.withDeploymentName(selectedModel)
+				.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
+						.withName("getCurrentWeather")
+						.withDescription("Get the current weather in a given location")
+						.withResponseConverter((response) -> "" + response.temp() + response.unit())
+						.build()))
+				.build();
+
+		ChatResponse response = chatModel.call(new Prompt(messages, promptOptions));
+
+		logger.info("Response: {}", response);
+
+		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("30.0", "30");
+		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("10.0", "10");
+		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15.0", "15");
+	}
+
 	@Test
 	void streamFunctionCallTest() {
 		UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -131,23 +131,19 @@ class AzureOpenAiChatModelFunctionCallIT {
 
 		var response = chatModel.stream(new Prompt(messages, promptOptions));
 
-		final var counter = new AtomicInteger();
-		String content = response.doOnEach(listSignal -> counter.getAndIncrement())
-			.collectList()
-			.block()
-			.stream()
+		List<ChatResponse> responses = response.collectList().block();
+		String stitchedResponseContent = responses.stream()
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
 			.map(AssistantMessage::getContent)
-			.filter(Objects::nonNull)
 			.collect(Collectors.joining());
 
 		logger.info("Response: {}", response);
 
-		assertThat(content).containsAnyOf("30.0", "30");
-		assertThat(content).containsAnyOf("10.0", "10");
-		assertThat(content).containsAnyOf("15.0", "15");
+		assertThat(stitchedResponseContent).containsAnyOf("30.0", "30");
+		assertThat(stitchedResponseContent).containsAnyOf("10.0", "10");
+		assertThat(stitchedResponseContent).containsAnyOf("15.0", "15");
 	}
 
 	@Test

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
@@ -186,14 +187,14 @@ class AzureOpenAiChatModelFunctionCallIT {
 	public static class TestConfiguration {
 
 		@Bean
-		public OpenAIClient openAIClient() {
+		public OpenAIAsyncClient openAIClient() {
 			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
 				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-				.buildClient();
+				.buildAsyncClient();
 		}
 
 		@Bean
-		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClient openAIClient, String selectedModel) {
+		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIAsyncClient openAIClient, String selectedModel) {
 			return new AzureOpenAiChatModel(openAIClient,
 					AzureOpenAiChatOptions.builder().withDeploymentName(selectedModel).withMaxTokens(500).build());
 		}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -69,13 +69,13 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-				.withDeploymentName(selectedModel)
-				.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
-						.withName("getCurrentWeather")
-						.withDescription("Get the current weather in a given location")
-						.withResponseConverter((response) -> "" + response.temp() + response.unit())
-						.build()))
-				.build();
+			.withDeploymentName(selectedModel)
+			.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
+				.withName("getCurrentWeather")
+				.withDescription("Get the current weather in a given location")
+				.withResponseConverter((response) -> "" + response.temp() + response.unit())
+				.build()))
+			.build();
 
 		ChatResponse response = chatModel.call(new Prompt(messages, promptOptions));
 
@@ -95,13 +95,13 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-				.withDeploymentName(selectedModel)
-				.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
-						.withName("getCurrentWeather")
-						.withDescription("Get the current weather in a given location")
-						.withResponseConverter((response) -> "" + response.temp() + response.unit())
-						.build()))
-				.build();
+			.withDeploymentName(selectedModel)
+			.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
+				.withName("getCurrentWeather")
+				.withDescription("Get the current weather in a given location")
+				.withResponseConverter((response) -> "" + response.temp() + response.unit())
+				.build()))
+			.build();
 
 		ChatResponse response = chatModel.call(new Prompt(messages, promptOptions));
 
@@ -121,27 +121,27 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-				.withDeploymentName(selectedModel)
-				.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
-						.withName("getCurrentWeather")
-						.withDescription("Get the current weather in a given location")
-						.withResponseConverter((response) -> "" + response.temp() + response.unit())
-						.build()))
-				.build();
+			.withDeploymentName(selectedModel)
+			.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
+				.withName("getCurrentWeather")
+				.withDescription("Get the current weather in a given location")
+				.withResponseConverter((response) -> "" + response.temp() + response.unit())
+				.build()))
+			.build();
 
 		var response = chatModel.stream(new Prompt(messages, promptOptions));
 
 		final var counter = new AtomicInteger();
 		String content = response.doOnEach(listSignal -> counter.getAndIncrement())
-				.collectList()
-				.block()
-				.stream()
-				.map(ChatResponse::getResults)
-				.flatMap(List::stream)
-				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
-				.filter(Objects::nonNull)
-				.collect(Collectors.joining());
+			.collectList()
+			.block()
+			.stream()
+			.map(ChatResponse::getResults)
+			.flatMap(List::stream)
+			.map(Generation::getOutput)
+			.map(AssistantMessage::getContent)
+			.filter(Objects::nonNull)
+			.collect(Collectors.joining());
 
 		logger.info("Response: {}", response);
 
@@ -157,26 +157,26 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-				.withDeploymentName(selectedModel)
-				.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
-						.withName("getCurrentWeather")
-						.withDescription("Get the current weather in a given location")
-						.withResponseConverter((response) -> "" + response.temp() + response.unit())
-						.build()))
-				.build();
+			.withDeploymentName(selectedModel)
+			.withFunctionCallbacks(List.of(FunctionCallbackWrapper.builder(new MockWeatherService())
+				.withName("getCurrentWeather")
+				.withDescription("Get the current weather in a given location")
+				.withResponseConverter((response) -> "" + response.temp() + response.unit())
+				.build()))
+			.build();
 
 		Flux<ChatResponse> response = chatModel.stream(new Prompt(messages, promptOptions));
 
 		final var counter = new AtomicInteger();
 		String content = response.doOnEach(listSignal -> counter.getAndIncrement())
-				.collectList()
-				.block()
-				.stream()
-				.map(ChatResponse::getResults)
-				.flatMap(List::stream)
-				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
-				.collect(Collectors.joining());
+			.collectList()
+			.block()
+			.stream()
+			.map(ChatResponse::getResults)
+			.flatMap(List::stream)
+			.map(Generation::getOutput)
+			.map(AssistantMessage::getContent)
+			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
 		assertThat(counter.get()).isGreaterThan(30).as("The response should be chunked in more than 30 messages");
@@ -192,8 +192,8 @@ class AzureOpenAiChatModelFunctionCallIT {
 		@Bean
 		public OpenAIClient openAIClient() {
 			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
-					.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-					.buildClient();
+				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
+				.buildClient();
 		}
 
 		@Bean

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/image/AzureOpenAiImageModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/image/AzureOpenAiImageModelIT.java
@@ -1,5 +1,6 @@
 package org.springframework.ai.azure.openai.image;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
@@ -65,14 +66,14 @@ public class AzureOpenAiImageModelIT {
 	public static class TestConfiguration {
 
 		@Bean
-		public OpenAIClient openAIClient() {
+		public OpenAIAsyncClient openAIClient() {
 			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
 				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-				.buildClient();
+				.buildAsyncClient();
 		}
 
 		@Bean
-		public AzureOpenAiImageModel azureOpenAiImageModel(OpenAIClient openAIClient) {
+		public AzureOpenAiImageModel azureOpenAiImageModel(OpenAIAsyncClient openAIClient) {
 			return new AzureOpenAiImageModel(openAIClient,
 					AzureOpenAiImageOptions.builder().withDeploymentName("Dalle3").build());
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<spring-boot.version>3.3.0</spring-boot.version>
 		<spring-framework.version>6.1.4</spring-framework.version>
 		<ST4.version>4.3.4</ST4.version>
-		<azure-open-ai-client.version>1.0.0-beta.10</azure-open-ai-client.version>
+		<azure-open-ai-client.version>1.0.0-beta.8</azure-open-ai-client.version>
 		<jtokkit.version>1.0.0</jtokkit.version>
 		<victools.version>4.31.1</victools.version>
 		

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -293,7 +293,7 @@ Next, create an `AzureOpenAiChatModel` instance and use it to generate text resp
 var openAIClient = new OpenAIClientBuilder()
   .credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
   .endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-  .buildClient();
+  .buildAsyncClient();
 
 var openAIChatOptions = AzureOpenAiChatOptions.builder()
   .withDeploymentName("gpt-35-turbo")

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiAutoConfiguration.java
@@ -17,6 +17,7 @@ package org.springframework.ai.autoconfigure.azure.openai;
 
 import java.util.List;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import org.springframework.ai.azure.openai.AzureOpenAiChatModel;
 import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingModel;
 import org.springframework.ai.azure.openai.AzureOpenAiImageModel;
@@ -51,8 +52,8 @@ public class AzureOpenAiAutoConfiguration {
 	private final static String APPLICATION_ID = "spring-ai";
 
 	@Bean
-	@ConditionalOnMissingBean({ OpenAIClient.class, TokenCredential.class })
-	public OpenAIClient openAIClient(AzureOpenAiConnectionProperties connectionProperties) {
+	@ConditionalOnMissingBean({ OpenAIAsyncClient.class, TokenCredential.class })
+	public OpenAIAsyncClient openAIClient(AzureOpenAiConnectionProperties connectionProperties) {
 
 		if (StringUtils.hasText(connectionProperties.getApiKey())) {
 
@@ -61,7 +62,7 @@ public class AzureOpenAiAutoConfiguration {
 			return new OpenAIClientBuilder().endpoint(connectionProperties.getEndpoint())
 				.credential(new AzureKeyCredential(connectionProperties.getApiKey()))
 				.clientOptions(new ClientOptions().setApplicationId(APPLICATION_ID))
-				.buildClient();
+				.buildAsyncClient();
 		}
 
 		// Connect to OpenAI (e.g. not the Azure OpenAI). The deploymentName property is
@@ -70,7 +71,7 @@ public class AzureOpenAiAutoConfiguration {
 			return new OpenAIClientBuilder().endpoint("https://api.openai.com/v1")
 				.credential(new KeyCredential(connectionProperties.getOpenAiApiKey()))
 				.clientOptions(new ClientOptions().setApplicationId(APPLICATION_ID))
-				.buildClient();
+				.buildAsyncClient();
 		}
 
 		throw new IllegalArgumentException("Either API key or OpenAI API key must not be empty");
@@ -79,7 +80,7 @@ public class AzureOpenAiAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(TokenCredential.class)
-	public OpenAIClient openAIClientWithTokenCredential(AzureOpenAiConnectionProperties connectionProperties,
+	public OpenAIAsyncClient openAIClientWithTokenCredential(AzureOpenAiConnectionProperties connectionProperties,
 			TokenCredential tokenCredential) {
 
 		Assert.notNull(tokenCredential, "TokenCredential must not be null");
@@ -88,13 +89,13 @@ public class AzureOpenAiAutoConfiguration {
 		return new OpenAIClientBuilder().endpoint(connectionProperties.getEndpoint())
 			.credential(tokenCredential)
 			.clientOptions(new ClientOptions().setApplicationId(APPLICATION_ID))
-			.buildClient();
+			.buildAsyncClient();
 	}
 
 	@Bean
 	@ConditionalOnProperty(prefix = AzureOpenAiChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 			matchIfMissing = true)
-	public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClient openAIClient,
+	public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIAsyncClient openAIClient,
 			AzureOpenAiChatProperties chatProperties, List<FunctionCallback> toolFunctionCallbacks,
 			FunctionCallbackContext functionCallbackContext) {
 
@@ -111,7 +112,7 @@ public class AzureOpenAiAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = AzureOpenAiEmbeddingProperties.CONFIG_PREFIX, name = "enabled",
 			havingValue = "true", matchIfMissing = true)
-	public AzureOpenAiEmbeddingModel azureOpenAiEmbeddingModel(OpenAIClient openAIClient,
+	public AzureOpenAiEmbeddingModel azureOpenAiEmbeddingModel(OpenAIAsyncClient openAIClient,
 			AzureOpenAiEmbeddingProperties embeddingProperties) {
 		return new AzureOpenAiEmbeddingModel(openAIClient, embeddingProperties.getMetadataMode(),
 				embeddingProperties.getOptions());
@@ -128,7 +129,7 @@ public class AzureOpenAiAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = AzureOpenAiImageOptionsProperties.CONFIG_PREFIX, name = "enabled",
 			havingValue = "true", matchIfMissing = true)
-	public AzureOpenAiImageModel azureOpenAiImageClient(OpenAIClient openAIClient,
+	public AzureOpenAiImageModel azureOpenAiImageClient(OpenAIAsyncClient openAIClient,
 			AzureOpenAiImageOptionsProperties imageProperties) {
 
 		return new AzureOpenAiImageModel(openAIClient, imageProperties.getOptions());

--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
+import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
@@ -255,14 +256,14 @@ public class QdrantVectorStoreIT {
 		}
 
 		@Bean
-		public OpenAIClient openAIClient() {
+		public OpenAIAsyncClient openAIClient() {
 			return new OpenAIClientBuilder().credential(new AzureKeyCredential(System.getenv("AZURE_OPENAI_API_KEY")))
 				.endpoint(System.getenv("AZURE_OPENAI_ENDPOINT"))
-				.buildClient();
+				.buildAsyncClient();
 		}
 
 		@Bean
-		public AzureOpenAiEmbeddingModel azureEmbeddingModel(OpenAIClient openAIClient) {
+		public AzureOpenAiEmbeddingModel azureEmbeddingModel(OpenAIAsyncClient openAIClient) {
 			return new AzureOpenAiEmbeddingModel(openAIClient);
 		}
 


### PR DESCRIPTION
Follow up of https://github.com/spring-projects/spring-ai/pull/1042

As already raised in a few PRs the streaming is not really working at the moment for azure.. This PR contains the following fixes:

1. Refactor Azure to actually work identically to OpenAI. The code is copied from the OpenAIModel. Retry template is not yet implemented. This looks like a lot of changes in the PR, but in general it is just a copy/paste from OpenAI (with some adjustments so that is compliant to the Azure Library)
2. Switch to Async Azure Client, so that streaming is *actually* working (by switching to the Azure Async Client). The documentation is super hard to understand (by Azure), but after testing it is clear that only the async library is actually async and streams at least line by line (not token by token) -  see https://github.com/spring-projects/spring-ai/pull/796 ++ https://github.com/spring-projects/spring-ai/pull/796 --> Note: this change might be breaking for spring ai consumers, as this will cause function al
3. rollback to azure beta 8, due to issues in the JSON decoder errors ( https://github.com/Azure/azure-sdk-for-java/issues/40629 )

Can you have a look if that is the correct direction for you? 
