### PR TITLE
Added information about models that are no longer supported

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -166,6 +166,8 @@ ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
         OpenAiChatOptions.builder().withModel(OpenAiApi.ChatModel.GPT_4_VISION_PREVIEW.getValue()).build()));
 ----
 
+TIP: GPT_4_VISION_PREVIEW will continue to be available only to existing users of this model starting June 17, 2024. If you are not an existing user, please use the GPT_4_O or GPT_4_TURBO models. More details https://platform.openai.com/docs/deprecations/2024-06-06-gpt-4-32k-and-vision-preview-models[here]
+
 or the image URL equivalent using the `GPT_4_O` model :
 
 [source,java]


### PR DESCRIPTION
Hello 

Currently, GPT_4_VISION_PREVIEW will continue to be available only to existing users of this model starting June 17, 2024. So, when a request is made, the following response code is returned.

```kotlin
        val path = Paths.get("/Users/yeseong0412/Desktop/alpha-map-server/multimodal.test.png");
        val imageData = Files.readAllBytes(path);

        val userMessage = UserMessage("Explain what do you see on this picture?",
            listOf(Media(MimeTypeUtils.IMAGE_PNG, imageData)))

        val response = openAiChatModel.call(
            Prompt(listOf(userMessage),
                OpenAiChatOptions.Builder()
                    .withModel(OpenAiApi.ChatModel.GPT_4_VISION_PREVIEW.value)
                    .build())
        )
```

```json
{
    "error": {
        "message": "The model `gpt-4-vision-preview` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations",
        "type": "invalid_request_error",
        "param": null,
        "code": "model_not_found"
    }
}
```

So users added TIP and links to related resources to deal with the same problem.



