### PR TITLE
Bedrock API: Add option to configure API endpoint (#1018)

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/api/AnthropicChatBedrockApi.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.bedrock.anthropic.api;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -107,6 +108,21 @@ public class AnthropicChatBedrockApi extends
 	public AnthropicChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new AnthropicChatBedrockApi instance using the provided credentials provider, region and object mapper.
+	 *
+	 * @param modelId The model id to use. See the {@link AnthropicChatModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public AnthropicChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+								   ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	// https://github.com/build-on-aws/amazon-bedrock-java-examples/blob/main/example_code/bedrock-runtime/src/main/java/aws/community/examples/InvokeBedrockStreamingAsync.java

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/Anthropic3ChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/api/Anthropic3ChatBedrockApi.java
@@ -29,6 +29,7 @@ import reactor.core.publisher.Flux;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -111,6 +112,21 @@ public class Anthropic3ChatBedrockApi extends
 	public Anthropic3ChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new AnthropicChatBedrockApi instance using the provided credentials provider, region and object mapper.
+	 *
+	 * @param modelId The model id to use. See the {@link AnthropicChatModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public Anthropic3ChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+									ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	// https://github.com/build-on-aws/amazon-bedrock-java-examples/blob/main/example_code/bedrock-runtime/src/main/java/aws/community/examples/InvokeBedrockStreamingAsync.java

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.bedrock.api;
 
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
@@ -107,6 +108,11 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 		this(modelId, credentialsProvider, region, objectMapper, Duration.ofMinutes(5));
 	}
 
+	public AbstractBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+							  ObjectMapper objectMapper, Duration timeout) {
+		this(modelId, credentialsProvider, region, objectMapper, timeout, null);
+	}
+
 	/**
 	 * Create a new AbstractBedrockApi instance using the provided credentials provider, region and object mapper.
 	 *
@@ -120,7 +126,7 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 	 */
 	public AbstractBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, String region,
 			ObjectMapper objectMapper, Duration timeout) {
-		this(modelId, credentialsProvider, Region.of(region), objectMapper, timeout);
+		this(modelId, credentialsProvider, Region.of(region), objectMapper, timeout, null);
 	}
 
 	/**
@@ -135,7 +141,7 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 	 * all HTTP requests including retries, unmarshalling, etc. This value should always be positive, if present.
 	 */
 	public AbstractBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
-			ObjectMapper objectMapper, Duration timeout) {
+			ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
 
 		Assert.hasText(modelId, "Model id must not be empty");
 		Assert.notNull(credentialsProvider, "Credentials provider must not be null");
@@ -152,12 +158,14 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 				.region(this.region)
 				.credentialsProvider(credentialsProvider)
 				.overrideConfiguration(c -> c.apiCallTimeout(timeout))
+				.endpointOverride(endpointOverride)
 				.build();
 
 		this.clientStreaming = BedrockRuntimeAsyncClient.builder()
 				.region(this.region)
 				.credentialsProvider(credentialsProvider)
 				.overrideConfiguration(c -> c.apiCallTimeout(timeout))
+				.endpointOverride(endpointOverride)
 				.build();
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereChatBedrockApi.java
@@ -16,6 +16,7 @@
 // @formatter:off
 package org.springframework.ai.bedrock.cohere.api;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -106,6 +107,21 @@ public class CohereChatBedrockApi extends
 	public CohereChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new CohereChatBedrockApi instance using the provided credentials provider, region and object mapper.
+	 *
+	 * @param modelId The model id to use. See the {@link CohereChatModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public CohereChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+								ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
@@ -16,6 +16,7 @@
 // @formatter:off
 package org.springframework.ai.bedrock.cohere.api;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -107,6 +108,22 @@ public class CohereEmbeddingBedrockApi extends
 	public CohereEmbeddingBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new CohereEmbeddingBedrockApi instance using the provided credentials provider, region and object
+	 * mapper.
+	 *
+	 * @param modelId The model id to use. See the {@link CohereEmbeddingModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public CohereEmbeddingBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+									 ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/api/Ai21Jurassic2ChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/api/Ai21Jurassic2ChatBedrockApi.java
@@ -16,6 +16,7 @@
 // @formatter:off
 package org.springframework.ai.bedrock.jurassic2.api;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -107,6 +108,21 @@ public class Ai21Jurassic2ChatBedrockApi extends
 	public Ai21Jurassic2ChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 									ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new Ai21Jurassic2ChatBedrockApi instance.
+	 *
+	 * @param modelId The model id to use. See the {@link Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public Ai21Jurassic2ChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+									   ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/api/LlamaChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/api/LlamaChatBedrockApi.java
@@ -28,6 +28,7 @@ import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi.LlamaChatReq
 import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi.LlamaChatResponse;
 import org.springframework.ai.model.ChatModelDescription;
 
+import java.net.URI;
 import java.time.Duration;
 
 // @formatter:off
@@ -104,6 +105,21 @@ public class LlamaChatBedrockApi extends
 	public LlamaChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new LlamaChatBedrockApi instance using the provided credentials provider, region and object mapper.
+	 *
+	 * @param modelId The model id to use. See the {@link LlamaChatModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public LlamaChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+							   ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanChatBedrockApi.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.bedrock.titan.api;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -107,6 +108,21 @@ public class TitanChatBedrockApi extends
 	public TitanChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new TitanEmbeddingBedrockApi instance.
+	 *
+	 * @param modelId The model id to use. See the {@link TitanEmbeddingBedrockApi.TitanEmbeddingModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public TitanChatBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+									ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	/**

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.ai.bedrock.titan.api;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -79,6 +80,21 @@ public class TitanEmbeddingBedrockApi extends
 	public TitanEmbeddingBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
 			ObjectMapper objectMapper, Duration timeout) {
 		super(modelId, credentialsProvider, region, objectMapper, timeout);
+	}
+
+	/**
+	 * Create a new TitanEmbeddingBedrockApi instance.
+	 *
+	 * @param modelId The model id to use. See the {@link TitanEmbeddingModel} for the supported models.
+	 * @param credentialsProvider The credentials provider to connect to AWS.
+	 * @param region The AWS region to use.
+	 * @param objectMapper The object mapper to use for JSON serialization and deserialization.
+	 * @param timeout The timeout to use.
+	 * @param endpointOverride The endpoint to use.
+	 */
+	public TitanEmbeddingBedrockApi(String modelId, AwsCredentialsProvider credentialsProvider, Region region,
+									ObjectMapper objectMapper, Duration timeout, URI endpointOverride) {
+		super(modelId, credentialsProvider, region, objectMapper, timeout, endpointOverride);
 	}
 
 	/**


### PR DESCRIPTION
#1018
Add URL parameter to the constructor to set the `endpointOverride` in `SdkClientBuilder`. 
The URL can be null as the `endpointOverride` is also null by default.
