### PR TITLE
Update jtokkit from 1.0.0 to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 		<spring-framework.version>6.1.4</spring-framework.version>
 		<ST4.version>4.3.4</ST4.version>
 		<azure-open-ai-client.version>1.0.0-beta.10</azure-open-ai-client.version>
-		<jtokkit.version>1.0.0</jtokkit.version>
+		<jtokkit.version>1.1.0</jtokkit.version>
 		<victools.version>4.31.1</victools.version>
 		
 		<!-- NOTE: keep them align -->


### PR DESCRIPTION
Adds o200k_base encoding used by gpt4o and gpt4o-mini
