### PR TITLE
Add Cloud Bindings module to Spring AI BOM

### DIFF
--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -463,6 +463,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-spring-cloud-bindings</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-elasticsearch-store-spring-boot-starter</artifactId>


### PR DESCRIPTION
Fix missing "spring-ai-spring-cloud-bindings" in Spring AI BOM