### PR TITLE
Use RedisProperties to pass host and port configuration

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/redis/RedisVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/redis/RedisVectorStoreAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
@@ -41,7 +42,7 @@ public class RedisVectorStoreAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public RedisVectorStore vectorStore(EmbeddingModel embeddingModel, RedisVectorStoreProperties properties,
-			JedisConnectionFactory jedisConnectionFactory) {
+										RedisProperties redisProperties) {
 
 		var config = RedisVectorStoreConfig.builder()
 			.withIndexName(properties.getIndex())
@@ -49,7 +50,7 @@ public class RedisVectorStoreAutoConfiguration {
 			.build();
 
 		return new RedisVectorStore(config, embeddingModel,
-				new JedisPooled(jedisConnectionFactory.getHostName(), jedisConnectionFactory.getPort()),
+				new JedisPooled(redisProperties.getHost(), redisProperties.getPort()),
 				properties.isInitializeSchema());
 	}
 


### PR DESCRIPTION
#1094  use RedisProperties to obtain the configuration and instantiate JedisPooled inside RedisVectorStore. This way, other RedisConnectionFactory implementations can also be used. 