### PR TITLE
Support function calling in Ollama API

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
@@ -21,6 +21,7 @@ import org.springframework.ai.model.ChatModelDescription;
  * Helper class for common Ollama models.
  *
  * @author Siarhei Blashuk
+ * @author Thomas Vitale
  * @since 0.8.1
  */
 public enum OllamaModel implements ChatModelDescription {
@@ -36,9 +37,20 @@ public enum OllamaModel implements ChatModelDescription {
 	LLAMA3("llama3"),
 
 	/**
+	 * The 8B language model from Meta.
+	 */
+	LLAMA3_1("llama3-1"),
+
+	/**
 	 * The 7B parameters model
 	 */
 	MISTRAL("mistral"),
+
+	/**
+	 * A 12B model with 128k context length, built by Mistral AI in collaboration with
+	 * NVIDIA.
+	 */
+	MISTRAL_NEMO("mistral-nemo"),
 
 	/**
 	 * The 2.7B uncensored Dolphin model

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -33,6 +33,7 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  * Helper class for creating strongly-typed Ollama options.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  * @since 0.8.0
  * @see <a href=
  * "https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values">Ollama
@@ -46,7 +47,8 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 
 	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "format", "keep_alive");
 
-	// Following fields are ptions which must be set when the model is loaded into memory.
+	// Following fields are options which must be set when the model is loaded into
+	// memory.
 
 	// @formatter:off
 	/**
@@ -63,12 +65,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 	 * ???
 	 */
 	@JsonProperty("num_batch") private Integer numBatch;
-
-	/**
-	 * The number of GQA groups in the transformer layer. Required for some models,
-	 * for example it is 8 for llama2:70b.
-	 */
-	@JsonProperty("num_gqa") private Integer numGQA;
 
 	/**
 	 * The number of layers to send to the GPU(s). On macOS it defaults to 1
@@ -289,11 +285,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 		return this;
 	}
 
-	public OllamaOptions withNumGQA(Integer numGQA) {
-		this.numGQA = numGQA;
-		return this;
-	}
-
 	public OllamaOptions withNumGPU(Integer numGPU) {
 		this.numGPU = numGPU;
 		return this;
@@ -462,14 +453,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 
 	public void setNumBatch(Integer numBatch) {
 		this.numBatch = numBatch;
-	}
-
-	public Integer getNumGQA() {
-		return this.numGQA;
-	}
-
-	public void setNumGQA(Integer numGQA) {
-		this.numGQA = numGQA;
 	}
 
 	public Integer getNumGPU() {
@@ -727,7 +710,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 			.withUseNUMA(fromOptions.getUseNUMA())
 			.withNumCtx(fromOptions.getNumCtx())
 			.withNumBatch(fromOptions.getNumBatch())
-			.withNumGQA(fromOptions.getNumGQA())
 			.withNumGPU(fromOptions.getNumGPU())
 			.withMainGPU(fromOptions.getMainGPU())
 			.withLowVRAM(fromOptions.getLowVRAM())
@@ -755,7 +737,6 @@ public class OllamaOptions implements ChatOptions, EmbeddingOptions {
 			.withPenalizeNewline(fromOptions.getPenalizeNewline())
 			.withStop(fromOptions.getStop());
 	}
-
 
 	// @formatter:on
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.ollama.api.OllamaModel;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.ollama.OllamaContainer;
@@ -58,18 +59,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Disabled("For manual smoke testing only.")
 class OllamaChatModelIT {
 
-	private static String MODEL = "mistral";
+	private static final String MODEL = OllamaModel.MISTRAL.getName();
 
 	private static final Log logger = LogFactory.getLog(OllamaChatModelIT.class);
 
 	@Container
-	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.1.32");
+	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.2.8");
 
 	static String baseUrl;
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL + " ' generative ... would take several minutes ...");
+		logger.info("Start pulling the '" + MODEL + " ' model ... can take several minutes ...");
 		ollamaContainer.execInContainer("ollama", "pull", MODEL);
 		logger.info(MODEL + " pulling competed!");
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMultimodalIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMultimodalIT.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.ollama.api.OllamaModel;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.ollama.OllamaContainer;
@@ -46,18 +47,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Disabled("For manual smoke testing only.")
 class OllamaChatModelMultimodalIT {
 
-	private static String MODEL = "llava";
+	private static final String MODEL = OllamaModel.LLAVA.getName();
 
-	private static final Log logger = LogFactory.getLog(OllamaChatModelIT.class);
+	private static final Log logger = LogFactory.getLog(OllamaChatModelMultimodalIT.class);
 
 	@Container
-	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.1.32");
+	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.2.8");
 
 	static String baseUrl;
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL + " ' generative ... would take several minutes ...");
+		logger.info("Start pulling the '" + MODEL + " ' model ... can take several minutes ...");
 		ollamaContainer.execInContainer("ollama", "pull", MODEL);
 		logger.info(MODEL + " pulling competed!");
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelIT.java
@@ -23,13 +23,13 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.ollama.api.OllamaModel;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.ollama.OllamaContainer;
 
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.ollama.api.OllamaApi;
-import org.springframework.ai.ollama.api.OllamaApiIT;
 import org.springframework.ai.ollama.api.OllamaOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -43,18 +43,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 class OllamaEmbeddingModelIT {
 
-	private static String MODEL = "llava";
+	private static final String MODEL = OllamaModel.MISTRAL.getName();
 
-	private static final Log logger = LogFactory.getLog(OllamaApiIT.class);
+	private static final Log logger = LogFactory.getLog(OllamaEmbeddingModelIT.class);
 
 	@Container
-	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.1.32");
+	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.2.8");
 
 	static String baseUrl;
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL + " ' generative ... would take several minutes ...");
+		logger.info("Start pulling the '" + MODEL + " ' model ... can take several minutes ...");
 		ollamaContainer.execInContainer("ollama", "pull", MODEL);
 		logger.info(MODEL + " pulling competed!");
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
@@ -38,26 +38,29 @@ import org.springframework.ai.ollama.api.OllamaApi.GenerateResponse;
 import org.springframework.ai.ollama.api.OllamaApi.Message;
 import org.springframework.ai.ollama.api.OllamaApi.Message.Role;
 
-import static org.assertj.core.api.Assertions.assertThat;;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 @Disabled("For manual smoke testing only.")
 @Testcontainers
 public class OllamaApiIT {
 
+	private static final String MODEL = OllamaModel.ORCA_MINI.getName();
+
 	private static final Log logger = LogFactory.getLog(OllamaApiIT.class);
 
 	@Container
-	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.1.32");
+	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.2.8");
 
 	static OllamaApi ollamaApi;
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the 'orca-mini' generative (3GB) ... would take several minutes ...");
-		ollamaContainer.execInContainer("ollama", "pull", "orca-mini");
+		logger.info("Start pulling the '" + MODEL + " ' model ... can take several minutes ...");
+		ollamaContainer.execInContainer("ollama", "pull", MODEL);
 		logger.info("orca-mini pulling competed!");
 
 		ollamaApi = new OllamaApi("http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434));
@@ -68,7 +71,7 @@ public class OllamaApiIT {
 
 		var request = GenerateRequest
 			.builder("What is the capital of Bulgaria and what is the size? What it the national anthem?")
-			.withModel("orca-mini")
+			.withModel(MODEL)
 			.withStream(false)
 			.build();
 
@@ -84,7 +87,7 @@ public class OllamaApiIT {
 	@Test
 	public void chat() {
 
-		var request = ChatRequest.builder("orca-mini")
+		var request = ChatRequest.builder(MODEL)
 			.withStream(false)
 			.withMessages(List.of(
 					Message.builder(Role.SYSTEM)
@@ -111,7 +114,7 @@ public class OllamaApiIT {
 	@Test
 	public void streamingChat() {
 
-		var request = ChatRequest.builder("orca-mini")
+		var request = ChatRequest.builder(MODEL)
 			.withStream(true)
 			.withMessages(List.of(Message.builder(Role.USER)
 				.withContent("What is the capital of Bulgaria and what is the size? " + "What it the national anthem?")
@@ -138,7 +141,7 @@ public class OllamaApiIT {
 	@Test
 	public void embedText() {
 
-		EmbeddingRequest request = new EmbeddingRequest("orca-mini", "I like to eat apples");
+		EmbeddingRequest request = new EmbeddingRequest(MODEL, "I like to eat apples");
 
 		EmbeddingResponse response = ollamaApi.embeddings(request);
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/MockWeatherService.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/MockWeatherService.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.ollama.api.tool;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import java.util.function.Function;
+
+/**
+ * Adapted from MockWeatherService in the OpenAI module (by Christian Tzolov).
+ *
+ * @author Thomas Vitale
+ */
+public class MockWeatherService implements Function<MockWeatherService.Request, MockWeatherService.Response> {
+
+	/**
+	 * Weather Function request.
+	 */
+	@JsonInclude(Include.NON_NULL)
+	@JsonClassDescription("Weather API request")
+	public record Request(
+	// @formatter:off
+			@JsonProperty(required = true, value = "location")
+			@JsonPropertyDescription("The city and state e.g. San Francisco, CA")
+			String location,
+
+			@JsonProperty(required = true, value = "unit")
+			@JsonPropertyDescription("Temperature unit")
+			Unit unit
+	// @formatter:on
+	) {
+	}
+
+	/**
+	 * Temperature units.
+	 */
+	public enum Unit {
+
+		/**
+		 * Celsius.
+		 */
+		C("metric"),
+		/**
+		 * Fahrenheit.
+		 */
+		F("imperial");
+
+		/**
+		 * Human-readable unit name.
+		 */
+		public final String unitName;
+
+		Unit(String text) {
+			this.unitName = text;
+		}
+
+	}
+
+	/**
+	 * Weather Function response.
+	 */
+	public record Response(
+	// @formatter:off
+			double temp,
+			double feels_like,
+			double temp_min,
+			double temp_max,
+			int pressure,
+			int humidity,
+			Unit unit
+	// @formatter:on
+	) {
+	}
+
+	@Override
+	public Response apply(Request request) {
+		double temperature = 0;
+		if (request.location().contains("Paris")) {
+			temperature = 15;
+		}
+		else if (request.location().contains("Tokyo")) {
+			temperature = 10;
+		}
+		else if (request.location().contains("San Francisco")) {
+			temperature = 30;
+		}
+
+		return new Response(temperature, 15, 20, 2, 53, 45, Unit.C);
+	}
+
+}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/OllamaAiApiToolFunctionCallIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/OllamaAiApiToolFunctionCallIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.ollama.api.tool;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.ai.ollama.api.OllamaModel;
+import org.springframework.ai.ollama.api.OllamaOptions;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.ollama.OllamaContainer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Adapted from OpenAiApiToolFunctionCallIT in the OpenAI module (by Christian Tzolov).
+ *
+ * @author Thomas Vitale
+ */
+@Disabled("For manual smoke testing only.")
+@Testcontainers
+public class OllamaAiApiToolFunctionCallIT {
+
+	private static final String MODEL = OllamaModel.MISTRAL.getName();
+
+	private static final Logger logger = LoggerFactory.getLogger(OllamaAiApiToolFunctionCallIT.class);
+
+	MockWeatherService weatherService = new MockWeatherService();
+
+	@Container
+	static OllamaContainer ollamaContainer = new OllamaContainer("ollama/ollama:0.2.8");
+
+	static OllamaApi ollamaApi;
+
+	@BeforeAll
+	public static void beforeAll() throws IOException, InterruptedException {
+		logger.info("Start pulling the '" + MODEL + " ' model ... can take several minutes ...");
+		ollamaContainer.execInContainer("ollama", "pull", MODEL);
+		logger.info("orca-mini pulling competed!");
+
+		ollamaApi = new OllamaApi("http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434));
+	}
+
+	@Test
+	public void toolFunctionCall() {
+		// Step 1: Send the question and the list of available functions to the model.
+		var message = OllamaApi.Message.builder(OllamaApi.Message.Role.USER)
+			.withContent("What's the weather like in San Francisco, Tokyo, and Paris?")
+			.build();
+
+		var functionTool = new OllamaApi.Tool(OllamaApi.Tool.Type.FUNCTION,
+				new OllamaApi.Tool.ToolFunction("Get the weather in location. Return temperature in Celsius.",
+						"getCurrentWeather", ModelOptionsUtils.jsonToMap("""
+								{
+									"type": "object",
+									"properties": {
+										"location": {
+											"type": "string",
+											"description": "The city and state e.g. San Francisco, CA"
+										},
+										"unit": {
+											"type": "string",
+											"enum": ["C", "F"]
+										}
+									},
+									"required": ["location", "unit"]
+								}
+								""")));
+
+		List<OllamaApi.Message> messages = new ArrayList<>(List.of(message));
+
+		OllamaApi.ChatRequest chatRequest = OllamaApi.ChatRequest.builder(MODEL)
+			.withMessages(messages)
+			.withTools(List.of(functionTool))
+			.withOptions(OllamaOptions.create().withTemperature(0.0f))
+			.build();
+
+		OllamaApi.ChatResponse chatResponse = ollamaApi.chat(chatRequest);
+
+		assertThat(chatResponse).isNotNull();
+		assertThat(chatResponse.message()).isNotNull();
+
+		OllamaApi.Message responseMessage = chatResponse.message();
+
+		assertThat(responseMessage.role()).isEqualTo(OllamaApi.Message.Role.ASSISTANT);
+		assertThat(responseMessage.toolCalls()).isNotNull();
+
+		// Step 2a. Extend the conversation with the previous model response.
+		messages.add(responseMessage);
+
+		// Step 2b. For each tool call, execute the function and add response to the
+		// conversation history.
+		for (OllamaApi.Message.ToolCall toolCall : responseMessage.toolCalls()) {
+			var functionName = toolCall.function().name();
+			if ("getCurrentWeather".equals(functionName)) {
+				MockWeatherService.Request weatherRequest = fromMap(toolCall.function().arguments(),
+						MockWeatherService.Request.class);
+
+				MockWeatherService.Response weatherResponse = weatherService.apply(weatherRequest);
+
+				// extend conversation with function response.
+				messages.add(OllamaApi.Message.builder(OllamaApi.Message.Role.TOOL)
+					.withContent("" + weatherResponse.temp() + weatherRequest.unit())
+					.build());
+			}
+		}
+
+		// Step 2c. Call the model again with the function execution results, aiming to
+		// receive the final answer to the original question.
+
+		OllamaApi.ChatRequest functionResponseRequest = OllamaApi.ChatRequest.builder(MODEL)
+			.withMessages(messages)
+			.withOptions(OllamaOptions.create().withTemperature(0.0f))
+			.build();
+
+		OllamaApi.ChatResponse chatResponse2 = ollamaApi.chat(functionResponseRequest);
+
+		logger.info("Final response: \n" + chatResponse2);
+
+		assertThat(chatResponse2).isNotNull();
+		assertThat(chatResponse2.message()).isNotNull();
+
+		assertThat(chatResponse2.message().role()).isEqualTo(OllamaApi.Message.Role.ASSISTANT);
+		assertThat(chatResponse2.message().content()).contains("San Francisco").containsAnyOf("30.0°C", "30°C");
+		assertThat(chatResponse2.message().content()).contains("Tokyo").containsAnyOf("10.0°C", "10°C");
+		assertThat(chatResponse2.message().content()).contains("Paris").containsAnyOf("15.0°C", "15°C");
+	}
+
+	private static <T> T fromMap(Map<String, Object> map, Class<T> targetClass) {
+		return new ObjectMapper().convertValue(map, targetClass);
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaImage.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaImage.java
@@ -17,6 +17,6 @@ package org.springframework.ai.autoconfigure.ollama;
 
 public class OllamaImage {
 
-	static final String IMAGE = "ollama/ollama:0.1.32";
+	static final String IMAGE = "ollama/ollama:0.2.8";
 
 }

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactoryTest.java
@@ -53,7 +53,7 @@ class OllamaContainerConnectionDetailsFactoryTest {
 
 	@Container
 	@ServiceConnection
-	static OllamaContainer ollama = new OllamaContainer("ollama/ollama:0.1.29");
+	static OllamaContainer ollama = new OllamaContainer("ollama/ollama:0.2.8");
 
 	@Autowired
 	private OllamaEmbeddingModel embeddingModel;


### PR DESCRIPTION
* Update Ollama API types with the latest definitions for Generation and Chat Completion.
* Include support for function calling at the API level + integration tests.
* Refine integration tests to use latest Ollama version and parametrized models.

A second PR will raise the function calling support at the ChatModel level.

Fixes gh-720