### PR TITLE
Remove flush operations to prevent excessive segment creation in Milvus

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -297,10 +297,6 @@ public class MilvusVectorStore implements VectorStore, InitializingBean {
 		if (status.getException() != null) {
 			throw new RuntimeException("Failed to insert:", status.getException());
 		}
-		this.milvusClient.flush(FlushParam.newBuilder()
-			.withDatabaseName(this.config.databaseName)
-			.addCollectionName(this.config.collectionName)
-			.build());
 	}
 
 	@Override


### PR DESCRIPTION
![tupian](https://github.com/user-attachments/assets/e575a79f-aad4-4a77-9c41-8e4f5ceb9f92)

[Typically, this method is called once all the data is ingested. You are advised not to call this method frequently since it could generate a lot of tiny segments and lead to unstable problems.
](https://milvus.io/api-reference/java/v2.4.x/v1/Collection/flush.md)

I found that the flush operation is time-consuming, and frequent flush operations result in the creation of many segments, which can impact performance. This also increases the pressure during the compaction process.