### PR TITLE
Introduce MarkdownDocumentReader

### DIFF
--- a/document-readers/markdown-reader/pom.xml
+++ b/document-readers/markdown-reader/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-markdown-document-reader</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Document Reader - Markdown</name>
+	<description>Spring AI Markdown document reader</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-core</artifactId>
+			<version>${parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.commonmark</groupId>
+			<artifactId>commonmark</artifactId>
+			<version>${commonmark.version}</version>
+		</dependency>
+
+		<!-- TESTING -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -183,7 +183,12 @@ public class MarkdownDocumentReader implements DocumentReader {
 			if (!currentParagraphs.isEmpty()) {
 				String content = String.join("", currentParagraphs);
 
-				Document document = currentDocumentBuilder.withContent(content).build();
+				Document.Builder builder = currentDocumentBuilder.withContent(content);
+
+				config.additionalMetadata.forEach(builder::withMetadata);
+
+				Document document = builder.build();
+
 				documents.add(document);
 
 				currentParagraphs.clear();

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -14,17 +14,28 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Reads the given Markdown resource and groups headers paragraphs into
- * {@link Document}'s.
+ * Reads the given Markdown resource and groups headers, paragraphs, or text divided by
+ * horizontal lines (depending on the
+ * {@link MarkdownDocumentReaderConfig#horizontalRuleCreateDocument} configuration) into
+ * {@link Document}s.
  *
  * @author Piotr Olaszewski
  */
 public class MarkdownDocumentReader implements DocumentReader {
 
+	/**
+	 * The resource points to the Markdown document.
+	 */
 	private final Resource markdownResource;
 
+	/**
+	 * Configuration to a parsing process.
+	 */
 	private final MarkdownDocumentReaderConfig config;
 
+	/**
+	 * Markdown parser.
+	 */
 	private final Parser parser;
 
 	public MarkdownDocumentReader(String markdownResource) {
@@ -41,6 +52,10 @@ public class MarkdownDocumentReader implements DocumentReader {
 		this.parser = Parser.builder().build();
 	}
 
+	/**
+	 * Extracts and returns a list of documents from the resource.
+	 * @return List of extracted {@link Document}
+	 */
 	@Override
 	public List<Document> get() {
 		try (var input = markdownResource.getInputStream()) {
@@ -56,6 +71,9 @@ public class MarkdownDocumentReader implements DocumentReader {
 		}
 	}
 
+	/**
+	 * A convenient class for visiting handled nodes in the Markdown document.
+	 */
 	static class DocumentVisitor extends AbstractVisitor {
 
 		private final List<Document> documents = new ArrayList<>();

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -103,6 +103,12 @@ public class MarkdownDocumentReader implements DocumentReader {
 		}
 
 		@Override
+		public void visit(ListItem listItem) {
+			translateLineBreakToSpace();
+			super.visit(listItem);
+		}
+
+		@Override
 		public void visit(BlockQuote blockQuote) {
 			if (!config.includeBlockquote) {
 				buildAndFlush();

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -1,9 +1,6 @@
 package org.springframework.ai.reader.markdown;
 
-import org.commonmark.node.AbstractVisitor;
-import org.commonmark.node.Heading;
-import org.commonmark.node.Node;
-import org.commonmark.node.Text;
+import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentReader;
@@ -66,6 +63,14 @@ public class MarkdownDocumentReader implements DocumentReader {
 			currentDocumentBuilder = Document.builder();
 
 			super.visit(heading);
+		}
+
+		@Override
+		public void visit(SoftLineBreak softLineBreak) {
+			if (!currentParagraphs.isEmpty()) {
+				currentParagraphs.add(" ");
+			}
+			super.visit(softLineBreak);
 		}
 
 		@Override

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -92,13 +92,13 @@ public class MarkdownDocumentReader implements DocumentReader {
 
 		@Override
 		public void visit(SoftLineBreak softLineBreak) {
-			lineBreakToSpaceTranslate();
+			translateLineBreakToSpace();
 			super.visit(softLineBreak);
 		}
 
 		@Override
 		public void visit(HardLineBreak hardLineBreak) {
-			lineBreakToSpaceTranslate();
+			translateLineBreakToSpace();
 			super.visit(hardLineBreak);
 		}
 
@@ -133,7 +133,7 @@ public class MarkdownDocumentReader implements DocumentReader {
 			currentDocumentBuilder = Document.builder();
 		}
 
-		private void lineBreakToSpaceTranslate() {
+		private void translateLineBreakToSpace() {
 			if (!currentParagraphs.isEmpty()) {
 				currentParagraphs.add(" ");
 			}

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -1,0 +1,103 @@
+package org.springframework.ai.reader.markdown;
+
+import org.commonmark.node.AbstractVisitor;
+import org.commonmark.node.Heading;
+import org.commonmark.node.Node;
+import org.commonmark.node.Text;
+import org.commonmark.parser.Parser;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reads the given Markdown resource and groups headers paragraphs into
+ * {@link Document}'s.
+ *
+ * @author Piotr Olaszewski
+ */
+public class MarkdownDocumentReader implements DocumentReader {
+
+	private final Resource markdownResource;
+
+	private final Parser parser;
+
+	public MarkdownDocumentReader(String markdownResource) {
+		this(new DefaultResourceLoader().getResource(markdownResource));
+	}
+
+	public MarkdownDocumentReader(Resource markdownResource) {
+		this.markdownResource = markdownResource;
+		this.parser = Parser.builder().build();
+	}
+
+	@Override
+	public List<Document> get() {
+		try (var input = markdownResource.getInputStream()) {
+			Node node = parser.parseReader(new InputStreamReader(input));
+
+			DocumentVisitor documentVisitor = new DocumentVisitor();
+			node.accept(documentVisitor);
+
+			return documentVisitor.getDocuments();
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	static class DocumentVisitor extends AbstractVisitor {
+
+		private final List<Document> documents = new ArrayList<>();
+
+		private final List<String> currentParagraphs = new ArrayList<>();
+
+		private Document.Builder currentDocumentBuilder;
+
+		@Override
+		public void visit(Heading heading) {
+			buildAndFlush();
+
+			currentDocumentBuilder = Document.builder();
+
+			super.visit(heading);
+		}
+
+		@Override
+		public void visit(Text text) {
+			if (text.getParent() instanceof Heading heading) {
+				currentDocumentBuilder.withMetadata("category", "header_%d".formatted(heading.getLevel()))
+					.withMetadata("title", text.getLiteral());
+			}
+			else {
+				currentParagraphs.add(text.getLiteral());
+			}
+
+			super.visit(text);
+		}
+
+		public List<Document> getDocuments() {
+			buildAndFlush();
+
+			return documents;
+		}
+
+		private void buildAndFlush() {
+			if (!currentParagraphs.isEmpty()) {
+				String content = String.join("", currentParagraphs);
+
+				Document document = currentDocumentBuilder.withContent(content).build();
+				documents.add(document);
+
+				currentParagraphs.clear();
+			}
+		}
+
+	}
+
+}

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -99,6 +99,14 @@ public class MarkdownDocumentReader implements DocumentReader {
 		}
 
 		@Override
+		public void visit(HardLineBreak hardLineBreak) {
+			if (!currentParagraphs.isEmpty()) {
+				currentParagraphs.add(" ");
+			}
+			super.visit(hardLineBreak);
+		}
+
+		@Override
 		public void visit(Text text) {
 			if (text.getParent() instanceof Heading heading) {
 				currentDocumentBuilder.withMetadata("category", "header_%d".formatted(heading.getLevel()))

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -103,9 +103,20 @@ public class MarkdownDocumentReader implements DocumentReader {
 		}
 
 		@Override
+		public void visit(BlockQuote blockQuote) {
+			if (!config.includeBlockquote) {
+				buildAndFlush();
+			}
+
+			translateLineBreakToSpace();
+			currentDocumentBuilder.withMetadata("category", "blockquote");
+			super.visit(blockQuote);
+		}
+
+		@Override
 		public void visit(Code code) {
 			currentParagraphs.add(code.getLiteral());
-			currentDocumentBuilder.withMetadata("code", "inline");
+			currentDocumentBuilder.withMetadata("category", "code_inline");
 			super.visit(code);
 		}
 
@@ -117,7 +128,7 @@ public class MarkdownDocumentReader implements DocumentReader {
 
 			translateLineBreakToSpace();
 			currentParagraphs.add(fencedCodeBlock.getLiteral());
-			currentDocumentBuilder.withMetadata("code", "block");
+			currentDocumentBuilder.withMetadata("category", "code_block");
 			currentDocumentBuilder.withMetadata("lang", fencedCodeBlock.getInfo());
 
 			buildAndFlush();

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -103,6 +103,29 @@ public class MarkdownDocumentReader implements DocumentReader {
 		}
 
 		@Override
+		public void visit(Code code) {
+			currentParagraphs.add(code.getLiteral());
+			currentDocumentBuilder.withMetadata("code", "inline");
+			super.visit(code);
+		}
+
+		@Override
+		public void visit(FencedCodeBlock fencedCodeBlock) {
+			if (!config.includeCodeBlock) {
+				buildAndFlush();
+			}
+
+			translateLineBreakToSpace();
+			currentParagraphs.add(fencedCodeBlock.getLiteral());
+			currentDocumentBuilder.withMetadata("code", "block");
+			currentDocumentBuilder.withMetadata("lang", fencedCodeBlock.getInfo());
+
+			buildAndFlush();
+
+			super.visit(fencedCodeBlock);
+		}
+
+		@Override
 		public void visit(Text text) {
 			if (text.getParent() instanceof Heading heading) {
 				currentDocumentBuilder.withMetadata("category", "header_%d".formatted(heading.getLevel()))

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -92,17 +92,13 @@ public class MarkdownDocumentReader implements DocumentReader {
 
 		@Override
 		public void visit(SoftLineBreak softLineBreak) {
-			if (!currentParagraphs.isEmpty()) {
-				currentParagraphs.add(" ");
-			}
+			lineBreakToSpaceTranslate();
 			super.visit(softLineBreak);
 		}
 
 		@Override
 		public void visit(HardLineBreak hardLineBreak) {
-			if (!currentParagraphs.isEmpty()) {
-				currentParagraphs.add(" ");
-			}
+			lineBreakToSpaceTranslate();
 			super.visit(hardLineBreak);
 		}
 
@@ -135,6 +131,12 @@ public class MarkdownDocumentReader implements DocumentReader {
 				currentParagraphs.clear();
 			}
 			currentDocumentBuilder = Document.builder();
+		}
+
+		private void lineBreakToSpaceTranslate() {
+			if (!currentParagraphs.isEmpty()) {
+				currentParagraphs.add(" ");
+			}
 		}
 
 	}

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
@@ -9,9 +9,12 @@ public class MarkdownDocumentReaderConfig {
 
 	public final boolean includeCodeBlock;
 
+	public final boolean includeBlockquote;
+
 	public MarkdownDocumentReaderConfig(Builder builder) {
 		horizontalRuleCreateDocument = builder.horizontalRuleCreateDocument;
 		includeCodeBlock = builder.includeCodeBlock;
+		includeBlockquote = builder.includeBlockquote;
 	}
 
 	public static MarkdownDocumentReaderConfig defaultConfig() {
@@ -28,6 +31,8 @@ public class MarkdownDocumentReaderConfig {
 
 		private boolean includeCodeBlock = false;
 
+		private boolean includeBlockquote = false;
+
 		private Builder() {
 		}
 
@@ -38,6 +43,11 @@ public class MarkdownDocumentReaderConfig {
 
 		public Builder withIncludeCodeBlock(boolean includeCodeBlock) {
 			this.includeCodeBlock = includeCodeBlock;
+			return this;
+		}
+
+		public Builder withIncludeBlockquote(boolean includeBlockquote) {
+			this.includeBlockquote = includeBlockquote;
 			return this;
 		}
 

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
@@ -1,0 +1,40 @@
+package org.springframework.ai.reader.markdown.config;
+
+/**
+ * @author Piotr Olaszewski
+ */
+public class MarkdownDocumentReaderConfig {
+
+	public final boolean horizontalRuleCreateDocument;
+
+	public MarkdownDocumentReaderConfig(Builder builder) {
+		horizontalRuleCreateDocument = builder.horizontalRuleCreateDocument;
+	}
+
+	public static MarkdownDocumentReaderConfig defaultConfig() {
+		return builder().build();
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private boolean horizontalRuleCreateDocument = false;
+
+		private Builder() {
+		}
+
+		public Builder withHorizontalRuleCreateDocument(boolean horizontalRuleCreateDocument) {
+			this.horizontalRuleCreateDocument = horizontalRuleCreateDocument;
+			return this;
+		}
+
+		public MarkdownDocumentReaderConfig build() {
+			return new MarkdownDocumentReaderConfig(this);
+		}
+
+	}
+
+}

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
@@ -2,6 +2,10 @@ package org.springframework.ai.reader.markdown.config;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.reader.markdown.MarkdownDocumentReader;
+import org.springframework.util.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Common configuration for the {@link MarkdownDocumentReader}.
@@ -16,10 +20,13 @@ public class MarkdownDocumentReaderConfig {
 
 	public final boolean includeBlockquote;
 
+	public final Map<String, Object> additionalMetadata;
+
 	public MarkdownDocumentReaderConfig(Builder builder) {
 		horizontalRuleCreateDocument = builder.horizontalRuleCreateDocument;
 		includeCodeBlock = builder.includeCodeBlock;
 		includeBlockquote = builder.includeBlockquote;
+		additionalMetadata = builder.additionalMetadata;
 	}
 
 	/**
@@ -40,6 +47,8 @@ public class MarkdownDocumentReaderConfig {
 		private boolean includeCodeBlock = false;
 
 		private boolean includeBlockquote = false;
+
+		private Map<String, Object> additionalMetadata = new HashMap<>();
 
 		private Builder() {
 		}
@@ -78,6 +87,27 @@ public class MarkdownDocumentReaderConfig {
 		 */
 		public Builder withIncludeBlockquote(boolean includeBlockquote) {
 			this.includeBlockquote = includeBlockquote;
+			return this;
+		}
+
+		/**
+		 * Adds this additional metadata to the all built {@link Document}s.
+		 * @return this builder
+		 */
+		public Builder withAdditionalMetadata(String key, Object value) {
+			Assert.notNull(key, "key must not be null");
+			Assert.notNull(value, "value must not be null");
+			this.additionalMetadata.put(key, value);
+			return this;
+		}
+
+		/**
+		 * Adds this additional metadata to the all built {@link Document}s.
+		 * @return this builder
+		 */
+		public Builder withAdditionalMetadata(Map<String, Object> additionalMetadata) {
+			Assert.notNull(additionalMetadata, "additionalMetadata must not be null");
+			this.additionalMetadata = additionalMetadata;
 			return this;
 		}
 

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
@@ -1,6 +1,11 @@
 package org.springframework.ai.reader.markdown.config;
 
+import org.springframework.ai.document.Document;
+import org.springframework.ai.reader.markdown.MarkdownDocumentReader;
+
 /**
+ * Common configuration for the {@link MarkdownDocumentReader}.
+ *
  * @author Piotr Olaszewski
  */
 public class MarkdownDocumentReaderConfig {
@@ -17,6 +22,9 @@ public class MarkdownDocumentReaderConfig {
 		includeBlockquote = builder.includeBlockquote;
 	}
 
+	/**
+	 * @return the default configuration
+	 */
 	public static MarkdownDocumentReaderConfig defaultConfig() {
 		return builder().build();
 	}
@@ -36,21 +44,46 @@ public class MarkdownDocumentReaderConfig {
 		private Builder() {
 		}
 
+		/**
+		 * Text divided by horizontal lines will create new {@link Document}s. The default
+		 * is {@code false}, meaning text separated by horizontal lines won't create a new
+		 * document.
+		 * @param horizontalRuleCreateDocument flag to determine whether new documents are
+		 * created from text divided by horizontal line
+		 * @return this builder
+		 */
 		public Builder withHorizontalRuleCreateDocument(boolean horizontalRuleCreateDocument) {
 			this.horizontalRuleCreateDocument = horizontalRuleCreateDocument;
 			return this;
 		}
 
+		/**
+		 * Whatever to include code blocks in {@link Document}s. The default is
+		 * {@code false}, which means all code blocks are in separate documents.
+		 * @param includeCodeBlock flag to include code block into paragraph document or
+		 * create new with code only
+		 * @return this builder
+		 */
 		public Builder withIncludeCodeBlock(boolean includeCodeBlock) {
 			this.includeCodeBlock = includeCodeBlock;
 			return this;
 		}
 
+		/**
+		 * Whatever to include blockquotes in {@link Document}s. The default is
+		 * {@code false}, which means all blockquotes are in separate documents.
+		 * @param includeBlockquote flag to include blockquotes into paragraph document or
+		 * create new with blockquote only
+		 * @return this builder
+		 */
 		public Builder withIncludeBlockquote(boolean includeBlockquote) {
 			this.includeBlockquote = includeBlockquote;
 			return this;
 		}
 
+		/**
+		 * @return the immutable configuration
+		 */
 		public MarkdownDocumentReaderConfig build() {
 			return new MarkdownDocumentReaderConfig(this);
 		}

--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/config/MarkdownDocumentReaderConfig.java
@@ -7,8 +7,11 @@ public class MarkdownDocumentReaderConfig {
 
 	public final boolean horizontalRuleCreateDocument;
 
+	public final boolean includeCodeBlock;
+
 	public MarkdownDocumentReaderConfig(Builder builder) {
 		horizontalRuleCreateDocument = builder.horizontalRuleCreateDocument;
+		includeCodeBlock = builder.includeCodeBlock;
 	}
 
 	public static MarkdownDocumentReaderConfig defaultConfig() {
@@ -23,11 +26,18 @@ public class MarkdownDocumentReaderConfig {
 
 		private boolean horizontalRuleCreateDocument = false;
 
+		private boolean includeCodeBlock = false;
+
 		private Builder() {
 		}
 
 		public Builder withHorizontalRuleCreateDocument(boolean horizontalRuleCreateDocument) {
 			this.horizontalRuleCreateDocument = horizontalRuleCreateDocument;
+			return this;
+		}
+
+		public Builder withIncludeCodeBlock(boolean includeCodeBlock) {
+			this.includeCodeBlock = includeCodeBlock;
 			return this;
 		}
 

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -2,6 +2,7 @@ package org.springframework.ai.reader.markdown;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.reader.markdown.config.MarkdownDocumentReaderConfig;
 
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,51 @@ class MarkdownDocumentReaderTest {
 					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim."),
 					tuple(Map.of("category", "header_3", "title", "Header 3"),
 							"Aenean eu leo eu nibh tristique posuere quis quis massa."));
+	}
 
+	@Test
+	void testDocumentDividedViaHorizontalRules() {
+		MarkdownDocumentReaderConfig config = MarkdownDocumentReaderConfig.builder()
+			.withHorizontalRuleCreateDocument(true)
+			.build();
+
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/horizontal-rules.md", config);
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(7)
+			.extracting(Document::getMetadata, Document::getContent)
+			.containsOnly(tuple(Map.of(),
+					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida."),
+					tuple(Map.of(),
+							"Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim."),
+					tuple(Map.of(),
+							"Nullam nisi dui, egestas nec sem nec, interdum lobortis enim. Pellentesque odio orci, faucibus eu luctus nec, venenatis et magna."),
+					tuple(Map.of(),
+							"Vestibulum nec eros non felis fermentum posuere eget ac risus. Curabitur et fringilla massa. Cras facilisis nec nisl sit amet sagittis."),
+					tuple(Map.of(),
+							"Aenean eu leo eu nibh tristique posuere quis quis massa. Nullam lacinia luctus sem ut vehicula."),
+					tuple(Map.of(),
+							"Aenean quis vulputate mi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam tincidunt nunc a tortor tincidunt, nec lobortis diam rhoncus."),
+					tuple(Map.of(), "Nulla facilisi. Phasellus eget tellus sed nibh ornare interdum eu eu mi."));
+	}
+
+	@Test
+	void testDocumentNotDividedViaHorizontalRulesWhenIsDisabled() {
+		MarkdownDocumentReaderConfig config = MarkdownDocumentReaderConfig.builder()
+			.withHorizontalRuleCreateDocument(false)
+			.build();
+
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/horizontal-rules.md", config);
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(1);
+
+		Document documentsFirst = documents.get(0);
+		assertThat(documentsFirst.getMetadata()).isEmpty();
+		assertThat(documentsFirst.getContent()).startsWith("Lorem ipsum dolor sit amet, consectetur adipiscing elit")
+			.endsWith("Phasellus eget tellus sed nibh ornare interdum eu eu mi.");
 	}
 
 }

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -23,13 +23,28 @@ class MarkdownDocumentReaderTest {
 		assertThat(documents).hasSize(4)
 			.extracting(Document::getMetadata, Document::getContent)
 			.containsOnly(tuple(Map.of("category", "header_1", "title", "Header 1a"),
-					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sednisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
+					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
 					tuple(Map.of("category", "header_1", "title", "Header 1b"),
-							"Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam lobortis risus libero, sedsollicitudin risus cursus in. Morbi enim metus, ornare vel lacinia eget, venenatis vel nibh."),
+							"Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam lobortis risus libero, sed sollicitudin risus cursus in. Morbi enim metus, ornare vel lacinia eget, venenatis vel nibh."),
 					tuple(Map.of("category", "header_2", "title", "Header 2b"),
-							"Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapienodio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero."),
+							"Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero."),
 					tuple(Map.of("category", "header_2", "title", "Header 2c"),
 							"Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit."));
+	}
+
+	@Test
+	void testWithFormatting() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/with-formatting.md");
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(2)
+			.extracting(Document::getMetadata, Document::getContent)
+			.containsOnly(tuple(Map.of("category", "header_1", "title", "This is a fancy header name"),
+					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim."),
+					tuple(Map.of("category", "header_3", "title", "Header 3"),
+							"Aenean eu leo eu nibh tristique posuere quis quis massa."));
+
 	}
 
 }

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -92,4 +92,18 @@ class MarkdownDocumentReaderTest {
 			.endsWith("Phasellus eget tellus sed nibh ornare interdum eu eu mi.");
 	}
 
+	@Test
+	void testSimpleMarkdownDocumentWithHardAndSoftLineBreaks() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/simple.md");
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(1);
+
+		Document documentsFirst = documents.get(0);
+		assertThat(documentsFirst.getMetadata()).isEmpty();
+		assertThat(documentsFirst.getContent()).isEqualTo(
+				"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim.Nullam nisi dui, egestas nec sem nec, interdum lobortis enim. Pellentesque odio orci, faucibus eu luctus nec, venenatis et magna. Vestibulum nec eros non felis fermentum posuere eget ac risus.Aenean eu leo eu nibh tristique posuere quis quis massa. Nullam lacinia luctus sem ut vehicula.");
+	}
+
 }

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -120,11 +120,11 @@ class MarkdownDocumentReaderTest {
 			assertThat(document.getMetadata()).isEqualTo(Map.of());
 			assertThat(document.getContent()).isEqualTo("This is a Java sample application:");
 		}, document -> {
-			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "code", "block"));
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "category", "code_block"));
 			assertThat(document.getContent()).startsWith("package com.example.demo;")
 				.contains("SpringApplication.run(DemoApplication.class, args);");
 		}, document -> {
-			assertThat(document.getMetadata()).isEqualTo(Map.of("code", "inline"));
+			assertThat(document.getMetadata()).isEqualTo(Map.of("category", "code_inline"));
 			assertThat(document.getContent()).isEqualTo(
 					"Markdown also provides the possibility to use inline code formatting throughout the entire sentence.");
 		}, document -> {
@@ -132,7 +132,7 @@ class MarkdownDocumentReaderTest {
 			assertThat(document.getContent())
 				.isEqualTo("Another possibility is to set block code without specific highlighting:");
 		}, document -> {
-			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "code", "block"));
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "category", "code_block"));
 			assertThat(document.getContent()).isEqualTo("./mvnw spring-javaformat:apply\n");
 		});
 	}
@@ -149,18 +149,50 @@ class MarkdownDocumentReaderTest {
 		List<Document> documents = reader.get();
 
 		assertThat(documents).satisfiesExactly(document -> {
-			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "code", "block"));
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "category", "code_block"));
 			assertThat(document.getContent()).startsWith("This is a Java sample application: package com.example.demo")
 				.contains("SpringApplication.run(DemoApplication.class, args);");
 		}, document -> {
-			assertThat(document.getMetadata()).isEqualTo(Map.of("code", "inline"));
+			assertThat(document.getMetadata()).isEqualTo(Map.of("category", "code_inline"));
 			assertThat(document.getContent()).isEqualTo(
 					"Markdown also provides the possibility to use inline code formatting throughout the entire sentence.");
 		}, document -> {
-			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "code", "block"));
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "category", "code_block"));
 			assertThat(document.getContent()).isEqualTo(
 					"Another possibility is to set block code without specific highlighting: ./mvnw spring-javaformat:apply\n");
 		});
+	}
+
+	@Test
+	void testBlockquote() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/blockquote.md");
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(2)
+			.extracting(Document::getMetadata, Document::getContent)
+			.containsOnly(tuple(Map.of(),
+					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
+					tuple(Map.of("category", "blockquote"),
+							"Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit."));
+	}
+
+	@Test
+	void testBlockquoteWhenBlockquoteShouldNotBeSeparatedDocument() {
+		MarkdownDocumentReaderConfig config = MarkdownDocumentReaderConfig.builder()
+			.withIncludeBlockquote(true)
+			.build();
+
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/blockquote.md", config);
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(1);
+
+		Document documentsFirst = documents.get(0);
+		assertThat(documentsFirst.getMetadata()).isEqualTo(Map.of("category", "blockquote"));
+		assertThat(documentsFirst.getContent()).isEqualTo(
+				"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue. Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit.");
 	}
 
 }

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -209,4 +209,22 @@ class MarkdownDocumentReaderTest {
 							"Aenean eu leo eu nibh tristique posuere quis quis massa. Aenean imperdiet libero dui, nec malesuada dui maximus vel. Vestibulum sed dui condimentum, cursus libero in, dapibus tortor. Etiam facilisis enim in egestas dictum."));
 	}
 
+	@Test
+	void testWithAdditionalMetadata() {
+		MarkdownDocumentReaderConfig config = MarkdownDocumentReaderConfig.builder()
+			.withAdditionalMetadata("service", "some-service-name")
+			.withAdditionalMetadata("env", "prod")
+			.build();
+
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/simple.md", config);
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(1);
+
+		Document documentsFirst = documents.get(0);
+		assertThat(documentsFirst.getMetadata()).isEqualTo(Map.of("service", "some-service-name", "env", "prod"));
+		assertThat(documentsFirst.getContent()).startsWith("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
+	}
+
 }

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -1,0 +1,35 @@
+package org.springframework.ai.reader.markdown;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.Document;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+/**
+ * @author Piotr Olaszewski
+ */
+class MarkdownDocumentReaderTest {
+
+	@Test
+	void testOnlyHeadersWithParagraphs() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/only-headers.md");
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(4)
+			.extracting(Document::getMetadata, Document::getContent)
+			.containsOnly(tuple(Map.of("category", "header_1", "title", "Header 1a"),
+					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sednisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
+					tuple(Map.of("category", "header_1", "title", "Header 1b"),
+							"Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam lobortis risus libero, sedsollicitudin risus cursus in. Morbi enim metus, ornare vel lacinia eget, venenatis vel nibh."),
+					tuple(Map.of("category", "header_2", "title", "Header 2b"),
+							"Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapienodio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero."),
+					tuple(Map.of("category", "header_2", "title", "Header 2c"),
+							"Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit."));
+	}
+
+}

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -106,4 +106,61 @@ class MarkdownDocumentReaderTest {
 				"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim.Nullam nisi dui, egestas nec sem nec, interdum lobortis enim. Pellentesque odio orci, faucibus eu luctus nec, venenatis et magna. Vestibulum nec eros non felis fermentum posuere eget ac risus.Aenean eu leo eu nibh tristique posuere quis quis massa. Nullam lacinia luctus sem ut vehicula.");
 	}
 
+	@Test
+	void testCode() {
+		MarkdownDocumentReaderConfig config = MarkdownDocumentReaderConfig.builder()
+			.withHorizontalRuleCreateDocument(true)
+			.build();
+
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/code.md", config);
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).satisfiesExactly(document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of());
+			assertThat(document.getContent()).isEqualTo("This is a Java sample application:");
+		}, document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "code", "block"));
+			assertThat(document.getContent()).startsWith("package com.example.demo;")
+				.contains("SpringApplication.run(DemoApplication.class, args);");
+		}, document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of("code", "inline"));
+			assertThat(document.getContent()).isEqualTo(
+					"Markdown also provides the possibility to use inline code formatting throughout the entire sentence.");
+		}, document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of());
+			assertThat(document.getContent())
+				.isEqualTo("Another possibility is to set block code without specific highlighting:");
+		}, document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "code", "block"));
+			assertThat(document.getContent()).isEqualTo("./mvnw spring-javaformat:apply\n");
+		});
+	}
+
+	@Test
+	void testCodeWhenCodeBlockShouldNotBeSeparatedDocument() {
+		MarkdownDocumentReaderConfig config = MarkdownDocumentReaderConfig.builder()
+			.withHorizontalRuleCreateDocument(true)
+			.withIncludeCodeBlock(true)
+			.build();
+
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/code.md", config);
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).satisfiesExactly(document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "java", "code", "block"));
+			assertThat(document.getContent()).startsWith("This is a Java sample application: package com.example.demo")
+				.contains("SpringApplication.run(DemoApplication.class, args);");
+		}, document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of("code", "inline"));
+			assertThat(document.getContent()).isEqualTo(
+					"Markdown also provides the possibility to use inline code formatting throughout the entire sentence.");
+		}, document -> {
+			assertThat(document.getMetadata()).isEqualTo(Map.of("lang", "", "code", "block"));
+			assertThat(document.getContent()).isEqualTo(
+					"Another possibility is to set block code without specific highlighting: ./mvnw spring-javaformat:apply\n");
+		});
+	}
+
 }

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -195,4 +195,18 @@ class MarkdownDocumentReaderTest {
 				"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue. Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit.");
 	}
 
+	@Test
+	void testLists() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/lists.md");
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(2)
+			.extracting(Document::getMetadata, Document::getContent)
+			.containsOnly(tuple(Map.of("category", "header_2", "title", "Ordered list"),
+					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue. Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor."),
+					tuple(Map.of("category", "header_2", "title", "Unordered list"),
+							"Aenean eu leo eu nibh tristique posuere quis quis massa. Aenean imperdiet libero dui, nec malesuada dui maximus vel. Vestibulum sed dui condimentum, cursus libero in, dapibus tortor. Etiam facilisis enim in egestas dictum."));
+	}
+
 }

--- a/document-readers/markdown-reader/src/test/resources/blockquote.md
+++ b/document-readers/markdown-reader/src/test/resources/blockquote.md
@@ -1,0 +1,8 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed
+nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue.
+
+> Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget
+> sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a
+> porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum
+> suscipit.
+

--- a/document-readers/markdown-reader/src/test/resources/code.md
+++ b/document-readers/markdown-reader/src/test/resources/code.md
@@ -1,0 +1,25 @@
+This is a Java sample application:
+
+```java
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}
+```
+
+Markdown also provides the possibility to `use inline code formatting throughout` the entire sentence.
+
+---
+
+Another possibility is to set block code without specific highlighting:
+
+```
+./mvnw spring-javaformat:apply
+```

--- a/document-readers/markdown-reader/src/test/resources/horizontal-rules.md
+++ b/document-readers/markdown-reader/src/test/resources/horizontal-rules.md
@@ -1,0 +1,27 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida.
+
+---
+
+Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu
+elementum dignissim.
+
+***
+Nullam nisi dui, egestas nec sem nec, interdum lobortis enim. Pellentesque odio orci, faucibus eu luctus nec, venenatis
+et magna.
+
+* * *
+
+Vestibulum nec eros non felis fermentum posuere eget ac risus. Curabitur et fringilla massa. Cras facilisis nec nisl sit
+amet sagittis.
+
+*****
+
+Aenean eu leo eu nibh tristique posuere quis quis massa. Nullam lacinia luctus sem ut vehicula.
+
+---------------------------------------
+
+Aenean quis vulputate mi. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nam tincidunt nunc a tortor tincidunt, nec lobortis diam rhoncus.
+
+- - -
+
+Nulla facilisi. Phasellus eget tellus sed nibh ornare interdum eu eu mi.

--- a/document-readers/markdown-reader/src/test/resources/lists.md
+++ b/document-readers/markdown-reader/src/test/resources/lists.md
@@ -1,0 +1,17 @@
+## Ordered list
+
+1. Lorem ipsum dolor sit *amet*, consectetur adipiscing elit. **Curabitur** diam eros, laoreet sit _amet_ cursus vitae,
+   varius sed nisi.
+2. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue.
+3. Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget
+   sapien odio.
+    1. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum
+       suscipit.
+    2. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor.
+
+## Unordered list
+
+* Aenean eu leo eu nibh tristique posuere quis quis massa.
+* Aenean imperdiet libero dui, nec malesuada dui maximus vel. Vestibulum sed dui condimentum, cursus libero in, dapibus
+  tortor.
+    * Etiam facilisis enim in egestas dictum.

--- a/document-readers/markdown-reader/src/test/resources/only-headers.md
+++ b/document-readers/markdown-reader/src/test/resources/only-headers.md
@@ -1,0 +1,20 @@
+# Header 1a
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed
+nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue.
+
+# Header 1b
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam lobortis risus libero, sed
+sollicitudin risus cursus in. Morbi enim metus, ornare vel lacinia eget, venenatis vel nibh.
+
+## Header 2b
+
+Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien
+odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero.
+
+# Header 1c
+
+## Header 2c
+
+Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit.

--- a/document-readers/markdown-reader/src/test/resources/simple.md
+++ b/document-readers/markdown-reader/src/test/resources/simple.md
@@ -1,0 +1,8 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan
+tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim.
+
+Nullam nisi dui, egestas nec sem nec, interdum lobortis enim. Pellentesque odio orci, faucibus eu luctus nec, venenatis et magna. Vestibulum nec eros non felis fermentum posuere eget ac risus.
+
+Aenean eu leo eu nibh tristique posuere quis quis massa.\
+Nullam lacinia luctus sem ut vehicula.
+

--- a/document-readers/markdown-reader/src/test/resources/with-formatting.md
+++ b/document-readers/markdown-reader/src/test/resources/with-formatting.md
@@ -1,0 +1,9 @@
+# This is a fancy header name
+
+Lorem ipsum dolor sit amet, **consectetur adipiscing elit**. Donec tincidunt velit non bibendum gravida. Cras accumsan
+tincidunt ornare. Donec hendrerit consequat tellus *blandit* accumsan. Aenean aliquam metus at ***arcu elementum***
+dignissim.
+
+### Header 3
+
+Aenean eu leo eu nibh tristique _posuere quis quis massa_. 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 		<module>spring-ai-spring-boot-testcontainers</module>
 		<module>spring-ai-spring-cloud-bindings</module>
 
+		<module>document-readers/markdown-reader</module>
 		<module>document-readers/pdf-reader</module>
 		<module>document-readers/tika-reader</module>
 
@@ -186,6 +187,7 @@
 		<qdrant.version>1.9.1</qdrant.version>
 		<typesense.version>0.5.0</typesense.version>
 		<opensearch-client.version>2.10.1</opensearch-client.version>
+		<commonmark.version>0.22.0</commonmark.version>
 
 		<!-- testing dependencies -->
 		<httpclient5.version>5.3.1</httpclient5.version>


### PR DESCRIPTION
## Motivation

@markpollack and @tzolov, maybe you are interested in the new `MarkdownDocumentReader`, which can read structured Markdown documents. As @markpollack wrote in #105, it could be valuable. I agree.

So, I've prepared a simple implementation of that `DocumentReader`.

## Description

For parsing Markdown documents, I've used the [commonmark/commonmark-java](https://github.com/commonmark/commonmark-java) library.

### Document dividing

By default, all documents are divided by headers. This includes all header types from 1 to 6. For a simple document like:

```markdown
# AAA
content 1

## BBB
content 2

### CCC
content 3

#### DDD
content 4

##### EEE
content 5

###### FFF
content 6
```

Six documents will be generated. Each of these documents will have entries in the metadata as follows:

* `category` => `header_X`, where `X` is the number of the header
* `title` => `<header title>`, e.g.: `BBB` from the example

There is also an option to divide the Markdown document by horizontal lines. This is not the default option, but it can be turned on through configuration.

### Blockquotes and Code Blocks support

All blockquotes and code blocks are treated as separate documents. For code blocks where we the language can be determined, it is included in the `lang` metadata entry.

This behavior can be changed by setting options.

### Additional metadata

The Markdown reader configuration also provides support for additional metadata, which may be set for all processed documents. It contains fixed values that offer more context about the created document, such as the service name that provides the document, or the environment in which it was created.

## TODO

- [x] Add `MarkdownDocumentReader` to the [documentation](https://docs.spring.io/spring-ai/reference/api/etl-pipeline.html#_documentreader)
- [ ] Update a [ETL Class Diagram](https://docs.spring.io/spring-ai/reference/api/etl-pipeline.html#etl-class-diagram)