### PR TITLE
fix: AbstractToolCallSupport wrong method name

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -208,7 +208,7 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 		}
 
 		AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), toolCalls);
-		ToolResponseMessage toolResponseMessage = this.executeFuncitons(assistantMessage);
+		ToolResponseMessage toolResponseMessage = this.executeFunctions(assistantMessage);
 
 		// History
 		List<Message> toolCallMessageConversation = new ArrayList<>(previousMessages);

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -233,7 +233,7 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 		AssistantMessage assistantMessage = new AssistantMessage(nativeAssistantMessage.getContent(), Map.of(),
 				assistantToolCalls);
 
-		ToolResponseMessage toolResponseMessage = this.executeFuncitons(assistantMessage);
+		ToolResponseMessage toolResponseMessage = this.executeFunctions(assistantMessage);
 
 		// History
 		List<Message> messages = new ArrayList<>(previousMessages);

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -221,7 +221,7 @@ public class MistralAiChatModel extends AbstractToolCallSupport implements ChatM
 		AssistantMessage assistantMessage = new AssistantMessage(nativeAssistantMessage.content(), Map.of(),
 				assistantToolCalls);
 
-		ToolResponseMessage toolResponseMessage = this.executeFuncitons(assistantMessage);
+		ToolResponseMessage toolResponseMessage = this.executeFunctions(assistantMessage);
 
 		// History
 		List<Message> messages = new ArrayList<>(previousMessages);
@@ -241,7 +241,7 @@ public class MistralAiChatModel extends AbstractToolCallSupport implements ChatM
 		return msg;
 	}
 
-	protected ToolResponseMessage executeFuncitons(AssistantMessage assistantMessage) {
+	protected ToolResponseMessage executeFunctions(AssistantMessage assistantMessage) {
 
 		List<ToolResponseMessage.ToolResponse> toolResponses = new ArrayList<>();
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -195,7 +195,7 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 
 		AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), assistantToolCalls);
 
-		ToolResponseMessage toolResponseMessage = this.executeFuncitons(assistantMessage);
+		ToolResponseMessage toolResponseMessage = this.executeFunctions(assistantMessage);
 
 		// History
 		List<Message> toolCallMessageConversation = new ArrayList<>(previousMessages);

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
@@ -99,7 +99,7 @@ public abstract class AbstractToolCallSupport {
 
 	protected List<Message> handleToolCalls(Prompt prompt, ChatResponse response) {
 		AssistantMessage assistantMessage = response.getResult().getOutput();
-		ToolResponseMessage toolMessageResponse = this.executeFuncitons(assistantMessage);
+		ToolResponseMessage toolMessageResponse = this.executeFunctions(assistantMessage);
 		return this.buildToolCallConversation(prompt.getInstructions(), assistantMessage, toolMessageResponse);
 	}
 
@@ -147,7 +147,7 @@ public abstract class AbstractToolCallSupport {
 		return retrievedFunctionCallbacks;
 	}
 
-	protected ToolResponseMessage executeFuncitons(AssistantMessage assistantMessage) {
+	protected ToolResponseMessage executeFunctions(AssistantMessage assistantMessage) {
 
 		List<ToolResponseMessage.ToolResponse> toolResponses = new ArrayList<>();
 


### PR DESCRIPTION
fix `AbstractToolCallSupport` wrong method name `executeFuncitons` -> `executeFunctions`