### PR TITLE
Enhanced OpenSearchVectorStore - Squashed

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
@@ -43,14 +43,15 @@ A simple configuration can either be provided via Spring Boot's `application.yml
 [source,yaml]
 ----
 spring:
-  opensearch:
-    uris: <opensearch instance URIs>
-    username: <opensearch username>
-    password: <opensearch password>
-    indexName: <opensearch index name>
-    mappingJson: <JSON mapping for opensearch index>
 # API key if needed, e.g. OpenAI
   ai:
+    vectorstore:
+      opensearch:
+        uris: <opensearch instance URIs>
+        username: <opensearch username>
+        password: <opensearch password>
+        indexName: <opensearch index name>
+        mappingJson: <JSON mapping for opensearch index>
     openai:
       api:
         key: <api-key>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
@@ -124,21 +124,26 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.opensearch.username`| Username for accessing the OpenSearch cluster. | -
 |`spring.ai.vectorstore.opensearch.password`| Password for the specified username. | -
 |`spring.ai.vectorstore.opensearch.indexName`| Name of the default index to be used within the OpenSearch cluster. | `spring-ai-document-index`
+|`spring.ai.vectorstore.opensearch.useApproximateKnn`| Whether to use the approximate k-NN method for searches.
+If true, the approximate k-NN method is used for faster searches and better performance at large scales. See link:https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn[Approximate k-NN search].
+If false, the exact brute-force k-NN method is used for highly accurate searches. See link:https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script/[Exact k-NN with scoring script]. | `false`
+|`spring.ai.vectorstore.mongodb.initialize-schema`| whether to initialize the backend schema for you | `false`
+
 |`spring.ai.vectorstore.opensearch.mappingJson`| JSON string defining the mapping for the index; specifies how documents and their
 fields are stored and indexed. |
 {
     "properties":{
         "embedding":{
-        "type":"knn_vector",
-        "dimension":1536
+            "type":"knn_vector",
+            "dimension":1536
         }
     }
 }
-|`spring.opensearch.aws.host`| Hostname of the OpenSearch instance. | -
-|`spring.opensearch.aws.service-name`| AWS service name for the OpenSearch instance. | -
-|`spring.opensearch.aws.access-key`| AWS access key for the OpenSearch instance. | -
-|`spring.opensearch.aws.secret-key`| AWS secret key for the OpenSearch instance. | -
-|`spring.opensearch.aws.region`| AWS region for the OpenSearch instance. | -
+|`spring.ai.vectorstore.opensearch.aws.host`| Hostname of the OpenSearch instance. | -
+|`spring.ai.vectorstore.opensearch.aws.service-name`| AWS service name for the OpenSearch instance. | -
+|`spring.ai.vectorstore.opensearch.aws.access-key`| AWS access key for the OpenSearch instance. | -
+|`spring.ai.vectorstore.opensearch.aws.secret-key`| AWS secret key for the OpenSearch instance. | -
+|`spring.ai.vectorstore.opensearch.aws.region`| AWS region for the OpenSearch instance. | -
 |===
 
 === Customizing OpenSearch Client Configuration

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.OpenSearchVectorStore;
+import org.springframework.ai.vectorstore.OpenSearchVectorStoreOptions;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -58,10 +59,12 @@ public class OpenSearchVectorStoreAutoConfiguration {
 	@ConditionalOnMissingBean
 	OpenSearchVectorStore vectorStore(OpenSearchVectorStoreProperties properties, OpenSearchClient openSearchClient,
 			EmbeddingModel embeddingModel) {
-		var indexName = Optional.ofNullable(properties.getIndexName()).orElse(OpenSearchVectorStore.DEFAULT_INDEX_NAME);
-		var mappingJson = Optional.ofNullable(properties.getMappingJson())
-			.orElse(OpenSearchVectorStore.DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536);
-		return new OpenSearchVectorStore(indexName, openSearchClient, embeddingModel, mappingJson,
+		OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
+		Optional.ofNullable(properties.getIndexName()).ifPresent(openSearchVectorStoreOptions::setIndexName);
+		Optional.ofNullable(properties.getMappingJson()).ifPresent(openSearchVectorStoreOptions::setMappingJson);
+		Optional.ofNullable(properties.getUseApproximateKnn())
+			.ifPresent(openSearchVectorStoreOptions::setUseApproximateKnn);
+		return new OpenSearchVectorStore(openSearchClient, embeddingModel, openSearchVectorStoreOptions,
 				properties.isInitializeSchema());
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreAutoConfiguration.java
@@ -44,6 +44,10 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * @author Jemin Huh
+ * @since 1.0.0
+ */
 @AutoConfiguration
 @ConditionalOnClass({ OpenSearchVectorStore.class, EmbeddingModel.class, OpenSearchClient.class })
 @EnableConfigurationProperties(OpenSearchVectorStoreProperties.class)

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.ai.autoconfigure.vectorstore.opensearch;
 
-import org.springframework.ai.autoconfigure.vectorstore.CommonVectorStoreProperties;
+import org.springframework.ai.autoconfigure.CommonVectorStoreProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
@@ -37,6 +37,8 @@ public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties
 	private String password;
 
 	private String mappingJson;
+
+	private Boolean useApproximateKnn;
 
 	private Aws aws = new Aws();
 
@@ -74,6 +76,14 @@ public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties
 
 	public String getMappingJson() {
 		return mappingJson;
+	}
+
+	public Boolean getUseApproximateKnn() {
+		return useApproximateKnn;
+	}
+
+	public void setUseApproximateKnn(Boolean useApproximateKnn) {
+		this.useApproximateKnn = useApproximateKnn;
 	}
 
 	public void setMappingJson(String mappingJson) {

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.ai.autoconfigure.vectorstore.opensearch;
 
-import org.springframework.ai.autoconfigure.CommonVectorStoreProperties;
+import org.springframework.ai.autoconfigure.vectorstore.CommonVectorStoreProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
@@ -74,16 +74,16 @@ public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties
 		this.password = password;
 	}
 
+	public String getMappingJson() {
+		return mappingJson;
+	}
+
 	public Boolean getUseApproximateKnn() {
 		return useApproximateKnn;
 	}
 
 	public void setUseApproximateKnn(Boolean useApproximateKnn) {
 		this.useApproximateKnn = useApproximateKnn;
-	}
-
-	public String getMappingJson() {
-		return mappingJson;
 	}
 
 	public void setMappingJson(String mappingJson) {

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/opensearch/OpenSearchVectorStoreProperties.java
@@ -36,9 +36,9 @@ public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties
 
 	private String password;
 
-	private String mappingJson;
-
 	private Boolean useApproximateKnn;
+
+	private String mappingJson;
 
 	private Aws aws = new Aws();
 
@@ -74,16 +74,16 @@ public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties
 		this.password = password;
 	}
 
-	public String getMappingJson() {
-		return mappingJson;
-	}
-
 	public Boolean getUseApproximateKnn() {
 		return useApproximateKnn;
 	}
 
 	public void setUseApproximateKnn(Boolean useApproximateKnn) {
 		this.useApproximateKnn = useApproximateKnn;
+	}
+
+	public String getMappingJson() {
+		return mappingJson;
 	}
 
 	public void setMappingJson(String mappingJson) {

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 
 /**
  * @author Jemin Huh
+ * @author Soby Chacko
  * @since 1.0.0
  */
 public class OpenSearchVectorStore implements VectorStore, InitializingBean {
@@ -112,7 +113,7 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 				document.setEmbedding(this.embeddingModel.embed(document));
 			}
 			bulkRequestBuilder
-				.operations(op -> op.index(idx -> idx.index(this.index).id(document.getId()).document(document)));
+					.operations(op -> op.index(idx -> idx.index(this.index).id(document.getId()).document(document)));
 		}
 		bulkRequest(bulkRequestBuilder.build());
 	}
@@ -146,47 +147,41 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 		float[] floatEmbedding = new float[embedding.size()];
 		for (int i = 0; i < embedding.size(); i++)
 			floatEmbedding[i] = embedding.get(i).floatValue();
-		return similaritySearch(
-				isUseApproximateKnn ? buildApproximateQuery(topK, similarityThreshold, filterExpression, floatEmbedding)
-						: buildExactQuery(embedding, topK, similarityThreshold, filterExpression));
+		return similaritySearch(isUseApproximateKnn ? buildApproximateQuery(topK, similarityThreshold, filterExpression,
+				floatEmbedding) : buildExactQuery(embedding, topK, similarityThreshold, filterExpression));
 	}
 
 	private org.opensearch.client.opensearch.core.SearchRequest buildApproximateQuery(int topK,
-			double similarityThreshold, Filter.Expression filterExpression, float[] floatEmbedding) {
+			double similarityThreshold,
+			Filter.Expression filterExpression, float[] floatEmbedding) {
 		return new org.opensearch.client.opensearch.core.SearchRequest.Builder()
-			.query(Query.of(builder -> builder.knn(KnnQueryBuilder -> KnnQueryBuilder
-				.filter(Query
-					.of(queryBuilder -> queryBuilder.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
-						.query(getOpenSearchQueryString(filterExpression)))))
-				.field("embedding")
-				.k(topK)
-				.vector(floatEmbedding))))
-			.minScore(similarityThreshold)
-			.build();
+				.query(Query.of(builder -> builder.knn(KnnQueryBuilder -> KnnQueryBuilder.filter(Query.of(
+								queryBuilder -> queryBuilder.queryString(
+										queryStringQuerybuilder -> queryStringQuerybuilder.query(
+												getOpenSearchQueryString(filterExpression)))))
+						.field("embedding").k(topK).vector(floatEmbedding))))
+				.minScore(similarityThreshold).build();
 	}
 
 	private org.opensearch.client.opensearch.core.SearchRequest buildExactQuery(List<Double> embedding, int topK,
 			double similarityThreshold, Filter.Expression filterExpression) {
-		return new org.opensearch.client.opensearch.core.SearchRequest.Builder()
-			.query(buildExactQuery(embedding, filterExpression))
-			.sort(sortOptionsBuilder -> sortOptionsBuilder
-				.score(scoreSortBuilder -> scoreSortBuilder.order(SortOrder.Desc)))
-			.size(topK)
-			.minScore(similarityThreshold)
-			.build();
+		return new org.opensearch.client.opensearch.core.SearchRequest.Builder().query(
+						buildExactQuery(embedding, filterExpression)).sort(sortOptionsBuilder -> sortOptionsBuilder.score(
+						scoreSortBuilder -> scoreSortBuilder.order(SortOrder.Desc))).size(topK).minScore(similarityThreshold)
+				.build();
 	}
 
 	private Query buildExactQuery(List<Double> embedding, Filter.Expression filterExpression) {
 		return Query.of(queryBuilder -> queryBuilder.scriptScore(scriptScoreQueryBuilder -> {
 			scriptScoreQueryBuilder
-				.query(queryBuilder2 -> queryBuilder2.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
-					.query(getOpenSearchQueryString(filterExpression))))
-				.script(scriptBuilder -> scriptBuilder
-					.inline(inlineScriptBuilder -> inlineScriptBuilder.source("knn_score")
-						.lang("knn")
-						.params("field", JsonData.of("embedding"))
-						.params("query_value", JsonData.of(embedding))
-						.params("space_type", JsonData.of(this.similarityFunction))));
+					.query(queryBuilder2 -> queryBuilder2.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
+							.query(getOpenSearchQueryString(filterExpression))))
+					.script(scriptBuilder -> scriptBuilder
+							.inline(inlineScriptBuilder -> inlineScriptBuilder.source("knn_score")
+									.lang("knn")
+									.params("field", JsonData.of("embedding"))
+									.params("query_value", JsonData.of(embedding))
+									.params("space_type", JsonData.of(this.similarityFunction))));
 			// https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script
 			// k-NN ensures non-negative scores by adding 1 to cosine similarity,
 			// extending OpenSearch scores to 0-2.
@@ -205,11 +200,11 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	private List<Document> similaritySearch(org.opensearch.client.opensearch.core.SearchRequest searchRequest) {
 		try {
 			return this.openSearchClient.search(searchRequest, Document.class)
-				.hits()
-				.hits()
-				.stream()
-				.map(this::toDocument)
-				.collect(Collectors.toList());
+					.hits()
+					.hits()
+					.stream()
+					.map(this::toDocument)
+					.collect(Collectors.toList());
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);
@@ -225,10 +220,9 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	public boolean exists(String targetIndex) {
 		try {
 			BooleanResponse response = this.openSearchClient.indices()
-				.exists(existRequestBuilder -> existRequestBuilder.index(targetIndex));
+					.exists(existRequestBuilder -> existRequestBuilder.index(targetIndex));
 			return response.value();
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -250,19 +244,14 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() {
-		if (!this.initializeSchema) {
-			return;
-		}
-
 		/**
-		 * Generates a JSON string for the k-NN vector mapping configuration. The
-		 * knn_vector field allows k-NN vectors ingestion into OpenSearch and supports
-		 * various k-NN searches.
+		 * Generates a JSON string for the k-NN vector mapping configuration.
+		 * The knn_vector field allows k-NN vectors ingestion into OpenSearch and supports various k-NN searches.
 		 * https://opensearch.org/docs/latest/search-plugins/knn/knn-index#method-definitions
 		 */
-		if (!exists(this.index)) {
-			createIndexMapping(Objects.requireNonNullElseGet(openSearchVectorStoreOptions.getMappingJson(),
-					() -> this.isUseApproximateKnn ? """
+		if (this.initializeSchema && !exists(this.index)) {
+			createIndexMapping(Objects.requireNonNullElseGet(openSearchVectorStoreOptions.getMappingJson(), () ->
+					this.isUseApproximateKnn ? """
 							   {
 							       "properties": {
 							           "embedding": {
@@ -276,8 +265,8 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 							           }
 							       }
 							   }
-							""".formatted(this.openSearchVectorStoreOptions.getDimensions(), this.similarityFunction)
-							: DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536));
+							""".formatted(this.openSearchVectorStoreOptions.getDimensions(),
+							this.similarityFunction) : DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536));
 		}
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
@@ -113,7 +113,7 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 				document.setEmbedding(this.embeddingModel.embed(document));
 			}
 			bulkRequestBuilder
-					.operations(op -> op.index(idx -> idx.index(this.index).id(document.getId()).document(document)));
+				.operations(op -> op.index(idx -> idx.index(this.index).id(document.getId()).document(document)));
 		}
 		bulkRequest(bulkRequestBuilder.build());
 	}
@@ -147,41 +147,47 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 		float[] floatEmbedding = new float[embedding.size()];
 		for (int i = 0; i < embedding.size(); i++)
 			floatEmbedding[i] = embedding.get(i).floatValue();
-		return similaritySearch(isUseApproximateKnn ? buildApproximateQuery(topK, similarityThreshold, filterExpression,
-				floatEmbedding) : buildExactQuery(embedding, topK, similarityThreshold, filterExpression));
+		return similaritySearch(
+				isUseApproximateKnn ? buildApproximateQuery(topK, similarityThreshold, filterExpression, floatEmbedding)
+						: buildExactQuery(embedding, topK, similarityThreshold, filterExpression));
 	}
 
 	private org.opensearch.client.opensearch.core.SearchRequest buildApproximateQuery(int topK,
-			double similarityThreshold,
-			Filter.Expression filterExpression, float[] floatEmbedding) {
+			double similarityThreshold, Filter.Expression filterExpression, float[] floatEmbedding) {
 		return new org.opensearch.client.opensearch.core.SearchRequest.Builder()
-				.query(Query.of(builder -> builder.knn(KnnQueryBuilder -> KnnQueryBuilder.filter(Query.of(
-								queryBuilder -> queryBuilder.queryString(
-										queryStringQuerybuilder -> queryStringQuerybuilder.query(
-												getOpenSearchQueryString(filterExpression)))))
-						.field("embedding").k(topK).vector(floatEmbedding))))
-				.minScore(similarityThreshold).build();
+			.query(Query.of(builder -> builder.knn(KnnQueryBuilder -> KnnQueryBuilder
+				.filter(Query
+					.of(queryBuilder -> queryBuilder.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
+						.query(getOpenSearchQueryString(filterExpression)))))
+				.field("embedding")
+				.k(topK)
+				.vector(floatEmbedding))))
+			.minScore(similarityThreshold)
+			.build();
 	}
 
 	private org.opensearch.client.opensearch.core.SearchRequest buildExactQuery(List<Double> embedding, int topK,
 			double similarityThreshold, Filter.Expression filterExpression) {
-		return new org.opensearch.client.opensearch.core.SearchRequest.Builder().query(
-						buildExactQuery(embedding, filterExpression)).sort(sortOptionsBuilder -> sortOptionsBuilder.score(
-						scoreSortBuilder -> scoreSortBuilder.order(SortOrder.Desc))).size(topK).minScore(similarityThreshold)
-				.build();
+		return new org.opensearch.client.opensearch.core.SearchRequest.Builder()
+			.query(buildExactQuery(embedding, filterExpression))
+			.sort(sortOptionsBuilder -> sortOptionsBuilder
+				.score(scoreSortBuilder -> scoreSortBuilder.order(SortOrder.Desc)))
+			.size(topK)
+			.minScore(similarityThreshold)
+			.build();
 	}
 
 	private Query buildExactQuery(List<Double> embedding, Filter.Expression filterExpression) {
 		return Query.of(queryBuilder -> queryBuilder.scriptScore(scriptScoreQueryBuilder -> {
 			scriptScoreQueryBuilder
-					.query(queryBuilder2 -> queryBuilder2.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
-							.query(getOpenSearchQueryString(filterExpression))))
-					.script(scriptBuilder -> scriptBuilder
-							.inline(inlineScriptBuilder -> inlineScriptBuilder.source("knn_score")
-									.lang("knn")
-									.params("field", JsonData.of("embedding"))
-									.params("query_value", JsonData.of(embedding))
-									.params("space_type", JsonData.of(this.similarityFunction))));
+				.query(queryBuilder2 -> queryBuilder2.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
+					.query(getOpenSearchQueryString(filterExpression))))
+				.script(scriptBuilder -> scriptBuilder
+					.inline(inlineScriptBuilder -> inlineScriptBuilder.source("knn_score")
+						.lang("knn")
+						.params("field", JsonData.of("embedding"))
+						.params("query_value", JsonData.of(embedding))
+						.params("space_type", JsonData.of(this.similarityFunction))));
 			// https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script
 			// k-NN ensures non-negative scores by adding 1 to cosine similarity,
 			// extending OpenSearch scores to 0-2.
@@ -200,11 +206,11 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	private List<Document> similaritySearch(org.opensearch.client.opensearch.core.SearchRequest searchRequest) {
 		try {
 			return this.openSearchClient.search(searchRequest, Document.class)
-					.hits()
-					.hits()
-					.stream()
-					.map(this::toDocument)
-					.collect(Collectors.toList());
+				.hits()
+				.hits()
+				.stream()
+				.map(this::toDocument)
+				.collect(Collectors.toList());
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);
@@ -220,9 +226,10 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	public boolean exists(String targetIndex) {
 		try {
 			BooleanResponse response = this.openSearchClient.indices()
-					.exists(existRequestBuilder -> existRequestBuilder.index(targetIndex));
+				.exists(existRequestBuilder -> existRequestBuilder.index(targetIndex));
 			return response.value();
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -245,13 +252,14 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	@Override
 	public void afterPropertiesSet() {
 		/**
-		 * Generates a JSON string for the k-NN vector mapping configuration.
-		 * The knn_vector field allows k-NN vectors ingestion into OpenSearch and supports various k-NN searches.
+		 * Generates a JSON string for the k-NN vector mapping configuration. The
+		 * knn_vector field allows k-NN vectors ingestion into OpenSearch and supports
+		 * various k-NN searches.
 		 * https://opensearch.org/docs/latest/search-plugins/knn/knn-index#method-definitions
 		 */
 		if (this.initializeSchema && !exists(this.index)) {
-			createIndexMapping(Objects.requireNonNullElseGet(openSearchVectorStoreOptions.getMappingJson(), () ->
-					this.isUseApproximateKnn ? """
+			createIndexMapping(Objects.requireNonNullElseGet(openSearchVectorStoreOptions.getMappingJson(),
+					() -> this.isUseApproximateKnn ? """
 							   {
 							       "properties": {
 							           "embedding": {
@@ -265,8 +273,8 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 							           }
 							       }
 							   }
-							""".formatted(this.openSearchVectorStoreOptions.getDimensions(),
-							this.similarityFunction) : DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536));
+							""".formatted(this.openSearchVectorStoreOptions.getDimensions(), this.similarityFunction)
+							: DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536));
 		}
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023 - 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
 
 /**
  * @author Jemin Huh
- * @author Soby Chacko
  * @since 1.0.0
  */
 public class OpenSearchVectorStore implements VectorStore, InitializingBean {
@@ -53,8 +52,6 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	public static final String COSINE_SIMILARITY_FUNCTION = "cosinesimil";
 
 	private static final Logger logger = LoggerFactory.getLogger(OpenSearchVectorStore.class);
-
-	public static final String DEFAULT_INDEX_NAME = "spring-ai-document-index";
 
 	public static final String DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536 = """
 			{
@@ -67,6 +64,8 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 			}
 			""";
 
+	private final OpenSearchVectorStoreOptions openSearchVectorStoreOptions;
+
 	private final EmbeddingModel embeddingModel;
 
 	private final OpenSearchClient openSearchClient;
@@ -75,41 +74,33 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 
 	private final FilterExpressionConverter filterExpressionConverter;
 
-	private final String mappingJson;
+	private final String similarityFunction;
 
-	private String similarityFunction;
+	private final boolean isUseApproximateKnn;
 
 	private final boolean initializeSchema;
 
+	public OpenSearchVectorStore(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
+		this(openSearchClient, embeddingModel, new OpenSearchVectorStoreOptions());
+	}
+
 	public OpenSearchVectorStore(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel,
-			boolean initializeSchema) {
-		this(openSearchClient, embeddingModel, DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536,
-				initializeSchema);
+			OpenSearchVectorStoreOptions openSearchVectorStoreOptions) {
+		this(openSearchClient, embeddingModel, openSearchVectorStoreOptions, true);
 	}
 
-	public OpenSearchVectorStore(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel, String mappingJson,
-			boolean initializeSchema) {
-		this(DEFAULT_INDEX_NAME, openSearchClient, embeddingModel, mappingJson, initializeSchema);
-	}
-
-	public OpenSearchVectorStore(String index, OpenSearchClient openSearchClient, EmbeddingModel embeddingModel,
-			String mappingJson, boolean initializeSchema) {
-		Objects.requireNonNull(embeddingModel, "RestClient must not be null");
+	public OpenSearchVectorStore(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel,
+			OpenSearchVectorStoreOptions openSearchVectorStoreOptions, boolean initializeSchema) {
+		Objects.requireNonNull(openSearchClient, "OpenSearchClient must not be null");
 		Objects.requireNonNull(embeddingModel, "EmbeddingModel must not be null");
 		this.openSearchClient = openSearchClient;
 		this.embeddingModel = embeddingModel;
-		this.index = index;
-		this.mappingJson = mappingJson;
+		this.openSearchVectorStoreOptions = openSearchVectorStoreOptions;
+		this.index = openSearchVectorStoreOptions.getIndexName();
 		this.filterExpressionConverter = new OpenSearchAiSearchFilterExpressionConverter();
-		// the potential functions for vector fields at
-		// https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#spaces
-		this.similarityFunction = COSINE_SIMILARITY_FUNCTION;
+		this.similarityFunction = openSearchVectorStoreOptions.getSimilarity();
+		this.isUseApproximateKnn = openSearchVectorStoreOptions.isUseApproximateKnn();
 		this.initializeSchema = initializeSchema;
-	}
-
-	public OpenSearchVectorStore withSimilarityFunction(String similarityFunction) {
-		this.similarityFunction = similarityFunction;
-		return this;
 	}
 
 	@Override
@@ -121,7 +112,7 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 				document.setEmbedding(this.embeddingModel.embed(document));
 			}
 			bulkRequestBuilder
-				.operations(op -> op.index(idx -> idx.index(this.index).id(document.getId()).document(document)));
+					.operations(op -> op.index(idx -> idx.index(this.index).id(document.getId()).document(document)));
 		}
 		bulkRequest(bulkRequestBuilder.build());
 	}
@@ -152,26 +143,44 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 
 	public List<Document> similaritySearch(List<Double> embedding, int topK, double similarityThreshold,
 			Filter.Expression filterExpression) {
-		return similaritySearch(new org.opensearch.client.opensearch.core.SearchRequest.Builder()
-			.query(getOpenSearchSimilarityQuery(embedding, filterExpression))
-			.sort(sortOptionsBuilder -> sortOptionsBuilder
-				.score(scoreSortBuilder -> scoreSortBuilder.order(SortOrder.Desc)))
-			.size(topK)
-			.minScore(similarityThreshold)
-			.build());
+		float[] floatEmbedding = new float[embedding.size()];
+		for (int i = 0; i < embedding.size(); i++)
+			floatEmbedding[i] = embedding.get(i).floatValue();
+		return similaritySearch(isUseApproximateKnn ? buildApproximateQuery(topK, similarityThreshold, filterExpression,
+				floatEmbedding) : buildExactQuery(embedding, topK, similarityThreshold, filterExpression));
 	}
 
-	private Query getOpenSearchSimilarityQuery(List<Double> embedding, Filter.Expression filterExpression) {
+	private org.opensearch.client.opensearch.core.SearchRequest buildApproximateQuery(int topK,
+			double similarityThreshold,
+			Filter.Expression filterExpression, float[] floatEmbedding) {
+		return new org.opensearch.client.opensearch.core.SearchRequest.Builder()
+				.query(Query.of(builder -> builder.knn(KnnQueryBuilder -> KnnQueryBuilder.filter(Query.of(
+								queryBuilder -> queryBuilder.queryString(
+										queryStringQuerybuilder -> queryStringQuerybuilder.query(
+												getOpenSearchQueryString(filterExpression)))))
+						.field("embedding").k(topK).vector(floatEmbedding))))
+				.minScore(similarityThreshold).build();
+	}
+
+	private org.opensearch.client.opensearch.core.SearchRequest buildExactQuery(List<Double> embedding, int topK,
+			double similarityThreshold, Filter.Expression filterExpression) {
+		return new org.opensearch.client.opensearch.core.SearchRequest.Builder().query(
+						buildExactQuery(embedding, filterExpression)).sort(sortOptionsBuilder -> sortOptionsBuilder.score(
+						scoreSortBuilder -> scoreSortBuilder.order(SortOrder.Desc))).size(topK).minScore(similarityThreshold)
+				.build();
+	}
+
+	private Query buildExactQuery(List<Double> embedding, Filter.Expression filterExpression) {
 		return Query.of(queryBuilder -> queryBuilder.scriptScore(scriptScoreQueryBuilder -> {
 			scriptScoreQueryBuilder
-				.query(queryBuilder2 -> queryBuilder2.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
-					.query(getOpenSearchQueryString(filterExpression))))
-				.script(scriptBuilder -> scriptBuilder
-					.inline(inlineScriptBuilder -> inlineScriptBuilder.source("knn_score")
-						.lang("knn")
-						.params("field", JsonData.of("embedding"))
-						.params("query_value", JsonData.of(embedding))
-						.params("space_type", JsonData.of(this.similarityFunction))));
+					.query(queryBuilder2 -> queryBuilder2.queryString(queryStringQuerybuilder -> queryStringQuerybuilder
+							.query(getOpenSearchQueryString(filterExpression))))
+					.script(scriptBuilder -> scriptBuilder
+							.inline(inlineScriptBuilder -> inlineScriptBuilder.source("knn_score")
+									.lang("knn")
+									.params("field", JsonData.of("embedding"))
+									.params("query_value", JsonData.of(embedding))
+									.params("space_type", JsonData.of(this.similarityFunction))));
 			// https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script
 			// k-NN ensures non-negative scores by adding 1 to cosine similarity,
 			// extending OpenSearch scores to 0-2.
@@ -190,13 +199,12 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	private List<Document> similaritySearch(org.opensearch.client.opensearch.core.SearchRequest searchRequest) {
 		try {
 			return this.openSearchClient.search(searchRequest, Document.class)
-				.hits()
-				.hits()
-				.stream()
-				.map(this::toDocument)
-				.collect(Collectors.toList());
-		}
-		catch (IOException e) {
+					.hits()
+					.hits()
+					.stream()
+					.map(this::toDocument)
+					.collect(Collectors.toList());
+		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -210,33 +218,57 @@ public class OpenSearchVectorStore implements VectorStore, InitializingBean {
 	public boolean exists(String targetIndex) {
 		try {
 			BooleanResponse response = this.openSearchClient.indices()
-				.exists(existRequestBuilder -> existRequestBuilder.index(targetIndex));
+					.exists(existRequestBuilder -> existRequestBuilder.index(targetIndex));
 			return response.value();
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	private CreateIndexResponse createIndexMapping(String index, String mappingJson) {
+	private CreateIndexResponse createIndexMapping(String mappingJson) {
 		JsonpMapper jsonpMapper = openSearchClient._transport().jsonpMapper();
 		try {
 			return this.openSearchClient.indices()
-				.create(new CreateIndexRequest.Builder().index(index)
-					.settings(settingsBuilder -> settingsBuilder.knn(true))
-					.mappings(TypeMapping._DESERIALIZER.deserialize(
-							jsonpMapper.jsonProvider().createParser(new StringReader(mappingJson)), jsonpMapper))
-					.build());
-		}
-		catch (IOException e) {
+					.create(new CreateIndexRequest.Builder().index(this.index)
+							.settings(settingsBuilder -> settingsBuilder.knn(true))
+							.mappings(TypeMapping._DESERIALIZER.deserialize(
+									jsonpMapper.jsonProvider().createParser(new StringReader(mappingJson)),
+									jsonpMapper))
+							.build());
+		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
 
 	@Override
 	public void afterPropertiesSet() {
-		if (this.initializeSchema && !exists(this.index)) {
-			createIndexMapping(this.index, this.mappingJson);
+		if (!this.initializeSchema) {
+			return;
+		}
+
+		/**
+		 * Generates a JSON string for the k-NN vector mapping configuration.
+		 * The knn_vector field allows k-NN vectors ingestion into OpenSearch and supports various k-NN searches.
+		 * https://opensearch.org/docs/latest/search-plugins/knn/knn-index#method-definitions
+		 */
+		if (!exists(this.index)) {
+			createIndexMapping(Objects.requireNonNullElseGet(openSearchVectorStoreOptions.getMappingJson(), () ->
+					this.isUseApproximateKnn ? """
+							   {
+							       "properties": {
+							           "embedding": {
+							               "type": "knn_vector",
+							               "dimension": "%d",
+							               "method": {
+							                   "name": "hnsw",
+							                   "engine": "lucene",
+							                   "space_type": "%s"
+							               }
+							           }
+							       }
+							   }
+							""".formatted(this.openSearchVectorStoreOptions.getDimensions(),
+							this.similarityFunction) : DEFAULT_MAPPING_EMBEDDING_TYPE_KNN_VECTOR_DIMENSION_1536));
 		}
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreOptions.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreOptions.java
@@ -32,16 +32,17 @@ public class OpenSearchVectorStoreOptions {
 	private int dimensions = 1536;
 
 	/**
-	 * The similarity function to use. the potential functions for vector fields at
+	 * The similarity function to use.
+	 * the potential functions for vector fields at
 	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#spaces
 	 */
 	private String similarity = "cosinesimil";
 
 	/**
-	 * Indicates whether to use approximate kNN. If true, the approximate kNN method is
-	 * used for faster searches and maintains good performance even at large scales.
-	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/ If false,
-	 * the exact brute-force kNN method is used for precise and highly accurate searches.
+	 * Indicates whether to use approximate kNN.
+	 * If true, the approximate kNN method is used for faster searches and maintains good performance even at large scales.
+	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/
+	 * If false, the exact brute-force kNN method is used for precise and highly accurate searches.
 	 * https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script/
 	 */
 	private boolean useApproximateKnn = false;

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreOptions.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreOptions.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.vectorstore;
+
+/**
+ * @author Jemin Huh
+ * @since 1.0.0
+ */
+public class OpenSearchVectorStoreOptions {
+
+	/**
+	 * The name of the index to store the vectors.
+	 */
+	private String indexName = "spring-ai-document-index";
+
+	/**
+	 * The number of dimensions in the vector.
+	 */
+	private int dimensions = 1536;
+
+	/**
+	 * The similarity function to use.
+	 * the potential functions for vector fields at
+	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#spaces
+	 */
+	private String similarity = "cosinesimil";
+
+	/**
+	 * Indicates whether to use approximate kNN.
+	 * If true, the approximate kNN method is used for faster searches and maintains good performance even at large scales.
+	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/
+	 * If false, the exact brute-force kNN method is used for precise and highly accurate searches.
+	 * https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script/
+	 */
+	private boolean useApproximateKnn = false;
+
+	private String mappingJson;
+
+	public String getIndexName() {
+		return this.indexName;
+	}
+
+	public void setIndexName(String indexName) {
+		this.indexName = indexName;
+	}
+
+	public int getDimensions() {
+		return this.dimensions;
+	}
+
+	public void setDimensions(int dims) {
+		this.dimensions = dims;
+	}
+
+	public String getSimilarity() {
+		return similarity;
+	}
+
+	public void setSimilarity(String similarity) {
+		this.similarity = similarity;
+	}
+
+	public boolean isUseApproximateKnn() {
+		return this.useApproximateKnn;
+	}
+
+	public void setUseApproximateKnn(boolean useApproximateKnn) {
+		this.useApproximateKnn = useApproximateKnn;
+	}
+
+	public String getMappingJson() {
+		return mappingJson;
+	}
+
+	public void setMappingJson(String mappingJson) {
+		this.mappingJson = mappingJson;
+	}
+
+}

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreOptions.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreOptions.java
@@ -32,17 +32,16 @@ public class OpenSearchVectorStoreOptions {
 	private int dimensions = 1536;
 
 	/**
-	 * The similarity function to use.
-	 * the potential functions for vector fields at
+	 * The similarity function to use. the potential functions for vector fields at
 	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#spaces
 	 */
 	private String similarity = "cosinesimil";
 
 	/**
-	 * Indicates whether to use approximate kNN.
-	 * If true, the approximate kNN method is used for faster searches and maintains good performance even at large scales.
-	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/
-	 * If false, the exact brute-force kNN method is used for precise and highly accurate searches.
+	 * Indicates whether to use approximate kNN. If true, the approximate kNN method is
+	 * used for faster searches and maintains good performance even at large scales.
+	 * https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/ If false,
+	 * the exact brute-force kNN method is used for precise and highly accurate searches.
 	 * https://opensearch.org/docs/latest/search-plugins/knn/knn-score-script/
 	 */
 	private boolean useApproximateKnn = false;

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
@@ -80,7 +80,8 @@ class OpenSearchVectorStoreIT {
 		var resource = new DefaultResourceLoader().getResource(uri);
 		try {
 			return resource.getContentAsString(StandardCharsets.UTF_8);
-		} catch (IOException e) {
+		}
+		catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -98,23 +99,22 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void addAndSearchTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-							hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+						hasSize(1));
 
 			List<Document> results = vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
+				.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -128,20 +128,19 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-							hasSize(0));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+						hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void searchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -153,73 +152,71 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)),
-							hasSize(3));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)), hasSize(3));
 
 			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'NL'"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'NL'"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'BG'"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'BG'"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'BG' && year == 2020"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'BG' && year == 2020"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country in ['BG']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country in ['BG']"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country in ['BG','NL']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country in ['BG','NL']"));
 
 			assertThat(results).hasSize(3);
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country not in ['BG']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country not in ['BG']"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("NOT(country not in ['BG'])"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("NOT(country not in ['BG'])"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression(
-							"activationDate > " +
-									ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression(
+						"activationDate > " + ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument2.getId());
@@ -228,30 +225,29 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)),
-							hasSize(0));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)), hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void documentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
 			vectorStore.add(List.of(document));
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
-							hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
+						hasSize(1));
 
 			List<Document> results = vectorStore
-					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
+				.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -267,8 +263,8 @@ class OpenSearchVectorStoreIT {
 			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar").withTopK(5);
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
-							equalTo("The World is Big and Salvation Lurks Around the Corner"));
+				.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
+						equalTo("The World is Big and Salvation Lurks Around the Corner"));
 
 			results = vectorStore.similaritySearch(fooBarSearchRequest);
 
@@ -288,18 +284,18 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void searchThresholdTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			SearchRequest query = SearchRequest.query("Great Depression")
-					.withTopK(50)
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+				.withTopK(50)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
 
 			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
 
@@ -325,31 +321,29 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
-							hasSize(0));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
+						hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateAddAndSearchTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-							hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+						hasSize(1));
 
 			List<Document> results = vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
+				.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -363,20 +357,19 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-							hasSize(0));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+						hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateSearchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -388,73 +381,71 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)),
-							hasSize(3));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)), hasSize(3));
 
 			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'NL'"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'NL'"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'BG'"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'BG'"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'BG' && year == 2020"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'BG' && year == 2020"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country in ['BG']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country in ['BG']"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country in ['BG','NL']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country in ['BG','NL']"));
 
 			assertThat(results).hasSize(3);
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country not in ['BG']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country not in ['BG']"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("NOT(country not in ['BG'])"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("NOT(country not in ['BG'])"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression(
-							"activationDate > " +
-									ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression(
+						"activationDate > " + ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument2.getId());
@@ -463,30 +454,29 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)),
-							hasSize(0));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)), hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateDocumentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
 			vectorStore.add(List.of(document));
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
-							hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
+						hasSize(1));
 
 			List<Document> results = vectorStore
-					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
+				.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -502,8 +492,8 @@ class OpenSearchVectorStoreIT {
 			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar").withTopK(5);
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
-							equalTo("The World is Big and Salvation Lurks Around the Corner"));
+				.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
+						equalTo("The World is Big and Salvation Lurks Around the Corner"));
 
 			results = vectorStore.similaritySearch(fooBarSearchRequest);
 
@@ -523,18 +513,18 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateAearchThresholdTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			SearchRequest query = SearchRequest.query("Great Depression")
-					.withTopK(50)
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+				.withTopK(50)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
 
 			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
 
@@ -560,15 +550,14 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
-							hasSize(0));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
+						hasSize(0));
 		});
 	}
 
 	@SpringBootConfiguration
-	@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
+	@EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class })
 	public static class TestApplication {
 
 		@Bean("vectorStore_" + DEFAULT)
@@ -578,8 +567,7 @@ class OpenSearchVectorStoreIT {
 		}
 
 		@Bean("vectorStore_l2")
-		public OpenSearchVectorStore vectorStoreL2(OpenSearchClient openSearchClient,
-				EmbeddingModel embeddingModel) {
+		public OpenSearchVectorStore vectorStoreL2(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
 			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
 			openSearchVectorStoreOptions.setIndexName("index_l2");
 			openSearchVectorStoreOptions.setSimilarity("l2");
@@ -587,8 +575,7 @@ class OpenSearchVectorStoreIT {
 		}
 
 		@Bean("vectorStore_innerproduct")
-		public OpenSearchVectorStore vectorStoreLinf(OpenSearchClient openSearchClient,
-				EmbeddingModel embeddingModel) {
+		public OpenSearchVectorStore vectorStoreLinf(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
 			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
 			openSearchVectorStoreOptions.setIndexName("index_innerproduct");
 			openSearchVectorStoreOptions.setSimilarity("innerproduct");
@@ -638,9 +625,10 @@ class OpenSearchVectorStoreIT {
 		public OpenSearchClient openSearchClient() {
 			try {
 				return new OpenSearchClient(ApacheHttpClient5TransportBuilder
-						.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
-						.build());
-			} catch (URISyntaxException e) {
+					.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
+					.build());
+			}
+			catch (URISyntaxException e) {
 				throw new RuntimeException(e);
 			}
 		}

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023 - 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,11 +54,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-/**
- * @author Jemin Huh
- * @author Soby Chacko
- * @since 1.0.0
- */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenSearchVectorStoreIT {
@@ -85,8 +80,7 @@ class OpenSearchVectorStoreIT {
 		var resource = new DefaultResourceLoader().getResource(uri);
 		try {
 			return resource.getContentAsString(StandardCharsets.UTF_8);
-		}
-		catch (IOException e) {
+		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
@@ -98,31 +92,29 @@ class OpenSearchVectorStoreIT {
 	@BeforeEach
 	void cleanDatabase() {
 		getContextRunner().run(context -> {
-			VectorStore vectorStore = context.getBean(VectorStore.class);
+			VectorStore vectorStore = context.getBean("vectorStore", VectorStore.class);
 			vectorStore.delete(List.of("_all"));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l1", "l2", "linf" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void addAndSearchTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean(OpenSearchVectorStore.class);
-
-			if (!DEFAULT.equals(similarityFunction)) {
-				vectorStore.withSimilarityFunction(similarityFunction);
-			}
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-						hasSize(1));
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+							hasSize(1));
 
 			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -136,22 +128,20 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-						hasSize(0));
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+							hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l1", "l2", "linf" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void searchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean(OpenSearchVectorStore.class);
-
-			if (!DEFAULT.equals(similarityFunction)) {
-				vectorStore.withSimilarityFunction(similarityFunction);
-			}
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -163,71 +153,73 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)), hasSize(3));
+					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)),
+							hasSize(3));
 
 			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country == 'NL'"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'NL'"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country == 'BG'"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'BG'"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country == 'BG' && year == 2020"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'BG' && year == 2020"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country in ['BG']"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country in ['BG']"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country in ['BG','NL']"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country in ['BG','NL']"));
 
 			assertThat(results).hasSize(3);
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country not in ['BG']"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country not in ['BG']"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("NOT(country not in ['BG'])"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("NOT(country not in ['BG'])"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression(
-						"activationDate > " + ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression(
+							"activationDate > " +
+									ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument2.getId());
@@ -236,31 +228,30 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)), hasSize(0));
+					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)),
+							hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l1", "l2", "linf" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void documentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean(OpenSearchVectorStore.class);
-			if (!DEFAULT.equals(similarityFunction)) {
-				vectorStore.withSimilarityFunction(similarityFunction);
-			}
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
 			vectorStore.add(List.of(document));
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
-						hasSize(1));
+					.until(() -> vectorStore
+									.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
+							hasSize(1));
 
 			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
+					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -276,8 +267,8 @@ class OpenSearchVectorStoreIT {
 			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar").withTopK(5);
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
-						equalTo("The World is Big and Salvation Lurks Around the Corner"));
+					.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
+							equalTo("The World is Big and Salvation Lurks Around the Corner"));
 
 			results = vectorStore.similaritySearch(fooBarSearchRequest);
 
@@ -297,20 +288,18 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l1", "l2", "linf" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void searchThresholdTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean(OpenSearchVectorStore.class);
-			if (!DEFAULT.equals(similarityFunction)) {
-				vectorStore.withSimilarityFunction(similarityFunction);
-			}
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			SearchRequest query = SearchRequest.query("Great Depression")
-				.withTopK(50)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+					.withTopK(50)
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
 
 			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
 
@@ -336,31 +325,324 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
-						hasSize(0));
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
+							hasSize(0));
+		});
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	public void approximateAddAndSearchTest(String similarityFunction) {
+
+		getContextRunner().run(context -> {
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+
+			vectorStore.add(documents);
+
+			Awaitility.await()
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+							hasSize(1));
+
+			List<Document> results = vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
+
+			assertThat(results).hasSize(1);
+			Document resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(documents.get(2).getId());
+			assertThat(resultDoc.getContent()).contains("The Great Depression (1929–1939) was an economic shock");
+			assertThat(resultDoc.getMetadata()).hasSize(2);
+			assertThat(resultDoc.getMetadata()).containsKey("meta2");
+			assertThat(resultDoc.getMetadata()).containsKey("distance");
+
+			// Remove all documents from the store
+			vectorStore.delete(documents.stream().map(Document::getId).toList());
+
+			Awaitility.await()
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+							hasSize(0));
+		});
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	public void approximateSearchWithFilters(String similarityFunction) {
+
+		getContextRunner().run(context -> {
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+
+			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
+			var nlDocument = new Document("2", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "NL", "activationDate", new Date(2000)));
+			var bgDocument2 = new Document("3", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2023, "activationDate", new Date(3000)));
+
+			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)),
+							hasSize(3));
+
+			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'NL'"));
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
+
+			results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'BG'"));
+
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
+			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
+
+			results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'BG' && year == 2020"));
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
+
+			results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country in ['BG']"));
+
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
+			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
+
+			results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country in ['BG','NL']"));
+
+			assertThat(results).hasSize(3);
+
+			results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country not in ['BG']"));
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
+
+			results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("NOT(country not in ['BG'])"));
+
+			assertThat(results).hasSize(2);
+			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
+			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
+
+			results = vectorStore.similaritySearch(SearchRequest.query("The World")
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression(
+							"activationDate > " +
+									ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getId()).isEqualTo(bgDocument2.getId());
+
+			// Remove all documents from the store
+			vectorStore.delete(documents.stream().map(Document::getId).toList());
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)),
+							hasSize(0));
+		});
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	public void approximateDocumentUpdateTest(String similarityFunction) {
+
+		getContextRunner().run(context -> {
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+
+			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
+					Map.of("meta1", "meta1"));
+			vectorStore.add(List.of(document));
+
+			Awaitility.await()
+					.until(() -> vectorStore
+									.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
+							hasSize(1));
+
+			List<Document> results = vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
+
+			assertThat(results).hasSize(1);
+			Document resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(document.getId());
+			assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
+			assertThat(resultDoc.getMetadata()).containsKey("meta1");
+			assertThat(resultDoc.getMetadata()).containsKey("distance");
+
+			Document sameIdDocument = new Document(document.getId(),
+					"The World is Big and Salvation Lurks Around the Corner", Map.of("meta2", "meta2"));
+
+			vectorStore.add(List.of(sameIdDocument));
+			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar").withTopK(5);
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
+							equalTo("The World is Big and Salvation Lurks Around the Corner"));
+
+			results = vectorStore.similaritySearch(fooBarSearchRequest);
+
+			assertThat(results).hasSize(1);
+			resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(document.getId());
+			assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
+			assertThat(resultDoc.getMetadata()).containsKey("meta2");
+			assertThat(resultDoc.getMetadata()).containsKey("distance");
+
+			// Remove all documents from the store
+			vectorStore.delete(List.of(document.getId()));
+
+			Awaitility.await().until(() -> vectorStore.similaritySearch(fooBarSearchRequest), hasSize(0));
+
+		});
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	public void approximateAearchThresholdTest(String similarityFunction) {
+
+		getContextRunner().run(context -> {
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+
+			vectorStore.add(documents);
+
+			SearchRequest query = SearchRequest.query("Great Depression")
+					.withTopK(50)
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+
+			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
+
+			List<Document> fullResult = vectorStore.similaritySearch(query);
+
+			List<Float> distances = fullResult.stream().map(doc -> (Float) doc.getMetadata().get("distance")).toList();
+
+			assertThat(distances).hasSize(3);
+
+			float threshold = (distances.get(0) + distances.get(1)) / 2;
+
+			List<Document> results = vectorStore.similaritySearch(
+					SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(1 - threshold));
+
+			assertThat(results).hasSize(1);
+			Document resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(documents.get(2).getId());
+			assertThat(resultDoc.getContent()).contains("The Great Depression (1929–1939) was an economic shock");
+			assertThat(resultDoc.getMetadata()).containsKey("meta2");
+			assertThat(resultDoc.getMetadata()).containsKey("distance");
+
+			// Remove all documents from the store
+			vectorStore.delete(documents.stream().map(Document::getId).toList());
+
+			Awaitility.await()
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
+							hasSize(0));
 		});
 	}
 
 	@SpringBootConfiguration
-	@EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class })
+	@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
 	public static class TestApplication {
 
+		@Bean("vectorStore_" + DEFAULT)
+		public OpenSearchVectorStore vectorStoreDefault(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
+			return new OpenSearchVectorStore(openSearchClient, embeddingModel);
+		}
+
+		@Bean("vectorStore_l2")
+		public OpenSearchVectorStore vectorStoreL2(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
+			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
+			openSearchVectorStoreOptions.setIndexName("index_l2");
+			openSearchVectorStoreOptions.setSimilarity("l2");
+			return new OpenSearchVectorStore(openSearchClient, embeddingModel, openSearchVectorStoreOptions);
+		}
+
+		@Bean("vectorStore_innerproduct")
+		public OpenSearchVectorStore vectorStoreLinf(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
+			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
+			openSearchVectorStoreOptions.setIndexName("index_innerproduct");
+			openSearchVectorStoreOptions.setSimilarity("innerproduct");
+			return new OpenSearchVectorStore(openSearchClient, embeddingModel, openSearchVectorStoreOptions);
+		}
+
+		@Bean("vectorStore_approximate_" + DEFAULT)
+		public OpenSearchVectorStore vectorStoreApproximateDefault(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
+			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
+			openSearchVectorStoreOptions.setIndexName("index_approximate_" + DEFAULT);
+			openSearchVectorStoreOptions.setUseApproximateKnn(true);
+			return new OpenSearchVectorStore(openSearchClient, embeddingModel, openSearchVectorStoreOptions);
+		}
+
+		@Bean("vectorStore_approximate_l2")
+		public OpenSearchVectorStore vectorStoreApproximateL2(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
+			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
+			openSearchVectorStoreOptions.setIndexName("index_approximate_l2");
+			openSearchVectorStoreOptions.setSimilarity("l2");
+			openSearchVectorStoreOptions.setUseApproximateKnn(true);
+			return new OpenSearchVectorStore(openSearchClient, embeddingModel, openSearchVectorStoreOptions);
+		}
+
+		@Bean("vectorStore_approximate_innerproduct")
+		public OpenSearchVectorStore vectorStoreApproximateLinf(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
+			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
+			openSearchVectorStoreOptions.setIndexName("index_approximate_innerproduct");
+			openSearchVectorStoreOptions.setSimilarity("innerproduct");
+			openSearchVectorStoreOptions.setUseApproximateKnn(true);
+			return new OpenSearchVectorStore(openSearchClient, embeddingModel, openSearchVectorStoreOptions);
+		}
+
 		@Bean
-		public OpenSearchVectorStore vectorStore(EmbeddingModel embeddingModel) {
-			try {
-				return new OpenSearchVectorStore(new OpenSearchClient(ApacheHttpClient5TransportBuilder
-					.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
-					.build()), embeddingModel, true);
-			}
-			catch (URISyntaxException e) {
-				throw new RuntimeException(e);
-			}
+		public OpenSearchVectorStore vectorStore(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
+			return new OpenSearchVectorStore(openSearchClient, embeddingModel);
 		}
 
 		@Bean
 		public EmbeddingModel embeddingModel() {
 			return new OpenAiEmbeddingModel(new OpenAiApi(System.getenv("OPENAI_API_KEY")));
+		}
+
+		@Bean
+		public OpenSearchClient openSearchClient() {
+			try {
+				return new OpenSearchClient(ApacheHttpClient5TransportBuilder
+						.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
+						.build());
+			} catch (URISyntaxException e) {
+				throw new RuntimeException(e);
+			}
 		}
 
 	}

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
@@ -104,12 +104,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void addAndSearchTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
@@ -140,12 +140,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void searchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -235,12 +235,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void documentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
@@ -289,18 +289,18 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void searchThresholdTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			SearchRequest query = SearchRequest.query("Great Depression")
-					.withTopK(50)
-					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+				.withTopK(50)
+				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
 
 			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
 
@@ -326,30 +326,29 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
-							hasSize(0));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
+						hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateAddAndSearchTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-							hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+						hasSize(1));
 
 			List<Document> results = vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
+				.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -363,20 +362,19 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(
-											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-							hasSize(0));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+						hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateSearchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -388,73 +386,71 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)),
-							hasSize(3));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)), hasSize(3));
 
 			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'NL'"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'NL'"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'BG'"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'BG'"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country == 'BG' && year == 2020"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country == 'BG' && year == 2020"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country in ['BG']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country in ['BG']"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country in ['BG','NL']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country in ['BG','NL']"));
 
 			assertThat(results).hasSize(3);
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("country not in ['BG']"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("country not in ['BG']"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression("NOT(country not in ['BG'])"));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression("NOT(country not in ['BG'])"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-					.withTopK(5)
-					.withSimilarityThresholdAll()
-					.withFilterExpression(
-							"activationDate > " +
-									ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
+				.withTopK(5)
+				.withSimilarityThresholdAll()
+				.withFilterExpression(
+						"activationDate > " + ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument2.getId());
@@ -463,30 +459,29 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)),
-							hasSize(0));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)), hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateDocumentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
 			vectorStore.add(List.of(document));
 
 			Awaitility.await()
-					.until(() -> vectorStore
-									.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
-							hasSize(1));
+				.until(() -> vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
+						hasSize(1));
 
 			List<Document> results = vectorStore
-					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
+				.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -502,8 +497,8 @@ class OpenSearchVectorStoreIT {
 			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar").withTopK(5);
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
-							equalTo("The World is Big and Salvation Lurks Around the Corner"));
+				.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
+						equalTo("The World is Big and Salvation Lurks Around the Corner"));
 
 			results = vectorStore.similaritySearch(fooBarSearchRequest);
 
@@ -523,12 +518,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
+	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
 	public void approximateAearchThresholdTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore =
-					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
+					OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
@@ -577,8 +572,7 @@ class OpenSearchVectorStoreIT {
 		}
 
 		@Bean("vectorStore_l2")
-		public OpenSearchVectorStore vectorStoreL2(OpenSearchClient openSearchClient,
-				EmbeddingModel embeddingModel) {
+		public OpenSearchVectorStore vectorStoreL2(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
 			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
 			openSearchVectorStoreOptions.setIndexName("index_l2");
 			openSearchVectorStoreOptions.setSimilarity("l2");
@@ -586,8 +580,7 @@ class OpenSearchVectorStoreIT {
 		}
 
 		@Bean("vectorStore_innerproduct")
-		public OpenSearchVectorStore vectorStoreLinf(OpenSearchClient openSearchClient,
-				EmbeddingModel embeddingModel) {
+		public OpenSearchVectorStore vectorStoreLinf(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
 			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
 			openSearchVectorStoreOptions.setIndexName("index_innerproduct");
 			openSearchVectorStoreOptions.setSimilarity("innerproduct");
@@ -637,9 +630,10 @@ class OpenSearchVectorStoreIT {
 		public OpenSearchClient openSearchClient() {
 			try {
 				return new OpenSearchClient(ApacheHttpClient5TransportBuilder
-						.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
-						.build());
-			} catch (URISyntaxException e) {
+					.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
+					.build());
+			}
+			catch (URISyntaxException e) {
 				throw new RuntimeException(e);
 			}
 		}

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/OpenSearchVectorStoreIT.java
@@ -54,6 +54,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+/**
+ * @author Jemin Huh
+ * @author Soby Chacko
+ * @since 1.0.0
+ */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class OpenSearchVectorStoreIT {
@@ -99,12 +104,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void addAndSearchTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
@@ -135,12 +140,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void searchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -230,12 +235,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void documentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
@@ -284,18 +289,18 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void searchThresholdTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_" + similarityFunction, OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			SearchRequest query = SearchRequest.query("Great Depression")
-				.withTopK(50)
-				.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+					.withTopK(50)
+					.withSimilarityThreshold(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
 
 			Awaitility.await().until(() -> vectorStore.similaritySearch(query), hasSize(3));
 
@@ -321,29 +326,30 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
-						hasSize(0));
+					.until(() -> vectorStore
+									.similaritySearch(SearchRequest.query("Great Depression").withTopK(50).withSimilarityThreshold(0)),
+							hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void approximateAddAndSearchTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-						hasSize(1));
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+							hasSize(1));
 
 			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
+					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -357,19 +363,20 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
-						hasSize(0));
+					.until(() -> vectorStore
+									.similaritySearch(
+											SearchRequest.query("Great Depression").withTopK(1).withSimilarityThreshold(0)),
+							hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void approximateSearchWithFilters(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
 
 			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
@@ -381,71 +388,73 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)), hasSize(3));
+					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(5)),
+							hasSize(3));
 
 			List<Document> results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country == 'NL'"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'NL'"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country == 'BG'"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'BG'"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country == 'BG' && year == 2020"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country == 'BG' && year == 2020"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country in ['BG']"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country in ['BG']"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country in ['BG','NL']"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country in ['BG','NL']"));
 
 			assertThat(results).hasSize(3);
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("country not in ['BG']"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("country not in ['BG']"));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(nlDocument.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression("NOT(country not in ['BG'])"));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression("NOT(country not in ['BG'])"));
 
 			assertThat(results).hasSize(2);
 			assertThat(results.get(0).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 			assertThat(results.get(1).getId()).isIn(bgDocument.getId(), bgDocument2.getId());
 
 			results = vectorStore.similaritySearch(SearchRequest.query("The World")
-				.withTopK(5)
-				.withSimilarityThresholdAll()
-				.withFilterExpression(
-						"activationDate > " + ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
+					.withTopK(5)
+					.withSimilarityThresholdAll()
+					.withFilterExpression(
+							"activationDate > " +
+									ZonedDateTime.parse("1970-01-01T00:00:02Z").toInstant().toEpochMilli()));
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getId()).isEqualTo(bgDocument2.getId());
@@ -454,29 +463,30 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(documents.stream().map(Document::getId).toList());
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)), hasSize(0));
+					.until(() -> vectorStore.similaritySearch(SearchRequest.query("The World").withTopK(1)),
+							hasSize(0));
 		});
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void approximateDocumentUpdateTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
 
 			Document document = new Document(UUID.randomUUID().toString(), "Spring AI rocks!!",
 					Map.of("meta1", "meta1"));
 			vectorStore.add(List.of(document));
 
 			Awaitility.await()
-				.until(() -> vectorStore
-					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
-						hasSize(1));
+					.until(() -> vectorStore
+									.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5)),
+							hasSize(1));
 
 			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
+					.similaritySearch(SearchRequest.query("Spring").withSimilarityThreshold(0).withTopK(5));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -492,8 +502,8 @@ class OpenSearchVectorStoreIT {
 			SearchRequest fooBarSearchRequest = SearchRequest.query("FooBar").withTopK(5);
 
 			Awaitility.await()
-				.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
-						equalTo("The World is Big and Salvation Lurks Around the Corner"));
+					.until(() -> vectorStore.similaritySearch(fooBarSearchRequest).get(0).getContent(),
+							equalTo("The World is Big and Salvation Lurks Around the Corner"));
 
 			results = vectorStore.similaritySearch(fooBarSearchRequest);
 
@@ -513,12 +523,12 @@ class OpenSearchVectorStoreIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { DEFAULT, "l2", "innerproduct" })
+	@ValueSource(strings = {DEFAULT, "l2", "innerproduct"})
 	public void approximateAearchThresholdTest(String similarityFunction) {
 
 		getContextRunner().run(context -> {
-			OpenSearchVectorStore vectorStore = context.getBean("vectorStore_approximate_" + similarityFunction,
-					OpenSearchVectorStore.class);
+			OpenSearchVectorStore vectorStore =
+					context.getBean("vectorStore_approximate_" + similarityFunction, OpenSearchVectorStore.class);
 
 			vectorStore.add(documents);
 
@@ -567,7 +577,8 @@ class OpenSearchVectorStoreIT {
 		}
 
 		@Bean("vectorStore_l2")
-		public OpenSearchVectorStore vectorStoreL2(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
+		public OpenSearchVectorStore vectorStoreL2(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
 			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
 			openSearchVectorStoreOptions.setIndexName("index_l2");
 			openSearchVectorStoreOptions.setSimilarity("l2");
@@ -575,7 +586,8 @@ class OpenSearchVectorStoreIT {
 		}
 
 		@Bean("vectorStore_innerproduct")
-		public OpenSearchVectorStore vectorStoreLinf(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
+		public OpenSearchVectorStore vectorStoreLinf(OpenSearchClient openSearchClient,
+				EmbeddingModel embeddingModel) {
 			OpenSearchVectorStoreOptions openSearchVectorStoreOptions = new OpenSearchVectorStoreOptions();
 			openSearchVectorStoreOptions.setIndexName("index_innerproduct");
 			openSearchVectorStoreOptions.setSimilarity("innerproduct");
@@ -625,10 +637,9 @@ class OpenSearchVectorStoreIT {
 		public OpenSearchClient openSearchClient() {
 			try {
 				return new OpenSearchClient(ApacheHttpClient5TransportBuilder
-					.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
-					.build());
-			}
-			catch (URISyntaxException e) {
+						.builder(HttpHost.create(opensearchContainer.getHttpHostAddress()))
+						.build());
+			} catch (URISyntaxException e) {
 				throw new RuntimeException(e);
 			}
 		}


### PR DESCRIPTION
These changes enable support for both Exact k-NN and Approximate k-NN searches in OpenSearch. The code was updated and refactored to include this new functionality, as it previously only supported Exact k-NN. This work is based on the squashed changes from `Enhance OpenSearchVectorStore #987`.

- Enhanced OpenSearchVectorStore to support both exact and approximate k-NN search methods.
- Updated integration tests to cover common similarity metrics (cosinesimil, l2, innerproduct) for both exact and approximate k-NN.
- Made necessary updates to the auto-configuration to accommodate the new support for approximate k-NN.
- Updated the OpenSearch Vectorstore documentation to reflect these changes.