### PR TITLE
Make MeterObservationHandler conditional on MeterRegistry bean

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -130,7 +130,7 @@ class OpenAiChatModelIT extends AbstractIT {
 			});
 		chatResponseFlux.subscribe();
 		assertThat(latch.await(120, TimeUnit.SECONDS)).isTrue();
-		assertThat(answer).contains("the 1st ");
+		assertThat(answer).contains("1st ");
 	}
 
 	@Test
@@ -153,7 +153,7 @@ class OpenAiChatModelIT extends AbstractIT {
 			});
 		chatResponseFlux.subscribe();
 		assertThat(latch.await(120, TimeUnit.SECONDS)).isTrue();
-		assertThat(answer).contains("the 1st ");
+		assertThat(answer).contains("1st ");
 	}
 
 	@Test

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/observation/ChatObservationAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/observation/ChatObservationAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.ai.chat.observation.ChatModelMeterObservationHandler;
 import org.springframework.ai.chat.observation.ChatModelPromptContentObservationFilter;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -46,7 +47,7 @@ public class ChatObservationAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnClass(MeterRegistry.class)
+	@ConditionalOnBean(MeterRegistry.class)
 	ChatModelMeterObservationHandler chatModelMeterObservationHandler(ObjectProvider<MeterRegistry> meterRegistry) {
 		return new ChatModelMeterObservationHandler(meterRegistry.getObject());
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/embedding/observation/EmbeddingObservationAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/embedding/observation/EmbeddingObservationAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.observation.EmbeddingModelMeterObservationHandler;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -37,7 +38,7 @@ public class EmbeddingObservationAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnClass(MeterRegistry.class)
+	@ConditionalOnBean(MeterRegistry.class)
 	EmbeddingModelMeterObservationHandler embeddingModelMeterObservationHandler(
 			ObjectProvider<MeterRegistry> meterRegistry) {
 		return new EmbeddingModelMeterObservationHandler(meterRegistry.getObject());

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/observation/ChatObservationAutoConfigurationTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/observation/ChatObservationAutoConfigurationTests.java
@@ -33,13 +33,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChatObservationAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(ChatObservationAutoConfiguration.class))
-		.withBean(CompositeMeterRegistry.class);
+		.withConfiguration(AutoConfigurations.of(ChatObservationAutoConfiguration.class));
 
 	@Test
-	void meterObservationHandler() {
-		contextRunner.run(context -> {
+	void meterObservationHandlerEnabled() {
+		contextRunner.withBean(CompositeMeterRegistry.class).run(context -> {
 			assertThat(context).hasSingleBean(ChatModelMeterObservationHandler.class);
+		});
+	}
+
+	@Test
+	void meterObservationHandlerDisabled() {
+		contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean(ChatModelMeterObservationHandler.class);
 		});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/embedding/observation/EmbeddingObservationAutoConfigurationTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/embedding/observation/EmbeddingObservationAutoConfigurationTests.java
@@ -31,13 +31,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EmbeddingObservationAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(EmbeddingObservationAutoConfiguration.class))
-		.withBean(CompositeMeterRegistry.class);
+		.withConfiguration(AutoConfigurations.of(EmbeddingObservationAutoConfiguration.class));
 
 	@Test
-	void meterObservationHandler() {
-		contextRunner.run(context -> {
+	void meterObservationHandlerEnabled() {
+		contextRunner.withBean(CompositeMeterRegistry.class).run(context -> {
 			assertThat(context).hasSingleBean(EmbeddingModelMeterObservationHandler.class);
+		});
+	}
+
+	@Test
+	void meterObservationHandlerDisabled() {
+		contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean(EmbeddingModelMeterObservationHandler.class);
 		});
 	}
 


### PR DESCRIPTION
Right now, it's conditional on the class. It must be conditional on the presence of a `MeterRegistry` bean instead.
