### PR TITLE
feat: Add responseMimeType option in vertexAiGeminiChatOptions

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -359,6 +359,9 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 		if (options.getStopSequences() != null) {
 			generationConfigBuilder.addAllStopSequences(options.getStopSequences());
 		}
+		if (options.getResponseMimeType() != null) {
+			generationConfigBuilder.setResponseMimeType(options.getResponseMimeType());
+		}
 
 		return generationConfigBuilder.build();
 	}

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -76,6 +76,12 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 	 * Gemini model name.
 	 */
 	private @JsonProperty("modelName") String model;
+	/**
+	 * Optional. Output response mimetype of the generated candidate text.
+	 * - text/plain: (default) Text output.
+	 * - application/json: JSON response in the candidates.
+	 */
+	private @JsonProperty("responseMimeType") String responseMimeType;
 
 	/**
 	 * Tool Function Callbacks to register with the ChatModel.
@@ -147,6 +153,12 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 
 		public Builder withModel(ChatModel model) {
 			this.options.setModel(model.getValue());
+			return this;
+		}
+
+		public Builder withResponseMimeType(String mimeType){
+			Assert.notNull(mimeType, "mimeType must not be null");
+			this.options.setResponseMimeType(mimeType);
 			return this;
 		}
 
@@ -238,6 +250,14 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 		this.model = modelName;
 	}
 
+	public String getResponseMimeType() {
+		return this.responseMimeType;
+	}
+
+	public String setResponseMimeType(String mimeType) {
+		return this.responseMimeType = mimeType;
+	}
+
 	public List<FunctionCallback> getFunctionCallbacks() {
 		return this.functionCallbacks;
 	}
@@ -265,6 +285,7 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 		result = prime * result + ((candidateCount == null) ? 0 : candidateCount.hashCode());
 		result = prime * result + ((maxOutputTokens == null) ? 0 : maxOutputTokens.hashCode());
 		result = prime * result + ((model == null) ? 0 : model.hashCode());
+		result = prime * result + ((responseMimeType == null) ? 0 : responseMimeType.hashCode());
 		result = prime * result + ((functionCallbacks == null) ? 0 : functionCallbacks.hashCode());
 		result = prime * result + ((functions == null) ? 0 : functions.hashCode());
 		return result;
@@ -321,6 +342,13 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 		}
 		else if (!model.equals(other.model))
 			return false;
+		if (responseMimeType == null) {
+			if (other.responseMimeType != null)
+				return false;
+		}
+		else if (!responseMimeType.equals(other.responseMimeType)) {
+			return false;
+		}
 		if (functionCallbacks == null) {
 			if (other.functionCallbacks != null)
 				return false;
@@ -340,8 +368,9 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 	public String toString() {
 		return "VertexAiGeminiChatOptions [stopSequences=" + stopSequences + ", temperature=" + temperature + ", topP="
 				+ topP + ", topK=" + topK + ", candidateCount=" + candidateCount + ", maxOutputTokens="
-				+ maxOutputTokens + ", model=" + model + ", functionCallbacks=" + functionCallbacks + ", functions="
-				+ functions + ", getClass()=" + getClass() + ", getStopSequences()=" + getStopSequences()
+				+ maxOutputTokens + ", model=" + model + ", responseMimeType=" + responseMimeType
+				+ ", functionCallbacks=" + functionCallbacks + ", functions=" + functions
+				+ ", getClass()=" + getClass() + ", getStopSequences()=" + getStopSequences()
 				+ ", getTemperature()=" + getTemperature() + ", getTopP()=" + getTopP() + ", getTopK()=" + getTopK()
 				+ ", getCandidateCount()=" + getCandidateCount() + ", getMaxOutputTokens()=" + getMaxOutputTokens()
 				+ ", getModel()=" + getModel() + ", getFunctionCallbacks()=" + getFunctionCallbacks()
@@ -364,6 +393,7 @@ public class VertexAiGeminiChatOptions implements FunctionCallingOptions, ChatOp
 		options.setMaxOutputTokens(fromOptions.getMaxOutputTokens());
 		options.setModel(fromOptions.getModel());
 		options.setFunctionCallbacks(fromOptions.getFunctionCallbacks());
+		options.setResponseMimeType(fromOptions.getResponseMimeType());
 		options.setFunctions(fromOptions.getFunctions());
 		return options;
 	}

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/CreateGeminiRequestTests.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/CreateGeminiRequestTests.java
@@ -191,4 +191,35 @@ public class CreateGeminiRequestTests {
 			.isEqualTo("Overridden function description");
 	}
 
+	@Test
+	public void createRequestWithGenerationConfigOptions() {
+
+		var client = new VertexAiGeminiChatModel(vertexAI,
+				VertexAiGeminiChatOptions.builder()
+						.withModel("DEFAULT_MODEL")
+						.withTemperature(66.6f)
+						.withMaxOutputTokens(100)
+						.withTopK(10.0f)
+						.withTopP(5.0f)
+						.withStopSequences(List.of("stop1", "stop2"))
+						.withCandidateCount(1)
+						.withResponseMimeType("application/json")
+						.build());
+
+		GeminiRequest request = client.createGeminiRequest(new Prompt("Test message content"));
+
+		assertThat(request.contents()).hasSize(1);
+
+		assertThat(request.model().getSystemInstruction()).isNotPresent();
+		assertThat(request.model().getModelName()).isEqualTo("DEFAULT_MODEL");
+		assertThat(request.model().getGenerationConfig().getTemperature()).isEqualTo(66.6f);
+		assertThat(request.model().getGenerationConfig().getMaxOutputTokens()).isEqualTo(100);
+		assertThat(request.model().getGenerationConfig().getTopK()).isEqualTo(10.0f);
+		assertThat(request.model().getGenerationConfig().getTopP()).isEqualTo(5.0f);
+		assertThat(request.model().getGenerationConfig().getCandidateCount()).isEqualTo(1);
+		assertThat(request.model().getGenerationConfig().getStopSequences(0)).isEqualTo("stop1");
+		assertThat(request.model().getGenerationConfig().getStopSequences(1)).isEqualTo("stop2");
+		assertThat(request.model().getGenerationConfig().getResponseMimeType()).isEqualTo("application/json");
+	}
+
 }


### PR DESCRIPTION
The Gemini model provides the `responseMimeType` parameter, as documented in the [Gemini Model Reference](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini?_ga=2.232454687.1873628075.1702319245-1182285243.1701938872&hl=ko#parameters). 

However, when I attempting to call the Gemini model using Spring AI, there is no direct option to set this parameter. 
To work around this, I used reflection in my project:
```kotlin
        val chatModel = VertexAiGeminiChatModel(
            VertexAI(System.getenv("GEMINI_PROJECT_ID"), System.getenv("GEMINI_LOCATION"))
        )

        val generationConfig = GenerationConfig.newBuilder()
            .setResponseMimeType("application/json") // responseMimeType 을 설정할 수 없어서. 직접 접근하여 설정하였다.
            .setTemperature(0.8f)
            .build()

        val generationConfigField = VertexAiGeminiChatModel::class.java.getDeclaredField("generationConfig")
        generationConfigField.isAccessible = true
        generationConfigField.set(chatModel, generationConfig)
```


Therefore, it would be beneficial if the `responseMimeType` parameter was officially supported. The model generated by default in `VertexAiGeminiChatModel` is `GEMINI_1_5_PRO`, so this option is available from this version onwards, so it should be added as needed.

