### PR TITLE
Add OpenAiChatModel stream observability

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -318,12 +318,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 						}).toList();
 					// @formatter:on
 
-						if (chatCompletion2.usage() != null) {
-							return new ChatResponse(generations, from(chatCompletion2, null));
-						}
-						else {
-							return new ChatResponse(generations);
-						}
+						return new ChatResponse(generations, from(chatCompletion2, null));
 					}
 					catch (Exception e) {
 						logger.error("Error processing chat completion", e);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/MessageTypeContentTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/MessageTypeContentTests.java
@@ -104,7 +104,7 @@ public class MessageTypeContentTests {
 
 		when(openAiApi.chatCompletionStream(pomptCaptor.capture(), headersCaptor.capture())).thenReturn(fluxResponse);
 
-		chatModel.stream(new Prompt(List.of(new UserMessage("test message"))));
+		chatModel.stream(new Prompt(List.of(new UserMessage("test message")))).subscribe();
 
 		validateStringContent(pomptCaptor.getValue());
 		assertThat(headersCaptor.getValue()).isEmpty();
@@ -137,8 +137,10 @@ public class MessageTypeContentTests {
 		when(openAiApi.chatCompletionStream(pomptCaptor.capture(), headersCaptor.capture())).thenReturn(fluxResponse);
 
 		URL mediaUrl = new URL("http://test");
-		chatModel.stream(new Prompt(
-				List.of(new UserMessage("test message", List.of(new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl))))));
+		chatModel
+			.stream(new Prompt(
+					List.of(new UserMessage("test message", List.of(new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl))))))
+			.subscribe();
 
 		validateComplexContent(pomptCaptor.getValue());
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiPaymentTransactionIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiPaymentTransactionIT.java
@@ -53,8 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Tzolov
  */
 @SpringBootTest
-@EnabledIfEnvironmentVariable(named = "VERTEX_AI_GEMINI_PROJECT_ID", matches = ".*")
-@EnabledIfEnvironmentVariable(named = "VERTEX_AI_GEMINI_LOCATION", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
 public class OpenAiPaymentTransactionIT {
 
 	private final static Logger logger = LoggerFactory.getLogger(OpenAiPaymentTransactionIT.class);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -163,6 +164,7 @@ public class OpenAiRetryTests {
 	}
 
 	@Test
+	@Disabled("Currently stream() does not implmement retry")
 	public void openAiChatStreamTransientError() {
 
 		var choice = new ChatCompletionChunk.ChunkChoice(ChatCompletionFinishReason.STOP, 0,
@@ -184,6 +186,7 @@ public class OpenAiRetryTests {
 	}
 
 	@Test
+	@Disabled("Currently stream() does not implmement retry")
 	public void openAiChatStreamNonTransientError() {
 		when(openAiApi.chatCompletionStream(isA(ChatCompletionRequest.class), any()))
 			.thenThrow(new RuntimeException("Non Transient Error"));

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
@@ -187,7 +187,7 @@ public class OpenAiRetryTests {
 	public void openAiChatStreamNonTransientError() {
 		when(openAiApi.chatCompletionStream(isA(ChatCompletionRequest.class), any()))
 			.thenThrow(new RuntimeException("Non Transient Error"));
-		assertThrows(RuntimeException.class, () -> chatModel.stream(new Prompt("text")));
+		assertThrows(RuntimeException.class, () -> chatModel.stream(new Prompt("text")).subscribe());
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.DefaultChatClient;
 import org.springframework.ai.openai.OpenAiTestConfiguration;
 import org.springframework.ai.openai.api.tool.MockWeatherService;
 import org.springframework.ai.openai.testutils.AbstractIT;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -24,6 +24,15 @@ import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.EmptyRateLimit;
+import org.springframework.ai.chat.metadata.PromptMetadata;
+import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.util.StringUtils;
+
 import reactor.core.publisher.Flux;
 
 /**
@@ -43,13 +52,37 @@ public class MessageAggregator {
 		AtomicReference<StringBuilder> stringBufferRef = new AtomicReference<>(new StringBuilder());
 		AtomicReference<Map<String, Object>> mapRef = new AtomicReference<>();
 
+		AtomicReference<ChatGenerationMetadata> generationMetadataRef = new AtomicReference<>(
+				ChatGenerationMetadata.NULL);
+
+		AtomicReference<Long> metadataUsagePromptTokensRef = new AtomicReference<>(0L);
+		AtomicReference<Long> metadataUsageGenerationTokensRef = new AtomicReference<>(0L);
+		AtomicReference<Long> metadataUsageTotalTokensRef = new AtomicReference<>(0L);
+
+		AtomicReference<PromptMetadata> metadataPromptMetadataRef = new AtomicReference<>(PromptMetadata.empty());
+		AtomicReference<RateLimit> metadataRateLimitRef = new AtomicReference<>(new EmptyRateLimit());
+
+		AtomicReference<String> metadataIdRef = new AtomicReference<>("");
+		AtomicReference<String> metadataModelRef = new AtomicReference<>("");
+
 		return fluxChatResponse.doOnSubscribe(subscription -> {
-			// logger.info("Aggregation Subscribe:" + subscription);
 			stringBufferRef.set(new StringBuilder());
 			mapRef.set(new HashMap<>());
+			metadataIdRef.set("");
+			metadataModelRef.set("");
+			metadataUsagePromptTokensRef.set(0L);
+			metadataUsageGenerationTokensRef.set(0L);
+			metadataUsageTotalTokensRef.set(0L);
+			metadataPromptMetadataRef.set(PromptMetadata.empty());
+			metadataRateLimitRef.set(new EmptyRateLimit());
+
 		}).doOnNext(chatResponse -> {
-			// logger.info("Aggregation Next:" + chatResponse);
+
 			if (chatResponse.getResult() != null) {
+				if (chatResponse.getResult().getMetadata() != null
+						&& chatResponse.getResult().getMetadata() != ChatGenerationMetadata.NULL) {
+					generationMetadataRef.set(chatResponse.getResult().getMetadata());
+				}
 				if (chatResponse.getResult().getOutput().getContent() != null) {
 					stringBufferRef.get().append(chatResponse.getResult().getOutput().getContent());
 				}
@@ -57,15 +90,80 @@ public class MessageAggregator {
 					mapRef.get().putAll(chatResponse.getResult().getOutput().getMetadata());
 				}
 			}
+			if (chatResponse.getMetadata() != null) {
+				if (chatResponse.getMetadata().getUsage() != null) {
+					Usage usage = chatResponse.getMetadata().getUsage();
+					metadataUsagePromptTokensRef.set(
+							usage.getPromptTokens() > 0 ? usage.getPromptTokens() : metadataUsagePromptTokensRef.get());
+					metadataUsageGenerationTokensRef.set(usage.getGenerationTokens() > 0 ? usage.getGenerationTokens()
+							: metadataUsageGenerationTokensRef.get());
+					metadataUsageTotalTokensRef
+						.set(usage.getTotalTokens() > 0 ? usage.getTotalTokens() : metadataUsageTotalTokensRef.get());
+				}
+				if (chatResponse.getMetadata().getPromptMetadata() != null
+						&& chatResponse.getMetadata().getPromptMetadata().iterator().hasNext()) {
+					metadataPromptMetadataRef.set(chatResponse.getMetadata().getPromptMetadata());
+				}
+				if (chatResponse.getMetadata().getRateLimit() != null
+						&& !(metadataRateLimitRef.get() instanceof EmptyRateLimit)) {
+					metadataRateLimitRef.set(chatResponse.getMetadata().getRateLimit());
+				}
+				if (StringUtils.hasText(chatResponse.getMetadata().getId())) {
+					metadataIdRef.set(chatResponse.getMetadata().getId());
+				}
+				if (StringUtils.hasText(chatResponse.getMetadata().getModel())) {
+					metadataModelRef.set(chatResponse.getMetadata().getModel());
+				}
+			}
 		}).doOnComplete(() -> {
-			// logger.debug("Aggregation Complete");
-			onAggregationComplete
-				.accept(new ChatResponse(List.of(new Generation(stringBufferRef.get().toString(), mapRef.get()))));
+
+			var usage = new DefaultUsage(metadataUsagePromptTokensRef.get(), metadataUsageGenerationTokensRef.get(),
+					metadataUsageTotalTokensRef.get());
+
+			var chatResponseMetadata = ChatResponseMetadata.builder()
+				.withId(metadataIdRef.get())
+				.withModel(metadataModelRef.get())
+				.withRateLimit(metadataRateLimitRef.get())
+				.withUsage(usage)
+				.withPromptMetadata(metadataPromptMetadataRef.get())
+				.build();
+
+			onAggregationComplete.accept(new ChatResponse(
+					List.of(new Generation(new AssistantMessage(stringBufferRef.get().toString(), mapRef.get()),
+							generationMetadataRef.get())),
+					chatResponseMetadata));
+
 			stringBufferRef.set(new StringBuilder());
 			mapRef.set(new HashMap<>());
+			metadataIdRef.set("");
+			metadataModelRef.set("");
+			metadataUsagePromptTokensRef.set(0L);
+			metadataUsageGenerationTokensRef.set(0L);
+			metadataUsageTotalTokensRef.set(0L);
+			metadataPromptMetadataRef.set(PromptMetadata.empty());
+			metadataRateLimitRef.set(new EmptyRateLimit());
+
 		}).doOnError(e -> {
 			logger.error("Aggregation Error", e);
 		});
+	}
+
+	public record DefaultUsage(long promptTokens, long generationTokens, long totalTokens) implements Usage {
+
+		@Override
+		public Long getPromptTokens() {
+			return promptTokens();
+		}
+
+		@Override
+		public Long getGenerationTokens() {
+			return generationTokens();
+		}
+
+		@Override
+		public Long getTotalTokens() {
+			return totalTokens();
+		}
 	}
 
 }


### PR DESCRIPTION
Integrated Micrometer's `Observation` into the `OpenAiChatModel#stream` reactive chain.

Included changes:

- Added ability to aggregate streaming responses for use in `Observation` metadata.
- Improved error handling and logging for chat response processing.
- Updated unit tests to include new observation logic and subscribe to `Flux` responses.
- Refined validation of observations in both normal and streaming chat operations.
- Disabled retry for streaming which used `RetryTemplate` - should use `.retryWhen` operator as the next step.
- Added an integration test.

This PR is a joint effort with @tzolov.

Resolves #1190