### PR TITLE
Remove unnecessary if statement in 'toolFunctionCall' test code from OpenAiApiToolFunctionCallIT

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
@@ -102,49 +102,46 @@ public class OpenAiApiToolFunctionCallIT {
 
 		ChatCompletionMessage responseMessage = chatCompletion.getBody().choices().get(0).message();
 
+		// Check if the model wanted to call a function
 		assertThat(responseMessage.role()).isEqualTo(Role.ASSISTANT);
 		assertThat(responseMessage.toolCalls()).isNotNull();
 
-		// Check if the model wanted to call a function
-		if (responseMessage.toolCalls() != null) {
+		// extend conversation with assistant's reply.
+		messages.add(responseMessage);
 
-			// extend conversation with assistant's reply.
-			messages.add(responseMessage);
+		// Send the info for each function call and function response to the model.
+		for (ToolCall toolCall : responseMessage.toolCalls()) {
+			var functionName = toolCall.function().name();
+			if ("getCurrentWeather".equals(functionName)) {
+				MockWeatherService.Request weatherRequest = fromJson(toolCall.function().arguments(),
+						MockWeatherService.Request.class);
 
-			// Send the info for each function call and function response to the model.
-			for (ToolCall toolCall : responseMessage.toolCalls()) {
-				var functionName = toolCall.function().name();
-				if ("getCurrentWeather".equals(functionName)) {
-					MockWeatherService.Request weatherRequest = fromJson(toolCall.function().arguments(),
-							MockWeatherService.Request.class);
+				MockWeatherService.Response weatherResponse = weatherService.apply(weatherRequest);
 
-					MockWeatherService.Response weatherResponse = weatherService.apply(weatherRequest);
-
-					// extend conversation with function response.
-					messages.add(new ChatCompletionMessage("" + weatherResponse.temp() + weatherRequest.unit(),
-							Role.TOOL, functionName, toolCall.id(), null, null));
-				}
+				// extend conversation with function response.
+				messages.add(new ChatCompletionMessage("" + weatherResponse.temp() + weatherRequest.unit(),
+						Role.TOOL, functionName, toolCall.id(), null, null));
 			}
-
-			var functionResponseRequest = new ChatCompletionRequest(messages, "gpt-4o", 0.5f);
-
-			ResponseEntity<ChatCompletion> chatCompletion2 = completionApi
-				.chatCompletionEntity(functionResponseRequest);
-
-			logger.info("Final response: " + chatCompletion2.getBody());
-
-			assertThat(chatCompletion2.getBody().choices()).isNotEmpty();
-
-			assertThat(chatCompletion2.getBody().choices().get(0).message().role()).isEqualTo(Role.ASSISTANT);
-			assertThat(chatCompletion2.getBody().choices().get(0).message().content()).contains("San Francisco")
-				.containsAnyOf("30.0°C", "30°C");
-			assertThat(chatCompletion2.getBody().choices().get(0).message().content()).contains("Tokyo")
-				.containsAnyOf("10.0°C", "10°C");
-			;
-			assertThat(chatCompletion2.getBody().choices().get(0).message().content()).contains("Paris")
-				.containsAnyOf("15.0°C", "15°C");
-			;
 		}
+
+		var functionResponseRequest = new ChatCompletionRequest(messages, "gpt-4o", 0.5f);
+
+		ResponseEntity<ChatCompletion> chatCompletion2 = completionApi
+			.chatCompletionEntity(functionResponseRequest);
+
+		logger.info("Final response: " + chatCompletion2.getBody());
+
+		assertThat(chatCompletion2.getBody().choices()).isNotEmpty();
+
+		assertThat(chatCompletion2.getBody().choices().get(0).message().role()).isEqualTo(Role.ASSISTANT);
+		assertThat(chatCompletion2.getBody().choices().get(0).message().content()).contains("San Francisco")
+			.containsAnyOf("30.0°C", "30°C");
+		assertThat(chatCompletion2.getBody().choices().get(0).message().content()).contains("Tokyo")
+			.containsAnyOf("10.0°C", "10°C");
+		;
+		assertThat(chatCompletion2.getBody().choices().get(0).message().content()).contains("Paris")
+			.containsAnyOf("15.0°C", "15°C");
+		;
 
 	}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
@@ -119,15 +119,14 @@ public class OpenAiApiToolFunctionCallIT {
 				MockWeatherService.Response weatherResponse = weatherService.apply(weatherRequest);
 
 				// extend conversation with function response.
-				messages.add(new ChatCompletionMessage("" + weatherResponse.temp() + weatherRequest.unit(),
-						Role.TOOL, functionName, toolCall.id(), null, null));
+				messages.add(new ChatCompletionMessage("" + weatherResponse.temp() + weatherRequest.unit(), Role.TOOL,
+						functionName, toolCall.id(), null, null));
 			}
 		}
 
 		var functionResponseRequest = new ChatCompletionRequest(messages, "gpt-4o", 0.5f);
 
-		ResponseEntity<ChatCompletion> chatCompletion2 = completionApi
-			.chatCompletionEntity(functionResponseRequest);
+		ResponseEntity<ChatCompletion> chatCompletion2 = completionApi.chatCompletionEntity(functionResponseRequest);
 
 		logger.info("Final response: " + chatCompletion2.getBody());
 


### PR DESCRIPTION
To improve the readability of the test, I removed the unnecessary `if (responseMessage.toolCalls() != null)` check

The if statement is redundant and will always evaluate to true, since `assertThat(responseMessage.toolCalls()).isNotNull()` ensures that `toolCalls()` is not null.