### PR TITLE
Introduce support for GenAI for Tanzu Platform bindings

### DIFF
--- a/spring-ai-spring-cloud-bindings/src/main/java/org/springframework/ai/bindings/TanzuBindingsPropertiesProcessor.java
+++ b/spring-ai-spring-cloud-bindings/src/main/java/org/springframework/ai/bindings/TanzuBindingsPropertiesProcessor.java
@@ -1,0 +1,47 @@
+package org.springframework.ai.bindings;
+
+import org.springframework.cloud.bindings.Binding;
+import org.springframework.cloud.bindings.Bindings;
+import org.springframework.cloud.bindings.boot.BindingsPropertiesProcessor;
+import org.springframework.core.env.Environment;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * An implementation of {@link BindingsPropertiesProcessor} that detects {@link Binding}s
+ * of type: {@value TYPE}.
+ *
+ * @author Stuart Charlton
+ */
+public class TanzuBindingsPropertiesProcessor implements BindingsPropertiesProcessor {
+
+	/**
+	 * The {@link Binding} type that this processor is interested in: {@value}.
+	 **/
+	public static final String TYPE = "genai";
+
+	@Override
+	public void process(Environment environment, Bindings bindings, Map<String, Object> properties) {
+		if (!BindingsValidator.isTypeEnabled(environment, TYPE)) {
+			return;
+		}
+
+		bindings.filterBindings(TYPE).forEach(binding -> {
+			if (binding.getSecret().get("model-capabilities") != null) {
+				String[] capabilities = binding.getSecret().get("model-capabilities").trim().split("\\s*,\\s*");
+				if (Arrays.stream(capabilities).anyMatch("chat"::equals)) {
+					properties.put("spring.ai.openai.chat.api-key", binding.getSecret().get("api-key"));
+					properties.put("spring.ai.openai.chat.base-url", binding.getSecret().get("uri"));
+					properties.put("spring.ai.openai.chat.options.model", binding.getSecret().get("model-name"));
+				}
+				if (Arrays.stream(capabilities).anyMatch("embedding"::equals)) {
+					properties.put("spring.ai.openai.embedding.api-key", binding.getSecret().get("api-key"));
+					properties.put("spring.ai.openai.embedding.base-url", binding.getSecret().get("uri"));
+					properties.put("spring.ai.openai.embedding.options.model", binding.getSecret().get("model-name"));
+				}
+			}
+		});
+	}
+
+}

--- a/spring-ai-spring-cloud-bindings/src/main/resources/META-INF/spring.factories
+++ b/spring-ai-spring-cloud-bindings/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ org.springframework.cloud.bindings.boot.BindingsPropertiesProcessor=\
 org.springframework.ai.bindings.ChromaBindingsPropertiesProcessor,\
 org.springframework.ai.bindings.OllamaBindingsPropertiesProcessor,\
 org.springframework.ai.bindings.OpenAiBindingsPropertiesProcessor,\
+org.springframework.ai.bindings.TanzuBindingsPropertiesProcessor,\
 org.springframework.ai.bindings.WeaviateBindingsPropertiesProcessor


### PR DESCRIPTION
Tanzu Platform for Kubernetes currently can utilize the GenAI for Tanzu Platform 0.6 service via a PreProvisionedService with a secret derived from a TPCF service key.  The unit tests provided reflect the current state of this contract.

