### PR TITLE
Refactor Separation of embedding logic through the DocumentTransformer

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/DocumentEmbeddingTransformer.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/DocumentEmbeddingTransformer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.transformer;
+
+import java.util.List;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentTransformer;
+import org.springframework.ai.embedding.EmbeddingModel;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * DocumentEmbeddingTransformer injects embedding values into each Document using the
+ * EmbeddingModel if the Document does not already have embedding data.
+ *
+ * @author youngmoneee
+ * @since 1.0.0
+ */
+public class DocumentEmbeddingTransformer implements DocumentTransformer {
+
+	private final EmbeddingModel embeddingModel;
+
+	public DocumentEmbeddingTransformer(EmbeddingModel embeddingModel) {
+		this.embeddingModel = embeddingModel;
+	}
+
+	/**
+	 * Embedding values are generated using the embedding model provided through the
+	 * constructor and then injected into each Document object.
+	 * @param documents to process.
+	 * @return processed documents
+	 */
+	@Override
+	public List<Document> apply(List<Document> documents) {
+		return Flux.fromIterable(documents).flatMap(document -> {
+			if (document.getEmbedding() == null || document.getEmbedding().length == 0)
+				return Mono
+					.zip(Mono.just(document), Mono.fromCallable(() -> embeddingModel.embed(document)), (doc, embed) -> {
+						doc.setEmbedding(embed);
+						return doc;
+					})
+					.subscribeOn(Schedulers.boundedElastic());
+			return Mono.just(document);
+		}).collectList().block();
+	}
+
+}


### PR DESCRIPTION
This PR aims to achieve two objectives through the proposed changes:

1. Separate the common embedding logic present in the VectorStore implementations using the DocumentTransformer interface. By isolating the logic that adds embedding data before inserting Documents into the VectorStore, maintainability and testability are improved.
2. Improve batch processing performance by executing blocking operations asynchronously. Sequential and synchronous Embedding Request tasks are executed on a separate Scheduler using Reactor, leading to enhanced performance.”

https://github.com/spring-projects/spring-ai/blob/10e1e13fa204b2f634ee874fcee2360f94f18185/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java#L327

In the example code, the map operation `synchronously` performs the next task only after the previous task has been completed.

https://github.com/spring-projects/spring-ai/blob/10e1e13fa204b2f634ee874fcee2360f94f18185/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java#L363-L368

https://github.com/spring-projects/spring-ai/blob/10e1e13fa204b2f634ee874fcee2360f94f18185/spring-ai-core/src/main/java/org/springframework/ai/embedding/EmbeddingModel.java#L55-L62

The `call` method `synchronously` requests an EmbeddingResponse object, creating a significant bottleneck due to the sequential execution of these blocking methods.

For comparison, when embedding and inserting the same 100 Document objects into a vector database, the original code took 106 seconds.

<img width="195" alt="Screenshot 2024-08-19 at 12 57 38 AM" src="https://github.com/user-attachments/assets/8a6e7845-764d-4f73-9026-29862f1ea69c">

https://github.com/spring-projects/spring-ai/blob/eb58cf4d0a4e0f1f1cd51a10dfa595315513f4fe/spring-ai-core/src/main/java/org/springframework/ai/transformer/DocumentEmbeddingTransformer.java#L49-L59

To decrease this bottleneck, the code internally uses Reactor objects to execute these blocking methods asynchronously, minimizing the need for major code modifications.

<img width="169" alt="Screenshot 2024-08-19 at 1 01 24 AM" src="https://github.com/user-attachments/assets/29447bde-cb2a-43ae-8b8b-2d7e723fc59a">

And, after modifying the code to process the tasks on a separate asynchronous scheduler, the execution time was reduced to 8.6 seconds, representing a 92% decrease in processing time.

---
This PR aimed to optimize performance with minimal changes to the existing code.
However, in the long term, I think that expressing the ETL pipeline as a stream rather than batch processing through a List would be more appropriate.

I have created an issue( #1219 ) related to this topic. I would appreciate any insights or thoughts you might have.

It would be great if you could take a look at the issue when you have time.

Thanks 🧑🏼‍💻