### PR TITLE
Fixing MongoDB vector store support test failures

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/mongo/MongoDBAtlasVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/mongo/MongoDBAtlasVectorStoreAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,10 @@ package org.springframework.ai.autoconfigure.vectorstore.mongo;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.MongoDBAtlasVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.convert.converter.Converter;
@@ -40,9 +37,10 @@ import java.util.Arrays;
 /**
  * @author Eddú Meléndez
  * @author Christian Tzolov
+ * @author Soby Chacko
  * @since 1.0.0
  */
-@AutoConfiguration(after = MongoDataAutoConfiguration.class)
+@AutoConfiguration
 @ConditionalOnClass({ MongoDBAtlasVectorStore.class, EmbeddingModel.class, MongoTemplate.class })
 @EnableConfigurationProperties(MongoDBAtlasVectorStoreProperties.class)
 public class MongoDBAtlasVectorStoreAutoConfiguration {
@@ -92,17 +90,8 @@ public class MongoDBAtlasVectorStoreAutoConfiguration {
 	}
 
 	@Bean
-	public BeanPostProcessor mongoCustomConversionsPostProcessor() {
-		return new BeanPostProcessor() {
-			@Override
-			public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-				if (bean instanceof MongoCustomConversions) {
-					return new MongoCustomConversions(
-							Arrays.asList(mimeTypeToStringConverter(), stringToMimeTypeConverter()));
-				}
-				return bean;
-			}
-		};
+	public MongoCustomConversions mongoCustomConversions() {
+		return new MongoCustomConversions(Arrays.asList(mimeTypeToStringConverter(), stringToMimeTypeConverter()));
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/mongo/MongoDBAtlasVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/mongo/MongoDBAtlasVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 - 2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,6 @@ import io.micrometer.observation.tck.TestObservationRegistry;
  */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
-@Disabled("Disabled due to https://github.com/spring-projects/spring-ai/issues/698")
 class MongoDBAtlasVectorStoreAutoConfigurationIT {
 
 	@Container


### PR DESCRIPTION
Remove the requirement of MongoDB vector store auto-configuration only after `MongoDataAutoConfiguration`. This enables the `MongoDBAtlasVectorStoreAutoConfiguration` to properly provide custom Mongo conversions.

In `MongoDBAtlasVectorStoreIT` and `MongoDbVectorStoreObservationIT` tests, properly provision the `MongoTemplate` with custom conversions as these tests are not relying on auto-configuration.
