### PR TITLE
Allow `String` prompt in `ChatClient`

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -73,6 +73,8 @@ public interface ChatClient {
 
 	ChatClientRequestSpec prompt();
 
+	ChatClientPromptRequestSpec prompt(String content);
+
 	ChatClientPromptRequestSpec prompt(Prompt prompt);
 
 	/**

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -91,6 +91,11 @@ public class DefaultChatClient implements ChatClient {
 	}
 
 	@Override
+	public ChatClientPromptRequestSpec prompt(String content) {
+		return new DefaultChatClientPromptRequestSpec(this.chatModel, new Prompt(content));
+	}
+
+	@Override
 	public ChatClientPromptRequestSpec prompt(Prompt prompt) {
 		return new DefaultChatClientPromptRequestSpec(this.chatModel, prompt);
 	}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
@@ -436,6 +436,19 @@ public class ChatClientTest {
 	}
 
 	@Test
+	public void simpleUserPromptAsString() {
+		when(chatModel.call(promptCaptor.capture()))
+				.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("response")))));
+
+		assertThat(ChatClient.builder(chatModel).build().prompt("User prompt").call().content())
+				.isEqualTo("response");
+
+		Message userMessage = promptCaptor.getValue().getInstructions().get(0);
+		assertThat(userMessage.getContent()).isEqualTo("User prompt");
+		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
+	}
+
+	@Test
 	public void simpleUserPrompt() {
 		when(chatModel.call(promptCaptor.capture()))
 			.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("response")))));


### PR DESCRIPTION
Allow simple prompts as `String` when using the `ChatClient`.

```java
var response = chatClient.prompt("What did Gandalf say to the Balrog?")
                         .call()
                         .content();
```

Fixes gh-1286
