### PR TITLE
Autowire WebClient.Builder into OllamaApi

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -100,7 +100,7 @@ public class OllamaApi {
 	 * @param baseUrl The base url of the Ollama server.
 	 */
 	public OllamaApi(String baseUrl) {
-		this(baseUrl, RestClient.builder());
+		this(baseUrl, RestClient.builder(), WebClient.builder());
 	}
 
 	/**
@@ -109,7 +109,7 @@ public class OllamaApi {
 	 * @param baseUrl The base url of the Ollama server.
 	 * @param restClientBuilder The {@link RestClient.Builder} to use.
 	 */
-	public OllamaApi(String baseUrl, RestClient.Builder restClientBuilder) {
+	public OllamaApi(String baseUrl, RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder) {
 
 		this.responseErrorHandler = new OllamaResponseErrorHandler();
 
@@ -120,7 +120,7 @@ public class OllamaApi {
 
 		this.restClient = restClientBuilder.baseUrl(baseUrl).defaultHeaders(defaultHeaders).build();
 
-		this.webClient = WebClient.builder().baseUrl(baseUrl).defaultHeaders(defaultHeaders).build();
+		this.webClient = webClientBuilder.baseUrl(baseUrl).defaultHeaders(defaultHeaders).build();
 	}
 
 	// --------------------------------------------------------------------------

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * {@link AutoConfiguration Auto-configuration} for Ollama Chat Client.
@@ -61,8 +62,9 @@ public class OllamaAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public OllamaApi ollamaApi(OllamaConnectionDetails connectionDetails, RestClient.Builder restClientBuilder) {
-		return new OllamaApi(connectionDetails.getBaseUrl(), restClientBuilder);
+	public OllamaApi ollamaApi(OllamaConnectionDetails connectionDetails, RestClient.Builder restClientBuilder,
+			WebClient.Builder webClientBuilder) {
+		return new OllamaApi(connectionDetails.getBaseUrl(), restClientBuilder, webClientBuilder);
 	}
 
 	@Bean


### PR DESCRIPTION
`OllamaApi` creates its own `WebClient.Builder` rather than take one via its constructor. (This is in contrast to its `RestClient.Builder` which it accepts via a constructor. )

As such, this prevents customization of the `WebClient.Builder` outside of `OllamaApi`. 

This PR changes `OllamaApi` to accept a `WebClient.Builder` via the constructor the same way that it already accepts a `RestClient.Builder` via the constructor.