### PR TITLE
Fix where previous Assistant Messages were not being added to the parts list

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -431,7 +431,7 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 		else if (message instanceof AssistantMessage assistantMessage) {
 			List<Part> parts = new ArrayList<>();
 			if (StringUtils.hasText(assistantMessage.getContent())) {
-				List.of(Part.newBuilder().setText(assistantMessage.getContent()).build());
+				parts.add(Part.newBuilder().setText(assistantMessage.getContent()).build());
 			}
 			if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 				parts.addAll(assistantMessage.getToolCalls()


### PR DESCRIPTION
The Google Gemini Vertex Chat Model was not adding previous Assistant Messages to the parts list - this results in a failure when submitting a call:

`Results in: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Unable to submit request because it must include at least one parts field, which describes the prompt input. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini`


