### PR TITLE
Elasticsearch vector store - Wrong error reported fix

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -50,16 +50,14 @@ TIP: Refer to the xref:getting-started.adoc#repositories[Repositories] section t
 
 
 The vector store implementation can initialize the requisite schema for you, but you must opt-in by specifying the `initializeSchema` boolean in the appropriate constructor or by setting `...initialize-schema=true` in the `application.properties` file.
-Alternatively you can opt-out the initialization and either:
-
-- let Elasticsearch create the index automatically when the first batch of data is indexed - this works well for simple usecases, or for when the vector dimension is unknown: Elasticsearch will be able to infer it from the data received. The only similarity function allowed using this approach is `cosine`.
-- create the index manually using the Elasticsearch client - useful if the index needs advanced mapping or additional configuration which `initializeSchema` does not provide. 
+Alternatively you can opt-out the initialization and create the index manually using the Elasticsearch client, which can be useful if the index needs advanced mapping or additional configuration.
 
 NOTE: this is a breaking change! In earlier versions of Spring AI, this schema initialization happened by default.
 
 
 
 Please have a look at the list of <<elasticsearchvector-properties,configuration parameters>> for the vector store to learn about the default values and configuration options.
+These properties can be also set by configuring the `ElasticsearchVectorStoreOptions` bean.
 
 Additionally, you will need a configured `EmbeddingModel` bean. Refer to the xref:api/embeddings.adoc#available-implementations[EmbeddingModel] section for more information.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -50,6 +50,10 @@ TIP: Refer to the xref:getting-started.adoc#repositories[Repositories] section t
 
 
 The vector store implementation can initialize the requisite schema for you, but you must opt-in by specifying the `initializeSchema` boolean in the appropriate constructor or by setting `...initialize-schema=true` in the `application.properties` file.
+Alternatively you can opt-out the initialization and either:
+
+- let Elasticsearch create the index automatically when the first batch of data is indexed - this works well for simple usecases, or for when the vector dimension is unknown: Elasticsearch will be able to infer it from the data received. The only similarity function allowed using this approach is `cosine`.
+- create the index manually using the Elasticsearch client - useful if the index needs advanced mapping or additional configuration which `initializeSchema` does not provide. 
 
 NOTE: this is a breaking change! In earlier versions of Spring AI, this schema initialization happened by default.
 

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -114,8 +114,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 	@Override
 	public void doAdd(List<Document> documents) {
 		if (!indexExists()) {
-			throw new IllegalArgumentException(
-					"Index not found");
+			throw new IllegalArgumentException("Index not found");
 		}
 		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
 

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -105,6 +105,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		Objects.requireNonNull(embeddingModel, "EmbeddingModel must not be null");
 		this.elasticsearchClient = new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper(
 				new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))));
+		elasticsearchClient.withTransportOptions(t -> t.addHeader("user-agent", "spring-ai"));
 		this.embeddingModel = embeddingModel;
 		this.options = options;
 		this.filterExpressionConverter = new ElasticsearchAiSearchFilterExpressionConverter();

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -112,11 +112,9 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 
 	@Override
 	public void doAdd(List<Document> documents) {
-		// Elasticsearch can automatically create an index if it does not exist, but it
-		// will always use the default similarity function 'cosine'
-		if (!indexExists() && !options.getSimilarity().equals(SimilarityFunction.cosine)) {
+		if (!indexExists()) {
 			throw new IllegalArgumentException(
-					"Index not found, cannot use similarity functions other than 'cosine' if the index has not been previously configured");
+					"Index not found");
 		}
 		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
 

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -113,6 +113,8 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 
 	@Override
 	public void doAdd(List<Document> documents) {
+		// For the index to be present, either it must be pre-created or set the
+		// initializeSchema to true.
 		if (!indexExists()) {
 			throw new IllegalArgumentException("Index not found");
 		}
@@ -140,13 +142,13 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 	@Override
 	public Optional<Boolean> doDelete(List<String> idList) {
 		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
-		// We call operations on BulkRequest.Builder only if the index exists.
 		// For the index to be present, either it must be pre-created or set the
 		// initializeSchema to true.
-		if (indexExists()) {
-			for (String id : idList) {
-				bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(this.options.getIndexName()).id(id)));
-			}
+		if (!indexExists()) {
+			throw new IllegalArgumentException("Index not found");
+		}
+		for (String id : idList) {
+			bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(this.options.getIndexName()).id(id)));
 		}
 		return Optional.of(bulkRequest(bulkRequestBuilder.build()).errors());
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-ai/issues/1316 as discussed in the issue, also updates the documentation to better explain the various index initialization possibilities. 

Added `user-agent` header to the elasticsearch client configuration. This is what we at Elastic will use to keep track of the usage of Spring AI, so that we can see statistics in the [Elastic Cloud](https://cloud.elastic.co/) metrics, better understand the needs of Spring users and contribute more to the project. 