### PR TITLE
Fix incorrect comments in OpenAiAudioApi and OpenAiApi

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -93,6 +93,7 @@ public class OpenAiApi {
 	 * @param baseUrl api base URL.
 	 * @param apiKey OpenAI apiKey.
 	 * @param restClientBuilder RestClient builder.
+	 * @param webClientBuilder WebClient builder.
 	 */
 	public OpenAiApi(String baseUrl, String apiKey, RestClient.Builder restClientBuilder,
 			WebClient.Builder webClientBuilder) {
@@ -104,6 +105,7 @@ public class OpenAiApi {
 	 * @param baseUrl api base URL.
 	 * @param apiKey OpenAI apiKey.
 	 * @param restClientBuilder RestClient builder.
+	 * @param webClientBuilder WebClient builder.
 	 * @param responseErrorHandler Response error handler.
 	 */
 	public OpenAiApi(String baseUrl, String apiKey, RestClient.Builder restClientBuilder,
@@ -116,7 +118,10 @@ public class OpenAiApi {
 	 * Create a new chat completion api.
 	 * @param baseUrl api base URL.
 	 * @param apiKey OpenAI apiKey.
+	 * @param completionsPath the path to the chat completions endpoint.
+	 * @param embeddingsPath the path to the embeddings endpoint.
 	 * @param restClientBuilder RestClient builder.
+	 * @param webClientBuilder WebClient builder.
 	 * @param responseErrorHandler Response error handler.
 	 */
 	public OpenAiApi(String baseUrl, String apiKey, String completionsPath, String embeddingsPath,
@@ -132,7 +137,10 @@ public class OpenAiApi {
 	 * @param baseUrl api base URL.
 	 * @param apiKey OpenAI apiKey.
 	 * @param headers the http headers to use.
+	 * @param completionsPath the path to the chat completions endpoint.
+	 * @param embeddingsPath the path to the embeddings endpoint.
 	 * @param restClientBuilder RestClient builder.
+	 * @param webClientBuilder WebClient builder.
 	 * @param responseErrorHandler Response error handler.
 	 */
 	public OpenAiApi(String baseUrl, String apiKey, MultiValueMap<String, String> headers, String completionsPath,

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
@@ -62,7 +62,7 @@ public class OpenAiAudioApi {
 	}
 
 	/**
-	 * Create an new chat completion api.
+	 * Create a new audio api.
 	 * @param baseUrl api base URL.
 	 * @param openAiToken OpenAI apiKey.
 	 * @param restClientBuilder RestClient builder.
@@ -81,7 +81,7 @@ public class OpenAiAudioApi {
 	}
 
 	/**
-	 * Create an new chat completion api.
+	 * Create a new audio api.
 	 * @param baseUrl api base URL.
 	 * @param apiKey OpenAI apiKey.
 	 * @param restClientBuilder RestClient builder.
@@ -96,7 +96,7 @@ public class OpenAiAudioApi {
 	}
 
 	/**
-	 * Create an new chat completion api.
+	 * Create a new audio api.
 	 * @param baseUrl api base URL.
 	 * @param apiKey OpenAI apiKey.
 	 * @param headers the http headers to use.


### PR DESCRIPTION
Hello, this PR fixed incorrect Javadoc comments in OpenAiAudioApi and OpenAiApi constructors.

<br>

PR contents:
- Fixed incorrect comment in OpenAiAudioApi (referred to chat completion instead of audio API).
- Added missing @param for webClientBuilder in OpenAiApi.

<br>

Fixes #1329 

<br>

Thank you!