### PR TITLE
Overload EvaluationRequest constructor

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/evaluation/EvaluationRequest.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/evaluation/EvaluationRequest.java
@@ -2,6 +2,7 @@ package org.springframework.ai.evaluation;
 
 import org.springframework.ai.model.Content;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -22,7 +23,7 @@ public class EvaluationRequest {
 	private final String responseContent;
 
 	public EvaluationRequest(String userText, String responseContent) {
-		this(userText, List.of(), responseContent);
+		this(userText, Collections.emptyList(), responseContent);
 	}
 
 	public EvaluationRequest(String userText, List<Content> dataList, String responseContent) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/evaluation/EvaluationRequest.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/evaluation/EvaluationRequest.java
@@ -21,6 +21,10 @@ public class EvaluationRequest {
 
 	private final String responseContent;
 
+	public EvaluationRequest(String userText, String responseContent) {
+		this(userText, List.of(), responseContent);
+	}
+
 	public EvaluationRequest(String userText, List<Content> dataList, String responseContent) {
 		this.userText = userText;
 		this.dataList = dataList;


### PR DESCRIPTION
I find that more often than not, I create an `EvaluationRequest` by passing in `List.of()` or `Collections.emptyList()` as the 2nd constructor argument (data list). 

As a convenience, I thought it would be nice if there were a constructor that defaulted to an empty list.