### PR TITLE
Fix typo in Cassandra Vector Storage docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/apache-cassandra.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/apache-cassandra.adoc
@@ -87,7 +87,7 @@ You can use the following properties in your Spring Boot configuration to custom
 
 |`spring.ai.vectorstore.cassandra.keyspace`|springframework
 |`spring.ai.vectorstore.cassandra.table`|ai_vector_store
-|`spring.ai.vectorstore.cassandra.initialze-schema`|false
+|`spring.ai.vectorstore.cassandra.initialize-schema`|false
 |`spring.ai.vectorstore.cassandra.index-name`|
 |`spring.ai.vectorstore.cassandra.content-column-name`|content
 |`spring.ai.vectorstore.cassandra.embedding-column-name`|embedding


### PR DESCRIPTION
A typo in the configuration property: `spring.ai.vectorstore.cassandra.initialze-schema`. Replaced with `spring.ai.vectorstore.cassandra.initialize-schema`