### PR TITLE
Fix host in ChromaDockerComposeConnectionDetailsFactory

### DIFF
--- a/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/chroma/ChromaDockerComposeConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/chroma/ChromaDockerComposeConnectionDetailsFactory.java
@@ -60,7 +60,7 @@ class ChromaDockerComposeConnectionDetailsFactory
 
 		@Override
 		public String getHost() {
-			return this.host;
+			return "http://%s".formatted(this.host);
 		}
 
 		@Override


### PR DESCRIPTION
Host should start with `http://`

Fixes #1395
