### PR TITLE
GH-1199: Prevent timeouts with configurable batching for PgVectorStor…

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfiguration.java
@@ -71,6 +71,7 @@ public class PgVectorStoreAutoConfiguration {
 			.withObservationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.withSearchObservationConvention(customObservationConvention.getIfAvailable(() -> null))
 			.withBatchingStrategy(batchingStrategy)
+			.withMaxDocumentBatchSize(properties.getMaxDocumentBatchSize())
 			.build();
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreProperties.java
@@ -24,6 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * @author Christian Tzolov
  * @author Muthukumaran Navaneethakrishnan
+ * @author Soby Chacko
  */
 @ConfigurationProperties(PgVectorStoreProperties.CONFIG_PREFIX)
 public class PgVectorStoreProperties extends CommonVectorStoreProperties {
@@ -44,6 +45,8 @@ public class PgVectorStoreProperties extends CommonVectorStoreProperties {
 	private String schemaName = PgVectorStore.DEFAULT_SCHEMA_NAME;
 
 	private boolean schemaValidation = PgVectorStore.DEFAULT_SCHEMA_VALIDATION;
+
+	private int maxDocumentBatchSize = PgVectorStore.MAX_DOCUMENT_BATCH_SIZE;
 
 	public int getDimensions() {
 		return dimensions;
@@ -99,6 +102,14 @@ public class PgVectorStoreProperties extends CommonVectorStoreProperties {
 
 	public void setSchemaValidation(boolean schemaValidation) {
 		this.schemaValidation = schemaValidation;
+	}
+
+	public int getMaxDocumentBatchSize() {
+		return this.maxDocumentBatchSize;
+	}
+
+	public void setMaxDocumentBatchSize(int maxDocumentBatchSize) {
+		this.maxDocumentBatchSize = maxDocumentBatchSize;
 	}
 
 }

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
@@ -18,10 +18,12 @@ package org.springframework.ai.vectorstore;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
@@ -81,6 +83,8 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	public final FilterExpressionConverter filterExpressionConverter = new PgVectorFilterExpressionConverter();
 
+	public static final int MAX_DOCUMENT_BATCH_SIZE = 10_000;
+
 	private final String vectorTableName;
 
 	private final String vectorIndexName;
@@ -109,6 +113,8 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private final BatchingStrategy batchingStrategy;
 
+	private final int maxDocumentBatchSize;
+
 	public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
 		this(jdbcTemplate, embeddingModel, INVALID_EMBEDDING_DIMENSION, PgDistanceType.COSINE_DISTANCE, false,
 				PgIndexType.NONE, false);
@@ -132,7 +138,6 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 		this(DEFAULT_SCHEMA_NAME, vectorTableName, DEFAULT_SCHEMA_VALIDATION, jdbcTemplate, embeddingModel, dimensions,
 				distanceType, removeExistingVectorStoreTable, createIndexMethod, initializeSchema);
-
 	}
 
 	private PgVectorStore(String schemaName, String vectorTableName, boolean vectorTableValidationsEnabled,
@@ -141,14 +146,14 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 		this(schemaName, vectorTableName, vectorTableValidationsEnabled, jdbcTemplate, embeddingModel, dimensions,
 				distanceType, removeExistingVectorStoreTable, createIndexMethod, initializeSchema,
-				ObservationRegistry.NOOP, null, new TokenCountBatchingStrategy());
+				ObservationRegistry.NOOP, null, new TokenCountBatchingStrategy(), MAX_DOCUMENT_BATCH_SIZE);
 	}
 
 	private PgVectorStore(String schemaName, String vectorTableName, boolean vectorTableValidationsEnabled,
 			JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int dimensions, PgDistanceType distanceType,
 			boolean removeExistingVectorStoreTable, PgIndexType createIndexMethod, boolean initializeSchema,
 			ObservationRegistry observationRegistry, VectorStoreObservationConvention customObservationConvention,
-			BatchingStrategy batchingStrategy) {
+			BatchingStrategy batchingStrategy, int maxDocumentBatchSize) {
 
 		super(observationRegistry, customObservationConvention);
 
@@ -172,6 +177,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		this.initializeSchema = initializeSchema;
 		this.schemaValidator = new PgVectorSchemaValidator(jdbcTemplate);
 		this.batchingStrategy = batchingStrategy;
+		this.maxDocumentBatchSize = maxDocumentBatchSize;
 	}
 
 	public PgDistanceType getDistanceType() {
@@ -180,40 +186,50 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	@Override
 	public void doAdd(List<Document> documents) {
-
-		int size = documents.size();
-
 		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
 
-		this.jdbcTemplate.batchUpdate(
-				"INSERT INTO " + getFullyQualifiedTableName()
-						+ " (id, content, metadata, embedding) VALUES (?, ?, ?::jsonb, ?) " + "ON CONFLICT (id) DO "
-						+ "UPDATE SET content = ? , metadata = ?::jsonb , embedding = ? ",
-				new BatchPreparedStatementSetter() {
-					@Override
-					public void setValues(PreparedStatement ps, int i) throws SQLException {
+		List<List<Document>> batchedDocuments = batchDocuments(documents);
+		batchedDocuments.forEach(this::insertOrUpdateBatch);
+	}
 
-						var document = documents.get(i);
-						var content = document.getContent();
-						var json = toJson(document.getMetadata());
-						var embedding = document.getEmbedding();
-						var pGvector = new PGvector(embedding);
+	private List<List<Document>> batchDocuments(List<Document> documents) {
+		List<List<Document>> batches = new ArrayList<>();
+		for (int i = 0; i < documents.size(); i += this.maxDocumentBatchSize) {
+			batches.add(documents.subList(i, Math.min(i + this.maxDocumentBatchSize, documents.size())));
+		}
+		return batches;
+	}
 
-						StatementCreatorUtils.setParameterValue(ps, 1, SqlTypeValue.TYPE_UNKNOWN,
-								UUID.fromString(document.getId()));
-						StatementCreatorUtils.setParameterValue(ps, 2, SqlTypeValue.TYPE_UNKNOWN, content);
-						StatementCreatorUtils.setParameterValue(ps, 3, SqlTypeValue.TYPE_UNKNOWN, json);
-						StatementCreatorUtils.setParameterValue(ps, 4, SqlTypeValue.TYPE_UNKNOWN, pGvector);
-						StatementCreatorUtils.setParameterValue(ps, 5, SqlTypeValue.TYPE_UNKNOWN, content);
-						StatementCreatorUtils.setParameterValue(ps, 6, SqlTypeValue.TYPE_UNKNOWN, json);
-						StatementCreatorUtils.setParameterValue(ps, 7, SqlTypeValue.TYPE_UNKNOWN, pGvector);
-					}
+	private void insertOrUpdateBatch(List<Document> batch) {
+		String sql = "INSERT INTO " + getFullyQualifiedTableName()
+				+ " (id, content, metadata, embedding) VALUES (?, ?, ?::jsonb, ?) " + "ON CONFLICT (id) DO "
+				+ "UPDATE SET content = ? , metadata = ?::jsonb , embedding = ? ";
 
-					@Override
-					public int getBatchSize() {
-						return size;
-					}
-				});
+		this.jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+
+				var document = batch.get(i);
+				var content = document.getContent();
+				var json = toJson(document.getMetadata());
+				var embedding = document.getEmbedding();
+				var pGvector = new PGvector(embedding);
+
+				StatementCreatorUtils.setParameterValue(ps, 1, SqlTypeValue.TYPE_UNKNOWN,
+						UUID.fromString(document.getId()));
+				StatementCreatorUtils.setParameterValue(ps, 2, SqlTypeValue.TYPE_UNKNOWN, content);
+				StatementCreatorUtils.setParameterValue(ps, 3, SqlTypeValue.TYPE_UNKNOWN, json);
+				StatementCreatorUtils.setParameterValue(ps, 4, SqlTypeValue.TYPE_UNKNOWN, pGvector);
+				StatementCreatorUtils.setParameterValue(ps, 5, SqlTypeValue.TYPE_UNKNOWN, content);
+				StatementCreatorUtils.setParameterValue(ps, 6, SqlTypeValue.TYPE_UNKNOWN, json);
+				StatementCreatorUtils.setParameterValue(ps, 7, SqlTypeValue.TYPE_UNKNOWN, pGvector);
+			}
+
+			@Override
+			public int getBatchSize() {
+				return batch.size();
+			}
+		});
 	}
 
 	private String toJson(Map<String, Object> map) {
@@ -509,6 +525,8 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
 
+		private int maxDocumentBatchSize = MAX_DOCUMENT_BATCH_SIZE;
+
 		@Nullable
 		private VectorStoreObservationConvention searchObservationConvention;
 
@@ -576,11 +594,17 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 			return this;
 		}
 
+		public Builder withMaxDocumentBatchSize(int maxDocumentBatchSize) {
+			this.maxDocumentBatchSize = maxDocumentBatchSize;
+			return this;
+		}
+
 		public PgVectorStore build() {
 			return new PgVectorStore(this.schemaName, this.vectorTableName, this.vectorTableValidationsEnabled,
 					this.jdbcTemplate, this.embeddingModel, this.dimensions, this.distanceType,
 					this.removeExistingVectorStoreTable, this.indexType, this.initializeSchema,
-					this.observationRegistry, this.searchObservationConvention, this.batchingStrategy);
+					this.observationRegistry, this.searchObservationConvention, this.batchingStrategy,
+					this.maxDocumentBatchSize);
 		}
 
 	}


### PR DESCRIPTION
…e inserts

Resolves https://github.com/spring-projects/spring-ai/issues/1199

- Implement configurable maxDocumentBatchSize to prevent insert timeouts when adding large numbers of documents
- Update PgVectorStore to process document inserts in controlled batches
- Add maxDocumentBatchSize property to PgVectorStoreProperties
- Update PgVectorStoreAutoConfiguration to use the new batching property
- Add tests to verify batching behavior and performance

This change addresses the issue of PgVectorStore inserts timing out due to large document volumes. By introducing configurable batching, users can now control the insert process to avoid timeouts while maintaining performance and reducing memory overhead for large-scale document additions.

