### PR TITLE
Add Meta Llama 3.1, 3.2 instruct model enums to Bedrock

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/api/LlamaChatBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/api/LlamaChatBedrockApi.java
@@ -226,7 +226,42 @@ public class LlamaChatBedrockApi extends
 		/**
 		 * meta.llama3-70b-instruct-v1:0
 		 */
-		LLAMA3_70B_INSTRUCT_V1("meta.llama3-70b-instruct-v1:0");
+		LLAMA3_70B_INSTRUCT_V1("meta.llama3-70b-instruct-v1:0"),
+
+		/**
+		 * meta.llama3-1-8b-instruct-v1:0
+		 */
+		LLAMA3_1_8B_INSTRUCT_V1("meta.llama3-1-8b-instruct-v1:0"),
+
+		/**
+		 * meta.llama3-1-70b-instruct-v1:0
+		 */
+		LLAMA3_1_70B_INSTRUCT_V1("meta.llama3-1-70b-instruct-v1:0"),
+
+		/**
+		 * meta.llama3-1-405b-instruct-v1:0
+		 */
+		LLAMA3_1_405B_INSTRUCT_V1("meta.llama3-1-405b-instruct-v1:0"),
+
+		/**
+		 * meta.llama3-2-1b-instruct-v1:0
+		 */
+		LLAMA3_2_1B_INSTRUCT_V1("meta.llama3-2-1b-instruct-v1:0"),
+
+		/**
+		 * meta.llama3-2-3b-instruct-v1:0
+		 */
+		LLAMA3_2_3B_INSTRUCT_V1("meta.llama3-2-3b-instruct-v1:0"),
+
+		/**
+		 * meta.llama3-2-11b-instruct-v1:0
+		 */
+		LLAMA3_2_11B_INSTRUCT_V1("meta.llama3-2-11b-instruct-v1:0"),
+
+		/**
+		 * meta.llama3-2-90b-instruct-v1:0
+		 */
+		LLAMA3_2_90B_INSTRUCT_V1("meta.llama3-2-90b-instruct-v1:0");
 
 		private final String id;
 


### PR DESCRIPTION
Add Meta Llama 3.1, 3.2 instruct model enums to Bedrock

Reference for model ids - https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
