### PR TITLE
Remove unnecessary null checks in AzureOpenAiChatOptions.Builder

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -283,7 +283,6 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions, ChatOptio
 		}
 
 		public Builder withResponseFormat(AzureOpenAiResponseFormat responseFormat) {
-			Assert.notNull(responseFormat, "responseFormat must not be null");
 			this.options.responseFormat = responseFormat;
 			return this;
 		}
@@ -294,25 +293,21 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions, ChatOptio
 		}
 
 		public Builder withSeed(Long seed) {
-			Assert.notNull(seed, "seed must not be null");
 			this.options.seed = seed;
 			return this;
 		}
 
 		public Builder withLogprobs(Boolean logprobs) {
-			Assert.notNull(logprobs, "logprobs must not be null");
 			this.options.logprobs = logprobs;
 			return this;
 		}
 
 		public Builder withTopLogprobs(Integer topLogprobs) {
-			Assert.notNull(topLogprobs, "topLogprobs must not be null");
 			this.options.topLogProbs = topLogprobs;
 			return this;
 		}
 
 		public Builder withEnhancements(AzureChatEnhancementConfiguration enhancements) {
-			Assert.notNull(enhancements, "enhancements must not be null");
 			this.options.enhancements = enhancements;
 			return this;
 		}


### PR DESCRIPTION
This is related to https://github.com/spring-projects/spring-ai/issues/889

This commit addresses a bug where certain fields were being made indirectly mandatory due to Assert.notNull checks in the Builder's with* methods. Specifically:

- Removed Assert.notNull checks from withResponseFormat, withSeed, withLogprobs, withTopLogprobs, and withEnhancements methods.

These checks were causing exceptions in AzureOpenAiChatModel.getDefaultOptions when not all fields were set, leading to failures in methods like ChatClient.create, even when using the AzureOpenAiChatModel constructor with OpenAIClient.

The removal of these checks aligns with the @JsonInclude(Include.NON_NULL) annotation on AzureOpenAiChatOptions, which already ignores null options. This change maintains the intended flexibility while preventing unintended mandatory requirements.
