### PR TITLE
Correctly set Chroma collection id when initializeSchema set to false

### DIFF
--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
@@ -185,13 +185,16 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-
-		if (!this.initializeSchema)
-			return;
-
 		var collection = this.chromaApi.getCollection(this.collectionName);
 		if (collection == null) {
-			collection = this.chromaApi.createCollection(new ChromaApi.CreateCollectionRequest(this.collectionName));
+			if (initializeSchema) {
+				collection = this.chromaApi
+					.createCollection(new ChromaApi.CreateCollectionRequest(this.collectionName));
+			}
+			else {
+				throw new RuntimeException("Collection " + this.collectionName
+						+ " doesn't exist. It won't be created when initializeSchema is set to false.");
+			}
 		}
 		this.collectionId = collection.id();
 	}


### PR DESCRIPTION
In the current implementation of `ChromaVectorStore`, when `initializeSchema` is set to `false`, `collectionId` will be set to `null`, all Chroma API calls will fail with 404 error due to empty collection id.

I updated the logic of handling `initializeSchema`. When the collection doesn't exist, if `initializeSchema` is set to `true`, the collection will be created. Otherwise, an exception is thrown. This makes sure that `collectionId` will be correctly set.