### PR TITLE
Enable setting json root via json pointer

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/reader/JsonReader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/reader/JsonReader.java
@@ -106,8 +106,8 @@ public class JsonReader implements DocumentReader {
 	public List<Document> get(JsonNode rootNode) {
 		if (rootNode.isArray()) {
 			return StreamSupport.stream(rootNode.spliterator(), true)
-					.map(jsonNode -> parseJsonNode(jsonNode, objectMapper))
-					.toList();
+				.map(jsonNode -> parseJsonNode(jsonNode, objectMapper))
+				.toList();
 		}
 		else {
 			return Collections.singletonList(parseJsonNode(rootNode, objectMapper));
@@ -124,4 +124,5 @@ public class JsonReader implements DocumentReader {
 			throw new RuntimeException(e);
 		}
 	}
+
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/reader/JsonReader.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/reader/JsonReader.java
@@ -16,6 +16,7 @@
 package org.springframework.ai.reader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,33 +70,19 @@ public class JsonReader implements DocumentReader {
 		this.jsonKeysToUse = List.of(jsonKeysToUse);
 	}
 
-	public List<Document> get(JsonNode rootNode) {
-		if (rootNode.isArray()) {
-			return StreamSupport.stream(rootNode.spliterator(), true)
-				.map(jsonNode -> parseJsonNode(jsonNode, objectMapper))
-				.toList();
-		}
-		else {
-			return Collections.singletonList(parseJsonNode(rootNode, objectMapper));
-		}
-	}
-
 	@Override
 	public List<Document> get() {
 		try {
 			JsonNode rootNode = objectMapper.readTree(this.resource.getInputStream());
-			return get(rootNode);
-		}
-		catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
 
-	public List<Document> get(String pointer) {
-		try {
-			JsonNode rootNode = objectMapper.readTree(this.resource.getInputStream());
-			rootNode = rootNode.at(pointer);
-			return get(rootNode);
+			if (rootNode.isArray()) {
+				return StreamSupport.stream(rootNode.spliterator(), true)
+					.map(jsonNode -> parseJsonNode(jsonNode, objectMapper))
+					.toList();
+			}
+			else {
+				return Collections.singletonList(parseJsonNode(rootNode, objectMapper));
+			}
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);
@@ -116,4 +103,25 @@ public class JsonReader implements DocumentReader {
 		return new Document(content, metadata);
 	}
 
+	public List<Document> get(JsonNode rootNode) {
+		if (rootNode.isArray()) {
+			return StreamSupport.stream(rootNode.spliterator(), true)
+					.map(jsonNode -> parseJsonNode(jsonNode, objectMapper))
+					.toList();
+		}
+		else {
+			return Collections.singletonList(parseJsonNode(rootNode, objectMapper));
+		}
+	}
+
+	public List<Document> get(String pointer) {
+		try {
+			JsonNode rootNode = objectMapper.readTree(this.resource.getInputStream());
+			rootNode = rootNode.at(pointer);
+			return get(rootNode);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
@@ -28,22 +28,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 public class JsonReaderTests {
 
-	@Value("classpath:bikes.json")
+	@Value("classpath:events.json")
 	private Resource arrayResource;
 
 	@Value("classpath:person.json")
 	private Resource ObjectResource;
-
-	@Test
-	void loadJsonArray() {
-		assertThat(arrayResource).isNotNull();
-		JsonReader jsonReader = new JsonReader(arrayResource, "description");
-		List<Document> documents = jsonReader.get();
-		assertThat(documents).isNotEmpty();
-		for (Document document : documents) {
-			assertThat(document.getContent()).isNotEmpty();
-		}
-	}
 
 	@Test
 	void loadJsonObject() {
@@ -54,6 +43,28 @@ public class JsonReaderTests {
 		for (Document document : documents) {
 			assertThat(document.getContent()).isNotEmpty();
 		}
+	}
+
+	@Test
+	void loadJsonArrayFromPointer() {
+		assertThat(arrayResource).isNotNull();
+		JsonReader jsonReader = new JsonReader(arrayResource, "description");
+		List<Document> documents = jsonReader.get("/0/sessions");
+		assertThat(documents).isNotEmpty();
+		for (Document document : documents) {
+			assertThat(document.getContent()).isNotEmpty();
+			assertThat(document.getContent()).contains("Session");
+		}
+	}
+
+	@Test
+	void loadJsonObjectFromPointer() {
+		assertThat(ObjectResource).isNotNull();
+		JsonReader jsonReader = new JsonReader(ObjectResource, "name");
+		List<Document> documents = jsonReader.get("/store");
+		assertThat(documents).isNotEmpty();
+		assertThat(documents.size()).isEqualTo(1);
+		assertThat(documents.get(0).getContent()).contains("name: Bike Shop");
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
@@ -28,11 +28,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 public class JsonReaderTests {
 
-	@Value("classpath:events.json")
-	private Resource arrayResource;
-
 	@Value("classpath:person.json")
 	private Resource ObjectResource;
+
+	@Value("classpath:bikes.json")
+	private Resource arrayResource;
+
+	@Value("classpath:events.json")
+	private Resource eventsResource;
+
+	@Test
+	void loadJsonArray() {
+		assertThat(arrayResource).isNotNull();
+		JsonReader jsonReader = new JsonReader(arrayResource, "description");
+		List<Document> documents = jsonReader.get();
+		assertThat(documents).isNotEmpty();
+		for (Document document : documents) {
+			assertThat(document.getContent()).isNotEmpty();
+		}
+	}
 
 	@Test
 	void loadJsonObject() {
@@ -48,7 +62,7 @@ public class JsonReaderTests {
 	@Test
 	void loadJsonArrayFromPointer() {
 		assertThat(arrayResource).isNotNull();
-		JsonReader jsonReader = new JsonReader(arrayResource, "description");
+		JsonReader jsonReader = new JsonReader(eventsResource, "description");
 		List<Document> documents = jsonReader.get("/0/sessions");
 		assertThat(documents).isNotEmpty();
 		for (Document document : documents) {
@@ -66,5 +80,4 @@ public class JsonReaderTests {
 		assertThat(documents.size()).isEqualTo(1);
 		assertThat(documents.get(0).getContent()).contains("name: Bike Shop");
 	}
-
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/reader/JsonReaderTests.java
@@ -80,4 +80,5 @@ public class JsonReaderTests {
 		assertThat(documents.size()).isEqualTo(1);
 		assertThat(documents.get(0).getContent()).contains("name: Bike Shop");
 	}
+
 }

--- a/spring-ai-core/src/test/resources/events.json
+++ b/spring-ai-core/src/test/resources/events.json
@@ -1,0 +1,15 @@
+[
+  {
+    "sessions": [
+      {
+        "description": "Session one"
+      },
+      {
+        "description": "Session two"
+      },
+      {
+        "description": "Session three"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
I found some JSON in the wild which I want to use, but the doc is not currently ingestable via the existing JsonReader.  events.json in the test resources is a simplified example of the wild json.