### PR TITLE
Fix: remove duplicate entry for elasticsearch.initialize-schema

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -146,7 +146,6 @@ Properties starting with the `spring.ai.vectorstore.elasticsearch.*` prefix are 
 |`spring.ai.vectorstore.elasticsearch.index-name` | The name of the index to store the vectors. | spring-ai-document-index
 |`spring.ai.vectorstore.elasticsearch.dimensions` | The number of dimensions in the vector. | 1536
 |`spring.ai.vectorstore.elasticsearch.similarity` | The similarity function to use. | `cosine`
-|`spring.ai.vectorstore.elasticsearch.initialize-schema`| whether to initialize the required schema  | `false`
 |===
 
 The following similarity functions are available:


### PR DESCRIPTION
Removed the duplicate entry of the 'spring.ai.vectorstore.elasticsearch.initialize-schema' property  from the Elasticsearch Vector Store documentation to enhance clarity and avoid confusion.
