### PR TITLE
Add the public access modifier to ElasticsearchVectorStoreAutoConfiguration

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
@@ -46,7 +46,7 @@ import io.micrometer.observation.ObservationRegistry;
 @AutoConfiguration(after = ElasticsearchRestClientAutoConfiguration.class)
 @ConditionalOnClass({ ElasticsearchVectorStore.class, EmbeddingModel.class, RestClient.class })
 @EnableConfigurationProperties(ElasticsearchVectorStoreProperties.class)
-class ElasticsearchVectorStoreAutoConfiguration {
+public class ElasticsearchVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(BatchingStrategy.class)


### PR DESCRIPTION
Add the `public` access modifier to `ElasticsearchVectorStoreAutoConfiguration` class, so that it can be excluded and a custom configuration can be defined. 

This makes it consistent with all the other vector store auto configurations classes.

Fixes https://github.com/spring-projects/spring-ai/issues/1462
