### PR TITLE
Fix anthropicApi visibility in AnthropicChatModel

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -89,7 +89,7 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 	/**
 	 * The lower-level API for the Anthropic service.
 	 */
-	public final AnthropicApi anthropicApi;
+	private final AnthropicApi anthropicApi;
 
 	/**
 	 * The default options used for the chat completion requests.


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring) ✅
* Rebase your changes on the latest `main` branch and squash your commits ✅
* Add/Update unit tests as needed ✅
* Run a build and make sure all tests pass prior to submission ✅

---

I updated the AnthropicChatModel by changing the anthropicApi field from public to private.

- Ensures consistency since all other major variables are private
- Aligns with how other AI provider models handle their APIs
- Verified that anthropicApi is only used internally, avoiding external issues

Thank you for reviewing this contribution. 