### PR TITLE
Improve chat client and advisor observations

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -77,6 +77,7 @@ import reactor.core.scheduler.Schedulers;
  * @author Arjen Poutsma
  * @author Soby Chacko
  * @author Dariusz Jedrzejczyk
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 public class DefaultChatClient implements ChatClient {
@@ -360,8 +361,11 @@ public class DefaultChatClient implements ChatClient {
 		private ChatResponse doGetObservableChatResponse(DefaultChatClientRequestSpec inputRequest,
 				String formatParam) {
 
-			ChatClientObservationContext observationContext = new ChatClientObservationContext(inputRequest,
-					formatParam, false);
+			ChatClientObservationContext observationContext = ChatClientObservationContext.builder()
+				.withRequest(inputRequest)
+				.withFormat(formatParam)
+				.withStream(false)
+				.build();
 
 			var observation = ChatClientObservationDocumentation.AI_CHAT_CLIENT.observation(
 					inputRequest.getCustomObservationConvention(), DEFAULT_CHAT_CLIENT_OBSERVATION_CONVENTION,
@@ -407,8 +411,10 @@ public class DefaultChatClient implements ChatClient {
 		private Flux<ChatResponse> doGetObservableFluxChatResponse(DefaultChatClientRequestSpec inputRequest) {
 			return Flux.deferContextual(contextView -> {
 
-				ChatClientObservationContext observationContext = new ChatClientObservationContext(inputRequest, "",
-						true);
+				ChatClientObservationContext observationContext = ChatClientObservationContext.builder()
+					.withRequest(inputRequest)
+					.withStream(true)
+					.build();
 
 				Observation observation = ChatClientObservationDocumentation.AI_CHAT_CLIENT.observation(
 						inputRequest.getCustomObservationConvention(), DEFAULT_CHAT_CLIENT_OBSERVATION_CONVENTION,

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
@@ -85,6 +85,7 @@ public class DefaultAroundAdvisorChain implements CallAroundAdvisorChain, Stream
 			.withAdvisorType(AdvisorObservationContext.Type.AROUND)
 			.withAdvisedRequest(advisedRequest)
 			.withAdvisorRequestContext(advisedRequest.adviseContext())
+			.withOrder(advisor.getOrder())
 			.build();
 
 		return AdvisorObservationDocumentation.AI_ADVISOR
@@ -106,6 +107,7 @@ public class DefaultAroundAdvisorChain implements CallAroundAdvisorChain, Stream
 				.withAdvisorType(AdvisorObservationContext.Type.AROUND)
 				.withAdvisedRequest(advisedRequest)
 				.withAdvisorRequestContext(advisedRequest.adviseContext())
+				.withOrder(advisor.getOrder())
 				.build();
 
 			var observation = AdvisorObservationDocumentation.AI_ADVISOR.observation(null,

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationConvention.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationConvention.java
@@ -19,6 +19,8 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
 
 /**
+ * Interface for an {@link ObservationConvention} for chat client advisors.
+ *
  * @author Christian Tzolov
  * @since 1.0.0
  */

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationDocumentation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationDocumentation.java
@@ -27,7 +27,7 @@ import io.micrometer.observation.docs.ObservationDocumentation;
 public enum AdvisorObservationDocumentation implements ObservationDocumentation {
 
 	/**
-	 * AI Chat Client observations
+	 * AI Advisor observations
 	 */
 	AI_ADVISOR {
 		@Override
@@ -65,7 +65,7 @@ public enum AdvisorObservationDocumentation implements ObservationDocumentation 
 		ADVISOR_TYPE {
 			@Override
 			public String asString() {
-				return "spring.ai.chat.client.advisor.type";
+				return "spring.ai.advisor.type";
 			}
 		}
 
@@ -74,12 +74,12 @@ public enum AdvisorObservationDocumentation implements ObservationDocumentation 
 	public enum HighCardinalityKeyNames implements KeyName {
 
 		/**
-		 * Chat Model name.
+		 * Advisor name.
 		 */
 		ADVISOR_NAME {
 			@Override
 			public String asString() {
-				return "spring.ai.chat.client.advisor.name";
+				return "spring.ai.advisor.name";
 			}
 		},
 		/**
@@ -88,7 +88,7 @@ public enum AdvisorObservationDocumentation implements ObservationDocumentation 
 		ADVISOR_ORDER {
 			@Override
 			public String asString() {
-				return "spring.ai.chat.client.advisor.order";
+				return "spring.ai.advisor.order";
 			}
 		}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
@@ -17,6 +17,7 @@ package org.springframework.ai.chat.client.advisor.observation;
 
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation.HighCardinalityKeyNames;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation.LowCardinalityKeyNames;
+import org.springframework.ai.observation.conventions.SpringAiKind;
 import org.springframework.ai.util.ParsingUtils;
 import org.springframework.lang.Nullable;
 
@@ -27,18 +28,9 @@ import io.micrometer.common.KeyValues;
  * @author Christian Tzolov
  * @since 1.0.0
  */
-
 public class DefaultAdvisorObservationConvention implements AdvisorObservationConvention {
 
-	public static final String DEFAULT_NAME = "spring.ai.chat.client.advisor";
-
-	private static final String CHAT_CLIENT_ADVISOR_SPRING_AI_KIND = "chat_client_advisor";
-
-	private static final KeyValue ADVISOR_TYPE_NONE = KeyValue.of(LowCardinalityKeyNames.ADVISOR_TYPE,
-			KeyValue.NONE_VALUE);
-
-	private static final KeyValue ADVISOR_NAME_NONE = KeyValue.of(HighCardinalityKeyNames.ADVISOR_NAME,
-			KeyValue.NONE_VALUE);
+	public static final String DEFAULT_NAME = "spring.ai.advisor";
 
 	private final String name;
 
@@ -73,15 +65,12 @@ public class DefaultAdvisorObservationConvention implements AdvisorObservationCo
 	}
 
 	protected KeyValue advisorType(AdvisorObservationContext context) {
-		if (context.getAdvisorType() != null) {
-			return KeyValue.of(LowCardinalityKeyNames.ADVISOR_TYPE, context.getAdvisorType().name());
-		}
-		return ADVISOR_TYPE_NONE;
+		return KeyValue.of(LowCardinalityKeyNames.ADVISOR_TYPE, context.getAdvisorType().name());
 	}
 
 	protected KeyValue springAiKind() {
 		return KeyValue.of(AdvisorObservationDocumentation.LowCardinalityKeyNames.SPRING_AI_KIND,
-				CHAT_CLIENT_ADVISOR_SPRING_AI_KIND);
+				SpringAiKind.ADVISOR.value());
 	}
 
 	// ------------------------
@@ -94,10 +83,7 @@ public class DefaultAdvisorObservationConvention implements AdvisorObservationCo
 	}
 
 	protected KeyValue advisorName(AdvisorObservationContext context) {
-		if (context.getAdvisorType() != null) {
-			return KeyValue.of(HighCardinalityKeyNames.ADVISOR_NAME, context.getAdvisorName());
-		}
-		return ADVISOR_NAME_NONE;
+		return KeyValue.of(HighCardinalityKeyNames.ADVISOR_NAME, context.getAdvisorName());
 	}
 
 	protected KeyValue advisorOrder(AdvisorObservationContext context) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/package-info.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/package-info.java
@@ -13,33 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.ai.observation.conventions;
 
-/**
- * Types of Spring AI constructs which can be observed.
- *
- * @author Thomas Vitale
- * @since 1.0.0
- */
-public enum SpringAiKind {
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.chat.client.advisor.observation;
 
-	// @formatter:off
-
-	// Please, keep the alphabetical sorting.
-	ADVISOR("advisor"),
-	CHAT_CLIENT("chat_client"),
-	VECTOR_STORE("vector_store");
-
-	private final String value;
-
-	SpringAiKind(String value) {
-		this.value = value;
-	}
-
-	public String value() {
-		return this.value;
-	}
-
-	// @formatter:on
-
-}
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationContext.java
@@ -21,25 +21,30 @@ import org.springframework.ai.observation.conventions.AiOperationType;
 import org.springframework.ai.observation.conventions.AiProvider;
 
 import io.micrometer.observation.Observation;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
+ * Context used to store metadata for chat client workflows.
+ *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  * @since 1.0.0
  */
-
 public class ChatClientObservationContext extends Observation.Context {
-
-	private final boolean stream;
-
-	private final String format;
 
 	private final DefaultChatClientRequestSpec request;
 
 	private final AiOperationMetadata operationMetadata = new AiOperationMetadata(AiOperationType.FRAMEWORK.value(),
 			AiProvider.SPRING_AI.value());
 
-	public ChatClientObservationContext(DefaultChatClientRequestSpec requestSpec, String format, Boolean isStream) {
+	private final boolean stream;
 
+	@Nullable
+	private String format;
+
+	ChatClientObservationContext(DefaultChatClientRequestSpec requestSpec, String format, boolean isStream) {
+		Assert.notNull(requestSpec, "requestSpec cannot be null");
 		this.request = requestSpec;
 		this.format = format;
 		this.stream = isStream;
@@ -57,8 +62,49 @@ public class ChatClientObservationContext extends Observation.Context {
 		return this.stream;
 	}
 
+	@Nullable
 	public String getFormat() {
 		return this.format;
+	}
+
+	public void setFormat(@Nullable String format) {
+		this.format = format;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private DefaultChatClientRequestSpec request;
+
+		private String format;
+
+		private boolean isStream = false;
+
+		private Builder() {
+		}
+
+		public Builder withRequest(DefaultChatClientRequestSpec request) {
+			this.request = request;
+			return this;
+		}
+
+		public Builder withFormat(String format) {
+			this.format = format;
+			return this;
+		}
+
+		public Builder withStream(boolean isStream) {
+			this.isStream = isStream;
+			return this;
+		}
+
+		public ChatClientObservationContext build() {
+			return new ChatClientObservationContext(this.request, this.format, this.isStream);
+		}
+
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationConvention.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationConvention.java
@@ -19,10 +19,11 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
 
 /**
+ * Interface for an {@link ObservationConvention} for chat client workflows.
+ *
  * @author Christian Tzolov
  * @since 1.0.0
  */
-
 public interface ChatClientObservationConvention extends ObservationConvention<ChatClientObservationContext> {
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationDocumentation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/ChatClientObservationDocumentation.java
@@ -21,6 +21,8 @@ import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.ObservationDocumentation;
 
 /**
+ * Documented conventions for chat client observations.
+ *
  * @author Christian Tzolov
  * @since 1.0.0
  */
@@ -88,7 +90,7 @@ public enum ChatClientObservationDocumentation implements ObservationDocumentati
 		CHAT_CLIENT_TOOL_FUNCTION_CALLBACKS {
 			@Override
 			public String asString() {
-				return "spring.ai.chat.client.tool.functioncallbacks";
+				return "spring.ai.chat.client.tool.function.callbacks";
 			}
 		},
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/package-info.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/observation/package-info.java
@@ -13,33 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.ai.observation.conventions;
 
-/**
- * Types of Spring AI constructs which can be observed.
- *
- * @author Thomas Vitale
- * @since 1.0.0
- */
-public enum SpringAiKind {
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.chat.client.observation;
 
-	// @formatter:off
-
-	// Please, keep the alphabetical sorting.
-	ADVISOR("advisor"),
-	CHAT_CLIENT("chat_client"),
-	VECTOR_STORE("vector_store");
-
-	private final String value;
-
-	SpringAiKind(String value) {
-		this.value = value;
-	}
-
-	public String value() {
-		return this.value;
-	}
-
-	// @formatter:on
-
-}
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-ai-core/src/main/java/org/springframework/ai/observation/tracing/TracingHelper.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/observation/tracing/TracingHelper.java
@@ -28,6 +28,7 @@ import org.springframework.util.StringUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 
 /**
@@ -64,10 +65,16 @@ public final class TracingHelper {
 		return null;
 	}
 
+	public static String concatenateMaps(Map<String, Object> keyValues) {
+		var keyValuesJoiner = new StringJoiner(", ", "[", "]");
+		keyValues.forEach((key, value) -> keyValuesJoiner.add("\"" + key + "\":\"" + value + "\""));
+		return keyValuesJoiner.toString();
+	}
+
 	public static String concatenateStrings(List<String> strings) {
-		var promptMessagesJoiner = new StringJoiner(", ", "[", "]");
-		strings.forEach(string -> promptMessagesJoiner.add("\"" + string + "\""));
-		return promptMessagesJoiner.toString();
+		var stringsJoiner = new StringJoiner(", ", "[", "]");
+		strings.forEach(string -> stringsJoiner.add("\"" + string + "\""));
+		return stringsJoiner.toString();
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationContextTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationContextTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for {@link AdvisorObservationContext}.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 class AdvisorObservationContextTests {
 
@@ -42,14 +43,14 @@ class AdvisorObservationContextTests {
 		assertThatThrownBy(() -> AdvisorObservationContext.builder()
 			.withAdvisorType(AdvisorObservationContext.Type.BEFORE)
 			.build()).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("The advisorName must not be empty!");
+			.hasMessageContaining("advisorName must not be null or empty");
 	}
 
 	@Test
 	void missingAdvisorType() {
 		assertThatThrownBy(() -> AdvisorObservationContext.builder().withAdvisorName("MyName").build())
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("The advisorType must not be null!");
+			.hasMessageContaining("advisorType must not be null");
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
@@ -23,11 +23,13 @@ import org.springframework.ai.chat.client.advisor.observation.AdvisorObservation
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.observation.Observation;
+import org.springframework.ai.observation.conventions.SpringAiKind;
 
 /**
  * Unit tests for {@link DefaultAdvisorObservationConvention}.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 class DefaultAdvisorObservationConventionTests {
 
@@ -64,8 +66,9 @@ class DefaultAdvisorObservationConventionTests {
 			.withAdvisorType(AdvisorObservationContext.Type.AROUND)
 			.build();
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(observationContext)).contains(
-				KeyValue.of(LowCardinalityKeyNames.ADVISOR_TYPE.asString(), "AROUND"),
-				KeyValue.of(LowCardinalityKeyNames.SPRING_AI_KIND.asString(), "chat_client_advisor"));
+				KeyValue.of(LowCardinalityKeyNames.ADVISOR_TYPE.asString(),
+						AdvisorObservationContext.Type.AROUND.name()),
+				KeyValue.of(LowCardinalityKeyNames.SPRING_AI_KIND.asString(), SpringAiKind.ADVISOR.value()));
 	}
 
 	@Test

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientInputContentObservationFilterTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientInputContentObservationFilterTests.java
@@ -33,9 +33,10 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
 /**
- * Unit tests for {@link ChatClientImportContentObservationFilter}.
+ * Unit tests for {@link ChatClientInputContentObservationFilter}.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 @ExtendWith(MockitoExtension.class)
 class ChatClientInputContentObservationFilterTests {
@@ -55,14 +56,13 @@ class ChatClientInputContentObservationFilterTests {
 
 	@Test
 	void whenEmptyInputContentThenReturnOriginalContext() {
-
 		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 		ChatClientObservationConvention customObservationConvention = null;
 
 		var request = new DefaultChatClientRequestSpec(chatModel, "", Map.of(), "", Map.of(), List.of(), List.of(),
 				List.of(), List.of(), null, List.of(), Map.of(), observationRegistry, customObservationConvention);
 
-		var expectedContext = new ChatClientObservationContext(request, "", false);
+		var expectedContext = ChatClientObservationContext.builder().withRequest(request).build();
 
 		var actualContext = observationFilter.map(expectedContext);
 
@@ -71,7 +71,6 @@ class ChatClientInputContentObservationFilterTests {
 
 	@Test
 	void whenWithTextThenAugmentContext() {
-
 		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 		ChatClientObservationConvention customObservationConvention = null;
 
@@ -79,7 +78,7 @@ class ChatClientInputContentObservationFilterTests {
 				"sample system text", Map.of("sp1", "sp1v"), List.of(), List.of(), List.of(), List.of(), null,
 				List.of(), Map.of(), observationRegistry, customObservationConvention);
 
-		var originalContext = new ChatClientObservationContext(request, "", false);
+		var originalContext = ChatClientObservationContext.builder().withRequest(request).build();
 
 		var augmentedContext = observationFilter.map(originalContext);
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientObservationContextTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientObservationContextTests.java
@@ -33,6 +33,7 @@ import io.micrometer.observation.ObservationRegistry;
  * Unit tests for {@link ChatClientObservationContext}.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 @ExtendWith(MockitoExtension.class)
 class ChatClientObservationContextTests {
@@ -46,7 +47,7 @@ class ChatClientObservationContextTests {
 		var request = new DefaultChatClientRequestSpec(chatModel, "", Map.of(), "", Map.of(), List.of(), List.of(),
 				List.of(), List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null);
 
-		var observationContext = new ChatClientObservationContext(request, "", true);
+		var observationContext = ChatClientObservationContext.builder().withRequest(request).withStream(true).build();
 
 		assertThat(observationContext).isNotNull();
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
@@ -118,7 +118,6 @@ public class ChromaVectorStoreAutoConfigurationIT {
 				.hasObservationWithNameEqualTo(DefaultVectorStoreObservationConvention.DEFAULT_NAME)
 				.that()
 				.hasContextualNameEqualTo("chroma delete")
-				.hasHighCardinalityKeyValue(HighCardinalityKeyNames.DB_VECTOR_QUERY_FILTER.asString(), "none")
 				.hasBeenStarted()
 				.hasBeenStopped();
 			observationRegistry.clear();


### PR DESCRIPTION
* Make ChatClient and Advisor observation logic null-safe
* Simplify naming for Advisor observations
* Include high-cardinality attributes only if a value is present
* Fix condition to include system test to chat client observations
* Add Advisor order information to context
* Streamline usage of enums and utils to reduce hard-coded/duplications
* Fix pending Chroma integration test