### PR TITLE
feature: Add common TranscriptionModel interface for audio transcription

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModel.java
@@ -29,8 +29,8 @@ import org.springframework.ai.azure.openai.AzureOpenAiAudioTranscriptionOptions.
 import org.springframework.ai.azure.openai.AzureOpenAiAudioTranscriptionOptions.StructuredResponse.Word;
 import org.springframework.ai.azure.openai.AzureOpenAiAudioTranscriptionOptions.TranscriptResponseFormat;
 import org.springframework.ai.azure.openai.metadata.AzureOpenAiAudioTranscriptionResponseMetadata;
-import org.springframework.ai.model.Model;
 import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.TranscriptionModel;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -45,7 +45,7 @@ import java.util.List;
  *
  * @author Piotr Olaszewski
  */
-public class AzureOpenAiAudioTranscriptionModel implements Model<AudioTranscriptionPrompt, AudioTranscriptionResponse> {
+public class AzureOpenAiAudioTranscriptionModel implements TranscriptionModel {
 
 	private static final List<AudioTranscriptionFormat> JSON_FORMATS = List.of(AudioTranscriptionFormat.JSON,
 			AudioTranscriptionFormat.VERBOSE_JSON);

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.metadata.RateLimit;
-import org.springframework.ai.model.Model;
+import org.springframework.ai.model.TranscriptionModel;
 import org.springframework.ai.openai.api.OpenAiAudioApi;
 import org.springframework.ai.openai.api.OpenAiAudioApi.StructuredResponse;
 import org.springframework.ai.audio.transcription.AudioTranscription;
@@ -60,7 +60,7 @@ import org.springframework.util.Assert;
  * @see OpenAiAudioApi
  * @since 0.8.1
  */
-public class OpenAiAudioTranscriptionModel implements Model<AudioTranscriptionPrompt, AudioTranscriptionResponse> {
+public class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/TranscriptionModel.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/TranscriptionModel.java
@@ -1,0 +1,21 @@
+package org.springframework.ai.model;
+
+import org.springframework.ai.audio.transcription.AudioTranscriptionOptions;
+import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
+import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
+import org.springframework.core.io.Resource;
+
+public interface TranscriptionModel extends Model<AudioTranscriptionPrompt, AudioTranscriptionResponse> {
+
+	AudioTranscriptionResponse call(AudioTranscriptionPrompt transcriptionPrompt);
+
+	default String transcribe(Resource resource) {
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource);
+		return this.call(prompt).getResult().getOutput();
+	}
+
+	default String transcribe(Resource resource, AudioTranscriptionOptions options) {
+		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
+		return this.call(prompt).getResult().getOutput();
+	}
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/TranscriptionModel.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/TranscriptionModel.java
@@ -18,4 +18,5 @@ public interface TranscriptionModel extends Model<AudioTranscriptionPrompt, Audi
 		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
 		return this.call(prompt).getResult().getOutput();
 	}
+
 }


### PR DESCRIPTION
- Created TranscriptionModel interface that extends Model<AudioTranscriptionPrompt, AudioTranscriptionResponse>
- Implemented `call(AudioTranscriptionPrompt)` method for better compatibility between OpenAI and Azure OpenAI transcription models
- Added default convenience methods for handling Resource and AudioTranscriptionOptions to return transcription as a String

Resolution of this opened issue: https://github.com/spring-projects/spring-ai/issues/1478
