### PR TITLE
Refactor FunctionCallback API to use ToolContext instead of Map

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelFunctionCallingIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelFunctionCallingIT.java
@@ -25,6 +25,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.function.FunctionCallbackWrapper;
 import org.springframework.ai.openai.OpenAiChatModel;
@@ -71,12 +72,12 @@ class OpenAiChatModelFunctionCallingIT {
 	@Test
 	void functionCallWithToolContextTest() {
 
-		var biFunction = new BiFunction<MockWeatherService.Request, Map<String, Object>, MockWeatherService.Response>() {
+		var biFunction = new BiFunction<MockWeatherService.Request, ToolContext, MockWeatherService.Response>() {
 
 			@Override
-			public Response apply(Request request, Map<String, Object> toolContext) {
+			public Response apply(Request request, ToolContext toolContext) {
 
-				assertThat(toolContext).containsEntry("sessionId", "123");
+				assertThat(toolContext.context).containsEntry("sessionId", "123");
 
 				double temperature = 0;
 				if (request.location().contains("Paris")) {
@@ -133,12 +134,12 @@ class OpenAiChatModelFunctionCallingIT {
 	@Test
 	void streamFunctionCallWithToolContextTest() {
 
-		var biFunction = new BiFunction<MockWeatherService.Request, Map<String, Object>, MockWeatherService.Response>() {
+		var biFunction = new BiFunction<MockWeatherService.Request, ToolContext, MockWeatherService.Response>() {
 
 			@Override
-			public Response apply(Request request, Map<String, Object> toolContext) {
+			public Response apply(Request request, ToolContext toolContext) {
 
-				assertThat(toolContext).containsEntry("sessionId", "123");
+				assertThat(toolContext.getContext()).containsEntry("sessionId", "123");
 
 				double temperature = 0;
 				if (request.location().contains("Paris")) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.openai.OpenAiTestConfiguration;
 import org.springframework.ai.openai.api.tool.MockWeatherService;
 import org.springframework.ai.openai.api.tool.MockWeatherService.Request;
@@ -115,12 +115,12 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 	@Test
 	void defaultFunctionCallTestWithToolContext() {
 
-		var biFunction = new BiFunction<MockWeatherService.Request, Map<String, Object>, MockWeatherService.Response>() {
+		var biFunction = new BiFunction<MockWeatherService.Request, ToolContext, MockWeatherService.Response>() {
 
 			@Override
-			public Response apply(Request request, Map<String, Object> toolContext) {
+			public Response apply(Request request, ToolContext toolContext) {
 
-				assertThat(toolContext).containsEntry("sessionId", "123");
+				assertThat(toolContext.getContext()).containsEntry("sessionId", "123");
 
 				double temperature = 0;
 				if (request.location().contains("Paris")) {
@@ -155,12 +155,12 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 	@Test
 	void functionCallTestWithToolContext() {
 
-		var biFunction = new BiFunction<MockWeatherService.Request, Map<String, Object>, MockWeatherService.Response>() {
+		var biFunction = new BiFunction<MockWeatherService.Request, ToolContext, MockWeatherService.Response>() {
 
 			@Override
-			public Response apply(Request request, Map<String, Object> toolContext) {
+			public Response apply(Request request, ToolContext toolContext) {
 
-				assertThat(toolContext).containsEntry("sessionId", "123");
+				assertThat(toolContext.getContext()).containsEntry("sessionId", "123");
 
 				double temperature = 0;
 				if (request.location().contains("Paris")) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -26,6 +26,7 @@ import org.springframework.ai.chat.client.observation.ChatClientObservationConve
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.converter.StructuredOutputConverter;
@@ -202,7 +203,7 @@ public interface ChatClient {
 				java.util.function.Function<I, O> function);
 
 		<I, O> ChatClientRequestSpec function(String name, String description,
-				java.util.function.BiFunction<I, Map<String, Object>, O> function);
+				java.util.function.BiFunction<I, ToolContext, O> function);
 
 		<I, O> ChatClientRequestSpec functions(FunctionCallback... functionCallbacks);
 
@@ -267,7 +268,7 @@ public interface ChatClient {
 		<I, O> Builder defaultFunction(String name, String description, java.util.function.Function<I, O> function);
 
 		<I, O> Builder defaultFunction(String name, String description,
-				java.util.function.BiFunction<I, Map<String, Object>, O> function);
+				java.util.function.BiFunction<I, ToolContext, O> function);
 
 		Builder defaultFunctions(String... functionNames);
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -46,6 +46,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.converter.BeanOutputConverter;
@@ -693,7 +694,7 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		public <I, O> ChatClientRequestSpec function(String name, String description,
-				java.util.function.BiFunction<I, Map<String, Object>, O> biFunction) {
+				java.util.function.BiFunction<I, ToolContext, O> biFunction) {
 
 			Assert.hasText(name, "the name must be non-null and non-empty");
 			Assert.hasText(description, "the description must be non-null and non-empty");

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -29,6 +29,7 @@ import org.springframework.ai.chat.client.DefaultChatClient.DefaultChatClientReq
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.core.io.Resource;
@@ -142,7 +143,7 @@ public class DefaultChatClientBuilder implements Builder {
 	}
 
 	public <I, O> Builder defaultFunction(String name, String description,
-			java.util.function.BiFunction<I, Map<String, Object>, O> biFunction) {
+			java.util.function.BiFunction<I, ToolContext, O> biFunction) {
 		this.defaultRequest.function(name, description, biFunction);
 		return this;
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequest.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequest.java
@@ -62,7 +62,7 @@ public record AdvisedRequest(ChatModel chatModel, String userText, String system
 		Map<String, Object> userParams, Map<String, Object> systemParams, List<Advisor> advisors,
 		Map<String, Object> advisorParams, Map<String, Object> adviseContext, Map<String, Object> toolContext) {
 
-	public AdvisedRequest updateContext(Function<Map<String, Object>, Map<String, Object>> contextTransform) {
+	public AdvisedRequest updateAdvisedContext(Function<Map<String, Object>, Map<String, Object>> contextTransform) {
 		return from(this)
 			.withAdviseContext(Collections.unmodifiableMap(contextTransform.apply(new HashMap<>(this.adviseContext))))
 			.build();
@@ -94,8 +94,6 @@ public record AdvisedRequest(ChatModel chatModel, String userText, String system
 
 	public static class Builder {
 
-		public Map<String, Object> toolContext;
-
 		private ChatModel chatModel;
 
 		private String userText = "";
@@ -121,6 +119,8 @@ public record AdvisedRequest(ChatModel chatModel, String userText, String system
 		private Map<String, Object> advisorParams = Map.of();
 
 		private Map<String, Object> adviseContext = Map.of();
+
+		public Map<String, Object> toolContext = Map.of();
 
 		public Builder withChatModel(ChatModel chatModel) {
 			this.chatModel = chatModel;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
@@ -16,6 +16,7 @@
 package org.springframework.ai.chat.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -137,11 +138,13 @@ public abstract class AbstractToolCallSupport {
 		}
 		AssistantMessage assistantMessage = toolCallGeneration.get().getOutput();
 
-		Map<String, Object> toolContext = null;
-		if (prompt.getOptions() instanceof FunctionCallingOptions functionCallOptions) {
-			toolContext = functionCallOptions.getToolContext();
+		Map<String, Object> toolContextMap = Map.of();
+		if (prompt.getOptions() instanceof FunctionCallingOptions functionCallOptions
+				&& !CollectionUtils.isEmpty(functionCallOptions.getToolContext())) {
+			toolContextMap = functionCallOptions.getToolContext();
 		}
-		ToolResponseMessage toolMessageResponse = this.executeFunctions(assistantMessage, toolContext);
+		ToolResponseMessage toolMessageResponse = this.executeFunctions(assistantMessage,
+				new ToolContext(toolContextMap));
 
 		return this.buildToolCallConversation(prompt.getInstructions(), assistantMessage, toolMessageResponse);
 	}
@@ -190,7 +193,7 @@ public abstract class AbstractToolCallSupport {
 		return retrievedFunctionCallbacks;
 	}
 
-	protected ToolResponseMessage executeFunctions(AssistantMessage assistantMessage, Map<String, Object> toolContext) {
+	protected ToolResponseMessage executeFunctions(AssistantMessage assistantMessage, ToolContext toolContext) {
 
 		List<ToolResponseMessage.ToolResponse> toolResponses = new ArrayList<>();
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ToolContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ToolContext.java
@@ -1,0 +1,38 @@
+/*
+* Copyright 2024 - 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.chat.model;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+
+public class ToolContext {
+
+	public Map<String, Object> context;
+
+	public ToolContext(Map<String, Object> context) {
+		this.context = Collections.unmodifiableMap(context);
+	}
+
+	public Map<String, Object> getContext() {
+		return this.context;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractFunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractFunctionCallback.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.ai.model.function;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.util.Assert;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.springframework.util.Assert;
 
 /**
  * Abstract implementation of the {@link FunctionCallback} for interacting with the
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
  * @param <O> the 3rd party service output type.
  * @author Christian Tzolov
  */
-abstract class AbstractFunctionCallback<I, O> implements BiFunction<I, Map<String, Object>, O>, FunctionCallback {
+abstract class AbstractFunctionCallback<I, O> implements BiFunction<I, ToolContext, O>, FunctionCallback {
 
 	private final String name;
 
@@ -101,7 +101,7 @@ abstract class AbstractFunctionCallback<I, O> implements BiFunction<I, Map<Strin
 	}
 
 	@Override
-	public String call(String functionInput, Map<String, Object> toolContext) {
+	public String call(String functionInput, ToolContext toolContext) {
 		I request = fromJson(functionInput, inputType);
 		O response = this.apply(request, toolContext);
 		return this.responseConverter.apply(response);

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
@@ -17,6 +17,8 @@ package org.springframework.ai.model.function;
 
 import java.util.Map;
 
+import org.springframework.ai.chat.model.ToolContext;
+
 /**
  * Represents a model function call handler. Implementations are registered with the
  * Models and called on prompts that trigger the function call.
@@ -60,13 +62,13 @@ public interface FunctionCallback {
 	 * @param functionInput JSON string with the function arguments to be passed to the
 	 * function. The arguments are defined as JSON schema usually registered with the the
 	 * model. Arguments are provided by the AI model.
-	 * @param functionContext Map with the function context. The context is used to pass
+	 * @param tooContext Map with the function context. The context is used to pass
 	 * additional user provided state in addition to the arguments provided by the AI
 	 * model.
 	 * @return String containing the function call response.
 	 */
-	default String call(String functionInput, Map<String, Object> functionContext) {
-		if (functionContext != null) {
+	default String call(String functionInput, ToolContext tooContext) {
+		if (tooContext != null) {
 			throw new UnsupportedOperationException("Function context is not supported!");
 		}
 		return call(functionInput);

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
@@ -16,12 +16,10 @@
 package org.springframework.ai.model.function;
 
 import java.lang.reflect.Type;
-import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
-
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.beans.BeansException;
 import org.springframework.cloud.function.context.catalog.FunctionTypeUtils;
 import org.springframework.cloud.function.context.config.FunctionContextUtils;
@@ -32,6 +30,8 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 
 /**
  * A Spring {@link ApplicationContextAware} implementation that provides a way to retrieve
@@ -127,7 +127,7 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 				.build();
 		}
 		else if (bean instanceof BiFunction<?, ?, ?> biFunction) {
-			return FunctionCallbackWrapper.builder((BiFunction<?, Map<String, Object>, ?>) biFunction)
+			return FunctionCallbackWrapper.builder((BiFunction<?, ToolContext, ?>) biFunction)
 				.withName(functionName)
 				.withSchemaType(this.schemaType)
 				.withDescription(functionDescription)

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
@@ -77,6 +77,6 @@ public interface FunctionCallingOptions extends ChatOptions {
 
 	Map<String, Object> getToolContext();
 
-	void setToolContext(Map<String, Object> functionContext);
+	void setToolContext(Map<String, Object> tooContext);
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/AdvisorsTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/AdvisorsTests.java
@@ -88,7 +88,7 @@ public class AdvisorsTests {
 		@Override
 		public AdvisedResponse aroundCall(AdvisedRequest advisedRequest, CallAroundAdvisorChain chain) {
 
-			this.advisedRequest = advisedRequest.updateContext(context -> {
+			this.advisedRequest = advisedRequest.updateAdvisedContext(context -> {
 				context.put("aroundCallBefore" + getName(), "AROUND_CALL_BEFORE " + getName());
 				context.put("lastBefore", getName());
 				return context;
@@ -108,7 +108,7 @@ public class AdvisorsTests {
 		@Override
 		public Flux<AdvisedResponse> aroundStream(AdvisedRequest advisedRequest, StreamAroundAdvisorChain chain) {
 
-			this.advisedRequest = advisedRequest.updateContext(context -> {
+			this.advisedRequest = advisedRequest.updateAdvisedContext(context -> {
 				context.put("aroundStreamBefore" + name, "AROUND_STREAM_BEFORE " + name);
 				context.put("lastBefore", name);
 				return context;

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
@@ -230,10 +230,10 @@ You can set the tool context when building your chat options and use a BiFunctio
 
 [source,java]
 ----
-BiFunction<MockWeatherService.Request, Map<String, Object>, MockWeatherService.Response> weatherFunction =
+BiFunction<MockWeatherService.Request, ToolContext, MockWeatherService.Response> weatherFunction =
     (request, toolContext) -> {
-        String sessionId = (String) toolContext.get("sessionId");
-        String userId = (String) toolContext.get("userId");
+        String sessionId = (String) toolContext.getContext().get("sessionId");
+        String userId = (String) toolContext.getContext().get("userId");
 
         // Use sessionId and userId in your function logic
         double temperature = 0;

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionBeanIT.java
@@ -15,22 +15,22 @@
  */
 package org.springframework.ai.autoconfigure.azure.tool;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.ai.autoconfigure.azure.tool.DeploymentNameUtil.getDeploymentName;
+
 import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.ai.autoconfigure.azure.openai.AzureOpenAiAutoConfiguration;
 import org.springframework.ai.azure.openai.AzureOpenAiChatModel;
 import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
-import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.function.FunctionCallingOptionsBuilder.PortableFunctionCallingOptions;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -38,9 +38,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Description;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.ai.autoconfigure.azure.tool.DeploymentNameUtil.getDeploymentName;
 
 @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_ENDPOINT", matches = ".+")
@@ -110,18 +107,6 @@ class FunctionCallWithFunctionBeanIT {
 		@Description("Get the weather in location")
 		public Function<MockWeatherService.Request, MockWeatherService.Response> weatherFunction() {
 			return new MockWeatherService();
-		}
-
-		@Bean
-		@Description("Get the weather in location")
-		public Function<MockWeatherService.Request, Function<Map<String, Object>, MockWeatherService.Response>> weatherFunctionWithContext() {
-			return request -> context -> new MockWeatherService().apply(request);
-		}
-
-		@Bean
-		@Description("Get the weather in location")
-		public BiFunction<MockWeatherService.Request, Map<String, Object>, MockWeatherService.Response> weatherFunctionWithContext2() {
-			return (request, context) -> new MockWeatherService().apply(request);
 		}
 
 		// Relies on the Request's JsonClassDescription annotation to provide the

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -32,6 +32,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.function.FunctionCallingOptions;
 import org.springframework.ai.model.function.FunctionCallingOptionsBuilder.PortableFunctionCallingOptions;
@@ -187,7 +188,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 		@Bean
 		@Description("Get the weather in location")
-		public BiFunction<MockWeatherService.Request, Map<String, Object>, MockWeatherService.Response> weatherFunctionWithContext() {
+		public BiFunction<MockWeatherService.Request, ToolContext, MockWeatherService.Response> weatherFunctionWithContext() {
 			return (request, context) -> {
 				return new MockWeatherService().apply(request);
 			};


### PR DESCRIPTION
 - Replaced `Map<String, Object>` with `ToolContext` in the `FunctionCallback`, `AbstractFunctionCallback`, and related classes.
 - Updated all BiFunction definitions to use `ToolContext` as the second parameter, enhancing the clarity and structure of the tool context management.
 - Modified `FunctionCallbackWrapper` and `FunctionCallbackContext` to adapt to the new `ToolContext` parameter.
 - Adjusted the handling of tool context in the documentation and test classes.
 - Updated relevant test cases to reflect the API changes and modified the function handling logic to ensure consistency.

