### PR TITLE
Cleanup grammar in documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/ollama-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/ollama-chat-functions.adoc
@@ -2,7 +2,7 @@
 
 TIP: You need Ollama 0.2.8 or newer.
 
-TIP: You need https://ollama.com/search?c=tools[Models] pre-trained for Tools support. 
+TIP: You need https://ollama.com/search?c=tools[Models] pre-trained for Tools support.
 Usually, such models are tagged with a `Tools` tag.
 For example `mistral`, `firefunction-v2` or `llama3.1:70b`.
 
@@ -14,10 +14,10 @@ The Ollama models tagged with the `Tools` label (see https://ollama.com/search?c
 
 The Ollama API does not call the function directly; instead, the model generates JSON that you can use to call the function in your code and return the result back to the model to complete the conversation.
 Spring AI provides flexible and user-friendly ways to register and call custom functions.
-In general, the custom functions need to provide a function `name`,  `description`, and the function call `signature` (as JSON schema) to let the model know what arguments the function expects.  
+In general, the custom functions need to provide a function `name`,  `description`, and the function call `signature` (as JSON schema) to let the model know what arguments the function expects.
 The `description` helps the model to understand when to call the function.
 
-As a developer, you need to implement a function that takes the function call arguments sent from the AI model, and responds with the result back to the model.  
+As a developer, you need to implement a function that takes the function call arguments sent from the AI model, and responds with the result back to the model.
 Your function can in turn invoke other 3rd party services to provide the results.
 
 Spring AI makes this as easy as defining a `@Bean` definition that returns a `java.util.Function` and supplying the bean name as an option when invoking the `ChatModel`.
@@ -117,7 +117,7 @@ public record Request(String location, Unit unit) {}
 
 It is a best practice to annotate the request object with information such that the generated JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
 
-==== FunctionCallback Wrapper
+==== FunctionCallbackWrapper
 
 Another way to register a function is to create a `FunctionCallbackWrapper` like this:
 
@@ -196,7 +196,7 @@ ChatResponse response = chatModel.call(new Prompt(userMessage, promptOptions));
 
 NOTE: The in-prompt registered functions are enabled by default for the duration of this request.
 
-This approach allows to choose dynamically different functions to be called based on the user input.
+This approach allows you to dynamically choose different functions to be called based on the user input.
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackInPromptIT.java[FunctionCallbackInPromptIT.java] integration test provides a complete example of how to register a function with the `OllamaChatModel` and use it in a prompt request.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
@@ -8,7 +8,7 @@ The RAG use case is text to augment the capabilities of generative models by ret
 
 == API Overview
 
-The ETL pipelines creates, transforms and stores `Document` instances. 
+The ETL pipelines creates, transforms and stores `Document` instances.
 
 image::spring-ai-document1-api.jpg[Spring AI Message API, width=400, align="center"]
 
@@ -20,7 +20,7 @@ There are three main components of the ETL pipeline,
 * `DocumentTransformer` that implements `Function<List<Document>, List<Document>>`
 * `DocumentWriter` that implements `Consumer<List<Document>>`
 
-The `Document` class content is created from PDFs, text files and other document types throught the help of `DocumentReader`.
+The `Document` class content is created from PDFs, text files and other document types with the help of `DocumentReader`.
 
 To construct a simple ETL pipeline, you can chain together an instance of each type.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
@@ -1,7 +1,7 @@
 [[vector-databases]]
 = Vector Databases
 
-A vector databases is a specialized type of database that plays an essential role in AI applications.
+A vector database is a specialized type of database that plays an essential role in AI applications.
 
 In vector databases, queries differ from traditional relational databases.
 Instead of exact matches, they perform similarity searches.
@@ -334,5 +334,3 @@ Expression exp = b.and(b.eq("genre", "drama"), b.gte("year", 2020)).build();
 == Understanding Vectors
 
 xref:api/vectordbs/understand-vectordbs.adoc[Understanding Vectors]
-
-


### PR DESCRIPTION
* Fixes grammar in (Ollama) Function Calling.
* Fixes grammar in ETL Pipeline.
* Fixes grammar in Vector Databases.

Closes #1494