### PR TITLE
Upgrade pinecone java client to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
 		<elasticsearch-java.version>8.13.3</elasticsearch-java.version>
 		<milvus.version>2.3.4</milvus.version>
 		<gemfire.testcontainers.version>2.3.0</gemfire.testcontainers.version>
-		<pinecone.version>0.8.0</pinecone.version>
+		<pinecone.version>2.1.0</pinecone.version>
 		<fastjson.version>2.0.46</fastjson.version>
 		<azure-search.version>11.6.1</azure-search.version>
 		<weaviate-client.version>4.5.1</weaviate-client.version>

--- a/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/PineconeVectorStoreIT.java
+++ b/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/PineconeVectorStoreIT.java
@@ -281,8 +281,6 @@ public class PineconeVectorStoreIT {
 
 			return PineconeVectorStoreConfig.builder()
 				.withApiKey(System.getenv("PINECONE_API_KEY"))
-				.withEnvironment(PINECONE_ENVIRONMENT)
-				.withProjectId(PINECONE_PROJECT_ID)
 				.withIndexName(PINECONE_INDEX_NAME)
 				.withNamespace(PINECONE_NAMESPACE)
 				.withContentFieldName(CUSTOM_CONTENT_FIELD_NAME)

--- a/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/PineconeVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-pinecone-store/src/test/java/org/springframework/ai/vectorstore/PineconeVectorStoreObservationIT.java
@@ -188,8 +188,6 @@ public class PineconeVectorStoreObservationIT {
 
 			return PineconeVectorStoreConfig.builder()
 				.withApiKey(System.getenv("PINECONE_API_KEY"))
-				.withEnvironment(PINECONE_ENVIRONMENT)
-				.withProjectId(PINECONE_PROJECT_ID)
 				.withIndexName(PINECONE_INDEX_NAME)
 				.withNamespace(PINECONE_NAMESPACE)
 				.withContentFieldName(CUSTOM_CONTENT_FIELD_NAME)


### PR DESCRIPTION
[Pinecone Java Client](https://github.com/pinecone-io/pinecone-java-client) released 2.1.0, and currently spring-ai still uses 0.8.0 version.