### PR TITLE
Add builder pattern and order parameter to advisors

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest;
 import org.springframework.ai.chat.client.advisor.api.AdvisedResponse;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAroundAdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -43,7 +44,12 @@ public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemo
 	}
 
 	public MessageChatMemoryAdvisor(ChatMemory chatMemory, String defaultConversationId, int chatHistoryWindowSize) {
-		super(chatMemory, defaultConversationId, chatHistoryWindowSize, true);
+		this(chatMemory, defaultConversationId, chatHistoryWindowSize, Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER);
+	}
+
+	public MessageChatMemoryAdvisor(ChatMemory chatMemory, String defaultConversationId, int chatHistoryWindowSize,
+			int order) {
+		super(chatMemory, defaultConversationId, chatHistoryWindowSize, true, order);
 	}
 
 	@Override
@@ -99,6 +105,23 @@ public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemo
 			.toList();
 
 		this.getChatMemoryStore().add(this.doGetConversationId(advisedResponse.adviseContext()), assistantMessages);
+	}
+
+	public static Builder builder(ChatMemory chatMemory) {
+		return new Builder(chatMemory);
+	}
+
+	public static class Builder extends AbstractChatMemoryAdvisor.AbstractBuilder<ChatMemory> {
+
+		protected Builder(ChatMemory chatMemory) {
+			super(chatMemory);
+		}
+
+		public MessageChatMemoryAdvisor build() {
+			return new MessageChatMemoryAdvisor(this.chatMemory, this.conversationId, this.chatMemoryRetrieveSize,
+					this.order);
+		}
+
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest;
 import org.springframework.ai.chat.client.advisor.api.AdvisedResponse;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAroundAdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -66,7 +67,13 @@ public class PromptChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemor
 
 	public PromptChatMemoryAdvisor(ChatMemory chatMemory, String defaultConversationId, int chatHistoryWindowSize,
 			String systemTextAdvise) {
-		super(chatMemory, defaultConversationId, chatHistoryWindowSize, true);
+		this(chatMemory, defaultConversationId, chatHistoryWindowSize, systemTextAdvise,
+				Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER);
+	}
+
+	public PromptChatMemoryAdvisor(ChatMemory chatMemory, String defaultConversationId, int chatHistoryWindowSize,
+			String systemTextAdvise, int order) {
+		super(chatMemory, defaultConversationId, chatHistoryWindowSize, true, order);
 		this.systemTextAdvise = systemTextAdvise;
 	}
 
@@ -131,6 +138,30 @@ public class PromptChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemor
 			.toList();
 
 		this.getChatMemoryStore().add(this.doGetConversationId(advisedResponse.adviseContext()), assistantMessages);
+	}
+
+	public static Builder builder(ChatMemory chatMemory) {
+		return new Builder(chatMemory);
+	}
+
+	public static class Builder extends AbstractChatMemoryAdvisor.AbstractBuilder<ChatMemory> {
+
+		private String systemTextAdvise = DEFAULT_SYSTEM_TEXT_ADVISE;
+
+		protected Builder(ChatMemory chatMemory) {
+			super(chatMemory);
+		}
+
+		public Builder withSystemTextAdvise(String systemTextAdvise) {
+			this.systemTextAdvise = systemTextAdvise;
+			return this;
+		}
+
+		public PromptChatMemoryAdvisor build() {
+			return new PromptChatMemoryAdvisor(this.chatMemory, this.conversationId, this.chatMemoryRetrieveSize,
+					this.systemTextAdvise, this.order);
+		}
+
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest;
 import org.springframework.ai.chat.client.advisor.api.AdvisedResponse;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAroundAdvisorChain;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -78,7 +79,13 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 
 	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String defaultConversationId,
 			int chatHistoryWindowSize, String systemTextAdvise) {
-		super(vectorStore, defaultConversationId, chatHistoryWindowSize, true);
+		this(vectorStore, defaultConversationId, chatHistoryWindowSize, systemTextAdvise,
+				Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER);
+	}
+
+	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String defaultConversationId,
+			int chatHistoryWindowSize, String systemTextAdvise, int order) {
+		super(vectorStore, defaultConversationId, chatHistoryWindowSize, true, order);
 		this.systemTextAdvise = systemTextAdvise;
 	}
 
@@ -166,6 +173,31 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 			.toList();
 
 		return docs;
+	}
+
+	public static Builder builder(VectorStore chatMemory) {
+		return new Builder(chatMemory);
+	}
+
+	public static class Builder extends AbstractChatMemoryAdvisor.AbstractBuilder<VectorStore> {
+
+		private String systemTextAdvise = DEFAULT_SYSTEM_TEXT_ADVISE;
+
+		protected Builder(VectorStore chatMemory) {
+			super(chatMemory);
+		}
+
+		public Builder withSystemTextAdvise(String systemTextAdvise) {
+			this.systemTextAdvise = systemTextAdvise;
+			return this;
+		}
+
+		@Override
+		public VectorStoreChatMemoryAdvisor build() {
+			return new VectorStoreChatMemoryAdvisor(this.chatMemory, this.conversationId, this.chatMemoryRetrieveSize,
+					this.systemTextAdvise);
+		}
+
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -423,7 +423,8 @@ The following advisor implementations use the `ChatMemory` interface to advice t
 
 * `MessageChatMemoryAdvisor` :  Memory is retrieved and added as a collection of messages to the prompt
 * `PromptChatMemoryAdvisor` :  Memory is retrieved and added into the prompt's system text.
-* `VectorStoreChatMemoryAdvisor`  : The constructor `VectorStoreChatMemoryAdvisor(VectorStore vectorStore,  String defaultConversationId, int chatHistoryWindowSize)` lets you specify the VectorStore to retrieve the chat history from, the unique conversation ID, the size of the chat history to be retrieved in token size.
+* `VectorStoreChatMemoryAdvisor`  : The constructor `VectorStoreChatMemoryAdvisor(VectorStore vectorStore,  String defaultConversationId, int chatHistoryWindowSize, int order)` lets you specify the VectorStore to retrieve the chat history from, the unique conversation ID, the size of the chat history to be retrieved in token size. 
+The VectorStoreChatMemoryAdvisor.builder() method lets you specify the default conversation ID, the chat history window size, and the order of the chat history to be retrieved.
 
 A sample `@Service` implementation that uses several advisors is shown below.
 
@@ -452,10 +453,9 @@ public class CustomerSupportAssistant {
                     If there is a charge for the change, you MUST ask the user to consent before proceeding.
                     """)
             .defaultAdvisors(
-                    new PromptChatMemoryAdvisor(chatMemory),
-                    // new MessageChatMemoryAdvisor(chatMemory), // CHAT MEMORY
+                    new MessageChatMemoryAdvisor(chatMemory), // CHAT MEMORY
                     new QuestionAnswerAdvisor(vectorStore, SearchRequest.defaults()), // RAG
-                    new LoggingAdvisor())
+                    new SimpleLoggerAdvisor())
             .defaultFunctions("getBookingDetails", "changeBooking", "cancelBooking") // FUNCTION CALLING
             .build();
     }


### PR DESCRIPTION
 - Introduce builder pattern for MessageChatMemoryAdvisor, PromptChatMemoryAdvisor, QuestionAnswerAdvisor, SafeGuardAdvisor, and VectorStoreChatMemoryAdvisor.
 - Add 'order' parameter to control advisor execution priority
 - Modify constructors to include the new 'order' parameter
 - Update AbstractChatMemoryAdvisor to support the new 'order' parameter
