### PR TITLE
fix MiniMax embedding model autoconfiguration & context isolation

### DIFF
--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
@@ -205,4 +205,8 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 		return optionBuilder.build();
 	}
 
+	public void setObservationConvention(EmbeddingModelObservationConvention observationConvention) {
+		this.observationConvention = observationConvention;
+	}
+
 }

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/embedding/EmbeddingIT.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/embedding/EmbeddingIT.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.minimax.MiniMaxEmbeddingModel;
+import org.springframework.ai.minimax.MiniMaxTestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -29,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Geng Rong
  */
-@SpringBootTest
+@SpringBootTest(classes = MiniMaxTestConfiguration.class)
 @EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
 class EmbeddingIT {
 


### PR DESCRIPTION
the PR content:

1. fix MiniMax embedding model auto configuration
2. fix context isolation in unit tests 
