### PR TITLE
Add missing usage collection to BedrockAnthropic3ChatModel call with prompt

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -91,7 +91,7 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder()
 			.withId(response.id())
 			.withModel(response.model())
-			.withUsage(extractUsage(response))
+			.withUsage(extractUsage(response.usage()))
 			.build();
 
 		return new ChatResponse(generations, metadata);
@@ -124,17 +124,17 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 		});
 	}
 
-	private Usage extractUsage(AnthropicChatResponse response) {
+	private Usage extractUsage(Anthropic3ChatBedrockApi.AnthropicUsage usage) {
 		return new Usage() {
 
 			@Override
 			public Long getPromptTokens() {
-				return response.usage().inputTokens().longValue();
+				return usage.inputTokens().longValue();
 			}
 
 			@Override
 			public Long getGenerationTokens() {
-				return response.usage().outputTokens().longValue();
+				return usage.outputTokens().longValue();
 			}
 		};
 	}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -18,10 +18,10 @@ package org.springframework.ai.bedrock.anthropic3;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import reactor.core.publisher.Flux;
 
@@ -82,8 +82,9 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 		AnthropicChatResponse response = this.anthropicChatApi.chatCompletion(request);
 
 		List<Generation> generations = response.content().stream().map(content -> {
-			return new Generation(content.text(), Map.of())
-				.withGenerationMetadata(ChatGenerationMetadata.from(response.stopReason(), null));
+			return new Generation(new AssistantMessage(content.text()),
+					ChatGenerationMetadata.from(response.stopReason(), new Anthropic3ChatBedrockApi.AnthropicUsage(
+							response.usage().inputTokens(), response.usage().outputTokens())));
 		}).toList();
 
 		return new ChatResponse(generations);


### PR DESCRIPTION
This PR adds the returning of ChatResponseMetadata from calls to 

```java
BedrockAnthropic3ChatModel.call(Prompt prompt)
```

Includes id, model, inputTokens and outputTokens usage data.

additionally this method was refactored to remove the use of deprecated methods.

Fixes https://github.com/spring-projects/spring-ai/issues/1025
Partially fixes https://github.com/spring-projects/spring-ai/issues/1519