### PR TITLE
Support Ollama APIs for model management

### DIFF
--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.ai.ollama;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -40,7 +39,6 @@ import org.springframework.context.annotation.Bean;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Flux;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -54,25 +52,13 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 
 	private static final Logger logger = LoggerFactory.getLogger(OllamaChatModelFunctionCallingIT.class);
 
-	private static final String MODEL = OllamaModel.MISTRAL.getName();
-
-	static String baseUrl = "http://localhost:11434";
-
-	@BeforeAll
-	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL + " ' generative ... would take several minutes ...");
-		ollamaContainer.execInContainer("ollama", "pull", MODEL);
-		logger.info(MODEL + " pulling competed!");
-
-		baseUrl = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
-	}
+	private static final String MODEL = OllamaModel.LLAMA3_2.getName();
 
 	@Autowired
 	ChatModel chatModel;
 
 	@Test
 	void functionCallTest() {
-
 		UserMessage userMessage = new UserMessage(
 				"What's the weather like in San Francisco, Tokyo, and Paris? Return temperatures in Celsius.");
 
@@ -97,7 +83,6 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 	@Disabled("Ollama API does not support streaming function calls yet")
 	@Test
 	void streamFunctionCallTest() {
-
 		UserMessage userMessage = new UserMessage(
 				"What's the weather like in San Francisco, Tokyo, and Paris? Return temperatures in Celsius.");
 
@@ -132,7 +117,7 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 
 		@Bean
 		public OllamaApi ollamaApi() {
-			return new OllamaApi(baseUrl);
+			return buildOllamaApiWithModel(MODEL);
 		}
 
 		@Bean

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
@@ -34,7 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -53,6 +52,8 @@ import static org.springframework.ai.chat.observation.ChatModelObservationDocume
 @DisabledIf("isDisabled")
 public class OllamaChatModelObservationIT extends BaseOllamaIT {
 
+	private static final String MODEL = OllamaModel.LLAMA3_2.getName();
+
 	@Autowired
 	TestObservationRegistry observationRegistry;
 
@@ -67,7 +68,7 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 	@Test
 	void observationForChatOperation() {
 		var options = OllamaOptions.builder()
-			.withModel(OllamaModel.MISTRAL.getName())
+			.withModel(MODEL)
 			.withFrequencyPenalty(0.0)
 			.withNumPredict(2048)
 			.withPresencePenalty(0.0)
@@ -91,7 +92,7 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 	@Test
 	void observationForStreamingChatOperation() {
 		var options = OllamaOptions.builder()
-			.withModel(OllamaModel.MISTRAL.getName())
+			.withModel(MODEL)
 			.withFrequencyPenalty(0.0)
 			.withNumPredict(2048)
 			.withPresencePenalty(0.0)
@@ -128,11 +129,11 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
-			.hasContextualNameEqualTo("chat " + OllamaModel.MISTRAL.getName())
+			.hasContextualNameEqualTo("chat " + MODEL)
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.CHAT.value())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.OLLAMA.value())
-			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.REQUEST_MODEL.asString(), OllamaModel.MISTRAL.getName())
+			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.REQUEST_MODEL.asString(), MODEL)
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.RESPONSE_MODEL.asString(), responseMetadata.getModel())
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString(), "0.0")
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString(), "2048")
@@ -164,7 +165,7 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 
 		@Bean
 		public OllamaApi openAiApi() {
-			return new OllamaApi();
+			return buildOllamaApiWithModel(MODEL);
 		}
 
 		@Bean

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelIT.java
@@ -15,20 +15,12 @@
  */
 package org.springframework.ai.ollama;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.util.List;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.ollama.api.OllamaApi;
-import org.springframework.ai.ollama.api.OllamaApiIT;
+import org.springframework.ai.ollama.api.OllamaModel;
 import org.springframework.ai.ollama.api.OllamaOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -36,25 +28,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SpringBootTest
 @DisabledIf("isDisabled")
 @Testcontainers
 class OllamaEmbeddingModelIT extends BaseOllamaIT {
 
-	private static final String MODEL = "mxbai-embed-large";
-
-	private static final Log logger = LogFactory.getLog(OllamaApiIT.class);
-
-	static String baseUrl = "http://localhost:11434";
-
-	@BeforeAll
-	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL + " ' generative ... would take several minutes ...");
-		ollamaContainer.execInContainer("ollama", "pull", MODEL);
-		logger.info(MODEL + " pulling competed!");
-
-		baseUrl = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
-	}
+	private static final String MODEL = OllamaModel.NOMIC_EMBED_TEXT.getName();
 
 	@Autowired
 	private OllamaEmbeddingModel embeddingModel;
@@ -73,7 +56,7 @@ class OllamaEmbeddingModelIT extends BaseOllamaIT {
 		assertThat(embeddingResponse.getMetadata().getUsage().getPromptTokens()).isEqualTo(4);
 		assertThat(embeddingResponse.getMetadata().getUsage().getTotalTokens()).isEqualTo(4);
 
-		assertThat(embeddingModel.dimensions()).isEqualTo(1024);
+		assertThat(embeddingModel.dimensions()).isEqualTo(768);
 	}
 
 	@SpringBootConfiguration
@@ -81,7 +64,7 @@ class OllamaEmbeddingModelIT extends BaseOllamaIT {
 
 		@Bean
 		public OllamaApi ollamaApi() {
-			return new OllamaApi(baseUrl);
+			return buildOllamaApiWithModel(MODEL);
 		}
 
 		@Bean

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelObservationIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelObservationIT.java
@@ -18,9 +18,6 @@ package org.springframework.ai.ollama;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.springframework.ai.embedding.EmbeddingRequest;
@@ -32,7 +29,6 @@ import org.springframework.ai.embedding.observation.EmbeddingModelObservationDoc
 import org.springframework.ai.observation.conventions.AiOperationType;
 import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.ollama.api.OllamaApi;
-import org.springframework.ai.ollama.api.OllamaApiIT;
 import org.springframework.ai.ollama.api.OllamaModel;
 import org.springframework.ai.ollama.api.OllamaOptions;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +36,6 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,8 +49,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisabledIf("isDisabled")
 public class OllamaEmbeddingModelObservationIT extends BaseOllamaIT {
 
-	private static final Log logger = LogFactory.getLog(OllamaApiIT.class);
-
 	private static final String MODEL = OllamaModel.NOMIC_EMBED_TEXT.getName();
 
 	@Autowired
@@ -63,17 +56,6 @@ public class OllamaEmbeddingModelObservationIT extends BaseOllamaIT {
 
 	@Autowired
 	OllamaEmbeddingModel embeddingModel;
-
-	static String baseUrl = "http://localhost:11434";
-
-	@BeforeAll
-	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL + " ' generative ... would take several minutes ...");
-		ollamaContainer.execInContainer("ollama", "pull", MODEL);
-		logger.info(MODEL + " pulling competed!");
-
-		baseUrl = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
-	}
 
 	@Test
 	void observationForEmbeddingOperation() {
@@ -117,7 +99,7 @@ public class OllamaEmbeddingModelObservationIT extends BaseOllamaIT {
 
 		@Bean
 		public OllamaApi openAiApi() {
-			return new OllamaApi(baseUrl);
+			return buildOllamaApiWithModel(MODEL);
 		}
 
 		@Bean

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaImage.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaImage.java
@@ -22,6 +22,6 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class OllamaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.3.9");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.3.13");
 
 }

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiModelsIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiModelsIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.ollama.api;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.springframework.ai.ollama.BaseOllamaIT;
+import org.springframework.http.HttpStatus;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the Ollama APIs to manage models.
+ *
+ * @author Thomas Vitale
+ */
+@Testcontainers
+@DisabledIf("isDisabled")
+public class OllamaApiModelsIT extends BaseOllamaIT {
+
+	private static final String MODEL = OllamaModel.NOMIC_EMBED_TEXT.getName();
+
+	static OllamaApi ollamaApi;
+
+	@BeforeAll
+	public static void beforeAll() throws IOException, InterruptedException {
+		ollamaApi = buildOllamaApiWithModel(MODEL);
+	}
+
+	@Test
+	public void listModels() {
+		var listModelResponse = ollamaApi.listModels();
+
+		assertThat(listModelResponse).isNotNull();
+		assertThat(listModelResponse.models().size()).isGreaterThan(0);
+		assertThat(listModelResponse.models().stream().anyMatch(model -> model.name().contains(MODEL))).isTrue();
+	}
+
+	@Test
+	public void showModel() {
+		var showModelRequest = new OllamaApi.ShowModelRequest(MODEL);
+		var showModelResponse = ollamaApi.showModel(showModelRequest);
+
+		assertThat(showModelResponse).isNotNull();
+		assertThat(showModelResponse.details().family()).isEqualTo("nomic-bert");
+	}
+
+	@Test
+	public void copyAndDeleteModel() {
+		var customModel = "schrodinger";
+		var copyModelRequest = new OllamaApi.CopyModelRequest(MODEL, customModel);
+		var copyModelResponse = ollamaApi.copyModel(copyModelRequest);
+		assertThat(copyModelResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		var deleteModelRequest = new OllamaApi.DeleteModelRequest(customModel);
+		var deleteModelResponse = ollamaApi.deleteModel(deleteModelRequest);
+		assertThat(deleteModelResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	public void pullModel() {
+		var deleteModelRequest = new OllamaApi.DeleteModelRequest(MODEL);
+		var deleteModelResponse = ollamaApi.deleteModel(deleteModelRequest);
+		assertThat(deleteModelResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+		var listModelResponse = ollamaApi.listModels();
+		assertThat(listModelResponse.models().stream().anyMatch(model -> model.name().contains(MODEL))).isFalse();
+
+		var pullModelRequest = new OllamaApi.PullModelRequest(MODEL);
+		var progressResponse = ollamaApi.pullModel(pullModelRequest);
+		assertThat(progressResponse.status()).contains("success");
+
+		listModelResponse = ollamaApi.listModels();
+		assertThat(listModelResponse.models().stream().anyMatch(model -> model.name().contains(MODEL))).isTrue();
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/BaseOllamaIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/BaseOllamaIT.java
@@ -1,21 +1,22 @@
-package org.springframework.ai.ollama;
+package org.springframework.ai.autoconfigure.ollama;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.ollama.api.OllamaApi;
 import org.testcontainers.ollama.OllamaContainer;
+
+import java.io.IOException;
 
 public class BaseOllamaIT {
 
 	private static final Logger logger = LoggerFactory.getLogger(BaseOllamaIT.class);
 
 	// Toggle for running tests locally on native Ollama for a faster feedback loop.
-	private static final boolean useTestcontainers = false;
+	private static final boolean useTestcontainers = true;
 
 	public static final OllamaContainer ollamaContainer;
 
 	static {
-		ollamaContainer = new OllamaContainer(OllamaImage.DEFAULT_IMAGE).withReuse(true);
+		ollamaContainer = new OllamaContainer(OllamaImage.IMAGE).withReuse(true);
 		ollamaContainer.start();
 	}
 
@@ -30,25 +31,19 @@ public class BaseOllamaIT {
 	 * to the file ".testcontainers.properties" located in your home directory
 	 */
 	public static boolean isDisabled() {
-		return false;
+		return true;
 	}
 
-	public static OllamaApi buildOllamaApiWithModel(String model) {
+	public static String buildConnectionWithModel(String model) throws IOException, InterruptedException {
 		var baseUrl = "http://localhost:11434";
 		if (useTestcontainers) {
 			baseUrl = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
+
+			logger.info("Start pulling the '{}' model. The operation can take several minutes...", model);
+			ollamaContainer.execInContainer("ollama", "pull", model);
+			logger.info("Completed pulling the '{}' model", model);
 		}
-		var ollamaApi = new OllamaApi(baseUrl);
-
-		ensureModelIsPresent(ollamaApi, model);
-
-		return ollamaApi;
-	}
-
-	public static void ensureModelIsPresent(OllamaApi ollamaApi, String model) {
-		logger.info("Start pulling the '{}' model. The operation can take several minutes...", model);
-		ollamaApi.pullModel(new OllamaApi.PullModelRequest(model));
-		logger.info("Completed pulling the '{}' model", model);
+		return baseUrl;
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaEmbeddingAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaEmbeddingAutoConfigurationIT.java
@@ -19,11 +19,9 @@ import java.io.IOException;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.junit.jupiter.Container;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.springframework.ai.ollama.api.OllamaModel;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import org.springframework.ai.embedding.EmbeddingResponse;
@@ -31,7 +29,6 @@ import org.springframework.ai.ollama.OllamaEmbeddingModel;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.testcontainers.ollama.OllamaContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,26 +37,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Thomas Vitale
  * @since 0.8.0
  */
-@Disabled("For manual smoke testing only.")
 @Testcontainers
-public class OllamaEmbeddingAutoConfigurationIT {
+@DisabledIf("isDisabled")
+public class OllamaEmbeddingAutoConfigurationIT extends BaseOllamaIT {
 
-	private static final Logger logger = LoggerFactory.getLogger(OllamaEmbeddingAutoConfigurationIT.class);
+	private static final String MODEL_NAME = OllamaModel.NOMIC_EMBED_TEXT.getName();
 
-	private static final String MODEL_NAME = "orca-mini";
-
-	@Container
-	static OllamaContainer ollamaContainer = new OllamaContainer(OllamaImage.IMAGE);
-
-	static String baseUrl = "http://localhost:11434";
+	static String baseUrl;
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL_NAME + " ' generative ... would take several minutes ...");
-		ollamaContainer.execInContainer("ollama", "pull", MODEL_NAME);
-		logger.info(MODEL_NAME + " pulling competed!");
-
-		baseUrl = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
+		baseUrl = buildConnectionWithModel(MODEL_NAME);
 	}
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -75,7 +63,7 @@ public class OllamaEmbeddingAutoConfigurationIT {
 			EmbeddingResponse embeddingResponse = embeddingModel.embedForResponse(List.of("Hello World"));
 			assertThat(embeddingResponse.getResults()).hasSize(1);
 			assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
-			assertThat(embeddingModel.dimensions()).isEqualTo(3200);
+			assertThat(embeddingModel.dimensions()).isEqualTo(768);
 		});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaImage.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaImage.java
@@ -17,6 +17,6 @@ package org.springframework.ai.autoconfigure.ollama;
 
 public class OllamaImage {
 
-	public static final String IMAGE = "ollama/ollama:0.3.9";
+	public static final String IMAGE = "ollama/ollama:0.3.13";
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackInPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackInPromptIT.java
@@ -24,10 +24,11 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.autoconfigure.ollama.BaseOllamaIT;
 import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
-import org.springframework.ai.autoconfigure.ollama.OllamaImage;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -35,35 +36,27 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.function.FunctionCallbackWrapper;
 import org.springframework.ai.ollama.OllamaChatModel;
+import org.springframework.ai.ollama.api.OllamaModel;
 import org.springframework.ai.ollama.api.OllamaOptions;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.ollama.OllamaContainer;
 
 import reactor.core.publisher.Flux;
 
-@Disabled("For manual smoke testing only.")
 @Testcontainers
-public class FunctionCallbackInPromptIT {
+@DisabledIf("isDisabled")
+public class FunctionCallbackInPromptIT extends BaseOllamaIT {
 
 	private static final Logger logger = LoggerFactory.getLogger(FunctionCallbackInPromptIT.class);
 
-	private static String MODEL_NAME = "mistral";
+	private static final String MODEL_NAME = OllamaModel.LLAMA3_2.getName();
 
-	@Container
-	static OllamaContainer ollamaContainer = new OllamaContainer(OllamaImage.IMAGE);
-
-	static String baseUrl = "http://localhost:11434";
+	static String baseUrl;
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL_NAME + " ' generative ... would take several minutes ...");
-		ollamaContainer.execInContainer("ollama", "pull", MODEL_NAME);
-		logger.info(MODEL_NAME + " pulling competed!");
-
-		baseUrl = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
+		baseUrl = buildConnectionWithModel(MODEL_NAME);
 	}
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withPropertyValues(
@@ -103,7 +96,6 @@ public class FunctionCallbackInPromptIT {
 	@Disabled("Ollama API does not support streaming function calls yet")
 	@Test
 	void streamingFunctionCallTest() {
-
 		contextRunner.run(context -> {
 
 			OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackWrapperIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackWrapperIT.java
@@ -21,13 +21,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.autoconfigure.ollama.BaseOllamaIT;
 import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
-import org.springframework.ai.autoconfigure.ollama.OllamaImage;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -38,37 +39,29 @@ import org.springframework.ai.model.function.FunctionCallbackWrapper;
 import org.springframework.ai.model.function.FunctionCallingOptions;
 import org.springframework.ai.model.function.FunctionCallingOptionsBuilder.PortableFunctionCallingOptions;
 import org.springframework.ai.ollama.OllamaChatModel;
+import org.springframework.ai.ollama.api.OllamaModel;
 import org.springframework.ai.ollama.api.OllamaOptions;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.ollama.OllamaContainer;
 
 import reactor.core.publisher.Flux;
 
-@Disabled("For manual smoke testing only.")
 @Testcontainers
-public class FunctionCallbackWrapperIT {
+@DisabledIf("isDisabled")
+public class FunctionCallbackWrapperIT extends BaseOllamaIT {
 
-	private static final Log logger = LogFactory.getLog(FunctionCallbackWrapperIT.class);
+	private static final Logger logger = LoggerFactory.getLogger(FunctionCallbackWrapperIT.class);
 
-	private static String MODEL_NAME = "mistral";
+	private static final String MODEL_NAME = OllamaModel.LLAMA3_2.getName();
 
-	@Container
-	static OllamaContainer ollamaContainer = new OllamaContainer(OllamaImage.IMAGE);
-
-	static String baseUrl = "http://localhost:11434";
+	static String baseUrl;
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL_NAME + " ' generative ... would take several minutes ...");
-		ollamaContainer.execInContainer("ollama", "pull", MODEL_NAME);
-		logger.info(MODEL_NAME + " pulling competed!");
-
-		baseUrl = "http://" + ollamaContainer.getHost() + ":" + ollamaContainer.getMappedPort(11434);
+		baseUrl = buildConnectionWithModel(MODEL_NAME);
 	}
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withPropertyValues(
@@ -96,7 +89,6 @@ public class FunctionCallbackWrapperIT {
 			logger.info("Response: " + response);
 
 			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
-
 		});
 	}
 

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactoryTest.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactoryTest.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.ai.testcontainers.service.connection.ollama;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.autoconfigure.ollama.OllamaAutoConfiguration;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.ollama.OllamaEmbeddingModel;
@@ -44,15 +44,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Thomas Vitale
  */
 @SpringJUnitConfig
-@Disabled("requires more memory than is often available on dev machines")
+@Disabled("Slow on CPU. Only run manually.")
 @Testcontainers
 @TestPropertySource(properties = "spring.ai.ollama.embedding.options.model="
 		+ OllamaContainerConnectionDetailsFactoryTest.MODEL_NAME)
 class OllamaContainerConnectionDetailsFactoryTest {
 
-	private static final Log logger = LogFactory.getLog(OllamaContainerConnectionDetailsFactoryTest.class);
+	private static final Logger logger = LoggerFactory.getLogger(OllamaContainerConnectionDetailsFactoryTest.class);
 
-	static final String MODEL_NAME = "orca-mini";
+	static final String MODEL_NAME = "nomic-embed-text";
 
 	@Container
 	@ServiceConnection
@@ -63,9 +63,9 @@ class OllamaContainerConnectionDetailsFactoryTest {
 
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
-		logger.info("Start pulling the '" + MODEL_NAME + " ' generative ... would take several minutes ...");
+		logger.info("Start pulling the '{}' model. The operation can take several minutes...", MODEL_NAME);
 		ollama.execInContainer("ollama", "pull", MODEL_NAME);
-		logger.info(MODEL_NAME + " pulling competed!");
+		logger.info("Completed pulling the '{}' model", MODEL_NAME);
 	}
 
 	@Test
@@ -73,7 +73,7 @@ class OllamaContainerConnectionDetailsFactoryTest {
 		EmbeddingResponse embeddingResponse = this.embeddingModel.embedForResponse(List.of("Hello World"));
 		assertThat(embeddingResponse.getResults()).hasSize(1);
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
-		assertThat(this.embeddingModel.dimensions()).isEqualTo(3200);
+		assertThat(this.embeddingModel.dimensions()).isEqualTo(768);
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaImage.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaImage.java
@@ -22,6 +22,6 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class OllamaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.3.9");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.3.13");
 
 }


### PR DESCRIPTION
* Extend the OllamaApi to support listing, copying, deleting, and pulling models programmatically.
* Improve setup for integration testing with Ollama and Testcontainers.

Enables gh-526