### PR TITLE
fix(docs): correct response key from "generation" to "completion" in  example code

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -234,7 +234,7 @@ When calling the application endpoint via curl, the result is:
 [source,bash]
 ----
 ❯ curl localhost:8080/ai/simple
-{"generation":"Why did the pirate go to the comedy club? To hear some arrr-rated jokes! Arrr, matey!"}
+{"completion":"Why did the pirate go to the comedy club? To hear some arrr-rated jokes! Arrr, matey!"}
 ----
 
 === Default System Text with parameters


### PR DESCRIPTION
### Description
This PR corrects an error in the documentation for Spring AI's `ChatClient` example. The response key in the curl example was incorrectly labeled as `"generation"` instead of `"completion"`, which better aligns with the API’s response format.

### Changes
- Updated the response example to reflect `"completion"` as the correct key.

### Issue Reference
Fixes #1533 Documentation: Correct response key from "generation" to "completion" in example code

### Checklist
- [x] Signed the [Contributor License Agreement (CLA)](https://cla.pivotal.io/sign/spring)
- [x] Rebased changes on the latest `main` branch and squashed commits
- [x] Reviewed and updated unit tests as needed (N/A for this documentation change)
- [x] Ran the build and confirmed that all tests pass

Thank you for reviewing this PR!

#1533 