### PR TITLE
docs: Fix Typographical Errors in spring-ai-docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -73,7 +73,7 @@ then the `spring.ai.azure.openai.chat.options.deployment-name` is treathed as an
 ==== Access the OpenAI Model
 
 You can configure the client to use directly `OpenAI` instead of the `Azure OpenAI` deployed models. 
-For this you need to set the `spring.ai.azure.openai.openai-api-key=<Your OpenAI Key>` instead of `spring.ai.azure.openai.api-key=<Yur Azure OpenAi Key>`.
+For this you need to set the `spring.ai.azure.openai.openai-api-key=<Your OpenAI Key>` instead of `spring.ai.azure.openai.api-key=<Your Azure OpenAi Key>`.
 
 === Add Repositories and BOM
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -67,7 +67,7 @@ This is because in OpenAI there is no `Deployment Name`, only a `Model Name`.
 
 NOTE: The property `spring.ai.azure.openai.chat.options.model` has been renamed to `spring.ai.azure.openai.chat.options.deployment-name`.
 
-NOTE: If you decide to connect to `OpenAI` instead of `Azure OpeanAI`, by setting the `spring.ai.azure.openai.openai-api-key=<Your OpenAI Key>` property, 
+NOTE: If you decide to connect to `OpenAI` instead of `Azure OpenAI`, by setting the `spring.ai.azure.openai.openai-api-key=<Your OpenAI Key>` property, 
 then the `spring.ai.azure.openai.chat.options.deployment-name` is treathed as an link:https://platform.openai.com/docs/models[OpenAI model] name.
 
 ==== Access the OpenAI Model

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock/bedrock-cohere.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock/bedrock-cohere.adoc
@@ -229,7 +229,7 @@ CohereChatBedrockApi cohereChatApi = new CohereChatBedrockApi(
 	Duration.ofMillis(1000L));
 
 var request = CohereChatRequest
-	.builder("What is the capital of Bulgaria and what is the size? What it the national anthem?")
+	.builder("What is the capital of Bulgaria and what is the size? What is the national anthem?")
 	.withStream(false)
 	.withTemperature(0.5f)
 	.withTopP(0.8f)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
@@ -1,6 +1,6 @@
 = Anthropic Function Calling
 
-TIP: Starting of Jul 1th, 2024, streaming function calling and Tool use is supporetd. 
+TIP: Starting of Jul 1st, 2024, streaming function calling and Tool use is supported. 
 
 You can register custom Java functions with the `AnthropicChatModel` and have the Anthropic models intelligently choose to output a JSON object containing arguments to call one or many of the registered functions.
 This allows you to connect the LLM capabilities with external tools and APIs.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/azure-open-ai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/azure-open-ai-chat-functions.adoc
@@ -40,7 +40,7 @@ To support the response of the chatbot, we will register our own function that t
 
 When the response to the prompt to the model needs to answer a question such as `"What’s the weather like in Boston?"` the AI model will invoke the client providing the location value as an argument to be passed to the function.  This RPC-like data is passed as JSON.
 
-Our function can some SaaS based weather service API and returns the weather response back to the model to complete the conversation.  In this example we will use a simple implementation named `MockWeatherService` that hard codes the temperature for various locations.
+Our function can have some SaaS based weather service API and returns the weather response back to the model to complete the conversation.  In this example we will use a simple implementation named `MockWeatherService` that hard codes the temperature for various locations.
 
 The following `MockWeatherService.java` represents the weather service API:
 
@@ -154,7 +154,7 @@ ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
 logger.info("Response: {}", response);
 ----
 
-// NOTE: You can can have multiple functions registered in your `ChatModel` but only those enabled in the prompt request will be considered for the function calling.
+// NOTE: You can have multiple functions registered in your `ChatModel` but only those enabled in the prompt request will be considered for the function calling.
 
 Above user question will trigger 3 calls to `CurrentWeather` function (one for each city) and the final response will be something like this:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/vertexai-gemini-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/vertexai-gemini-chat.adoc
@@ -130,7 +130,7 @@ Below is a simple code example extracted from https://github.com/spring-projects
 ----
 byte[] data = new ClassPathResource("/vertex-test.png").getContentAsByteArray();
 
-var userMessage = new UserMessage("Explain what do you see o this picture?",
+var userMessage = new UserMessage("Explain what do you see on this picture?",
         List.of(new Media(MimeTypeUtils.IMAGE_PNG, data)));
 
 ChatResponse response = chatModel.call(new Prompt(List.of(userMessage)));


### PR DESCRIPTION
### Related Issues[#1544]

### Description
- Corrected "what it" to "what is" in bedrock-cohere.adoc.
- Corrected "1st" and "supportted" to "supported" in anthropic-chat-function.adoc.
- Corrected "can some" and "can can" in azure-open-ai-chat.adoc.
- Corrected "opean" to "open" in azure-openai-chat.adoc.
- Corrected "Yur" to "Your" in azure-openai-chat.adoc.
- Corrected "o" to "on" in vertexai-gemini-chat.adoc.
