### PR TITLE
Enhance Ollama model auto-pull feature

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -379,7 +379,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 	 * Pull the given model into Ollama based on the specified strategy.
 	 */
 	private void initializeModelIfEnabled(String model, PullModelStrategy pullModelStrategy) {
-		if (!PullModelStrategy.NEVER.equals(pullModelStrategy)) {
+		if (pullModelStrategy != null && !PullModelStrategy.NEVER.equals(pullModelStrategy)) {
 			this.modelManager.pullModel(model, pullModelStrategy);
 		}
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
@@ -163,7 +163,7 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 	 * Pull the given model into Ollama based on the specified strategy.
 	 */
 	private void initializeModelIfEnabled(String model, PullModelStrategy pullModelStrategy) {
-		if (!PullModelStrategy.NEVER.equals(pullModelStrategy)) {
+		if (pullModelStrategy != null && !PullModelStrategy.NEVER.equals(pullModelStrategy)) {
 			this.modelManager.pullModel(model, pullModelStrategy);
 		}
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -309,7 +309,7 @@ public class OllamaOptions implements FunctionCallingOptions, ChatOptions, Embed
 	 * Strategy for pulling models at run-time.
 	 */
 	@JsonIgnore
-	private PullModelStrategy pullModelStrategy = PullModelStrategy.NEVER;
+	private PullModelStrategy pullModelStrategy;
 
 	public static OllamaOptions builder() {
 		return new OllamaOptions();

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/management/ModelManagementOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/management/ModelManagementOptions.java
@@ -16,6 +16,7 @@
 package org.springframework.ai.ollama.management;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Options for managing models in Ollama.
@@ -23,8 +24,9 @@ import java.time.Duration;
  * @author Thomas Vitale
  * @since 1.0.0
  */
-public record ModelManagementOptions(PullModelStrategy pullModelStrategy, Duration timeout, Integer maxRetries) {
+public record ModelManagementOptions(PullModelStrategy pullModelStrategy, List<String> additionalModels,
+		Duration timeout, Integer maxRetries) {
 	public static ModelManagementOptions defaults() {
-		return new ModelManagementOptions(PullModelStrategy.NEVER, Duration.ofMinutes(5), 0);
+		return new ModelManagementOptions(PullModelStrategy.NEVER, List.of(), Duration.ofMinutes(5), 0);
 	}
 }

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/management/OllamaModelManager.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/management/OllamaModelManager.java
@@ -48,6 +48,10 @@ public class OllamaModelManager {
 	public OllamaModelManager(OllamaApi ollamaApi, ModelManagementOptions options) {
 		this.ollamaApi = ollamaApi;
 		this.options = options;
+
+		if (!CollectionUtils.isEmpty(options.additionalModels())) {
+			options.additionalModels().forEach(this::pullModel);
+		}
 	}
 
 	public boolean isModelAvailable(String modelName) {

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/BaseOllamaIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/BaseOllamaIT.java
@@ -3,6 +3,7 @@ package org.springframework.ai.ollama;
 import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.management.OllamaModelManager;
 import org.springframework.ai.ollama.management.PullModelStrategy;
+import org.springframework.util.StringUtils;
 import org.testcontainers.ollama.OllamaContainer;
 
 public class BaseOllamaIT {
@@ -31,6 +32,10 @@ public class BaseOllamaIT {
 		return false;
 	}
 
+	public static OllamaApi buildOllamaApi() {
+		return buildOllamaApiWithModel(null);
+	}
+
 	public static OllamaApi buildOllamaApiWithModel(String model) {
 		var baseUrl = "http://localhost:11434";
 		if (useTestcontainers) {
@@ -38,7 +43,9 @@ public class BaseOllamaIT {
 		}
 		var ollamaApi = new OllamaApi(baseUrl);
 
-		ensureModelIsPresent(ollamaApi, model);
+		if (StringUtils.hasText(model)) {
+			ensureModelIsPresent(ollamaApi, model);
+		}
 
 		return ollamaApi;
 	}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/management/OllamaModelManagerIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/management/OllamaModelManagerIT.java
@@ -23,6 +23,8 @@ import org.springframework.ai.ollama.api.OllamaModel;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -73,6 +75,23 @@ class OllamaModelManagerIT extends BaseOllamaIT {
 
 		model = "all-minilm:latest";
 		modelManager.pullModel(model, PullModelStrategy.WHEN_MISSING);
+		isModelAvailable = modelManager.isModelAvailable(model);
+		assertThat(isModelAvailable).isTrue();
+
+		modelManager.deleteModel(model);
+		isModelAvailable = modelManager.isModelAvailable(model);
+		assertThat(isModelAvailable).isFalse();
+	}
+
+	@Test
+	public void pullAdditionalModels() {
+		var model = "all-minilm";
+		var isModelAvailable = modelManager.isModelAvailable(model);
+		assertThat(isModelAvailable).isFalse();
+
+		new OllamaModelManager(buildOllamaApi(),
+				new ModelManagementOptions(PullModelStrategy.WHEN_MISSING, List.of(model), Duration.ofMinutes(5), 0));
+
 		isModelAvailable = modelManager.isModelAvailable(model);
 		assertThat(isModelAvailable).isTrue();
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -72,6 +72,8 @@ Here are the properties for initializing the Ollama integration and xref:auto-pu
 | spring.ai.ollama.init.pull-model-strategy | Whether to pull models at startup-time and how. | `never`
 | spring.ai.ollama.init.timeout | How long to wait for a model to be pulled. | `5m`
 | spring.ai.ollama.init.max-retries | Maximum number of retries for the model pull operation. | `0`
+| spring.ai.ollama.init.chat.include | Include this type of models in the initialization task. | `true`
+| spring.ai.ollama.init.chat.additional-models | Additional models to initialize besides the ones configured via default properties. | `[]`
 |====
 
 === Chat Properties
@@ -188,6 +190,34 @@ spring:
 
 CAUTION: The application will not complete its initialization until all the models become available in Ollama. Depending on the model size and the speed of the Internet connection, your application might be slow at starting up.
 
+You can also initialize additional models at startup time, useful for those models used dynamically at runtime.
+
+[source,yaml]
+----
+spring:
+  ai:
+    ollama:
+      init:
+        pull-model-strategy: always
+        chat:
+          additional-models:
+            - llama3.2
+            - qwen2.5
+----
+
+If you want to apply the pulling strategy only to other types of models, you can exclude the chat models from the initialization task.
+
+[source,yaml]
+----
+spring:
+  ai:
+    ollama:
+      init:
+        pull-model-strategy: always
+        chat:
+          include: false
+----
+
 === Pulling models at runtime
 
 To enable auto-pulling of models at runtime, you can configure the `pullModelStrategy` option in your `OllamaOptions`:
@@ -205,7 +235,7 @@ ChatResponse response = chatModel.call(new Prompt(
 
 You can also configure this option using the following property: `spring.ai.ollama.chat.options.pull-model-strategy=always`.
 
-CAUTION: The time to process an incoming request might incur unexpected delays, waiting for the needed model to become available in Ollama. Depending on the model size and the speed of the Internet connection, your application might be slow at processing requests.
+CAUTION: The time to process an incoming request might incur unexpected delays, waiting for the needed model to become available in Ollama. Depending on the model size and the speed of the Internet connection, your application might be slow at processing requests. You might want to initialize these models at startup time instead, using the `spring.ai.ollama.init.chat.additional-models` property.
 
 == Function Calling
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
@@ -76,6 +76,8 @@ Here are the properties for initializing the Ollama integration and xref:auto-pu
 | spring.ai.ollama.init.pull-model-strategy | Whether to pull models at startup-time and how. | `never`
 | spring.ai.ollama.init.timeout | How long to wait for a model to be pulled. | `5m`
 | spring.ai.ollama.init.max-retries | Maximum number of retries for the model pull operation. | `0`
+| spring.ai.ollama.init.embedding.include | Include this type of models in the initialization task. | `true`
+| spring.ai.ollama.init.embedding.additional-models | Additional models to initialize besides the ones configured via default properties. | `[]`
 |====
 
 === Embedding Properties
@@ -190,6 +192,34 @@ spring:
 
 CAUTION: The application will not complete its initialization until all the models become available in Ollama. Depending on the model size and the speed of the Internet connection, your application might be slow at starting up.
 
+You can also initialize additional models at startup time, useful for those models used dynamically at runtime.
+
+[source,yaml]
+----
+spring:
+  ai:
+    ollama:
+      init:
+        pull-model-strategy: always
+        embedding:
+          additional-models:
+            - mxbai-embed-large
+            - nomic-embed-text
+----
+
+If you want to apply the pulling strategy only to other types of models, you can exclude the embedding models from the initialization task.
+
+[source,yaml]
+----
+spring:
+  ai:
+    ollama:
+      init:
+        pull-model-strategy: always
+        embedding:
+          include: false
+----
+
 === Pulling models at runtime
 
 To enable auto-pulling of models at runtime, you can configure the `pullModelStrategy` option in your `OllamaOptions`:
@@ -206,7 +236,7 @@ EmbeddingResponse embeddingResponse = embeddingModel
 
 You can also configure this option using the following property: `spring.ai.ollama.embedding.options.pull-model-strategy=always`.
 
-CAUTION: The time to process an incoming request might incur unexpected delays, waiting for the needed model to become available in Ollama. Depending on the model size and the speed of the Internet connection, your application might be slow at processing requests.
+CAUTION: The time to process an incoming request might incur unexpected delays, waiting for the needed model to become available in Ollama. Depending on the model size and the speed of the Internet connection, your application might be slow at processing requests. You might want to initialize these models at startup time instead, using the `spring.ai.ollama.init.embedding.additional-models` property.
 
 == Sample Controller
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaInitializationProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaInitializationProperties.java
@@ -19,6 +19,7 @@ import org.springframework.ai.ollama.management.PullModelStrategy;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Ollama initialization configuration properties.
@@ -35,6 +36,16 @@ public class OllamaInitializationProperties {
 	 * Whether to pull models at startup-time and how.
 	 */
 	private PullModelStrategy pullModelStrategy = PullModelStrategy.NEVER;
+
+	/**
+	 * Chat models initialization settings.
+	 */
+	private final ModelTypeInit chat = new ModelTypeInit();
+
+	/**
+	 * Embedding models initialization settings.
+	 */
+	private final ModelTypeInit embedding = new ModelTypeInit();
 
 	/**
 	 * How long to wait for a model to be pulled.
@@ -54,6 +65,14 @@ public class OllamaInitializationProperties {
 		this.pullModelStrategy = pullModelStrategy;
 	}
 
+	public ModelTypeInit getChat() {
+		return chat;
+	}
+
+	public ModelTypeInit getEmbedding() {
+		return embedding;
+	}
+
 	public Duration getTimeout() {
 		return timeout;
 	}
@@ -68,6 +87,37 @@ public class OllamaInitializationProperties {
 
 	public void setMaxRetries(int maxRetries) {
 		this.maxRetries = maxRetries;
+	}
+
+	public static class ModelTypeInit {
+
+		/**
+		 * Include this type of models in the initialization task.
+		 */
+		private boolean include = true;
+
+		/**
+		 * Additional models to initialize besides the ones configured via default
+		 * properties.
+		 */
+		private List<String> additionalModels = List.of();
+
+		public boolean isInclude() {
+			return include;
+		}
+
+		public void setInclude(boolean include) {
+			this.include = include;
+		}
+
+		public List<String> getAdditionalModels() {
+			return additionalModels;
+		}
+
+		public void setAdditionalModels(List<String> additionalModels) {
+			this.additionalModels = additionalModels;
+		}
+
 	}
 
 }


### PR DESCRIPTION
* Fix configuration inheritance issue when default value is not specified.
* Make it possible to enable the auto-pull feature only for specific model types (e.g. for chat models only).
* Add the possibility to list explicit models to auto-pull at startup time.