### PR TITLE
fix: fixed NPE while splitting document chunks

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
@@ -87,8 +87,12 @@ public abstract class TextSplitter implements DocumentTransformer {
 			for (String chunk : chunks) {
 				// only primitive values are in here -
 				Map<String, Object> metadataCopy = metadata.entrySet()
-					.stream()
-					.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+						.stream()
+						.filter(e -> e.getKey() != null && e.getValue() != null)
+						.collect(Collectors.toMap(
+								Map.Entry::getKey,
+								Map.Entry::getValue
+						));
 				Document newDoc = new Document(chunk, metadataCopy);
 
 				if (this.copyContentFormatter) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
@@ -87,12 +87,9 @@ public abstract class TextSplitter implements DocumentTransformer {
 			for (String chunk : chunks) {
 				// only primitive values are in here -
 				Map<String, Object> metadataCopy = metadata.entrySet()
-						.stream()
-						.filter(e -> e.getKey() != null && e.getValue() != null)
-						.collect(Collectors.toMap(
-								Map.Entry::getKey,
-								Map.Entry::getValue
-						));
+					.stream()
+					.filter(e -> e.getKey() != null && e.getValue() != null)
+					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 				Document newDoc = new Document(chunk, metadataCopy);
 
 				if (this.copyContentFormatter) {


### PR DESCRIPTION
Fixed NPE when processing splitted shards of text,  If metadata has entry 
"key" with null value will cause NPE 
More detailed information provided in https://github.com/spring-projects/spring-ai/issues/1571