### PR TITLE
docs: remove "1.0-SNAPSHOT" keyword in all OpenAI links

### DIFF
--- a/models/spring-ai-openai/README.md
+++ b/models/spring-ai-openai/README.md
@@ -6,4 +6,4 @@
 
 [OpenAI Transcription Generation](https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/audio/transcriptions/openai-transcriptions.html)
 
-[OpenAI Text-to-Speech (TTS)](https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/audio/speech/openai-speech.html)
+[OpenAI Text-to-Speech (TTS)](https://docs.spring.io/spring-ai/reference/api/audio/speech/openai-speech.html)

--- a/models/spring-ai-openai/README.md
+++ b/models/spring-ai-openai/README.md
@@ -1,9 +1,9 @@
-[OpenAI Chat Documentation](https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/chat/openai-chat.html)
+[OpenAI Chat Documentation](https://docs.spring.io/spring-ai/reference/api/chat/openai-chat.html)
 
-[OpenAI Embedding Documentation](https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/embeddings/openai-embeddings.html)
+[OpenAI Embedding Documentation](https://docs.spring.io/spring-ai/reference/api/embeddings/openai-embeddings.html)
 
-[OpenAI Image Generation](https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/image/openai-image.html)
+[OpenAI Image Generation](https://docs.spring.io/spring-ai/reference/api/image/openai-image.html)
 
-[OpenAI Transcription Generation](https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/audio/transcriptions/openai-transcriptions.html)
+[OpenAI Transcription Generation](https://docs.spring.io/spring-ai/reference/api/audio/transcriptions/openai-transcriptions.html)
 
 [OpenAI Text-to-Speech (TTS)](https://docs.spring.io/spring-ai/reference/api/audio/speech/openai-speech.html)


### PR DESCRIPTION
I removed snapshop link in OpenAI TTS link.
    - before TTS link: https://docs.spring.io/spring-ai/reference/1.0-SNAPSHOT/api/audio/speech/openai-speech.html
    - after TTS link: https://docs.spring.io/spring-ai/reference/api/audio/speech/openai-speech.html

Additionally, I discovered that other links were also incorrect due to the "1.0-SNAPSHOT" keyword, so I removed the "1.0-SNAPSHOT" term from all the links.

close #1574 

Before
![스크린샷 2024-10-21 오후 3 46 57](https://github.com/user-attachments/assets/29baf64f-b98f-4d73-8155-c03bcd466d50)

After
![스크린샷 2024-10-21 오후 3 49 21](https://github.com/user-attachments/assets/f976d48b-a322-40c2-a1b9-13fd7e7536eb)

