### PR TITLE
Merge runtime options for Stability AI image gen

### DIFF
--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
@@ -88,8 +88,7 @@ public class StabilityAiImageModel implements ImageModel {
 		// Merge the runtime options passed via the prompt with the default options
 		// configured via the constructor.
 		// Runtime options overwrite StabilityAiImageModel options
-		StabilityAiImageOptions runtimeOptions = (StabilityAiImageOptions) imagePrompt.getOptions();
-		StabilityAiImageOptions requestImageOptions = mergeOptions(runtimeOptions, this.defaultOptions);
+		StabilityAiImageOptions requestImageOptions = mergeOptions(imagePrompt.getOptions(), this.defaultOptions);
 
 		// Copy the org.springframework.ai.model derived ImagePrompt and ImageOptions data
 		// types to the data types used in StabilityAiApi
@@ -118,13 +117,11 @@ public class StabilityAiImageModel implements ImageModel {
 	 * Merge runtime and default {@link ImageOptions} to compute the final options to use
 	 * in the request.
 	 */
-	private StabilityAiImageOptions mergeOptions(StabilityAiImageOptions runtimeOptions,
-			StabilityAiImageOptions defaultOptions) {
+	private StabilityAiImageOptions mergeOptions(ImageOptions runtimeOptions, StabilityAiImageOptions defaultOptions) {
 		if (runtimeOptions == null) {
 			return defaultOptions;
 		}
-
-		return StabilityAiImageOptions.builder()
+		StabilityAiImageOptions.Builder builder = StabilityAiImageOptions.builder()
 			// Handle portable image options
 			.withModel(ModelOptionsUtils.mergeOption(runtimeOptions.getModel(), defaultOptions.getModel()))
 			.withN(ModelOptionsUtils.mergeOption(runtimeOptions.getN(), defaultOptions.getN()))
@@ -132,15 +129,24 @@ public class StabilityAiImageModel implements ImageModel {
 					defaultOptions.getResponseFormat()))
 			.withWidth(ModelOptionsUtils.mergeOption(runtimeOptions.getWidth(), defaultOptions.getWidth()))
 			.withHeight(ModelOptionsUtils.mergeOption(runtimeOptions.getHeight(), defaultOptions.getHeight()))
-			.withStylePreset(ModelOptionsUtils.mergeOption(runtimeOptions.getStyle(), defaultOptions.getStyle()))
+			.withStylePreset(ModelOptionsUtils.mergeOption(runtimeOptions.getStyle(), defaultOptions.getStyle()));
+
+		if (runtimeOptions instanceof StabilityAiImageOptions) {
+			StabilityAiImageOptions stabilityOptions = (StabilityAiImageOptions) runtimeOptions;
 			// Handle Stability AI specific image options
-			.withCfgScale(defaultOptions.getCfgScale())
-			.withClipGuidancePreset(defaultOptions.getClipGuidancePreset())
-			.withSampler(runtimeOptions.getSampler())
-			.withSeed(defaultOptions.getSeed())
-			.withSteps(runtimeOptions.getSteps())
-			.withStylePreset(runtimeOptions.getStylePreset())
-			.build();
+			builder
+				.withCfgScale(
+						ModelOptionsUtils.mergeOption(stabilityOptions.getCfgScale(), defaultOptions.getCfgScale()))
+				.withClipGuidancePreset(ModelOptionsUtils.mergeOption(stabilityOptions.getClipGuidancePreset(),
+						defaultOptions.getClipGuidancePreset()))
+				.withSampler(ModelOptionsUtils.mergeOption(stabilityOptions.getSampler(), defaultOptions.getSampler()))
+				.withSeed(ModelOptionsUtils.mergeOption(stabilityOptions.getSeed(), defaultOptions.getSeed()))
+				.withSteps(ModelOptionsUtils.mergeOption(stabilityOptions.getSteps(), defaultOptions.getSteps()))
+				.withStylePreset(ModelOptionsUtils.mergeOption(stabilityOptions.getStylePreset(),
+						defaultOptions.getStylePreset()));
+		}
+
+		return builder.build();
 	}
 
 }

--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
@@ -88,8 +88,9 @@ public class StabilityAiImageModel implements ImageModel {
 		// Merge the runtime options passed via the prompt with the default options
 		// configured via the constructor.
 		// Runtime options overwrite StabilityAiImageModel options
-		StabilityAiImageOptions requestImageOptions = mergeOptions(imagePrompt.getOptions(), this.defaultOptions);
-
+		StabilityAiImageOptions runtimeOptions = (StabilityAiImageOptions) imagePrompt.getOptions();
+		StabilityAiImageOptions requestImageOptions = mergeOptions(runtimeOptions, this.defaultOptions);
+		System.err.println("requestImageOptions: " + requestImageOptions);
 		// Copy the org.springframework.ai.model derived ImagePrompt and ImageOptions data
 		// types to the data types used in StabilityAiApi
 		StabilityAiApi.GenerateImageRequest generateImageRequest = getGenerateImageRequest(imagePrompt,
@@ -117,7 +118,8 @@ public class StabilityAiImageModel implements ImageModel {
 	 * Merge runtime and default {@link ImageOptions} to compute the final options to use
 	 * in the request.
 	 */
-	private StabilityAiImageOptions mergeOptions(ImageOptions runtimeOptions, StabilityAiImageOptions defaultOptions) {
+	private StabilityAiImageOptions mergeOptions(StabilityAiImageOptions runtimeOptions,
+			StabilityAiImageOptions defaultOptions) {
 		if (runtimeOptions == null) {
 			return defaultOptions;
 		}
@@ -134,10 +136,10 @@ public class StabilityAiImageModel implements ImageModel {
 			// Handle Stability AI specific image options
 			.withCfgScale(defaultOptions.getCfgScale())
 			.withClipGuidancePreset(defaultOptions.getClipGuidancePreset())
-			.withSampler(defaultOptions.getSampler())
+			.withSampler(runtimeOptions.getSampler())
 			.withSeed(defaultOptions.getSeed())
-			.withSteps(defaultOptions.getSteps())
-			.withStylePreset(defaultOptions.getStylePreset())
+			.withSteps(runtimeOptions.getSteps())
+			.withStylePreset(runtimeOptions.getStylePreset())
 			.build();
 	}
 

--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
@@ -90,7 +90,7 @@ public class StabilityAiImageModel implements ImageModel {
 		// Runtime options overwrite StabilityAiImageModel options
 		StabilityAiImageOptions runtimeOptions = (StabilityAiImageOptions) imagePrompt.getOptions();
 		StabilityAiImageOptions requestImageOptions = mergeOptions(runtimeOptions, this.defaultOptions);
-		System.err.println("requestImageOptions: " + requestImageOptions);
+
 		// Copy the org.springframework.ai.model derived ImagePrompt and ImageOptions data
 		// types to the data types used in StabilityAiApi
 		StabilityAiApi.GenerateImageRequest generateImageRequest = getGenerateImageRequest(imagePrompt,

--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiApi.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiApi.java
@@ -100,7 +100,7 @@ public class StabilityAiApi {
 			@JsonProperty("cfg_scale") Float cfgScale, @JsonProperty("clip_guidance_preset") String clipGuidancePreset,
 			@JsonProperty("sampler") String sampler, @JsonProperty("samples") Integer samples,
 			@JsonProperty("seed") Long seed, @JsonProperty("steps") Integer steps,
-			@JsonProperty("style_present") String stylePreset) {
+			@JsonProperty("style_preset") String stylePreset) {
 
 		public static Builder builder() {
 			return new Builder();


### PR DESCRIPTION
This PR fixes two problems with Stability AI image generation:

- For Stability AI-specific options, the `mergeOptions()` method was only copying the default options (which were null unless otherwise specified in configuration properties). Consequently, setting those options (such as style preset) in Java code achieved nothing. The main part of this PR fixes that to merge the Stability default properties with runtime properties the same as for portable options.
- There was a typo in the JSON property name for style_preset (it was "style_present"), preventing that property from being serialized into JSON correctly.