### PR TITLE
Refine FactCheckingEvaluator prompt to specify yes/no answer.

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/evaluation/FactCheckingEvaluator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/evaluation/FactCheckingEvaluator.java
@@ -64,6 +64,9 @@ import org.springframework.ai.chat.client.ChatClient;
 public class FactCheckingEvaluator implements Evaluator {
 
 	private static final String DEFAULT_EVALUATION_PROMPT_TEXT = """
+				Evaluate whether or not the following claim is supported by the provided document.
+				Respond with "yes" if the claim is supported, or "no" if it is not.
+
 				Document: \\n {document}\\n
 				Claim: \\n {claim}
 			""";


### PR DESCRIPTION
This PR addresses what I believe is a shortcoming in the existing prompt used in `FactCheckingEvaluator`.

Specifically: No matter what I provided to `FactCheckingEvaluator`, `isPass()` was always returning `false`. I did a little debugging and noticed that the evaluation response was a long-winded explanation of how the response content either aligned or didn't align with the given context. But the decision on whether the fact-checking passes was based on the much simpler expectation that the evaluation response was either "yes" or "no" (case-insensitive).

This change refines the prompt used by `FactCheckingEvaluator` to specify a yes/no answer, which seems to have resulted in good `isPass()` values in my testing (at least when evaluated against the default OpenAI GPT-4o model).