### PR TITLE
Fix flaky tests in `PostgresMlEmbeddingModelIT`

### DIFF
--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
@@ -135,7 +135,7 @@ public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements 
 		return this.jdbcTemplate.queryForObject(
 				"SELECT pgml.embed(?, ?, ?::JSONB)" + this.defaultOptions.getVectorType().cast + " AS embedding",
 				this.defaultOptions.getVectorType().rowMapper, this.defaultOptions.getTransformer(), text,
-				this.defaultOptions.getKwargs());
+				ModelOptionsUtils.toJsonString(this.defaultOptions.getKwargs()));
 	}
 
 	@Override
@@ -203,7 +203,6 @@ public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements 
 	@Override
 	public void afterPropertiesSet() {
 		this.jdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS pgml");
-		this.jdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS hstore");
 		if (StringUtils.hasText(this.defaultOptions.getVectorType().extensionName)) {
 			this.jdbcTemplate
 				.execute("CREATE EXTENSION IF NOT EXISTS " + this.defaultOptions.getVectorType().extensionName);


### PR DESCRIPTION
This PR removes creating unnecessary hstore postgres extension in `PostgresMlEmbeddingModel` that caused flaky tests.

Now all tests pass

<img width="695" alt="image" src="https://github.com/user-attachments/assets/e6ac7b8c-4d53-4579-96c6-696908d6637d">
