### PR TITLE
Fix HTML document title on main page to "Introduction"

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 [[introduction]]
+= Introduction
 
 image::spring_ai_logo_with_text.svg[Integration Problem, width=300, align="left"]
 


### PR DESCRIPTION
Updated the document title in the .adoc file to provide a descriptive title for the main page. 