### PR TITLE
GH-513 fix: Support custom field names for Milvus VectorStore collection

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Eddú Meléndez
  * @author Soby Chacko
+ * @author Ilayaperumal Gopinathan
  */
 @AutoConfiguration
 @ConditionalOnClass({ MilvusVectorStore.class, EmbeddingModel.class })
@@ -75,6 +76,11 @@ public class MilvusVectorStoreAutoConfiguration {
 			.withMetricType(MetricType.valueOf(properties.getMetricType().name()))
 			.withIndexParameters(properties.getIndexParameters())
 			.withEmbeddingDimension(properties.getEmbeddingDimension())
+			.withIDFieldName(properties.getIdFieldName())
+			.withAutoId(properties.isAutoId())
+			.withContentFieldName(properties.getContentFieldName())
+			.withMetadataFieldName(properties.getMetadataFieldName())
+			.withEmbeddingFieldName(properties.getEmbeddingFieldName())
 			.build();
 
 		return new MilvusVectorStore(milvusClient, embeddingModel, config, properties.isInitializeSchema(),

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreProperties.java
@@ -23,6 +23,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christian Tzolov
+ * @author Ilayaperumal Gopinathan
  */
 @ConfigurationProperties(MilvusVectorStoreProperties.CONFIG_PREFIX)
 public class MilvusVectorStoreProperties extends CommonVectorStoreProperties {
@@ -58,6 +59,31 @@ public class MilvusVectorStoreProperties extends CommonVectorStoreProperties {
 	 * The index parameters to be used for the Milvus collection.
 	 */
 	private String indexParameters = "{\"nlist\":1024}";
+
+	/**
+	 * The ID field name for the collection.
+	 */
+	private String idFieldName = MilvusVectorStore.DOC_ID_FIELD_NAME;
+
+	/**
+	 * Boolean flag to indicate if the auto-id is used.
+	 */
+	private boolean isAutoId = false;
+
+	/**
+	 * The content field name for the collection.
+	 */
+	private String contentFieldName = MilvusVectorStore.CONTENT_FIELD_NAME;
+
+	/**
+	 * The metadata field name for the collection.
+	 */
+	private String metadataFieldName = MilvusVectorStore.METADATA_FIELD_NAME;
+
+	/**
+	 * The embedding field name for the collection.
+	 */
+	private String embeddingFieldName = MilvusVectorStore.EMBEDDING_FIELD_NAME;
 
 	public String getDatabaseName() {
 		return this.databaseName;
@@ -111,6 +137,50 @@ public class MilvusVectorStoreProperties extends CommonVectorStoreProperties {
 	public void setIndexParameters(String indexParameters) {
 		Assert.notNull(indexParameters, "indexParameters can not be null");
 		this.indexParameters = indexParameters;
+	}
+
+	public String getIdFieldName() {
+		return this.idFieldName;
+	}
+
+	public void setIdFieldName(String idFieldName) {
+		Assert.notNull(idFieldName, "idFieldName can not be null");
+		this.idFieldName = idFieldName;
+	}
+
+	public boolean isAutoId() {
+		return this.isAutoId;
+	}
+
+	public void setAutoId(boolean autoId) {
+		this.isAutoId = autoId;
+	}
+
+	public String getContentFieldName() {
+		return this.contentFieldName;
+	}
+
+	public void setContentFieldName(String contentFieldName) {
+		Assert.notNull(contentFieldName, "contentFieldName can not be null");
+		this.contentFieldName = contentFieldName;
+	}
+
+	public String getMetadataFieldName() {
+		return this.metadataFieldName;
+	}
+
+	public void setMetadataFieldName(String metadataFieldName) {
+		Assert.notNull(metadataFieldName, "metadataFieldName can not be null");
+		this.metadataFieldName = metadataFieldName;
+	}
+
+	public String getEmbeddingFieldName() {
+		return this.embeddingFieldName;
+	}
+
+	public void setEmbeddingFieldName(String embeddingFieldName) {
+		Assert.notNull(embeddingFieldName, "embeddingFieldName can not be null");
+		this.embeddingFieldName = embeddingFieldName;
 	}
 
 	public enum MilvusMetricType {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfigurationIT.java
@@ -46,6 +46,7 @@ import static org.springframework.ai.autoconfigure.vectorstore.observation.Obser
  * @author Eddú Meléndez
  * @author Soby Chacko
  * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
  */
 @Testcontainers
 public class MilvusVectorStoreAutoConfigurationIT {

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/milvus/MilvusVectorStoreAutoConfigurationIT.java
@@ -109,6 +109,57 @@ public class MilvusVectorStoreAutoConfigurationIT {
 			});
 	}
 
+	@Test
+	public void searchWithCustomFields() {
+		contextRunner
+			.withPropertyValues("spring.ai.vectorstore.milvus.metricType=COSINE",
+					"spring.ai.vectorstore.milvus.indexType=IVF_FLAT",
+					"spring.ai.vectorstore.milvus.embeddingDimension=384",
+					"spring.ai.vectorstore.milvus.collectionName=myCustomCollection",
+					"spring.ai.vectorstore.milvus.idFieldName=identity",
+					"spring.ai.vectorstore.milvus.contentFieldName=text",
+					"spring.ai.vectorstore.milvus.embeddingFieldName=vectors",
+					"spring.ai.vectorstore.milvus.metadataFieldName=meta",
+					"spring.ai.vectorstore.milvus.initializeSchema=true",
+					"spring.ai.vectorstore.milvus.client.host=" + milvus.getHost(),
+					"spring.ai.vectorstore.milvus.client.port=" + milvus.getMappedPort(19530))
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+				TestObservationRegistry observationRegistry = context.getBean(TestObservationRegistry.class);
+
+				vectorStore.add(documents);
+
+				assertObservationRegistry(observationRegistry, VectorStoreProvider.MILVUS,
+						VectorStoreObservationContext.Operation.ADD);
+				observationRegistry.clear();
+
+				List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Spring").withTopK(1));
+
+				assertThat(results).hasSize(1);
+				Document resultDoc = results.get(0);
+				assertThat(resultDoc.getId()).isEqualTo(documents.get(0).getId());
+				assertThat(resultDoc.getContent()).contains(
+						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
+				assertThat(resultDoc.getMetadata()).hasSize(2);
+				assertThat(resultDoc.getMetadata()).containsKeys("spring", "distance");
+
+				assertObservationRegistry(observationRegistry, VectorStoreProvider.MILVUS,
+						VectorStoreObservationContext.Operation.QUERY);
+				observationRegistry.clear();
+
+				// Remove all documents from the store
+				vectorStore.delete(documents.stream().map(doc -> doc.getId()).toList());
+
+				results = vectorStore.similaritySearch(SearchRequest.query("Spring").withTopK(1));
+				assertThat(results).hasSize(0);
+
+				assertObservationRegistry(observationRegistry, VectorStoreProvider.MILVUS,
+						VectorStoreObservationContext.Operation.DELETE);
+				observationRegistry.clear();
+
+			});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class Config {
 

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusVectorStoreCustomFieldNamesIT.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusVectorStoreCustomFieldNamesIT.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2023 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.vectorstore;
+
+import io.milvus.client.MilvusServiceClient;
+import io.milvus.param.ConnectParam;
+import io.milvus.param.IndexType;
+import io.milvus.param.MetricType;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.TokenCountBatchingStrategy;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.vectorstore.MilvusVectorStore.MilvusVectorStoreConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.milvus.MilvusContainer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+@Testcontainers
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+public class MilvusVectorStoreCustomFieldNamesIT {
+
+	@Container
+	private static MilvusContainer milvusContainer = new MilvusContainer(MilvusImage.DEFAULT_IMAGE);
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(TestApplication.class);
+
+	List<Document> documents = List.of(
+			new Document(getText("classpath:/test/data/spring.ai.txt"), Map.of("meta1", "meta1")),
+			new Document(getText("classpath:/test/data/time.shelter.txt")),
+			new Document(getText("classpath:/test/data/great.depression.txt"), Map.of("meta2", "meta2")));
+
+	public static String getText(String uri) {
+		var resource = new DefaultResourceLoader().getResource(uri);
+		try {
+			return resource.getContentAsString(StandardCharsets.UTF_8);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void resetCollection(VectorStore vectorStore) {
+		((MilvusVectorStore) vectorStore).dropCollection();
+		((MilvusVectorStore) vectorStore).createCollection();
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = { "COSINE" })
+	public void searchWithCustomFieldNames(String metricType) {
+
+		contextRunner
+			.withPropertyValues("test.spring.ai.vectorstore.milvus.metricType=" + metricType,
+					"test.spring.ai.vectorstore.milvus.idFieldName=document_id",
+					"test.spring.ai.vectorstore.milvus.contentFieldName=text",
+					"test.spring.ai.vectorstore.milvus.embeddingFieldName=vector",
+					"test.spring.ai.vectorstore.milvus.metadataFieldName=meta")
+			.run(context -> {
+
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				resetCollection(vectorStore);
+
+				vectorStore.add(documents);
+
+				List<Document> fullResult = vectorStore.similaritySearch(SearchRequest.query("Spring"));
+
+				List<Float> distances = fullResult.stream()
+					.map(doc -> (Float) doc.getMetadata().get("distance"))
+					.toList();
+
+				assertThat(distances).hasSize(3);
+
+				float threshold = (distances.get(0) + distances.get(1)) / 2;
+
+				List<Document> results = vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(1 - threshold));
+
+				assertThat(results).hasSize(1);
+				Document resultDoc = results.get(0);
+				assertThat(String.valueOf(resultDoc.getId())).isEqualTo(documents.get(0).getId());
+				assertThat(resultDoc.getContent()).contains(
+						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
+				assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+
+			});
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = { "COSINE" })
+	public void searchWithoutMetadataFieldOverride(String metricType) {
+
+		contextRunner
+			.withPropertyValues("test.spring.ai.vectorstore.milvus.metricType=" + metricType,
+					"test.spring.ai.vectorstore.milvus.idFieldName=identity",
+					"test.spring.ai.vectorstore.milvus.contentFieldName=text",
+					"test.spring.ai.vectorstore.milvus.embeddingFieldName=embed")
+			.run(context -> {
+
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				resetCollection(vectorStore);
+
+				vectorStore.add(documents);
+
+				List<Document> fullResult = vectorStore.similaritySearch(SearchRequest.query("Spring"));
+
+				List<Float> distances = fullResult.stream()
+					.map(doc -> (Float) doc.getMetadata().get("distance"))
+					.toList();
+
+				assertThat(distances).hasSize(3);
+
+				float threshold = (distances.get(0) + distances.get(1)) / 2;
+
+				List<Document> results = vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(1 - threshold));
+
+				assertThat(results).hasSize(1);
+				Document resultDoc = results.get(0);
+				assertThat(String.valueOf(resultDoc.getId())).isEqualTo(documents.get(0).getId());
+				assertThat(resultDoc.getContent()).contains(
+						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
+				assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+
+			});
+	}
+
+	@ParameterizedTest(name = "{0} : {displayName} ")
+	@ValueSource(strings = { "COSINE" })
+	public void searchWithAutoIdEnabled(String metricType) {
+
+		contextRunner
+			.withPropertyValues("test.spring.ai.vectorstore.milvus.metricType=" + metricType,
+					"test.spring.ai.vectorstore.milvus.isAutoId=true",
+					"test.spring.ai.vectorstore.milvus.idFieldName=identity",
+					"test.spring.ai.vectorstore.milvus.contentFieldName=media",
+					"test.spring.ai.vectorstore.milvus.metadataFieldName=meta",
+					"test.spring.ai.vectorstore.milvus.embeddingFieldName=embed")
+			.run(context -> {
+
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				resetCollection(vectorStore);
+
+				vectorStore.add(documents);
+
+				List<Document> fullResult = vectorStore.similaritySearch(SearchRequest.query("Spring"));
+
+				List<Float> distances = fullResult.stream()
+					.map(doc -> (Float) doc.getMetadata().get("distance"))
+					.toList();
+
+				assertThat(distances).hasSize(3);
+
+				float threshold = (distances.get(0) + distances.get(1)) / 2;
+
+				List<Document> results = vectorStore
+					.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(1 - threshold));
+
+				assertThat(results).hasSize(1);
+				Document resultDoc = results.get(0);
+				// Verify that the auto ID is used
+				assertThat(String.valueOf(resultDoc.getId())).isNotEqualTo(documents.get(0).getId());
+				assertThat(resultDoc.getContent()).contains(
+						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
+				assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+
+			});
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class })
+	public static class TestApplication {
+
+		@Value("${test.spring.ai.vectorstore.milvus.metricType}")
+		private MetricType metricType;
+
+		@Value("${test.spring.ai.vectorstore.milvus.idFieldName}")
+		private String idFieldName;
+
+		@Value("${test.spring.ai.vectorstore.milvus.isAutoId:false}")
+		private Boolean isAutoId;
+
+		@Value("${test.spring.ai.vectorstore.milvus.contentFieldName}")
+		private String contentFieldName;
+
+		@Value("${test.spring.ai.vectorstore.milvus.embeddingFieldName}")
+		private String embeddingFieldName;
+
+		@Value("${test.spring.ai.vectorstore.milvus.metadataFieldName:metadata}")
+		private String metadataFieldName;
+
+		@Bean
+		public VectorStore vectorStore(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
+			MilvusVectorStoreConfig config = MilvusVectorStoreConfig.builder()
+				.withCollectionName("test_vector_store_custom_fields")
+				.withDatabaseName("default")
+				.withIndexType(IndexType.IVF_FLAT)
+				.withMetricType(metricType)
+				.withIDFieldName(idFieldName)
+				.withAutoId(isAutoId)
+				.withContentFieldName(contentFieldName)
+				.withEmbeddingFieldName(embeddingFieldName)
+				.withMetadataFieldName(metadataFieldName)
+				.build();
+			return new MilvusVectorStore(milvusClient, embeddingModel, config, true, new TokenCountBatchingStrategy());
+		}
+
+		@Bean
+		public MilvusServiceClient milvusClient() {
+			return new MilvusServiceClient(ConnectParam.newBuilder()
+				.withAuthorization("minioadmin", "minioadmin")
+				.withUri(milvusContainer.getEndpoint())
+				.build());
+		}
+
+		@Bean
+		public EmbeddingModel embeddingModel() {
+			return new OpenAiEmbeddingModel(new OpenAiApi(System.getenv("OPENAI_API_KEY")));
+		}
+
+	}
+
+}

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusVectorStoreCustomFieldNamesIT.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusVectorStoreCustomFieldNamesIT.java
@@ -51,7 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
-public class MilvusVectorStoreCustomFieldNamesIT {
+class MilvusVectorStoreCustomFieldNamesIT {
 
 	@Container
 	private static MilvusContainer milvusContainer = new MilvusContainer(MilvusImage.DEFAULT_IMAGE);
@@ -81,7 +81,7 @@ public class MilvusVectorStoreCustomFieldNamesIT {
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
 	@ValueSource(strings = { "COSINE" })
-	public void searchWithCustomFieldNames(String metricType) {
+	void searchWithCustomFieldNames(String metricType) {
 
 		contextRunner
 			.withPropertyValues("test.spring.ai.vectorstore.milvus.metricType=" + metricType,
@@ -122,7 +122,7 @@ public class MilvusVectorStoreCustomFieldNamesIT {
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
 	@ValueSource(strings = { "COSINE" })
-	public void searchWithoutMetadataFieldOverride(String metricType) {
+	void searchWithoutMetadataFieldOverride(String metricType) {
 
 		contextRunner
 			.withPropertyValues("test.spring.ai.vectorstore.milvus.metricType=" + metricType,
@@ -162,7 +162,7 @@ public class MilvusVectorStoreCustomFieldNamesIT {
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
 	@ValueSource(strings = { "COSINE" })
-	public void searchWithAutoIdEnabled(String metricType) {
+	void searchWithAutoIdEnabled(String metricType) {
 
 		contextRunner
 			.withPropertyValues("test.spring.ai.vectorstore.milvus.metricType=" + metricType,
@@ -205,7 +205,7 @@ public class MilvusVectorStoreCustomFieldNamesIT {
 
 	@SpringBootConfiguration
 	@EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class })
-	public static class TestApplication {
+	static class TestApplication {
 
 		@Value("${test.spring.ai.vectorstore.milvus.metricType}")
 		private MetricType metricType;
@@ -226,7 +226,7 @@ public class MilvusVectorStoreCustomFieldNamesIT {
 		private String metadataFieldName;
 
 		@Bean
-		public VectorStore vectorStore(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
+		VectorStore vectorStore(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
 			MilvusVectorStoreConfig config = MilvusVectorStoreConfig.builder()
 				.withCollectionName("test_vector_store_custom_fields")
 				.withDatabaseName("default")
@@ -242,7 +242,7 @@ public class MilvusVectorStoreCustomFieldNamesIT {
 		}
 
 		@Bean
-		public MilvusServiceClient milvusClient() {
+		MilvusServiceClient milvusClient() {
 			return new MilvusServiceClient(ConnectParam.newBuilder()
 				.withAuthorization("minioadmin", "minioadmin")
 				.withUri(milvusContainer.getEndpoint())
@@ -250,7 +250,7 @@ public class MilvusVectorStoreCustomFieldNamesIT {
 		}
 
 		@Bean
-		public EmbeddingModel embeddingModel() {
+		EmbeddingModel embeddingModel() {
 			return new OpenAiEmbeddingModel(new OpenAiApi(System.getenv("OPENAI_API_KEY")));
 		}
 


### PR DESCRIPTION
- Add configuration properties to override the default field names for doc_id, content, metadata and embedding
- Add support to allow auto-id when enabled
- Add tests

Resolves #513
