### PR TITLE
Fix example codes in docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -450,7 +450,7 @@ public class CustomerSupportAssistant {
 
         this.chatClient = builder
             .defaultSystem("""
-                    You are a customer chat support agent of an airline named "Funnair".", Respond in a friendly,
+                    You are a customer chat support agent of an airline named "Funnair". Respond in a friendly,
                     helpful, and joyful manner.
 
                     Before providing information about a booking or cancelling a booking, you MUST always
@@ -524,7 +524,7 @@ Example usage:
 
 [source,java]
 ----
-javaCopySimpleLoggerAdvisor customLogger = new SimpleLoggerAdvisor(
+SimpleLoggerAdvisor customLogger = new SimpleLoggerAdvisor(
     request -> "Custom request: " + request.userText,
     response -> "Custom response: " + response.getResult()
 );

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
@@ -235,6 +235,7 @@ class MyTextReader {
     MyTextReader(@Value("classpath:text-source.txt") Resource resource) {
         this.resource = resource;
     }
+
 	List<Document> loadText() {
 		TextReader textReader = new TextReader(this.resource);
 		textReader.getCustomMetadata().put("filename", "text-source.txt");
@@ -447,7 +448,7 @@ dependencies {
 @Component
 public class MyPagePdfDocumentReader {
 
-	List<Document> getDocsFromPdfwithCatalog() {
+	List<Document> getDocsFromPdfWithCatalog() {
 
         ParagraphPdfDocumentReader pdfReader = new ParagraphPdfDocumentReader("classpath:/sample1.pdf",
                 PdfDocumentReaderConfig.builder()
@@ -458,7 +459,7 @@ public class MyPagePdfDocumentReader {
                     .withPagesPerDocument(1)
                     .build());
 
-	return pdfReader.read();
+	    return pdfReader.read();
     }
 }
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/imageclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/imageclient.adoc
@@ -144,7 +144,7 @@ public class ImageGeneration implements ModelResult<Image> {
 
 	private Image image;
 
-    	@Override
+    @Override
 	public Image getOutput() {...}
 
 	@Override

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testing.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testing.adoc
@@ -12,7 +12,7 @@ The Spring AI interface for evaluating responses is `Evaluator`, defined as:
 ----
 @FunctionalInterface
 public interface Evaluator {
-    EvaluationResponse evaluate(EvaluationRequest evaluationRequest)
+    EvaluationResponse evaluate(EvaluationRequest evaluationRequest);
 }
 ----
 


### PR DESCRIPTION
chatclient.adoc
 - Replaced javaCopySimpleLoggerAdvisor with SimpleLoggerAdvisor
 - Fixed typo in the multiline String for ChatClient example

etl-pipeline.adoc
 - Fixed indent in the ParagraphPdfDocumentReader example

imageclient.adoc
 - Fixed indent of override annotation in the ImageGeneration example

testing.adoc
 - Added a semicolon to the Evaluator interface

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
