### PR TITLE
Add spring-ai-starter-azure-cosmos-db-store submodule to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 		<module>vector-stores/spring-ai-typesense-store</module>
 
 		<module>vector-stores/spring-ai-weaviate-store</module>
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-azure-cosmos-db-store</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-azure-store</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-cassandra-store</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-chroma-store</module>


### PR DESCRIPTION
Idk why the spring-ai-starter-azure-cosmos-db-store module is not declared
but it seems to be missing 
so adding it


Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
