### PR TITLE
Introduce Kotlin tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
 		<azure-open-ai-client.version>1.0.0-beta.10</azure-open-ai-client.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
 		<victools.version>4.31.1</victools.version>
+		<kotlin.version>1.9.25</kotlin.version>
 
 		<!-- NOTE: keep them align -->
 		<bedrockruntime.version>2.26.7</bedrockruntime.version>
@@ -314,6 +315,37 @@
 				<version>${maven-site-plugin.version}</version>
 			</plugin>
 			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<version>${kotlin.version}</version>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+								<sourceDir>${project.basedir}/src/test/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven-compiler-plugin.version}</version>
@@ -323,6 +355,32 @@
 						<compilerArg>-parameters</compilerArg>
 					</compilerArgs>
 				</configuration>
+				<executions>
+					<!-- Replacing default-compile as it is treated specially by Maven -->
+					<execution>
+						<id>default-compile</id>
+						<phase>none</phase>
+					</execution>
+					<!-- Replacing default-testCompile as it is treated specially by Maven -->
+					<execution>
+						<id>default-testCompile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>java-compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/spring-ai-core/pom.xml
+++ b/spring-ai-core/pom.xml
@@ -140,6 +140,20 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<version>${kotlin.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
+			<version>${jackson.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<profiles>

--- a/spring-ai-core/src/test/kotlin/org/springframework/ai/utils/JacksonUtilsKotlinTests.kt
+++ b/spring-ai-core/src/test/kotlin/org/springframework/ai/utils/JacksonUtilsKotlinTests.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.ai.util.JacksonUtils
+
+/**
+ * Kotlin unit tests for [JacksonUtils].
+ *
+ * @author Sebastien Deleuze
+ */
+class JacksonUtilsKotlinTests {
+
+	@Test
+	fun `Deserialize to a Kotlin data class with Jackson modules detected by JacksonUtils#instantiateAvailableModules`() {
+		val jsonMapper = JsonMapper.builder().addModules(JacksonUtils.instantiateAvailableModules()).build()
+		val output = jsonMapper.readValue("{\"name\":\"Robert\",\"age\":42}", User::class.java)
+		Assertions.assertThat(output).isEqualTo(User("Robert", 42))
+	}
+
+	@Test
+	fun `Serialize a Kotlin data class with Jackson modules detected by JacksonUtils#instantiateAvailableModules`() {
+		val jsonMapper = JsonMapper.builder().addModules(JacksonUtils.instantiateAvailableModules()).build()
+		val output = jsonMapper.writeValueAsString(User("Robert", 42))
+		Assertions.assertThat(output).isEqualTo("{\"name\":\"Robert\",\"age\":42}")
+	}
+
+	data class User(val name: String, val age: Int)
+
+}


### PR DESCRIPTION
This commit configures Maven to support compiling Kotlin main and test classes, and adds a `JacksonUtilsKotlinTests` class that ensures that serialization and deserialization of Kotlin data classes works as expected.

The Maven configuration follows recommendations from https://kotlinlang.org/docs/maven.html.