### PR TITLE
Fixed an exception where the collectionName could not be found when MilvusVectorStore executed the doDelete method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 		<oracle.version>23.4.0.24.05</oracle.version>
 		<postgresql.version>42.7.2</postgresql.version>
 		<elasticsearch-java.version>8.13.3</elasticsearch-java.version>
-		<milvus.version>2.3.4</milvus.version>
+		<milvus.version>2.3.5</milvus.version>
 		<gemfire.testcontainers.version>2.3.0</gemfire.testcontainers.version>
 		<pinecone.version>0.8.0</pinecone.version>
 		<fastjson.version>2.0.46</fastjson.version>

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -195,6 +195,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 				idList.stream().map(id -> "'" + id + "'").collect(Collectors.joining(",")));
 
 		R<MutationResult> status = this.milvusClient.delete(DeleteParam.newBuilder()
+			.withDatabaseName(this.config.databaseName)
 			.withCollectionName(this.config.collectionName)
 			.withExpr(deleteExpression)
 			.build());


### PR DESCRIPTION
When MilvusVectorStore executes doDelete method, if we do not use the default database (default), DeleteParam does not pass the specified DatabaseName, in the actual query will be searched according to the default. There is no collection in the default library, and the collectionName cannot be found