### PR TITLE
Fixed Azure Vector Store initialization where the embedding field was not set as Retrievable.

### DIFF
--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -349,6 +349,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 			.setSortable(true));
 		fields.add(new SearchField(EMBEDDING_FIELD_NAME, SearchFieldDataType.collection(SearchFieldDataType.SINGLE))
 			.setSearchable(true)
+			.setHidden(false)
 			.setVectorSearchDimensions(dimensions)
 			// This must match a vector search configuration name.
 			.setVectorSearchProfileName(SPRING_AI_VECTOR_PROFILE));


### PR DESCRIPTION
In Azure Vector Store, the _embedding_ field need to set as _retrievable_.
_com.azure.search.documents.indexes.models.SearchField_ class does not have a _retrievable_ field, but the "_hidden_" field is equivalent to "_retrievable_". For details, refer to the "toJson" and "fromJson" methods.

fix https://github.com/spring-projects/spring-ai/issues/1628