### PR TITLE
Fix Vector Database providers list

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -26,7 +26,7 @@ Spring AI provides the following features:
 ** xref:api/audio/speech.adoc[Text to Speech]
 ** xref:api/moderation[Moderation]
 * xref:api/structured-output-converter.adoc[Structured Outputs] - Mapping of AI Model output to POJOs.
-* Support for all major xref:api/vectordbs.adoc[Vector Database providers] such as Apache Cassandra, Azure Vector Search, Chroma, Milvus, MongoDB Atlas, Neo4j, Oracle, PostgreSQL/PGVector, PineCone, Qdrant, Redis, and Weaviate.
+* Support for all major xref:api/vectordbs.adoc[Vector Database providers] such as Apache Cassandra, Azure Vector Search, Chroma, Elasticsearch, Milvus, MongoDB Atlas, Neo4j, OpenSearch, Oracle, PostgreSQL/PGVector, PineCone, Qdrant, Redis, SAP Hana, Typesense and Weaviate.
 * Portable API across Vector Store providers, including a novel SQL-like metadata filter API.
 * xref:api/functions.adoc[Tools/Function Calling] - permits the model to request the execution of client-side tools and functions, thereby accessing necessary real-time information as required.
 * xref:observability/index.adoc[Observability] - Provides insights into AI-related operations.


### PR DESCRIPTION
index.adoc

Added missing Vector Database providers to the list:
- Included Elasticsearch, OpenSearch, SAP Hana, and Typesense
