### PR TITLE
Fix: convert API records to POJOs and fix related tests

### DIFF
--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -60,7 +60,6 @@ import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage.ChatC
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage.Role;
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage.ToolCall;
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionRequest;
-import org.springframework.ai.minimax.api.MiniMaxApi.FunctionTool;
 import org.springframework.ai.minimax.api.MiniMaxApiConstants;
 import org.springframework.ai.minimax.metadata.MiniMaxUsage;
 import org.springframework.ai.model.ModelOptionsUtils;
@@ -508,11 +507,11 @@ public class MiniMaxChatModel extends AbstractToolCallSupport implements ChatMod
 		return request;
 	}
 
-	private List<FunctionTool> getFunctionTools(Set<String> functionNames) {
+	private List<MiniMaxApi.FunctionTool> getFunctionTools(Set<String> functionNames) {
 		return this.resolveFunctionCallbacks(functionNames).stream().map(functionCallback -> {
-			var function = new FunctionTool.Function(functionCallback.getDescription(), functionCallback.getName(),
-					functionCallback.getInputTypeSchema());
-			return new FunctionTool(function);
+			var function = new MiniMaxApi.FunctionTool.Function(functionCallback.getDescription(),
+					functionCallback.getName(), functionCallback.getInputTypeSchema());
+			return new MiniMaxApi.FunctionTool(function);
 		}).toList();
 	}
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -331,14 +331,35 @@ public class MiniMaxApi {
 
 	/**
 	 * Represents a tool the model may call. Currently, only functions are supported as a tool.
-	 *
-	 * @param type The type of the tool. Currently, only 'function' is supported.
-	 * @param function The function definition.
 	 */
-	@JsonInclude(Include.NON_NULL)
-	public record FunctionTool(
-			@JsonProperty("type") Type type,
-			@JsonProperty("function") Function function) {
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class FunctionTool {
+
+		/**
+		 *  The type of the tool. Currently, only 'function' is supported.
+		 */
+		private Type type = Type.FUNCTION;
+
+		/**
+		 * The function definition.
+		 */
+		private Function function;
+
+		public FunctionTool() {
+
+		}
+
+		/**
+		 * Create a tool of type 'function' and the given function definition.
+		 * @param type the tool type
+		 * @param function function definition
+		 */
+		public FunctionTool(
+				@JsonProperty("type") Type type,
+				@JsonProperty("function") Function function) {
+			this.type = type;
+			this.function = function;
+		}
 
 		/**
 		 * Create a tool of type 'function' and the given function definition.
@@ -348,8 +369,22 @@ public class MiniMaxApi {
 			this(Type.FUNCTION, function);
 		}
 
-		public static FunctionTool webSearchFunctionTool() {
-			return new FunctionTool(Type.WEB_SEARCH, null);
+		@JsonProperty("type")
+		public Type getType() {
+			return this.type;
+		}
+
+		@JsonProperty("function")
+		public Function getFunction() {
+			return this.function;
+		}
+
+		public void setType(Type type) {
+			this.type = type;
+		}
+
+		public void setFunction(Function function) {
+			this.function = function;
 		}
 
 		/**
@@ -361,35 +396,104 @@ public class MiniMaxApi {
 			 */
 			@JsonProperty("function")
 			FUNCTION,
+
 			@JsonProperty("web_search")
 			WEB_SEARCH
 		}
 
+		public static FunctionTool webSearchFunctionTool() {
+			return new FunctionTool(FunctionTool.Type.WEB_SEARCH, null);
+		}
+
+
 		/**
 		 * Function definition.
-		 *
-		 * @param description A description of what the function does, used by the model to choose when and how to call
-		 * the function.
-		 * @param name The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes,
-		 * with a maximum length of 64.
-		 * @param parameters The parameters the functions accepts, described as a JSON Schema object. To describe a
-		 * function that accepts no parameters, provide the value {"type": "object", "properties": {}}.
 		 */
-		public record Function(
-				@JsonProperty("description") String description,
-				@JsonProperty("name") String name,
-				@JsonProperty("parameters") String parameters) {
+		public static class Function {
+
+			@JsonProperty("description")
+			private String description;
+
+			@JsonProperty("name")
+			private String name;
+
+			@JsonProperty("parameters")
+			private Map<String, Object> parameters;
+
+			private String jsonSchema;
+
+			private Function() {
+
+			}
+
+			/**
+			 * Create tool function definition.
+			 *
+			 * @param description A description of what the function does, used by the model to choose when and how to call
+			 * the function.
+			 * @param name The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes,
+			 * with a maximum length of 64.
+			 * @param parameters The parameters the functions accepts, described as a JSON Schema object. To describe a
+			 * function that accepts no parameters, provide the value {"type": "object", "properties": {}}.
+			 */
+			public Function(
+					String description,
+					String name,
+					Map<String, Object> parameters) {
+				this.description = description;
+				this.name = name;
+				this.parameters = parameters;
+			}
 
 			/**
 			 * Create tool function definition.
 			 *
 			 * @param description tool function description.
 			 * @param name tool function name.
-			 * @param parameters tool function schema.
+			 * @param jsonSchema tool function schema as json.
 			 */
-			public Function(String description, String name, Map<String, Object> parameters) {
-				this(description, name, ModelOptionsUtils.toJsonString(parameters));
+			public Function(String description, String name, String jsonSchema) {
+				this(description, name, ModelOptionsUtils.jsonToMap(jsonSchema));
 			}
+
+			@JsonProperty("description")
+			public String getDescription() {
+				return this.description;
+			}
+
+			@JsonProperty("name")
+			public String getName() {
+				return this.name;
+			}
+
+			@JsonProperty("parameters")
+			public Map<String, Object> getParameters() {
+				return this.parameters;
+			}
+
+			public void setDescription(String description) {
+				this.description = description;
+			}
+
+			public void setName(String name) {
+				this.name = name;
+			}
+
+			public void setParameters(Map<String, Object> parameters) {
+				this.parameters = parameters;
+			}
+
+			public String getJsonSchema() {
+				return this.jsonSchema;
+			}
+
+			public void setJsonSchema(String jsonSchema) {
+				this.jsonSchema = jsonSchema;
+				if (jsonSchema != null) {
+					this.parameters = ModelOptionsUtils.jsonToMap(jsonSchema);
+				}
+			}
+
 		}
 	}
 

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/ChatCompletionRequestTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/ChatCompletionRequestTests.java
@@ -83,7 +83,7 @@ public class ChatCompletionRequestTests {
 		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).isEqualTo(TOOL_FUNCTION_NAME);
+		assertThat(request.tools().get(0).getFunction().getName()).isEqualTo(TOOL_FUNCTION_NAME);
 	}
 
 	@Test
@@ -120,7 +120,7 @@ public class ChatCompletionRequestTests {
 				MiniMaxChatOptions.builder().withFunction(TOOL_FUNCTION_NAME).build()), false);
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).as("Explicitly enabled function")
+		assertThat(request.tools().get(0).getFunction().getName()).as("Explicitly enabled function")
 			.isEqualTo(TOOL_FUNCTION_NAME);
 
 		// Override the default options function with one from the prompt
@@ -134,7 +134,7 @@ public class ChatCompletionRequestTests {
 				false);
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).as("Explicitly enabled function")
+		assertThat(request.tools().get(0).getFunction().getName()).as("Explicitly enabled function")
 			.isEqualTo(TOOL_FUNCTION_NAME);
 
 		assertThat(client.getFunctionCallbackRegister()).hasSize(1);

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxApiToolFunctionCallIT.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxApiToolFunctionCallIT.java
@@ -33,7 +33,6 @@ import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage.Role;
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionMessage.ToolCall;
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionRequest;
 import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionRequest.ToolChoiceBuilder;
-import org.springframework.ai.minimax.api.MiniMaxApi.FunctionTool.Type;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,31 +66,33 @@ public class MiniMaxApiToolFunctionCallIT {
 		var message = new ChatCompletionMessage(
 				"What's the weather like in San Francisco? Return the temperature in Celsius.", Role.USER);
 
-		var functionTool = new MiniMaxApi.FunctionTool(Type.FUNCTION, new MiniMaxApi.FunctionTool.Function(
-				"Get the weather in location. Return temperature in 30°F or 30°C format.", "getCurrentWeather", """
-						{
-							"type": "object",
-							"properties": {
-								"location": {
-									"type": "string",
-									"description": "The city and state e.g. San Francisco, CA"
-								},
-								"lat": {
-									"type": "number",
-									"description": "The city latitude"
-								},
-								"lon": {
-									"type": "number",
-									"description": "The city longitude"
-								},
-								"unit": {
-									"type": "string",
-									"enum": ["C", "F"]
+		var functionTool = new MiniMaxApi.FunctionTool(MiniMaxApi.FunctionTool.Type.FUNCTION,
+				new MiniMaxApi.FunctionTool.Function(
+						"Get the weather in location. Return temperature in 30°F or 30°C format.", "getCurrentWeather",
+						"""
+								{
+									"type": "object",
+									"properties": {
+										"location": {
+											"type": "string",
+											"description": "The city and state e.g. San Francisco, CA"
+										},
+										"lat": {
+											"type": "number",
+											"description": "The city latitude"
+										},
+										"lon": {
+											"type": "number",
+											"description": "The city longitude"
+										},
+										"unit": {
+											"type": "string",
+											"enum": ["C", "F"]
+										}
+									},
+									"required": ["location", "lat", "lon", "unit"]
 								}
-							},
-							"required": ["location", "lat", "lon", "unit"]
-						}
-						"""));
+								"""));
 
 		List<ChatCompletionMessage> messages = new ArrayList<>(List.of(message));
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -318,12 +318,21 @@ public class MistralAiApi {
 	/**
 	 * Represents a tool the model may call. Currently, only functions are supported as a
 	 * tool.
-	 *
-	 * @param type The type of the tool. Currently, only 'function' is supported.
-	 * @param function The function definition.
 	 */
 	@JsonInclude(Include.NON_NULL)
-	public record FunctionTool(@JsonProperty("type") Type type, @JsonProperty("function") Function function) {
+	public static class FunctionTool {
+
+		// The type of the tool. Currently, only 'function' is supported.
+		@JsonProperty("type")
+		Type type = Type.FUNCTION;
+
+		// The function definition.
+		@JsonProperty("function")
+		Function function;
+
+		public FunctionTool() {
+
+		}
 
 		/**
 		 * Create a tool of type 'function' and the given function definition.
@@ -331,6 +340,27 @@ public class MistralAiApi {
 		 */
 		public FunctionTool(Function function) {
 			this(Type.FUNCTION, function);
+		}
+
+		public FunctionTool(Type type, Function function) {
+			this.type = type;
+			this.function = function;
+		}
+
+		public Type getType() {
+			return this.type;
+		}
+
+		public Function getFunction() {
+			return this.function;
+		}
+
+		public void setType(Type type) {
+			this.type = type;
+		}
+
+		public void setFunction(Function function) {
+			this.function = function;
 		}
 
 		/**
@@ -348,17 +378,39 @@ public class MistralAiApi {
 
 		/**
 		 * Function definition.
-		 *
-		 * @param description A description of what the function does, used by the model
-		 * to choose when and how to call the function.
-		 * @param name The name of the function to be called. Must be a-z, A-Z, 0-9, or
-		 * contain underscores and dashes, with a maximum length of 64.
-		 * @param parameters The parameters the functions accepts, described as a JSON
-		 * Schema object. To describe a function that accepts no parameters, provide the
-		 * value {"type": "object", "properties": {}}.
 		 */
-		public record Function(@JsonProperty("description") String description, @JsonProperty("name") String name,
-				@JsonProperty("parameters") Map<String, Object> parameters) {
+		public static class Function {
+
+			@JsonProperty("description")
+			private String description;
+
+			@JsonProperty("name")
+			private String name;
+
+			@JsonProperty("parameters")
+			private Map<String, Object> parameters;
+
+			private String jsonSchema;
+
+			private Function() {
+
+			}
+
+			/**
+			 * Create tool function definition.
+			 * @param description A description of what the function does, used by the
+			 * model to choose when and how to call the function.
+			 * @param name The name of the function to be called. Must be a-z, A-Z, 0-9,
+			 * or contain underscores and dashes, with a maximum length of 64.
+			 * @param parameters The parameters the functions accepts, described as a JSON
+			 * Schema object. To describe a function that accepts no parameters, provide
+			 * the value {"type": "object", "properties": {}}.
+			 */
+			public Function(String description, String name, Map<String, Object> parameters) {
+				this.description = description;
+				this.name = name;
+				this.parameters = parameters;
+			}
 
 			/**
 			 * Create tool function definition.
@@ -368,6 +420,41 @@ public class MistralAiApi {
 			 */
 			public Function(String description, String name, String jsonSchema) {
 				this(description, name, ModelOptionsUtils.jsonToMap(jsonSchema));
+			}
+
+			public String getDescription() {
+				return this.description;
+			}
+
+			public String getName() {
+				return this.name;
+			}
+
+			public Map<String, Object> getParameters() {
+				return this.parameters;
+			}
+
+			public void setDescription(String description) {
+				this.description = description;
+			}
+
+			public void setName(String name) {
+				this.name = name;
+			}
+
+			public void setParameters(Map<String, Object> parameters) {
+				this.parameters = parameters;
+			}
+
+			public String getJsonSchema() {
+				return this.jsonSchema;
+			}
+
+			public void setJsonSchema(String jsonSchema) {
+				this.jsonSchema = jsonSchema;
+				if (jsonSchema != null) {
+					this.parameters = ModelOptionsUtils.jsonToMap(jsonSchema);
+				}
 			}
 
 		}

--- a/models/spring-ai-openai/pom.xml
+++ b/models/spring-ai-openai/pom.xml
@@ -131,7 +131,8 @@
             <artifactId>ollama</artifactId>
             <scope>test</scope>
         </dependency>
-		
+
+
 	</dependencies>
 
 </project>

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -37,8 +37,8 @@ import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.ResponseFormat;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.StreamOptions;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.ToolChoiceBuilder;
-import org.springframework.ai.openai.api.OpenAiApi.FunctionTool;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Christian Tzolov
@@ -133,7 +133,7 @@ public class OpenAiChatOptions implements FunctionCallingOptions, ChatOptions {
 	 * A list of tools the model may call. Currently, only functions are supported as a tool. Use this to
 	 * provide a list of functions the model may generate JSON inputs for.
 	 */
-	private @JsonProperty("tools") List<FunctionTool> tools;
+	private @JsonProperty("tools") List<OpenAiApi.FunctionTool> tools;
 	/**
 	 * Controls which (if any) function is called by the model. none means the model will not call a
 	 * function and instead generates a message. auto means the model can pick between generating a message or calling a
@@ -314,6 +314,14 @@ public class OpenAiChatOptions implements FunctionCallingOptions, ChatOptions {
 	}
 
 	public void setResponseFormat(ResponseFormat responseFormat) {
+		if (responseFormat != null) {
+			ResponseFormat.JsonSchema jsonSchema = StringUtils.hasText(responseFormat.getSchema())
+					? new ResponseFormat.JsonSchema(responseFormat.getName(), responseFormat.getSchema(),
+							responseFormat.getStrict())
+					: null;
+
+			responseFormat.setJsonSchema(jsonSchema);
+		}
 		this.responseFormat = responseFormat;
 	}
 
@@ -370,11 +378,11 @@ public class OpenAiChatOptions implements FunctionCallingOptions, ChatOptions {
 		this.topP = topP;
 	}
 
-	public List<FunctionTool> getTools() {
+	public List<OpenAiApi.FunctionTool> getTools() {
 		return this.tools;
 	}
 
-	public void setTools(List<FunctionTool> tools) {
+	public void setTools(List<OpenAiApi.FunctionTool> tools) {
 		this.tools = tools;
 	}
 
@@ -593,7 +601,7 @@ public class OpenAiChatOptions implements FunctionCallingOptions, ChatOptions {
 			return this;
 		}
 
-		public Builder withTools(List<FunctionTool> tools) {
+		public Builder withTools(List<OpenAiApi.FunctionTool> tools) {
 			this.options.tools = tools;
 			return this;
 		}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/ChatCompletionRequestTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/ChatCompletionRequestTests.java
@@ -83,7 +83,7 @@ public class ChatCompletionRequestTests {
 		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).isEqualTo(TOOL_FUNCTION_NAME);
+		assertThat(request.tools().get(0).getFunction().getName()).isEqualTo(TOOL_FUNCTION_NAME);
 	}
 
 	@Test
@@ -120,7 +120,7 @@ public class ChatCompletionRequestTests {
 				OpenAiChatOptions.builder().withFunction(TOOL_FUNCTION_NAME).build()), false);
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).as("Explicitly enabled function")
+		assertThat(request.tools().get(0).getFunction().getName()).as("Explicitly enabled function")
 			.isEqualTo(TOOL_FUNCTION_NAME);
 
 		// Override the default options function with one from the prompt
@@ -134,7 +134,7 @@ public class ChatCompletionRequestTests {
 				false);
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).as("Explicitly enabled function")
+		assertThat(request.tools().get(0).getFunction().getName()).as("Explicitly enabled function")
 			.isEqualTo(TOOL_FUNCTION_NAME);
 
 		assertThat(client.getFunctionCallbackRegister()).hasSize(1);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
@@ -34,7 +34,6 @@ import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.Role;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.ToolCall;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.ToolChoiceBuilder;
-import org.springframework.ai.openai.api.OpenAiApi.FunctionTool.Type;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +70,7 @@ public class OpenAiApiToolFunctionCallIT {
 		var message = new ChatCompletionMessage("What's the weather like in San Francisco, Tokyo, and Paris?",
 				Role.USER);
 
-		var functionTool = new OpenAiApi.FunctionTool(Type.FUNCTION,
+		var functionTool = new OpenAiApi.FunctionTool(OpenAiApi.FunctionTool.Type.FUNCTION,
 				new OpenAiApi.FunctionTool.Function("Get the weather in location. Return temperature in Celsius.",
 						"getCurrentWeather", ModelOptionsUtils.jsonToMap("""
 								{

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -68,7 +68,6 @@ import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionMessage.Media
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionMessage.Role;
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionMessage.ToolCall;
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionRequest;
-import org.springframework.ai.zhipuai.api.ZhiPuAiApi.FunctionTool;
 import org.springframework.ai.zhipuai.api.ZhiPuApiConstants;
 import org.springframework.ai.zhipuai.metadata.ZhiPuAiUsage;
 import org.springframework.http.ResponseEntity;
@@ -470,11 +469,11 @@ public class ZhiPuAiChatModel extends AbstractToolCallSupport implements ChatMod
 			.build();
 	}
 
-	private List<FunctionTool> getFunctionTools(Set<String> functionNames) {
+	private List<ZhiPuAiApi.FunctionTool> getFunctionTools(Set<String> functionNames) {
 		return this.resolveFunctionCallbacks(functionNames).stream().map(functionCallback -> {
-			var function = new FunctionTool.Function(functionCallback.getDescription(), functionCallback.getName(),
-					functionCallback.getInputTypeSchema());
-			return new FunctionTool(function);
+			var function = new ZhiPuAiApi.FunctionTool.Function(functionCallback.getDescription(),
+					functionCallback.getName(), functionCallback.getInputTypeSchema());
+			return new ZhiPuAiApi.FunctionTool(function);
 		}).toList();
 	}
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -31,7 +31,6 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.model.function.FunctionCallingOptions;
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi;
-import org.springframework.ai.zhipuai.api.ZhiPuAiApi.FunctionTool;
 import org.springframework.util.Assert;
 
 /**
@@ -74,7 +73,10 @@ public class ZhiPuAiChatOptions implements FunctionCallingOptions, ChatOptions {
 	 * A list of tools the model may call. Currently, only functions are supported as a tool. Use this to
 	 * provide a list of functions the model may generate JSON inputs for.
 	 */
-	private @JsonProperty("tools") List<FunctionTool> tools;
+	private @JsonProperty("tools") List<ZhiPuAiApi.FunctionTool> tools;
+
+	private @JsonProperty("tools1")  List<ZhiPuAiApi.Foo> foos;
+
 	/**
 	 * Controls which (if any) function is called by the model. none means the model will not call a
 	 * function and instead generates a message. auto means the model can pick between generating a message or calling a
@@ -207,11 +209,11 @@ public class ZhiPuAiChatOptions implements FunctionCallingOptions, ChatOptions {
 		this.topP = topP;
 	}
 
-	public List<FunctionTool> getTools() {
+	public List<ZhiPuAiApi.FunctionTool> getTools() {
 		return this.tools;
 	}
 
-	public void setTools(List<FunctionTool> tools) {
+	public void setTools(List<ZhiPuAiApi.FunctionTool> tools) {
 		this.tools = tools;
 	}
 
@@ -473,7 +475,7 @@ public class ZhiPuAiChatOptions implements FunctionCallingOptions, ChatOptions {
 			return this;
 		}
 
-		public Builder withTools(List<FunctionTool> tools) {
+		public Builder withTools(List<ZhiPuAiApi.FunctionTool> tools) {
 			this.options.tools = tools;
 			return this;
 		}

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -312,16 +312,48 @@ public class ZhiPuAiApi {
 		}
 	}
 
+	public class Foo {
+
+		String foo;
+
+		public Foo() {
+
+		}
+		public Foo(String foo) {
+			this.foo = foo;
+		}
+	}
+
+
 	/**
 	 * Represents a tool the model may call. Currently, only functions are supported as a tool.
-	 *
-	 * @param type The type of the tool. Currently, only 'function' is supported.
-	 * @param function The function definition.
 	 */
-	@JsonInclude(Include.NON_NULL)
-	public record FunctionTool(
-			@JsonProperty("type") Type type,
-			@JsonProperty("function") Function function) {
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public static class FunctionTool {
+
+		// The type of the tool. Currently, only 'function' is supported.
+		@JsonProperty("type")
+		private Function function;
+
+		//	The function definition.
+		@JsonProperty("function")
+		private Type type = Type.FUNCTION;
+
+		public FunctionTool() {
+
+		}
+
+		/**
+		 * Create a tool of type 'function' and the given function definition.
+		 * @param type the tool type
+		 * @param function function definition
+		 */
+		public FunctionTool(
+				Type type,
+				Function function) {
+			this.type = type;
+			this.function = function;
+		}
 
 		/**
 		 * Create a tool of type 'function' and the given function definition.
@@ -329,6 +361,22 @@ public class ZhiPuAiApi {
 		 */
 		public FunctionTool(Function function) {
 			this(Type.FUNCTION, function);
+		}
+
+		public Type getType() {
+			return this.type;
+		}
+
+		public Function getFunction() {
+			return this.function;
+		}
+
+		public void setType(Type type) {
+			this.type = type;
+		}
+
+		public void setFunction(Function function) {
+			this.function = function;
 		}
 
 		/**
@@ -344,18 +392,42 @@ public class ZhiPuAiApi {
 
 		/**
 		 * Function definition.
-		 *
-		 * @param description A description of what the function does, used by the model to choose when and how to call
-		 * the function.
-		 * @param name The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes,
-		 * with a maximum length of 64.
-		 * @param parameters The parameters the functions accepts, described as a JSON Schema object. To describe a
-		 * function that accepts no parameters, provide the value {"type": "object", "properties": {}}.
 		 */
-		public record Function(
-				@JsonProperty("description") String description,
-				@JsonProperty("name") String name,
-				@JsonProperty("parameters") Map<String, Object> parameters) {
+		public static class Function {
+
+			@JsonProperty("description")
+			private String description;
+
+			@JsonProperty("name")
+			private String name;
+
+			@JsonProperty("parameters")
+			private Map<String, Object> parameters;
+
+			private String jsonSchema;
+
+			private Function() {
+
+			}
+
+			/**
+			 * Create tool function definition.
+			 *
+			 * @param description A description of what the function does, used by the model to choose when and how to call
+			 * the function.
+			 * @param name The name of the function to be called. Must be a-z, A-Z, 0-9, or contain underscores and dashes,
+			 * with a maximum length of 64.
+			 * @param parameters The parameters the functions accepts, described as a JSON Schema object. To describe a
+			 * function that accepts no parameters, provide the value {"type": "object", "properties": {}}.
+			 */
+			public Function(
+					String description,
+					String name,
+					Map<String, Object> parameters) {
+				this.description = description;
+				this.name = name;
+				this.parameters = parameters;
+			}
 
 			/**
 			 * Create tool function definition.
@@ -367,6 +439,42 @@ public class ZhiPuAiApi {
 			public Function(String description, String name, String jsonSchema) {
 				this(description, name, ModelOptionsUtils.jsonToMap(jsonSchema));
 			}
+
+			public String getDescription() {
+				return this.description;
+			}
+
+			public String getName() {
+				return this.name;
+			}
+
+			public Map<String, Object> getParameters() {
+				return this.parameters;
+			}
+
+			public void setDescription(String description) {
+				this.description = description;
+			}
+
+			public void setName(String name) {
+				this.name = name;
+			}
+
+			public void setParameters(Map<String, Object> parameters) {
+				this.parameters = parameters;
+			}
+
+			public String getJsonSchema() {
+				return this.jsonSchema;
+			}
+
+			public void setJsonSchema(String jsonSchema) {
+				this.jsonSchema = jsonSchema;
+				if (jsonSchema != null) {
+					this.parameters = ModelOptionsUtils.jsonToMap(jsonSchema);
+				}
+			}
+
 		}
 	}
 

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ChatCompletionRequestTests.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ChatCompletionRequestTests.java
@@ -83,7 +83,7 @@ public class ChatCompletionRequestTests {
 		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).isEqualTo(TOOL_FUNCTION_NAME);
+		assertThat(request.tools().get(0).getFunction().getName()).isEqualTo(TOOL_FUNCTION_NAME);
 	}
 
 	@Test
@@ -120,7 +120,7 @@ public class ChatCompletionRequestTests {
 				ZhiPuAiChatOptions.builder().withFunction(TOOL_FUNCTION_NAME).build()), false);
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).as("Explicitly enabled function")
+		assertThat(request.tools().get(0).getFunction().getName()).as("Explicitly enabled function")
 			.isEqualTo(TOOL_FUNCTION_NAME);
 
 		// Override the default options function with one from the prompt
@@ -134,7 +134,7 @@ public class ChatCompletionRequestTests {
 				false);
 
 		assertThat(request.tools()).hasSize(1);
-		assertThat(request.tools().get(0).function().name()).as("Explicitly enabled function")
+		assertThat(request.tools().get(0).getFunction().getName()).as("Explicitly enabled function")
 			.isEqualTo(TOOL_FUNCTION_NAME);
 
 		assertThat(client.getFunctionCallbackRegister()).hasSize(1);

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiApiToolFunctionCallIT.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiApiToolFunctionCallIT.java
@@ -34,7 +34,6 @@ import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionMessage.Role;
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionMessage.ToolCall;
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionRequest;
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi.ChatCompletionRequest.ToolChoiceBuilder;
-import org.springframework.ai.zhipuai.api.ZhiPuAiApi.FunctionTool.Type;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,7 +67,7 @@ public class ZhiPuAiApiToolFunctionCallIT {
 		var message = new ChatCompletionMessage(
 				"What's the weather like in San Francisco? Return the temperature in Celsius.", Role.USER);
 
-		var functionTool = new ZhiPuAiApi.FunctionTool(Type.FUNCTION,
+		var functionTool = new ZhiPuAiApi.FunctionTool(ZhiPuAiApi.FunctionTool.Type.FUNCTION,
 				new ZhiPuAiApi.FunctionTool.Function(
 						"Get the weather in location. Return temperature in 30°F or 30°C format.", "getCurrentWeather",
 						ModelOptionsUtils.jsonToMap("""

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/MiniMaxPropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/MiniMaxPropertiesTests.java
@@ -229,11 +229,11 @@ public class MiniMaxPropertiesTests {
 
 				assertThat(chatProperties.getOptions().getTools()).hasSize(1);
 				var tool = chatProperties.getOptions().getTools().get(0);
-				assertThat(tool.type()).isEqualTo(MiniMaxApi.FunctionTool.Type.FUNCTION);
-				var function = tool.function();
-				assertThat(function.name()).isEqualTo("myFunction1");
-				assertThat(function.description()).isEqualTo("function description");
-				assertThat(function.parameters()).isNotEmpty();
+				assertThat(tool.getType()).isEqualTo(MiniMaxApi.FunctionTool.Type.FUNCTION);
+				var function = tool.getFunction();
+				assertThat(function.getName()).isEqualTo("myFunction1");
+				assertThat(function.getDescription()).isEqualTo("function description");
+				assertThat(function.getParameters()).isNotEmpty();
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/OpenAiPropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/OpenAiPropertiesTests.java
@@ -26,8 +26,8 @@ import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.OpenAiImageModel;
+import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.ToolChoiceBuilder;
-import org.springframework.ai.openai.api.OpenAiApi.FunctionTool.Type;
 import org.springframework.ai.openai.api.OpenAiAudioApi;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -426,11 +426,11 @@ public class OpenAiPropertiesTests {
 
 				assertThat(chatProperties.getOptions().getTools()).hasSize(1);
 				var tool = chatProperties.getOptions().getTools().get(0);
-				assertThat(tool.type()).isEqualTo(Type.FUNCTION);
-				var function = tool.function();
-				assertThat(function.name()).isEqualTo("myFunction1");
-				assertThat(function.description()).isEqualTo("function description");
-				assertThat(function.parameters()).isNotEmpty();
+				assertThat(tool.getType()).isEqualTo(OpenAiApi.FunctionTool.Type.FUNCTION);
+				var function = tool.getFunction();
+				assertThat(function.getName()).isEqualTo("myFunction1");
+				assertThat(function.getDescription()).isEqualTo("function description");
+				assertThat(function.getParameters()).isNotEmpty();
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
@@ -36,6 +36,7 @@ import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.observation.DefaultVectorStoreObservationConvention;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationDocumentation.HighCardinalityKeyNames;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -127,11 +128,12 @@ public class ChromaVectorStoreAutoConfigurationIT {
 
 	@Test
 	public void throwExceptionOnMissingCollectionAndDisabledInitializedSchema() {
-
 		this.contextRunner.withPropertyValues("spring.ai.vectorstore.chroma.initializeSchema=false")
 			.run(context -> assertThatThrownBy(() -> context.getBean(VectorStore.class))
-				.isInstanceOf(RuntimeException.class)
-				.hasMessage(
+				.isInstanceOf(IllegalStateException.class)
+				.hasCauseInstanceOf(BeanCreationException.class)
+				.hasRootCauseExactlyInstanceOf(RuntimeException.class)
+				.hasRootCauseMessage(
 						"Collection TestCollection doesn't exist and won't be created as the initializeSchema is set to false."));
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/hanadb/HanaCloudVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/hanadb/HanaCloudVectorStoreAutoConfigurationIT.java
@@ -18,9 +18,9 @@ package org.springframework.ai.autoconfigure.vectorstore.hanadb;
 
 import java.util.List;
 
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration;

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/ZhiPuAiPropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/ZhiPuAiPropertiesTests.java
@@ -273,11 +273,11 @@ public class ZhiPuAiPropertiesTests {
 
 				assertThat(chatProperties.getOptions().getTools()).hasSize(1);
 				var tool = chatProperties.getOptions().getTools().get(0);
-				assertThat(tool.type()).isEqualTo(ZhiPuAiApi.FunctionTool.Type.FUNCTION);
-				var function = tool.function();
-				assertThat(function.name()).isEqualTo("myFunction1");
-				assertThat(function.description()).isEqualTo("function description");
-				assertThat(function.parameters()).isNotEmpty();
+				assertThat(tool.getType()).isEqualTo(ZhiPuAiApi.FunctionTool.Type.FUNCTION);
+				var function = tool.getFunction();
+				assertThat(function.getName()).isEqualTo("myFunction1");
+				assertThat(function.getDescription()).isEqualTo("function description");
+				assertThat(function.getParameters()).isNotEmpty();
 			});
 	}
 


### PR DESCRIPTION
Following removal of Spring Boot's ConstructorBinding, convert record types to regular POJOs to maintain JSON serialization. Update API classes:

- Convert FunctionTool and Function records to standard Java classes with getters/setters
- Update test assertions to use getter methods instead of record accessors
- Fix failing tests in MiniMax, OpenAi and ZhiPu API implementations

This keeps core API models independent of Spring Boot while ensuring proper serialization through standard Java beans.

