### PR TITLE
Support case with missing system text in VectorStoreChatMemoryAdvisor

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
@@ -37,11 +37,13 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.model.Content;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.util.StringUtils;
 
 /**
  * Memory is retrieved from a VectorStore added into the prompt's system text.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<VectorStore> {
@@ -58,7 +60,6 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 			LONG_TERM_MEMORY:
 			{long_term_memory}
 			---------------------
-
 			""";
 
 	private final String systemTextAdvise;
@@ -128,7 +129,13 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 
 	private AdvisedRequest before(AdvisedRequest request) {
 
-		String advisedSystemText = request.systemText() + System.lineSeparator() + this.systemTextAdvise;
+		String advisedSystemText;
+		if (StringUtils.hasText(request.systemText())) {
+			advisedSystemText = request.systemText() + System.lineSeparator() + this.systemTextAdvise;
+		}
+		else {
+			advisedSystemText = this.systemTextAdvise;
+		}
 
 		var searchRequest = SearchRequest.query(request.userText())
 			.withTopK(this.doGetChatMemoryRetrieveSize(request.adviseContext()))

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
@@ -106,7 +106,6 @@ class PgVectorStoreWithChatMemoryAdvisorIT {
 		assertThat(promptCaptor.getValue().getInstructions().get(0)).isInstanceOf(SystemMessage.class);
 		assertThat(promptCaptor.getValue().getInstructions().get(0).getContent()).isEqualTo("""
 
-
 				Use the long term conversation memory from the LONG_TERM_MEMORY section to provide accurate answers.
 
 				---------------------
@@ -114,7 +113,6 @@ class PgVectorStoreWithChatMemoryAdvisorIT {
 				Tell me a good joke
 				Tell me a bad joke
 				---------------------
-
 				""");
 	}
 


### PR DESCRIPTION
The system text advise prompt is only joined with the value of the system text if it's non-null and non-empty.