### PR TITLE
Fix duplicate keys in ChatResponseMetadata for OllamaApi.ChatResponse

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -74,6 +74,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author luocongqiu
  * @author Thomas Vitale
+ * @author Jihoon Kim
  * @since 1.0.0
  */
 public class OllamaChatModel extends AbstractToolCallSupport implements ChatModel {
@@ -97,7 +98,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 		Assert.notNull(ollamaApi, "ollamaApi must not be null");
 		Assert.notNull(defaultOptions, "defaultOptions must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
-		Assert.notNull(observationRegistry, "modelManagementOptions must not be null");
+		Assert.notNull(modelManagementOptions, "modelManagementOptions must not be null");
 		this.chatApi = ollamaApi;
 		this.defaultOptions = defaultOptions;
 		this.observationRegistry = observationRegistry;
@@ -118,8 +119,8 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 			.withKeyValue("eval-duration", response.evalDuration())
 			.withKeyValue("eval-count", response.evalCount())
 			.withKeyValue("load-duration", response.loadDuration())
-			.withKeyValue("eval-duration", response.promptEvalDuration())
-			.withKeyValue("eval-count", response.promptEvalCount())
+			.withKeyValue("prompt-eval-duration", response.promptEvalDuration())
+			.withKeyValue("prompt-eval-count", response.promptEvalCount())
 			.withKeyValue("total-duration", response.totalDuration())
 			.withKeyValue("done", response.done())
 			.build();

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.ollama;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.ai.ollama.api.OllamaModel;
+import org.springframework.ai.ollama.api.OllamaOptions;
+
+/**
+ * @author Jihoon Kim
+ * @since 1.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+public class OllamaChatModelTests {
+
+	@Mock
+	OllamaApi ollamaApi;
+
+	@Mock
+	OllamaApi.ChatResponse response;
+
+	@Test
+	public void buildOllamaChatModel() {
+		Exception exception = assertThrows(IllegalArgumentException.class,
+				() -> OllamaChatModel.builder()
+					.withOllamaApi(ollamaApi)
+					.withDefaultOptions(OllamaOptions.create().withModel(OllamaModel.LLAMA2))
+					.withModelManagementOptions(null)
+					.build());
+		assertEquals("modelManagementOptions must not be null", exception.getMessage());
+	}
+
+	@Test
+	public void buildChatResponseMetadata() {
+		Duration evalDuration = Duration.ofSeconds(1);
+		Integer evalCount = 101;
+
+		Duration promptEvalDuration = Duration.ofSeconds(8);
+		Integer promptEvalCount = 808;
+
+		given(response.evalDuration()).willReturn(evalDuration);
+		given(response.evalCount()).willReturn(evalCount);
+		given(response.promptEvalDuration()).willReturn(promptEvalDuration);
+		given(response.promptEvalCount()).willReturn(promptEvalCount);
+
+		ChatResponseMetadata metadata = OllamaChatModel.from(response);
+
+		assertEquals(evalDuration, metadata.get("eval-duration"));
+		assertEquals(evalCount, metadata.get("eval-count"));
+		assertEquals(promptEvalDuration, metadata.get("prompt-eval-duration"));
+		assertEquals(promptEvalCount, metadata.get("prompt-eval-count"));
+	}
+
+}


### PR DESCRIPTION
1. Resolve duplicate metadata keys when creating ChatResponseMetadata from OllamaApi.ChatResponse. 

`eval-duration` and `eval-count` were duplicated.
so they have been updated to `prompt-eval-duration` and `prompt-eval-count` to avoid overwrite.

AS-IS
<img width="1753" alt="image" src="https://github.com/user-attachments/assets/86691931-a077-4644-938f-fb813db7d407">

TO-BE
<img width="1761" alt="image" src="https://github.com/user-attachments/assets/b10d18fd-3ec3-4931-b65c-95b8e3505bc3">


2. Fix assertion for `ModelManagementOptions` .

AS-IS
Incorrect object was being asserted. `observationRegistry`
So, NPE occurs at line 105 where OllamaModelManager is being created.
<img width="1860" alt="image" src="https://github.com/user-attachments/assets/00a20888-5b2c-4e32-b234-2baace224d5f">

TO-BE
Replace observationRegistry with `ModelManagementOptions`
Proper exception handling and error messages for modelManagementOptions.
<img width="1939" alt="image" src="https://github.com/user-attachments/assets/fafe11a9-4823-452a-9691-203140fb7caf">
