### PR TITLE
GH-1335: Add JSON schema property order support

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -54,6 +54,7 @@ import org.springframework.lang.NonNull;
  * @author Kirk Lund
  * @author Josh Long
  * @author Sebastien Deleuze
+ * @author Soby Chacko
  */
 public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 
@@ -125,7 +126,8 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 * Generates the JSON schema for the target type.
 	 */
 	private void generateSchema() {
-		JacksonModule jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED);
+		JacksonModule jacksonModule = new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+				JacksonOption.RESPECT_JSONPROPERTY_ORDER);
 		SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(
 				com.github.victools.jsonschema.generator.SchemaVersion.DRAFT_2020_12,
 				com.github.victools.jsonschema.generator.OptionPreset.PLAIN_JSON)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output-converter.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/structured-output-converter.adoc
@@ -139,6 +139,21 @@ Generation generation = chatModel.call(
 ActorsFilms actorsFilms = this.beanOutputConverter.convert(this.generation.getOutput().getContent());
 ----
 
+=== Property Ordering in Generated Schema
+
+The `BeanOutputConverter` supports custom property ordering in the generated JSON schema through the `@JsonPropertyOrder` annotation.
+This annotation allows you to specify the exact sequence in which properties should appear in the schema, regardless of their declaration order in the class or record.
+
+For example, to ensure specific ordering of properties in the `ActorsFilms` record:
+
+[source,java]
+----
+@JsonPropertyOrder({"actor", "movies"})
+record ActorsFilms(String actor, List<String> movies) {}
+----
+
+This annotation works with both records and regular Java classes.
+
 ==== Generic Bean Types
 
 Use the `ParameterizedTypeReference` constructor to specify a more complex target class structure.


### PR DESCRIPTION
Fixes: #1335

https://github.com/spring-projects/spring-ai/issues/1335

Add support for maintaining JSON property order in generated schemas using @JsonPropertyOrder. Users can now control the order of properties in their JSON schemas by annotating their classes/records with @JsonPropertyOrder.

- Add JacksonOption.RESPECT_JSONPROPERTY_ORDER to BeanOutputConverter
- Add test to verify schema property ordering
- Update documentation with property ordering example
