### PR TITLE
GH-1679 Disable BedrockConverseProxyChatAutoConfiguration by default

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/bedrock-converse.adoc
@@ -73,7 +73,7 @@ The prefix `spring.ai.bedrock.converse.chat` is the property prefix that configu
 |====
 | Property | Description | Default
 
-| spring.ai.bedrock.converse.chat.enabled | Enable Bedrock Converse chat model. | true
+| spring.ai.bedrock.converse.chat.enabled | Enable Bedrock Converse chat model. | false
 | spring.ai.bedrock.converse.chat.options.model | The model ID to use. You can use the https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html[Supported models and model features]  | anthropic.claude-3-sonnet-20240229-v1:0
 | spring.ai.bedrock.converse.chat.options.temperature | Controls the randomness of the output. Values can range over [0.0,1.0] | 0.8
 | spring.ai.bedrock.converse.chat.options.top-p | The maximum cumulative probability of tokens to consider when sampling. | AWS Bedrock default

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatAutoConfiguration.java
@@ -53,7 +53,7 @@ import org.springframework.context.annotation.Import;
 @EnableConfigurationProperties({ BedrockConverseProxyChatProperties.class, BedrockAwsConnectionConfiguration.class })
 @ConditionalOnClass({ BedrockRuntimeClient.class, BedrockRuntimeAsyncClient.class })
 @ConditionalOnProperty(prefix = BedrockConverseProxyChatProperties.CONFIG_PREFIX, name = "enabled",
-		havingValue = "true", matchIfMissing = true)
+		havingValue = "true")
 @Import(BedrockAwsConnectionConfiguration.class)
 public class BedrockConverseProxyChatAutoConfiguration {
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatProperties.java
@@ -35,7 +35,7 @@ public class BedrockConverseProxyChatProperties {
 	/**
 	 * Enable Bedrock Converse chat model.
 	 */
-	private boolean enabled = true;
+	private boolean enabled = false;
 
 	@NestedConfigurationProperty
 	private PortableFunctionCallingOptions options = PortableFunctionCallingOptions.builder()

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatAutoConfigurationIT.java
@@ -43,7 +43,7 @@ public class BedrockConverseProxyChatAutoConfigurationIT {
 	private static final Log logger = LogFactory.getLog(BedrockConverseProxyChatAutoConfigurationIT.class);
 
 	private final ApplicationContextRunner contextRunner = BedrockTestUtils.getContextRunner()
-		.withPropertyValues(
+		.withPropertyValues("spring.ai.bedrock.converse.chat.enabled=true",
 				"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0",
 				"spring.ai.bedrock.converse.chat.options.temperature=0.5")
 		.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class));

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatPropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatPropertiesTests.java
@@ -35,6 +35,7 @@ public class BedrockConverseProxyChatPropertiesTests {
 
 		new ApplicationContextRunner().withPropertyValues(
 		// @formatter:off
+				"spring.ai.bedrock.converse.chat.enabled=true",
 				"spring.ai.bedrock.converse.chat.options.model=MODEL_XYZ",
 
 				"spring.ai.bedrock.converse.chat.options.max-tokens=123",
@@ -65,10 +66,10 @@ public class BedrockConverseProxyChatPropertiesTests {
 	@Test
 	public void chatCompletionDisabled() {
 
-		// It is enabled by default
+		// It is disabled by default
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class))
-			.run(context -> assertThat(context.getBeansOfType(BedrockConverseProxyChatProperties.class)).isNotEmpty());
+			.run(context -> assertThat(context.getBeansOfType(BedrockConverseProxyChatProperties.class)).isEmpty());
 
 		// Explicitly enable the chat auto-configuration.
 		new ApplicationContextRunner().withPropertyValues("spring.ai.bedrock.converse.chat.enabled=true")

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/tool/FunctionCallWithFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/tool/FunctionCallWithFunctionBeanIT.java
@@ -55,7 +55,7 @@ class FunctionCallWithFunctionBeanIT {
 	void functionCallTest() {
 
 		this.contextRunner
-			.withPropertyValues(
+			.withPropertyValues("spring.ai.bedrock.converse.chat.enabled=true",
 					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0")
 			.run(context -> {
 
@@ -84,7 +84,7 @@ class FunctionCallWithFunctionBeanIT {
 	void functionStreamTest() {
 
 		this.contextRunner
-			.withPropertyValues(
+			.withPropertyValues("spring.ai.bedrock.converse.chat.enabled=true",
 					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0")
 			.run(context -> {
 


### PR DESCRIPTION
  - Set the default value for spring.ai.bedrock.anthropic.chat.enabled to false to disable the BedrockConverseProxyChatAutoConfiguration by default
  - This will make sure that the BedrockConverseProxy auto configuration wouldn't conflict with other related Bedrock autoconfigs (ex: BedrockAnthropic3ChatAutoConfiguration)

 - Update documentation for the default behaviour
 - Update tests

Resolves #1679
