### PR TITLE
[WIP] feat: Add support for Consumer and Supplier function callbacks

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
@@ -211,7 +211,7 @@ class AnthropicChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris?  Use Celsius."))
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.call()
 				.content();
 		// @formatter:on
@@ -226,7 +226,7 @@ class AnthropicChatClientIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultFunction("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.defaultFunction("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Use Celsius."))
 				.build()
 			.prompt()
@@ -245,7 +245,7 @@ class AnthropicChatClientIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Use Celsius.")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.stream()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseChatClientIT.java
@@ -212,7 +212,7 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel)
 				.prompt("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.call()
 				.content();
 		// @formatter:on
@@ -228,7 +228,7 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel)
 				.prompt("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.advisors(new SimpleLoggerAdvisor())
 				.call()
 				.content();
@@ -244,7 +244,7 @@ class BedrockConverseChatClientIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-			.defaultFunction("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+			.defaultFunction("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 			.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius."))
 			.build()
 			.prompt()
@@ -263,7 +263,7 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius.")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.stream()
 				.content();
 		// @formatter:on
@@ -280,7 +280,7 @@ class BedrockConverseChatClientIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in Paris? Return the temperature in Celsius.")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.stream()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
@@ -224,7 +224,7 @@ class MistralAiChatClientIT {
 		String response = ChatClient.create(this.chatModel).prompt()
 				.options(MistralAiChatOptions.builder().withModel(MistralAiApi.ChatModel.SMALL).withToolChoice(ToolChoice.AUTO).build())
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Use parallel function calling if required. Response should be in Celsius."))
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.call()
 				.content();
 		// @formatter:on
@@ -242,7 +242,7 @@ class MistralAiChatClientIT {
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
 				.defaultOptions(MistralAiChatOptions.builder().withModel(MistralAiApi.ChatModel.SMALL).build())
-				.defaultFunction("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.defaultFunction("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris? Use parallel function calling if required. Response should be in Celsius."))
 			.build()
 			.prompt().call().content();
@@ -262,7 +262,7 @@ class MistralAiChatClientIT {
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.options(MistralAiChatOptions.builder().withModel(MistralAiApi.ChatModel.SMALL).build())
 				.user("What's the weather like in San Francisco, Tokyo, and Paris? Use parallel function calling if required. Response should be in Celsius.")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.stream()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiTestConfiguration.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiTestConfiguration.java
@@ -79,7 +79,6 @@ public class OpenAiTestConfiguration {
 	@Bean
 	public OpenAiImageModel openAiImageModel(OpenAiImageApi imageApi) {
 		OpenAiImageModel openAiImageModel = new OpenAiImageModel(imageApi);
-		// openAiImageModel.setModel("foobar");
 		return openAiImageModel;
 	}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
@@ -249,7 +249,7 @@ class OpenAiChatClientIT extends AbstractIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris?"))
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.call()
 				.content();
 		// @formatter:on
@@ -287,12 +287,9 @@ class OpenAiChatClientIT extends AbstractIT {
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
 				.user("Turn the light on in the kitchen and in the living room")
-				.function("turnLight", "Turn light on or off in a room",  new Consumer<LightInfo>() {
-					@Override
-					public void accept(LightInfo lightInfo) {
+				.function("turnLight", "Turn light on or off in a room",  LightInfo.class, (LightInfo lightInfo) -> {
 						logger.info("Turning light to [" + lightInfo.isOn + "] in " + lightInfo.roomName());
 						state.put(lightInfo.roomName(), lightInfo.isOn());
-					}
 				})
 				.call()
 				.content();
@@ -308,7 +305,8 @@ class OpenAiChatClientIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultFunction("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.defaultFunction("getCurrentWeather", "Get the weather in location",
+					MockWeatherService.Request.class, new MockWeatherService())
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris?"))
 			.build()
 			.prompt().call().content();
@@ -325,7 +323,8 @@ class OpenAiChatClientIT extends AbstractIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", 
+				MockWeatherService.Request.class, new MockWeatherService())
 				.stream()
 				.content();
 		// @formatter:on

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientMultipleFunctionCallsIT.java
@@ -83,7 +83,8 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 		// @formatter:off
 		response = chatClientBuilder.build().prompt()
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris?"))
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", 
+				MockWeatherService.Request.class, new MockWeatherService())
 				.call()
 				.content();
 		// @formatter:on
@@ -110,7 +111,8 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultFunction("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.defaultFunction("getCurrentWeather", "Get the weather in location", 
+					MockWeatherService.Request.class, new MockWeatherService())
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris?"))
 			.build()
 			.prompt().call().content();
@@ -149,7 +151,7 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultFunction("getCurrentWeather", "Get the weather in location", biFunction)
+				.defaultFunction("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, biFunction)
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris?"))
 				.defaultToolContext(Map.of("sessionId", "123"))
 			.build()
@@ -189,7 +191,7 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 
 		// @formatter:off
 		String response = ChatClient.builder(this.chatModel)
-				.defaultFunction("getCurrentWeather", "Get the weather in location", biFunction)
+				.defaultFunction("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, biFunction)
 				.defaultUser(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris?"))
 				.build()
 			.prompt()
@@ -208,7 +210,7 @@ class OpenAiChatClientMultipleFunctionCallsIT extends AbstractIT {
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
 				.user("What's the weather like in San Francisco, Tokyo, and Paris?")
-				.function("getCurrentWeather", "Get the weather in location", new MockWeatherService())
+				.function("getCurrentWeather", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 				.stream()
 				.content();
 		// @formatter:on

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -212,20 +212,38 @@ public interface ChatClient {
 
 		<T extends ChatOptions> ChatClientRequestSpec options(T options);
 
+		/**
+		 * @deprecated Use
+		 * {@link #function(String, String, Class, java.util.function.Function)} instead.
+		 * Because of JVM type erasure, for lambda to work, the inputType class is
+		 * required to be provided explicitly.
+		 */
+		@Deprecated
 		<I, O> ChatClientRequestSpec function(String name, String description,
 				java.util.function.Function<I, O> function);
-
-		<I, O> ChatClientRequestSpec function(String name, String description,
-				java.util.function.BiFunction<I, ToolContext, O> function);
-
-		<I, O> ChatClientRequestSpec functions(FunctionCallback... functionCallbacks);
 
 		<I, O> ChatClientRequestSpec function(String name, String description, Class<I> inputType,
 				java.util.function.Function<I, O> function);
 
+		/**
+		 * @deprecated Use
+		 * {@link #functions(String, String, Class,java.util.function.BiFunction)} Because
+		 * of JVM type erasure, for lambda to work, the inputType class is required to be
+		 * provided explicitly.
+		 */
+		@Deprecated
+		<I, O> ChatClientRequestSpec function(String name, String description,
+				java.util.function.BiFunction<I, ToolContext, O> function);
+
+		<I, O> ChatClientRequestSpec function(String name, String description, Class<I> inputType,
+				java.util.function.BiFunction<I, ToolContext, O> function);
+
+		<I, O> ChatClientRequestSpec functions(FunctionCallback... functionCallbacks);
+
 		<I, O> ChatClientRequestSpec function(String name, String description, java.util.function.Supplier<O> supplier);
 
-		<I, O> ChatClientRequestSpec function(String name, String description, java.util.function.Consumer<I> consumer);
+		<I, O> ChatClientRequestSpec function(String name, String description, Class<I> inputType,
+				java.util.function.Consumer<I> consumer);
 
 		ChatClientRequestSpec functions(String... functionBeanNames);
 
@@ -282,10 +300,35 @@ public interface ChatClient {
 
 		Builder defaultSystem(Consumer<PromptSystemSpec> systemSpecConsumer);
 
+		/**
+		 * @deprecated Use
+		 * {@link #defaultFunction(String, String, Class, java.util.function.Function)}
+		 * instead. Because of JVM type erasure, for lambda to work, the inputType class
+		 * is required to be provided explicitly.
+		 */
+		@Deprecated
 		<I, O> Builder defaultFunction(String name, String description, java.util.function.Function<I, O> function);
 
+		<I, O> Builder defaultFunction(String name, String description, Class<I> inputType,
+				java.util.function.Function<I, O> function);
+
+		/**
+		 * @deprecated Use
+		 * {@link #defaultFunction(String, String, Class, java.util.function.BiFunction)}
+		 * instead. Because of JVM type erasure, for lambda to work, the inputType class
+		 * is required to be provided explicitly.
+		 */
+		@Deprecated
 		<I, O> Builder defaultFunction(String name, String description,
 				java.util.function.BiFunction<I, ToolContext, O> function);
+
+		<I, O> Builder defaultFunction(String name, String description, Class<I> inputType,
+				java.util.function.BiFunction<I, ToolContext, O> function);
+
+		<I, O> Builder defaultFunction(String name, String description, java.util.function.Supplier<O> supplier);
+
+		<I, O> Builder defaultFunction(String name, String description, Class<I> inputType,
+				java.util.function.Consumer<I> consumer);
 
 		Builder defaultFunctions(String... functionNames);
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -223,6 +223,10 @@ public interface ChatClient {
 		<I, O> ChatClientRequestSpec function(String name, String description, Class<I> inputType,
 				java.util.function.Function<I, O> function);
 
+		<I, O> ChatClientRequestSpec function(String name, String description, java.util.function.Supplier<O> supplier);
+
+		<I, O> ChatClientRequestSpec function(String name, String description, java.util.function.Consumer<I> consumer);
+
 		ChatClientRequestSpec functions(String... functionBeanNames);
 
 		ChatClientRequestSpec toolContext(Map<String, Object> toolContext);

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -836,11 +836,40 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		/**
+		 * @deprecated since 1.0.0 in favor of
+		 * {@link #function(String, String, Class, java.util.function.Function)} Because
+		 * of JVM type erasure, the inputType class is required to be provided explicitly.
+		 */
+		@Deprecated(since = "1.0.0", forRemoval = true)
 		public <I, O> ChatClientRequestSpec function(String name, String description,
 				java.util.function.Function<I, O> function) {
 			return this.function(name, description, null, function);
 		}
 
+		public <I, O> ChatClientRequestSpec function(String name, String description, @Nullable Class<I> inputType,
+				java.util.function.Function<I, O> function) {
+
+			Assert.hasText(name, "name cannot be null or empty");
+			Assert.hasText(description, "description cannot be null or empty");
+			Assert.notNull(function, "function cannot be null");
+
+			var fcw = FunctionCallbackWrapper.builder(function)
+				.withDescription(description)
+				.withName(name)
+				.withInputType(inputType)
+				.withResponseConverter(Object::toString)
+				.build();
+			this.functionCallbacks.add(fcw);
+			return this;
+		}
+
+		/**
+		 * @deprecated since 1.0.0 in favor of
+		 * {@link #function(String, String, Class, java.util.function.BiFunction)} Because
+		 * of JVM type erasure, the inputType class is required to be provided explicitly.
+		 */
+		@Deprecated
 		public <I, O> ChatClientRequestSpec function(String name, String description,
 				java.util.function.BiFunction<I, ToolContext, O> biFunction) {
 
@@ -857,14 +886,14 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
-		public <I, O> ChatClientRequestSpec function(String name, String description, @Nullable Class<I> inputType,
-				java.util.function.Function<I, O> function) {
+		public <I, O> ChatClientRequestSpec function(String name, String description, Class<I> inputType,
+				java.util.function.BiFunction<I, ToolContext, O> biFunction) {
 
 			Assert.hasText(name, "name cannot be null or empty");
 			Assert.hasText(description, "description cannot be null or empty");
-			Assert.notNull(function, "function cannot be null");
+			Assert.notNull(biFunction, "biFunction cannot be null");
 
-			var fcw = FunctionCallbackWrapper.builder(function)
+			FunctionCallbackWrapper<I, O> fcw = FunctionCallbackWrapper.builder(biFunction)
 				.withDescription(description)
 				.withName(name)
 				.withInputType(inputType)
@@ -890,7 +919,7 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
-		public <I, O> ChatClientRequestSpec function(String name, String description,
+		public <I, O> ChatClientRequestSpec function(String name, String description, Class<I> inputType,
 				java.util.function.Consumer<I> consumer) {
 
 			Assert.hasText(name, "name cannot be null or empty");
@@ -900,7 +929,7 @@ public class DefaultChatClient implements ChatClient {
 			var fcw = FunctionCallbackWrapper.builder(consumer)
 				.withDescription(description)
 				.withName(name)
-				// .withResponseConverter(Object::toString)
+				.withInputType(inputType)
 				.build();
 			this.functionCallbacks.add(fcw);
 			return this;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -874,6 +874,38 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		public <I, O> ChatClientRequestSpec function(String name, String description,
+				java.util.function.Supplier<O> supplier) {
+
+			Assert.hasText(name, "name cannot be null or empty");
+			Assert.hasText(description, "description cannot be null or empty");
+			Assert.notNull(supplier, "supplier cannot be null");
+
+			var fcw = FunctionCallbackWrapper.builder(supplier)
+				.withDescription(description)
+				.withName(name)
+				.withInputType(Void.class)
+				.build();
+			this.functionCallbacks.add(fcw);
+			return this;
+		}
+
+		public <I, O> ChatClientRequestSpec function(String name, String description,
+				java.util.function.Consumer<I> consumer) {
+
+			Assert.hasText(name, "name cannot be null or empty");
+			Assert.hasText(description, "description cannot be null or empty");
+			Assert.notNull(consumer, "consumer cannot be null");
+
+			var fcw = FunctionCallbackWrapper.builder(consumer)
+				.withDescription(description)
+				.withName(name)
+				// .withResponseConverter(Object::toString)
+				.build();
+			this.functionCallbacks.add(fcw);
+			return this;
+		}
+
 		public ChatClientRequestSpec functions(String... functionBeanNames) {
 			Assert.notNull(functionBeanNames, "functionBeanNames cannot be null");
 			Assert.noNullElements(functionBeanNames, "functionBeanNames cannot contain null elements");

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -143,14 +143,39 @@ public class DefaultChatClientBuilder implements Builder {
 		return this;
 	}
 
+	@Deprecated
 	public <I, O> Builder defaultFunction(String name, String description, java.util.function.Function<I, O> function) {
 		this.defaultRequest.function(name, description, function);
 		return this;
 	}
 
+	public <I, O> Builder defaultFunction(String name, String description, Class<I> inputType,
+			java.util.function.Function<I, O> function) {
+		this.defaultRequest.function(name, description, inputType, function);
+		return this;
+	}
+
+	@Deprecated
 	public <I, O> Builder defaultFunction(String name, String description,
 			java.util.function.BiFunction<I, ToolContext, O> biFunction) {
 		this.defaultRequest.function(name, description, biFunction);
+		return this;
+	}
+
+	public <I, O> Builder defaultFunction(String name, String description, Class<I> inputType,
+			java.util.function.BiFunction<I, ToolContext, O> biFunction) {
+		this.defaultRequest.function(name, description, inputType, biFunction);
+		return this;
+	}
+
+	public <I, O> Builder defaultFunction(String name, String description, java.util.function.Supplier<O> supplier) {
+		this.defaultRequest.function(name, description, supplier);
+		return this;
+	}
+
+	public <I, O> Builder defaultFunction(String name, String description, Class<I> inputType,
+			java.util.function.Consumer<I> consumer) {
+		this.defaultRequest.function(name, description, inputType, consumer);
 		return this;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.converter;
 
-import java.lang.reflect.Type;
 import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -37,6 +36,7 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.model.ModelOptionsUtils.CustomizedTypeReference;
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.lang.NonNull;
@@ -94,7 +94,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 * @param typeRef The target class type reference.
 	 */
 	public BeanOutputConverter(ParameterizedTypeReference<T> typeRef) {
-		this(new CustomizedTypeReference<>(typeRef), null);
+		this(CustomizedTypeReference.forType(typeRef), null);
 	}
 
 	/**
@@ -105,7 +105,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 * @param objectMapper Custom object mapper for JSON operations. endings.
 	 */
 	public BeanOutputConverter(ParameterizedTypeReference<T> typeRef, ObjectMapper objectMapper) {
-		this(new CustomizedTypeReference<>(typeRef), objectMapper);
+		this(CustomizedTypeReference.forType(typeRef), objectMapper);
 	}
 
 	/**
@@ -218,21 +218,6 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 */
 	public String getJsonSchema() {
 		return this.jsonSchema;
-	}
-
-	private static class CustomizedTypeReference<T> extends TypeReference<T> {
-
-		private final Type type;
-
-		CustomizedTypeReference(ParameterizedTypeReference<T> typeRef) {
-			this.type = typeRef.getType();
-		}
-
-		@Override
-		public Type getType() {
-			return this.type;
-		}
-
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
@@ -51,6 +51,7 @@ import org.springframework.ai.util.JacksonUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
@@ -358,8 +359,13 @@ public abstract class ModelOptionsUtils {
 		}
 
 		ObjectNode node = SCHEMA_GENERATOR_CACHE.get().generateSchema(clazz);
-		if (toUpperCaseTypeValues) { // Required for OpenAPI 3.0 (at least Vertex AI
-			// version of it).
+
+		if (ClassUtils.isVoidType(clazz) && node.get("properties") == null) {
+			node.putObject("properties");
+		}
+
+		// Required for OpenAPI 3.0 (at least Vertex AI version of it).
+		if (toUpperCaseTypeValues) {
 			toUpperCaseTypeValues(node);
 		}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractFunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/AbstractFunctionCallback.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.model.ModelOptionsUtils.CustomizedTypeReference;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.Assert;
 
 /**
@@ -47,7 +49,7 @@ abstract class AbstractFunctionCallback<I, O> implements BiFunction<I, ToolConte
 
 	private final String description;
 
-	private final Class<I> inputType;
+	private final ParameterizedTypeReference<I> inputType;
 
 	private final String inputTypeSchema;
 
@@ -70,8 +72,8 @@ abstract class AbstractFunctionCallback<I, O> implements BiFunction<I, ToolConte
 	 * @param objectMapper Used to convert the function's input and output types to and
 	 * from JSON.
 	 */
-	protected AbstractFunctionCallback(String name, String description, String inputTypeSchema, Class<I> inputType,
-			Function<O, String> responseConverter, ObjectMapper objectMapper) {
+	protected AbstractFunctionCallback(String name, String description, String inputTypeSchema,
+			ParameterizedTypeReference<I> inputType, Function<O, String> responseConverter, ObjectMapper objectMapper) {
 		Assert.notNull(name, "Name must not be null");
 		Assert.notNull(description, "Description must not be null");
 		Assert.notNull(inputType, "InputType must not be null");
@@ -116,9 +118,9 @@ abstract class AbstractFunctionCallback<I, O> implements BiFunction<I, ToolConte
 		return this.andThen(this.responseConverter).apply(request, null);
 	}
 
-	private <T> T fromJson(String json, Class<T> targetClass) {
+	private <T> T fromJson(String json, ParameterizedTypeReference<T> targetClass) {
 		try {
-			return this.objectMapper.readValue(json, targetClass);
+			return this.objectMapper.readValue(json, CustomizedTypeReference.forType(targetClass));
 		}
 		catch (JsonProcessingException e) {
 			throw new RuntimeException(e);

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
@@ -124,11 +124,13 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 			}
 		}
 		if (bean instanceof Function<?, ?> function) {
+			// ResolvableType.forInstance(function);
 			return FunctionCallbackWrapper.builder(function)
 				.withName(beanName)
 				.withSchemaType(this.schemaType)
 				.withDescription(functionDescription)
-				.withInputType(functionInputClass)
+				.withInputType(functionInputType)
+				// .withInputType(functionInputClass)
 				.build();
 		}
 		if (bean instanceof Consumer<?> consumer) {
@@ -136,7 +138,8 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 				.withName(beanName)
 				.withSchemaType(this.schemaType)
 				.withDescription(functionDescription)
-				.withInputType(functionInputClass)
+				.withInputType(functionInputType)
+				// .withInputType(functionInputClass)
 				.build();
 		}
 		if (bean instanceof Supplier<?> supplier) {
@@ -144,7 +147,7 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 				.withName(beanName)
 				.withSchemaType(this.schemaType)
 				.withDescription(functionDescription)
-				.withInputType(functionInputClass)
+				.withInputType(functionInputType)
 				.build();
 		}
 		else if (bean instanceof BiFunction<?, ?, ?>) {
@@ -152,7 +155,8 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 				.withName(beanName)
 				.withSchemaType(this.schemaType)
 				.withDescription(functionDescription)
-				.withInputType(functionInputClass)
+				.withInputType(functionInputType)
+				// .withInputType(functionInputClass)
 				.build();
 		}
 		else {

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackContext.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.model.function;
 
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import kotlin.jvm.functions.Function1;
@@ -123,6 +125,22 @@ public class FunctionCallbackContext implements ApplicationContextAware {
 		}
 		if (bean instanceof Function<?, ?> function) {
 			return FunctionCallbackWrapper.builder(function)
+				.withName(beanName)
+				.withSchemaType(this.schemaType)
+				.withDescription(functionDescription)
+				.withInputType(functionInputClass)
+				.build();
+		}
+		if (bean instanceof Consumer<?> consumer) {
+			return FunctionCallbackWrapper.builder(consumer)
+				.withName(beanName)
+				.withSchemaType(this.schemaType)
+				.withDescription(functionDescription)
+				.withInputType(functionInputClass)
+				.build();
+		}
+		if (bean instanceof Supplier<?> supplier) {
+			return FunctionCallbackWrapper.builder(supplier)
 				.withName(beanName)
 				.withSchemaType(this.schemaType)
 				.withDescription(functionDescription)

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackWrapper.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackWrapper.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.model.function;
 
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,6 +58,19 @@ public final class FunctionCallbackWrapper<I, O> extends AbstractFunctionCallbac
 	}
 
 	public static <I, O> Builder<I, O> builder(Function<I, O> function) {
+		return new Builder<>(function);
+	}
+
+	public static <Void, O> Builder<Void, O> builder(Supplier<O> supplier) {
+		Function<Void, O> function = (input) -> supplier.get();
+		return new Builder<>(function);
+	}
+
+	public static <I, Void> Builder<I, Void> builder(Consumer<I> consumer) {
+		Function<I, Void> function = (input) -> {
+			consumer.accept(input);
+			return null;
+		};
 		return new Builder<>(function);
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/TypeResolverHelper.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/TypeResolverHelper.java
@@ -20,7 +20,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
@@ -188,6 +190,12 @@ public abstract class TypeResolverHelper {
 		}
 		else if (BiFunction.class.isAssignableFrom(resolvableClass)) {
 			functionArgumentResolvableType = functionType.as(BiFunction.class);
+		}
+		else if (Supplier.class.isAssignableFrom(resolvableClass)) {
+			return ResolvableType.forClass(Void.class);
+		}
+		else if (Consumer.class.isAssignableFrom(resolvableClass)) {
+			functionArgumentResolvableType = functionType.as(Consumer.class);
 		}
 		else if (KotlinDetector.isKotlinPresent()) {
 			if (KotlinDelegate.isKotlinFunction(resolvableClass)) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/TypeResolverHelper.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/TypeResolverHelper.java
@@ -65,6 +65,16 @@ public abstract class TypeResolverHelper {
 	}
 
 	/**
+	 * Returns the input class of a given Consumer class.
+	 * @param consumerClass The consumer class.
+	 * @return The input class of the consumer.
+	 */
+	public static Class<?> getConsumerInputClass(Class<? extends Consumer<?>> consumerClass) {
+		ResolvableType resolvableType = ResolvableType.forClass(consumerClass).as(Consumer.class);
+		return (resolvableType == ResolvableType.NONE ? Object.class : resolvableType.getGeneric(0).toClass());
+	}
+
+	/**
 	 * Returns the output class of a given function class.
 	 * @param functionClass The function class.
 	 * @return The output class of the function.

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
@@ -217,7 +217,7 @@ public class ChatClientTest {
 						.param("param1", "value1")
 						.param("param2", "value2"))
 				.defaultFunctions("fun1", "fun2")
-				.defaultFunction("fun3", "fun3description", mockFunction)
+				.defaultFunction("fun3", "fun3description", String.class, mockFunction)
 				.defaultUser(u -> u.text("Default user text {uparam1}, {uparam2}")
 						.param("uparam1", "value1")
 						.param("uparam2", "value2")
@@ -344,7 +344,7 @@ public class ChatClientTest {
 						.param("param1", "value1")
 						.param("param2", "value2"))
 				.defaultFunctions("fun1", "fun2")
-				.defaultFunction("fun3", "fun3description", mockFunction)
+				.defaultFunction("fun3", "fun3description", String.class, mockFunction)
 				.defaultUser(u -> u.text("Default user text {uparam1}, {uparam2}")
 						.param("uparam1", "value1")
 						.param("uparam2", "value2")
@@ -541,9 +541,9 @@ public class ChatClientTest {
 		assertThat(userMessage.getMedia().iterator().next().getData())
 			.isEqualTo("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png");
 
-		FunctionCallingOptions runtieOptions = (FunctionCallingOptions) this.promptCaptor.getValue().getOptions();
+		FunctionCallingOptions runtimeOptions = (FunctionCallingOptions) this.promptCaptor.getValue().getOptions();
 
-		assertThat(runtieOptions.getFunctions()).containsExactly("function1");
+		assertThat(runtimeOptions.getFunctions()).containsExactly("function1");
 		assertThat(options.getFunctions()).isEmpty();
 	}
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1468,6 +1468,25 @@ class DefaultChatClientTests {
 	}
 
 	@Test
+	void whenSupplierFunctionThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		spec = spec.function("name", "description", () -> "hello");
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getFunctionCallbacks()).anyMatch(callback -> callback.getName().equals("name"));
+	}
+
+	@Test
+	void whenConsumerFunctionThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		Consumer<String> consumer = input -> System.out.println(input);
+		spec = spec.function("name", "description", consumer);
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getFunctionCallbacks()).anyMatch(callback -> callback.getName().equals("name"));
+	}
+
+	@Test
 	void whenFunctionBeanNamesElementIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1354,7 +1354,7 @@ class DefaultChatClientTests {
 	void whenFunctionNameIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function(null, "description", input -> "hello"))
+		assertThatThrownBy(() -> spec.function(null, "description", String.class, input -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1363,7 +1363,7 @@ class DefaultChatClientTests {
 	void whenFunctionNameIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("", "description", input -> "hello"))
+		assertThatThrownBy(() -> spec.function("", "description", String.class, input -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1372,7 +1372,7 @@ class DefaultChatClientTests {
 	void whenFunctionDescriptionIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("name", null, input -> "hello"))
+		assertThatThrownBy(() -> spec.function("name", null, String.class, input -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("description cannot be null or empty");
 	}
@@ -1381,7 +1381,7 @@ class DefaultChatClientTests {
 	void whenFunctionDescriptionIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("name", "", input -> "hello"))
+		assertThatThrownBy(() -> spec.function("name", "", String.class, input -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("description cannot be null or empty");
 	}
@@ -1390,7 +1390,7 @@ class DefaultChatClientTests {
 	void whenFunctionLambdaIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("name", "description", (Function) null))
+		assertThatThrownBy(() -> spec.function("name", "description", String.class, (Function) null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("function cannot be null");
 	}
@@ -1399,7 +1399,7 @@ class DefaultChatClientTests {
 	void whenFunctionThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		spec = spec.function("name", "description", input -> "hello");
+		spec = spec.function("name", "description", String.class, input -> "hello");
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getFunctionCallbacks()).anyMatch(callback -> callback.getName().equals("name"));
 	}
@@ -1417,7 +1417,7 @@ class DefaultChatClientTests {
 	void whenBiFunctionNameIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function(null, "description", (input, ctx) -> "hello"))
+		assertThatThrownBy(() -> spec.function(null, "description", String.class, (input, ctx) -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1426,7 +1426,7 @@ class DefaultChatClientTests {
 	void whenBiFunctionNameIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("", "description", (input, ctx) -> "hello"))
+		assertThatThrownBy(() -> spec.function("", "description", String.class, (input, ctx) -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("name cannot be null or empty");
 	}
@@ -1435,7 +1435,7 @@ class DefaultChatClientTests {
 	void whenBiFunctionDescriptionIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("name", null, (input, ctx) -> "hello"))
+		assertThatThrownBy(() -> spec.function("name", null, String.class, (input, ctx) -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("description cannot be null or empty");
 	}
@@ -1444,7 +1444,7 @@ class DefaultChatClientTests {
 	void whenBiFunctionDescriptionIsEmptyThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("name", "", (input, ctx) -> "hello"))
+		assertThatThrownBy(() -> spec.function("name", "", String.class, (input, ctx) -> "hello"))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("description cannot be null or empty");
 	}
@@ -1453,7 +1453,7 @@ class DefaultChatClientTests {
 	void whenBiFunctionLambdaIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.function("name", "description", (BiFunction) null))
+		assertThatThrownBy(() -> spec.function("name", "description", String.class, (BiFunction) null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("biFunction cannot be null");
 	}
@@ -1462,7 +1462,7 @@ class DefaultChatClientTests {
 	void whenBiFunctionThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		spec = spec.function("name", "description", (input, ctx) -> "hello");
+		spec = spec.function("name", "description", String.class, (input, ctx) -> "hello");
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getFunctionCallbacks()).anyMatch(callback -> callback.getName().equals("name"));
 	}
@@ -1481,7 +1481,7 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		Consumer<String> consumer = input -> System.out.println(input);
-		spec = spec.function("name", "description", consumer);
+		spec = spec.function("name", "description", String.class, consumer);
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getFunctionCallbacks()).anyMatch(callback -> callback.getName().equals("name"));
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/functions.adoc
@@ -277,6 +277,7 @@ ChatResponse response = this.chatClient.prompt("What's the weather like in San F
     .functions(new FunctionCallbackWrapper<>(
 		"CurrentWeather", // name
 		"Get the weather in location", // function description
+        MockWeatherService.Request.class, // input type
 		new MockWeatherService()))
     .call()
     .chatResponse();
@@ -405,6 +406,7 @@ BiFunction<MockWeatherService.Request, ToolContext, MockWeatherService.Response>
 
 ChatResponse response = chatClient.prompt("What's the weather like in San Francisco, Tokyo, and Paris?")
     .functions(FunctionCallbackWrapper.builder(this.weatherFunction)
+        .withInputType(MockWeatherService.Request.class)
         .withName("getCurrentWeather")
         .withDescription("Get the weather in location")
         .build())

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackInPrompt2IT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackInPrompt2IT.java
@@ -18,7 +18,6 @@ package org.springframework.ai.autoconfigure.openai.tool;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -61,7 +60,7 @@ public class FunctionCallbackInPrompt2IT {
 
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("What's the weather like in San Francisco, Tokyo, and Paris?")
-					.function("CurrentWeatherService", "Get the weather in location", new MockWeatherService())
+					.function("CurrentWeatherService", "Get the weather in location", MockWeatherService.Request.class, new MockWeatherService())
 					.call().content();
 			// @formatter:on
 
@@ -80,7 +79,7 @@ public class FunctionCallbackInPrompt2IT {
 			// @formatter:off
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("What's the weather like in Amsterdam?")
-					.function("CurrentWeatherService", "Get the weather in location",
+					.function("CurrentWeatherService", "Get the weather in location", MockWeatherService.Request.class,
 							new Function<MockWeatherService.Request, String>() {
 								@Override
 								public String apply(MockWeatherService.Request request) {
@@ -109,14 +108,11 @@ public class FunctionCallbackInPrompt2IT {
 			// @formatter:off
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("Turn the light on in the kitchen and in the living room!")
-					.function("turnLight", "Turn light on or off in a room",
-							new Consumer<LightInfo>() {
-								@Override
-								public void accept(LightInfo lightInfo) {
-									logger.info("Turning light to [" + lightInfo.isOn + "] in " + lightInfo.roomName());
-									state.put(lightInfo.roomName(), lightInfo.isOn());
-												}
-							})
+					.function("turnLight", "Turn light on or off in a room",LightInfo.class,
+						lightInfo -> {
+							logger.info("Turning light to [" + lightInfo.isOn + "] in " + lightInfo.roomName());
+							state.put(lightInfo.roomName(), lightInfo.isOn());
+						})
 					.call().content();
 			// @formatter:on
 			logger.info("Response: {}", content);
@@ -135,7 +131,8 @@ public class FunctionCallbackInPrompt2IT {
 			// @formatter:off
 			String content = ChatClient.builder(chatModel).build().prompt()
 					.user("What's the weather like in San Francisco, Tokyo, and Paris?")
-					.function("CurrentWeatherService", "Get the weather in location", new MockWeatherService())
+					.function("CurrentWeatherService", "Get the weather in location", 
+						MockWeatherService.Request.class, new MockWeatherService())
 					.stream().content()
 					.collectList().block().stream().collect(Collectors.joining());
 			// @formatter:on

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -304,6 +304,26 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 		});
 	}
 
+	@Test
+	void trainScheduler() {
+		this.contextRunner.run(context -> {
+
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage(
+					"Please schedule a train from San Francisco to Los Angeles on 2023-12-25");
+
+			PortableFunctionCallingOptions functionOptions = FunctionCallingOptions.builder()
+				.withFunction("trainReservation")
+				.build();
+
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), functionOptions));
+
+			logger.info("Response: {}", response.getResult().getOutput().getContent());
+		});
+	}
+
 	@Configuration
 	static class Config {
 
@@ -372,6 +392,28 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				logger.info("Turning light on in the living room");
 				feedback.put("turnLivingRoomLightOnSupplier", Boolean.TRUE);
 				return "Done";
+			};
+		}
+
+		record TrainSearchSchedule(String from, String to, String date) {
+		}
+
+		record TrainSearchScheduleResponse(String from, String to, String date, String trainNumber) {
+		}
+
+		record TrainSearchRequest<T>(T data) {
+		}
+
+		record TrainSearchResponse<T>(T data) {
+		}
+
+		@Bean
+		@Description("Schedule a train reservation")
+		public Function<TrainSearchRequest<TrainSearchSchedule>, TrainSearchResponse<TrainSearchScheduleResponse>> trainReservation() {
+			return (TrainSearchRequest<TrainSearchSchedule> request) -> {
+				logger.info("Turning light to [" + request.data().from() + "] in " + request.data().to());
+				return new TrainSearchResponse<>(
+						new TrainSearchScheduleResponse(request.data().from(), request.data().to(), "", "123"));
 			};
 		}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -18,10 +18,14 @@ package org.springframework.ai.autoconfigure.openai.tool;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
@@ -52,179 +56,252 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
 class FunctionCallbackWithPlainFunctionBeanIT {
 
-	private final Logger logger = LoggerFactory.getLogger(FunctionCallbackWithPlainFunctionBeanIT.class);
+	private final static Logger logger = LoggerFactory.getLogger(FunctionCallbackWithPlainFunctionBeanIT.class);
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"))
+		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"),
+				"spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName())
 		.withConfiguration(AutoConfigurations.of(OpenAiAutoConfiguration.class))
 		.withUserConfiguration(Config.class);
 
+	private static Map<String, Object> feedback = new ConcurrentHashMap<>();
+
+	@BeforeEach
+	void setUp() {
+		feedback.clear();
+	}
+
 	@Test
 	void functionCallWithDirectBiFunction() {
-		this.contextRunner.withPropertyValues("spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName())
-			.run(context -> {
+		this.contextRunner.run(context -> {
 
-				OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
 
-				ChatClient chatClient = ChatClient.builder(chatModel).build();
+			ChatClient chatClient = ChatClient.builder(chatModel).build();
 
-				String content = chatClient.prompt("What's the weather like in San Francisco, Tokyo, and Paris?")
-					.functions("weatherFunctionWithContext")
-					.toolContext(Map.of("sessionId", "123"))
-					.call()
-					.content();
-				logger.info(content);
+			String content = chatClient.prompt("What's the weather like in San Francisco, Tokyo, and Paris?")
+				.functions("weatherFunctionWithContext")
+				.toolContext(Map.of("sessionId", "123"))
+				.call()
+				.content();
+			logger.info(content);
 
-				// Test weatherFunction
-				UserMessage userMessage = new UserMessage(
-						"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage(
+					"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						OpenAiChatOptions.builder()
-							.withFunction("weatherFunctionWithContext")
-							.withToolContext(Map.of("sessionId", "123"))
-							.build()));
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder()
+						.withFunction("weatherFunctionWithContext")
+						.withToolContext(Map.of("sessionId", "123"))
+						.build()));
 
-				logger.info("Response: {}", response);
+			logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
 
-			});
+		});
 	}
 
 	@Test
 	void functionCallWithBiFunctionClass() {
-		this.contextRunner.withPropertyValues("spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName())
-			.run(context -> {
+		this.contextRunner.run(context -> {
 
-				OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
 
-				ChatClient chatClient = ChatClient.builder(chatModel).build();
+			ChatClient chatClient = ChatClient.builder(chatModel).build();
 
-				String content = chatClient.prompt("What's the weather like in San Francisco, Tokyo, and Paris?")
-					.functions("weatherFunctionWithClassBiFunction")
-					.toolContext(Map.of("sessionId", "123"))
-					.call()
-					.content();
-				logger.info(content);
+			String content = chatClient.prompt("What's the weather like in San Francisco, Tokyo, and Paris?")
+				.functions("weatherFunctionWithClassBiFunction")
+				.toolContext(Map.of("sessionId", "123"))
+				.call()
+				.content();
+			logger.info(content);
 
-				// Test weatherFunction
-				UserMessage userMessage = new UserMessage(
-						"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage(
+					"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						OpenAiChatOptions.builder()
-							.withFunction("weatherFunctionWithClassBiFunction")
-							.withToolContext(Map.of("sessionId", "123"))
-							.build()));
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder()
+						.withFunction("weatherFunctionWithClassBiFunction")
+						.withToolContext(Map.of("sessionId", "123"))
+						.build()));
 
-				logger.info("Response: {}", response);
+			logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
 
-			});
+		});
 	}
 
 	@Test
 	void functionCallTest() {
-		this.contextRunner.withPropertyValues("spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName())
-			.run(context -> {
+		this.contextRunner.run(context -> {
 
-				OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
 
-				// Test weatherFunction
-				UserMessage userMessage = new UserMessage(
-						"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage(
+					"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						OpenAiChatOptions.builder().withFunction("weatherFunction").build()));
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder().withFunction("weatherFunction").build()));
 
-				logger.info("Response: {}", response);
+			logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
 
-				// Test weatherFunctionTwo
-				response = chatModel.call(new Prompt(List.of(userMessage),
-						OpenAiChatOptions.builder().withFunction("weatherFunctionTwo").build()));
+			// Test weatherFunctionTwo
+			response = chatModel.call(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder().withFunction("weatherFunctionTwo").build()));
 
-				logger.info("Response: {}", response);
+			logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
 
-			});
+		});
 	}
 
 	@Test
 	void functionCallWithPortableFunctionCallingOptions() {
-		this.contextRunner
-			.withPropertyValues("spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName(),
-					"spring.ai.openai.chat.options.temperature=0.1")
-			.run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.openai.chat.options.temperature=0.1").run(context -> {
 
-				OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
 
-				// Test weatherFunction
-				UserMessage userMessage = new UserMessage(
-						"What's the weather like in San Francisco, Tokyo, and Paris?");
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");
 
-				PortableFunctionCallingOptions functionOptions = FunctionCallingOptions.builder()
-					.withFunction("weatherFunction")
-					.build();
+			PortableFunctionCallingOptions functionOptions = FunctionCallingOptions.builder()
+				.withFunction("weatherFunction")
+				.build();
 
-				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), functionOptions));
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), functionOptions));
 
-				logger.info("Response: {}", response.getResult().getOutput().getContent());
+			logger.info("Response: {}", response.getResult().getOutput().getContent());
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
-			});
+			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		});
 	}
 
 	@Test
 	void streamFunctionCallTest() {
-		this.contextRunner
-			.withPropertyValues("spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName(),
-					"spring.ai.openai.chat.options.temperature=0.1")
-			.run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.openai.chat.options.temperature=0.1").run(context -> {
 
-				OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
 
-				// Test weatherFunction
-				UserMessage userMessage = new UserMessage(
-						"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage(
+					"What's the weather like in San Francisco, Tokyo, and Paris? You can call the following functions 'weatherFunction'");
 
-				Flux<ChatResponse> response = chatModel.stream(new Prompt(List.of(userMessage),
-						OpenAiChatOptions.builder().withFunction("weatherFunction").build()));
+			Flux<ChatResponse> response = chatModel.stream(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder().withFunction("weatherFunction").build()));
 
-				String content = response.collectList()
-					.block()
-					.stream()
-					.map(ChatResponse::getResults)
-					.flatMap(List::stream)
-					.map(Generation::getOutput)
-					.map(AssistantMessage::getContent)
-					.collect(Collectors.joining());
-				logger.info("Response: {}", content);
+			String content = response.collectList()
+				.block()
+				.stream()
+				.map(ChatResponse::getResults)
+				.flatMap(List::stream)
+				.map(Generation::getOutput)
+				.map(AssistantMessage::getContent)
+				.collect(Collectors.joining());
+			logger.info("Response: {}", content);
 
-				assertThat(content).contains("30", "10", "15");
+			assertThat(content).contains("30", "10", "15");
 
-				// Test weatherFunctionTwo
-				response = chatModel.stream(new Prompt(List.of(userMessage),
-						OpenAiChatOptions.builder().withFunction("weatherFunctionTwo").build()));
+			// Test weatherFunctionTwo
+			response = chatModel.stream(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder().withFunction("weatherFunctionTwo").build()));
 
-				content = response.collectList()
-					.block()
-					.stream()
-					.map(ChatResponse::getResults)
-					.flatMap(List::stream)
-					.map(Generation::getOutput)
-					.map(AssistantMessage::getContent)
-					.collect(Collectors.joining());
-				logger.info("Response: {}", content);
+			content = response.collectList()
+				.block()
+				.stream()
+				.map(ChatResponse::getResults)
+				.flatMap(List::stream)
+				.map(Generation::getOutput)
+				.map(AssistantMessage::getContent)
+				.collect(Collectors.joining());
+			logger.info("Response: {}", content);
 
-				assertThat(content).isNotEmpty().withFailMessage("Content returned from OpenAI model is empty");
-				assertThat(content).contains("30", "10", "15");
+			assertThat(content).isNotEmpty().withFailMessage("Content returned from OpenAI model is empty");
+			assertThat(content).contains("30", "10", "15");
 
-			});
+		});
+	}
+
+	@Test
+	void functionCallingVoidResponse() {
+		this.contextRunner.run(context -> {
+
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage("Turn the light on in the kitchen and in the living room");
+
+			ChatResponse response = chatModel
+				.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withFunction("turnLight").build()));
+
+			logger.info("Response: {}", response);
+			assertThat(feedback).hasSize(2);
+			assertThat(feedback.get("kitchen")).isEqualTo(Boolean.valueOf(true));
+			assertThat(feedback.get("living room")).isEqualTo(Boolean.valueOf(true));
+		});
+	}
+
+	@Test
+	void functionCallingConsumer() {
+		this.contextRunner.run(context -> {
+
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage("Turn the light on in the kitchen and in the living room");
+
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder().withFunction("turnLightConsumer").build()));
+
+			logger.info("Response: {}", response);
+			assertThat(feedback).hasSize(2);
+			assertThat(feedback.get("kitchen")).isEqualTo(Boolean.valueOf(true));
+			assertThat(feedback.get("living room")).isEqualTo(Boolean.valueOf(true));
+
+		});
+	}
+
+	@Test
+	void functionCallingVoidArguments() {
+		this.contextRunner.run(context -> {
+
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage("Turn the light on in the living room");
+
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder().withFunction("turnLivingRoomLightOn").build()));
+
+			logger.info("Response: {}", response);
+			assertThat(feedback).hasSize(1);
+			assertThat(feedback.get("turnLivingRoomLightOn")).isEqualTo(Boolean.valueOf(true));
+		});
+	}
+
+	@Test
+	void functionCallingSupplier() {
+		this.contextRunner.run(context -> {
+
+			OpenAiChatModel chatModel = context.getBean(OpenAiChatModel.class);
+
+			// Test weatherFunction
+			UserMessage userMessage = new UserMessage("Turn the light on in the living room");
+
+			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder().withFunction("turnLivingRoomLightOnSupplier").build()));
+
+			logger.info("Response: {}", response);
+			assertThat(feedback).hasSize(1);
+			assertThat(feedback.get("turnLivingRoomLightOnSupplier")).isEqualTo(Boolean.valueOf(true));
+		});
 	}
 
 	@Configuration
@@ -254,6 +331,48 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 		public Function<MockWeatherService.Request, MockWeatherService.Response> weatherFunctionTwo() {
 			MockWeatherService weatherService = new MockWeatherService();
 			return (weatherService::apply);
+		}
+
+		record LightInfo(String roomName, boolean isOn) {
+		}
+
+		@Bean
+		@Description("Turn light on or off in a room")
+		public Function<LightInfo, Void> turnLight() {
+			return (LightInfo lightInfo) -> {
+				logger.info("Turning light to [" + lightInfo.isOn + "] in " + lightInfo.roomName());
+				feedback.put(lightInfo.roomName(), lightInfo.isOn());
+				return null;
+			};
+		}
+
+		@Bean
+		@Description("Turn light on or off in a room")
+		public Consumer<LightInfo> turnLightConsumer() {
+			return (LightInfo lightInfo) -> {
+				logger.info("Turning light to [" + lightInfo.isOn + "] in " + lightInfo.roomName());
+				feedback.put(lightInfo.roomName(), lightInfo.isOn());
+			};
+		}
+
+		@Bean
+		@Description("Turns light on in the living room")
+		public Function<Void, String> turnLivingRoomLightOn() {
+			return (Void v) -> {
+				logger.info("Turning light on in the living room");
+				feedback.put("turnLivingRoomLightOn", Boolean.TRUE);
+				return "Done";
+			};
+		}
+
+		@Bean
+		@Description("Turns light on in the living room")
+		public Supplier<String> turnLivingRoomLightOnSupplier() {
+			return () -> {
+				logger.info("Turning light on in the living room");
+				feedback.put("turnLivingRoomLightOnSupplier", Boolean.TRUE);
+				return "Done";
+			};
 		}
 
 	}


### PR DESCRIPTION
Depends on https://github.com/spring-projects/spring-ai/pull/1732

- Add support for Java Consumer and Supplier functional interfaces in function callbacks
- Handle void type inputs and outputs in function callbacks
- Add test cases for void responses, Consumer callbacks, and Supplier callbacks
- Update ModelOptionsUtils to properly handle void type schemas

Resolves #1718 , #1277 , #1118, #860
