### PR TITLE
feat: Move the advisor name to low cardinality key values

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationDocumentation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationDocumentation.java
@@ -68,11 +68,7 @@ public enum AdvisorObservationDocumentation implements ObservationDocumentation 
 			public String asString() {
 				return "spring.ai.advisor.type";
 			}
-		}
-
-	}
-
-	public enum HighCardinalityKeyNames implements KeyName {
+		},
 
 		/**
 		 * Advisor name.
@@ -83,6 +79,11 @@ public enum AdvisorObservationDocumentation implements ObservationDocumentation 
 				return "spring.ai.advisor.name";
 			}
 		},
+
+	}
+
+	public enum HighCardinalityKeyNames implements KeyName {
+
 		/**
 		 * Advisor order in the advisor chain.
 		 */

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
@@ -62,7 +62,7 @@ public class DefaultAdvisorObservationConvention implements AdvisorObservationCo
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(AdvisorObservationContext context) {
-		return KeyValues.of(springAiKind(), advisorType(context));
+		return KeyValues.of(springAiKind(), advisorType(context), advisorName(context));
 	}
 
 	protected KeyValue advisorType(AdvisorObservationContext context) {
@@ -70,8 +70,11 @@ public class DefaultAdvisorObservationConvention implements AdvisorObservationCo
 	}
 
 	protected KeyValue springAiKind() {
-		return KeyValue.of(AdvisorObservationDocumentation.LowCardinalityKeyNames.SPRING_AI_KIND,
-				SpringAiKind.ADVISOR.value());
+		return KeyValue.of(LowCardinalityKeyNames.SPRING_AI_KIND, SpringAiKind.ADVISOR.value());
+	}
+
+	protected KeyValue advisorName(AdvisorObservationContext context) {
+		return KeyValue.of(LowCardinalityKeyNames.ADVISOR_NAME, context.getAdvisorName());
 	}
 
 	// ------------------------
@@ -80,11 +83,7 @@ public class DefaultAdvisorObservationConvention implements AdvisorObservationCo
 
 	@Override
 	public KeyValues getHighCardinalityKeyValues(AdvisorObservationContext context) {
-		return KeyValues.of(advisorName(context), advisorOrder(context));
-	}
-
-	protected KeyValue advisorName(AdvisorObservationContext context) {
-		return KeyValue.of(HighCardinalityKeyNames.ADVISOR_NAME, context.getAdvisorName());
+		return KeyValues.of(advisorOrder(context));
 	}
 
 	protected KeyValue advisorOrder(AdvisorObservationContext context) {

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
@@ -69,6 +69,7 @@ class DefaultAdvisorObservationConventionTests {
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(observationContext)).contains(
 				KeyValue.of(LowCardinalityKeyNames.ADVISOR_TYPE.asString(),
 						AdvisorObservationContext.Type.AROUND.name()),
+				KeyValue.of(LowCardinalityKeyNames.ADVISOR_NAME.asString(), "MyName"),
 				KeyValue.of(LowCardinalityKeyNames.SPRING_AI_KIND.asString(), SpringAiKind.ADVISOR.value()));
 	}
 
@@ -81,7 +82,6 @@ class DefaultAdvisorObservationConventionTests {
 			.build();
 
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext))
-			.contains(KeyValue.of(HighCardinalityKeyNames.ADVISOR_NAME.asString(), "MyName"))
 			.contains(KeyValue.of(HighCardinalityKeyNames.ADVISOR_ORDER.asString(), "678"));
 	}
 


### PR DESCRIPTION
- Adviser name is moved from hight to low cardinality key values.
- Updated tests in  to reflect these changes, ensuring the new low cardinality key is correctly captured.

Resolves #1716