### PR TITLE
extension function for Chatclient.CalLResponseSpec.entity(Class<?>) a…

### DIFF
--- a/spring-ai-core/src/main/kotlin/org/springframework/ai/chat/client/ChatClientExtensions.kt
+++ b/spring-ai-core/src/main/kotlin/org/springframework/ai/chat/client/ChatClientExtensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client
+
+/**
+ * Extension for [ChatClient] providing a `entity<Foo>()` variant.
+ *
+ * @author Josh Long
+ */
+
+inline fun <reified T> ChatClient.CallResponseSpec.entity(): T = entity(T::class.java) as T

--- a/spring-ai-core/src/main/kotlin/org/springframework/ai/chat/client/ChatClientExtensions.kt
+++ b/spring-ai-core/src/main/kotlin/org/springframework/ai/chat/client/ChatClientExtensions.kt
@@ -16,10 +16,17 @@
 
 package org.springframework.ai.chat.client
 
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.core.ParameterizedTypeReference
+
 /**
- * Extension for [ChatClient] providing a `entity<Foo>()` variant.
+ * Extensions for [ChatClient] providing a reified generic adapters for `entity` and `responseEntity`
  *
  * @author Josh Long
  */
 
-inline fun <reified T> ChatClient.CallResponseSpec.entity(): T = entity(T::class.java) as T
+inline fun <reified T> ChatClient.CallResponseSpec.entity(): T =
+	entity(object : ParameterizedTypeReference<T>() {}) as T
+
+inline fun <reified T> ChatClient.CallResponseSpec.responseEntity(): ResponseEntity<ChatResponse, T> =
+	responseEntity(object : ParameterizedTypeReference<T>() {}) 

--- a/spring-ai-core/src/test/kotlin/org/springframework/ai/chat/client/ChatClientExtensionsTests.kt
+++ b/spring-ai-core/src/test/kotlin/org/springframework/ai/chat/client/ChatClientExtensionsTests.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class ChatClientExtensionsTests {
+
+	private val crs = mockk<ChatClient.CallResponseSpec>()
+
+	data class Joke(val setup: String, val punchline: String)
+
+	@Test
+	fun withEntityType() {
+		val joke = Joke(
+			setup = "Why did the scarecrow win an award?",
+			punchline = "Because he was outstanding in his field!"
+		)
+		every { crs.entity(any<Class<*>>()) } returns joke 
+		crs.entity<Joke>()
+		verify { crs.entity(Joke::class.java) }
+	}
+}

--- a/spring-ai-core/src/test/kotlin/org/springframework/ai/chat/client/ChatClientExtensionsTests.kt
+++ b/spring-ai-core/src/test/kotlin/org/springframework/ai/chat/client/ChatClientExtensionsTests.kt
@@ -20,21 +20,28 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.core.ParameterizedTypeReference
 
 class ChatClientExtensionsTests {
-
-	private val crs = mockk<ChatClient.CallResponseSpec>()
 
 	data class Joke(val setup: String, val punchline: String)
 
 	@Test
-	fun withEntityType() {
-		val joke = Joke(
-			setup = "Why did the scarecrow win an award?",
-			punchline = "Because he was outstanding in his field!"
-		)
-		every { crs.entity(any<Class<*>>()) } returns joke 
+	fun responseEntity() {
+		val crs = mockk<ChatClient.CallResponseSpec>()
+		val re = mockk<ResponseEntity<ChatResponse, Joke>>()
+		every { crs.responseEntity<Joke>() } returns re
+		crs.responseEntity<Joke>()
+		verify { crs.responseEntity(object : ParameterizedTypeReference<Joke>() {}) }
+	}
+	
+	@Test
+	fun entity() {
+		val crs = mockk<ChatClient.CallResponseSpec>()
+		val joke =  mockk<Joke>()
+		every { crs.entity(any<ParameterizedTypeReference<Joke>>()) } returns joke 
 		crs.entity<Joke>()
-		verify { crs.entity(Joke::class.java) }
+		verify { crs.entity(object : ParameterizedTypeReference<Joke>(){}) }
 	}
 }


### PR DESCRIPTION
this adds kotlin support for using the `ChatClient` to get typesafe responses back

```kotlin
val joke:Joke = cc
      .prompt("tell me a joke")
      .call()
      .entity<Joke>()
println(joke)
```

this is as opposed to the more verbose and less idiomatic Kotlin code without the extension function

````
val joke : Joke = cc
    .prompt("tell me a joke")
    .call()
    .entity(Joke::class.java)
```