### PR TITLE
GH-1529 Fix ChromaVectorStore delete Ids operation

### DIFF
--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/BaseOllamaIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/BaseOllamaIT.java
@@ -19,7 +19,6 @@ package org.springframework.ai.ollama;
 import java.time.Duration;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.ollama.OllamaContainer;
 

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/ChromaApi.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/ChromaApi.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.ai.chroma.ChromaApi.QueryRequest.Include;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -188,17 +187,16 @@ public class ChromaApi {
 			.toBodilessEntity();
 	}
 
-	public List<String> deleteEmbeddings(String collectionId, DeleteEmbeddingsRequest deleteRequest) {
+	public String deleteEmbeddings(String collectionId, DeleteEmbeddingsRequest deleteRequest) {
 
-		return this.restClient.post()
+		return String.valueOf(this.restClient.post()
 			.uri("/api/v1/collections/{collection_id}/delete", collectionId)
 			.headers(this::httpHeaders)
 			.body(deleteRequest)
 			.retrieve()
-			.toEntity(new ParameterizedTypeReference<List<String>>() {
-
-			})
-			.getBody();
+			.toEntity(String.class)
+			.getStatusCode()
+			.value());
 	}
 
 	public Long countEmbeddings(String collectionId) {

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
@@ -162,9 +162,8 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 	@Override
 	public Optional<Boolean> doDelete(List<String> idList) {
 		Assert.notNull(idList, "Document id list must not be null");
-		List<String> deletedIds = this.chromaApi.deleteEmbeddings(this.collectionId,
-				new DeleteEmbeddingsRequest(idList));
-		return Optional.of(deletedIds.size() == idList.size());
+		String status = this.chromaApi.deleteEmbeddings(this.collectionId, new DeleteEmbeddingsRequest(idList));
+		return Optional.of(status.equals("200"));
 	}
 
 	@Override

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/ChromaImage.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/ChromaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class ChromaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.11");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.16");
 
 	private ChromaImage() {
 

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreIT.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreIT.java
@@ -19,6 +19,7 @@ package org.springframework.ai.vectorstore;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -83,7 +84,8 @@ public class ChromaVectorStoreIT {
 			assertThat(resultDoc.getMetadata()).containsKeys("meta2", "distance");
 
 			// Remove all documents from the store
-			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());
+			assertThat(vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList()))
+				.isEqualTo(Optional.of(Boolean.TRUE));
 
 			List<Document> results2 = vectorStore.similaritySearch(SearchRequest.query("Great").withTopK(1));
 			assertThat(results2).hasSize(0);


### PR DESCRIPTION
 - As a result of the the change:https://github.com/chroma-core/chroma/pull/2880  introduced in chroma:0.5.13,the delete operation doesn't return any values. Hence, we need to check the Http Client Response with the status code instead of return value.
   - Check the status code for successful delete operation
   - Update test

Resolves #1529
