### PR TITLE
feat: Introduce FunctionCallback.Builder

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.converter;
 
-import java.lang.reflect.Type;
 import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -37,6 +36,7 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.model.ModelOptionsUtils.CustomizedTypeReference;
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.lang.NonNull;
@@ -94,7 +94,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 * @param typeRef The target class type reference.
 	 */
 	public BeanOutputConverter(ParameterizedTypeReference<T> typeRef) {
-		this(new CustomizedTypeReference<>(typeRef), null);
+		this(CustomizedTypeReference.forType(typeRef), null);
 	}
 
 	/**
@@ -105,7 +105,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 * @param objectMapper Custom object mapper for JSON operations. endings.
 	 */
 	public BeanOutputConverter(ParameterizedTypeReference<T> typeRef, ObjectMapper objectMapper) {
-		this(new CustomizedTypeReference<>(typeRef), objectMapper);
+		this(CustomizedTypeReference.forType(typeRef), objectMapper);
 	}
 
 	/**
@@ -218,21 +218,6 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 	 */
 	public String getJsonSchema() {
 		return this.jsonSchema;
-	}
-
-	private static class CustomizedTypeReference<T> extends TypeReference<T> {
-
-		private final Type type;
-
-		CustomizedTypeReference(ParameterizedTypeReference<T> typeRef) {
-			this.type = typeRef.getType();
-		}
-
-		@Override
-		public Type getType() {
-			return this.type;
-		}
-
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallbackBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallbackBuilder.java
@@ -1,0 +1,219 @@
+/*
+* Copyright 2024 - 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.model.function;
+
+import java.lang.reflect.Method;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.function.FunctionCallback.Builder;
+import org.springframework.ai.model.function.FunctionCallbackContext.SchemaType;
+import org.springframework.ai.util.JacksonUtils;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+public class DefaultFunctionCallbackBuilder<I, O> implements FunctionCallback.Builder<I, O> {
+
+	private final Function<I, O> function;
+
+	private final BiFunction<I, ToolContext, O> biFunction;
+
+	private String name;
+
+	private String description;
+
+	private ResolvableType inputType;
+
+	private SchemaType schemaType = SchemaType.JSON_SCHEMA;
+
+	// By default the response is converted to a JSON string.
+	private Function<O, String> responseConverter = ModelOptionsUtils::toJsonString;
+
+	// optional
+	private String inputTypeSchema;
+
+	private ObjectMapper objectMapper = JsonMapper.builder()
+		.addModules(JacksonUtils.instantiateAvailableModules())
+		.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+		.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+		.build();
+
+	//
+	/**
+	 * Object instance that contains the method to be invoked. If the method is static
+	 * this object can be null.
+	 */
+	private final Object functionObject;
+
+	/**
+	 * The method to be invoked.
+	 */
+	private final Method method;
+
+	public DefaultFunctionCallbackBuilder(Function<I, O> function) {
+		this.function = function;
+		this.biFunction = null;
+		this.functionObject = null;
+		this.method = null;
+	}
+
+	public DefaultFunctionCallbackBuilder(BiFunction<I, ToolContext, O> biFunction) {
+		this.function = null;
+		this.biFunction = biFunction;
+		this.functionObject = null;
+		this.method = null;
+	}
+
+	public DefaultFunctionCallbackBuilder(Method method) {
+		this.function = null;
+		this.biFunction = null;
+		this.functionObject = null;
+		this.method = method;
+	}
+
+	public DefaultFunctionCallbackBuilder(Object functionObject, Method method) {
+		this.function = null;
+		this.biFunction = null;
+		this.functionObject = functionObject;
+		this.method = method;
+	}
+
+	@Override
+	public Builder<I, O> name(String name) {
+		Assert.isNull(this.method, "Name can not be set when using Method");
+		Assert.hasText(name, "Name must not be empty");
+		this.name = name;
+		return this;
+	}
+
+	@Override
+	public Builder<I, O> description(String description) {
+		Assert.hasText(description, "Description must not be empty");
+		this.description = description;
+		return this;
+	}
+
+	@Override
+	public Builder<I, O> inputType(Class<?> inputType) {
+		Assert.isNull(this.method, "InputType can not be set when using Method");
+		Assert.notNull(inputType, "InputType must not be null");
+		this.inputType = ResolvableType.forClass(inputType);
+		return this;
+	}
+
+	@Override
+	public Builder<I, O> inputType(ResolvableType inputType) {
+		Assert.isNull(this.method, "InputType can not be set when using Method");
+		Assert.notNull(inputType, "InputType must not be null");
+		this.inputType = inputType;
+		return this;
+	}
+
+	@Override
+	public Builder<I, O> schemaType(SchemaType schemaType) {
+		Assert.notNull(schemaType, "SchemaType must not be null");
+		this.schemaType = schemaType;
+		return this;
+	}
+
+	@Override
+	public Builder<I, O> responseConverter(Function<O, String> responseConverter) {
+		Assert.notNull(responseConverter, "ResponseConverter must not be null");
+		this.responseConverter = responseConverter;
+		return this;
+	}
+
+	@Override
+	public Builder<I, O> inputTypeSchema(String inputTypeSchema) {
+		Assert.isNull(this.method, "InputType can not be set when using Method");
+		Assert.hasText(inputTypeSchema, "InputTypeSchema must not be empty");
+		this.inputTypeSchema = inputTypeSchema;
+		return this;
+	}
+
+	@Override
+	public Builder<I, O> objectMapper(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		this.objectMapper = objectMapper;
+		return this;
+	}
+
+	@Override
+	public FunctionCallback build() {
+
+		Assert.hasText(this.description, "Description must not be empty");
+		Assert.notNull(this.objectMapper, "ObjectMapper must not be null");
+
+		if (this.method != null) {
+			return new MethodFunctionCallback(this.functionObject, this.method, this.description, this.objectMapper);
+		}
+
+		Assert.hasText(this.name, "Name must not be empty");
+		Assert.notNull(this.responseConverter, "ResponseConverter must not be null");
+		Assert.notNull(this.inputType, "InputType must not be null");
+
+		if (this.inputTypeSchema == null) {
+			boolean upperCaseTypeValues = this.schemaType == SchemaType.OPEN_API_SCHEMA;
+			this.inputTypeSchema = ModelOptionsUtils.getJsonSchema(this.inputType, upperCaseTypeValues);
+		}
+
+		BiFunction<I, ToolContext, O> finalBiFunction = (this.biFunction != null) ? this.biFunction
+				: (request, context) -> this.function.apply(request);
+
+		return new FunctionCallbackWrapper<>(this.name, this.description, this.inputTypeSchema, this.inputType,
+				this.responseConverter, this.objectMapper, finalBiFunction);
+	}
+
+	public FunctionCallback build2() {
+
+		Assert.hasText(this.name, "Name must not be empty");
+		Assert.hasText(this.description, "Description must not be empty");
+
+		if (this.objectMapper == null) {
+			this.objectMapper = JsonMapper.builder()
+				.addModules(JacksonUtils.instantiateAvailableModules())
+				.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+				.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+				.build();
+		}
+
+		Assert.notNull(this.responseConverter, "ResponseConverter must not be null");
+		Assert.notNull(this.inputType, "InputType must not be null");
+
+		if (this.inputTypeSchema == null) {
+			boolean upperCaseTypeValues = this.schemaType == SchemaType.OPEN_API_SCHEMA;
+			this.inputTypeSchema = ModelOptionsUtils.getJsonSchema(this.inputType, upperCaseTypeValues);
+		}
+
+		BiFunction<I, ToolContext, O> finalBiFunction = (this.biFunction != null) ? this.biFunction
+				: (request, context) -> this.function.apply(request);
+
+		return new FunctionCallbackWrapper<>(this.name, this.description, this.inputTypeSchema, this.inputType,
+				this.responseConverter, this.objectMapper, finalBiFunction);
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
@@ -16,7 +16,13 @@
 
 package org.springframework.ai.model.function;
 
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.model.function.FunctionCallbackContext.SchemaType;
+import org.springframework.core.ResolvableType;
 
 /**
  * Represents a model function call handler. Implementations are registered with the
@@ -71,6 +77,64 @@ public interface FunctionCallback {
 			throw new UnsupportedOperationException("Function context is not supported!");
 		}
 		return call(functionInput);
+	}
+
+	interface Builder<I, O> {
+
+		/**
+		 * Function name. Unique within the model.
+		 */
+		Builder<I, O> name(String name);
+
+		/**
+		 * Function description. This description is used by the model do decide if the
+		 * function should be called or not.
+		 */
+		Builder<I, O> description(String description);
+
+		/**
+		 * Function input type. The input type is used to validate the function input
+		 * arguments.
+		 */
+		Builder<I, O> inputType(Class<?> inputType);
+
+		/**
+		 * Function input type. The input type is used to validate the function input
+		 * arguments. The {@link ResolvableType} can be used to provide a generic type
+		 * with parameterized types.
+		 */
+		Builder<I, O> inputType(ResolvableType inputType);
+
+		/**
+		 * Specifies what {@link SchemaType} is used by the AI model to validate the
+		 * function input arguments. Most models use JSON Schema, except Vertex AI that
+		 * uses OpenAPI types.
+		 */
+		Builder<I, O> schemaType(SchemaType schemaType);
+
+		/**
+		 * Function response converter. The default implementation converts the output
+		 * into String before sending it to the Model. Provide a custom function
+		 * responseConverter implementation to override this.
+		 */
+		Builder<I, O> responseConverter(Function<O, String> responseConverter);
+
+		/**
+		 * You can provide the Input Type Schema directly. In this case it won't be
+		 * generated from the inputType.
+		 */
+		Builder<I, O> inputTypeSchema(String inputTypeSchema);
+
+		/**
+		 * Custom object mapper for JSON operations.
+		 */
+		Builder<I, O> objectMapper(ObjectMapper objectMapper);
+
+		/**
+		 * Builds the {@link FunctionCallback} instance.
+		 */
+		FunctionCallback build();
+
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackWrapper.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallbackWrapper.java
@@ -28,6 +28,7 @@ import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.function.FunctionCallbackContext.SchemaType;
 import org.springframework.ai.util.JacksonUtils;
+import org.springframework.core.ResolvableType;
 import org.springframework.util.Assert;
 
 /**
@@ -38,13 +39,18 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @author Sebastien Deleuze
- *
  */
 public final class FunctionCallbackWrapper<I, O> extends AbstractFunctionCallback<I, O> {
 
 	private final BiFunction<I, ToolContext, O> biFunction;
 
 	private FunctionCallbackWrapper(String name, String description, String inputTypeSchema, Class<I> inputType,
+			Function<O, String> responseConverter, ObjectMapper objectMapper, BiFunction<I, ToolContext, O> function) {
+		this(name, description, inputTypeSchema, ResolvableType.forClass(inputType), responseConverter, objectMapper,
+				function);
+	}
+
+	public FunctionCallbackWrapper(String name, String description, String inputTypeSchema, ResolvableType inputType,
 			Function<O, String> responseConverter, ObjectMapper objectMapper, BiFunction<I, ToolContext, O> function) {
 		super(name, description, inputTypeSchema, inputType, responseConverter, objectMapper);
 		Assert.notNull(function, "Function must not be null");
@@ -64,6 +70,10 @@ public final class FunctionCallbackWrapper<I, O> extends AbstractFunctionCallbac
 		return this.biFunction.apply(input, context);
 	}
 
+	/**
+	 * @deprecated in favor of {@link DefaultFunctionCallbackBuilder}
+	 */
+	@Deprecated
 	public static class Builder<I, O> {
 
 		private final BiFunction<I, ToolContext, O> biFunction;


### PR DESCRIPTION
- Introduce FunctionCallback.Builder interface for improved builder pattern.
- Add support for generic type parameters via ResolvableType. Enhance function callbacks with generic type support.
- Move CustomizedTypeReference to ModelOptionsUtils for broader reuse.
- Deprecate old FunctionCallbackWrapper.Builder in favor of DefaultFunctionCallbackBuilder.
- Add JSON schema generation support for ResolvableType.

Resolves #1731

