### PR TITLE
fix huggingface generate text

### DIFF
--- a/models/spring-ai-huggingface/src/main/resources/openapi.json
+++ b/models/spring-ai-huggingface/src/main/resources/openapi.json
@@ -37,7 +37,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GenerateResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GenerateResponse"
+                  }
                 }
               },
               "text/event-stream": {


### PR DESCRIPTION
fix issue #1727  when using text-generation-inference models



I think the [openapi.json ](https://github.com/huggingface/text-generation-inference/blob/v2.4.0/docs/openapi.json) needs to be fixed.
you can find the response type is an array [here](https://github.com/huggingface/text-generation-inference/blob/a7850008429c4c1c4a2ded7bbed4c1b12d22d287/router/src/server.rs#L145)


test models:
microsoft/Phi-3-mini-4k-instruct
mistralai/Mistral-7B-Instruct-v0.3
Qwen/Qwen2.5-Coder-32B-Instruct


microsoft/Phi-3-mini-4k-instruct
<img width="934" alt="image" src="https://github.com/user-attachments/assets/9083aa77-9e68-4225-82e0-c47026577a92">

mistralai/Mistral-7B-Instruct-v0.3
<img width="944" alt="image" src="https://github.com/user-attachments/assets/4fa77655-a3c4-47a0-a014-3c9b37e9903e">

Qwen/Qwen2.5-Coder-32B-Instruct
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/e14c12a4-e76a-44ee-9633-4a19c9adaee0">
