### PR TITLE
GH-1599 Remove deprecations prior to M2

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -114,16 +114,13 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 				inputTokens.set(response.message().usage().inputTokens());
 			}
 			String content = response.type() == StreamingType.CONTENT_BLOCK_DELTA ? response.delta().text() : "";
-
-			var generation = new Generation(content);
-
+			ChatGenerationMetadata chatGenerationMetadata = null;
 			if (response.type() == StreamingType.MESSAGE_DELTA) {
-				generation = generation.withGenerationMetadata(ChatGenerationMetadata
-					.from(response.delta().stopReason(), new Anthropic3ChatBedrockApi.AnthropicUsage(inputTokens.get(),
-							response.usage().outputTokens())));
+				chatGenerationMetadata = ChatGenerationMetadata.from(response.delta().stopReason(),
+						new Anthropic3ChatBedrockApi.AnthropicUsage(inputTokens.get(),
+								response.usage().outputTokens()));
 			}
-
-			return new ChatResponse(List.of(generation));
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(content), chatGenerationMetadata)));
 		});
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
@@ -25,6 +25,7 @@ import org.springframework.ai.bedrock.MessageToPromptConverter;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatResponse;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
@@ -61,7 +62,10 @@ public class BedrockCohereChatModel implements ChatModel, StreamingChatModel {
 	@Override
 	public ChatResponse call(Prompt prompt) {
 		CohereChatResponse response = this.chatApi.chatCompletion(this.createRequest(prompt, false));
-		List<Generation> generations = response.generations().stream().map(g -> new Generation(g.text())).toList();
+		List<Generation> generations = response.generations()
+			.stream()
+			.map(g -> new Generation(new AssistantMessage(g.text())))
+			.toList();
 
 		return new ChatResponse(generations);
 	}
@@ -73,9 +77,9 @@ public class BedrockCohereChatModel implements ChatModel, StreamingChatModel {
 				String finishReason = g.finishReason().name();
 				Usage usage = BedrockUsage.from(g.amazonBedrockInvocationMetrics());
 				return new ChatResponse(List
-					.of(new Generation("").withGenerationMetadata(ChatGenerationMetadata.from(finishReason, usage))));
+					.of(new Generation(new AssistantMessage(""), ChatGenerationMetadata.from(finishReason, usage))));
 			}
-			return new ChatResponse(List.of(new Generation(g.text())));
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(g.text()))));
 		});
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
@@ -19,6 +19,7 @@ package org.springframework.ai.bedrock.jurassic2;
 import org.springframework.ai.bedrock.MessageToPromptConverter;
 import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi;
 import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatRequest;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -68,8 +69,8 @@ public class BedrockAi21Jurassic2ChatModel implements ChatModel {
 
 		return new ChatResponse(response.completions()
 			.stream()
-			.map(completion -> new Generation(completion.data().text())
-				.withGenerationMetadata(ChatGenerationMetadata.from(completion.finishReason().reason(), null)))
+			.map(completion -> new Generation(new AssistantMessage(completion.data().text()),
+					ChatGenerationMetadata.from(completion.finishReason().reason(), null)))
 			.toList());
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
@@ -24,6 +24,7 @@ import org.springframework.ai.bedrock.MessageToPromptConverter;
 import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi;
 import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi.LlamaChatRequest;
 import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi.LlamaChatResponse;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
@@ -68,7 +69,7 @@ public class BedrockLlamaChatModel implements ChatModel, StreamingChatModel {
 
 		LlamaChatResponse response = this.chatApi.chatCompletion(request);
 
-		return new ChatResponse(List.of(new Generation(response.generation()).withGenerationMetadata(
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(response.generation()),
 				ChatGenerationMetadata.from(response.stopReason().name(), extractUsage(response)))));
 	}
 
@@ -81,8 +82,8 @@ public class BedrockLlamaChatModel implements ChatModel, StreamingChatModel {
 
 		return fluxResponse.map(response -> {
 			String stopReason = response.stopReason() != null ? response.stopReason().name() : null;
-			return new ChatResponse(List.of(new Generation(response.generation())
-				.withGenerationMetadata(ChatGenerationMetadata.from(stopReason, extractUsage(response)))));
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(response.generation()),
+					ChatGenerationMetadata.from(stopReason, extractUsage(response)))));
 		});
 	}
 

--- a/models/spring-ai-huggingface/src/main/java/org/springframework/ai/huggingface/HuggingfaceChatModel.java
+++ b/models/spring-ai-huggingface/src/main/java/org/springframework/ai/huggingface/HuggingfaceChatModel.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -103,7 +105,7 @@ public class HuggingfaceChatModel implements ChatModel {
 				new TypeReference<Map<String, Object>>() {
 
 				});
-		Generation generation = new Generation(generatedText, detailsMap);
+		Generation generation = new Generation(new AssistantMessage(generatedText, detailsMap));
 		generations.add(generation);
 		return new ChatResponse(generations);
 	}

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -224,10 +224,7 @@ public class MiniMaxApi {
 		ABAB_6_5_T_Chat("abab6.5t-chat"),
 		ABAB_6_5_G_Chat("abab6.5g-chat"),
 		ABAB_5_5_Chat("abab5.5-chat"),
-		ABAB_5_5_S_Chat("abab5.5s-chat"),
-
-		@Deprecated(since = "1.0.0-M2", forRemoval = true) // Replaced by ABAB_6_5_S_Chat
-		ABAB_6_Chat("abab6-chat");
+		ABAB_5_5_S_Chat("abab5.5s-chat");
 
 		public final String  value;
 
@@ -269,11 +266,6 @@ public class MiniMaxApi {
 		 */
 		@JsonProperty("tool_calls")
 		TOOL_CALLS,
-		/**
-		 * (deprecated) The model called a function.
-		 */
-		@JsonProperty("function_call")
-		FUNCTION_CALL,
 		/**
 		 * Only for compatibility with Mistral AI API.
 		 */

--- a/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/api/MoonshotApi.java
+++ b/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/api/MoonshotApi.java
@@ -196,11 +196,6 @@ public class MoonshotApi {
 		@JsonProperty("tool_calls")
 		TOOL_CALLS,
 		/**
-		 * (deprecated) The model called a function.
-		 */
-		@JsonProperty("function_call")
-		FUNCTION_CALL,
-		/**
 		 * Only for compatibility with Mistral AI API.
 		 */
 		@JsonProperty("tool_call")

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
@@ -24,13 +24,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.ollama.BaseOllamaIT;
 import org.springframework.ai.ollama.api.OllamaApi.ChatRequest;
 import org.springframework.ai.ollama.api.OllamaApi.ChatResponse;
 import org.springframework.ai.ollama.api.OllamaApi.EmbeddingsRequest;
 import org.springframework.ai.ollama.api.OllamaApi.EmbeddingsResponse;
-import org.springframework.ai.ollama.api.OllamaApi.GenerateRequest;
-import org.springframework.ai.ollama.api.OllamaApi.GenerateResponse;
 import org.springframework.ai.ollama.api.OllamaApi.Message;
 import org.springframework.ai.ollama.api.OllamaApi.Message.Role;
 
@@ -47,23 +46,6 @@ public class OllamaApiIT extends BaseOllamaIT {
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
 		initializeOllama(MODEL);
-	}
-
-	@Test
-	public void generation() {
-		var request = GenerateRequest
-			.builder("What is the capital of Bulgaria and what is the size? What it the national anthem?")
-			.withModel(MODEL)
-			.withStream(false)
-			.build();
-
-		GenerateResponse response = getOllamaApi().generate(request);
-
-		System.out.println(response);
-
-		assertThat(response).isNotNull();
-		assertThat(response.model()).contains(MODEL);
-		assertThat(response.response()).contains("Sofia");
 	}
 
 	@Test

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -398,25 +398,10 @@ public class OpenAiApi {
 		GPT_4_TURBO_PREVIEW("gpt-4-turbo-preview"),
 
 		/**
-		 * GPT-4 with the ability to understand images, in addition to all other GPT-4
-		 * Turbo capabilities. Currently points to gpt-4-1106-vision-preview. Returns a
-		 * maximum of 4,096 output tokens Context window: 128k tokens
-		 */
-		@Deprecated(since = "1.0.0-M2", forRemoval = true) // Replaced by GPT_4_O
-		GPT_4_VISION_PREVIEW("gpt-4-vision-preview"),
-
-		/**
 		 * Currently points to gpt-4-0613. Snapshot of gpt-4 from June 13th 2023 with
 		 * improved function calling support. Context window: 8k tokens
 		 */
 		GPT_4("gpt-4"),
-
-		/**
-		 * Currently points to gpt-4-32k-0613. Snapshot of gpt-4-32k from June 13th 2023
-		 * with improved function calling support. Context window: 32k tokens
-		 */
-		@Deprecated(since = "1.0.0-M2", forRemoval = true) // Replaced by GPT_4_O
-		GPT_4_32K("gpt-4-32k"),
 
 		/**
 		 * Currently points to gpt-3.5-turbo-0125. model with higher accuracy at
@@ -483,11 +468,6 @@ public class OpenAiApi {
 		 */
 		@JsonProperty("tool_calls")
 		TOOL_CALLS,
-		/**
-		 * (deprecated) The model called a function.
-		 */
-		@JsonProperty("function_call")
-		FUNCTION_CALL,
 		/**
 		 * Only for compatibility with Mistral AI API.
 		 */

--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
@@ -88,56 +88,6 @@ public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements 
 		this.createExtension = createExtension;
 	}
 
-	/**
-	 * a constructor
-	 * @param jdbcTemplate JdbcTemplate
-	 * @param transformer huggingface sentence-transformer name
-	 */
-	@Deprecated(since = "0.8.0", forRemoval = true)
-	public PostgresMlEmbeddingModel(JdbcTemplate jdbcTemplate, String transformer) {
-		this(jdbcTemplate, transformer, VectorType.PG_ARRAY);
-	}
-
-	/**
-	 * a constructor
-	 * @deprecated Use the constructor with {@link PostgresMlEmbeddingOptions} instead.
-	 * @param jdbcTemplate JdbcTemplate
-	 * @param transformer huggingface sentence-transformer name
-	 * @param vectorType vector type in PostgreSQL
-	 */
-	@Deprecated(since = "0.8.0", forRemoval = true)
-	public PostgresMlEmbeddingModel(JdbcTemplate jdbcTemplate, String transformer, VectorType vectorType) {
-		this(jdbcTemplate, transformer, vectorType, Map.of(), MetadataMode.EMBED, false);
-	}
-
-	/**
-	 * a constructor * @deprecated Use the constructor with
-	 * {@link PostgresMlEmbeddingOptions} instead.
-	 * @param jdbcTemplate JdbcTemplate
-	 * @param transformer huggingface sentence-transformer name
-	 * @param vectorType vector type in PostgreSQL
-	 * @param kwargs optional arguments
-	 */
-	@Deprecated(since = "0.8.0", forRemoval = true)
-	public PostgresMlEmbeddingModel(JdbcTemplate jdbcTemplate, String transformer, VectorType vectorType,
-			Map<String, Object> kwargs, MetadataMode metadataMode, boolean createExtension) {
-		Assert.notNull(jdbcTemplate, "jdbc template must not be null.");
-		Assert.notNull(transformer, "transformer must not be null.");
-		Assert.notNull(vectorType, "vectorType must not be null.");
-		Assert.notNull(kwargs, "kwargs must not be null.");
-		Assert.notNull(metadataMode, "metadataMode must not be null.");
-
-		this.jdbcTemplate = jdbcTemplate;
-
-		this.defaultOptions = PostgresMlEmbeddingOptions.builder()
-			.withTransformer(transformer)
-			.withVectorType(vectorType)
-			.withMetadataMode(metadataMode)
-			.withKwargs(ModelOptionsUtils.toJsonString(kwargs))
-			.build();
-		this.createExtension = createExtension;
-	}
-
 	@SuppressWarnings("null")
 	@Override
 	public float[] embed(String text) {

--- a/models/spring-ai-vertex-ai-embedding/src/test/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModelIT.java
+++ b/models/spring-ai-vertex-ai-embedding/src/test/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModelIT.java
@@ -16,6 +16,10 @@
 
 package org.springframework.ai.vertexai.embedding.multimodal;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
@@ -104,10 +108,12 @@ class VertexAiMultimodalEmbeddingModelIT {
 	}
 
 	@Test
-	void textMediaEmbedding() {
+	void textMediaEmbedding() throws MalformedURLException {
 		assertThat(this.multiModelEmbeddingModel).isNotNull();
 
-		var document = Document.builder().withMedia(new Media(MimeTypeUtils.TEXT_PLAIN, "Hello World")).build();
+		var document = Document.builder()
+			.withMedia(new Media(MimeTypeUtils.TEXT_PLAIN, URI.create("http://example.com/image.png").toURL()))
+			.build();
 
 		DocumentEmbeddingRequest embeddingRequest = new DocumentEmbeddingRequest(document);
 

--- a/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/WatsonxAiChatModelTest.java
+++ b/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/WatsonxAiChatModelTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -172,9 +173,9 @@ public class WatsonxAiChatModelTest {
 		given(mockChatApi.generate(any(WatsonxAiChatRequest.class)))
 			.willReturn(ResponseEntity.of(Optional.of(fakeResponse)));
 
-		Generation expectedGenerator = new Generation("LLM response")
-			.withGenerationMetadata(ChatGenerationMetadata.from("max_tokens",
-					Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning")))));
+		Generation expectedGenerator = new Generation(new AssistantMessage("LLM response"),
+				ChatGenerationMetadata.from("max_tokens",
+						Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning")))));
 
 		ChatResponse expectedResponse = new ChatResponse(List.of(expectedGenerator));
 		ChatResponse response = chatModel.call(prompt);
@@ -205,10 +206,9 @@ public class WatsonxAiChatModelTest {
 		Flux<WatsonxAiChatResponse> fakeResponse = Flux.just(fakeResponseFirst, fakeResponseSecond);
 		given(mockChatApi.generateStreaming(any(WatsonxAiChatRequest.class))).willReturn(fakeResponse);
 
-		Generation firstGen = new Generation("LLM resp")
-			.withGenerationMetadata(ChatGenerationMetadata.from("max_tokens",
-					Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning")))));
-		Generation secondGen = new Generation("onse");
+		Generation firstGen = new Generation(new AssistantMessage("LLM resp"), ChatGenerationMetadata.from("max_tokens",
+				Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning")))));
+		Generation secondGen = new Generation(new AssistantMessage("onse"));
 
 		Flux<ChatResponse> response = chatModel.stream(prompt);
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -280,11 +280,6 @@ public class ZhiPuAiApi {
 		@JsonProperty("tool_calls")
 		TOOL_CALLS,
 		/**
-		 * (deprecated) The model called a function.
-		 */
-		@JsonProperty("function_call")
-		FUNCTION_CALL,
-		/**
 		 * Only for compatibility with Mistral AI API.
 		 */
 		@JsonProperty("tool_call")

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/Generation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/Generation.java
@@ -16,13 +16,11 @@
 
 package org.springframework.ai.chat.model;
 
-import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.model.ModelResult;
-import org.springframework.lang.Nullable;
 
 /**
  * Represents a response returned by the AI.
@@ -32,22 +30,6 @@ public class Generation implements ModelResult<AssistantMessage> {
 	private final AssistantMessage assistantMessage;
 
 	private ChatGenerationMetadata chatGenerationMetadata;
-
-	/**
-	 * @deprecated Use {@link #Generation(AssistantMessage)} constructor instead.
-	 */
-	@Deprecated
-	public Generation(String text) {
-		this(text, Map.of());
-	}
-
-	/**
-	 * @deprecated Use {@link #Generation(AssistantMessage)} constructor instead.
-	 */
-	@Deprecated
-	public Generation(String text, Map<String, Object> properties) {
-		this(new AssistantMessage(text, properties));
-	}
 
 	public Generation(AssistantMessage assistantMessage) {
 		this(assistantMessage, ChatGenerationMetadata.NULL);
@@ -67,18 +49,6 @@ public class Generation implements ModelResult<AssistantMessage> {
 	public ChatGenerationMetadata getMetadata() {
 		ChatGenerationMetadata chatGenerationMetadata = this.chatGenerationMetadata;
 		return chatGenerationMetadata != null ? chatGenerationMetadata : ChatGenerationMetadata.NULL;
-	}
-
-	/**
-	 * @deprecated Use {@link #Generation(AssistantMessage, ChatGenerationMetadata)}
-	 * constructor instead.
-	 * @param chatGenerationMetadata
-	 * @return
-	 */
-	@Deprecated
-	public Generation withGenerationMetadata(@Nullable ChatGenerationMetadata chatGenerationMetadata) {
-		this.chatGenerationMetadata = chatGenerationMetadata;
-		return this;
 	}
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/StructuredOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/StructuredOutputConverter.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.converter;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.lang.NonNull;
 
 /**
  * Converts the (raw) LLM output into a structured responses of type. The
@@ -29,12 +28,5 @@ import org.springframework.lang.NonNull;
  * @author Christian Tzolov
  */
 public interface StructuredOutputConverter<T> extends Converter<String, T>, FormatProvider {
-
-	/**
-	 * @deprecated Use the {@link #convert(Object)} instead.
-	 */
-	default T parse(@NonNull String source) {
-		return this.convert(source);
-	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/Media.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/Media.java
@@ -38,21 +38,6 @@ public class Media {
 
 	private final Object data;
 
-	/**
-	 * The Media class represents the data and metadata of a media attachment in a
-	 * message. It consists of a MIME type and the raw data.
-	 *
-	 * This class is used as a parameter in the constructor of the UserMessage class.
-	 * @deprecated This constructor is deprecated since version 1.0.0 M1 and will be
-	 * removed in a future release.
-	 */
-	@Deprecated(since = "1.0.0 M1", forRemoval = true)
-	public Media(MimeType mimeType, Object data) {
-		Assert.notNull(mimeType, "MimeType must not be null");
-		this.mimeType = mimeType;
-		this.data = data;
-	}
-
 	public Media(MimeType mimeType, URL url) {
 		Assert.notNull(mimeType, "MimeType must not be null");
 		this.mimeType = mimeType;

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/MethodFunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/MethodFunctionCallback.java
@@ -167,6 +167,7 @@ public class MethodFunctionCallback implements FunctionCallback {
 				return ModelOptionsUtils.toJsonString(response);
 
 			}
+
 			return "" + response;
 		}
 		catch (Exception e) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersLexer.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersLexer.java
@@ -43,12 +43,6 @@ public class FiltersLexer extends Lexer {
 
 	public static final String[] ruleNames = makeRuleNames();
 
-	/**
-	 * @deprecated Use {@link #VOCABULARY} instead.
-	 */
-	@Deprecated
-	public static final String[] tokenNames;
-
 	public static final String _serializedATN = "\u0004\u0000\u001a\u00e5\u0006\uffff\uffff\u0002\u0000\u0007\u0000\u0002"
 			+ "\u0001\u0007\u0001\u0002\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002"
 			+ "\u0004\u0007\u0004\u0002\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0002"
@@ -241,12 +235,6 @@ public class FiltersLexer extends Lexer {
 	}
 
 	@Override
-	@Deprecated
-	public String[] getTokenNames() {
-		return tokenNames;
-	}
-
-	@Override
 
 	public Vocabulary getVocabulary() {
 		return VOCABULARY;
@@ -284,20 +272,6 @@ public class FiltersLexer extends Lexer {
 
 	static {
 		RuntimeMetaData.checkVersion("4.13.1", RuntimeMetaData.VERSION);
-	}
-
-	static {
-		tokenNames = new String[_SYMBOLIC_NAMES.length];
-		for (int i = 0; i < tokenNames.length; i++) {
-			tokenNames[i] = VOCABULARY.getLiteralName(i);
-			if (tokenNames[i] == null) {
-				tokenNames[i] = VOCABULARY.getSymbolicName(i);
-			}
-
-			if (tokenNames[i] == null) {
-				tokenNames[i] = "<INVALID>";
-			}
-		}
 	}
 
 	static {

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersLexer.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersLexer.java
@@ -43,6 +43,12 @@ public class FiltersLexer extends Lexer {
 
 	public static final String[] ruleNames = makeRuleNames();
 
+	/**
+	 * @deprecated Use {@link #VOCABULARY} instead.
+	 */
+	@Deprecated
+	public static final String[] tokenNames;
+
 	public static final String _serializedATN = "\u0004\u0000\u001a\u00e5\u0006\uffff\uffff\u0002\u0000\u0007\u0000\u0002"
 			+ "\u0001\u0007\u0001\u0002\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002"
 			+ "\u0004\u0007\u0004\u0002\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0002"
@@ -235,6 +241,12 @@ public class FiltersLexer extends Lexer {
 	}
 
 	@Override
+	@Deprecated
+	public String[] getTokenNames() {
+		return tokenNames;
+	}
+
+	@Override
 
 	public Vocabulary getVocabulary() {
 		return VOCABULARY;
@@ -272,6 +284,20 @@ public class FiltersLexer extends Lexer {
 
 	static {
 		RuntimeMetaData.checkVersion("4.13.1", RuntimeMetaData.VERSION);
+	}
+
+	static {
+		tokenNames = new String[_SYMBOLIC_NAMES.length];
+		for (int i = 0; i < tokenNames.length; i++) {
+			tokenNames[i] = VOCABULARY.getLiteralName(i);
+			if (tokenNames[i] == null) {
+				tokenNames[i] = VOCABULARY.getSymbolicName(i);
+			}
+
+			if (tokenNames[i] == null) {
+				tokenNames[i] = "<INVALID>";
+			}
+		}
 	}
 
 	static {

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersParser.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersParser.java
@@ -57,12 +57,6 @@ public class FiltersParser extends Parser {
 
 	public static final String[] ruleNames = makeRuleNames();
 
-	/**
-	 * @deprecated Use {@link #VOCABULARY} instead.
-	 */
-	@Deprecated
-	public static final String[] tokenNames;
-
 	public static final String _serializedATN = "\u0004\u0001\u001aY\u0002\u0000\u0007\u0000\u0002\u0001\u0007\u0001\u0002"
 			+ "\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004\u0007\u0004\u0002"
 			+ "\u0005\u0007\u0005\u0001\u0000\u0001\u0000\u0001\u0000\u0001\u0000\u0001"
@@ -136,20 +130,6 @@ public class FiltersParser extends Parser {
 	}
 
 	static {
-		tokenNames = new String[_SYMBOLIC_NAMES.length];
-		for (int i = 0; i < tokenNames.length; i++) {
-			tokenNames[i] = VOCABULARY.getLiteralName(i);
-			if (tokenNames[i] == null) {
-				tokenNames[i] = VOCABULARY.getSymbolicName(i);
-			}
-
-			if (tokenNames[i] == null) {
-				tokenNames[i] = "<INVALID>";
-			}
-		}
-	}
-
-	static {
 		_decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
 		for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
 			_decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
@@ -179,8 +159,9 @@ public class FiltersParser extends Parser {
 
 	@Override
 	@Deprecated
+	// Usage of token names is removed and hence this returns null.
 	public String[] getTokenNames() {
-		return tokenNames;
+		return null;
 	}
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersParser.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/antlr4/FiltersParser.java
@@ -57,6 +57,12 @@ public class FiltersParser extends Parser {
 
 	public static final String[] ruleNames = makeRuleNames();
 
+	/**
+	 * @deprecated Use {@link #VOCABULARY} instead.
+	 */
+	@Deprecated
+	public static final String[] tokenNames;
+
 	public static final String _serializedATN = "\u0004\u0001\u001aY\u0002\u0000\u0007\u0000\u0002\u0001\u0007\u0001\u0002"
 			+ "\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004\u0007\u0004\u0002"
 			+ "\u0005\u0007\u0005\u0001\u0000\u0001\u0000\u0001\u0000\u0001\u0000\u0001"
@@ -130,6 +136,20 @@ public class FiltersParser extends Parser {
 	}
 
 	static {
+		tokenNames = new String[_SYMBOLIC_NAMES.length];
+		for (int i = 0; i < tokenNames.length; i++) {
+			tokenNames[i] = VOCABULARY.getLiteralName(i);
+			if (tokenNames[i] == null) {
+				tokenNames[i] = VOCABULARY.getSymbolicName(i);
+			}
+
+			if (tokenNames[i] == null) {
+				tokenNames[i] = "<INVALID>";
+			}
+		}
+	}
+
+	static {
 		_decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
 		for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {
 			_decisionToDFA[i] = new DFA(_ATN.getDecisionState(i), i);
@@ -159,9 +179,8 @@ public class FiltersParser extends Parser {
 
 	@Override
 	@Deprecated
-	// Usage of token names is removed and hence this returns null.
 	public String[] getTokenNames() {
-		return null;
+		return tokenNames;
 	}
 
 	@Override

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
@@ -26,6 +26,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
@@ -56,9 +57,9 @@ public class ChatClientResponseEntityTests {
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().withKeyValue("key1", "value1").build();
 
-		var chatResponse = new ChatResponse(List.of(new Generation("""
+		var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("""
 				{"name":"John", "age":30}
-				""")), metadata);
+				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
 
@@ -82,12 +83,12 @@ public class ChatClientResponseEntityTests {
 	@Test
 	public void parametrizedResponseEntityTest() {
 
-		var chatResponse = new ChatResponse(List.of(new Generation("""
+		var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("""
 				[
 					{"name":"Max", "age":10},
 					{"name":"Adi", "age":13}
 				]
-				""")));
+				"""))));
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
 
@@ -112,9 +113,9 @@ public class ChatClientResponseEntityTests {
 	@Test
 	public void customSoCResponseEntityTest() {
 
-		var chatResponse = new ChatResponse(List.of(new Generation("""
+		var chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage("""
 					{"name":"Max", "age":10},
-				""")));
+				"""))));
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStoreProperties.java
@@ -89,18 +89,6 @@ public class CassandraVectorStoreProperties extends CommonVectorStoreProperties 
 		this.embeddingColumnName = embeddingColumnName;
 	}
 
-	@Deprecated
-	public boolean getDisallowSchemaCreation() {
-		logger.warn("getDisallowSchemaCreation() is deprecated, use isInitializeSchema()");
-		return !super.isInitializeSchema();
-	}
-
-	@Deprecated
-	public void setDisallowSchemaCreation(boolean disallowSchemaCreation) {
-		logger.warn("setDisallowSchemaCreation(boolean) is deprecated, use setInitializeSchema(boolean)");
-		super.setInitializeSchema(!disallowSchemaCreation);
-	}
-
 	public boolean getReturnEmbeddings() {
 		return this.returnEmbeddings;
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStorePropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/cassandra/CassandraVectorStorePropertiesTests.java
@@ -36,7 +36,6 @@ class CassandraVectorStorePropertiesTests {
 		assertThat(props.getContentColumnName()).isEqualTo(CassandraVectorStoreConfig.DEFAULT_CONTENT_COLUMN_NAME);
 		assertThat(props.getEmbeddingColumnName()).isEqualTo(CassandraVectorStoreConfig.DEFAULT_EMBEDDING_COLUMN_NAME);
 		assertThat(props.getIndexName()).isNull();
-		assertThat(props.getDisallowSchemaCreation()).isTrue();
 		assertThat(props.getFixedThreadPoolExecutorSize())
 			.isEqualTo(CassandraVectorStoreConfig.DEFAULT_ADD_CONCURRENCY);
 	}
@@ -49,7 +48,6 @@ class CassandraVectorStorePropertiesTests {
 		props.setContentColumnName("my_content");
 		props.setEmbeddingColumnName("my_vector");
 		props.setIndexName("my_sai");
-		props.setDisallowSchemaCreation(true);
 		props.setFixedThreadPoolExecutorSize(10);
 
 		assertThat(props.getKeyspace()).isEqualTo("my_keyspace");
@@ -57,7 +55,6 @@ class CassandraVectorStorePropertiesTests {
 		assertThat(props.getContentColumnName()).isEqualTo("my_content");
 		assertThat(props.getEmbeddingColumnName()).isEqualTo("my_vector");
 		assertThat(props.getIndexName()).isEqualTo("my_sai");
-		assertThat(props.getDisallowSchemaCreation()).isTrue();
 		assertThat(props.getFixedThreadPoolExecutorSize()).isEqualTo(10);
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/neo4j/Neo4jVectorStoreAutoConfigurationIT.java
@@ -52,8 +52,6 @@ import static org.springframework.ai.autoconfigure.vectorstore.observation.Obser
 @Testcontainers
 public class Neo4jVectorStoreAutoConfigurationIT {
 
-	// Needs to be Neo4j 5.15+, because Neo4j 5.15 deprecated the used embedding storing
-	// function.
 	@Container
 	static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:5.18"))
 		.withRandomPassword();

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jImage.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/Neo4jImage.java
@@ -23,8 +23,6 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class Neo4jImage {
 
-	// Needs to be Neo4j 5.15+ because Neo4j 5.15 deprecated the old vector index creation
-	// function.
 	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("neo4j:5.24");
 
 	private Neo4jImage() {

--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -81,18 +81,6 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 
 	/**
 	 * Constructs a new QdrantVectorStore.
-	 * @param config The configuration for the store.
-	 * @param embeddingModel The client for embedding operations.
-	 * @deprecated since 1.0.0 in favor of {@link QdrantVectorStore}.
-	 */
-	@Deprecated(since = "1.0.0", forRemoval = true)
-	public QdrantVectorStore(QdrantClient qdrantClient, QdrantVectorStoreConfig config, EmbeddingModel embeddingModel,
-			boolean initializeSchema) {
-		this(qdrantClient, config.collectionName, embeddingModel, initializeSchema);
-	}
-
-	/**
-	 * Constructs a new QdrantVectorStore.
 	 * @param qdrantClient A {@link QdrantClient} instance for interfacing with Qdrant.
 	 * @param collectionName The name of the collection to use in Qdrant.
 	 * @param embeddingModel The client for embedding operations.
@@ -280,68 +268,6 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		return VectorStoreObservationContext.builder(VectorStoreProvider.QDRANT.value(), operationName)
 			.withDimensions(this.embeddingModel.dimensions())
 			.withCollectionName(this.collectionName);
-
-	}
-
-	/**
-	 * Configuration class for the QdrantVectorStore.
-	 *
-	 * @deprecated since 1.0.0 in favor of {@link QdrantVectorStore}.
-	 */
-	@Deprecated(since = "1.0.0", forRemoval = true)
-	public static final class QdrantVectorStoreConfig {
-
-		private final String collectionName;
-
-		/*
-		 * Constructor using the builder.
-		 *
-		 * @param builder The configuration builder.
-		 */
-
-		private QdrantVectorStoreConfig(Builder builder) {
-			this.collectionName = builder.collectionName;
-		}
-
-		/**
-		 * Start building a new configuration.
-		 * @return The entry point for creating a new configuration.
-		 */
-		public static Builder builder() {
-			return new Builder();
-		}
-
-		/**
-		 * {@return the default config}
-		 */
-		public static QdrantVectorStoreConfig defaultConfig() {
-			return builder().build();
-		}
-
-		public final static class Builder {
-
-			private String collectionName;
-
-			private Builder() {
-			}
-
-			/**
-			 * @param collectionName REQUIRED. The name of the collection.
-			 */
-			public Builder withCollectionName(String collectionName) {
-				this.collectionName = collectionName;
-				return this;
-			}
-
-			/**
-			 * {@return the immutable configuration}
-			 */
-			public QdrantVectorStoreConfig build() {
-				Assert.notNull(this.collectionName, "collectionName cannot be null");
-				return new QdrantVectorStoreConfig(this);
-			}
-
-		}
 
 	}
 


### PR DESCRIPTION
 - Remove deprecated types,methods and references
   - Remove usage of "Generation(String text)" and replace with "Generation(AssistantMessage)"
   - Remove MiniMaxApi,MootShotApi,OpenAiApi,ZhiPuAiApi ChatCompletionFinishReason's FUNCTION_CALL
   - Remove OllamaApi's deprecated types
   - Remove deprecated constructors from PostgresMlEmbeddingModel
   - Remove deprecated constructor from Media
   - Remove tokenNames usage from antlr4 FiltersLexer and FiltersParser
   - Remove deprecated methods from CassandraVectorStoreProperties
   - Remove deprecated constructor and static config class from QdrantVectorStore
   - Minor cleanups on removing deprecated models and versions

Resolves #1599
