### PR TITLE
rename timeToLiveSeconds of cassandra property

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * @author Mick Semb Wever
+ * @author Jihoon Kim
  * @since 1.0.0
  */
 @AutoConfiguration(after = CassandraAutoConfiguration.class)
@@ -50,8 +51,8 @@ public class CassandraChatMemoryAutoConfiguration {
 		if (!properties.isInitializeSchema()) {
 			builder = builder.disallowSchemaChanges();
 		}
-		if (null != properties.getTimeToLiveSeconds()) {
-			builder = builder.withTimeToLive(properties.getTimeToLiveSeconds());
+		if (null != properties.getTimeToLive()) {
+			builder = builder.withTimeToLive(properties.getTimeToLive());
 		}
 
 		return CassandraChatMemory.create(builder.build());

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryProperties.java
@@ -28,6 +28,7 @@ import org.springframework.lang.Nullable;
 
 /**
  * @author Mick Semb Wever
+ * @author Jihoon Kim
  * @since 1.0.0
  */
 @ConfigurationProperties(CassandraChatMemoryProperties.CONFIG_PREFIX)
@@ -45,7 +46,7 @@ public class CassandraChatMemoryProperties extends CommonChatMemoryProperties {
 
 	private String userColumn = CassandraChatMemoryConfig.DEFAULT_USER_COLUMN_NAME;
 
-	private Duration timeToLiveSeconds = null;
+	private Duration timeToLive = null;
 
 	public String getKeyspace() {
 		return this.keyspace;
@@ -80,12 +81,12 @@ public class CassandraChatMemoryProperties extends CommonChatMemoryProperties {
 	}
 
 	@Nullable
-	public Duration getTimeToLiveSeconds() {
-		return this.timeToLiveSeconds;
+	public Duration getTimeToLive() {
+		return this.timeToLive;
 	}
 
-	public void setTimeToLiveSeconds(Duration timeToLiveSeconds) {
-		this.timeToLiveSeconds = timeToLiveSeconds;
+	public void setTimeToLive(Duration timeToLive) {
+		this.timeToLive = timeToLive;
 	}
 
 }

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryPropertiesTest.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryPropertiesTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Mick Semb Wever
+ * @author Jihoon Kim
  * @since 1.0.0
  */
 class CassandraChatMemoryPropertiesTest {
@@ -37,7 +38,7 @@ class CassandraChatMemoryPropertiesTest {
 		assertThat(props.getTable()).isEqualTo(CassandraChatMemoryConfig.DEFAULT_TABLE_NAME);
 		assertThat(props.getAssistantColumn()).isEqualTo(CassandraChatMemoryConfig.DEFAULT_ASSISTANT_COLUMN_NAME);
 		assertThat(props.getUserColumn()).isEqualTo(CassandraChatMemoryConfig.DEFAULT_USER_COLUMN_NAME);
-		assertThat(props.getTimeToLiveSeconds()).isNull();
+		assertThat(props.getTimeToLive()).isNull();
 		assertThat(props.isInitializeSchema()).isTrue();
 	}
 
@@ -48,14 +49,14 @@ class CassandraChatMemoryPropertiesTest {
 		props.setTable("my_table");
 		props.setAssistantColumn("my_assistant_column");
 		props.setUserColumn("my_user_column");
-		props.setTimeToLiveSeconds(Duration.ofDays(1));
+		props.setTimeToLive(Duration.ofDays(1));
 		props.setInitializeSchema(false);
 
 		assertThat(props.getKeyspace()).isEqualTo("my_keyspace");
 		assertThat(props.getTable()).isEqualTo("my_table");
 		assertThat(props.getAssistantColumn()).isEqualTo("my_assistant_column");
 		assertThat(props.getUserColumn()).isEqualTo("my_user_column");
-		assertThat(props.getTimeToLiveSeconds()).isEqualTo(Duration.ofDays(1));
+		assertThat(props.getTimeToLive()).isEqualTo(Duration.ofDays(1));
 		assertThat(props.isInitializeSchema()).isFalse();
 	}
 


### PR DESCRIPTION
fix issue #1728

rename `timeToLiveSeconds` to `timeToLive` because the type is Duration.

add test code for ISO-8601 Format and also numeric type


<img width="1071" alt="image" src="https://github.com/user-attachments/assets/6f14d48b-2358-4e6c-a156-250aed1edaf1">

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/e76de612-45f7-4d6b-b7ed-c99238fe07af">

