### PR TITLE
chore(deps): bump azure-openai to beta.12

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -30,29 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import com.azure.ai.openai.OpenAIAsyncClient;
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
-import com.azure.ai.openai.models.ChatChoice;
-import com.azure.ai.openai.models.ChatCompletions;
-import com.azure.ai.openai.models.ChatCompletionsFunctionToolCall;
-import com.azure.ai.openai.models.ChatCompletionsFunctionToolDefinition;
-import com.azure.ai.openai.models.ChatCompletionsJsonResponseFormat;
-import com.azure.ai.openai.models.ChatCompletionsOptions;
-import com.azure.ai.openai.models.ChatCompletionsResponseFormat;
-import com.azure.ai.openai.models.ChatCompletionsTextResponseFormat;
-import com.azure.ai.openai.models.ChatCompletionsToolCall;
-import com.azure.ai.openai.models.ChatCompletionsToolDefinition;
-import com.azure.ai.openai.models.ChatMessageContentItem;
-import com.azure.ai.openai.models.ChatMessageImageContentItem;
-import com.azure.ai.openai.models.ChatMessageImageUrl;
-import com.azure.ai.openai.models.ChatMessageTextContentItem;
-import com.azure.ai.openai.models.ChatRequestAssistantMessage;
-import com.azure.ai.openai.models.ChatRequestMessage;
-import com.azure.ai.openai.models.ChatRequestSystemMessage;
-import com.azure.ai.openai.models.ChatRequestToolMessage;
-import com.azure.ai.openai.models.ChatRequestUserMessage;
-import com.azure.ai.openai.models.CompletionsFinishReason;
-import com.azure.ai.openai.models.ContentFilterResultsForPrompt;
-import com.azure.ai.openai.models.FunctionCall;
-import com.azure.ai.openai.models.FunctionDefinition;
+import com.azure.ai.openai.models.*;
 import com.azure.core.util.BinaryData;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -390,7 +368,8 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 	private List<ChatCompletionsFunctionToolDefinition> getFunctionTools(Set<String> functionNames) {
 		return this.resolveFunctionCallbacks(functionNames).stream().map(functionCallback -> {
 
-			FunctionDefinition functionDefinition = new FunctionDefinition(functionCallback.getName());
+			ChatCompletionsFunctionToolDefinitionFunction functionDefinition = new ChatCompletionsFunctionToolDefinitionFunction(
+					functionCallback.getName());
 			functionDefinition.setDescription(functionCallback.getDescription());
 			BinaryData parameters = BinaryData
 				.fromObject(ModelOptionsUtils.jsonToMap(functionCallback.getInputTypeSchema()));

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/MergeUtils.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/MergeUtils.java
@@ -57,7 +57,7 @@ public final class MergeUtils {
 			ChatChoiceLogProbabilityInfo.class, int.class, CompletionsFinishReason.class };
 
 	private static final Class<?>[] chatResponseMessageConstructorArgumentTypes = new Class<?>[] { ChatRole.class,
-			String.class };
+			String.class, String.class };
 
 	private MergeUtils() {
 
@@ -236,8 +236,10 @@ public final class MergeUtils {
 			content = left.getContent();
 		}
 
+		String refusal = left.getRefusal() != null ? left.getRefusal() : right.getRefusal();
+
 		ChatResponseMessage instance = newInstance(chatResponseMessageConstructorArgumentTypes,
-				ChatResponseMessage.class, role, content);
+				ChatResponseMessage.class, role, refusal, content);
 
 		List<ChatCompletionsToolCall> toolCalls = new ArrayList<>();
 		if (left.getToolCalls() == null) {

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/MergeUtils.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/MergeUtils.java
@@ -210,9 +210,6 @@ public final class MergeUtils {
 				? left.getContentFilterResults() : right.getContentFilterResults();
 		setField(instance, "contentFilterResults", contentFilterResults);
 
-		var finishDetails = left.getFinishDetails() != null ? left.getFinishDetails() : right.getFinishDetails();
-		setField(instance, "finishDetails", finishDetails);
-
 		var enhancements = left.getEnhancements() != null ? left.getEnhancements() : right.getEnhancements();
 		setField(instance, "enhancements", enhancements);
 

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
 		<spring-cloud-function-context.version>4.1.3</spring-cloud-function-context.version>
 		<spring-boot.version>3.3.4</spring-boot.version>
 		<ST4.version>4.3.4</ST4.version>
-		<azure-open-ai-client.version>1.0.0-beta.10</azure-open-ai-client.version>
+		<azure-open-ai-client.version>1.0.0-beta.12</azure-open-ai-client.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
 		<victools.version>4.31.1</victools.version>
 		<kotlin.version>1.9.25</kotlin.version>


### PR DESCRIPTION
This is needed so that we can enable the "later" service versions (2024-08-01-preview and 2024-06-01-preview) in order to access the usage metrics when using streaming chat calls.
