### PR TITLE
feat(tools): Add conversation history to ToolContext

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.anthropic.client;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.anthropic.AnthropicTestConfiguration;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.function.FunctionCallback;
@@ -158,6 +160,9 @@ class AnthropicChatClientMethodInvokingFunctionCallbackIT {
 
 		assertThat(response).contains("30", "10", "15");
 		assertThat(arguments).containsEntry("tool", "value");
+		assertThat(arguments).containsKey(ToolContext.TOOL_CONVERSATION_KEY);
+		List<Message> tootConversationMessages = (List<Message>) arguments.get(ToolContext.TOOL_CONVERSATION_KEY);
+		assertThat(tootConversationMessages).hasSize(6);
 	}
 
 	@Test
@@ -252,6 +257,7 @@ class AnthropicChatClientMethodInvokingFunctionCallbackIT {
 
 		public String getWeatherWithContext(String city, Unit unit, ToolContext context) {
 			arguments.put("tool", context.getContext().get("tool"));
+			arguments.put(ToolContext.TOOL_CONVERSATION_KEY, context.getToolConversationHistory());
 			return getWeatherStatic(city, unit);
 		}
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
@@ -160,8 +160,8 @@ class AnthropicChatClientMethodInvokingFunctionCallbackIT {
 
 		assertThat(response).contains("30", "10", "15");
 		assertThat(arguments).containsEntry("tool", "value");
-		assertThat(arguments).containsKey(ToolContext.TOOL_CONVERSATION_KEY);
-		List<Message> tootConversationMessages = (List<Message>) arguments.get(ToolContext.TOOL_CONVERSATION_KEY);
+		assertThat(arguments).containsKey(ToolContext.TOOL_CALL_HISTORY);
+		List<Message> tootConversationMessages = (List<Message>) arguments.get(ToolContext.TOOL_CALL_HISTORY);
 		assertThat(tootConversationMessages).hasSize(6);
 	}
 
@@ -257,7 +257,7 @@ class AnthropicChatClientMethodInvokingFunctionCallbackIT {
 
 		public String getWeatherWithContext(String city, Unit unit, ToolContext context) {
 			arguments.put("tool", context.getContext().get("tool"));
-			arguments.put(ToolContext.TOOL_CONVERSATION_KEY, context.getToolConversationHistory());
+			arguments.put(ToolContext.TOOL_CALL_HISTORY, context.getToolCallHistory());
 			return getWeatherStatic(city, unit);
 		}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
@@ -146,10 +146,11 @@ public abstract class AbstractToolCallSupport {
 
 			toolContextMap = new HashMap<>(functionCallOptions.getToolContext());
 
-			List<Message> beforeFunctionCallConversationHistory = new ArrayList<>(prompt.copy().getInstructions());
-			beforeFunctionCallConversationHistory.add(new AssistantMessage(assistantMessage.getContent(),
-					assistantMessage.getMetadata(), assistantMessage.getToolCalls()));
-			toolContextMap.put(ToolContext.TOOL_CONVERSATION_KEY, beforeFunctionCallConversationHistory);
+			List<Message> toolCallHistory = new ArrayList<>(prompt.copy().getInstructions());
+			toolCallHistory.add(new AssistantMessage(assistantMessage.getContent(), assistantMessage.getMetadata(),
+					assistantMessage.getToolCalls()));
+
+			toolContextMap.put(ToolContext.TOOL_CALL_HISTORY, toolCallHistory);
 		}
 
 		ToolResponseMessage toolMessageResponse = this.executeFunctions(assistantMessage,

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -142,12 +143,22 @@ public abstract class AbstractToolCallSupport {
 		Map<String, Object> toolContextMap = Map.of();
 		if (prompt.getOptions() instanceof FunctionCallingOptions functionCallOptions
 				&& !CollectionUtils.isEmpty(functionCallOptions.getToolContext())) {
-			toolContextMap = functionCallOptions.getToolContext();
+
+			toolContextMap = new HashMap<>(functionCallOptions.getToolContext());
+
+			List<Message> beforeFunctionCallConversationHistory = new ArrayList<>(prompt.copy().getInstructions());
+			beforeFunctionCallConversationHistory.add(new AssistantMessage(assistantMessage.getContent(),
+					assistantMessage.getMetadata(), assistantMessage.getToolCalls()));
+			toolContextMap.put(ToolContext.TOOL_CONVERSATION_KEY, beforeFunctionCallConversationHistory);
 		}
+
 		ToolResponseMessage toolMessageResponse = this.executeFunctions(assistantMessage,
 				new ToolContext(toolContextMap));
 
-		return this.buildToolCallConversation(prompt.getInstructions(), assistantMessage, toolMessageResponse);
+		List<Message> toolConversationHistory = this.buildToolCallConversation(prompt.getInstructions(),
+				assistantMessage, toolMessageResponse);
+
+		return toolConversationHistory;
 	}
 
 	protected List<Message> buildToolCallConversation(List<Message> previousMessages, AssistantMessage assistantMessage,

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ToolContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ToolContext.java
@@ -36,15 +36,19 @@ import org.springframework.ai.chat.messages.Message;
  * {@code FunctionCallingOptions} and is used in the function execution process.
  * </p>
  *
+ * <p>
+ * The context map can contain any information that is relevant to the tool execution.
+ * </p>
+ *
  * @author Christian Tzolov
  * @since 1.0.0
  */
 public class ToolContext {
 
 	/**
-	 * The key for the tool conversation history stored in the context map.
+	 * The key for the running, tool call history stored in the context map.
 	 */
-	public static final String TOOL_CONVERSATION_KEY = "TOOL_CONVERSATION_KEY";
+	public static final String TOOL_CALL_HISTORY = "TOOL_CALL_HISTORY";
 
 	private final Map<String, Object> context;
 
@@ -69,8 +73,9 @@ public class ToolContext {
 	 * Returns the tool conversation history from the context map.
 	 * @return The tool conversation history.
 	 */
-	public List<Message> getToolConversationHistory() {
-		return (List<Message>) this.context.get(TOOL_CONVERSATION_KEY);
+	@SuppressWarnings("unchecked")
+	public List<Message> getToolCallHistory() {
+		return (List<Message>) this.context.get(TOOL_CALL_HISTORY);
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ToolContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ToolContext.java
@@ -17,7 +17,10 @@
 package org.springframework.ai.chat.model;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+
+import org.springframework.ai.chat.messages.Message;
 
 /**
  * Represents the context for tool execution in a function calling scenario.
@@ -38,6 +41,11 @@ import java.util.Map;
  */
 public class ToolContext {
 
+	/**
+	 * The key for the tool conversation history stored in the context map.
+	 */
+	public static final String TOOL_CONVERSATION_KEY = "TOOL_CONVERSATION_KEY";
+
 	private final Map<String, Object> context;
 
 	/**
@@ -55,6 +63,14 @@ public class ToolContext {
 	 */
 	public Map<String, Object> getContext() {
 		return this.context;
+	}
+
+	/**
+	 * Returns the tool conversation history from the context map.
+	 * @return The tool conversation history.
+	 */
+	public List<Message> getToolConversationHistory() {
+		return (List<Message>) this.context.get(TOOL_CONVERSATION_KEY);
 	}
 
 }


### PR DESCRIPTION
- Add TOOL_CONVERSATION_KEY constant to store conversation history
- Extend ToolContext with getToolConversationHistory method
- Include conversation history in tool context during function execution
- Add test coverage for tool conversation history verification

Resolves #1202

Decisions to make: 

- [ ] Should we have a dedicated `FunctionCallingOption` property to control the addition of the current tool conversation history to the TooContext.  Or assume that any ToolContext will provide this information? 
- [ ] Should we have a dedicated `ToolContext#getToolConversationHistory` or use the raw map with predefined key `TOOL_CONVERSATION_KEY`.