### PR TITLE
Refactor: Replace instanceof checks and switch expression

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -35,7 +35,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
@@ -472,13 +471,11 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 		if (prompt.getOptions() != null) {
 			OpenAiChatOptions updatedRuntimeOptions = null;
 
-			if (prompt.getOptions() instanceof FunctionCallingOptions) {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(((FunctionCallingOptions) prompt.getOptions()),
-						FunctionCallingOptions.class, OpenAiChatOptions.class);
+			if (prompt.getOptions() instanceof FunctionCallingOptions options) {
+				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(options, FunctionCallingOptions.class, OpenAiChatOptions.class);
 			}
-			else if (prompt.getOptions() instanceof OpenAiChatOptions) {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						OpenAiChatOptions.class);
+			else if (prompt.getOptions() instanceof OpenAiChatOptions options) {
+				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(options, ChatOptions.class, OpenAiChatOptions.class);
 			}
 
 			enabledToolsToUse.addAll(this.runtimeFunctionCallbackConfigurations(updatedRuntimeOptions));

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -416,51 +416,52 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 	ChatCompletionRequest createRequest(Prompt prompt, boolean stream) {
 
 		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(message -> {
-			if (message.getMessageType() == MessageType.USER || message.getMessageType() == MessageType.SYSTEM) {
-				Object content = message.getContent();
-				if (message instanceof UserMessage userMessage) {
-					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
-						List<MediaContent> contentList = new ArrayList<>(
-								List.of(new MediaContent(message.getContent())));
+			switch (message.getMessageType()) {
+				case USER, SYSTEM:
+					Object content = message.getContent();
+					if (message instanceof UserMessage userMessage) {
+						if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
+							List<MediaContent> contentList = new ArrayList<>(
+									List.of(new MediaContent(message.getContent())));
 
-						contentList.addAll(userMessage.getMedia()
-							.stream()
-							.map(media -> new MediaContent(new MediaContent.ImageUrl(
-									this.fromMediaData(media.getMimeType(), media.getData()))))
-							.toList());
+							contentList.addAll(userMessage.getMedia()
+									.stream()
+									.map(media -> new MediaContent(new MediaContent.ImageUrl(
+											this.fromMediaData(media.getMimeType(), media.getData()))))
+									.toList());
 
-						content = contentList;
+							content = contentList;
+						}
 					}
-				}
+					return List.of(new ChatCompletionMessage(content,
+							ChatCompletionMessage.Role.valueOf(message.getMessageType().name())));
+				case ASSISTANT:
+					var assistantMessage = (AssistantMessage) message;
+					List<ToolCall> toolCalls = null;
+					if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
+						toolCalls = assistantMessage.getToolCalls().stream().map(toolCall -> {
+							var function = new ChatCompletionFunction(toolCall.name(), toolCall.arguments());
+							return new ToolCall(toolCall.id(), toolCall.type(), function);
+						}).toList();
+					}
 
-				return List.of(new ChatCompletionMessage(content,
-						ChatCompletionMessage.Role.valueOf(message.getMessageType().name())));
-			}
-			else if (message.getMessageType() == MessageType.ASSISTANT) {
-				var assistantMessage = (AssistantMessage) message;
-				List<ToolCall> toolCalls = null;
-				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
-					toolCalls = assistantMessage.getToolCalls().stream().map(toolCall -> {
-						var function = new ChatCompletionFunction(toolCall.name(), toolCall.arguments());
-						return new ToolCall(toolCall.id(), toolCall.type(), function);
-					}).toList();
-				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getContent(),
-						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null));
-			}
-			else if (message.getMessageType() == MessageType.TOOL) {
-				ToolResponseMessage toolMessage = (ToolResponseMessage) message;
+					return List.of(new ChatCompletionMessage(assistantMessage.getContent(),
+							ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null));
+				case TOOL:
+					ToolResponseMessage toolMessage = (ToolResponseMessage) message;
+					toolMessage.getResponses().forEach(response ->
+							Assert.isTrue(response.id() != null, "ToolResponseMessage must have an id")
+					);
 
-				toolMessage.getResponses()
-					.forEach(response -> Assert.isTrue(response.id() != null, "ToolResponseMessage must have an id"));
-				return toolMessage.getResponses()
-					.stream()
-					.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
-							tr.id(), null, null))
-					.toList();
-			}
-			else {
-				throw new IllegalArgumentException("Unsupported message type: " + message.getMessageType());
+					return toolMessage.getResponses()
+							.stream()
+							.map(tr ->
+								new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
+									tr.id(), null, null)
+							)
+							.toList();
+				default:
+					throw new IllegalArgumentException("Unsupported message type: " + message.getMessageType());
 			}
 		}).flatMap(List::stream).toList();
 


### PR DESCRIPTION
I refactored some code to improve readability:
- Extracted the result of `instanceof` checks into variables
- Refactored to use switch expressions instead of `if-else` blocks