### PR TITLE
fix callback merging in AzureOpenAiChatModel constructor

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -53,6 +53,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Christian Tzolov
  * @author Mariusz Bernacki
  * @author Thomas Vitale
+ * @author Jihoon Kim
  * @since 1.0.0
  */
 public class AnthropicApi {
@@ -79,7 +80,7 @@ public class AnthropicApi {
 
 	private final StreamHelper streamHelper = new StreamHelper();
 
-	private WebClient webClient;
+	private final WebClient webClient;
 
 	/**
 	 * Create a new client api with DEFAULT_BASE_URL
@@ -259,7 +260,7 @@ public class AnthropicApi {
 		/**
 		 * The CLAUDE_INSTANT_1_2
 		 */
-		CLAUDE_INSTANT_1_2("claude-instant-1.2");
+		@Deprecated CLAUDE_INSTANT_1_2("claude-instant-1.2");
 		// @formatter:on
 
 		private final String value;
@@ -362,7 +363,7 @@ public class AnthropicApi {
 		/**
 		 * Artificially created event to aggregate tool use events.
 		 */
-		TOOL_USE_AGGREATE
+		TOOL_USE_AGGREGATE
 
 	}
 
@@ -885,7 +886,7 @@ public class AnthropicApi {
 
 		@Override
 		public EventType type() {
-			return EventType.TOOL_USE_AGGREATE;
+			return EventType.TOOL_USE_AGGREGATE;
 		}
 
 		/**

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
@@ -48,6 +48,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mariusz Bernacki
  * @author Christian Tzolov
+ * @author Jihoon Kim
  * @since 1.0.0
  */
 public class StreamHelper {
@@ -85,10 +86,10 @@ public class StreamHelper {
 			}
 		}
 		else if (event.type() == EventType.CONTENT_BLOCK_DELTA) {
-			ContentBlockDeltaEvent contentBolckDelta = (ContentBlockDeltaEvent) event;
-			if (ContentBlock.Type.INPUT_JSON_DELTA.getValue().equals(contentBolckDelta.delta().type())) {
+			ContentBlockDeltaEvent contentBlockDelta = (ContentBlockDeltaEvent) event;
+			if (ContentBlock.Type.INPUT_JSON_DELTA.getValue().equals(contentBlockDelta.delta().type())) {
 				return eventAggregator
-					.appendPartialJson(((ContentBlockDeltaJson) contentBolckDelta.delta()).partialJson());
+					.appendPartialJson(((ContentBlockDeltaJson) contentBlockDelta.delta()).partialJson());
 			}
 		}
 		else if (event.type() == EventType.CONTENT_BLOCK_STOP) {
@@ -119,7 +120,7 @@ public class StreamHelper {
 				.withUsage(messageStartEvent.message().usage())
 				.withContent(new ArrayList<>());
 		}
-		else if (event.type().equals(EventType.TOOL_USE_AGGREATE)) {
+		else if (event.type().equals(EventType.TOOL_USE_AGGREGATE)) {
 			ToolUseAggregationEvent eventToolUseBuilder = (ToolUseAggregationEvent) event;
 
 			if (!CollectionUtils.isEmpty(eventToolUseBuilder.getToolContentBlocks())) {

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -104,6 +104,7 @@ import org.springframework.util.CollectionUtils;
  * @author luocongqiu
  * @author timostark
  * @author Soby Chacko
+ * @author Jihoon Kim
  * @see ChatModel
  * @see com.azure.ai.openai.OpenAIClient
  * @since 1.0.0
@@ -160,7 +161,7 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 
 	public AzureOpenAiChatModel(OpenAIClientBuilder openAIClientBuilder, AzureOpenAiChatOptions options,
 			FunctionCallbackContext functionCallbackContext, List<FunctionCallback> toolFunctionCallbacks) {
-		this(openAIClientBuilder, options, functionCallbackContext, List.of(), ObservationRegistry.NOOP);
+		this(openAIClientBuilder, options, functionCallbackContext, toolFunctionCallbacks, ObservationRegistry.NOOP);
 	}
 
 	public AzureOpenAiChatModel(OpenAIClientBuilder openAIClientBuilder, AzureOpenAiChatOptions options,
@@ -234,10 +235,6 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 
 			Flux<ChatCompletions> chatCompletionsStream = this.openAIAsyncClient
 				.getChatCompletionsStream(options.getModel(), options);
-
-			// For chunked responses, only the first chunk contains the choice role.
-			// The rest of the chunks with same ID share the same role.
-			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
 
 			ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelTests.java
@@ -1,0 +1,82 @@
+package org.springframework.ai.azure.openai;
+
+import com.azure.ai.openai.OpenAIClientBuilder;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.ai.model.function.FunctionCallbackContext;
+
+/**
+ * @author Jihoon Kim
+ */
+@ExtendWith(MockitoExtension.class)
+public class AzureOpenAiChatModelTests {
+
+	@Mock
+	OpenAIClientBuilder mockClient;
+
+	@Mock
+	FunctionCallbackContext functionCallbackContext;
+
+	@Test
+	public void createAzureOpenAiChatModelTest() {
+		String callbackFromChatOptions = "callbackFromChatOptions";
+		String callbackFromConstructorParam = "callbackFromConstructorParam";
+
+		AzureOpenAiChatOptions chatOptions = AzureOpenAiChatOptions.builder()
+			.withFunctionCallbacks(List.of(new TestFunctionCallback(callbackFromChatOptions)))
+			.build();
+
+		List<FunctionCallback> functionCallbacks = List.of(new TestFunctionCallback(callbackFromConstructorParam));
+
+		AzureOpenAiChatModel openAiChatModel = new AzureOpenAiChatModel(mockClient, chatOptions,
+				functionCallbackContext, functionCallbacks);
+
+		assert 2 == openAiChatModel.getFunctionCallbackRegister().size();
+
+		assert callbackFromChatOptions == openAiChatModel.getFunctionCallbackRegister()
+			.get(callbackFromChatOptions)
+			.getName();
+
+		assert callbackFromConstructorParam == openAiChatModel.getFunctionCallbackRegister()
+			.get(callbackFromConstructorParam)
+			.getName();
+	}
+
+	private class TestFunctionCallback implements FunctionCallback {
+
+		private final String name;
+
+		public TestFunctionCallback(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String getDescription() {
+			return null;
+		}
+
+		@Override
+		public String getInputTypeSchema() {
+			return null;
+		}
+
+		@Override
+		public String call(String functionInput) {
+			return null;
+		}
+
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
@@ -41,6 +41,7 @@ import org.springframework.util.CollectionUtils;
  * @author Christian Tzolov
  * @author Grogdunn
  * @author Thomas Vitale
+ * @author Jihoon Kim
  * @since 1.0.0
  */
 public abstract class AbstractToolCallSupport {
@@ -85,7 +86,7 @@ public abstract class AbstractToolCallSupport {
 
 		if (!CollectionUtils.isEmpty(functionOptions.getFunctionCallbacks())) {
 			toolFunctionCallbacksCopy.addAll(functionOptions.getFunctionCallbacks());
-			// Make sure that that function callbacks are are registered directly to the
+			// Make sure that that function callbacks are registered directly to the
 			// functionCallbackRegister and not passed in the default options.
 			functionOptions.setFunctionCallbacks(List.of());
 		}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/anthropic-chat-functions.adoc
@@ -112,7 +112,7 @@ public record Request(String location, Unit unit) {}
 
 It is a best practice to annotate the request object with information such that the generated JSON schema of that function is as descriptive as possible to help the AI model pick the correct function to invoke.
 
-The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithFunctionBeanIT.java.java[FunctionCallWithFunctionBeanIT.java] demonstrates this approach.
+The link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithFunctionBeanIT.java[FunctionCallWithFunctionBeanIT.java] demonstrates this approach.
 
 
 ==== FunctionCallback


### PR DESCRIPTION
and minor fixes ( typo, unused code ).


Function callbacks from `chatOptions` and constructor parameters were not properly merged because the `toolFunctionCallbacks` field in `AzureOpenAiChatModel` was hardcoded to an empty list (`List.of()`).

Ensuring both sources of function callbacks are combined into the functionCallbackRegister during initialization.


AS-IS
Only one callback function was registered from `chatOptions`.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/f62ecc97-7fed-49af-a969-2c18113417c8">

TO-BE
Both callback functions were merged.

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/66816233-dd64-4fae-b27f-0f7350471bc9">
