### PR TITLE
Refactor: Centralize event type checks into utility method

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
@@ -54,18 +54,19 @@ import org.springframework.util.StringUtils;
 public class StreamHelper {
 
 	public boolean isToolUseStart(StreamEvent event) {
-		if (event == null || event.type() == null || event.type() != EventType.CONTENT_BLOCK_START) {
-			return false;
-		}
-		return ContentBlock.Type.TOOL_USE.getValue().equals(((ContentBlockStartEvent) event).contentBlock().type());
+    if (isInvalidEvent(event, EventType.CONTENT_BLOCK_START)) {
+        return false;
+    }
+    ContentBlockStartEvent contentBlockStartEvent = (ContentBlockStartEvent) event;
+    	return ContentBlock.Type.TOOL_USE.getValue().equals(contentBlockStartEvent.contentBlock().type());	
 	}
 
 	public boolean isToolUseFinish(StreamEvent event) {
+    	return !isInvalidEvent(event, EventType.CONTENT_BLOCK_STOP);
+	}
 
-		if (event == null || event.type() == null || event.type() != EventType.CONTENT_BLOCK_STOP) {
-			return false;
-		}
-		return true;
+	private boolean isInvalidEvent(StreamEvent event, EventType expectedType) {
+    	return event == null || event.type() == null || event.type() != expectedType;	
 	}
 
 	public StreamEvent mergeToolUseEvents(StreamEvent previousEvent, StreamEvent event) {


### PR DESCRIPTION
### Changes
Simplified and Improved Code Readability

Added a new `isInvalidEvent` method to centralize common null checks and type validation logic.
Refactored `isToolUseStart` and `isToolUseFinish` methods to remove redundant code and improve clarity.
Improved Maintainability

By separating shared logic into the isInvalidEvent method, future changes to EventType handling or related logic will require minimal updates.

### Why This Change Was Made
1. To reduce code duplication and improve readability and maintainability.
2. To make the logic more robust and easier to extend in the future by centralizing common checks.