### PR TITLE
feat: add operation type and provider metrics to advisor

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationDocumentation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/AdvisorObservationDocumentation.java
@@ -21,6 +21,8 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.ObservationDocumentation;
 
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+
 /**
  * AI Advisor observation documentation.
  *
@@ -54,6 +56,26 @@ public enum AdvisorObservationDocumentation implements ObservationDocumentation 
 	 * Low cardinality key names.
 	 */
 	public enum LowCardinalityKeyNames implements KeyName {
+
+		/**
+		 * The name of the operation being performed.
+		 */
+		AI_OPERATION_TYPE {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.AI_OPERATION_TYPE.value();
+			}
+		},
+
+		/**
+		 * The model provider as identified by the client instrumentation.
+		 */
+		AI_PROVIDER {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.AI_PROVIDER.value();
+			}
+		},
 
 		/**
 		 * Spring AI kind.

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConvention.java
@@ -21,6 +21,8 @@ import io.micrometer.common.KeyValues;
 
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation.HighCardinalityKeyNames;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation.LowCardinalityKeyNames;
+import org.springframework.ai.observation.conventions.AiOperationType;
+import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.observation.conventions.SpringAiKind;
 import org.springframework.ai.util.ParsingUtils;
 import org.springframework.lang.Nullable;
@@ -64,7 +66,16 @@ public class DefaultAdvisorObservationConvention implements AdvisorObservationCo
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(AdvisorObservationContext context) {
-		return KeyValues.of(springAiKind(), advisorType(context), advisorName(context));
+		return KeyValues.of(aiOperationType(context), aiProvider(context), springAiKind(), advisorType(context),
+				advisorName(context));
+	}
+
+	protected KeyValue aiOperationType(AdvisorObservationContext context) {
+		return KeyValue.of(LowCardinalityKeyNames.AI_OPERATION_TYPE, AiOperationType.FRAMEWORK.value());
+	}
+
+	protected KeyValue aiProvider(AdvisorObservationContext context) {
+		return KeyValue.of(LowCardinalityKeyNames.AI_PROVIDER, AiProvider.SPRING_AI.value());
 	}
 
 	protected KeyValue advisorType(AdvisorObservationContext context) {

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/observation/DefaultAdvisorObservationConventionTests.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation.HighCardinalityKeyNames;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationDocumentation.LowCardinalityKeyNames;
+import org.springframework.ai.observation.conventions.AiOperationType;
+import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.observation.conventions.SpringAiKind;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +71,8 @@ class DefaultAdvisorObservationConventionTests {
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(observationContext)).contains(
 				KeyValue.of(LowCardinalityKeyNames.ADVISOR_TYPE.asString(),
 						AdvisorObservationContext.Type.AROUND.name()),
+				KeyValue.of(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(), AiOperationType.FRAMEWORK.value()),
+				KeyValue.of(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.SPRING_AI.value()),
 				KeyValue.of(LowCardinalityKeyNames.ADVISOR_NAME.asString(), "MyName"),
 				KeyValue.of(LowCardinalityKeyNames.SPRING_AI_KIND.asString(), SpringAiKind.ADVISOR.value()));
 	}


### PR DESCRIPTION
Add AI_OPERATION_TYPE and AI_PROVIDER as low cardinality key names to advisor observations. 
The advisor AI_OPERATION_TYPE is set to 'framework' and the AI_PROVIDER to 'spring_ai'.

Resolves #1660
