### PR TITLE
GH-1749 Fix Chroma query/delete operation

### DIFF
--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaImage.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class ChromaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.11");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.18");
 
 	private ChromaImage() {
 

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/ChromaImage.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/ChromaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class ChromaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.16");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.18");
 
 	private ChromaImage() {
 

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/chroma/ChromaApiIT.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/chroma/ChromaApiIT.java
@@ -128,7 +128,8 @@ public class ChromaApiIT {
 		this.chromaApi.upsertEmbeddings(newCollection.id(), new AddEmbeddingsRequest("id3", new float[] { 6f, 6f, 6f },
 				Map.of("key1", "value2", "key2", false, "key4", 23.4), "Small World"));
 
-		var result = this.chromaApi.getEmbeddings(newCollection.id(), new GetEmbeddingsRequest(List.of("id2")));
+		var result = this.chromaApi.getEmbeddings(newCollection.id(),
+				new ChromaApi.GetSimpleEmbeddingsRequest((List.of("id2"))));
 		assertThat(result.ids().get(0)).isEqualTo("id2");
 
 		queryResult = this.chromaApi.queryCollection(newCollection.id(),
@@ -163,8 +164,8 @@ public class ChromaApiIT {
 
 		assertThat(this.chromaApi.countEmbeddings(collection.id())).isEqualTo(3);
 
-		var queryResult = this.chromaApi.queryCollection(collection.id(),
-				new QueryRequest(new float[] { 1f, 1f, 1f }, 3));
+		var queryResult = this.chromaApi.simpleQueryCollection(collection.id(),
+				new ChromaApi.SimpleQueryRequest(new float[] { 1f, 1f, 1f }, 3));
 
 		assertThat(queryResult.ids().get(0)).hasSize(3);
 		assertThat(queryResult.ids().get(0)).containsExactlyInAnyOrder("id1", "id2", "id3");


### PR DESCRIPTION
  - When Chroma query/delete operation doesn't involve a where clause, the latest Chroma API doesn't allow an empty map for the where parameter. This requires both the query and delete operations to remove explicit setting of where parameter with empty map.
    - Check the filter clause to query with or without `where` parameter
    - Update both query and delete operations
    - Update tests
    - Update the latest Chroma image 0.5.18 in the tests

Resolves #1749
