### PR TITLE
refactor(chroma): Align with the latest Chroma API

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
@@ -265,7 +265,7 @@ If all goes well, you should retrieve the document containing the text "Spring A
 === Run Chroma Locally
 
 ```shell
-docker run -it --rm --name chroma -p 8000:8000 ghcr.io/chroma-core/chroma:0.4.15
+docker run -it --rm --name chroma -p 8000:8000 ghcr.io/chroma-core/chroma:0.5.20
 ```
 
 Starts a chroma store at <http://localhost:8000/api/v1>

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/chroma/ChromaVectorStoreAutoConfigurationIT.java
@@ -55,7 +55,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 public class ChromaVectorStoreAutoConfigurationIT {
 
 	@Container
-	static ChromaDBContainer chroma = new ChromaDBContainer("ghcr.io/chroma-core/chroma:0.5.0");
+	static ChromaDBContainer chroma = new ChromaDBContainer("ghcr.io/chroma-core/chroma:0.5.20");
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(ChromaVectorStoreAutoConfiguration.class))

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaImage.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/chroma/ChromaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class ChromaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.11");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.20");
 
 	private ChromaImage() {
 

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/ChromaImage.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/ChromaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class ChromaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.16");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ghcr.io/chroma-core/chroma:0.5.20");
 
 	private ChromaImage() {
 

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreIT.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreIT.java
@@ -93,6 +93,34 @@ public class ChromaVectorStoreIT {
 	}
 
 	@Test
+	public void simpleSearch() {
+		this.contextRunner.run(context -> {
+
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			var document = Document.builder()
+				.withId("simpleDoc")
+				.withContent("The sky is blue because of Rayleigh scattering.")
+				.build();
+
+			vectorStore.add(List.of(document));
+
+			List<Document> results = vectorStore.similaritySearch("Why is the sky blue?");
+
+			assertThat(results).hasSize(1);
+			Document resultDoc = results.get(0);
+			assertThat(resultDoc.getId()).isEqualTo(document.getId());
+			assertThat(resultDoc.getContent()).isEqualTo("The sky is blue because of Rayleigh scattering.");
+
+			// Remove all documents from the store
+			assertThat(vectorStore.delete(List.of(document.getId()))).isEqualTo(Optional.of(Boolean.TRUE));
+
+			results = vectorStore.similaritySearch(SearchRequest.query("Why is the sky blue?"));
+			assertThat(results).hasSize(0);
+		});
+	}
+
+	@Test
 	public void addAndSearchWithFilters() {
 
 		this.contextRunner.run(context -> {


### PR DESCRIPTION
- Added Jackson annotations for JSON property handling in Chroma API request/response records. 
   Use @JsonInclude(JsonInclude.Include.NON_NULL) to ignore empty fields such as null where. 
   Use @JsonProperty(XYZ) to provide a strong contract with the Cohere API.
- Updated the Docker image for running Chroma locally and in tests to version 0.5.20.
- Enhanced  methods with non-null assertions for improved code safety.
- Added a simple search test to verify document similarity search functionality.