### PR TITLE
feat: Add Pixtral and Llama 3.2 Vision models to MistralAi and Ollama

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -270,7 +270,9 @@ public class MistralAiApi {
 		SMALL("mistral-small-latest"),
 		@Deprecated(since = "1.0.0-M1", forRemoval = true) // Mistral will be removing this model - see https://docs.mistral.ai/getting-started/models/models_overview/
 		MEDIUM("mistral-medium-latest"),
-		LARGE("mistral-large-latest");
+		LARGE("mistral-large-latest"),
+		PIXTRAL("pixtral-12b-2409"),
+		PIXTRAL_LARGE("pixtral-large-latest");
 		// @formatter:on
 
 		private final String value;

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
@@ -290,7 +290,9 @@ class MistralAiChatClientIT {
 
 	@Test
 	void validateCallResponseMetadata() {
-		String model = MistralAiApi.ChatModel.OPEN_MISTRAL_7B.getName();
+		// String model = MistralAiApi.ChatModel.OPEN_MISTRAL_7B.getName();
+		String model = MistralAiApi.ChatModel.PIXTRAL.getName();
+		// String model = MistralAiApi.ChatModel.PIXTRAL_LARGE.getName();
 		// @formatter:off
 		ChatResponse response = ChatClient.create(this.chatModel).prompt()
 				.options(MistralAiChatOptions.builder().withModel(model).build())

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
@@ -28,6 +28,11 @@ import org.springframework.ai.model.ChatModelDescription;
 public enum OllamaModel implements ChatModelDescription {
 
 	/**
+	 * Qwen 2.5
+	 */
+	QWEN_2_5_7B("qwen2.5"),
+
+	/**
 	 * Llama 2 is a collection of language models ranging from 7B to 70B parameters.
 	 */
 	LLAMA2("llama2"),
@@ -46,6 +51,16 @@ public enum OllamaModel implements ChatModelDescription {
 	 * The Llama 3.2 3B language model from Meta.
 	 */
 	LLAMA3_2("llama3.2"),
+
+	/**
+	 * The Llama 3.2 Vision 11B language model from Meta.
+	 */
+	LLAMA3_2_VISION_11b("llama3.2-vision"),
+
+	/**
+	 * The Llama 3.2 Vision 90B language model from Meta.
+	 */
+	LLAMA3_2_VISION_90b("llama3.2-vision:90b"),
 
 	/**
 	 * The Llama 3.2 1B language model from Meta.


### PR DESCRIPTION
- Add Pixtral models (PIXTRAL and PIXTRAL_LARGE) to MistralAiApi.ChatModel
- Update MistralAiChatClientIT to use Pixtral model for testing
- Add new Ollama models:
  * QWEN_2_5_7B
  * LLAMA3_2_VISION_11b
  * LLAMA3_2_VISION_90b
