### PR TITLE
Support similarity scores in Document API

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
@@ -71,7 +71,7 @@ public class Document implements MediaContent {
 	 * measure.
 	 */
 	@Nullable
-	private Double score;
+	private final Double score;
 
 	/**
 	 * Embedding of the document. Note: ephemeral field.
@@ -90,10 +90,6 @@ public class Document implements MediaContent {
 		this(content, new HashMap<>());
 	}
 
-	/**
-	 * @deprecated Use builder instead: {@link Document#builder()}.
-	 */
-	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public Document(String content, Map<String, Object> metadata) {
 		this(content, metadata, new RandomIdGenerator());
 	}
@@ -114,10 +110,6 @@ public class Document implements MediaContent {
 		this(idGenerator.generateId(content, metadata), content, metadata);
 	}
 
-	/**
-	 * @deprecated Use builder instead: {@link Document#builder()}.
-	 */
-	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public Document(String id, String content, Map<String, Object> metadata) {
 		this(id, content, List.of(), metadata);
 	}
@@ -194,10 +186,6 @@ public class Document implements MediaContent {
 		return this.score;
 	}
 
-	public void setScore(@Nullable Double score) {
-		this.score = score;
-	}
-
 	/**
 	 * Return the embedding that were calculated.
 	 * @deprecated We are considering getting rid of this, please comment on
@@ -233,20 +221,27 @@ public class Document implements MediaContent {
 		this.contentFormatter = contentFormatter;
 	}
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, content, media, metadata);
+	public Builder mutate() {
+		return new Builder().id(this.id)
+			.content(this.content)
+			.media(new ArrayList<>(this.media))
+			.metadata(this.metadata)
+			.score(this.score);
 	}
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
-			return true;
 		if (o == null || getClass() != o.getClass())
 			return false;
 		Document document = (Document) o;
 		return Objects.equals(id, document.id) && Objects.equals(content, document.content)
-				&& Objects.equals(media, document.media) && Objects.equals(metadata, document.metadata);
+				&& Objects.equals(media, document.media) && Objects.equals(metadata, document.metadata)
+				&& Objects.equals(score, document.score);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, content, media, metadata, score);
 	}
 
 	@Override
@@ -267,6 +262,7 @@ public class Document implements MediaContent {
 
 		private float[] embedding = new float[0];
 
+		@Nullable
 		private Double score;
 
 		private IdGenerator idGenerator = new RandomIdGenerator();
@@ -314,7 +310,7 @@ public class Document implements MediaContent {
 			return this;
 		}
 
-		public Builder score(Double score) {
+		public Builder score(@Nullable Double score) {
 			this.score = score;
 			return this;
 		}

--- a/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -31,6 +32,7 @@ import org.springframework.ai.document.id.IdGenerator;
 import org.springframework.ai.document.id.RandomIdGenerator;
 import org.springframework.ai.model.Media;
 import org.springframework.ai.model.MediaContent;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -61,7 +63,15 @@ public class Document implements MediaContent {
 	 * Metadata for the document. It should not be nested and values should be restricted
 	 * to string, int, float, boolean for simple use with Vector Dbs.
 	 */
-	private Map<String, Object> metadata;
+	private final Map<String, Object> metadata;
+
+	/**
+	 * Measure of similarity between the document embedding and the query vector. The
+	 * higher the score, the more they are similar. It's the opposite of the distance
+	 * measure.
+	 */
+	@Nullable
+	private Double score;
 
 	/**
 	 * Embedding of the document. Note: ephemeral field.
@@ -80,31 +90,61 @@ public class Document implements MediaContent {
 		this(content, new HashMap<>());
 	}
 
+	/**
+	 * @deprecated Use builder instead: {@link Document#builder()}.
+	 */
+	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public Document(String content, Map<String, Object> metadata) {
 		this(content, metadata, new RandomIdGenerator());
 	}
 
+	/**
+	 * @deprecated Use builder instead: {@link Document#builder()}.
+	 */
+	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public Document(String content, Collection<Media> media, Map<String, Object> metadata) {
 		this(new RandomIdGenerator().generateId(content, metadata), content, media, metadata);
 	}
 
+	/**
+	 * @deprecated Use builder instead: {@link Document#builder()}.
+	 */
+	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public Document(String content, Map<String, Object> metadata, IdGenerator idGenerator) {
 		this(idGenerator.generateId(content, metadata), content, metadata);
 	}
 
+	/**
+	 * @deprecated Use builder instead: {@link Document#builder()}.
+	 */
+	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public Document(String id, String content, Map<String, Object> metadata) {
 		this(id, content, List.of(), metadata);
 	}
 
+	/**
+	 * @deprecated Use builder instead: {@link Document#builder()}.
+	 */
+	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public Document(String id, String content, Collection<Media> media, Map<String, Object> metadata) {
-		Assert.hasText(id, "id must not be null or empty");
-		Assert.notNull(content, "content must not be null");
-		Assert.notNull(metadata, "metadata must not be null");
+		this(id, content, media, metadata, null);
+	}
+
+	public Document(String id, String content, @Nullable Collection<Media> media,
+			@Nullable Map<String, Object> metadata, @Nullable Double score) {
+		Assert.hasText(id, "id cannot be null or empty");
+		Assert.notNull(content, "content cannot be null");
+		Assert.notNull(media, "media cannot be null");
+		Assert.noNullElements(media, "media cannot have null elements");
+		Assert.notNull(metadata, "metadata cannot be null");
+		Assert.noNullElements(metadata.keySet(), "metadata cannot have null keys");
+		Assert.noNullElements(metadata.values(), "metadata cannot have null values");
 
 		this.id = id;
 		this.content = content;
-		this.media = media;
-		this.metadata = metadata;
+		this.media = media != null ? media : List.of();
+		this.metadata = metadata != null ? metadata : new HashMap<>();
+		this.score = score;
 	}
 
 	public static Builder builder() {
@@ -149,6 +189,15 @@ public class Document implements MediaContent {
 		return this.metadata;
 	}
 
+	@Nullable
+	public Double getScore() {
+		return this.score;
+	}
+
+	public void setScore(@Nullable Double score) {
+		this.score = score;
+	}
+
 	/**
 	 * Return the embedding that were calculated.
 	 * @deprecated We are considering getting rid of this, please comment on
@@ -186,57 +235,24 @@ public class Document implements MediaContent {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
-		result = prime * result + ((this.metadata == null) ? 0 : this.metadata.hashCode());
-		result = prime * result + ((this.content == null) ? 0 : this.content.hashCode());
-		return result;
+		return Objects.hash(id, content, media, metadata);
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
+	public boolean equals(Object o) {
+		if (this == o)
 			return true;
-		}
-		if (obj == null) {
+		if (o == null || getClass() != o.getClass())
 			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		Document other = (Document) obj;
-		if (this.id == null) {
-			if (other.id != null) {
-				return false;
-			}
-		}
-		else if (!this.id.equals(other.id)) {
-			return false;
-		}
-		if (this.metadata == null) {
-			if (other.metadata != null) {
-				return false;
-			}
-		}
-		else if (!this.metadata.equals(other.metadata)) {
-			return false;
-		}
-		if (this.content == null) {
-			if (other.content != null) {
-				return false;
-			}
-		}
-		else if (!this.content.equals(other.content)) {
-			return false;
-		}
-		return true;
+		Document document = (Document) o;
+		return Objects.equals(id, document.id) && Objects.equals(content, document.content)
+				&& Objects.equals(media, document.media) && Objects.equals(metadata, document.metadata);
 	}
 
 	@Override
 	public String toString() {
-		return "Document{" + "id='" + this.id + '\'' + ", metadata=" + this.metadata + ", content='" + this.content
-				+ '\'' + ", media=" + this.media + '}';
+		return "Document{" + "id='" + id + '\'' + ", content='" + content + '\'' + ", media=" + media + ", metadata="
+				+ metadata + ", score=" + score + '}';
 	}
 
 	public static class Builder {
@@ -249,56 +265,102 @@ public class Document implements MediaContent {
 
 		private Map<String, Object> metadata = new HashMap<>();
 
+		private float[] embedding = new float[0];
+
+		private Double score;
+
 		private IdGenerator idGenerator = new RandomIdGenerator();
 
-		public Builder withIdGenerator(IdGenerator idGenerator) {
-			Assert.notNull(idGenerator, "idGenerator must not be null");
+		public Builder idGenerator(IdGenerator idGenerator) {
+			Assert.notNull(idGenerator, "idGenerator cannot be null");
 			this.idGenerator = idGenerator;
 			return this;
 		}
 
-		public Builder withId(String id) {
-			Assert.hasText(id, "id must not be null or empty");
+		public Builder id(String id) {
+			Assert.hasText(id, "id cannot be null or empty");
 			this.id = id;
 			return this;
 		}
 
-		public Builder withContent(String content) {
-			Assert.notNull(content, "content must not be null");
+		public Builder content(String content) {
 			this.content = content;
 			return this;
 		}
 
-		public Builder withMedia(List<Media> media) {
-			Assert.notNull(media, "media must not be null");
+		public Builder media(List<Media> media) {
 			this.media = media;
 			return this;
 		}
 
-		public Builder withMedia(Media media) {
-			Assert.notNull(media, "media must not be null");
-			this.media.add(media);
+		public Builder media(Media... media) {
+			Assert.noNullElements(media, "media cannot contain null elements");
+			this.media.addAll(List.of(media));
 			return this;
 		}
 
-		public Builder withMetadata(Map<String, Object> metadata) {
-			Assert.notNull(metadata, "metadata must not be null");
+		public Builder metadata(Map<String, Object> metadata) {
 			this.metadata = metadata;
 			return this;
 		}
 
-		public Builder withMetadata(String key, Object value) {
-			Assert.notNull(key, "key must not be null");
-			Assert.notNull(value, "value must not be null");
+		public Builder metadata(String key, Object value) {
 			this.metadata.put(key, value);
 			return this;
+		}
+
+		public Builder embedding(float[] embedding) {
+			this.embedding = embedding;
+			return this;
+		}
+
+		public Builder score(Double score) {
+			this.score = score;
+			return this;
+		}
+
+		@Deprecated(since = "1.0.0-M5", forRemoval = true)
+		public Builder withIdGenerator(IdGenerator idGenerator) {
+			return idGenerator(idGenerator);
+		}
+
+		@Deprecated(since = "1.0.0-M5", forRemoval = true)
+		public Builder withId(String id) {
+			return id(id);
+		}
+
+		@Deprecated(since = "1.0.0-M5", forRemoval = true)
+		public Builder withContent(String content) {
+			return content(content);
+		}
+
+		@Deprecated(since = "1.0.0-M5", forRemoval = true)
+		public Builder withMedia(List<Media> media) {
+			return media(media);
+		}
+
+		@Deprecated(since = "1.0.0-M5", forRemoval = true)
+		public Builder withMedia(Media media) {
+			return media(media);
+		}
+
+		@Deprecated(since = "1.0.0-M5", forRemoval = true)
+		public Builder withMetadata(Map<String, Object> metadata) {
+			return metadata(metadata);
+		}
+
+		@Deprecated(since = "1.0.0-M5", forRemoval = true)
+		public Builder withMetadata(String key, Object value) {
+			return metadata(key, value);
 		}
 
 		public Document build() {
 			if (!StringUtils.hasText(this.id)) {
 				this.id = this.idGenerator.generateId(this.content, this.metadata);
 			}
-			return new Document(this.id, this.content, this.media, this.metadata);
+			var document = new Document(this.id, this.content, this.media, this.metadata, this.score);
+			document.setEmbedding(this.embedding);
+			return document;
 		}
 
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/document/DocumentMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/DocumentMetadata.java
@@ -14,26 +14,37 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.integration.tests;
+package org.springframework.ai.document;
 
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.vectorstore.SimpleVectorStore;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.springframework.ai.vectorstore.VectorStore;
 
 /**
- * Test application for integration tests.
+ * Common set of metadata keys used in {@link Document}s by {@link DocumentReader}s and
+ * {@link VectorStore}s.
  *
  * @author Thomas Vitale
+ * @since 1.0.0
  */
-@SpringBootApplication
-@Import(TestcontainersConfiguration.class)
-public class TestApplication {
+public enum DocumentMetadata {
 
-	@Bean
-	SimpleVectorStore simpleVectorStore(EmbeddingModel embeddingModel) {
-		return new SimpleVectorStore(embeddingModel);
+// @formatter:off
+
+	/**
+	 * Measure of distance between the document embedding and the query vector.
+	 * The lower the distance, the more they are similar.
+	 * It's the opposite of the similarity score.
+	 */
+	DISTANCE("distance");
+
+	private final String value;
+
+	DocumentMetadata(String value) {
+		this.value = value;
 	}
+	public String value() {
+		return this.value;
+	}
+
+// @formatter:on
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/document/package-info.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.document;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SearchRequest.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SearchRequest.java
@@ -22,6 +22,7 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
 import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -30,6 +31,7 @@ import org.springframework.util.Assert;
  * instance and then apply the 'with' methods to alter the default values.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 public final class SearchRequest {
 
@@ -51,6 +53,7 @@ public final class SearchRequest {
 
 	private double similarityThreshold = SIMILARITY_THRESHOLD_ACCEPT_ALL;
 
+	@Nullable
 	private Filter.Expression filterExpression;
 
 	private SearchRequest(String query) {
@@ -186,7 +189,7 @@ public final class SearchRequest {
 	 * filter criteria. The 'null' value stands for no expression filters.
 	 * @return this builder.
 	 */
-	public SearchRequest withFilterExpression(Filter.Expression expression) {
+	public SearchRequest withFilterExpression(@Nullable Filter.Expression expression) {
 		this.filterExpression = expression;
 		return this;
 	}
@@ -225,7 +228,7 @@ public final class SearchRequest {
 	 * 'null' value stands for no expression filters.
 	 * @return this.builder
 	 */
-	public SearchRequest withFilterExpression(String textExpression) {
+	public SearchRequest withFilterExpression(@Nullable String textExpression) {
 		this.filterExpression = (textExpression != null) ? new FilterExpressionTextParser().parse(textExpression)
 				: null;
 		return this;
@@ -243,6 +246,7 @@ public final class SearchRequest {
 		return this.similarityThreshold;
 	}
 
+	@Nullable
 	public Filter.Expression getFilterExpression() {
 		return this.filterExpression;
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStoreContent.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStoreContent.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.document.id.IdGenerator;
 import org.springframework.ai.document.id.RandomIdGenerator;
 import org.springframework.ai.model.Content;
@@ -133,6 +135,12 @@ public final class SimpleVectorStoreContent implements Content {
 	 */
 	public float[] getEmbedding() {
 		return Arrays.copyOf(this.embedding, this.embedding.length);
+	}
+
+	public Document toDocument(Double score) {
+		var metadata = new HashMap<>(this.metadata);
+		metadata.put(DocumentMetadata.DISTANCE.value(), 1.0 - score);
+		return Document.builder().id(this.id).content(this.content).metadata(metadata).score(score).build();
 	}
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/package-info.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.vectorstore;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentBuilderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentBuilderTests.java
@@ -42,13 +42,11 @@ public class DocumentBuilderTests {
 			URL mediaUrl2 = new URL("http://type2");
 			Media media1 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl1);
 			Media media2 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl2);
-			List<Media> mediaList = List.of(media1, media2);
-			return mediaList;
+			return List.of(media1, media2);
 		}
 		catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}
-
 	}
 
 	@BeforeEach
@@ -58,32 +56,26 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithIdGenerator() {
-		IdGenerator mockGenerator = new IdGenerator() {
+		IdGenerator mockGenerator = contents -> "mockedId";
 
-			@Override
-			public String generateId(Object... contents) {
-				return "mockedId";
-			}
-		};
-
-		Document.Builder result = this.builder.withIdGenerator(mockGenerator);
+		Document.Builder result = this.builder.idGenerator(mockGenerator);
 
 		assertThat(result).isSameAs(this.builder);
 
-		Document document = result.withContent("Test content").withMetadata("key", "value").build();
+		Document document = result.content("Test content").metadata("key", "value").build();
 
 		assertThat(document.getId()).isEqualTo("mockedId");
 	}
 
 	@Test
 	void testWithIdGeneratorNull() {
-		assertThatThrownBy(() -> this.builder.withIdGenerator(null)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("idGenerator must not be null");
+		assertThatThrownBy(() -> this.builder.idGenerator(null).build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("idGenerator cannot be null");
 	}
 
 	@Test
 	void testWithId() {
-		Document.Builder result = this.builder.withId("testId");
+		Document.Builder result = this.builder.id("testId");
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getId()).isEqualTo("testId");
@@ -91,16 +83,16 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithIdNullOrEmpty() {
-		assertThatThrownBy(() -> this.builder.withId(null)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("id must not be null or empty");
+		assertThatThrownBy(() -> this.builder.id(null).build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("id cannot be null or empty");
 
-		assertThatThrownBy(() -> this.builder.withId("")).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("id must not be null or empty");
+		assertThatThrownBy(() -> this.builder.id("").build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("id cannot be null or empty");
 	}
 
 	@Test
 	void testWithContent() {
-		Document.Builder result = this.builder.withContent("Test content");
+		Document.Builder result = this.builder.content("Test content");
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getContent()).isEqualTo("Test content");
@@ -108,14 +100,14 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithContentNull() {
-		assertThatThrownBy(() -> this.builder.withContent(null)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("content must not be null");
+		assertThatThrownBy(() -> this.builder.content(null).build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("content cannot be null");
 	}
 
 	@Test
 	void testWithMediaList() {
 		List<Media> mediaList = getMediaList();
-		Document.Builder result = this.builder.withMedia(mediaList);
+		Document.Builder result = this.builder.media(mediaList);
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getMedia()).isEqualTo(mediaList);
@@ -123,9 +115,9 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithMediaListNull() {
-		assertThatThrownBy(() -> this.builder.withMedia((List<Media>) null))
+		assertThatThrownBy(() -> this.builder.media((List<Media>) null).build())
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("media must not be null");
+			.hasMessageContaining("media cannot be null");
 	}
 
 	@Test
@@ -133,7 +125,7 @@ public class DocumentBuilderTests {
 		URL mediaUrl = new URL("http://test");
 		Media media = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl);
 
-		Document.Builder result = this.builder.withMedia(media);
+		Document.Builder result = this.builder.media(media);
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getMedia()).contains(media);
@@ -141,8 +133,8 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithMediaSingleNull() {
-		assertThatThrownBy(() -> this.builder.withMedia((Media) null)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("media must not be null");
+		assertThatThrownBy(() -> this.builder.media((Media) null).build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("media cannot contain null elements");
 	}
 
 	@Test
@@ -150,7 +142,7 @@ public class DocumentBuilderTests {
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key1", "value1");
 		metadata.put("key2", 2);
-		Document.Builder result = this.builder.withMetadata(metadata);
+		Document.Builder result = this.builder.metadata(metadata);
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getMetadata()).isEqualTo(metadata);
@@ -158,47 +150,51 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithMetadataMapNull() {
-		assertThatThrownBy(() -> this.builder.withMetadata((Map<String, Object>) null))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("metadata must not be null");
+		assertThatThrownBy(() -> this.builder.metadata(null).build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("metadata cannot be null");
 	}
 
 	@Test
 	void testWithMetadataKeyValue() {
-		Document.Builder result = this.builder.withMetadata("key", "value");
+		Document.Builder result = this.builder.metadata("key", "value");
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getMetadata()).containsEntry("key", "value");
 	}
 
 	@Test
-	void testWithMetadataKeyValueNull() {
-		assertThatThrownBy(() -> this.builder.withMetadata(null, "value")).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("key must not be null");
+	void testWithMetadataKeyNull() {
+		assertThatThrownBy(() -> this.builder.metadata(null, "value").build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("metadata cannot have null keys");
+	}
 
-		assertThatThrownBy(() -> this.builder.withMetadata("key", null)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("value must not be null");
+	@Test
+	void testWithMetadataValueNull() {
+		assertThatThrownBy(() -> this.builder.metadata("key", null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("metadata cannot have null values");
 	}
 
 	@Test
 	void testBuildWithoutId() {
-		Document document = this.builder.withContent("Test content").build();
+		Document document = this.builder.content("Test content").build();
 
 		assertThat(document.getId()).isNotNull().isNotEmpty();
 		assertThat(document.getContent()).isEqualTo("Test content");
 	}
 
 	@Test
-	void testBuildWithAllProperties() throws MalformedURLException {
+	void testBuildWithAllProperties() {
 
 		List<Media> mediaList = getMediaList();
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key", "value");
 
-		Document document = this.builder.withId("customId")
-			.withContent("Test content")
-			.withMedia(mediaList)
-			.withMetadata(metadata)
+		Document document = this.builder.id("customId")
+			.content("Test content")
+			.media(mediaList)
+			.metadata(metadata)
 			.build();
 
 		assertThat(document.getId()).isEqualTo("customId");

--- a/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreSimilarityTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreSimilarityTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Ilayaperumal Gopinathan
+ * @author Thomas Vitale
  */
 public class SimpleVectorStoreSimilarityTests {
 
@@ -38,8 +39,7 @@ public class SimpleVectorStoreSimilarityTests {
 
 		SimpleVectorStoreContent storeContent = new SimpleVectorStoreContent("1", "hello, how are you?", metadata,
 				testEmbedding);
-		SimpleVectorStore.Similarity similarity = new SimpleVectorStore.Similarity(storeContent, 0.6d);
-		Document document = similarity.getDocument();
+		Document document = storeContent.toDocument(0.6);
 		assertThat(document).isNotNull();
 		assertThat(document.getId()).isEqualTo("1");
 		assertThat(document.getContent()).isEqualTo("hello, how are you?");

--- a/spring-ai-integration-tests/pom.xml
+++ b/spring-ai-integration-tests/pom.xml
@@ -54,7 +54,6 @@
 			<scope>test</scope>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-openai-spring-boot-starter</artifactId>
@@ -72,6 +71,13 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-markdown-document-reader</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/vectorstore/SimpleVectorStoreIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/vectorstore/SimpleVectorStoreIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.integration.tests.vectorstore;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
+import org.springframework.ai.integration.tests.TestApplication;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link SimpleVectorStore}.
+ *
+ * @author Thomas Vitale
+ */
+@SpringBootTest(classes = TestApplication.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
+public class SimpleVectorStoreIT {
+
+	@Autowired
+	private SimpleVectorStore vectorStore;
+
+	List<Document> documents = List.of(
+			Document.builder()
+				.id("471a8c78-549a-4b2c-bce5-ef3ae6579be3")
+				.content(getText("classpath:/test/data/spring.ai.txt"))
+				.metadata(Map.of("meta1", "meta1"))
+				.build(),
+			Document.builder()
+				.id("bc51d7f7-627b-4ba6-adf4-f0bcd1998f8f")
+				.content(getText("classpath:/test/data/time.shelter.txt"))
+				.metadata(Map.of())
+				.build(),
+			Document.builder()
+				.id("d0237682-1150-44ff-b4d2-1be9b1731ee5")
+				.content(getText("classpath:/test/data/great.depression.txt"))
+				.metadata(Map.of("meta2", "meta2"))
+				.build());
+
+	public static String getText(String uri) {
+		var resource = new DefaultResourceLoader().getResource(uri);
+		try {
+			return resource.getContentAsString(StandardCharsets.UTF_8);
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@AfterEach
+	void setUp() {
+		vectorStore.delete(this.documents.stream().map(Document::getId).toList());
+	}
+
+	@Test
+	public void searchWithThreshold() {
+		Document document = Document.builder()
+			.id(UUID.randomUUID().toString())
+			.content("Spring AI rocks!!")
+			.metadata("meta1", "meta1")
+			.build();
+
+		vectorStore.add(List.of(document));
+
+		List<Document> results = vectorStore.similaritySearch(SearchRequest.query("Spring").withTopK(5));
+
+		assertThat(results).hasSize(1);
+		Document resultDoc = results.get(0);
+		assertThat(resultDoc.getId()).isEqualTo(document.getId());
+		assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
+		assertThat(resultDoc.getMetadata()).containsKey("meta1");
+		assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
+
+		Document sameIdDocument = Document.builder()
+			.id(document.getId())
+			.content("The World is Big and Salvation Lurks Around the Corner")
+			.metadata("meta2", "meta2")
+			.build();
+
+		vectorStore.add(List.of(sameIdDocument));
+
+		results = vectorStore.similaritySearch(SearchRequest.query("FooBar").withTopK(5));
+
+		assertThat(results).hasSize(1);
+		resultDoc = results.get(0);
+		assertThat(resultDoc.getId()).isEqualTo(document.getId());
+		assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
+		assertThat(resultDoc.getMetadata()).containsKey("meta2");
+		assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
+
+		vectorStore.delete(List.of(document.getId()));
+	}
+
+}

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStoreProperties.java
@@ -18,6 +18,7 @@ package org.springframework.ai.autoconfigure.vectorstore.pinecone;
 
 import java.time.Duration;
 
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.vectorstore.PineconeVectorStore;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -25,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for Pinecone Vector Store.
  *
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 @ConfigurationProperties(PineconeVectorStoreProperties.CONFIG_PREFIX)
 public class PineconeVectorStoreProperties {
@@ -43,7 +45,7 @@ public class PineconeVectorStoreProperties {
 
 	private String contentFieldName = PineconeVectorStore.CONTENT_FIELD_NAME;
 
-	private String distanceMetadataFieldName = PineconeVectorStore.DISTANCE_METADATA_FIELD_NAME;
+	private String distanceMetadataFieldName = DocumentMetadata.DISTANCE.value();
 
 	private Duration serverSideTimeout = Duration.ofSeconds(20);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStorePropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pinecone/PineconeVectorStorePropertiesTests.java
@@ -20,12 +20,14 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.vectorstore.PineconeVectorStore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 public class PineconeVectorStorePropertiesTests {
 
@@ -39,7 +41,7 @@ public class PineconeVectorStorePropertiesTests {
 		assertThat(props.getIndexName()).isNull();
 		assertThat(props.getServerSideTimeout()).isEqualTo(Duration.ofSeconds(20));
 		assertThat(props.getContentFieldName()).isEqualTo(PineconeVectorStore.CONTENT_FIELD_NAME);
-		assertThat(props.getDistanceMetadataFieldName()).isEqualTo(PineconeVectorStore.DISTANCE_METADATA_FIELD_NAME);
+		assertThat(props.getDistanceMetadataFieldName()).isEqualTo(DocumentMetadata.DISTANCE.value());
 	}
 
 	@Test

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/CosmosDBVectorStore.java
@@ -74,6 +74,7 @@ import org.springframework.ai.vectorstore.observation.VectorStoreObservationConv
  *
  * @author Theo van Kraay
  * @author Soby Chacko
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 public class CosmosDBVectorStore extends AbstractObservationVectorStore implements AutoCloseable {
@@ -338,7 +339,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 				.block();
 			// Convert JsonNode to Document
 			List<Document> docs = documents.stream()
-				.map(doc -> new Document(doc.get("id").asText(), doc.get("content").asText(), new HashMap<>()))
+				.map(doc -> Document.builder().id(doc.get("id").asText()).content(doc.get("content").asText()).build())
 				.collect(Collectors.toList());
 
 			return docs != null ? docs : List.of();

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/CosmosDBVectorStoreIT.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/CosmosDBVectorStoreIT.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Theo van Kraay
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 @EnabledIfEnvironmentVariable(named = "AZURE_COSMOSDB_ENDPOINT", matches = ".+")

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/CosmosDbImage.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/CosmosDbImage.java
@@ -14,26 +14,22 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.integration.tests;
+package org.springframework.ai.vectorstore;
 
-import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.vectorstore.SimpleVectorStore;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.testcontainers.utility.DockerImageName;
 
 /**
- * Test application for integration tests.
- *
  * @author Thomas Vitale
  */
-@SpringBootApplication
-@Import(TestcontainersConfiguration.class)
-public class TestApplication {
+public final class CosmosDbImage {
 
-	@Bean
-	SimpleVectorStore simpleVectorStore(EmbeddingModel embeddingModel) {
-		return new SimpleVectorStore(embeddingModel);
+	// It must always be "latest" or else Azure locks the image after a while. See:
+	// https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/60
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName
+		.parse("mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest");
+
+	private CosmosDbImage() {
+
 	}
 
 }

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
@@ -95,8 +96,6 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 	private static final String EMBEDDING_FIELD_NAME = "embedding";
 
 	private static final String METADATA_FIELD_NAME = "metadata";
-
-	private static final String DISTANCE_METADATA_FIELD_NAME = "distance";
 
 	private static final int DEFAULT_TOP_K = 4;
 
@@ -321,13 +320,15 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 
 						}) : Map.of();
 
-				metadata.put(DISTANCE_METADATA_FIELD_NAME, 1 - (float) result.getScore());
+				metadata.put(DocumentMetadata.DISTANCE.value(), 1.0 - result.getScore());
 
-				final Document doc = new Document(entry.id(), entry.content(), metadata);
-				doc.setEmbedding(EmbeddingUtils.toPrimitive(entry.embedding()));
-
-				return doc;
-
+				return Document.builder()
+					.id(entry.id())
+					.content(entry.content)
+					.metadata(metadata)
+					.score(result.getScore())
+					.embedding(EmbeddingUtils.toPrimitive(entry.embedding))
+					.build();
 			})
 			.collect(Collectors.toList());
 	}

--- a/vector-stores/spring-ai-azure-store/src/test/java/org/springframework/ai/vectorstore/azure/AzureVectorStoreIT.java
+++ b/vector-stores/spring-ai-azure-store/src/test/java/org/springframework/ai/vectorstore/azure/AzureVectorStoreIT.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.transformers.TransformersEmbeddingModel;
 import org.springframework.ai.vectorstore.SearchRequest;
@@ -52,6 +53,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 @EnabledIfEnvironmentVariable(named = "AZURE_AI_SEARCH_API_KEY", matches = ".+")
 @EnabledIfEnvironmentVariable(named = "AZURE_AI_SEARCH_ENDPOINT", matches = ".+")
@@ -103,7 +105,7 @@ public class AzureVectorStoreIT {
 			assertThat(resultDoc.getContent()).contains("The Great Depression (1929–1939) was an economic shock");
 			assertThat(resultDoc.getMetadata()).hasSize(2);
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			// Remove all documents from the store
 			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());
@@ -224,7 +226,7 @@ public class AzureVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
 			assertThat(resultDoc.getMetadata()).containsKey("meta1");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			Document sameIdDocument = new Document(document.getId(),
 					"The World is Big and Salvation Lurks Around the Corner",
@@ -245,7 +247,7 @@ public class AzureVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			// Remove all documents from the store
 			vectorStore.delete(List.of(document.getId()));
@@ -271,21 +273,22 @@ public class AzureVectorStoreIT {
 			List<Document> fullResult = vectorStore
 				.similaritySearch(SearchRequest.query("Depression").withTopK(5).withSimilarityThresholdAll());
 
-			List<Float> distances = fullResult.stream().map(doc -> (Float) doc.getMetadata().get("distance")).toList();
+			List<Double> scores = fullResult.stream().map(Document::getScore).toList();
 
-			assertThat(distances).hasSize(3);
+			assertThat(scores).hasSize(3);
 
-			float threshold = (distances.get(0) + distances.get(1)) / 2;
+			double similarityThreshold = (scores.get(0) + scores.get(1)) / 2;
 
-			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Depression").withTopK(5).withSimilarityThreshold(1 - threshold));
+			List<Document> results = vectorStore.similaritySearch(
+					SearchRequest.query("Depression").withTopK(5).withSimilarityThreshold(similarityThreshold));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
 			assertThat(resultDoc.getId()).isEqualTo(this.documents.get(2).getId());
 			assertThat(resultDoc.getContent()).contains("The Great Depression (1929–1939) was an economic shock");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
+			assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
 
 			// Remove all documents from the store
 			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreIT.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreIT.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.document.DocumentMetadata;
 import org.testcontainers.chromadb.ChromaDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -81,7 +82,7 @@ public class ChromaVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(this.documents.get(2).getId());
 			assertThat(resultDoc.getContent()).isEqualTo(
 					"Great Depression Great Depression Great Depression Great Depression Great Depression Great Depression");
-			assertThat(resultDoc.getMetadata()).containsKeys("meta2", "distance");
+			assertThat(resultDoc.getMetadata()).containsKeys("meta2", DocumentMetadata.DISTANCE.value());
 
 			// Remove all documents from the store
 			assertThat(vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList()))
@@ -179,7 +180,7 @@ public class ChromaVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
 			assertThat(resultDoc.getMetadata()).containsKey("meta1");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			Document sameIdDocument = new Document(document.getId(),
 					"The World is Big and Salvation Lurks Around the Corner",
@@ -194,7 +195,7 @@ public class ChromaVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			// Remove all documents from the store
 			vectorStore.delete(List.of(document.getId()));
@@ -213,13 +214,13 @@ public class ChromaVectorStoreIT {
 			var request = SearchRequest.query("Great").withTopK(5);
 			List<Document> fullResult = vectorStore.similaritySearch(request.withSimilarityThresholdAll());
 
-			List<Float> distances = fullResult.stream().map(doc -> (Float) doc.getMetadata().get("distance")).toList();
+			List<Double> scores = fullResult.stream().map(Document::getScore).toList();
 
-			assertThat(distances).hasSize(3);
+			assertThat(scores).hasSize(3);
 
-			float threshold = (distances.get(0) + distances.get(1)) / 2;
+			double similarityThreshold = (scores.get(0) + scores.get(1)) / 2;
 
-			List<Document> results = vectorStore.similaritySearch(request.withSimilarityThreshold(1 - threshold));
+			List<Document> results = vectorStore.similaritySearch(request.withSimilarityThreshold(similarityThreshold));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -227,7 +228,8 @@ public class ChromaVectorStoreIT {
 			assertThat(resultDoc.getContent()).isEqualTo(
 					"Great Depression Great Depression Great Depression Great Depression Great Depression Great Depression");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
+			assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
 
 			// Remove all documents from the store
 			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/vectorstore/ChromaVectorStoreObservationIT.java
@@ -107,7 +107,6 @@ public class ChromaVectorStoreObservationIT {
 				.hasHighCardinalityKeyValue(HighCardinalityKeyNames.DB_COLLECTION_NAME.asString(),
 						"TestCollection:" + vectorStore.getCollectionId())
 				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.DB_NAMESPACE.asString())
-				.hasHighCardinalityKeyValue(HighCardinalityKeyNames.DB_VECTOR_FIELD_NAME.asString(), "distance")
 				.doesNotHaveHighCardinalityKeyValueWithKey(
 						HighCardinalityKeyNames.DB_SEARCH_SIMILARITY_METRIC.asString())
 				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.DB_VECTOR_QUERY_TOP_K.asString())
@@ -141,7 +140,6 @@ public class ChromaVectorStoreObservationIT {
 				.hasHighCardinalityKeyValue(HighCardinalityKeyNames.DB_COLLECTION_NAME.asString(),
 						"TestCollection:" + vectorStore.getCollectionId())
 				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.DB_NAMESPACE.asString())
-				.hasHighCardinalityKeyValue(HighCardinalityKeyNames.DB_VECTOR_FIELD_NAME.asString(), "distance")
 				.doesNotHaveHighCardinalityKeyValueWithKey(
 						HighCardinalityKeyNames.DB_SEARCH_SIMILARITY_METRIC.asString())
 				.hasHighCardinalityKeyValue(HighCardinalityKeyNames.DB_VECTOR_QUERY_TOP_K.asString(), "1")

--- a/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/CoherenceVectorStore.java
+++ b/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/CoherenceVectorStore.java
@@ -37,6 +37,7 @@ import com.tangosol.net.Session;
 import com.tangosol.util.Filter;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.filter.Filter.Expression;
 import org.springframework.beans.factory.InitializingBean;
@@ -62,6 +63,7 @@ import org.springframework.beans.factory.InitializingBean;
  * </ul>
  *
  * @author Aleks Seovic
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 public class CoherenceVectorStore implements VectorStore, InitializingBean {
@@ -211,8 +213,13 @@ public class CoherenceVectorStore implements VectorStore, InitializingBean {
 			if (this.distanceType != DistanceType.COSINE || (1 - r.getDistance()) >= request.getSimilarityThreshold()) {
 				DocumentChunk.Id id = r.getKey();
 				DocumentChunk chunk = r.getValue();
-				chunk.metadata().put("distance", r.getDistance());
-				documents.add(new Document(id.docId(), chunk.text(), chunk.metadata()));
+				chunk.metadata().put(DocumentMetadata.DISTANCE.value(), r.getDistance());
+				documents.add(Document.builder()
+					.id(id.docId())
+					.content(chunk.text())
+					.metadata(chunk.metadata())
+					.score(1 - r.getDistance())
+					.build());
 			}
 		}
 		return documents;

--- a/vector-stores/spring-ai-coherence-store/src/test/java/org/springframework/ai/vectorstore/CoherenceVectorStoreIT.java
+++ b/vector-stores/spring-ai-coherence-store/src/test/java/org/springframework/ai/vectorstore/CoherenceVectorStoreIT.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.transformers.TransformersEmbeddingModel;
 import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
@@ -125,7 +126,7 @@ public class CoherenceVectorStoreIT {
 				assertThat(results).hasSize(1);
 				Document resultDoc = results.get(0);
 				assertThat(resultDoc.getId()).isEqualTo(this.documents.get(2).getId());
-				assertThat(resultDoc.getMetadata()).containsKeys("meta2", "distance");
+				assertThat(resultDoc.getMetadata()).containsKeys("meta2", DocumentMetadata.DISTANCE.value());
 
 				// Remove all documents from the store
 				vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());
@@ -223,7 +224,7 @@ public class CoherenceVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 
 			assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
-			assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+			assertThat(resultDoc.getMetadata()).containsKeys("meta1", DocumentMetadata.DISTANCE.value());
 
 			Document sameIdDocument = new Document(document.getId(),
 					"The World is Big and Salvation Lurks Around the Corner",
@@ -236,7 +237,7 @@ public class CoherenceVectorStoreIT {
 			resultDoc = results.get(0);
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
-			assertThat(resultDoc.getMetadata()).containsKeys("meta2", "distance");
+			assertThat(resultDoc.getMetadata()).containsKeys("meta2", DocumentMetadata.DISTANCE.value());
 
 			truncateMap(context, ((CoherenceVectorStore) vectorStore).getMapName());
 		});
@@ -257,18 +258,18 @@ public class CoherenceVectorStoreIT {
 
 			assertThat(isSortedByDistance(fullResult)).isTrue();
 
-			List<Double> distances = fullResult.stream()
-				.map(doc -> (Double) doc.getMetadata().get("distance"))
-				.toList();
+			List<Double> scores = fullResult.stream().map(Document::getScore).toList();
 
-			double threshold = 1d - (distances.get(0) + distances.get(1)) / 2f;
+			double similarityThreshold = (scores.get(0) + scores.get(1)) / 2;
 
-			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Time Shelter").withTopK(5).withSimilarityThreshold(threshold));
+			List<Document> results = vectorStore.similaritySearch(
+					SearchRequest.query("Time Shelter").withTopK(5).withSimilarityThreshold(similarityThreshold));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
 			assertThat(resultDoc.getId()).isEqualTo(this.documents.get(1).getId());
+			assertThat(resultDoc.getMetadata()).containsKeys("meta1", DocumentMetadata.DISTANCE.value());
+			assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
 
 			truncateMap(context, ((CoherenceVectorStore) vectorStore).getMapName());
 		});
@@ -276,7 +277,7 @@ public class CoherenceVectorStoreIT {
 
 	private static boolean isSortedByDistance(final List<Document> documents) {
 		final List<Double> distances = documents.stream()
-			.map(doc -> (Double) doc.getMetadata().get("distance"))
+			.map(doc -> (Double) doc.getMetadata().get(DocumentMetadata.DISTANCE.value()))
 			.toList();
 
 		if (CollectionUtils.isEmpty(distances) || distances.size() == 1) {

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
@@ -210,20 +211,23 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 
 	private Document toDocument(Hit<Document> hit) {
 		Document document = hit.source();
-		document.getMetadata().put("distance", calculateDistance(hit.score().floatValue()));
+		if (hit.score() != null) {
+			document.getMetadata().put(DocumentMetadata.DISTANCE.value(), 1 - normalizeSimilarityScore(hit.score()));
+			document.setScore(normalizeSimilarityScore(hit.score()));
+		}
 		return document;
 	}
 
 	// more info on score/distance calculation
 	// https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#knn-similarity-search
-	private float calculateDistance(Float score) {
+	private double normalizeSimilarityScore(double score) {
 		switch (this.options.getSimilarity()) {
 			case l2_norm:
 				// the returned value of l2_norm is the opposite of the other functions
 				// (closest to zero means more accurate), so to make it consistent
 				// with the other functions the reverse is returned applying a "1-"
 				// to the standard transformation
-				return (float) (1 - (java.lang.Math.sqrt((1 / score) - 1)));
+				return (1 - (java.lang.Math.sqrt((1 / score) - 1)));
 			// cosine and dot_product
 			default:
 				return (2 * score) - 1;

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -211,11 +211,12 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 
 	private Document toDocument(Hit<Document> hit) {
 		Document document = hit.source();
+		Document.Builder documentBuilder = document.mutate();
 		if (hit.score() != null) {
-			document.getMetadata().put(DocumentMetadata.DISTANCE.value(), 1 - normalizeSimilarityScore(hit.score()));
-			document.setScore(normalizeSimilarityScore(hit.score()));
+			documentBuilder.metadata(DocumentMetadata.DISTANCE.value(), 1 - normalizeSimilarityScore(hit.score()));
+			documentBuilder.score(normalizeSimilarityScore(hit.score()));
 		}
-		return document;
+		return documentBuilder.build();
 	}
 
 	// more info on score/distance calculation

--- a/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.DocumentMetadata;
 import reactor.util.annotation.NonNull;
 
 import org.springframework.ai.document.Document;
@@ -172,8 +173,6 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 	// Query Defaults
 	private static final String QUERY = "/query";
 
-	private static final String DISTANCE_METADATA_FIELD_NAME = "distance";
-
 	/**
 	 * Initializes the GemFireVectorStore after properties are set. This method is called
 	 * after all bean properties have been set and allows the bean to perform any
@@ -271,9 +270,9 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 					metadata = new HashMap<>();
 					metadata.put(DOCUMENT_FIELD, "--Deleted--");
 				}
-				metadata.put(DISTANCE_METADATA_FIELD_NAME, 1 - r.score);
+				metadata.put(DocumentMetadata.DISTANCE.value(), 1 - r.score);
 				String content = (String) metadata.remove(DOCUMENT_FIELD);
-				return new Document(r.key, content, metadata);
+				return Document.builder().id(r.key).content(content).metadata(metadata).score((double) r.score).build();
 			})
 			.collectList()
 			.onErrorMap(WebClientException.class, this::handleHttpClientException)

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusVectorStoreIT.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/MilvusVectorStoreIT.java
@@ -30,6 +30,7 @@ import io.milvus.param.MetricType;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.ai.document.DocumentMetadata;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.milvus.MilvusContainer;
@@ -106,7 +107,7 @@ public class MilvusVectorStoreIT {
 				assertThat(resultDoc.getContent()).contains(
 						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
 				assertThat(resultDoc.getMetadata()).hasSize(2);
-				assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+				assertThat(resultDoc.getMetadata()).containsKeys("meta1", DocumentMetadata.DISTANCE.value());
 
 				// Remove all documents from the store
 				vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());
@@ -200,7 +201,7 @@ public class MilvusVectorStoreIT {
 				assertThat(resultDoc.getId()).isEqualTo(document.getId());
 				assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
 				assertThat(resultDoc.getMetadata()).containsKey("meta1");
-				assertThat(resultDoc.getMetadata()).containsKey("distance");
+				assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 				Document sameIdDocument = new Document(document.getId(),
 						"The World is Big and Salvation Lurks Around the Corner",
@@ -215,7 +216,7 @@ public class MilvusVectorStoreIT {
 				assertThat(resultDoc.getId()).isEqualTo(document.getId());
 				assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
 				assertThat(resultDoc.getMetadata()).containsKey("meta2");
-				assertThat(resultDoc.getMetadata()).containsKey("distance");
+				assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 				vectorStore.delete(List.of(document.getId()));
 
@@ -238,24 +239,22 @@ public class MilvusVectorStoreIT {
 				List<Document> fullResult = vectorStore
 					.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThresholdAll());
 
-				List<Float> distances = fullResult.stream()
-					.map(doc -> (Float) doc.getMetadata().get("distance"))
-					.toList();
+				List<Double> scores = fullResult.stream().map(Document::getScore).toList();
 
-				assertThat(distances).hasSize(3);
+				assertThat(scores).hasSize(3);
 
-				float threshold = (distances.get(0) + distances.get(1)) / 2;
+				double similarityThreshold = (scores.get(0) + scores.get(1)) / 2;
 
-				List<Document> results = vectorStore
-					.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(1 - threshold));
+				List<Document> results = vectorStore.similaritySearch(
+						SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(similarityThreshold));
 
 				assertThat(results).hasSize(1);
 				Document resultDoc = results.get(0);
 				assertThat(resultDoc.getId()).isEqualTo(this.documents.get(0).getId());
 				assertThat(resultDoc.getContent()).contains(
 						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
-				assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
-
+				assertThat(resultDoc.getMetadata()).containsKeys("meta1", DocumentMetadata.DISTANCE.value());
+				assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
 			});
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
@@ -231,7 +232,10 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 
 	private Document toDocument(Hit<Document> hit) {
 		Document document = hit.source();
-		document.getMetadata().put("distance", 1 - hit.score().floatValue());
+		if (hit.score() != null) {
+			document.setScore(hit.score());
+			document.getMetadata().put(DocumentMetadata.DISTANCE.value(), 1 - hit.score().floatValue());
+		}
 		return document;
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/OpenSearchVectorStore.java
@@ -232,11 +232,12 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 
 	private Document toDocument(Hit<Document> hit) {
 		Document document = hit.source();
+		Document.Builder documentBuilder = document.mutate();
 		if (hit.score() != null) {
-			document.setScore(hit.score());
-			document.getMetadata().put(DocumentMetadata.DISTANCE.value(), 1 - hit.score().floatValue());
+			documentBuilder.metadata(DocumentMetadata.DISTANCE.value(), 1 - hit.score().floatValue());
+			documentBuilder.score(hit.score());
 		}
-		return document;
+		return documentBuilder.build();
 	}
 
 	public boolean exists(String targetIndex) {

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
@@ -502,12 +503,15 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 			Float distance = rs.getFloat(COLUMN_DISTANCE);
 
 			Map<String, Object> metadata = toMap(pgMetadata);
-			metadata.put(COLUMN_DISTANCE, distance);
+			metadata.put(DocumentMetadata.DISTANCE.value(), distance);
 
-			Document document = new Document(id, content, metadata);
-			document.setEmbedding(toFloatArray(embedding));
-
-			return document;
+			return Document.builder()
+				.id(id)
+				.content(content)
+				.metadata(metadata)
+				.score(1.0 - distance)
+				.embedding(toFloatArray(embedding))
+				.build();
 		}
 
 		private float[] toFloatArray(PGobject embedding) throws SQLException {

--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.springframework.ai.document.DocumentMetadata;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.qdrant.QdrantContainer;
@@ -107,7 +108,7 @@ public class QdrantVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(this.documents.get(2).getId());
 			assertThat(resultDoc.getContent()).isEqualTo(
 					"Great Depression Great Depression Great Depression Great Depression Great Depression Great Depression");
-			assertThat(resultDoc.getMetadata()).containsKeys("meta2", "distance");
+			assertThat(resultDoc.getMetadata()).containsKeys("meta2", DocumentMetadata.DISTANCE.value());
 
 			// Remove all documents from the store
 			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());
@@ -185,7 +186,7 @@ public class QdrantVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
 			assertThat(resultDoc.getMetadata()).containsKey("meta1");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			Document sameIdDocument = new Document(document.getId(),
 					"The World is Big and Salvation Lurks Around the Corner",
@@ -200,7 +201,7 @@ public class QdrantVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			vectorStore.delete(List.of(document.getId()));
 		});
@@ -218,13 +219,13 @@ public class QdrantVectorStoreIT {
 			var request = SearchRequest.query("Great").withTopK(5);
 			List<Document> fullResult = vectorStore.similaritySearch(request.withSimilarityThresholdAll());
 
-			List<Float> distances = fullResult.stream().map(doc -> (Float) doc.getMetadata().get("distance")).toList();
+			List<Double> scores = fullResult.stream().map(Document::getScore).toList();
 
-			assertThat(distances).hasSize(3);
+			assertThat(scores).hasSize(3);
 
-			float threshold = (distances.get(0) + distances.get(1)) / 2;
+			double similarityThreshold = (scores.get(0) + scores.get(1)) / 2;
 
-			List<Document> results = vectorStore.similaritySearch(request.withSimilarityThreshold(1 - threshold));
+			List<Document> results = vectorStore.similaritySearch(request.withSimilarityThreshold(similarityThreshold));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
@@ -232,7 +233,8 @@ public class QdrantVectorStoreIT {
 			assertThat(resultDoc.getContent()).isEqualTo(
 					"Great Depression Great Depression Great Depression Great Depression Great Depression Great Depression");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
+			assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
 
 			// Remove all documents from the store
 			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.document.DocumentMetadata;
 import org.typesense.api.Client;
 import org.typesense.api.FieldTypes;
 import org.typesense.model.CollectionResponse;
@@ -57,6 +58,7 @@ import org.springframework.util.Assert;
  * @author Pablo Sanchidrian Herrera
  * @author Soby Chacko
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 public class TypesenseVectorStore extends AbstractObservationVectorStore implements InitializingBean {
 
@@ -212,8 +214,13 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 					String content = rawDocument.get(CONTENT_FIELD_NAME).toString();
 					Map<String, Object> metadata = rawDocument.get(METADATA_FIELD_NAME) instanceof Map
 							? (Map<String, Object>) rawDocument.get(METADATA_FIELD_NAME) : Map.of();
-					metadata.put("distance", hit.getVectorDistance());
-					return new Document(docId, content, metadata);
+					metadata.put(DocumentMetadata.DISTANCE.value(), hit.getVectorDistance());
+					return Document.builder()
+						.id(docId)
+						.content(content)
+						.metadata(metadata)
+						.score(1.0 - hit.getVectorDistance())
+						.build();
 				}))
 				.toList();
 

--- a/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/TypesenseVectorStoreIT.java
+++ b/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/TypesenseVectorStoreIT.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.DocumentMetadata;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -96,7 +97,7 @@ public class TypesenseVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
 			assertThat(resultDoc.getMetadata()).containsKey("meta1");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			Document sameIdDocument = new Document(document.getId(),
 					"The World is Big and Salvation Lurks Around the Corner",
@@ -114,7 +115,7 @@ public class TypesenseVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			vectorStore.delete(List.of(document.getId()));
 
@@ -211,21 +212,22 @@ public class TypesenseVectorStoreIT {
 			List<Document> fullResult = vectorStore
 				.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThresholdAll());
 
-			List<Float> distances = fullResult.stream().map(doc -> (Float) doc.getMetadata().get("distance")).toList();
+			List<Double> scores = fullResult.stream().map(Document::getScore).toList();
 
-			assertThat(distances).hasSize(3);
+			assertThat(scores).hasSize(3);
 
-			float threshold = (distances.get(0) + distances.get(1)) / 2;
+			double similarityThreshold = (scores.get(0) + scores.get(1)) / 2;
 
-			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(1 - threshold));
+			List<Document> results = vectorStore.similaritySearch(
+					SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(similarityThreshold));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
 			assertThat(resultDoc.getId()).isEqualTo(this.documents.get(0).getId());
 			assertThat(resultDoc.getContent()).contains(
 					"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
-			assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+			assertThat(resultDoc.getMetadata()).containsKeys("meta1", DocumentMetadata.DISTANCE.value());
+			assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
 
 			((TypesenseVectorStore) vectorStore).dropCollection();
 

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
@@ -45,6 +45,7 @@ import io.weaviate.client.v1.graphql.query.fields.Field;
 import io.weaviate.client.v1.graphql.query.fields.Fields;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
@@ -73,10 +74,9 @@ import org.springframework.util.StringUtils;
  * @author Eddú Meléndez
  * @author Josh Long
  * @author Soby Chacko
+ * @author Thomas Vitale
  */
 public class WeaviateVectorStore extends AbstractObservationVectorStore {
-
-	public static final String DOCUMENT_METADATA_DISTANCE_KEY_NAME = "distance";
 
 	private static final String METADATA_FIELD_PREFIX = "meta_";
 
@@ -367,7 +367,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 
 		// Metadata
 		Map<String, Object> metadata = new HashMap<>();
-		metadata.put(DOCUMENT_METADATA_DISTANCE_KEY_NAME, 1 - certainty);
+		metadata.put(DocumentMetadata.DISTANCE.value(), 1 - certainty);
 
 		try {
 			String metadataJson = (String) item.get(METADATA_FIELD_NAME);
@@ -382,10 +382,13 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		// Content
 		String content = (String) item.get(CONTENT_FIELD_NAME);
 
-		var document = new Document(id, content, metadata);
-		document.setEmbedding(EmbeddingUtils.toPrimitive(EmbeddingUtils.doubleToFloat(embedding)));
-
-		return document;
+		return Document.builder()
+			.id(id)
+			.content(content)
+			.metadata(metadata)
+			.embedding(EmbeddingUtils.toPrimitive(EmbeddingUtils.doubleToFloat(embedding)))
+			.score(certainty)
+			.build();
 	}
 
 	@Override

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/WeaviateVectorStoreIT.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/WeaviateVectorStoreIT.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import io.weaviate.client.Config;
 import io.weaviate.client.WeaviateClient;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.document.DocumentMetadata;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -101,7 +102,7 @@ public class WeaviateVectorStoreIT {
 			assertThat(resultDoc.getContent()).contains(
 					"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
 			assertThat(resultDoc.getMetadata()).hasSize(2);
-			assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+			assertThat(resultDoc.getMetadata()).containsKeys("meta1", DocumentMetadata.DISTANCE.value());
 
 			// Remove all documents from the store
 			vectorStore.delete(this.documents.stream().map(doc -> doc.getId()).toList());
@@ -186,7 +187,7 @@ public class WeaviateVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("Spring AI rocks!!");
 			assertThat(resultDoc.getMetadata()).containsKey("meta1");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			Document sameIdDocument = new Document(document.getId(),
 					"The World is Big and Salvation Lurks Around the Corner",
@@ -201,7 +202,7 @@ public class WeaviateVectorStoreIT {
 			assertThat(resultDoc.getId()).isEqualTo(document.getId());
 			assertThat(resultDoc.getContent()).isEqualTo("The World is Big and Salvation Lurks Around the Corner");
 			assertThat(resultDoc.getMetadata()).containsKey("meta2");
-			assertThat(resultDoc.getMetadata()).containsKey("distance");
+			assertThat(resultDoc.getMetadata()).containsKey(DocumentMetadata.DISTANCE.value());
 
 			vectorStore.delete(List.of(document.getId()));
 
@@ -222,23 +223,22 @@ public class WeaviateVectorStoreIT {
 			List<Document> fullResult = vectorStore
 				.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThresholdAll());
 
-			List<Double> distances = fullResult.stream()
-				.map(doc -> (Double) doc.getMetadata().get("distance"))
-				.toList();
+			List<Double> scores = fullResult.stream().map(Document::getScore).toList();
 
-			assertThat(distances).hasSize(3);
+			assertThat(scores).hasSize(3);
 
-			double threshold = (distances.get(0) + distances.get(1)) / 2;
+			double similarityThreshold = (scores.get(0) + scores.get(1)) / 2;
 
-			List<Document> results = vectorStore
-				.similaritySearch(SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(1 - threshold));
+			List<Document> results = vectorStore.similaritySearch(
+					SearchRequest.query("Spring").withTopK(5).withSimilarityThreshold(similarityThreshold));
 
 			assertThat(results).hasSize(1);
 			Document resultDoc = results.get(0);
 			assertThat(resultDoc.getId()).isEqualTo(this.documents.get(0).getId());
 			assertThat(resultDoc.getContent()).contains(
 					"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
-			assertThat(resultDoc.getMetadata()).containsKeys("meta1", "distance");
+			assertThat(resultDoc.getMetadata()).containsKeys("meta1", DocumentMetadata.DISTANCE.value());
+			assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
 
 		});
 	}


### PR DESCRIPTION
Document
* Introduced “score” attribute in Document API. It stores the similarity score.
* Consolidate “distance” metadata for Documents. It stores the distance measurement.
* Adopted prefix-less naming convention in Document.Builder and deprecated old methods.
* Deprecated the many overloaded Document constructors in favour of Document.Builder.

Vector Stores
* Every vector store implementation now configures a “score” attribute with the similarity score of the Document embedding. It also includes the “distance” metadata with the distance measurement.
* Fixed error in Elasticsearch where distance and similarity were mixed up.
* Added missing integration tests for SimpleVectorStore.
* The Azure Vector Store and HanaDB Vector Store do not include those measurements because the product documentation do not include information about how the similarity score is returned, and without access to the cloud products I could not verify that via debugging.
* Improved tests to actually assert the result of the similarity search based on the returned score.