### PR TITLE
Fix typo: "onn" to "on"

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/function-callback.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/function-callback.adoc
@@ -58,7 +58,7 @@ Use `java.util.Supplier<O>` or `java.util.function.Function<Void, O>` to define 
 [source,java]
 ----
 FunctionCallback.builder()
-    .description("Turns light onn in the living room")
+    .description("Turns light on in the living room")
 	.function("turnsLight", () -> state.put("Light", "ON"))
     .inputType(Void.class)
 	.build();


### PR DESCRIPTION
This PR fixes a typo in the documentation/code where "onn" was corrected to "on".