### PR TITLE
refactor: enhance ChatGenerationMetadata with metadata Map and Builder

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -291,14 +291,14 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 			.stream()
 			.filter(content -> content.type() != ContentBlock.Type.TOOL_USE)
 			.map(content -> new Generation(new AssistantMessage(content.text(), Map.of()),
-					ChatGenerationMetadata.from(chatCompletion.stopReason(), null)))
+					ChatGenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build()))
 			.toList();
 
 		List<Generation> allGenerations = new ArrayList<>(generations);
 
 		if (chatCompletion.stopReason() != null && generations.isEmpty()) {
 			Generation generation = new Generation(new AssistantMessage(null, Map.of()),
-					ChatGenerationMetadata.from(chatCompletion.stopReason(), null));
+					ChatGenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build());
 			allGenerations.add(generation);
 		}
 
@@ -322,7 +322,7 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 
 			AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), toolCalls);
 			Generation toolCallGeneration = new Generation(assistantMessage,
-					ChatGenerationMetadata.from(chatCompletion.stopReason(), null));
+					ChatGenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build());
 			allGenerations.add(toolCallGeneration);
 		}
 

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -459,7 +459,10 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 	}
 
 	private ChatGenerationMetadata generateChoiceMetadata(ChatChoice choice) {
-		return ChatGenerationMetadata.from(String.valueOf(choice.getFinishReason()), choice.getContentFilterResults());
+		return ChatGenerationMetadata.builder()
+			.finishReason(String.valueOf(choice.getFinishReason()))
+			.metadata("contentFilterResults", choice.getContentFilterResults())
+			.build();
 	}
 
 	private PromptMetadata generatePromptMetadata(ChatCompletions chatCompletions) {

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatModelMetadataTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatModelMetadataTests.java
@@ -128,7 +128,7 @@ class AzureOpenAiChatModelMetadataTests {
 
 		assertThat(chatGenerationMetadata).isNotNull();
 		assertThat(chatGenerationMetadata.getFinishReason()).isEqualTo("stop");
-		assertContentFilterResults(chatGenerationMetadata.getContentFilterMetadata());
+		assertContentFilterResults(chatGenerationMetadata.get("contentFilterResults"));
 	}
 
 	private void assertContentFilterResultsForPrompt(ContentFilterResultDetailsForPrompt contentFilterResultForPrompt,

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -419,14 +419,14 @@ public class BedrockProxyChatModel extends AbstractToolCallSupport implements Ch
 			.stream()
 			.filter(content -> content.type() != ContentBlock.Type.TOOL_USE)
 			.map(content -> new Generation(new AssistantMessage(content.text(), Map.of()),
-					ChatGenerationMetadata.from(response.stopReasonAsString(), null)))
+					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build()))
 			.toList();
 
 		List<Generation> allGenerations = new ArrayList<>(generations);
 
 		if (response.stopReasonAsString() != null && generations.isEmpty()) {
 			Generation generation = new Generation(new AssistantMessage(null, Map.of()),
-					ChatGenerationMetadata.from(response.stopReasonAsString(), null));
+					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
 			allGenerations.add(generation);
 		}
 
@@ -451,7 +451,7 @@ public class BedrockProxyChatModel extends AbstractToolCallSupport implements Ch
 
 			AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), toolCalls);
 			Generation toolCallGeneration = new Generation(assistantMessage,
-					ChatGenerationMetadata.from(response.stopReasonAsString(), null));
+					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
 			allGenerations.add(toolCallGeneration);
 		}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -141,7 +141,7 @@ public final class ConverseApiUtils {
 
 				AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), toolCalls);
 				Generation toolCallGeneration = new Generation(assistantMessage,
-						ChatGenerationMetadata.from("tool_use", null));
+						ChatGenerationMetadata.builder().finishReason("tool_use").build());
 
 				var chatResponseMetaData = ChatResponseMetadata.builder()
 					.withUsage(new DefaultUsage(promptTokens, generationTokens, totalTokens))
@@ -176,7 +176,9 @@ public final class ConverseApiUtils {
 
 					var generation = new Generation(
 							new AssistantMessage(contentBlockDeltaEvent.delta().text(), Map.of()),
-							ChatGenerationMetadata.from(lastAggregation.metadataAggregation().stopReason(), null));
+							ChatGenerationMetadata.builder()
+								.finishReason(lastAggregation.metadataAggregation().stopReason())
+								.build());
 
 					return new Aggregation(
 							MetadataAggregation.builder().copy(lastAggregation.metadataAggregation()).build(),

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModel.java
@@ -83,8 +83,10 @@ public class BedrockAnthropicChatModel implements ChatModel, StreamingChatModel 
 			String stopReason = response.stopReason() != null ? response.stopReason() : null;
 			ChatGenerationMetadata chatGenerationMetadata = null;
 			if (response.amazonBedrockInvocationMetrics() != null) {
-				chatGenerationMetadata = ChatGenerationMetadata.from(stopReason,
-						response.amazonBedrockInvocationMetrics());
+				chatGenerationMetadata = ChatGenerationMetadata.builder()
+					.finishReason(stopReason)
+					.metadata("metrics", response.amazonBedrockInvocationMetrics())
+					.build();
 			}
 			return new ChatResponse(
 					List.of(new Generation(new AssistantMessage(response.completion()), chatGenerationMetadata)));

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -88,7 +88,7 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 		List<Generation> generations = response.content()
 			.stream()
 			.map(content -> new Generation(new AssistantMessage(content.text()),
-					ChatGenerationMetadata.from(response.stopReason(), null)))
+					ChatGenerationMetadata.builder().finishReason(response.stopReason()).build()))
 			.toList();
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder()
@@ -116,9 +116,12 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 			String content = response.type() == StreamingType.CONTENT_BLOCK_DELTA ? response.delta().text() : "";
 			ChatGenerationMetadata chatGenerationMetadata = null;
 			if (response.type() == StreamingType.MESSAGE_DELTA) {
-				chatGenerationMetadata = ChatGenerationMetadata.from(response.delta().stopReason(),
-						new Anthropic3ChatBedrockApi.AnthropicUsage(inputTokens.get(),
-								response.usage().outputTokens()));
+				chatGenerationMetadata = ChatGenerationMetadata.builder()
+					.finishReason(response.delta().stopReason())
+					.metadata("usage",
+							new Anthropic3ChatBedrockApi.AnthropicUsage(inputTokens.get(),
+									response.usage().outputTokens()))
+					.build();
 			}
 			return new ChatResponse(List.of(new Generation(new AssistantMessage(content), chatGenerationMetadata)));
 		});

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
@@ -78,8 +78,8 @@ public class BedrockCohereChatModel implements ChatModel, StreamingChatModel {
 			if (g.isFinished()) {
 				String finishReason = g.finishReason().name();
 				Usage usage = BedrockUsage.from(g.amazonBedrockInvocationMetrics());
-				return new ChatResponse(List
-					.of(new Generation(new AssistantMessage(""), ChatGenerationMetadata.from(finishReason, usage))));
+				return new ChatResponse(List.of(new Generation(new AssistantMessage(""),
+						ChatGenerationMetadata.builder().finishReason(finishReason).metadata("usage", usage).build())));
 			}
 			return new ChatResponse(List.of(new Generation(new AssistantMessage(g.text()))));
 		});

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
@@ -70,7 +70,7 @@ public class BedrockAi21Jurassic2ChatModel implements ChatModel {
 		return new ChatResponse(response.completions()
 			.stream()
 			.map(completion -> new Generation(new AssistantMessage(completion.data().text()),
-					ChatGenerationMetadata.from(completion.finishReason().reason(), null)))
+					ChatGenerationMetadata.builder().finishReason(completion.finishReason().reason()).build()))
 			.toList());
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
@@ -70,7 +70,10 @@ public class BedrockLlamaChatModel implements ChatModel, StreamingChatModel {
 		LlamaChatResponse response = this.chatApi.chatCompletion(request);
 
 		return new ChatResponse(List.of(new Generation(new AssistantMessage(response.generation()),
-				ChatGenerationMetadata.from(response.stopReason().name(), extractUsage(response)))));
+				ChatGenerationMetadata.builder()
+					.finishReason(response.stopReason().name())
+					.metadata("usage", extractUsage(response))
+					.build())));
 	}
 
 	@Override
@@ -83,7 +86,10 @@ public class BedrockLlamaChatModel implements ChatModel, StreamingChatModel {
 		return fluxResponse.map(response -> {
 			String stopReason = response.stopReason() != null ? response.stopReason().name() : null;
 			return new ChatResponse(List.of(new Generation(new AssistantMessage(response.generation()),
-					ChatGenerationMetadata.from(stopReason, extractUsage(response)))));
+					ChatGenerationMetadata.builder()
+						.finishReason(stopReason)
+						.metadata("usage", extractUsage(response))
+						.build())));
 		});
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
@@ -78,12 +78,17 @@ public class BedrockTitanChatModel implements ChatModel, StreamingChatModel {
 			ChatGenerationMetadata chatGenerationMetadata = null;
 			if (chunk.amazonBedrockInvocationMetrics() != null) {
 				String completionReason = chunk.completionReason().name();
-				chatGenerationMetadata = ChatGenerationMetadata.from(completionReason,
-						chunk.amazonBedrockInvocationMetrics());
+				chatGenerationMetadata = ChatGenerationMetadata.builder()
+					.finishReason(completionReason)
+					.metadata("usage", chunk.amazonBedrockInvocationMetrics())
+					.build();
 			}
 			else if (chunk.inputTextTokenCount() != null && chunk.totalOutputTextTokenCount() != null) {
 				String completionReason = chunk.completionReason().name();
-				chatGenerationMetadata = ChatGenerationMetadata.from(completionReason, extractUsage(chunk));
+				chatGenerationMetadata = ChatGenerationMetadata.builder()
+					.finishReason(completionReason)
+					.metadata("usage", extractUsage(chunk))
+					.build();
 			}
 			return new ChatResponse(
 					List.of(new Generation(new AssistantMessage(chunk.outputText()), chatGenerationMetadata)));

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -203,7 +203,7 @@ public class MiniMaxChatModel extends AbstractToolCallSupport implements ChatMod
 					});
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.from(finishReason, null);
+		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 
@@ -408,7 +408,7 @@ public class MiniMaxChatModel extends AbstractToolCallSupport implements ChatMod
 
 		var assistantMessage = new AssistantMessage(message.content(), metadata, toolCalls);
 		String finishReason = (completionFinishReason != null ? completionFinishReason.name() : "");
-		var generationMetadata = ChatGenerationMetadata.from(finishReason, null);
+		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -304,7 +304,7 @@ public class MistralAiChatModel extends AbstractToolCallSupport implements ChatM
 
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.from(finishReason, null);
+		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/MoonshotChatModel.java
+++ b/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/MoonshotChatModel.java
@@ -173,7 +173,7 @@ public class MoonshotChatModel extends AbstractToolCallSupport implements ChatMo
 
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.from(finishReason, null);
+		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
@@ -181,7 +181,9 @@ public class OCICohereChatModel implements ChatModel {
 		BaseChatResponse cr = ociChatResponse.getChatResult().getChatResponse();
 		if (cr instanceof CohereChatResponse resp) {
 			List<Generation> generations = new ArrayList<>();
-			ChatGenerationMetadata metadata = ChatGenerationMetadata.from(resp.getFinishReason().getValue(), null);
+			ChatGenerationMetadata metadata = ChatGenerationMetadata.builder()
+				.finishReason(resp.getFinishReason().getValue())
+				.build();
 			AssistantMessage message = new AssistantMessage(resp.getText(), Map.of());
 			generations.add(new Generation(message, metadata));
 			return generations;

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -156,7 +156,9 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 				ChatGenerationMetadata generationMetadata = ChatGenerationMetadata.NULL;
 				if (ollamaResponse.promptEvalCount() != null && ollamaResponse.evalCount() != null) {
-					generationMetadata = ChatGenerationMetadata.from(ollamaResponse.doneReason(), null);
+					generationMetadata = ChatGenerationMetadata.builder()
+						.finishReason(ollamaResponse.doneReason())
+						.build();
 				}
 
 				var generator = new Generation(assistantMessage, generationMetadata);
@@ -217,7 +219,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 				ChatGenerationMetadata generationMetadata = ChatGenerationMetadata.NULL;
 				if (chunk.promptEvalCount() != null && chunk.evalCount() != null) {
-					generationMetadata = ChatGenerationMetadata.from(chunk.doneReason(), null);
+					generationMetadata = ChatGenerationMetadata.builder().finishReason(chunk.doneReason()).build();
 				}
 
 				var generator = new Generation(assistantMessage, generationMetadata);

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -376,7 +376,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.from(finishReason, null);
+		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelWithChatResponseMetadataTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelWithChatResponseMetadataTests.java
@@ -119,7 +119,7 @@ public class OpenAiChatModelWithChatResponseMetadataTests {
 			ChatGenerationMetadata chatGenerationMetadata = generation.getMetadata();
 			assertThat(chatGenerationMetadata).isNotNull();
 			assertThat(chatGenerationMetadata.getFinishReason()).isEqualTo("STOP");
-			assertThat(chatGenerationMetadata.<Object>getContentFilterMetadata()).isNull();
+			assertThat(chatGenerationMetadata.getContentFilters()).isEmpty();
 		});
 	}
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -390,7 +390,9 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 		Map<String, Object> messageMetadata = Map.of("candidateIndex", candidateIndex, "finishReason",
 				candidateFinishReason);
 
-		ChatGenerationMetadata chatGenerationMetadata = ChatGenerationMetadata.from(candidateFinishReason.name(), null);
+		ChatGenerationMetadata chatGenerationMetadata = ChatGenerationMetadata.builder()
+			.finishReason(candidateFinishReason.name())
+			.build();
 
 		boolean isFunctionCall = candidate.getContent().getPartsList().stream().allMatch(Part::hasFunctionCall);
 

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatModel.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatModel.java
@@ -85,7 +85,10 @@ public class WatsonxAiChatModel implements ChatModel, StreamingChatModel {
 
 		WatsonxAiChatResponse response = this.watsonxAiApi.generate(request).getBody();
 		var generation = new Generation(new AssistantMessage(response.results().get(0).generatedText()),
-				ChatGenerationMetadata.from(response.results().get(0).stopReason(), response.system()));
+				ChatGenerationMetadata.builder()
+					.finishReason(response.results().get(0).stopReason())
+					.metadata("system", response.system())
+					.build());
 
 		return new ChatResponse(List.of(generation));
 	}
@@ -103,7 +106,10 @@ public class WatsonxAiChatModel implements ChatModel, StreamingChatModel {
 
 			ChatGenerationMetadata metadata = ChatGenerationMetadata.NULL;
 			if (chunk.system() != null) {
-				metadata = ChatGenerationMetadata.from(chunk.results().get(0).stopReason(), chunk.system());
+				metadata = ChatGenerationMetadata.builder()
+					.finishReason(chunk.results().get(0).stopReason())
+					.metadata("system", chunk.system())
+					.build();
 			}
 
 			Generation generation = new Generation(assistantMessage, metadata);

--- a/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/WatsonxAiChatModelTest.java
+++ b/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/WatsonxAiChatModelTest.java
@@ -174,8 +174,11 @@ public class WatsonxAiChatModelTest {
 			.willReturn(ResponseEntity.of(Optional.of(fakeResponse)));
 
 		Generation expectedGenerator = new Generation(new AssistantMessage("LLM response"),
-				ChatGenerationMetadata.from("max_tokens",
-						Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning")))));
+				ChatGenerationMetadata.builder()
+					.finishReason("max_tokens")
+					.metadata("system",
+							Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning"))))
+					.build());
 
 		ChatResponse expectedResponse = new ChatResponse(List.of(expectedGenerator));
 		ChatResponse response = chatModel.call(prompt);
@@ -206,8 +209,12 @@ public class WatsonxAiChatModelTest {
 		Flux<WatsonxAiChatResponse> fakeResponse = Flux.just(fakeResponseFirst, fakeResponseSecond);
 		given(mockChatApi.generateStreaming(any(WatsonxAiChatRequest.class))).willReturn(fakeResponse);
 
-		Generation firstGen = new Generation(new AssistantMessage("LLM resp"), ChatGenerationMetadata.from("max_tokens",
-				Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning")))));
+		Generation firstGen = new Generation(new AssistantMessage("LLM resp"),
+				ChatGenerationMetadata.builder()
+					.finishReason("max_tokens")
+					.metadata("system",
+							Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning"))))
+					.build());
 		Generation secondGen = new Generation(new AssistantMessage("onse"));
 
 		Flux<ChatResponse> response = chatModel.stream(prompt);

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -188,7 +188,7 @@ public class ZhiPuAiChatModel extends AbstractToolCallSupport implements ChatMod
 
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.from(finishReason, null);
+		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/ChatGenerationMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/ChatGenerationMetadata.java
@@ -16,66 +16,129 @@
 
 package org.springframework.ai.chat.metadata;
 
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import org.springframework.ai.model.ResultMetadata;
-import org.springframework.lang.Nullable;
 
 /**
- * Abstract Data Type (ADT) encapsulating information on the completion choices in the AI
- * response.
+ *
+ * Represents the metadata associated with the generation of a chat response.
  *
  * @author John Blum
+ * @author Christian Tzolov
  * @since 0.7.0
  */
 public interface ChatGenerationMetadata extends ResultMetadata {
 
-	ChatGenerationMetadata NULL = ChatGenerationMetadata.from(null, null);
+	ChatGenerationMetadata NULL = builder().build();
 
-	/**
-	 * Factory method used to construct a new {@link ChatGenerationMetadata} from the
-	 * given {@link String finish reason} and content filter metadata.
-	 * @param finishReason {@link String} contain the reason for the choice completion.
-	 * @param contentFilterMetadata underlying AI provider metadata for filtering applied
-	 * to generation content.
-	 * @return a new {@link ChatGenerationMetadata} from the given {@link String finish
-	 * reason} and content filter metadata.
-	 */
-	static ChatGenerationMetadata from(String finishReason, Object contentFilterMetadata) {
-		return new ChatGenerationMetadata() {
+	// /**
+	// * Factory method used to construct a new {@link ChatGenerationMetadata} from the
+	// * given {@link String finish reason} and content filter metadata.
+	// * @param finishReason {@link String} contain the reason for the choice completion.
+	// * @param contentFilterMetadata underlying AI provider metadata for filtering
+	// applied
+	// * to generation content.
+	// * @return a new {@link ChatGenerationMetadata} from the given {@link String finish
+	// * reason} and content filter metadata.
+	// */
+	// static ChatGenerationMetadata from(String finishReason, Object
+	// contentFilterMetadata) {
+	// return new ChatGenerationMetadata() {
 
-			@Override
-			@SuppressWarnings("unchecked")
-			public <T> T getContentFilterMetadata() {
-				return (T) contentFilterMetadata;
-			}
+	// @Override
+	// @SuppressWarnings("unchecked")
+	// public <T> T getContentFilterMetadata() {
+	// return (T) contentFilterMetadata;
+	// }
 
-			@Override
-			public String getFinishReason() {
-				return finishReason;
-			}
+	// @Override
+	// public String getFinishReason() {
+	// return finishReason;
+	// }
 
-			@Override
-			public String toString() {
-				return "ChatGenerationMetadata{finishReason=" + finishReason + "," + "contentFilterMetadata="
-						+ contentFilterMetadata + "}";
-			}
-		};
-	}
+	// @Override
+	// public String toString() {
+	// return "ChatGenerationMetadata{finishReason=" + finishReason + "," +
+	// "contentFilterMetadata="
+	// + contentFilterMetadata + "}";
+	// }
+	// };
+	// }
 
-	/**
-	 * Returns the underlying AI provider metadata for filtering applied to generation
-	 * content.
-	 * @param <T> {@link Class Type} used to cast the filtered content metadata into the
-	 * AI provider-specific type.
-	 * @return the underlying AI provider metadata for filtering applied to generation
-	 * content.
-	 */
-	@Nullable
-	<T> T getContentFilterMetadata();
+	// /**
+	// * Returns the underlying AI provider metadata for filtering applied to generation
+	// * content.
+	// * @param <T> {@link Class Type} used to cast the filtered content metadata into the
+	// * AI provider-specific type.
+	// * @return the underlying AI provider metadata for filtering applied to generation
+	// * content.
+	// */
+	// @Nullable
+	// <T> T getContentFilterMetadata();
 
 	/**
 	 * Get the {@link String reason} this choice completed for the generation.
 	 * @return the {@link String reason} this choice completed for the generation.
 	 */
 	String getFinishReason();
+
+	Set<String> getContentFilters();
+
+	<T> T get(String key);
+
+	boolean containsKey(String key);
+
+	<T> T getOrDefault(String key, T defaultObject);
+
+	Set<Entry<String, Object>> entrySet();
+
+	Set<String> keySet();
+
+	boolean isEmpty();
+
+	public static Builder builder() {
+		return new DefaultChatGenerationMetadataBuilder();
+	}
+
+	/**
+	 * @author Christian Tzolov
+	 * @since 1.0.0
+	 */
+	public interface Builder {
+
+		/**
+		 * Set the reason this choice completed for the generation.
+		 */
+		Builder finishReason(String id);
+
+		/**
+		 * Add metadata to the Generation result.
+		 */
+		<T> Builder metadata(String key, T value);
+
+		/**
+		 * Add metadata to the Generation result.
+		 */
+		Builder metadata(Map<String, Object> metadata);
+
+		/**
+		 * Add content filter to the Generation result.
+		 */
+		Builder contentFilter(String contentFilter);
+
+		/**
+		 * Add content filters to the Generation result.
+		 */
+		Builder contentFilters(Set<String> contentFilters);
+
+		/**
+		 * Build the Generation metadata.
+		 */
+		ChatGenerationMetadata build();
+
+	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultChatGenerationMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultChatGenerationMetadata.java
@@ -1,0 +1,98 @@
+/*
+* Copyright 2024 - 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.chat.metadata;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+public class DefaultChatGenerationMetadata implements ChatGenerationMetadata {
+
+	private final Map<String, Object> metadata;
+
+	private final String finishReason;
+
+	private final Set<String> contentFilters = new HashSet<>();
+
+	DefaultChatGenerationMetadata(Map<String, Object> metadata, String finishReason, Set<String> contentFilters) {
+		this.metadata = metadata;
+		this.finishReason = finishReason;
+		this.contentFilters.addAll(contentFilters);
+	}
+
+	@Override
+	public <T> T get(String key) {
+		return (T) this.metadata.get(key);
+	}
+
+	@Override
+	public boolean containsKey(String key) {
+		return this.metadata.containsKey(key);
+	}
+
+	@Override
+	public <T> T getOrDefault(String key, T defaultObject) {
+		return containsKey(key) ? get(key) : defaultObject;
+	}
+
+	@Override
+	public Set<Entry<String, Object>> entrySet() {
+		return this.metadata.entrySet();
+	}
+
+	@Override
+	public Set<String> keySet() {
+		return this.metadata.keySet();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return this.metadata.isEmpty();
+	}
+
+	@Override
+	public String getFinishReason() {
+		return this.finishReason;
+	}
+
+	@Override
+	public Set<String> getContentFilters() {
+		return this.contentFilters;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(metadata, finishReason, contentFilters);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null || getClass() != obj.getClass())
+			return false;
+		DefaultChatGenerationMetadata other = (DefaultChatGenerationMetadata) obj;
+		return Objects.equals(metadata, other.metadata) && Objects.equals(finishReason, other.finishReason)
+				&& Objects.equals(contentFilters, other.contentFilters);
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultChatGenerationMetadataBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultChatGenerationMetadataBuilder.java
@@ -1,0 +1,76 @@
+/*
+* Copyright 2024 - 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.chat.metadata;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata.Builder;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+
+public class DefaultChatGenerationMetadataBuilder implements ChatGenerationMetadata.Builder {
+
+	private String finishReason;
+
+	private Map<String, Object> metadata = new HashMap<>();
+
+	private Set<String> contentFilters = new HashSet<>();
+
+	DefaultChatGenerationMetadataBuilder() {
+	}
+
+	@Override
+	public Builder finishReason(String finishReason) {
+		this.finishReason = finishReason;
+		return this;
+	}
+
+	@Override
+	public <T> Builder metadata(String key, T value) {
+		this.metadata.put(key, value);
+		return this;
+	}
+
+	@Override
+	public Builder metadata(Map<String, Object> metadata) {
+		this.metadata.putAll(metadata);
+		return this;
+	}
+
+	@Override
+	public Builder contentFilter(String contentFilter) {
+		this.contentFilters.add(contentFilter);
+		return this;
+	}
+
+	@Override
+	public Builder contentFilters(Set<String> contentFilters) {
+		this.contentFilters.addAll(contentFilters);
+		return this;
+	}
+
+	@Override
+	public ChatGenerationMetadata build() {
+		return new DefaultChatGenerationMetadata(this.metadata, this.finishReason, this.contentFilters);
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
@@ -111,7 +111,7 @@ class DefaultChatModelObservationConventionTests {
 			.build();
 		observationContext.setResponse(new ChatResponse(
 				List.of(new Generation(new AssistantMessage("response"),
-						ChatGenerationMetadata.from("this-is-the-end", null))),
+						ChatGenerationMetadata.builder().finishReason("this-is-the-end").build())),
 				ChatResponseMetadata.builder()
 					.withId("say33")
 					.withModel("mistral-42")
@@ -168,7 +168,8 @@ class DefaultChatModelObservationConventionTests {
 			.requestOptions(ChatOptionsBuilder.builder().withStopSequences(List.of()).build())
 			.build();
 		observationContext.setResponse(new ChatResponse(
-				List.of(new Generation(new AssistantMessage("response"), ChatGenerationMetadata.from("", null))),
+				List.of(new Generation(new AssistantMessage("response"),
+						ChatGenerationMetadata.builder().finishReason("").build())),
 				ChatResponseMetadata.builder().withId("").build()));
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext)
 			.stream()


### PR DESCRIPTION
- ChatGenerationMetadata provides Map for additional metadata
- Add Builder interface and DefaultChatGenerationMetadataBuilder
- Add DefaultChatGenerationMetadata implementation
- Update all AI model implementations to use the new builder pattern
- Deprecate ChatGenerationMetadata.from() factory method

Resolves #1805
