### PR TITLE
Issue #1796: Bugfix for serialization of Ollama duration metrics

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -16,18 +16,9 @@
 
 package org.springframework.ai.ollama.api;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Consumer;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -38,9 +29,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.http.HttpHeaders;
@@ -53,6 +41,16 @@ import org.springframework.util.StreamUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Java Client for the Ollama API. <a href="https://ollama.ai/">https://ollama.ai</a>
@@ -597,8 +595,8 @@ public class OllamaApi {
 	public record EmbeddingsResponse(
 			@JsonProperty("model") String model,
 			@JsonProperty("embeddings") List<float[]> embeddings,
-			@JsonProperty("total_duration") Long totalDuration,
-			@JsonProperty("load_duration") Long loadDuration,
+			@JsonProperty("total_duration") @JsonDeserialize(using = OllamaDurationDeserializer.class ) @JsonSerialize(using = OllamaDurationSerializer.class) Duration totalDuration,
+			@JsonProperty("load_duration") @JsonDeserialize(using = OllamaDurationDeserializer.class ) @JsonSerialize(using = OllamaDurationSerializer.class) Duration loadDuration,
 			@JsonProperty("prompt_eval_count") Integer promptEvalCount) {
 
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -27,6 +27,15 @@ import java.util.function.Consumer;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Flux;
@@ -538,12 +547,12 @@ public class OllamaApi {
 			@JsonProperty("message") Message message,
 			@JsonProperty("done_reason") String doneReason,
 			@JsonProperty("done") Boolean done,
-			@JsonProperty("total_duration") Duration totalDuration,
-			@JsonProperty("load_duration") Duration loadDuration,
+			@JsonProperty("total_duration") @JsonDeserialize(using = OllamaDurationDeserializer.class ) @JsonSerialize(using = OllamaDurationSerializer.class) Duration totalDuration,
+			@JsonProperty("load_duration") @JsonDeserialize(using = OllamaDurationDeserializer.class ) @JsonSerialize(using = OllamaDurationSerializer.class) Duration loadDuration,
 			@JsonProperty("prompt_eval_count") Integer promptEvalCount,
-			@JsonProperty("prompt_eval_duration") Duration promptEvalDuration,
+			@JsonProperty("prompt_eval_duration") @JsonDeserialize(using = OllamaDurationDeserializer.class ) @JsonSerialize(using = OllamaDurationSerializer.class) Duration promptEvalDuration,
 			@JsonProperty("eval_count") Integer evalCount,
-			@JsonProperty("eval_duration") Duration evalDuration
+			@JsonProperty("eval_duration") @JsonDeserialize(using = OllamaDurationDeserializer.class ) @JsonSerialize(using = OllamaDurationSerializer.class) Duration evalDuration
 	) {
 	}
 
@@ -684,5 +693,18 @@ public class OllamaApi {
 			@JsonProperty("completed") Long completed
 	) { }
 
+	private static final class OllamaDurationDeserializer extends JsonDeserializer<Duration>{
+		@Override
+		public Duration deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+			return Duration.ofNanos(jsonParser.getValueAsLong());
+		}
+	}
+
+	private static final class OllamaDurationSerializer extends JsonSerializer<Duration> {
+		@Override
+		public void serialize(Duration duration, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+			jsonGenerator.writeNumber(duration.toNanos());
+		}
+	}
 }
 // @formatter:on

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelTests.java
@@ -58,9 +58,11 @@ public class OllamaEmbeddingModelTests {
 
 		given(this.ollamaApi.embed(this.embeddingsRequestCaptor.capture()))
 			.willReturn(new EmbeddingsResponse("RESPONSE_MODEL_NAME",
-					List.of(new float[] { 1f, 2f, 3f }, new float[] { 4f, 5f, 6f }), 0L, 0L, 0))
+					List.of(new float[] { 1f, 2f, 3f }, new float[] { 4f, 5f, 6f }), Duration.ofNanos(0L),
+					Duration.ofNanos(0L), 0))
 			.willReturn(new EmbeddingsResponse("RESPONSE_MODEL_NAME2",
-					List.of(new float[] { 7f, 8f, 9f }, new float[] { 10f, 11f, 12f }), 0L, 0L, 0));
+					List.of(new float[] { 7f, 8f, 9f }, new float[] { 10f, 11f, 12f }), Duration.ofNanos(0L),
+					Duration.ofNanos(0L), 0));
 
 		// Tests default options
 		var defaultOptions = OllamaOptions.builder().withModel("DEFAULT_MODEL").build();

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.ollama.api;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -71,6 +72,12 @@ public class OllamaApiIT extends BaseOllamaIT {
 		assertThat(response.done()).isTrue();
 		assertThat(response.message().role()).isEqualTo(Role.ASSISTANT);
 		assertThat(response.message().content()).contains("Sofia");
+		assertThat(response.totalDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(response.loadDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(response.promptEvalDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(response.evalDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(response.promptEvalCount()).isGreaterThan(1);
+		assertThat(response.evalCount()).isGreaterThan(1);
 	}
 
 	@Test
@@ -97,6 +104,12 @@ public class OllamaApiIT extends BaseOllamaIT {
 		ChatResponse lastResponse = responses.get(responses.size() - 1);
 		assertThat(lastResponse.message().content()).isEmpty();
 		assertThat(lastResponse.done()).isTrue();
+		assertThat(lastResponse.totalDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(lastResponse.loadDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(lastResponse.promptEvalDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(lastResponse.evalDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(lastResponse.promptEvalCount()).isGreaterThan(1);
+		assertThat(lastResponse.evalCount()).isGreaterThan(1);
 	}
 
 	@Test

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
@@ -123,8 +123,8 @@ public class OllamaApiIT extends BaseOllamaIT {
 		assertThat(response.embeddings().get(0)).hasSize(3072);
 		assertThat(response.model()).isEqualTo(MODEL);
 		assertThat(response.promptEvalCount()).isEqualTo(5);
-		assertThat(response.loadDuration()).isGreaterThan(1);
-		assertThat(response.totalDuration()).isGreaterThan(1);
+		assertThat(response.loadDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
+		assertThat(response.totalDuration()).isBetween(Duration.ofNanos(1), Duration.ofSeconds(100));
 	}
 
 }

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiTest.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiTest.java
@@ -11,8 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.ai.ollama.api.OllamaApi.ChatResponse;
-import static org.springframework.ai.ollama.api.OllamaApi.Message;
+import static org.springframework.ai.ollama.api.OllamaApi.*;
 import static org.springframework.ai.ollama.api.OllamaApi.Message.Role.ASSISTANT;
 import static org.springframework.ai.ollama.api.OllamaApi.Message.ToolCall;
 import static org.springframework.ai.ollama.api.OllamaApi.Message.ToolCallFunction;
@@ -32,6 +31,19 @@ public class OllamaApiTest {
 
 		var serialized = objectMapper.writeValueAsString(original);
 		var deserialized = objectMapper.readValue(serialized, ChatResponse.class);
+
+		assertThat(deserialized).isEqualTo(original);
+	}
+
+	@Test
+	void embeddingsResponseSerializationRoundTrip() throws JsonProcessingException {
+		var objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+
+		var original = new EmbeddingsResponse("aModel", List.of(), Duration.ofSeconds(7), Duration.ofSeconds(1), 23);
+
+		var serialized = objectMapper.writeValueAsString(original);
+		var deserialized = objectMapper.readValue(serialized, EmbeddingsResponse.class);
 
 		assertThat(deserialized).isEqualTo(original);
 	}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiTest.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiTest.java
@@ -1,0 +1,39 @@
+package org.springframework.ai.ollama.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.ai.ollama.api.OllamaApi.ChatResponse;
+import static org.springframework.ai.ollama.api.OllamaApi.Message;
+import static org.springframework.ai.ollama.api.OllamaApi.Message.Role.ASSISTANT;
+import static org.springframework.ai.ollama.api.OllamaApi.Message.ToolCall;
+import static org.springframework.ai.ollama.api.OllamaApi.Message.ToolCallFunction;
+
+public class OllamaApiTest {
+
+	@Test
+	void chatResponseSerializationRoundTrip() throws JsonProcessingException {
+		var objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+
+		var original = new ChatResponse("aModel", Instant.now(),
+				new Message(ASSISTANT, "someContent", List.of("anImage"),
+						List.of(new ToolCall(new ToolCallFunction("functionName", Map.of("paramName", "paramValue"))))),
+				"weAreDone", true, Duration.ofSeconds(7), Duration.ofSeconds(1), 23, Duration.ofSeconds(2), 56,
+				Duration.ofSeconds(4));
+
+		var serialized = objectMapper.writeValueAsString(original);
+		var deserialized = objectMapper.readValue(serialized, ChatResponse.class);
+
+		assertThat(deserialized).isEqualTo(original);
+	}
+
+}


### PR DESCRIPTION
…ime unit is used while deserializing the duration values coming from Ollama.

Duration metrics are sent in nano seconds by Ollama, but interpreted as seconds by Spring AI. See issue #1796 for more details.
