### PR TITLE
fix: incorrect json property annotation for ZhiPuAI

### DIFF
--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -329,11 +329,11 @@ public class ZhiPuAiApi {
 
 		// The type of the tool. Currently, only 'function' is supported.
 		@JsonProperty("type")
-		private Function function;
+		private Type type = Type.FUNCTION;
 
 		//	The function definition.
 		@JsonProperty("function")
-		private Type type = Type.FUNCTION;
+		private Function function;
 
 		public FunctionTool() {
 


### PR DESCRIPTION
to fix mistakenly modified in commit [fd8cac57](https://github.com/spring-projects/spring-ai/commit/fd8cac57#diff-4df7db0c9a7afc1ea8ec3caacbcf625e455796fee3a1fd35f6257d1effdf3a2bR332)
related issue: https://github.com/spring-projects/spring-ai/issues/1828