### PR TITLE
Portable ChatOptions ignored by OpenAiChatModel

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -473,7 +473,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(((FunctionCallingOptions) prompt.getOptions()),
 						FunctionCallingOptions.class, OpenAiChatOptions.class);
 			}
-			else if (prompt.getOptions() instanceof OpenAiChatOptions) {
+			else {
 				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
 						OpenAiChatOptions.class);
 			}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.prompt.ChatOptionsBuilder;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -441,10 +442,11 @@ public class OpenAiChatModelIT extends AbstractIT {
 				List.of(new Media(MimeTypeUtils.parseMimeType("audio/mp3"), audioResource)));
 
 		ChatResponse response = chatModel
-			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
+			.call(new Prompt(List.of(userMessage), ChatOptionsBuilder.builder().withModel(modelName).build()));
 
 		logger.info(response.getResult().getOutput().getContent());
 		assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("hobbits");
+		assertThat(response.getMetadata().getModel()).containsIgnoringCase(modelName);
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")


### PR DESCRIPTION
When calling the `OpenAiChatModel` with `ChatOptions`, they are always ignored. Options are considered only when using `OpenAiChatOptions` or `FunctionCallingOptions`.

This seems a regression after the recent refactoring of `FunctionCallingOptions`. I checked all the model implementation and it's only OpenAI having this error.