### PR TITLE
GH-1826 Fix EmbeddingModel's usage on Document#embedding

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/EmbeddingIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/EmbeddingIT.java
@@ -66,12 +66,12 @@ class EmbeddingIT extends AbstractIT {
 	@Test
 	void embeddingBatchDocuments() throws Exception {
 		assertThat(this.embeddingModel).isNotNull();
-		List<float[]> embedded = this.embeddingModel.embed(
+		List<float[]> embeddings = this.embeddingModel.embed(
 				List.of(new Document("Hello world"), new Document("Hello Spring"), new Document("Hello Spring AI!")),
 				OpenAiEmbeddingOptions.builder().withModel(OpenAiApi.DEFAULT_EMBEDDING_MODEL).build(),
 				new TokenCountBatchingStrategy());
-		assertThat(embedded.size()).isEqualTo(3);
-		embedded.forEach(embedding -> assertThat(embedding.length).isEqualTo(this.embeddingModel.dimensions()));
+		assertThat(embeddings.size()).isEqualTo(3);
+		embeddings.forEach(embedding -> assertThat(embedding.length).isEqualTo(this.embeddingModel.dimensions()));
 	}
 
 	@Test

--- a/spring-ai-core/src/main/java/org/springframework/ai/embedding/BatchingStrategy.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/embedding/BatchingStrategy.java
@@ -31,7 +31,9 @@ public interface BatchingStrategy {
 
 	/**
 	 * {@link EmbeddingModel} implementations can call this method to optimize embedding
-	 * tokens. The incoming collection of {@link Document}s are split into su-batches.
+	 * tokens. The incoming collection of {@link Document}s are split into sub-batches. It
+	 * is important to preserve the order of the list of {@link Document}s when batching
+	 * as they are mapped to their corresponding embeddings by their order.
 	 * @param documents to batch
 	 * @return a list of sub-batches that contain {@link Document}s.
 	 */

--- a/spring-ai-core/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
@@ -17,7 +17,7 @@
 package org.springframework.ai.embedding;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -139,7 +139,9 @@ public class TokenCountBatchingStrategy implements BatchingStrategy {
 		List<List<Document>> batches = new ArrayList<>();
 		int currentSize = 0;
 		List<Document> currentBatch = new ArrayList<>();
-		Map<Document, Integer> documentTokens = new HashMap<>();
+		// Make sure the documentTokens' entry order is preserved by making it a
+		// LinkedHashMap.
+		Map<Document, Integer> documentTokens = new LinkedHashMap<>();
 
 		for (Document document : documents) {
 			int tokenCount = this.tokenCountEstimator

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/CosmosDBVectorStore.java
@@ -203,13 +203,14 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 	public void doAdd(List<Document> documents) {
 
 		// Batch the documents based on the batching strategy
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 
 		// Create a list to hold both the CosmosItemOperation and the corresponding
 		// document ID
 		List<ImmutablePair<String, CosmosItemOperation>> itemOperationsWithIds = documents.stream().map(doc -> {
-			CosmosItemOperation operation = CosmosBulkOperations
-				.getCreateItemOperation(mapCosmosDocument(doc, doc.getEmbedding()), new PartitionKey(doc.getId()));
+			CosmosItemOperation operation = CosmosBulkOperations.getCreateItemOperation(
+					mapCosmosDocument(doc, embeddings.get(documents.indexOf(doc))), new PartitionKey(doc.getId()));
 			return new ImmutablePair<>(doc.getId(), operation); // Pair the document ID
 			// with the operation
 		}).toList();

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -224,12 +224,13 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 			return; // nothing to do;
 		}
 
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 
 		final var searchDocuments = documents.stream().map(document -> {
 			SearchDocument searchDocument = new SearchDocument();
 			searchDocument.put(ID_FIELD_NAME, document.getId());
-			searchDocument.put(EMBEDDING_FIELD_NAME, document.getEmbedding());
+			searchDocument.put(EMBEDDING_FIELD_NAME, embeddings.get(documents.indexOf(document)));
 			searchDocument.put(CONTENT_FIELD_NAME, document.getContent());
 			searchDocument.put(METADATA_FIELD_NAME, new JSONObject(document.getMetadata()).toJSONString());
 
@@ -324,7 +325,6 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 				metadata.put(DISTANCE_METADATA_FIELD_NAME, 1 - (float) result.getScore());
 
 				final Document doc = new Document(entry.id(), entry.content(), metadata);
-				doc.setEmbedding(EmbeddingUtils.toPrimitive(entry.embedding()));
 
 				return doc;
 

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/CassandraVectorStore.java
@@ -182,7 +182,8 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 	public void doAdd(List<Document> documents) {
 		var futures = new CompletableFuture[documents.size()];
 
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 
 		int i = 0;
 		for (Document d : documents) {
@@ -197,7 +198,8 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 
 				builder = builder.setString(this.conf.schema.content(), d.getContent())
 					.setVector(this.conf.schema.embedding(),
-							CqlVector.newInstance(EmbeddingUtils.toList(d.getEmbedding())), Float.class);
+							CqlVector.newInstance(EmbeddingUtils.toList(embeddings.get(documents.indexOf(d)))),
+							Float.class);
 
 				for (var metadataColumn : this.conf.schema.metadataColumns()
 					.stream()
@@ -260,11 +262,6 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 				}
 			}
 			Document doc = new Document(getDocumentId(row), row.getString(this.conf.schema.content()), docFields);
-
-			if (this.conf.returnEmbeddings) {
-				doc.setEmbedding(EmbeddingUtils
-					.toPrimitive(row.getVector(this.conf.schema.embedding(), Float.class).stream().toList()));
-			}
 			documents.add(doc);
 		}
 		return documents;

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/CassandraVectorStoreConfig.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/CassandraVectorStoreConfig.java
@@ -90,6 +90,8 @@ public final class CassandraVectorStoreConfig implements AutoCloseable {
 
 	final boolean disallowSchemaChanges;
 
+	// TODO: Remove this flag as the document no longer holds embeddings.
+	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	final boolean returnEmbeddings;
 
 	final DocumentIdTranslator documentIdTranslator;

--- a/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/CassandraVectorStoreIT.java
+++ b/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/CassandraVectorStoreIT.java
@@ -121,18 +121,12 @@ class CassandraVectorStoreIT {
 
 				List<Document> documents = documents();
 				store.add(documents);
-				for (Document d : documents) {
-					assertThat(d.getEmbedding()).satisfiesAnyOf(e -> assertThat(e).isNotNull(),
-							e -> assertThat(e).isNotEmpty());
-				}
 
 				List<Document> results = store.similaritySearch(SearchRequest.query("Spring").withTopK(1));
 
 				assertThat(results).hasSize(1);
 				Document resultDoc = results.get(0);
 				assertThat(resultDoc.getId()).isEqualTo(documents().get(0).getId());
-				assertThat(resultDoc.getEmbedding()).satisfiesAnyOf(e -> assertThat(e).isNull(),
-						e -> assertThat(e).isEmpty());
 
 				assertThat(resultDoc.getContent()).contains(
 						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");
@@ -158,17 +152,12 @@ class CassandraVectorStoreIT {
 			try (CassandraVectorStore store = createTestStore(context, builder)) {
 				List<Document> documents = documents();
 				store.add(documents);
-				for (Document d : documents) {
-					assertThat(d.getEmbedding()).satisfiesAnyOf(e -> assertThat(e).isNotNull(),
-							e -> assertThat(e).isNotEmpty());
-				}
 
 				List<Document> results = store.similaritySearch(SearchRequest.query("Spring").withTopK(1));
 
 				assertThat(results).hasSize(1);
 				Document resultDoc = results.get(0);
 				assertThat(resultDoc.getId()).isEqualTo(documents().get(0).getId());
-				assertThat(resultDoc.getEmbedding()).isNotEmpty();
 
 				assertThat(resultDoc.getContent()).contains(
 						"Spring AI provides abstractions that serve as the foundation for developing AI applications.");

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/vectorstore/ChromaVectorStore.java
@@ -145,14 +145,14 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		List<String> contents = new ArrayList<>();
 		List<float[]> embeddings = new ArrayList<>();
 
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> documentEmbeddings = this.embeddingModel.embed(documents,
+				EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
 
 		for (Document document : documents) {
 			ids.add(document.getId());
 			metadatas.add(document.getMetadata());
 			contents.add(document.getContent());
-			document.setEmbedding(document.getEmbedding());
-			embeddings.add(document.getEmbedding());
+			embeddings.add(documentEmbeddings.get(documents.indexOf(document)));
 		}
 
 		this.chromaApi.upsertEmbeddings(this.collectionId,
@@ -193,9 +193,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 					metadata = new HashMap<>();
 				}
 				metadata.put(DISTANCE_FIELD_NAME, distance);
-				Document document = new Document(id, content, metadata);
-				document.setEmbedding(chromaEmbedding.embedding());
-				responseDocuments.add(document);
+				responseDocuments.add(new Document(id, content, metadata));
 			}
 		}
 

--- a/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/CoherenceVectorStore.java
+++ b/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/CoherenceVectorStore.java
@@ -165,9 +165,9 @@ public class CoherenceVectorStore implements VectorStore, InitializingBean {
 	public void add(final List<Document> documents) {
 		Map<DocumentChunk.Id, DocumentChunk> chunks = new HashMap<>((int) Math.ceil(documents.size() / 0.75f));
 		for (Document doc : documents) {
-			doc.setEmbedding(this.embeddingModel.embed(doc));
 			var id = toChunkId(doc.getId());
-			var chunk = new DocumentChunk(doc.getContent(), doc.getMetadata(), toFloat32Vector(doc.getEmbedding()));
+			var chunk = new DocumentChunk(doc.getContent(), doc.getMetadata(),
+					toFloat32Vector(this.embeddingModel.embed(doc)));
 			chunks.put(id, chunk);
 		}
 		this.documentChunks.putAll(chunks);

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -71,6 +71,7 @@ import org.springframework.util.Assert;
  * @author Soby Chacko
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
 public class ElasticsearchVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -132,11 +133,14 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		}
 		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
 
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 
 		for (Document document : documents) {
-			bulkRequestBuilder.operations(op -> op
-				.index(idx -> idx.index(this.options.getIndexName()).id(document.getId()).document(document)));
+			ElasticSearchDocument doc = new ElasticSearchDocument(document.getId(), document.getContent(),
+					document.getMetadata(), embeddings.get(documents.indexOf(document)));
+			bulkRequestBuilder.operations(
+					op -> op.index(idx -> idx.index(this.options.getIndexName()).id(document.getId()).document(doc)));
 		}
 		BulkResponse bulkRequest = bulkRequest(bulkRequestBuilder.build());
 		if (bulkRequest.errors()) {
@@ -275,6 +279,17 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 			return this.options.getSimilarity().name();
 		}
 		return SIMILARITY_TYPE_MAPPING.get(this.options.getSimilarity()).value();
+	}
+
+	/**
+	 * The representation of {@link Document} along with its embedding.
+	 *
+	 * @param id The id of the document
+	 * @param content The content of the document
+	 * @param metadata The metadata of the document
+	 * @param embedding The vectors representing the content of the document
+	 */
+	public record ElasticSearchDocument(String id, String content, Map<String, Object> metadata, float[] embedding) {
 	}
 
 }

--- a/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
@@ -209,10 +209,11 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 
 	@Override
 	public void doAdd(List<Document> documents) {
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 		UploadRequest upload = new UploadRequest(documents.stream()
-			.map(document -> new UploadRequest.Embedding(document.getId(), document.getEmbedding(), DOCUMENT_FIELD,
-					document.getContent(), document.getMetadata()))
+			.map(document -> new UploadRequest.Embedding(document.getId(), embeddings.get(documents.indexOf(document)),
+					DOCUMENT_FIELD, document.getContent(), document.getMetadata()))
 			.toList());
 
 		String embeddingsJson = null;

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -160,7 +160,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		List<List<Float>> embeddingArray = new ArrayList<>();
 
 		// TODO: Need to customize how we pass the embedding options
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 
 		for (Document document : documents) {
 			docIdArray.add(document.getId());
@@ -168,7 +169,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			// the content used to compute the embeddings
 			contentArray.add(document.getContent());
 			metadataArray.add(new JSONObject(document.getMetadata()));
-			embeddingArray.add(EmbeddingUtils.toList(document.getEmbedding()));
+			embeddingArray.add(EmbeddingUtils.toList(embeddings.get(documents.indexOf(document))));
 		}
 
 		List<InsertParam.Field> fields = new ArrayList<>();

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
@@ -107,9 +107,12 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 	@Override
 	public void doAdd(List<Document> documents) {
 
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 
-		var rows = documents.stream().map(this::documentToRecord).toList();
+		var rows = documents.stream()
+			.map(document -> documentToRecord(document, embeddings.get(documents.indexOf(document))))
+			.toList();
 
 		try (var session = this.driver.session()) {
 			var statement = """
@@ -203,8 +206,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		}
 	}
 
-	private Map<String, Object> documentToRecord(Document document) {
-		document.setEmbedding(document.getEmbedding());
+	private Map<String, Object> documentToRecord(Document document, float[] embedding) {
 
 		var row = new HashMap<String, Object>();
 
@@ -216,7 +218,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		document.getMetadata().forEach((k, v) -> properties.put("metadata." + k, Values.value(v)));
 		row.put("properties", properties);
 
-		row.put(this.config.embeddingProperty, Values.value(document.getEmbedding()));
+		row.put(this.config.embeddingProperty, Values.value(embedding));
 		return row;
 	}
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
@@ -146,9 +146,6 @@ class PgVectorStoreWithChatMemoryAdvisorIT {
 		EmbeddingModel embeddingModel = mock(EmbeddingModel.class);
 
 		Mockito.doAnswer(invocationOnMock -> {
-			Object[] arguments = invocationOnMock.getArguments();
-			List<Document> documents = (List<Document>) arguments[0];
-			documents.forEach(d -> d.setEmbedding(this.embed));
 			return List.of(this.embed, this.embed);
 		}).when(embeddingModel).embed(ArgumentMatchers.any(), any(), any());
 		given(embeddingModel.embed(any(String.class))).willReturn(this.embed);

--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
@@ -124,11 +124,12 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 	 * @param namespace The namespace to add the documents to
 	 */
 	public void add(List<Document> documents, String namespace) {
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 		List<Vector> upsertVectors = documents.stream()
 			.map(document -> Vector.newBuilder()
 				.setId(document.getId())
-				.addAllValues(EmbeddingUtils.toList(document.getEmbedding()))
+				.addAllValues(EmbeddingUtils.toList(embeddings.get(documents.indexOf(document))))
 				.setMetadata(metadataToStruct(document))
 				.build())
 			.toList();

--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -127,12 +127,13 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		try {
 
 			// Compute and assign an embedding to the document.
-			this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+			List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+					this.batchingStrategy);
 
 			List<PointStruct> points = documents.stream()
 				.map(document -> PointStruct.newBuilder()
 					.setId(io.qdrant.client.PointIdFactory.id(UUID.fromString(document.getId())))
-					.setVectors(io.qdrant.client.VectorsFactory.vectors(document.getEmbedding()))
+					.setVectors(io.qdrant.client.VectorsFactory.vectors(embeddings.get(documents.indexOf(document))))
 					.putAllPayload(toPayload(document))
 					.build())
 				.toList();

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
@@ -162,12 +162,12 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 	public void doAdd(List<Document> documents) {
 		try (Pipeline pipeline = this.jedis.pipelined()) {
 
-			this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+			List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+					this.batchingStrategy);
 
 			for (Document document : documents) {
-				document.setEmbedding(document.getEmbedding());
 				var fields = new HashMap<String, Object>();
-				fields.put(this.config.embeddingFieldName, document.getEmbedding());
+				fields.put(this.config.embeddingFieldName, embeddings.get(documents.indexOf(document)));
 				fields.put(this.config.contentFieldName, document.getContent());
 				fields.putAll(document.getMetadata());
 				pipeline.jsonSetWithEscape(key(document.getId()), JSON_SET_PATH, fields);

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
@@ -123,14 +123,15 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 	public void doAdd(List<Document> documents) {
 		Assert.notNull(documents, "Documents must not be null");
 
-		this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(), this.batchingStrategy);
+		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptionsBuilder.builder().build(),
+				this.batchingStrategy);
 
 		List<HashMap<String, Object>> documentList = documents.stream().map(document -> {
 			HashMap<String, Object> typesenseDoc = new HashMap<>();
 			typesenseDoc.put(DOC_ID_FIELD_NAME, document.getId());
 			typesenseDoc.put(CONTENT_FIELD_NAME, document.getContent());
 			typesenseDoc.put(METADATA_FIELD_NAME, document.getMetadata());
-			typesenseDoc.put(EMBEDDING_FIELD_NAME, document.getEmbedding());
+			typesenseDoc.put(EMBEDDING_FIELD_NAME, embeddings.get(documents.indexOf(document)));
 
 			return typesenseDoc;
 		}).toList();


### PR DESCRIPTION
  - Since the Document object's reference to the `embedding` is deprecated and will be removed, the VectorStore implementations require a way to store the embedding of the corresponding Document objects  
  
    - One way to fix this is, to have the EmbeddingModel#embed to return the embeddings in the same order as that of the Documents passed to it. 
         - Since both the Document and embedding collections use the List object, their iteration operation will make sure to keep them in line with the same order. 
              - A fix is required to preserve the order when batching strategy is applied.
	          - Updated the Javadoc for BatchingStrategy -
	          -  Fixed the Document List order in TokenCountBatchingStrategy

    - Refactored the vector store implementations to update this change

Resolves #GH-1826
