### PR TITLE
Fix wrong image size for openai

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
@@ -16,12 +16,11 @@
 
 package org.springframework.ai.openai;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.image.ImageOptions;
+
+import java.util.Objects;
 
 /**
  * OpenAI Image API options. OpenAiImageOptions.java
@@ -153,7 +152,9 @@ public class OpenAiImageOptions implements ImageOptions {
 
 	public void setWidth(Integer width) {
 		this.width = width;
-		this.size = this.width + "x" + this.height;
+		if (this.width != null && this.height != null) {
+			this.size = this.width + "x" + this.height;
+		}
 	}
 
 	@Override
@@ -174,7 +175,9 @@ public class OpenAiImageOptions implements ImageOptions {
 
 	public void setHeight(Integer height) {
 		this.height = height;
-		this.size = this.width + "x" + this.height;
+		if (this.width != null && this.height != null) {
+			this.size = this.width + "x" + this.height;
+		}
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiImageOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiImageOptionsTests.java
@@ -58,10 +58,10 @@ class OpenAiImageOptionsTests {
 	void whenWidthIsSet() {
 		OpenAiImageOptions options = new OpenAiImageOptions();
 		options.setWidth(1920);
-		assertThat(options.getHeight()).isEqualTo(null);
+		assertThat(options.getHeight()).isNull();
 		assertThat(options.getWidth()).isEqualTo(1920);
-		// This is because "setWidth()" computes "size" without checking for null values.
-		assertThat(options.getSize()).isEqualTo("1920xnull");
+		// 1920xnull is not a valid size, so "size" should be null.
+		assertThat(options.getSize()).isNull();
 	}
 
 	@Test
@@ -69,9 +69,9 @@ class OpenAiImageOptionsTests {
 		OpenAiImageOptions options = new OpenAiImageOptions();
 		options.setHeight(1080);
 		assertThat(options.getHeight()).isEqualTo(1080);
-		assertThat(options.getWidth()).isEqualTo(null);
-		// This is because "setHeight()" computes "size" without checking for null values.
-		assertThat(options.getSize()).isEqualTo("nullx1080");
+		assertThat(options.getWidth()).isNull();
+		// nullx1080 is not a valid size, so "size" should be null.
+		assertThat(options.getSize()).isNull();
 	}
 
 }


### PR DESCRIPTION
This pull request includes changes to the `OpenAiImageOptions` class and its corresponding test class to improve handling of width and height properties. The most important changes include updating the `setWidth` and `setHeight` methods to properly compute the `size` property only when both width and height are set, and updating the test cases to reflect these changes.

Improvements to width and height handling:

* [`models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java`](diffhunk://#diff-e1924db16aacae57eaff6b25852010df9e3361d6d862f6329000833a00c0399eR155-R158): Updated the `setWidth` and `setHeight` methods to compute `size` only when both width and height are non-null. [[1]](diffhunk://#diff-e1924db16aacae57eaff6b25852010df9e3361d6d862f6329000833a00c0399eR155-R158) [[2]](diffhunk://#diff-e1924db16aacae57eaff6b25852010df9e3361d6d862f6329000833a00c0399eR178-R181)

Test case updates:

* [`models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiImageOptionsTests.java`](diffhunk://#diff-f066ad592fbc08df198b3573ba66db1af21318a0da76b591f5092cfdb1634255L61-R74): Modified test cases to ensure `size` is null when either width or height is not set.

Code cleanup:

* [`models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java`](diffhunk://#diff-e1924db16aacae57eaff6b25852010df9e3361d6d862f6329000833a00c0399eL19-R24): Reorganized imports to follow standard conventions.