### PR TITLE
Ensure matching enum id to value for multilingual cohere embedding model

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
@@ -18,19 +18,18 @@ package org.springframework.ai.bedrock.cohere.api;
 
 // @formatter:off
 
-import java.time.Duration;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-
 import org.springframework.ai.bedrock.api.AbstractBedrockApi;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingResponse;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import java.time.Duration;
+import java.util.List;
 
 /**
  * Cohere Embedding API.
@@ -123,7 +122,7 @@ public class CohereEmbeddingBedrockApi extends
 		/**
 		 * cohere.embed-multilingual-v3
 		 */
-		COHERE_EMBED_MULTILINGUAL_V1("cohere.embed-multilingual-v3"),
+		COHERE_EMBED_MULTILINGUAL_V3("cohere.embed-multilingual-v3"),
 		/**
 		 * cohere.embed-english-v3
 		 */

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModelIT.java
@@ -170,7 +170,7 @@ class BedrockCohereEmbeddingModelIT {
 
 		@Bean
 		public CohereEmbeddingBedrockApi cohereEmbeddingApi() {
-			return new CohereEmbeddingBedrockApi(CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V1.id(),
+			return new CohereEmbeddingBedrockApi(CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3.id(),
 					EnvironmentVariableCredentialsProvider.create(), Region.US_EAST_1.id(), new ObjectMapper(),
 					Duration.ofMinutes(2));
 		}

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApiIT.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CohereEmbeddingBedrockApiIT {
 
 	CohereEmbeddingBedrockApi api = new CohereEmbeddingBedrockApi(
-			CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V1.id(), EnvironmentVariableCredentialsProvider.create(),
+			CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3.id(), EnvironmentVariableCredentialsProvider.create(),
 			Region.US_EAST_1.id(), new ObjectMapper(), Duration.ofMinutes(2));
 
 	@Test

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereEmbeddingProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereEmbeddingProperties.java
@@ -43,7 +43,7 @@ public class BedrockCohereEmbeddingProperties {
 	 * Bedrock Cohere Embedding generative name. Defaults to
 	 * 'cohere.embed-multilingual-v3'.
 	 */
-	private String model = CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V1.id();
+	private String model = CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3.id();
 
 	@NestedConfigurationProperty
 	private BedrockCohereEmbeddingOptions options = BedrockCohereEmbeddingOptions.builder()

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereEmbeddingAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereEmbeddingAutoConfigurationIT.java
@@ -44,7 +44,7 @@ public class BedrockCohereEmbeddingAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = BedrockTestUtils.getContextRunner()
 		.withPropertyValues("spring.ai.bedrock.cohere.embedding.enabled=true",
-				"spring.ai.bedrock.cohere.embedding.model=" + CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V1.id(),
+				"spring.ai.bedrock.cohere.embedding.model=" + CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3.id(),
 				"spring.ai.bedrock.cohere.embedding.options.inputType=SEARCH_DOCUMENT",
 				"spring.ai.bedrock.cohere.embedding.options.truncate=NONE")
 		.withConfiguration(AutoConfigurations.of(BedrockCohereEmbeddingAutoConfiguration.class));


### PR DESCRIPTION
This ensures that the enum name matches the actual value from Bedrock as a provider.
