### PR TITLE
refactor: Rename ChatGenerationMetadata -> GenerationMetadata

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -45,7 +45,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
 import org.springframework.ai.chat.model.ChatModel;
@@ -293,14 +293,14 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 			.stream()
 			.filter(content -> content.type() != ContentBlock.Type.TOOL_USE)
 			.map(content -> new Generation(new AssistantMessage(content.text(), Map.of()),
-					ChatGenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build()))
+					GenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build()))
 			.toList();
 
 		List<Generation> allGenerations = new ArrayList<>(generations);
 
 		if (chatCompletion.stopReason() != null && generations.isEmpty()) {
 			Generation generation = new Generation(new AssistantMessage(null, Map.of()),
-					ChatGenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build());
+					GenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build());
 			allGenerations.add(generation);
 		}
 
@@ -324,7 +324,7 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 
 			AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), toolCalls);
 			Generation toolCallGeneration = new Generation(assistantMessage,
-					ChatGenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build());
+					GenerationMetadata.builder().finishReason(chatCompletion.stopReason()).build());
 			allGenerations.add(toolCallGeneration);
 		}
 

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -63,7 +63,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.metadata.PromptMetadata;
@@ -458,8 +458,8 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 		}
 	}
 
-	private ChatGenerationMetadata generateChoiceMetadata(ChatChoice choice) {
-		return ChatGenerationMetadata.builder()
+	private GenerationMetadata generateChoiceMetadata(ChatChoice choice) {
+		return GenerationMetadata.builder()
 			.finishReason(String.valueOf(choice.getFinishReason()))
 			.metadata("contentFilterResults", choice.getContentFilterResults())
 			.build();

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatModelMetadataTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatModelMetadataTests.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.azure.openai.AzureOpenAiChatModel;
 import org.springframework.ai.azure.openai.MockAzureOpenAiTestConfiguration;
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.PromptMetadata;
@@ -124,11 +124,11 @@ class AzureOpenAiChatModelMetadataTests {
 
 	private void assertChoiceMetadata(Generation generation) {
 
-		ChatGenerationMetadata chatGenerationMetadata = generation.getMetadata();
+		GenerationMetadata generationMetadata = generation.getMetadata();
 
-		assertThat(chatGenerationMetadata).isNotNull();
-		assertThat(chatGenerationMetadata.getFinishReason()).isEqualTo("stop");
-		assertContentFilterResults(chatGenerationMetadata.get("contentFilterResults"));
+		assertThat(generationMetadata).isNotNull();
+		assertThat(generationMetadata.getFinishReason()).isEqualTo("stop");
+		assertContentFilterResults(generationMetadata.get("contentFilterResults"));
 	}
 
 	private void assertContentFilterResultsForPrompt(ContentFilterResultDetailsForPrompt contentFilterResultForPrompt,

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -71,7 +71,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
@@ -419,14 +419,14 @@ public class BedrockProxyChatModel extends AbstractToolCallSupport implements Ch
 			.stream()
 			.filter(content -> content.type() != ContentBlock.Type.TOOL_USE)
 			.map(content -> new Generation(new AssistantMessage(content.text(), Map.of()),
-					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build()))
+					GenerationMetadata.builder().finishReason(response.stopReasonAsString()).build()))
 			.toList();
 
 		List<Generation> allGenerations = new ArrayList<>(generations);
 
 		if (response.stopReasonAsString() != null && generations.isEmpty()) {
 			Generation generation = new Generation(new AssistantMessage(null, Map.of()),
-					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
+					GenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
 			allGenerations.add(generation);
 		}
 
@@ -451,7 +451,7 @@ public class BedrockProxyChatModel extends AbstractToolCallSupport implements Ch
 
 			AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), toolCalls);
 			Generation toolCallGeneration = new Generation(assistantMessage,
-					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
+					GenerationMetadata.builder().finishReason(response.stopReasonAsString()).build());
 			allGenerations.add(toolCallGeneration);
 		}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -46,7 +46,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolUseBlockStart;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -141,7 +141,7 @@ public final class ConverseApiUtils {
 
 				AssistantMessage assistantMessage = new AssistantMessage("", Map.of(), toolCalls);
 				Generation toolCallGeneration = new Generation(assistantMessage,
-						ChatGenerationMetadata.builder().finishReason("tool_use").build());
+						GenerationMetadata.builder().finishReason("tool_use").build());
 
 				var chatResponseMetaData = ChatResponseMetadata.builder()
 					.withUsage(new DefaultUsage(promptTokens, generationTokens, totalTokens))
@@ -176,7 +176,7 @@ public final class ConverseApiUtils {
 
 					var generation = new Generation(
 							new AssistantMessage(contentBlockDeltaEvent.delta().text(), Map.of()),
-							ChatGenerationMetadata.builder()
+							GenerationMetadata.builder()
 								.finishReason(lastAggregation.metadataAggregation().stopReason())
 								.build());
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModel.java
@@ -25,7 +25,7 @@ import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi;
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatRequest;
 import org.springframework.ai.bedrock.anthropic.api.AnthropicChatBedrockApi.AnthropicChatResponse;
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -81,15 +81,15 @@ public class BedrockAnthropicChatModel implements ChatModel, StreamingChatModel 
 
 		return fluxResponse.map(response -> {
 			String stopReason = response.stopReason() != null ? response.stopReason() : null;
-			ChatGenerationMetadata chatGenerationMetadata = null;
+			GenerationMetadata generationMetadata = null;
 			if (response.amazonBedrockInvocationMetrics() != null) {
-				chatGenerationMetadata = ChatGenerationMetadata.builder()
+				generationMetadata = GenerationMetadata.builder()
 					.finishReason(stopReason)
 					.metadata("metrics", response.amazonBedrockInvocationMetrics())
 					.build();
 			}
 			return new ChatResponse(
-					List.of(new Generation(new AssistantMessage(response.completion()), chatGenerationMetadata)));
+					List.of(new Generation(new AssistantMessage(response.completion()), generationMetadata)));
 		});
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -35,7 +35,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.Usage;
@@ -88,7 +88,7 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 		List<Generation> generations = response.content()
 			.stream()
 			.map(content -> new Generation(new AssistantMessage(content.text()),
-					ChatGenerationMetadata.builder().finishReason(response.stopReason()).build()))
+					GenerationMetadata.builder().finishReason(response.stopReason()).build()))
 			.toList();
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder()
@@ -114,16 +114,16 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 				inputTokens.set(response.message().usage().inputTokens());
 			}
 			String content = response.type() == StreamingType.CONTENT_BLOCK_DELTA ? response.delta().text() : "";
-			ChatGenerationMetadata chatGenerationMetadata = null;
+			GenerationMetadata generationMetadata = null;
 			if (response.type() == StreamingType.MESSAGE_DELTA) {
-				chatGenerationMetadata = ChatGenerationMetadata.builder()
+				generationMetadata = GenerationMetadata.builder()
 					.finishReason(response.delta().stopReason())
 					.metadata("usage",
 							new Anthropic3ChatBedrockApi.AnthropicUsage(inputTokens.get(),
 									response.usage().outputTokens()))
 					.build();
 			}
-			return new ChatResponse(List.of(new Generation(new AssistantMessage(content), chatGenerationMetadata)));
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(content), generationMetadata)));
 		});
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
@@ -26,7 +26,7 @@ import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereChatBedrockApi.CohereChatResponse;
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -79,7 +79,7 @@ public class BedrockCohereChatModel implements ChatModel, StreamingChatModel {
 				String finishReason = g.finishReason().name();
 				Usage usage = BedrockUsage.from(g.amazonBedrockInvocationMetrics());
 				return new ChatResponse(List.of(new Generation(new AssistantMessage(""),
-						ChatGenerationMetadata.builder().finishReason(finishReason).metadata("usage", usage).build())));
+						GenerationMetadata.builder().finishReason(finishReason).metadata("usage", usage).build())));
 			}
 			return new ChatResponse(List.of(new Generation(new AssistantMessage(g.text()))));
 		});

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
@@ -20,7 +20,7 @@ import org.springframework.ai.bedrock.MessageToPromptConverter;
 import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi;
 import org.springframework.ai.bedrock.jurassic2.api.Ai21Jurassic2ChatBedrockApi.Ai21Jurassic2ChatRequest;
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -70,7 +70,7 @@ public class BedrockAi21Jurassic2ChatModel implements ChatModel {
 		return new ChatResponse(response.completions()
 			.stream()
 			.map(completion -> new Generation(new AssistantMessage(completion.data().text()),
-					ChatGenerationMetadata.builder().finishReason(completion.finishReason().reason()).build()))
+					GenerationMetadata.builder().finishReason(completion.finishReason().reason()).build()))
 			.toList());
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
@@ -25,7 +25,7 @@ import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi;
 import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi.LlamaChatRequest;
 import org.springframework.ai.bedrock.llama.api.LlamaChatBedrockApi.LlamaChatResponse;
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -70,7 +70,7 @@ public class BedrockLlamaChatModel implements ChatModel, StreamingChatModel {
 		LlamaChatResponse response = this.chatApi.chatCompletion(request);
 
 		return new ChatResponse(List.of(new Generation(new AssistantMessage(response.generation()),
-				ChatGenerationMetadata.builder()
+				GenerationMetadata.builder()
 					.finishReason(response.stopReason().name())
 					.metadata("usage", extractUsage(response))
 					.build())));
@@ -86,7 +86,7 @@ public class BedrockLlamaChatModel implements ChatModel, StreamingChatModel {
 		return fluxResponse.map(response -> {
 			String stopReason = response.stopReason() != null ? response.stopReason().name() : null;
 			return new ChatResponse(List.of(new Generation(new AssistantMessage(response.generation()),
-					ChatGenerationMetadata.builder()
+					GenerationMetadata.builder()
 						.finishReason(stopReason)
 						.metadata("usage", extractUsage(response))
 						.build())));

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
@@ -26,7 +26,7 @@ import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatReq
 import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatResponse;
 import org.springframework.ai.bedrock.titan.api.TitanChatBedrockApi.TitanChatResponseChunk;
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -75,23 +75,23 @@ public class BedrockTitanChatModel implements ChatModel, StreamingChatModel {
 	@Override
 	public Flux<ChatResponse> stream(Prompt prompt) {
 		return this.chatApi.chatCompletionStream(this.createRequest(prompt)).map(chunk -> {
-			ChatGenerationMetadata chatGenerationMetadata = null;
+			GenerationMetadata generationMetadata = null;
 			if (chunk.amazonBedrockInvocationMetrics() != null) {
 				String completionReason = chunk.completionReason().name();
-				chatGenerationMetadata = ChatGenerationMetadata.builder()
+				generationMetadata = GenerationMetadata.builder()
 					.finishReason(completionReason)
 					.metadata("usage", chunk.amazonBedrockInvocationMetrics())
 					.build();
 			}
 			else if (chunk.inputTextTokenCount() != null && chunk.totalOutputTextTokenCount() != null) {
 				String completionReason = chunk.completionReason().name();
-				chatGenerationMetadata = ChatGenerationMetadata.builder()
+				generationMetadata = GenerationMetadata.builder()
 					.finishReason(completionReason)
 					.metadata("usage", extractUsage(chunk))
 					.build();
 			}
 			return new ChatResponse(
-					List.of(new Generation(new AssistantMessage(chunk.outputText()), chatGenerationMetadata)));
+					List.of(new Generation(new AssistantMessage(chunk.outputText()), generationMetadata)));
 		});
 	}
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -34,7 +34,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
@@ -205,7 +205,7 @@ public class MiniMaxChatModel extends AbstractToolCallSupport implements ChatMod
 					});
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
+		var generationMetadata = GenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 
@@ -410,7 +410,7 @@ public class MiniMaxChatModel extends AbstractToolCallSupport implements ChatMod
 
 		var assistantMessage = new AssistantMessage(message.content(), metadata, toolCalls);
 		String finishReason = (completionFinishReason != null ? completionFinishReason.name() : "");
-		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
+		var generationMetadata = GenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -34,7 +34,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
 import org.springframework.ai.chat.model.ChatModel;
@@ -304,7 +304,7 @@ public class MistralAiChatModel extends AbstractToolCallSupport implements ChatM
 
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
+		var generationMetadata = GenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/MoonshotChatModel.java
+++ b/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/MoonshotChatModel.java
@@ -33,7 +33,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
@@ -174,7 +174,7 @@ public class MoonshotChatModel extends AbstractToolCallSupport implements ChatMo
 
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
+		var generationMetadata = GenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
@@ -41,7 +41,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -181,7 +181,7 @@ public class OCICohereChatModel implements ChatModel {
 		BaseChatResponse cr = ociChatResponse.getChatResult().getChatResponse();
 		if (cr instanceof CohereChatResponse resp) {
 			List<Generation> generations = new ArrayList<>();
-			ChatGenerationMetadata metadata = ChatGenerationMetadata.builder()
+			GenerationMetadata metadata = GenerationMetadata.builder()
 				.finishReason(resp.getFinishReason().getValue())
 				.build();
 			AssistantMessage message = new AssistantMessage(resp.getText(), Map.of());

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -31,7 +31,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
 import org.springframework.ai.chat.model.ChatModel;
@@ -154,11 +154,9 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 				var assistantMessage = new AssistantMessage(ollamaResponse.message().content(), Map.of(), toolCalls);
 
-				ChatGenerationMetadata generationMetadata = ChatGenerationMetadata.NULL;
+				GenerationMetadata generationMetadata = GenerationMetadata.NULL;
 				if (ollamaResponse.promptEvalCount() != null && ollamaResponse.evalCount() != null) {
-					generationMetadata = ChatGenerationMetadata.builder()
-						.finishReason(ollamaResponse.doneReason())
-						.build();
+					generationMetadata = GenerationMetadata.builder().finishReason(ollamaResponse.doneReason()).build();
 				}
 
 				var generator = new Generation(assistantMessage, generationMetadata);
@@ -217,9 +215,9 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 				var assistantMessage = new AssistantMessage(content, Map.of(), toolCalls);
 
-				ChatGenerationMetadata generationMetadata = ChatGenerationMetadata.NULL;
+				GenerationMetadata generationMetadata = GenerationMetadata.NULL;
 				if (chunk.promptEvalCount() != null && chunk.evalCount() != null) {
-					generationMetadata = ChatGenerationMetadata.builder().finishReason(chunk.doneReason()).build();
+					generationMetadata = GenerationMetadata.builder().finishReason(chunk.doneReason()).build();
 				}
 
 				var generator = new Generation(assistantMessage, generationMetadata);

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -38,7 +38,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.metadata.RateLimit;
@@ -391,7 +391,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 					.toList();
 
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadataBuilder = ChatGenerationMetadata.builder().finishReason(finishReason);
+		var generationMetadataBuilder = GenerationMetadata.builder().finishReason(finishReason);
 
 		List<Media> media = new ArrayList<>();
 		String textContent = choice.message().content();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelWithChatResponseMetadataTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelWithChatResponseMetadataTests.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.PromptMetadata;
 import org.springframework.ai.chat.metadata.RateLimit;
@@ -116,10 +116,10 @@ public class OpenAiChatModelWithChatResponseMetadataTests {
 		assertThat(promptMetadata).isEmpty();
 
 		response.getResults().forEach(generation -> {
-			ChatGenerationMetadata chatGenerationMetadata = generation.getMetadata();
-			assertThat(chatGenerationMetadata).isNotNull();
-			assertThat(chatGenerationMetadata.getFinishReason()).isEqualTo("STOP");
-			assertThat(chatGenerationMetadata.getContentFilters()).isEmpty();
+			GenerationMetadata generationMetadata = generation.getMetadata();
+			assertThat(generationMetadata).isNotNull();
+			assertThat(generationMetadata.getFinishReason()).isEqualTo("STOP");
+			assertThat(generationMetadata.getContentFilters()).isEmpty();
 		});
 	}
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -54,7 +54,7 @@ import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
 import org.springframework.ai.chat.model.ChatModel;
@@ -390,7 +390,7 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 		Map<String, Object> messageMetadata = Map.of("candidateIndex", candidateIndex, "finishReason",
 				candidateFinishReason);
 
-		ChatGenerationMetadata chatGenerationMetadata = ChatGenerationMetadata.builder()
+		GenerationMetadata generationMetadata = GenerationMetadata.builder()
 			.finishReason(candidateFinishReason.name())
 			.build();
 
@@ -411,14 +411,14 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 
 			AssistantMessage assistantMessage = new AssistantMessage("", messageMetadata, assistantToolCalls);
 
-			return List.of(new Generation(assistantMessage, chatGenerationMetadata));
+			return List.of(new Generation(assistantMessage, generationMetadata));
 		}
 		else {
 			List<Generation> generations = candidate.getContent()
 				.getPartsList()
 				.stream()
 				.map(part -> new AssistantMessage(part.getText(), messageMetadata))
-				.map(assistantMessage -> new Generation(assistantMessage, chatGenerationMetadata))
+				.map(assistantMessage -> new Generation(assistantMessage, generationMetadata))
 				.toList();
 
 			return generations;

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatModel.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiChatModel.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -85,7 +85,7 @@ public class WatsonxAiChatModel implements ChatModel, StreamingChatModel {
 
 		WatsonxAiChatResponse response = this.watsonxAiApi.generate(request).getBody();
 		var generation = new Generation(new AssistantMessage(response.results().get(0).generatedText()),
-				ChatGenerationMetadata.builder()
+				GenerationMetadata.builder()
 					.finishReason(response.results().get(0).stopReason())
 					.metadata("system", response.system())
 					.build());
@@ -104,9 +104,9 @@ public class WatsonxAiChatModel implements ChatModel, StreamingChatModel {
 			String generatedText = chunk.results().get(0).generatedText();
 			AssistantMessage assistantMessage = new AssistantMessage(generatedText);
 
-			ChatGenerationMetadata metadata = ChatGenerationMetadata.NULL;
+			GenerationMetadata metadata = GenerationMetadata.NULL;
 			if (chunk.system() != null) {
-				metadata = ChatGenerationMetadata.builder()
+				metadata = GenerationMetadata.builder()
 					.finishReason(chunk.results().get(0).stopReason())
 					.metadata("system", chunk.system())
 					.build();

--- a/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/WatsonxAiChatModelTest.java
+++ b/models/spring-ai-watsonx-ai/src/test/java/org/springframework/ai/watsonx/WatsonxAiChatModelTest.java
@@ -28,7 +28,7 @@ import reactor.test.StepVerifier;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.ChatOptionsBuilder;
@@ -174,7 +174,7 @@ public class WatsonxAiChatModelTest {
 			.willReturn(ResponseEntity.of(Optional.of(fakeResponse)));
 
 		Generation expectedGenerator = new Generation(new AssistantMessage("LLM response"),
-				ChatGenerationMetadata.builder()
+				GenerationMetadata.builder()
 					.finishReason("max_tokens")
 					.metadata("system",
 							Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning"))))
@@ -210,7 +210,7 @@ public class WatsonxAiChatModelTest {
 		given(mockChatApi.generateStreaming(any(WatsonxAiChatRequest.class))).willReturn(fakeResponse);
 
 		Generation firstGen = new Generation(new AssistantMessage("LLM resp"),
-				ChatGenerationMetadata.builder()
+				GenerationMetadata.builder()
 					.finishReason("max_tokens")
 					.metadata("system",
 							Map.of("warnings", List.of(Map.of("message", "the message", "id", "disclaimer_warning"))))

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -36,7 +36,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.model.AbstractToolCallSupport;
@@ -188,7 +188,7 @@ public class ZhiPuAiChatModel extends AbstractToolCallSupport implements ChatMod
 
 		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
+		var generationMetadata = GenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultGenerationMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultGenerationMetadata.java
@@ -26,12 +26,12 @@ import java.util.Set;
 import org.springframework.util.Assert;
 
 /**
- * Default implementation of {@link ChatGenerationMetadata}.
+ * Default implementation of {@link GenerationMetadata}.
  *
  * @author Christian Tzolov
  * @since 1.0.0
  */
-public class DefaultChatGenerationMetadata implements ChatGenerationMetadata {
+public class DefaultGenerationMetadata implements GenerationMetadata {
 
 	private final Map<String, Object> metadata;
 
@@ -40,13 +40,13 @@ public class DefaultChatGenerationMetadata implements ChatGenerationMetadata {
 	private final Set<String> contentFilters;
 
 	/**
-	 * Create a new {@link DefaultChatGenerationMetadata} instance.
+	 * Create a new {@link DefaultGenerationMetadata} instance.
 	 * @param metadata the metadata map, must not be null
 	 * @param finishReason the finish reason, may be null
 	 * @param contentFilters the content filters, must not be null
 	 * @throws IllegalArgumentException if metadata or contentFilters is null
 	 */
-	DefaultChatGenerationMetadata(Map<String, Object> metadata, String finishReason, Set<String> contentFilters) {
+	DefaultGenerationMetadata(Map<String, Object> metadata, String finishReason, Set<String> contentFilters) {
 		Assert.notNull(metadata, "Metadata must not be null");
 		Assert.notNull(contentFilters, "Content filters must not be null");
 		this.metadata = metadata;
@@ -107,15 +107,15 @@ public class DefaultChatGenerationMetadata implements ChatGenerationMetadata {
 		if (obj == null || getClass() != obj.getClass()) {
 			return false;
 		}
-		DefaultChatGenerationMetadata other = (DefaultChatGenerationMetadata) obj;
+		DefaultGenerationMetadata other = (DefaultGenerationMetadata) obj;
 		return Objects.equals(this.metadata, other.metadata) && Objects.equals(this.finishReason, other.finishReason)
 				&& Objects.equals(this.contentFilters, other.contentFilters);
 	}
 
 	@Override
 	public String toString() {
-		return String.format("DefaultChatGenerationMetadata[finishReason='%s', filters=%d, metadata=%d]",
-				this.finishReason, this.contentFilters.size(), this.metadata.size());
+		return String.format("DefaultGenerationMetadata[finishReason='%s', filters=%d, metadata=%d]", this.finishReason,
+				this.contentFilters.size(), this.metadata.size());
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultGenerationMetadataBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/DefaultGenerationMetadataBuilder.java
@@ -21,14 +21,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata.Builder;
+import org.springframework.ai.chat.metadata.GenerationMetadata.Builder;
 
 /**
  * @author Christian Tzolov
  * @since 1.0.0
  */
 
-public class DefaultChatGenerationMetadataBuilder implements ChatGenerationMetadata.Builder {
+public class DefaultGenerationMetadataBuilder implements GenerationMetadata.Builder {
 
 	private String finishReason;
 
@@ -36,7 +36,7 @@ public class DefaultChatGenerationMetadataBuilder implements ChatGenerationMetad
 
 	private Set<String> contentFilters = new HashSet<>();
 
-	DefaultChatGenerationMetadataBuilder() {
+	DefaultGenerationMetadataBuilder() {
 	}
 
 	@Override
@@ -70,8 +70,8 @@ public class DefaultChatGenerationMetadataBuilder implements ChatGenerationMetad
 	}
 
 	@Override
-	public ChatGenerationMetadata build() {
-		return new DefaultChatGenerationMetadata(this.metadata, this.finishReason, this.contentFilters);
+	public GenerationMetadata build() {
+		return new DefaultGenerationMetadata(this.metadata, this.finishReason, this.contentFilters);
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/GenerationMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/GenerationMetadata.java
@@ -24,15 +24,15 @@ import org.springframework.ai.model.ResultMetadata;
 
 /**
  *
- * Represents the metadata associated with the generation of a chat response.
+ * Represents the metadata associated with the generation of an AI response.
  *
  * @author John Blum
  * @author Christian Tzolov
  * @since 0.7.0
  */
-public interface ChatGenerationMetadata extends ResultMetadata {
+public interface GenerationMetadata extends ResultMetadata {
 
-	ChatGenerationMetadata NULL = builder().build();
+	GenerationMetadata NULL = builder().build();
 
 	/**
 	 * Get the {@link String reason} this choice completed for the generation.
@@ -55,7 +55,7 @@ public interface ChatGenerationMetadata extends ResultMetadata {
 	boolean isEmpty();
 
 	static Builder builder() {
-		return new DefaultChatGenerationMetadataBuilder();
+		return new DefaultGenerationMetadataBuilder();
 	}
 
 	/**
@@ -92,7 +92,7 @@ public interface ChatGenerationMetadata extends ResultMetadata {
 		/**
 		 * Build the Generation metadata.
 		 */
-		ChatGenerationMetadata build();
+		GenerationMetadata build();
 
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/Generation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/Generation.java
@@ -19,7 +19,7 @@ package org.springframework.ai.chat.model;
 import java.util.Objects;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.model.ModelResult;
 
 /**
@@ -29,15 +29,15 @@ public class Generation implements ModelResult<AssistantMessage> {
 
 	private final AssistantMessage assistantMessage;
 
-	private ChatGenerationMetadata chatGenerationMetadata;
+	private GenerationMetadata generationMetadata;
 
 	public Generation(AssistantMessage assistantMessage) {
-		this(assistantMessage, ChatGenerationMetadata.NULL);
+		this(assistantMessage, GenerationMetadata.NULL);
 	}
 
-	public Generation(AssistantMessage assistantMessage, ChatGenerationMetadata chatGenerationMetadata) {
+	public Generation(AssistantMessage assistantMessage, GenerationMetadata generationMetadata) {
 		this.assistantMessage = assistantMessage;
-		this.chatGenerationMetadata = chatGenerationMetadata;
+		this.generationMetadata = generationMetadata;
 	}
 
 	@Override
@@ -46,9 +46,9 @@ public class Generation implements ModelResult<AssistantMessage> {
 	}
 
 	@Override
-	public ChatGenerationMetadata getMetadata() {
-		ChatGenerationMetadata chatGenerationMetadata = this.chatGenerationMetadata;
-		return chatGenerationMetadata != null ? chatGenerationMetadata : ChatGenerationMetadata.NULL;
+	public GenerationMetadata getMetadata() {
+		GenerationMetadata generationMetadata = this.generationMetadata;
+		return generationMetadata != null ? generationMetadata : GenerationMetadata.NULL;
 	}
 
 	@Override
@@ -60,18 +60,18 @@ public class Generation implements ModelResult<AssistantMessage> {
 			return false;
 		}
 		return Objects.equals(this.assistantMessage, that.assistantMessage)
-				&& Objects.equals(this.chatGenerationMetadata, that.chatGenerationMetadata);
+				&& Objects.equals(this.generationMetadata, that.generationMetadata);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.assistantMessage, this.chatGenerationMetadata);
+		return Objects.hash(this.assistantMessage, this.generationMetadata);
 	}
 
 	@Override
 	public String toString() {
-		return "Generation[" + "assistantMessage=" + this.assistantMessage + ", chatGenerationMetadata="
-				+ this.chatGenerationMetadata + ']';
+		return "Generation[" + "assistantMessage=" + this.assistantMessage + ", generationMetadata="
+				+ this.generationMetadata + ']';
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -28,7 +28,7 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.advisor.api.AdvisedResponse;
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.EmptyRateLimit;
 import org.springframework.ai.chat.metadata.PromptMetadata;
@@ -75,9 +75,8 @@ public class MessageAggregator {
 		AtomicReference<StringBuilder> messageTextContentRef = new AtomicReference<>(new StringBuilder());
 		AtomicReference<Map<String, Object>> messageMetadataMapRef = new AtomicReference<>();
 
-		// ChatGeneration Metadata
-		AtomicReference<ChatGenerationMetadata> generationMetadataRef = new AtomicReference<>(
-				ChatGenerationMetadata.NULL);
+		// Generation Metadata
+		AtomicReference<GenerationMetadata> generationMetadataRef = new AtomicReference<>(GenerationMetadata.NULL);
 
 		// Usage
 		AtomicReference<Long> metadataUsagePromptTokensRef = new AtomicReference<>(0L);
@@ -105,7 +104,7 @@ public class MessageAggregator {
 
 			if (chatResponse.getResult() != null) {
 				if (chatResponse.getResult().getMetadata() != null
-						&& chatResponse.getResult().getMetadata() != ChatGenerationMetadata.NULL) {
+						&& chatResponse.getResult().getMetadata() != GenerationMetadata.NULL) {
 					generationMetadataRef.set(chatResponse.getResult().getMetadata());
 				}
 				if (chatResponse.getResult().getOutput().getContent() != null) {

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/model/GenerationTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/model/GenerationTests.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,10 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class GenerationTests {
 
 	@Mock
-	private ChatGenerationMetadata mockChatGenerationMetadata1;
+	private GenerationMetadata mockGenerationMetadata1;
 
 	@Mock
-	private ChatGenerationMetadata mockChatGenerationMetadata2;
+	private GenerationMetadata mockGenerationMetadata2;
 
 	@BeforeEach
 	void setUp() {
@@ -58,27 +58,27 @@ public class GenerationTests {
 	@Test
 	void testConstructorWithMetadata() {
 		AssistantMessage assistantMessage = new AssistantMessage("Test Assistant Message");
-		Generation generation = new Generation(assistantMessage, this.mockChatGenerationMetadata1);
+		Generation generation = new Generation(assistantMessage, this.mockGenerationMetadata1);
 
-		assertEquals(this.mockChatGenerationMetadata1, generation.getMetadata());
+		assertEquals(this.mockGenerationMetadata1, generation.getMetadata());
 	}
 
 	@Test
 	void testGetMetadata_Null() {
 		AssistantMessage assistantMessage = new AssistantMessage("Test Assistant Message");
 		Generation generation = new Generation(assistantMessage);
-		ChatGenerationMetadata metadata = generation.getMetadata();
+		GenerationMetadata metadata = generation.getMetadata();
 
-		assertEquals(ChatGenerationMetadata.NULL, metadata);
+		assertEquals(GenerationMetadata.NULL, metadata);
 	}
 
 	@Test
 	void testGetMetadata_NotNull() {
 		AssistantMessage assistantMessage = new AssistantMessage("Test Assistant Message");
-		Generation generation = new Generation(assistantMessage, this.mockChatGenerationMetadata1);
-		ChatGenerationMetadata metadata = generation.getMetadata();
+		Generation generation = new Generation(assistantMessage, this.mockGenerationMetadata1);
+		GenerationMetadata metadata = generation.getMetadata();
 
-		assertEquals(this.mockChatGenerationMetadata1, metadata);
+		assertEquals(this.mockGenerationMetadata1, metadata);
 	}
 
 	@Test
@@ -103,8 +103,8 @@ public class GenerationTests {
 	void testEquals_SameMetadata() {
 		AssistantMessage assistantMessage1 = new AssistantMessage("Test Assistant Message");
 		AssistantMessage assistantMessage2 = new AssistantMessage("Test Assistant Message");
-		Generation generation1 = new Generation(assistantMessage1, this.mockChatGenerationMetadata1);
-		Generation generation2 = new Generation(assistantMessage2, this.mockChatGenerationMetadata1);
+		Generation generation1 = new Generation(assistantMessage1, this.mockGenerationMetadata1);
+		Generation generation2 = new Generation(assistantMessage2, this.mockGenerationMetadata1);
 
 		assertTrue(generation1.equals(generation2));
 	}
@@ -113,8 +113,8 @@ public class GenerationTests {
 	void testEquals_DifferentMetadata() {
 		AssistantMessage assistantMessage1 = new AssistantMessage("Test Assistant Message");
 		AssistantMessage assistantMessage2 = new AssistantMessage("Test Assistant Message");
-		Generation generation1 = new Generation(assistantMessage1, this.mockChatGenerationMetadata1);
-		Generation generation2 = new Generation(assistantMessage2, this.mockChatGenerationMetadata2);
+		Generation generation1 = new Generation(assistantMessage1, this.mockGenerationMetadata1);
+		Generation generation2 = new Generation(assistantMessage2, this.mockGenerationMetadata2);
 
 		assertFalse(generation1.equals(generation2));
 	}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
@@ -23,7 +23,7 @@ import io.micrometer.observation.Observation;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.GenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -111,7 +111,7 @@ class DefaultChatModelObservationConventionTests {
 			.build();
 		observationContext.setResponse(new ChatResponse(
 				List.of(new Generation(new AssistantMessage("response"),
-						ChatGenerationMetadata.builder().finishReason("this-is-the-end").build())),
+						GenerationMetadata.builder().finishReason("this-is-the-end").build())),
 				ChatResponseMetadata.builder()
 					.withId("say33")
 					.withModel("mistral-42")
@@ -169,7 +169,7 @@ class DefaultChatModelObservationConventionTests {
 			.build();
 		observationContext.setResponse(new ChatResponse(
 				List.of(new Generation(new AssistantMessage("response"),
-						ChatGenerationMetadata.builder().finishReason("").build())),
+						GenerationMetadata.builder().finishReason("").build())),
 				ChatResponseMetadata.builder().withId("").build()));
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext)
 			.stream()

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatmodel.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatmodel.adoc
@@ -199,13 +199,13 @@ Finally, the https://github.com/spring-projects/spring-ai/blob/main/spring-ai-co
 public class Generation implements ModelResult<AssistantMessage> {
 
 	private final AssistantMessage assistantMessage;
-	private ChatGenerationMetadata chatGenerationMetadata;
+	private GenerationMetadata generationMetadata;
 
 	@Override
 	public AssistantMessage getOutput() {...}
 
 	@Override
-	public ChatGenerationMetadata getMetadata() {...}
+	public GenerationMetadata getMetadata() {...}
 
     // other methods omitted
 }


### PR DESCRIPTION
 - To be consistent with the naming, the metadata for Generation is named as `GenerationMetadata`

Resolves #1863
