### PR TITLE
Document class now supports only single instance of text or media content

### DIFF
--- a/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
+++ b/document-readers/markdown-reader/src/main/java/org/springframework/ai/reader/markdown/MarkdownDocumentReader.java
@@ -226,7 +226,7 @@ public class MarkdownDocumentReader implements DocumentReader {
 			if (!this.currentParagraphs.isEmpty()) {
 				String content = String.join("", this.currentParagraphs);
 
-				Document.Builder builder = this.currentDocumentBuilder.content(content);
+				Document.Builder builder = this.currentDocumentBuilder.text(content);
 
 				this.config.additionalMetadata.forEach(builder::metadata);
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -378,7 +378,7 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 			.filter(message -> message.getMessageType() != MessageType.SYSTEM)
 			.map(message -> {
 				if (message.getMessageType() == MessageType.USER) {
-					List<ContentBlock> contents = new ArrayList<>(List.of(new ContentBlock(message.getContent())));
+					List<ContentBlock> contents = new ArrayList<>(List.of(new ContentBlock(message.getText())));
 					if (message instanceof UserMessage userMessage) {
 						if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 							List<ContentBlock> mediaContent = userMessage.getMedia().stream().map(media -> {
@@ -395,8 +395,8 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 				else if (message.getMessageType() == MessageType.ASSISTANT) {
 					AssistantMessage assistantMessage = (AssistantMessage) message;
 					List<ContentBlock> contentBlocks = new ArrayList<>();
-					if (StringUtils.hasText(message.getContent())) {
-						contentBlocks.add(new ContentBlock(message.getContent()));
+					if (StringUtils.hasText(message.getText())) {
+						contentBlocks.add(new ContentBlock(message.getText()));
 					}
 					if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 						for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
@@ -423,7 +423,7 @@ public class AnthropicChatModel extends AbstractToolCallSupport implements ChatM
 		String systemPrompt = prompt.getInstructions()
 			.stream()
 			.filter(m -> m.getMessageType() == MessageType.SYSTEM)
-			.map(m -> m.getContent())
+			.map(m -> m.getText())
 			.collect(Collectors.joining(System.lineSeparator()));
 
 		ChatCompletionRequest request = new ChatCompletionRequest(this.defaultOptions.getModel(), userMessages,

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelIT.java
@@ -105,7 +105,7 @@ class AnthropicChatModelIT {
 			.isEqualTo(response.getMetadata().getUsage().getPromptTokens()
 					+ response.getMetadata().getUsage().getGenerationTokens());
 		Generation generation = response.getResults().get(0);
-		assertThat(generation.getOutput().getContent()).contains("Blackbeard");
+		assertThat(generation.getOutput().getText()).contains("Blackbeard");
 		assertThat(generation.getMetadata().getFinishReason()).isEqualTo("end_turn");
 		logger.info(response.toString());
 	}
@@ -120,13 +120,13 @@ class AnthropicChatModelIT {
 				AnthropicChatOptions.builder().withModel("claude-3-sonnet-20240229").build());
 
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 
 		var promptWithMessageHistory = new Prompt(List.of(new UserMessage("Dummy"), response.getResult().getOutput(),
 				new UserMessage("Repeat the last assistant message.")));
 		response = this.chatModel.call(promptWithMessageHistory);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
 	@Test
@@ -162,7 +162,7 @@ class AnthropicChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = listOutputConverter.convert(generation.getOutput().getContent());
+		List<String> list = listOutputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -180,7 +180,7 @@ class AnthropicChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = mapOutputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = mapOutputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -199,7 +199,7 @@ class AnthropicChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = beanOutputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = beanOutputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -225,7 +225,7 @@ class AnthropicChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = beanOutputConverter.convert(generationTextFromStream);
@@ -244,8 +244,8 @@ class AnthropicChatModelIT {
 
 		var response = this.chatModel.call(new Prompt(List.of(userMessage)));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("banan", "apple", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("banan", "apple", "basket");
 	}
 
 	@Test
@@ -262,7 +262,7 @@ class AnthropicChatModelIT {
 					.withModel(AnthropicApi.ChatModel.CLAUDE_3_5_SONNET.getName())
 					.build()));
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Spring AI", "portable API");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Spring AI", "portable API");
 	}
 
 	@Test
@@ -288,7 +288,7 @@ class AnthropicChatModelIT {
 		logger.info("Response: {}", response);
 
 		Generation generation = response.getResult();
-		assertThat(generation.getOutput().getContent()).contains("30", "10", "15");
+		assertThat(generation.getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -317,7 +317,7 @@ class AnthropicChatModelIT {
 			.block()
 			.stream()
 			.filter(cr -> cr.getResult() != null)
-			.map(cr -> cr.getResult().getOutput().getContent())
+			.map(cr -> cr.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 
 		logger.info("Response: {}", content);

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelObservationIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelObservationIT.java
@@ -79,7 +79,7 @@ public class AnthropicChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -109,7 +109,7 @@ public class AnthropicChatModelObservationIT {
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
 			.filter(r -> r.getResult() != null)
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
@@ -84,7 +84,7 @@ class AnthropicChatClientIT {
 
 		logger.info("" + response);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -402,7 +402,7 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 			case USER:
 				// https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/openai/azure-ai-openai/README.md#text-completions-with-images
 				List<ChatMessageContentItem> items = new ArrayList<>();
-				items.add(new ChatMessageTextContentItem(message.getContent()));
+				items.add(new ChatMessageTextContentItem(message.getText()));
 				if (message instanceof UserMessage userMessage) {
 					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 						items.addAll(userMessage.getMedia()
@@ -413,7 +413,7 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 				}
 				return List.of(new ChatRequestUserMessage(items));
 			case SYSTEM:
-				return List.of(new ChatRequestSystemMessage(message.getContent()));
+				return List.of(new ChatRequestSystemMessage(message.getText()));
 			case ASSISTANT:
 				AssistantMessage assistantMessage = (AssistantMessage) message;
 				List<ChatCompletionsToolCall> toolCalls = null;
@@ -425,7 +425,7 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 						.map(tc -> ((ChatCompletionsToolCall) tc)) // !!!
 						.toList();
 				}
-				var azureAssistantMessage = new ChatRequestAssistantMessage(message.getContent());
+				var azureAssistantMessage = new ChatRequestAssistantMessage(message.getText());
 				azureAssistantMessage.setToolCalls(toolCalls);
 				return List.of(azureAssistantMessage);
 			case TOOL:

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
@@ -68,7 +68,7 @@ public class AzureOpenAiChatClientIT {
 		// @formatter:on
 
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -94,7 +94,7 @@ public class AzureOpenAiChatClientIT {
 
 		String generationTextFromStream = chatResponses
 				.stream()
-				.map(cr -> cr.getResult().getOutput().getContent())
+				.map(cr -> cr.getResult().getOutput().getText())
 				.collect(Collectors.joining());
 		// @formatter:on
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
@@ -77,7 +77,7 @@ class AzureOpenAiChatModelIT {
 
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -96,14 +96,14 @@ class AzureOpenAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard");
 
 		var promptWithMessageHistory = new Prompt(List.of(new UserMessage("Dummy"), response.getResult().getOutput(),
 				new UserMessage("Repeat the last assistant message.")));
 		response = this.chatModel.call(promptWithMessageHistory);
 
-		System.out.println(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard");
+		System.out.println(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard");
 	}
 
 	@Test
@@ -121,7 +121,7 @@ class AzureOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -140,7 +140,7 @@ class AzureOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -159,7 +159,7 @@ class AzureOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isNotNull();
 	}
 
@@ -177,7 +177,7 @@ class AzureOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -203,7 +203,7 @@ class AzureOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.filter(Objects::nonNull)
 			.collect(Collectors.joining());
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelObservationIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelObservationIT.java
@@ -76,7 +76,7 @@ class AzureOpenAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -106,7 +106,7 @@ class AzureOpenAiChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -80,7 +80,7 @@ class AzureOpenAiChatModelFunctionCallIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -104,7 +104,7 @@ class AzureOpenAiChatModelFunctionCallIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -132,7 +132,7 @@ class AzureOpenAiChatModelFunctionCallIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
@@ -169,7 +169,7 @@ class AzureOpenAiChatModelFunctionCallIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.filter(Objects::nonNull)
 			.collect(Collectors.joining());
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatModelMetadataTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/metadata/AzureOpenAiChatModelMetadataTests.java
@@ -84,7 +84,7 @@ class AzureOpenAiChatModelMetadataTests {
 
 		assertThat(generation).isNotNull()
 			.extracting(Generation::getOutput)
-			.extracting(AssistantMessage::getContent)
+			.extracting(AssistantMessage::getText)
 			.isEqualTo("No! You will actually land with a resounding thud. This is the way!");
 
 		// assertPromptMetadata(response);

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -249,7 +249,7 @@ public class BedrockProxyChatModel extends AbstractToolCallSupport implements Ch
 					List<ContentBlock> contents = new ArrayList<>();
 					if (message instanceof UserMessage) {
 						var userMessage = (UserMessage) message;
-						contents.add(ContentBlock.fromText(userMessage.getContent()));
+						contents.add(ContentBlock.fromText(userMessage.getText()));
 
 						if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 							List<ContentBlock> mediaContent = userMessage.getMedia().stream().map(media -> {
@@ -268,8 +268,8 @@ public class BedrockProxyChatModel extends AbstractToolCallSupport implements Ch
 				else if (message.getMessageType() == MessageType.ASSISTANT) {
 					AssistantMessage assistantMessage = (AssistantMessage) message;
 					List<ContentBlock> contentBlocks = new ArrayList<>();
-					if (StringUtils.hasText(message.getContent())) {
-						contentBlocks.add(ContentBlock.fromText(message.getContent()));
+					if (StringUtils.hasText(message.getText())) {
+						contentBlocks.add(ContentBlock.fromText(message.getText()));
 					}
 					if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 						for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
@@ -309,7 +309,7 @@ public class BedrockProxyChatModel extends AbstractToolCallSupport implements Ch
 		List<SystemContentBlock> systemMessages = prompt.getInstructions()
 			.stream()
 			.filter(m -> m.getMessageType() == MessageType.SYSTEM)
-			.map(sysMessage -> SystemContentBlock.builder().text(sysMessage.getContent()).build())
+			.map(sysMessage -> SystemContentBlock.builder().text(sysMessage.getText()).build())
 			.toList();
 
 		FunctionCallingOptions updatedRuntimeOptions = (FunctionCallingOptions) this.defaultOptions.copy();

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseChatClientIT.java
@@ -79,7 +79,7 @@ class BedrockConverseChatClientIT {
 
 		logger.info("" + response);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -196,7 +196,7 @@ class BedrockConverseChatClientIT {
 		String generationTextFromStream = chatResponses
 				.stream()
 				.filter(cr -> cr.getResult() != null)
-				.map(cr -> cr.getResult().getOutput().getContent())
+				.map(cr -> cr.getResult().getOutput().getText())
 				.collect(Collectors.joining());
 		// @formatter:on
 
@@ -259,7 +259,7 @@ class BedrockConverseChatClientIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -340,7 +340,7 @@ class BedrockConverseChatClientIT {
 
 		String content = chatResponses.stream()
 			.filter(cr -> cr.getResult() != null)
-			.map(cr -> cr.getResult().getOutput().getContent())
+			.map(cr -> cr.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseUsageAggregationTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseUsageAggregationTests.java
@@ -83,7 +83,7 @@ public class BedrockConverseUsageAggregationTests {
 		var result = this.chatModel.call(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isSameAs("Response Content Block");
+		assertThat(result.getResult().getOutput().getText()).isSameAs("Response Content Block");
 
 		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(16);
 		assertThat(result.getMetadata().getUsage().getGenerationTokens()).isEqualTo(14);
@@ -148,7 +148,7 @@ public class BedrockConverseUsageAggregationTests {
 				PortableFunctionCallingOptions.builder().withFunctionCallbacks(functionCallback).build()));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent())
+		assertThat(result.getResult().getOutput().getText())
 			.isSameAs(converseResponseFinal.output().message().content().get(0).text());
 
 		assertThat(result.getMetadata().getUsage().getPromptTokens()).isEqualTo(445 + 540);

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
@@ -101,7 +101,7 @@ class BedrockProxyChatModelIT {
 			.isEqualTo(response.getMetadata().getUsage().getPromptTokens()
 					+ response.getMetadata().getUsage().getGenerationTokens());
 		Generation generation = response.getResults().get(0);
-		assertThat(generation.getOutput().getContent()).contains("Blackbeard");
+		assertThat(generation.getOutput().getText()).contains("Blackbeard");
 		assertThat(generation.getMetadata().getFinishReason()).isEqualTo("end_turn");
 		logger.info(response.toString());
 	}
@@ -116,14 +116,14 @@ class BedrockProxyChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 
 		var promptWithMessageHistory = new Prompt(List.of(new UserMessage("Dummy"), response.getResult().getOutput(),
 				new UserMessage("Repeat the last assistant message.")));
 
 		response = this.chatModel.call(promptWithMessageHistory);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
 	@Test
@@ -159,7 +159,7 @@ class BedrockProxyChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = listOutputConverter.convert(generation.getOutput().getContent());
+		List<String> list = listOutputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -177,7 +177,7 @@ class BedrockProxyChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = mapOutputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = mapOutputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -196,7 +196,7 @@ class BedrockProxyChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = beanOutputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = beanOutputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -222,7 +222,7 @@ class BedrockProxyChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = beanOutputConverter.convert(generationTextFromStream);
@@ -241,8 +241,8 @@ class BedrockProxyChatModelIT {
 
 		var response = this.chatModel.call(new Prompt(List.of(userMessage)));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("banan", "apple", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("banan", "apple", "basket");
 	}
 
 	@Test
@@ -267,7 +267,7 @@ class BedrockProxyChatModelIT {
 		logger.info("Response: {}", response);
 
 		Generation generation = response.getResult();
-		assertThat(generation.getOutput().getContent()).contains("30", "10", "15");
+		assertThat(generation.getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -296,7 +296,7 @@ class BedrockProxyChatModelIT {
 			.block()
 			.stream()
 			.filter(cr -> cr.getResult() != null)
-			.map(cr -> cr.getResult().getOutput().getContent())
+			.map(cr -> cr.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 
 		logger.info("Response: {}", content);

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelObservationIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelObservationIT.java
@@ -80,7 +80,7 @@ public class BedrockProxyChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -109,7 +109,7 @@ public class BedrockProxyChatModelObservationIT {
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
 			.filter(r -> r.getResult() != null)
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/MessageToPromptConverter.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/MessageToPromptConverter.java
@@ -66,7 +66,7 @@ public final class MessageToPromptConverter {
 
 		final String systemMessages = messages.stream()
 			.filter(message -> message.getMessageType() == MessageType.SYSTEM)
-			.map(Message::getContent)
+			.map(Message::getText)
 			.collect(Collectors.joining(System.lineSeparator()));
 
 		final String userMessages = messages.stream()
@@ -83,11 +83,11 @@ public final class MessageToPromptConverter {
 	protected String messageToString(Message message) {
 		switch (message.getMessageType()) {
 			case SYSTEM:
-				return message.getContent();
+				return message.getText();
 			case USER:
-				return this.humanPrompt + " " + message.getContent();
+				return this.humanPrompt + " " + message.getText();
 			case ASSISTANT:
-				return this.assistantPrompt + " " + message.getContent();
+				return this.assistantPrompt + " " + message.getText();
 			case TOOL:
 				throw new IllegalArgumentException("Tool execution results are not supported for Bedrock models");
 		}

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -164,7 +164,7 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 		return prompt.getInstructions()
 			.stream()
 			.filter(m -> m.getMessageType() == MessageType.SYSTEM)
-			.map(Message::getContent)
+			.map(Message::getText)
 			.collect(Collectors.joining(System.lineSeparator()));
 	}
 
@@ -179,7 +179,7 @@ public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel
 			.stream()
 			.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
 			.map(message -> {
-				List<MediaContent> contents = new ArrayList<>(List.of(new MediaContent(message.getContent())));
+				List<MediaContent> contents = new ArrayList<>(List.of(new MediaContent(message.getText())));
 				if (message instanceof UserMessage userMessage) {
 					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 						List<MediaContent> mediaContent = userMessage.getMedia()

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModelIT.java
@@ -79,7 +79,7 @@ class BedrockAnthropicChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		String joke2 = joke2Stream.collectList()
 			.block()
@@ -87,7 +87,7 @@ class BedrockAnthropicChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(joke1).isNotBlank();
@@ -105,7 +105,7 @@ class BedrockAnthropicChatModelIT {
 
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -123,7 +123,7 @@ class BedrockAnthropicChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = converter.convert(generation.getOutput().getContent());
+		List<String> list = converter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -142,7 +142,7 @@ class BedrockAnthropicChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -164,7 +164,7 @@ class BedrockAnthropicChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConvert.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConvert.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -190,7 +190,7 @@ class BedrockAnthropicChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModelIT.java
@@ -82,7 +82,7 @@ class BedrockAnthropic3ChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		String joke2 = joke2Stream.collectList()
 			.block()
@@ -90,7 +90,7 @@ class BedrockAnthropic3ChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(joke1).isNotBlank();
@@ -108,7 +108,7 @@ class BedrockAnthropic3ChatModelIT {
 
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -126,7 +126,7 @@ class BedrockAnthropic3ChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -145,7 +145,7 @@ class BedrockAnthropic3ChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -166,7 +166,7 @@ class BedrockAnthropic3ChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -192,7 +192,7 @@ class BedrockAnthropic3ChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -211,8 +211,8 @@ class BedrockAnthropic3ChatModelIT {
 
 		var response = this.chatModel.call(new Prompt(List.of(userMessage)));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple", "basket");
 	}
 
 	@Test

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModelIT.java
@@ -77,7 +77,7 @@ class BedrockCohereChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		String joke2 = joke2Stream.collectList()
 			.block()
@@ -85,7 +85,7 @@ class BedrockCohereChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(joke1).isNotBlank();
@@ -102,7 +102,7 @@ class BedrockCohereChatModelIT {
 		Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", name, "voice", voice));
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -120,7 +120,7 @@ class BedrockCohereChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -139,7 +139,7 @@ class BedrockCohereChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -159,7 +159,7 @@ class BedrockCohereChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -185,7 +185,7 @@ class BedrockCohereChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModelIT.java
@@ -68,7 +68,7 @@ class BedrockAi21Jurassic2ChatModelIT {
 
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -85,7 +85,7 @@ class BedrockAi21Jurassic2ChatModelIT {
 
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat(response.getResult().getOutput().getContent()).matches(content -> content.contains("😄"));
+		assertThat(response.getResult().getOutput().getText()).matches(content -> content.contains("😄"));
 	}
 
 	@Test
@@ -105,7 +105,7 @@ class BedrockAi21Jurassic2ChatModelIT {
 
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat(response.getResult().getOutput().getContent()).doesNotContain("😄");
+		assertThat(response.getResult().getOutput().getText()).doesNotContain("😄");
 	}
 
 	@Test
@@ -122,7 +122,7 @@ class BedrockAi21Jurassic2ChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -138,7 +138,7 @@ class BedrockAi21Jurassic2ChatModelIT {
 
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("AI");
+		assertThat(response.getResult().getOutput().getText()).contains("AI");
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModelIT.java
@@ -75,7 +75,7 @@ class BedrockLlamaChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		String joke2 = joke2Stream.collectList()
 			.block()
@@ -83,7 +83,7 @@ class BedrockLlamaChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(joke1).isNotBlank();
@@ -104,7 +104,7 @@ class BedrockLlamaChatModelIT {
 
 		ChatResponse response = this.chatModel.call(prompt);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -122,7 +122,7 @@ class BedrockLlamaChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -140,7 +140,7 @@ class BedrockLlamaChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -161,7 +161,7 @@ class BedrockLlamaChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -187,7 +187,7 @@ class BedrockLlamaChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModelIT.java
@@ -76,7 +76,7 @@ class BedrockTitanChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		String joke2 = joke2Stream.collectList()
 			.block()
@@ -84,7 +84,7 @@ class BedrockTitanChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(joke1).isNotBlank();
@@ -101,7 +101,7 @@ class BedrockTitanChatModelIT {
 		Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", name, "voice", voice));
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -119,7 +119,7 @@ class BedrockTitanChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -139,7 +139,7 @@ class BedrockTitanChatModelIT {
 
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -160,7 +160,7 @@ class BedrockTitanChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -187,7 +187,7 @@ class BedrockTitanChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);

--- a/models/spring-ai-huggingface/src/test/java/org/springframework/ai/huggingface/client/ClientIT.java
+++ b/models/spring-ai-huggingface/src/test/java/org/springframework/ai/huggingface/client/ClientIT.java
@@ -51,14 +51,14 @@ public class ClientIT {
 				""";
 		Prompt prompt = new Prompt(mistral7bInstruct);
 		ChatResponse chatResponse = this.huggingfaceChatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 		String expectedResponse = """
 				{
 				  "name": "John",
 				  "lastname": "Smith",
 				  "address": "#1 Samuel St."
 				}""";
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo(expectedResponse);
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo(expectedResponse);
 		assertThat(chatResponse.getResult().getOutput().getMetadata()).containsKey("generated_tokens");
 		assertThat(chatResponse.getResult().getOutput().getMetadata()).containsEntry("generated_tokens", 32);
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -439,7 +439,7 @@ public class MiniMaxChatModel extends AbstractToolCallSupport implements ChatMod
 
 		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(message -> {
 			if (message.getMessageType() == MessageType.USER || message.getMessageType() == MessageType.SYSTEM) {
-				Object content = message.getContent();
+				Object content = message.getText();
 				return List.of(new ChatCompletionMessage(content,
 						ChatCompletionMessage.Role.valueOf(message.getMessageType().name())));
 			}
@@ -452,7 +452,7 @@ public class MiniMaxChatModel extends AbstractToolCallSupport implements ChatMod
 						return new ToolCall(toolCall.id(), toolCall.type(), function);
 					}).toList();
 				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getContent(),
+				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
 						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxRetryTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/api/MiniMaxRetryTests.java
@@ -98,7 +98,7 @@ public class MiniMaxRetryTests {
 		var result = this.chatModel.call(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}
@@ -126,7 +126,7 @@ public class MiniMaxRetryTests {
 		var result = this.chatModel.stream(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.collectList().block().get(0).getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.collectList().block().get(0).getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelObservationIT.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelObservationIT.java
@@ -82,7 +82,7 @@ public class MiniMaxChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -111,7 +111,7 @@ public class MiniMaxChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatOptionsTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatOptionsTests.java
@@ -59,7 +59,7 @@ public class MiniMaxChatOptionsTests {
 
 		// markSensitiveInfo is enabled by default
 		ChatResponse response = this.chatModel.call(new Prompt(messages));
-		String responseContent = response.getResult().getOutput().getContent();
+		String responseContent = response.getResult().getOutput().getText();
 
 		assertThat(responseContent).contains("133-**");
 		assertThat(responseContent).doesNotContain("133-12345678");
@@ -67,7 +67,7 @@ public class MiniMaxChatOptionsTests {
 		var chatOptions = MiniMaxChatOptions.builder().withMaskSensitiveInfo(false).build();
 
 		ChatResponse unmaskResponse = this.chatModel.call(new Prompt(messages, chatOptions));
-		String unmaskResponseContent = unmaskResponse.getResult().getOutput().getContent();
+		String unmaskResponseContent = unmaskResponse.getResult().getOutput().getText();
 
 		assertThat(unmaskResponseContent).contains("133-12345678");
 	}
@@ -97,7 +97,7 @@ public class MiniMaxChatOptionsTests {
 			.build();
 
 		ChatResponse response = this.chatModel.call(new Prompt(messages, options));
-		String responseContent = response.getResult().getOutput().getContent();
+		String responseContent = response.getResult().getOutput().getText();
 
 		assertThat(responseContent).contains("40");
 	}
@@ -132,7 +132,7 @@ public class MiniMaxChatOptionsTests {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.filter(Objects::nonNull)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -326,11 +326,11 @@ public class MistralAiChatModel extends AbstractToolCallSupport implements ChatM
 
 		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(message -> {
 			if (message instanceof UserMessage userMessage) {
-				return List.of(new MistralAiApi.ChatCompletionMessage(userMessage.getContent(),
+				return List.of(new MistralAiApi.ChatCompletionMessage(userMessage.getText(),
 						MistralAiApi.ChatCompletionMessage.Role.USER));
 			}
 			else if (message instanceof SystemMessage systemMessage) {
-				return List.of(new MistralAiApi.ChatCompletionMessage(systemMessage.getContent(),
+				return List.of(new MistralAiApi.ChatCompletionMessage(systemMessage.getText(),
 						MistralAiApi.ChatCompletionMessage.Role.SYSTEM));
 			}
 			else if (message instanceof AssistantMessage assistantMessage) {
@@ -342,7 +342,7 @@ public class MistralAiChatModel extends AbstractToolCallSupport implements ChatM
 					}).toList();
 				}
 
-				return List.of(new MistralAiApi.ChatCompletionMessage(assistantMessage.getContent(),
+				return List.of(new MistralAiApi.ChatCompletionMessage(assistantMessage.getText(),
 						MistralAiApi.ChatCompletionMessage.Role.ASSISTANT, null, toolCalls, null));
 			}
 			else if (message instanceof ToolResponseMessage toolResponseMessage) {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
@@ -70,7 +70,7 @@ class MistralAiChatClientIT {
 
 		logger.info("" + response);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -85,7 +85,7 @@ class MistralAiChatClientIT {
 				.call()
 				.chatResponse();
 		// @formatter:on
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard");
 
 		// @formatter:off
 		response = ChatClient.create(this.chatModel).prompt()
@@ -96,7 +96,7 @@ class MistralAiChatClientIT {
 		// @formatter:on
 
 		logger.info("" + response);
-		assertThat(response.getResult().getOutput().getContent().toLowerCase()).containsAnyOf("blackbeard",
+		assertThat(response.getResult().getOutput().getText().toLowerCase()).containsAnyOf("blackbeard",
 				"bartholomew roberts");
 	}
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
@@ -93,7 +93,7 @@ class MistralAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(systemMessage, userMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -111,7 +111,7 @@ class MistralAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -129,7 +129,7 @@ class MistralAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -148,7 +148,7 @@ class MistralAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -174,7 +174,7 @@ class MistralAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -204,7 +204,7 @@ class MistralAiChatModelIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("30.0", "30");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("30.0", "30");
 	}
 
 	@Test
@@ -231,7 +231,7 @@ class MistralAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelObservationIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelObservationIT.java
@@ -79,7 +79,7 @@ public class MistralAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -107,7 +107,7 @@ public class MistralAiChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiRetryTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiRetryTests.java
@@ -105,7 +105,7 @@ public class MistralAiRetryTests {
 		var result = this.chatModel.call(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}
@@ -134,7 +134,7 @@ public class MistralAiRetryTests {
 		var result = this.chatModel.stream(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.collectList().block().get(0).getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.collectList().block().get(0).getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}

--- a/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/MoonshotChatModel.java
+++ b/models/spring-ai-moonshot/src/main/java/org/springframework/ai/moonshot/MoonshotChatModel.java
@@ -349,7 +349,7 @@ public class MoonshotChatModel extends AbstractToolCallSupport implements ChatMo
 
 		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(message -> {
 			if (message.getMessageType() == MessageType.USER || message.getMessageType() == MessageType.SYSTEM) {
-				Object content = message.getContent();
+				Object content = message.getText();
 				return List.of(new ChatCompletionMessage(content,
 						ChatCompletionMessage.Role.valueOf(message.getMessageType().name())));
 			}
@@ -362,7 +362,7 @@ public class MoonshotChatModel extends AbstractToolCallSupport implements ChatMo
 						return new ToolCall(toolCall.id(), toolCall.type(), function);
 					}).toList();
 				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getContent(),
+				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
 						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {

--- a/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/MoonshotRetryTests.java
+++ b/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/MoonshotRetryTests.java
@@ -91,7 +91,7 @@ public class MoonshotRetryTests {
 		var result = this.chatModel.call(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}
@@ -119,7 +119,7 @@ public class MoonshotRetryTests {
 		var result = this.chatModel.stream(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.collectList().block().get(0).getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.collectList().block().get(0).getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}

--- a/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelFunctionCallingIT.java
+++ b/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelFunctionCallingIT.java
@@ -74,7 +74,7 @@ class MoonshotChatModelFunctionCallingIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -100,7 +100,7 @@ class MoonshotChatModelFunctionCallingIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.filter(Objects::nonNull)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);

--- a/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelIT.java
+++ b/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelIT.java
@@ -75,7 +75,7 @@ public class MoonshotChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -93,7 +93,7 @@ public class MoonshotChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -118,7 +118,7 @@ public class MoonshotChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -137,7 +137,7 @@ public class MoonshotChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 
 	}
 
@@ -162,7 +162,7 @@ public class MoonshotChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -190,7 +190,7 @@ public class MoonshotChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);

--- a/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelObservationIT.java
+++ b/models/spring-ai-moonshot/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelObservationIT.java
@@ -82,7 +82,7 @@ public class MoonshotChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -112,7 +112,7 @@ public class MoonshotChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
@@ -203,9 +203,9 @@ public class OCICohereChatModel implements ChatModel {
 		for (int i = 1; i < messages.size(); i++) {
 			Message message = messages.get(i);
 			switch (message.getMessageType()) {
-				case USER -> chatHistory.add(CohereUserMessage.builder().message(message.getContent()).build());
-				case ASSISTANT -> chatHistory.add(CohereChatBotMessage.builder().message(message.getContent()).build());
-				case SYSTEM -> chatHistory.add(CohereSystemMessage.builder().message(message.getContent()).build());
+				case USER -> chatHistory.add(CohereUserMessage.builder().message(message.getText()).build());
+				case ASSISTANT -> chatHistory.add(CohereChatBotMessage.builder().message(message.getText()).build());
+				case SYSTEM -> chatHistory.add(CohereSystemMessage.builder().message(message.getText()).build());
 				case TOOL -> {
 					if (message instanceof ToolResponseMessage tm) {
 						chatHistory.add(toToolMessage(tm));
@@ -237,7 +237,7 @@ public class OCICohereChatModel implements ChatModel {
 			.documents(options.getDocuments())
 			.tools(options.getTools())
 			.chatHistory(chatHistory)
-			.message(message.getContent())
+			.message(message.getText())
 			.build();
 		ServingMode servingMode = ServingModeHelper.get(options.getServingMode(), options.getModel());
 		ChatDetails chatDetails = ChatDetails.builder()

--- a/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/cohere/OCICohereChatModelIT.java
+++ b/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/cohere/OCICohereChatModelIT.java
@@ -54,7 +54,7 @@ public class OCICohereChatModelIT extends BaseOCIGenAITest {
 		assertThat(response).isNotNull();
 		assertThat(response.getMetadata().getModel()).isEqualTo(CHAT_MODEL_ID);
 		assertThat(response.getResult()).isNotNull();
-		assertThat(response.getResult().getOutput().getContent()).isNotBlank();
+		assertThat(response.getResult().getOutput().getText()).isNotBlank();
 	}
 
 }

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -256,7 +256,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 		List<OllamaApi.Message> ollamaMessages = prompt.getInstructions().stream().map(message -> {
 			if (message instanceof UserMessage userMessage) {
-				var messageBuilder = OllamaApi.Message.builder(Role.USER).withContent(message.getContent());
+				var messageBuilder = OllamaApi.Message.builder(Role.USER).withContent(message.getText());
 				if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 					messageBuilder.withImages(
 							userMessage.getMedia().stream().map(media -> this.fromMediaData(media.getData())).toList());
@@ -264,7 +264,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 				return List.of(messageBuilder.build());
 			}
 			else if (message instanceof SystemMessage systemMessage) {
-				return List.of(OllamaApi.Message.builder(Role.SYSTEM).withContent(systemMessage.getContent()).build());
+				return List.of(OllamaApi.Message.builder(Role.SYSTEM).withContent(systemMessage.getText()).build());
 			}
 			else if (message instanceof AssistantMessage assistantMessage) {
 				List<ToolCall> toolCalls = null;
@@ -276,7 +276,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 					}).toList();
 				}
 				return List.of(OllamaApi.Message.builder(Role.ASSISTANT)
-					.withContent(assistantMessage.getContent())
+					.withContent(assistantMessage.getText())
 					.withToolCalls(toolCalls)
 					.build());
 			}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
@@ -75,7 +75,7 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Disabled("Ollama API does not support streaming function calls yet")
@@ -104,7 +104,7 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
@@ -96,13 +96,13 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		Prompt prompt = new Prompt(List.of(systemMessage, userMessage), portableOptions);
 
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 
 		// ollama specific options
 		var ollamaOptions = new OllamaOptions().withLowVRAM(true);
 
 		response = this.chatModel.call(new Prompt(List.of(systemMessage, userMessage), ollamaOptions));
-		assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -120,13 +120,13 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		Prompt prompt = new Prompt(List.of(systemMessage, userMessage));
 
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard");
 
 		var promptWithMessageHistory = new Prompt(List.of(new UserMessage("Hello"), response.getResult().getOutput(),
 				new UserMessage("Tell me just the names of those pirates.")));
 		response = this.chatModel.call(promptWithMessageHistory);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard");
 	}
 
 	@Test
@@ -156,7 +156,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -175,7 +175,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result).isNotNull();
 		assertThat((String) result.get("R")).containsIgnoringCase("red");
 		assertThat((String) result.get("G")).containsIgnoringCase("green");
@@ -195,7 +195,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -219,7 +219,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMultimodalIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMultimodalIT.java
@@ -67,8 +67,8 @@ class OllamaChatModelMultimodalIT extends BaseOllamaIT {
 
 		var response = this.chatModel.call(new Prompt(List.of(userMessage)));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
@@ -80,7 +80,7 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -111,7 +111,7 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -449,11 +449,10 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 
 		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(message -> {
 			if (message.getMessageType() == MessageType.USER || message.getMessageType() == MessageType.SYSTEM) {
-				Object content = message.getContent();
+				Object content = message.getText();
 				if (message instanceof UserMessage userMessage) {
 					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
-						List<MediaContent> contentList = new ArrayList<>(
-								List.of(new MediaContent(message.getContent())));
+						List<MediaContent> contentList = new ArrayList<>(List.of(new MediaContent(message.getText())));
 
 						contentList.addAll(userMessage.getMedia().stream().map(this::mapToMediaContent).toList());
 
@@ -480,7 +479,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 					audioOutput = new AudioOutput(assistantMessage.getMedia().get(0).getId(), null, null, null);
 
 				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getContent(),
+				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
 						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null, audioOutput));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelFunctionCallingIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelFunctionCallingIT.java
@@ -139,7 +139,7 @@ class OpenAiChatModelFunctionCallingIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -207,7 +207,7 @@ class OpenAiChatModelFunctionCallingIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -89,7 +89,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 		// needs fine tuning... evaluateQuestionAndAnswer(request, response, false);
 	}
 
@@ -102,13 +102,13 @@ public class OpenAiChatModelIT extends AbstractIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 
 		var promptWithMessageHistory = new Prompt(List.of(new UserMessage("Dummy"), response.getResult().getOutput(),
 				new UserMessage("Repeat the last assistant message.")));
 		response = this.chatModel.call(promptWithMessageHistory);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
 	@Test
@@ -121,7 +121,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 		CountDownLatch latch = new CountDownLatch(1);
 
 		Flux<ChatResponse> chatResponseFlux = this.streamingChatModel.stream(prompt).doOnNext(chatResponse -> {
-			String responseContent = chatResponse.getResults().get(0).getOutput().getContent();
+			String responseContent = chatResponse.getResults().get(0).getOutput().getText();
 			answer.append(responseContent);
 		}).doOnComplete(() -> {
 			logger.info(answer.toString());
@@ -146,7 +146,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 			.stream()
 			.chatResponse()
 			.doOnNext(chatResponse -> {
-				String responseContent = chatResponse.getResults().get(0).getOutput().getContent();
+				String responseContent = chatResponse.getResults().get(0).getOutput().getText();
 				answer.append(responseContent);
 			})
 			.doOnComplete(() -> {
@@ -197,7 +197,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");
@@ -237,7 +237,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -256,7 +256,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -275,7 +275,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 	}
 
 	@Test
@@ -292,7 +292,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -318,7 +318,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -347,9 +347,9 @@ public class OpenAiChatModelIT extends AbstractIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("30.0", "30");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("10.0", "10");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15.0", "15");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("30.0", "30");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("10.0", "10");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("15.0", "15");
 	}
 
 	@Test
@@ -376,7 +376,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
@@ -424,9 +424,9 @@ public class OpenAiChatModelIT extends AbstractIT {
 		var response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket", "fruit stand");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket", "fruit stand");
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
@@ -440,9 +440,9 @@ public class OpenAiChatModelIT extends AbstractIT {
 		ChatResponse response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket", "fruit stand");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket", "fruit stand");
 	}
 
 	@Test
@@ -461,7 +461,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 		assertThat(content).contains("bananas", "apple");
@@ -480,8 +480,8 @@ public class OpenAiChatModelIT extends AbstractIT {
 					.withOutputAudio(new AudioParameters(Voice.ALLOY, AudioResponseFormat.WAV))
 					.build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).isNotEmpty();
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 
 		byte[] audio = response.getResult().getOutput().getMedia().get(0).getDataAsByteArray();
 		assertThat(audio).isNotEmpty();
@@ -516,8 +516,8 @@ public class OpenAiChatModelIT extends AbstractIT {
 		ChatResponse response = chatModel
 			.call(new Prompt(List.of(userMessage), ChatOptionsBuilder.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("hobbits");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("hobbits");
 		assertThat(response.getMetadata().getModel()).containsIgnoringCase(modelName);
 	}
 
@@ -537,7 +537,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 		assertThat(content).containsIgnoringCase("hobbits");

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
@@ -82,7 +82,7 @@ public class OpenAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -113,7 +113,7 @@ public class OpenAiChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelProxyToolCallsIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelProxyToolCallsIT.java
@@ -188,7 +188,7 @@ class OpenAiChatModelProxyToolCallsIT {
 
 		logger.info("Response: {}", chatResponse);
 
-		assertThat(chatResponse.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(chatResponse.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -220,7 +220,7 @@ class OpenAiChatModelProxyToolCallsIT {
 			.collectList()
 			.block()
 			.stream()
-			.map(cr -> cr.getResult().getOutput().getContent())
+			.map(cr -> cr.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 
 		logger.info("Response: {}", response);
@@ -306,7 +306,7 @@ class OpenAiChatModelProxyToolCallsIT {
 
 		logger.info("Response: {}", chatResponse);
 
-		assertThat(chatResponse.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(chatResponse.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -341,7 +341,7 @@ class OpenAiChatModelProxyToolCallsIT {
 		String response = responses.collectList()
 			.block()
 			.stream()
-			.map(cr -> cr.getResult().getOutput().getContent())
+			.map(cr -> cr.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 
 		logger.info("Response: {}", response);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelResponseFormatIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelResponseFormatIT.java
@@ -89,7 +89,7 @@ public class OpenAiChatModelResponseFormatIT {
 
 		assertThat(response).isNotNull();
 
-		String content = response.getResult().getOutput().getContent();
+		String content = response.getResult().getOutput().getText();
 
 		logger.info("Response content: {}", content);
 
@@ -132,7 +132,7 @@ public class OpenAiChatModelResponseFormatIT {
 
 		assertThat(response).isNotNull();
 
-		String content = response.getResult().getOutput().getContent();
+		String content = response.getResult().getOutput().getText();
 
 		logger.info("Response content: {}", content);
 
@@ -213,7 +213,7 @@ public class OpenAiChatModelResponseFormatIT {
 
 		assertThat(response).isNotNull();
 
-		String content = response.getResult().getOutput().getContent();
+		String content = response.getResult().getOutput().getText();
 
 		logger.info("Response content: {}", content);
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelTypeReferenceBeanOutputConverterIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelTypeReferenceBeanOutputConverterIT.java
@@ -62,7 +62,7 @@ class OpenAiChatModelTypeReferenceBeanOutputConverterIT extends AbstractIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<ActorsFilmsRecord> actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		List<ActorsFilmsRecord> actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms).hasSize(2);
 		assertThat(actorsFilms.get(0).actor()).isEqualTo("Tom Hanks");
@@ -94,7 +94,7 @@ class OpenAiChatModelTypeReferenceBeanOutputConverterIT extends AbstractIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		List<ActorsFilmsRecord> actorsFilms = outputConverter.convert(generationTextFromStream);

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiCompatibleChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiCompatibleChatModelIT.java
@@ -78,7 +78,7 @@ public class OpenAiCompatibleChatModelIT {
 		ChatResponse response = chatModel.call(prompt);
 
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@ParameterizedTest
@@ -94,7 +94,7 @@ public class OpenAiCompatibleChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
@@ -140,7 +140,7 @@ public class OpenAiRetryTests {
 		var result = this.chatModel.call(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}
@@ -169,7 +169,7 @@ public class OpenAiRetryTests {
 		var result = this.chatModel.stream(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.collectList().block().get(0).getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.collectList().block().get(0).getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
@@ -113,7 +113,7 @@ class OpenAiChatClientIT extends AbstractIT {
 
 		logger.info("" + response);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -232,7 +232,7 @@ class OpenAiChatClientIT extends AbstractIT {
 		String generationTextFromStream = chatResponses
 				.stream()
 				.filter(cr -> cr.getResult() != null)
-				.map(cr -> cr.getResult().getOutput().getContent())
+				.map(cr -> cr.getResult().getOutput().getText())
 				.collect(Collectors.joining());
 		// @formatter:on
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientProxyFunctionCallsIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientProxyFunctionCallsIT.java
@@ -179,7 +179,7 @@ class OpenAiChatClientProxyFunctionCallsIT extends AbstractIT {
 
 		logger.info("Response: {}", chatResponse);
 
-		assertThat(chatResponse.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(chatResponse.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/GroqWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/GroqWithOpenAiChatModelIT.java
@@ -90,7 +90,7 @@ class GroqWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -109,7 +109,7 @@ class GroqWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");
@@ -150,7 +150,7 @@ class GroqWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -169,7 +169,7 @@ class GroqWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -188,7 +188,7 @@ class GroqWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.getActor()).isNotEmpty();
 	}
 
@@ -206,7 +206,7 @@ class GroqWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -232,7 +232,7 @@ class GroqWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -260,7 +260,7 @@ class GroqWithOpenAiChatModelIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -287,7 +287,7 @@ class GroqWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
@@ -307,9 +307,9 @@ class GroqWithOpenAiChatModelIT {
 		var response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@Disabled("Groq does not support multi modality API")
@@ -324,9 +324,9 @@ class GroqWithOpenAiChatModelIT {
 		ChatResponse response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@Disabled("Groq does not support multi modality API")
@@ -345,7 +345,7 @@ class GroqWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 		assertThat(content).contains("bananas", "apple");

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/MistralWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/MistralWithOpenAiChatModelIT.java
@@ -89,7 +89,7 @@ class MistralWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -108,7 +108,7 @@ class MistralWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");
@@ -149,7 +149,7 @@ class MistralWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -168,7 +168,7 @@ class MistralWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -187,7 +187,7 @@ class MistralWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.getActor()).isNotEmpty();
 	}
 
@@ -205,7 +205,7 @@ class MistralWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -231,7 +231,7 @@ class MistralWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -262,7 +262,7 @@ class MistralWithOpenAiChatModelIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
@@ -291,7 +291,7 @@ class MistralWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
@@ -311,9 +311,9 @@ class MistralWithOpenAiChatModelIT {
 		var response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@Disabled("Mistral AI does not support multi modality API")
@@ -328,9 +328,9 @@ class MistralWithOpenAiChatModelIT {
 		ChatResponse response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@Disabled("Mistral AI does not support multi modality API")
@@ -349,7 +349,7 @@ class MistralWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 		assertThat(content).contains("bananas", "apple");

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/NvidiaWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/NvidiaWithOpenAiChatModelIT.java
@@ -87,7 +87,7 @@ class NvidiaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -106,7 +106,7 @@ class NvidiaWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");
@@ -146,7 +146,7 @@ class NvidiaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -165,7 +165,7 @@ class NvidiaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -184,7 +184,7 @@ class NvidiaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.getActor()).isNotEmpty();
 	}
 
@@ -202,7 +202,7 @@ class NvidiaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -228,7 +228,7 @@ class NvidiaWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.filter(c -> c != null)
 			.collect(Collectors.joining());
 
@@ -257,7 +257,7 @@ class NvidiaWithOpenAiChatModelIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -284,7 +284,7 @@ class NvidiaWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/OllamaWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/OllamaWithOpenAiChatModelIT.java
@@ -107,7 +107,7 @@ class OllamaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -126,7 +126,7 @@ class OllamaWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");
@@ -167,7 +167,7 @@ class OllamaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -186,7 +186,7 @@ class OllamaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -205,7 +205,7 @@ class OllamaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.getActor()).isNotEmpty();
 	}
 
@@ -223,7 +223,7 @@ class OllamaWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -249,7 +249,7 @@ class OllamaWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -279,7 +279,7 @@ class OllamaWithOpenAiChatModelIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Disabled("Ollama API does not support streaming function calls yet")
@@ -306,7 +306,7 @@ class OllamaWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
@@ -325,9 +325,9 @@ class OllamaWithOpenAiChatModelIT {
 		var response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@Disabled("Not supported by the current Ollama API")
@@ -342,9 +342,9 @@ class OllamaWithOpenAiChatModelIT {
 		ChatResponse response = this.chatModel
 			.call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@Disabled("Not supported by the current Ollama API")
@@ -365,7 +365,7 @@ class OllamaWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 		assertThat(content).contains("bananas", "apple");

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/PerplexityWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/PerplexityWithOpenAiChatModelIT.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
@@ -102,7 +101,7 @@ class PerplexityWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(systemMessage, userMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -123,7 +122,7 @@ class PerplexityWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");
@@ -162,7 +161,7 @@ class PerplexityWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -180,7 +179,7 @@ class PerplexityWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 	}
 
@@ -197,7 +196,7 @@ class PerplexityWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.getActor()).isNotEmpty();
 	}
 
@@ -214,7 +213,7 @@ class PerplexityWithOpenAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -239,7 +238,7 @@ class PerplexityWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.filter(c -> c != null)
 			.collect(Collectors.joining());
 
@@ -293,7 +292,7 @@ class PerplexityWithOpenAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/testutils/AbstractIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/testutils/AbstractIT.java
@@ -84,7 +84,7 @@ public abstract class AbstractIT {
 
 	protected void evaluateQuestionAndAnswer(String question, ChatResponse response, boolean factBased) {
 		assertThat(response).isNotNull();
-		String answer = response.getResult().getOutput().getContent();
+		String answer = response.getResult().getOutput().getText();
 		logger.info("Question: " + question);
 		logger.info("Answer:" + answer);
 		PromptTemplate userPromptTemplate = new PromptTemplate(this.userEvaluatorResource,
@@ -98,12 +98,12 @@ public abstract class AbstractIT {
 		}
 		Message userMessage = userPromptTemplate.createMessage();
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
-		String yesOrNo = this.chatModel.call(prompt).getResult().getOutput().getContent();
+		String yesOrNo = this.chatModel.call(prompt).getResult().getOutput().getText();
 		logger.info("Is Answer related to question: " + yesOrNo);
 		if (yesOrNo.equalsIgnoreCase("no")) {
 			SystemMessage notRelatedSystemMessage = new SystemMessage(this.qaEvaluatorNotRelatedResource);
 			prompt = new Prompt(List.of(userMessage, notRelatedSystemMessage));
-			String reasonForFailure = this.chatModel.call(prompt).getResult().getOutput().getContent();
+			String reasonForFailure = this.chatModel.call(prompt).getResult().getOutput().getText();
 			fail(reasonForFailure);
 		}
 		else {

--- a/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanChatModel.java
+++ b/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanChatModel.java
@@ -246,7 +246,7 @@ public class QianFanChatModel implements ChatModel, StreamingChatModel {
 	public ChatCompletionRequest createRequest(Prompt prompt, boolean stream) {
 		var chatCompletionMessages = prompt.getInstructions()
 			.stream()
-			.map(m -> new ChatCompletionMessage(m.getContent(),
+			.map(m -> new ChatCompletionMessage(m.getText(),
 					ChatCompletionMessage.Role.valueOf(m.getMessageType().name())))
 			.toList();
 		var systemMessageList = chatCompletionMessages.stream().filter(msg -> msg.role() == Role.SYSTEM).toList();

--- a/models/spring-ai-qianfan/src/test/java/org/springframework/ai/qianfan/api/QianFanRetryTests.java
+++ b/models/spring-ai-qianfan/src/test/java/org/springframework/ai/qianfan/api/QianFanRetryTests.java
@@ -104,7 +104,7 @@ public class QianFanRetryTests {
 		var result = this.chatClient.call(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}
@@ -130,7 +130,7 @@ public class QianFanRetryTests {
 		var result = this.chatClient.stream(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(Objects.requireNonNull(result.collectList().block()).get(0).getResult().getOutput().getContent())
+		assertThat(Objects.requireNonNull(result.collectList().block()).get(0).getResult().getOutput().getText())
 			.isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);

--- a/models/spring-ai-qianfan/src/test/java/org/springframework/ai/qianfan/chat/QianFanChatModelIT.java
+++ b/models/spring-ai-qianfan/src/test/java/org/springframework/ai/qianfan/chat/QianFanChatModelIT.java
@@ -68,7 +68,7 @@ class QianFanChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
 
 	@Test
@@ -87,7 +87,7 @@ class QianFanChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/models/spring-ai-qianfan/src/test/java/org/springframework/ai/qianfan/chat/QianFanChatModelObservationIT.java
+++ b/models/spring-ai-qianfan/src/test/java/org/springframework/ai/qianfan/chat/QianFanChatModelObservationIT.java
@@ -83,7 +83,7 @@ public class QianFanChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -112,7 +112,7 @@ public class QianFanChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
@@ -51,7 +51,6 @@ import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingUtils.ImageBui
 import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingUtils.MultimodalInstanceBuilder;
 import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingUtils.VideoBuilder;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.StringUtils;
@@ -149,43 +148,41 @@ public class VertexAiMultimodalEmbeddingModel implements DocumentEmbeddingModel 
 					new DocumentMetadata(document.getId(), MimeTypeUtils.TEXT_PLAIN, document.getContent()));
 		}
 
-		if (!CollectionUtils.isEmpty(document.getMedia())) {
-
-			for (Media media : document.getMedia()) {
-				if (media.getMimeType().isCompatibleWith(TEXT_MIME_TYPE)) {
-					instanceBuilder.withText(media.getData().toString());
-					documentMetadata.put(ModalityType.TEXT,
-							new DocumentMetadata(document.getId(), MimeTypeUtils.TEXT_PLAIN, media.getData()));
-					if (StringUtils.hasText(document.getContent())) {
-						logger.warn("Media type String overrides the Document text content!");
-					}
+		Media media = document.getMedia();
+		if (media != null) {
+			if (media.getMimeType().isCompatibleWith(TEXT_MIME_TYPE)) {
+				instanceBuilder.withText(media.getData().toString());
+				documentMetadata.put(ModalityType.TEXT,
+						new DocumentMetadata(document.getId(), MimeTypeUtils.TEXT_PLAIN, media.getData()));
+				if (StringUtils.hasText(document.getContent())) {
+					logger.warn("Media type String overrides the Document text content!");
 				}
-				else if (media.getMimeType().isCompatibleWith(IMAGE_MIME_TYPE)) {
-					if (SUPPORTED_IMAGE_MIME_SUB_TYPES.contains(media.getMimeType())) {
-						instanceBuilder
-							.withImage(ImageBuilder.of(media.getMimeType()).withImageData(media.getData()).build());
-						documentMetadata.put(ModalityType.IMAGE,
-								new DocumentMetadata(document.getId(), media.getMimeType(), media.getData()));
-					}
-					else {
-						logger.warn("Unsupported image mime type: {}", media.getMimeType());
-						throw new IllegalArgumentException("Unsupported image mime type: " + media.getMimeType());
-					}
-				}
-				else if (media.getMimeType().isCompatibleWith(VIDEO_MIME_TYPE)) {
-					instanceBuilder.withVideo(VideoBuilder.of(media.getMimeType())
-						.withVideoData(media.getData())
-						.withStartOffsetSec(mergedOptions.getVideoStartOffsetSec())
-						.withEndOffsetSec(mergedOptions.getVideoEndOffsetSec())
-						.withIntervalSec(mergedOptions.getVideoIntervalSec())
-						.build());
-					documentMetadata.put(ModalityType.VIDEO,
+			}
+			else if (media.getMimeType().isCompatibleWith(IMAGE_MIME_TYPE)) {
+				if (SUPPORTED_IMAGE_MIME_SUB_TYPES.contains(media.getMimeType())) {
+					instanceBuilder
+						.withImage(ImageBuilder.of(media.getMimeType()).withImageData(media.getData()).build());
+					documentMetadata.put(ModalityType.IMAGE,
 							new DocumentMetadata(document.getId(), media.getMimeType(), media.getData()));
 				}
 				else {
-					logger.warn("Unsupported media type: {}", media.getMimeType());
-					throw new IllegalArgumentException("Unsupported media type: " + media.getMimeType());
+					logger.warn("Unsupported image mime type: {}", media.getMimeType());
+					throw new IllegalArgumentException("Unsupported image mime type: " + media.getMimeType());
 				}
+			}
+			else if (media.getMimeType().isCompatibleWith(VIDEO_MIME_TYPE)) {
+				instanceBuilder.withVideo(VideoBuilder.of(media.getMimeType())
+					.withVideoData(media.getData())
+					.withStartOffsetSec(mergedOptions.getVideoStartOffsetSec())
+					.withEndOffsetSec(mergedOptions.getVideoEndOffsetSec())
+					.withIntervalSec(mergedOptions.getVideoIntervalSec())
+					.build());
+				documentMetadata.put(ModalityType.VIDEO,
+						new DocumentMetadata(document.getId(), media.getMimeType(), media.getData()));
+			}
+			else {
+				logger.warn("Unsupported media type: {}", media.getMimeType());
+				throw new IllegalArgumentException("Unsupported media type: " + media.getMimeType());
 			}
 		}
 

--- a/models/spring-ai-vertex-ai-embedding/src/test/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModelIT.java
+++ b/models/spring-ai-vertex-ai-embedding/src/test/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModelIT.java
@@ -186,7 +186,7 @@ class VertexAiMultimodalEmbeddingModelIT {
 	void textImageAndVideoEmbedding() {
 
 		var document = Document.builder()
-			.content("Hello World")
+			.text("Hello World")
 			.media(new Media(MimeTypeUtils.IMAGE_PNG, new ClassPathResource("/test.image.png")))
 			.media(new Media(new MimeType("video", "mp4"), new ClassPathResource("/test.video.mp4")))
 			.build();

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -186,16 +186,16 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 
 			List<Part> parts = new ArrayList<>();
 
-			if (systemMessage.getContent() != null) {
-				parts.add(Part.newBuilder().setText(systemMessage.getContent()).build());
+			if (systemMessage.getText() != null) {
+				parts.add(Part.newBuilder().setText(systemMessage.getText()).build());
 			}
 
 			return parts;
 		}
 		else if (message instanceof UserMessage userMessage) {
 			List<Part> parts = new ArrayList<>();
-			if (userMessage.getContent() != null) {
-				parts.add(Part.newBuilder().setText(userMessage.getContent()).build());
+			if (userMessage.getText() != null) {
+				parts.add(Part.newBuilder().setText(userMessage.getText()).build());
 			}
 
 			parts.addAll(mediaToParts(userMessage.getMedia()));
@@ -204,8 +204,8 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 		}
 		else if (message instanceof AssistantMessage assistantMessage) {
 			List<Part> parts = new ArrayList<>();
-			if (StringUtils.hasText(assistantMessage.getContent())) {
-				parts.add(Part.newBuilder().setText(assistantMessage.getContent()).build());
+			if (StringUtils.hasText(assistantMessage.getText())) {
+				parts.add(Part.newBuilder().setText(assistantMessage.getText()).build());
 			}
 			if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 				parts.addAll(assistantMessage.getToolCalls()

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiChatModelObservationIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiChatModelObservationIT.java
@@ -76,7 +76,7 @@ public class VertexAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -104,7 +104,7 @@ public class VertexAiChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
@@ -69,27 +69,27 @@ class VertexAiGeminiChatModelIT {
 	void roleTest() {
 		Prompt prompt = createPrompt(VertexAiGeminiChatOptions.builder().build());
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
 	@Test
 	void testMessageHistory() {
 		Prompt prompt = createPrompt(VertexAiGeminiChatOptions.builder().build());
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 
 		var promptWithMessageHistory = new Prompt(List.of(new UserMessage("Dummy"), prompt.getInstructions().get(1),
 				response.getResult().getOutput(), new UserMessage("Repeat the last assistant message.")));
 		response = this.chatModel.call(promptWithMessageHistory);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
 	@Test
 	void googleSearchTool() {
 		Prompt prompt = createPrompt(VertexAiGeminiChatOptions.builder().withGoogleSearchRetrieval(true).build());
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Blackbeard", "Bartholomew");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
 	@NotNull
@@ -119,7 +119,7 @@ class VertexAiGeminiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = converter.convert(generation.getOutput().getContent());
+		List<String> list = converter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 	}
 
@@ -137,7 +137,7 @@ class VertexAiGeminiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -157,7 +157,7 @@ class VertexAiGeminiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConvert.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConvert.convert(generation.getOutput().getText());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -173,7 +173,7 @@ class VertexAiGeminiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		// logger.info("" + actorsFilms);
@@ -201,7 +201,7 @@ class VertexAiGeminiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -224,7 +224,7 @@ class VertexAiGeminiChatModelIT {
 		// I see a bunch of bananas in a golden basket. The bananas are ripe and yellow.
 		// There are also some red apples in the basket. The basket is sitting on a table.
 		// The background is a blurred light blue color.'
-		assertThat(response.getResult().getOutput().getContent()).satisfies(content -> {
+		assertThat(response.getResult().getOutput().getText()).satisfies(content -> {
 			long count = Stream.of("bananas", "apple", "basket").filter(content::contains).count();
 			assertThat(count).isGreaterThanOrEqualTo(2);
 		});
@@ -258,7 +258,7 @@ class VertexAiGeminiChatModelIT {
 
 		var response = this.chatModel.call(new Prompt(List.of(userMessage)));
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("Spring AI", "portable API");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Spring AI", "portable API");
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiRetryTests.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiRetryTests.java
@@ -101,7 +101,7 @@ public class VertexAiGeminiRetryTests {
 
 		// Assertions
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isEqualTo("Response");
+		assertThat(result.getResult().getOutput().getText()).isEqualTo("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/function/VertexAiGeminiChatModelFunctionCallingIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/function/VertexAiGeminiChatModelFunctionCallingIT.java
@@ -95,7 +95,7 @@ public class VertexAiGeminiChatModelFunctionCallingIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 	}
 
 	@Test
@@ -127,14 +127,14 @@ public class VertexAiGeminiChatModelFunctionCallingIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15.0", "15");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("15.0", "15");
 
 		ChatResponse response2 = this.chatModel
 			.call(new Prompt("What is the payment status for transaction 696?", promptOptions));
 
 		logger.info("Response: {}", response2);
 
-		assertThat(response2.getResult().getOutput().getContent()).containsIgnoringCase("transaction 696 is PAYED");
+		assertThat(response2.getResult().getOutput().getText()).containsIgnoringCase("transaction 696 is PAYED");
 
 	}
 
@@ -168,14 +168,14 @@ public class VertexAiGeminiChatModelFunctionCallingIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+		assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		ChatResponse response2 = this.chatModel
 			.call(new Prompt("What is the payment status for transaction 696?", promptOptions));
 
 		logger.info("Response: {}", response2);
 
-		assertThat(response2.getResult().getOutput().getContent()).containsIgnoringCase("transaction 696 is PAYED");
+		assertThat(response2.getResult().getOutput().getText()).containsIgnoringCase("transaction 696 is PAYED");
 
 	}
 
@@ -205,7 +205,7 @@ public class VertexAiGeminiChatModelFunctionCallingIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		logger.info("Response: {}", responseString);

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/utils/MessageToPromptConverter.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/utils/MessageToPromptConverter.java
@@ -55,7 +55,7 @@ public final class MessageToPromptConverter {
 
 		final String systemMessages = messages.stream()
 				.filter(message -> message.getMessageType() == MessageType.SYSTEM)
-				.map(Message::getContent)
+				.map(Message::getText)
 				.collect(Collectors.joining("\n"));
 
 		final String userMessages = messages.stream()
@@ -70,11 +70,11 @@ public final class MessageToPromptConverter {
 	protected String messageToString(Message message) {
 		switch (message.getMessageType()) {
 			case SYSTEM:
-				return message.getContent();
+				return message.getText();
 			case USER:
-				return this.humanPrompt + message.getContent();
+				return this.humanPrompt + message.getText();
 			case ASSISTANT:
-				return this.assistantPrompt + message.getContent();
+				return this.assistantPrompt + message.getText();
 			case TOOL:
 				throw new IllegalArgumentException(TOOL_EXECUTION_NOT_SUPPORTED_FOR_WAI_MODELS);
 		}

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -359,11 +359,10 @@ public class ZhiPuAiChatModel extends AbstractToolCallSupport implements ChatMod
 
 		List<ChatCompletionMessage> chatCompletionMessages = prompt.getInstructions().stream().map(message -> {
 			if (message.getMessageType() == MessageType.USER || message.getMessageType() == MessageType.SYSTEM) {
-				Object content = message.getContent();
+				Object content = message.getText();
 				if (message instanceof UserMessage userMessage) {
 					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
-						List<MediaContent> contentList = new ArrayList<>(
-								List.of(new MediaContent(message.getContent())));
+						List<MediaContent> contentList = new ArrayList<>(List.of(new MediaContent(message.getText())));
 
 						contentList.addAll(userMessage.getMedia()
 							.stream()
@@ -387,7 +386,7 @@ public class ZhiPuAiChatModel extends AbstractToolCallSupport implements ChatMod
 						return new ToolCall(toolCall.id(), toolCall.type(), function);
 					}).toList();
 				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getContent(),
+				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
 						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiRetryTests.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiRetryTests.java
@@ -112,7 +112,7 @@ public class ZhiPuAiRetryTests {
 		var result = this.chatModel.call(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}
@@ -140,7 +140,7 @@ public class ZhiPuAiRetryTests {
 		var result = this.chatModel.stream(new Prompt("text"));
 
 		assertThat(result).isNotNull();
-		assertThat(result.collectList().block().get(0).getResult().getOutput().getContent()).isSameAs("Response");
+		assertThat(result.collectList().block().get(0).getResult().getOutput().getText()).isSameAs("Response");
 		assertThat(this.retryListener.onSuccessRetryCount).isEqualTo(2);
 		assertThat(this.retryListener.onErrorRetryCount).isEqualTo(2);
 	}

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/chat/ZhiPuAiChatModelIT.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/chat/ZhiPuAiChatModelIT.java
@@ -89,7 +89,7 @@ class ZhiPuAiChatModelIT {
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResults()).hasSize(1);
-		assertThat(response.getResults().get(0).getOutput().getContent()).contains("Blackbeard");
+		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 		// needs fine tuning... evaluateQuestionAndAnswer(request, response, false);
 	}
 
@@ -109,7 +109,7 @@ class ZhiPuAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		assertThat(stitchedResponseContent).contains("Blackbeard");
@@ -131,7 +131,7 @@ class ZhiPuAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		List<String> list = outputConverter.convert(generation.getOutput().getContent());
+		List<String> list = outputConverter.convert(generation.getOutput().getText());
 		assertThat(list).hasSize(5);
 
 	}
@@ -150,7 +150,7 @@ class ZhiPuAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		Map<String, Object> result = outputConverter.convert(generation.getOutput().getContent());
+		Map<String, Object> result = outputConverter.convert(generation.getOutput().getText());
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 
 	}
@@ -169,7 +169,7 @@ class ZhiPuAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilms actorsFilms = outputConverter.convert(generation.getOutput().getText());
 	}
 
 	@Test
@@ -186,7 +186,7 @@ class ZhiPuAiChatModelIT {
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
-		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getContent());
+		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
 		logger.info("" + actorsFilms);
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
@@ -211,7 +211,7 @@ class ZhiPuAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generationTextFromStream);
@@ -241,9 +241,9 @@ class ZhiPuAiChatModelIT {
 
 		logger.info("Response: {}", response);
 
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("30.0", "30");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("10.0", "10");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15.0", "15");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("30.0", "30");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("10.0", "10");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("15.0", "15");
 	}
 
 	@Test
@@ -270,7 +270,7 @@ class ZhiPuAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
@@ -291,9 +291,9 @@ class ZhiPuAiChatModelIT {
 		var response = this.chatModel
 			.call(new Prompt(List.of(userMessage), ZhiPuAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
@@ -307,9 +307,9 @@ class ZhiPuAiChatModelIT {
 		ChatResponse response = this.chatModel
 			.call(new Prompt(List.of(userMessage), ZhiPuAiChatOptions.builder().withModel(modelName).build()));
 
-		logger.info(response.getResult().getOutput().getContent());
-		assertThat(response.getResult().getOutput().getContent()).contains("bananas", "apple");
-		assertThat(response.getResult().getOutput().getContent()).containsAnyOf("bowl", "basket");
+		logger.info(response.getResult().getOutput().getText());
+		assertThat(response.getResult().getOutput().getText()).contains("bananas", "apple");
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("bowl", "basket");
 	}
 
 	@Test
@@ -327,7 +327,7 @@ class ZhiPuAiChatModelIT {
 			.map(ChatResponse::getResults)
 			.flatMap(List::stream)
 			.map(Generation::getOutput)
-			.map(AssistantMessage::getContent)
+			.map(AssistantMessage::getText)
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 		assertThat(content).contains("bananas", "apple");

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/chat/ZhiPuAiChatModelObservationIT.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/chat/ZhiPuAiChatModelObservationIT.java
@@ -80,7 +80,7 @@ public class ZhiPuAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
-		assertThat(chatResponse.getResult().getOutput().getContent()).isNotEmpty();
+		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
@@ -108,7 +108,7 @@ public class ZhiPuAiChatModelObservationIT {
 
 		String aggregatedResponse = responses.subList(0, responses.size() - 1)
 			.stream()
-			.map(r -> r.getResult().getOutput().getContent())
+			.map(r -> r.getResult().getOutput().getText())
 			.collect(Collectors.joining());
 		assertThat(aggregatedResponse).isNotEmpty();
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -115,8 +115,8 @@ public class DefaultChatClient implements ChatClient {
 			Message lastMessage = messages.get(messages.size() - 1);
 			if (lastMessage.getMessageType() == MessageType.USER) {
 				UserMessage userMessage = (UserMessage) lastMessage;
-				if (StringUtils.hasText(userMessage.getContent())) {
-					userText = lastMessage.getContent();
+				if (StringUtils.hasText(userMessage.getText())) {
+					userText = lastMessage.getText();
 				}
 				Collection<Media> messageMedia = userMessage.getMedia();
 				if (!CollectionUtils.isEmpty(messageMedia)) {
@@ -493,10 +493,10 @@ public class DefaultChatClient implements ChatClient {
 		@Nullable
 		private static String getContentFromChatResponse(@Nullable ChatResponse chatResponse) {
 			if (chatResponse == null || chatResponse.getResult() == null || chatResponse.getResult().getOutput() == null
-					|| chatResponse.getResult().getOutput().getContent() == null) {
+					|| chatResponse.getResult().getOutput().getText() == null) {
 				return null;
 			}
-			return chatResponse.getResult().getOutput().getContent();
+			return chatResponse.getResult().getOutput().getText();
 		}
 
 		@Override
@@ -562,10 +562,10 @@ public class DefaultChatClient implements ChatClient {
 		public Flux<String> content() {
 			return doGetObservableFluxChatResponse(this.request).map(r -> {
 				if (r.getResult() == null || r.getResult().getOutput() == null
-						|| r.getResult().getOutput().getContent() == null) {
+						|| r.getResult().getOutput().getText() == null) {
 					return "";
 				}
-				return r.getResult().getOutput().getContent();
+				return r.getResult().getOutput().getText();
 			}).filter(StringUtils::hasLength);
 		}
 
@@ -1005,11 +1005,11 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		public String content() {
-			return doGetChatResponse(this.prompt).getResult().getOutput().getContent();
+			return doGetChatResponse(this.prompt).getResult().getOutput().getText();
 		}
 
 		public List<String> contents() {
-			return doGetChatResponse(this.prompt).getResults().stream().map(r -> r.getOutput().getContent()).toList();
+			return doGetChatResponse(this.prompt).getResults().stream().map(r -> r.getOutput().getText()).toList();
 		}
 
 		public ChatResponse chatResponse() {
@@ -1046,10 +1046,10 @@ public class DefaultChatClient implements ChatClient {
 		public Flux<String> content() {
 			return doGetFluxChatResponse(this.prompt).map(r -> {
 				if (r.getResult() == null || r.getResult().getOutput() == null
-						|| r.getResult().getOutput().getContent() == null) {
+						|| r.getResult().getOutput().getText() == null) {
 					return "";
 				}
-				return r.getResult().getOutput().getContent();
+				return r.getResult().getOutput().getText();
 			}).filter(StringUtils::hasLength);
 		}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
@@ -111,7 +111,7 @@ public class PromptChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemor
 
 		String memory = (memoryMessages != null) ? memoryMessages.stream()
 			.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
-			.map(m -> m.getMessageType() + ":" + ((Content) m).getContent())
+			.map(m -> m.getMessageType() + ":" + ((Content) m).getText())
 			.collect(Collectors.joining(System.lineSeparator())) : "";
 
 		Map<String, Object> advisedSystemParams = new HashMap<>(request.systemParams());

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
@@ -227,7 +227,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 		context.put(RETRIEVED_DOCUMENTS, documents);
 
 		String documentContext = documents.stream()
-			.map(Content::getContent)
+			.map(Document::getText)
 			.collect(Collectors.joining(System.lineSeparator()));
 
 		// 4. Advise the user parameters.

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
@@ -43,6 +43,8 @@ import org.springframework.util.StringUtils;
 /**
  * Memory is retrieved from a VectorStore added into the prompt's system text.
  *
+ * This only works for text based exchanges with the models, not multi-modal exchanges.
+ *
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @since 1.0.0
@@ -146,7 +148,7 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 		List<Document> documents = this.getChatMemoryStore().similaritySearch(searchRequest);
 
 		String longTermMemory = documents.stream()
-			.map(Content::getContent)
+			.map(Document::getText)
 			.collect(Collectors.joining(System.lineSeparator()));
 
 		Map<String, Object> advisedSystemParams = new HashMap<>(request.systemParams());
@@ -187,7 +189,9 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 				if (message instanceof UserMessage userMessage) {
 					return Document.builder()
 						.content(userMessage.getContent())
-						.media(new ArrayList<>(userMessage.getMedia()))
+						//	userMessage.getMedia().get(0).getId()
+						//TODO vector store for memory would not store this into the vector store, could store an 'id' instead
+							// .media(userMessage.getMedia())
 						.metadata(metadata)
 						.build();
 				}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.chat.client.advisor;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,6 @@ import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.document.Document;
-import org.springframework.ai.model.Content;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.util.StringUtils;
@@ -188,15 +186,16 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 				metadata.put(DOCUMENT_METADATA_MESSAGE_TYPE, message.getMessageType().name());
 				if (message instanceof UserMessage userMessage) {
 					return Document.builder()
-						.content(userMessage.getContent())
-						//	userMessage.getMedia().get(0).getId()
-						//TODO vector store for memory would not store this into the vector store, could store an 'id' instead
-							// .media(userMessage.getMedia())
+						.text(userMessage.getText())
+						// userMessage.getMedia().get(0).getId()
+						// TODO vector store for memory would not store this into the
+						// vector store, could store an 'id' instead
+						// .media(userMessage.getMedia())
 						.metadata(metadata)
 						.build();
 				}
 				else if (message instanceof AssistantMessage assistantMessage) {
-					return Document.builder().content(assistantMessage.getContent()).metadata(metadata).build();
+					return Document.builder().text(assistantMessage.getText()).metadata(metadata).build();
 				}
 				throw new RuntimeException("Unknown message type: " + message.getMessageType());
 			})

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/AbstractMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/AbstractMessage.java
@@ -98,7 +98,7 @@ public abstract class AbstractMessage implements Message {
 	 * @return the content of the message
 	 */
 	@Override
-	public String getContent() {
+	public String getText() {
 		return this.textContent;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/SystemMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/SystemMessage.java
@@ -39,7 +39,7 @@ public class SystemMessage extends AbstractMessage {
 	}
 
 	@Override
-	public String getContent() {
+	public String getText() {
 		return this.textContent;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
@@ -71,7 +71,7 @@ public class UserMessage extends AbstractMessage implements MediaContent {
 	}
 
 	@Override
-	public Collection<Media> getMedia() {
+	public List<Media> getMedia() {
 		return this.media;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
@@ -66,7 +66,7 @@ public class UserMessage extends AbstractMessage implements MediaContent {
 
 	@Override
 	public String toString() {
-		return "UserMessage{" + "content='" + getContent() + '\'' + ", properties=" + this.metadata + ", messageType="
+		return "UserMessage{" + "content='" + getText() + '\'' + ", properties=" + this.metadata + ", messageType="
 				+ this.messageType + '}';
 	}
 
@@ -76,7 +76,7 @@ public class UserMessage extends AbstractMessage implements MediaContent {
 	}
 
 	@Override
-	public String getContent() {
+	public String getText() {
 		return this.textContent;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
@@ -147,7 +147,7 @@ public abstract class AbstractToolCallSupport {
 			toolContextMap = new HashMap<>(functionCallOptions.getToolContext());
 
 			List<Message> toolCallHistory = new ArrayList<>(prompt.copy().getInstructions());
-			toolCallHistory.add(new AssistantMessage(assistantMessage.getContent(), assistantMessage.getMetadata(),
+			toolCallHistory.add(new AssistantMessage(assistantMessage.getText(), assistantMessage.getMetadata(),
 					assistantMessage.getToolCalls()));
 
 			toolContextMap.put(ToolContext.TOOL_CALL_HISTORY, toolCallHistory);

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ChatModel.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/ChatModel.java
@@ -31,13 +31,13 @@ public interface ChatModel extends Model<Prompt, ChatResponse>, StreamingChatMod
 	default String call(String message) {
 		Prompt prompt = new Prompt(new UserMessage(message));
 		Generation generation = call(prompt).getResult();
-		return (generation != null) ? generation.getOutput().getContent() : "";
+		return (generation != null) ? generation.getOutput().getText() : "";
 	}
 
 	default String call(Message... messages) {
 		Prompt prompt = new Prompt(Arrays.asList(messages));
 		Generation generation = call(prompt).getResult();
-		return (generation != null) ? generation.getOutput().getContent() : "";
+		return (generation != null) ? generation.getOutput().getText() : "";
 	}
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -108,8 +108,8 @@ public class MessageAggregator {
 						&& chatResponse.getResult().getMetadata() != ChatGenerationMetadata.NULL) {
 					generationMetadataRef.set(chatResponse.getResult().getMetadata());
 				}
-				if (chatResponse.getResult().getOutput().getContent() != null) {
-					messageTextContentRef.get().append(chatResponse.getResult().getOutput().getContent());
+				if (chatResponse.getResult().getOutput().getText() != null) {
+					messageTextContentRef.get().append(chatResponse.getResult().getOutput().getText());
 				}
 				if (chatResponse.getResult().getOutput().getMetadata() != null) {
 					messageMetadataMapRef.get().putAll(chatResponse.getResult().getOutput().getMetadata());

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/StreamingChatModel.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/StreamingChatModel.java
@@ -30,15 +30,15 @@ public interface StreamingChatModel extends StreamingModel<Prompt, ChatResponse>
 	default Flux<String> stream(String message) {
 		Prompt prompt = new Prompt(message);
 		return stream(prompt).map(response -> (response.getResult() == null || response.getResult().getOutput() == null
-				|| response.getResult().getOutput().getContent() == null) ? ""
-						: response.getResult().getOutput().getContent());
+				|| response.getResult().getOutput().getText() == null) ? ""
+						: response.getResult().getOutput().getText());
 	}
 
 	default Flux<String> stream(Message... messages) {
 		Prompt prompt = new Prompt(Arrays.asList(messages));
 		return stream(prompt).map(response -> (response.getResult() == null || response.getResult().getOutput() == null
-				|| response.getResult().getOutput().getContent() == null) ? ""
-						: response.getResult().getOutput().getContent());
+				|| response.getResult().getOutput().getText() == null) ? ""
+						: response.getResult().getOutput().getText());
 	}
 
 	@Override

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContentProcessor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContentProcessor.java
@@ -37,7 +37,7 @@ public final class ChatModelObservationContentProcessor {
 			return List.of();
 		}
 
-		return context.getRequest().getInstructions().stream().map(Content::getContent).toList();
+		return context.getRequest().getInstructions().stream().map(Content::getText).toList();
 	}
 
 	public static List<String> completion(ChatModelObservationContext context) {
@@ -46,7 +46,7 @@ public final class ChatModelObservationContentProcessor {
 			return List.of();
 		}
 
-		if (!StringUtils.hasText(context.getResponse().getResult().getOutput().getContent())) {
+		if (!StringUtils.hasText(context.getResponse().getResult().getOutput().getText())) {
 			return List.of();
 		}
 
@@ -54,8 +54,8 @@ public final class ChatModelObservationContentProcessor {
 			.getResults()
 			.stream()
 			.filter(generation -> generation.getOutput() != null
-					&& StringUtils.hasText(generation.getOutput().getContent()))
-			.map(generation -> generation.getOutput().getContent())
+					&& StringUtils.hasText(generation.getOutput().getText()))
+			.map(generation -> generation.getOutput().getText())
 			.toList();
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -75,7 +75,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 	public String getContents() {
 		StringBuilder sb = new StringBuilder();
 		for (Message message : getInstructions()) {
-			sb.append(message.getContent());
+			sb.append(message.getText());
 		}
 		return sb.toString();
 	}
@@ -119,14 +119,13 @@ public class Prompt implements ModelRequest<List<Message>> {
 		List<Message> messagesCopy = new ArrayList<>();
 		this.messages.forEach(message -> {
 			if (message instanceof UserMessage userMessage) {
-				messagesCopy
-					.add(new UserMessage(userMessage.getContent(), userMessage.getMedia(), message.getMetadata()));
+				messagesCopy.add(new UserMessage(userMessage.getText(), userMessage.getMedia(), message.getMetadata()));
 			}
 			else if (message instanceof SystemMessage systemMessage) {
-				messagesCopy.add(new SystemMessage(systemMessage.getContent()));
+				messagesCopy.add(new SystemMessage(systemMessage.getText()));
 			}
 			else if (message instanceof AssistantMessage assistantMessage) {
-				messagesCopy.add(new AssistantMessage(assistantMessage.getContent(), assistantMessage.getMetadata(),
+				messagesCopy.add(new AssistantMessage(assistantMessage.getText(), assistantMessage.getMetadata(),
 						assistantMessage.getToolCalls()));
 			}
 			else if (message instanceof ToolResponseMessage toolResponseMessage) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/evaluation/Evaluator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/evaluation/Evaluator.java
@@ -30,7 +30,7 @@ public interface Evaluator {
 	default String doGetSupportingData(EvaluationRequest evaluationRequest) {
 		List<Content> data = evaluationRequest.getDataList();
 		return data.stream()
-			.map(Content::getContent)
+			.map(Content::getText)
 			.filter(StringUtils::hasText)
 			.collect(Collectors.joining(System.lineSeparator()));
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/Content.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/Content.java
@@ -33,7 +33,7 @@ public interface Content {
 	 * Get the content of the message.
 	 * @return the content of the message
 	 */
-	String getContent(); // TODO consider getText
+	String getText();
 
 	/**
 	 * Get the metadata associated with the content.

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/Media.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/Media.java
@@ -111,7 +111,6 @@ public class Media {
 		}
 	}
 
-
 	/**
 	 * Get the media id
 	 * @return the media id

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/Media.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/Media.java
@@ -111,6 +111,7 @@ public class Media {
 		}
 	}
 
+
 	/**
 	 * Get the media id
 	 * @return the media id

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/MediaContent.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/MediaContent.java
@@ -17,12 +17,13 @@
 package org.springframework.ai.model;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface MediaContent extends Content {
 
 	/**
 	 * Get the media associated with the content.
 	 */
-	Collection<Media> getMedia();
+	List<Media> getMedia();
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/rag/generation/augmentation/ContextualQueryAugmenter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/rag/generation/augmentation/ContextualQueryAugmenter.java
@@ -104,7 +104,7 @@ public final class ContextualQueryAugmenter implements QueryAugmenter {
 
 		// 1. Collect content from documents.
 		String documentContext = documents.stream()
-			.map(Content::getContent)
+			.map(Document::getText)
 			.collect(Collectors.joining(System.lineSeparator()));
 
 		// 2. Define prompt parameters.

--- a/spring-ai-core/src/main/java/org/springframework/ai/tokenizer/JTokkitTokenCountEstimator.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tokenizer/JTokkitTokenCountEstimator.java
@@ -56,8 +56,8 @@ public class JTokkitTokenCountEstimator implements TokenCountEstimator {
 	public int estimate(MediaContent content) {
 		int tokenCount = 0;
 
-		if (content.getContent() != null) {
-			tokenCount += this.estimate(content.getContent());
+		if (content.getText() != null) {
+			tokenCount += this.estimate(content.getText());
 		}
 
 		if (!CollectionUtils.isEmpty(content.getMedia())) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/KeywordMetadataEnricher.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/KeywordMetadataEnricher.java
@@ -65,7 +65,7 @@ public class KeywordMetadataEnricher implements DocumentTransformer {
 
 			var template = new PromptTemplate(String.format(KEYWORDS_TEMPLATE, this.keywordCount));
 			Prompt prompt = template.create(Map.of(CONTEXT_STR_PLACEHOLDER, document.getContent()));
-			String keywords = this.chatModel.call(prompt).getResult().getOutput().getContent();
+			String keywords = this.chatModel.call(prompt).getResult().getOutput().getText();
 			document.getMetadata().putAll(Map.of(EXCERPT_KEYWORDS_METADATA_KEY, keywords));
 		}
 		return documents;

--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/SummaryMetadataEnricher.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/SummaryMetadataEnricher.java
@@ -97,7 +97,7 @@ public class SummaryMetadataEnricher implements DocumentTransformer {
 
 			Prompt prompt = new PromptTemplate(this.summaryTemplate)
 				.create(Map.of(CONTEXT_STR_PLACEHOLDER, documentContext));
-			documentSummaries.add(this.chatModel.call(prompt).getResult().getOutput().getContent());
+			documentSummaries.add(this.chatModel.call(prompt).getResult().getOutput().getText());
 		}
 
 		for (int i = 0; i < documentSummaries.size(); i++) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStoreContent.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStoreContent.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -41,7 +42,7 @@ public final class SimpleVectorStoreContent implements Content {
 
 	private final String id;
 
-	private final String content;
+	private final String text;
 
 	private final Map<String, Object> metadata;
 
@@ -50,55 +51,56 @@ public final class SimpleVectorStoreContent implements Content {
 	/**
 	 * Creates a new instance with the given content, empty metadata, and embedding
 	 * vector.
-	 * @param content the content text, must not be null
+	 * @param text the content text, must not be null
 	 * @param embedding the embedding vector, must not be null
 	 */
 	@JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-	public SimpleVectorStoreContent(@JsonProperty("content") String content,
+	public SimpleVectorStoreContent(
+			@JsonProperty("text") @JsonAlias({"content"}) String text,
 			@JsonProperty("embedding") float[] embedding) {
-		this(content, new HashMap<>(), embedding);
+		this(text, new HashMap<>(), embedding);
 	}
 
 	/**
 	 * Creates a new instance with the given content, metadata, and embedding vector.
-	 * @param content the content text, must not be null
+	 * @param text the content text, must not be null
 	 * @param metadata the metadata map, must not be null
 	 * @param embedding the embedding vector, must not be null
 	 */
-	public SimpleVectorStoreContent(String content, Map<String, Object> metadata, float[] embedding) {
-		this(content, metadata, new RandomIdGenerator(), embedding);
+	public SimpleVectorStoreContent(String text, Map<String, Object> metadata, float[] embedding) {
+		this(text, metadata, new RandomIdGenerator(), embedding);
 	}
 
 	/**
 	 * Creates a new instance with the given content, metadata, custom ID generator, and
 	 * embedding vector.
-	 * @param content the content text, must not be null
+	 * @param text the content text, must not be null
 	 * @param metadata the metadata map, must not be null
 	 * @param idGenerator the ID generator to use, must not be null
 	 * @param embedding the embedding vector, must not be null
 	 */
-	public SimpleVectorStoreContent(String content, Map<String, Object> metadata, IdGenerator idGenerator,
+	public SimpleVectorStoreContent(String text, Map<String, Object> metadata, IdGenerator idGenerator,
 			float[] embedding) {
-		this(idGenerator.generateId(content, metadata), content, metadata, embedding);
+		this(idGenerator.generateId(text, metadata), text, metadata, embedding);
 	}
 
 	/**
 	 * Creates a new instance with all fields specified.
 	 * @param id the unique identifier, must not be empty
-	 * @param content the content text, must not be null
+	 * @param text the content text, must not be null
 	 * @param metadata the metadata map, must not be null
 	 * @param embedding the embedding vector, must not be null
 	 * @throws IllegalArgumentException if any parameter is null or if id is empty
 	 */
-	public SimpleVectorStoreContent(String id, String content, Map<String, Object> metadata, float[] embedding) {
+	public SimpleVectorStoreContent(String id, String text, Map<String, Object> metadata, float[] embedding) {
 		Assert.hasText(id, "id must not be null or empty");
-		Assert.notNull(content, "content must not be null");
+		Assert.notNull(text, "content must not be null");
 		Assert.notNull(metadata, "metadata must not be null");
 		Assert.notNull(embedding, "embedding must not be null");
 		Assert.isTrue(embedding.length > 0, "embedding vector must not be empty");
 
 		this.id = id;
-		this.content = content;
+		this.text = text;
 		this.metadata = Collections.unmodifiableMap(new HashMap<>(metadata));
 		this.embedding = Arrays.copyOf(embedding, embedding.length);
 	}
@@ -112,7 +114,7 @@ public final class SimpleVectorStoreContent implements Content {
 	public SimpleVectorStoreContent withEmbedding(float[] embedding) {
 		Assert.notNull(embedding, "embedding must not be null");
 		Assert.isTrue(embedding.length > 0, "embedding vector must not be empty");
-		return new SimpleVectorStoreContent(this.id, this.content, this.metadata, embedding);
+		return new SimpleVectorStoreContent(this.id, this.text, this.metadata, embedding);
 	}
 
 	public String getId() {
@@ -120,8 +122,8 @@ public final class SimpleVectorStoreContent implements Content {
 	}
 
 	@Override
-	public String getContent() {
-		return this.content;
+	public String getText() {
+		return this.text;
 	}
 
 	@Override
@@ -140,7 +142,7 @@ public final class SimpleVectorStoreContent implements Content {
 	public Document toDocument(Double score) {
 		var metadata = new HashMap<>(this.metadata);
 		metadata.put(DocumentMetadata.DISTANCE.value(), 1.0 - score);
-		return Document.builder().id(this.id).content(this.content).metadata(metadata).score(score).build();
+		return Document.builder().id(this.id).text(this.text).metadata(metadata).score(score).build();
 	}
 
 	@Override
@@ -152,14 +154,14 @@ public final class SimpleVectorStoreContent implements Content {
 			return false;
 		}
 		SimpleVectorStoreContent that = (SimpleVectorStoreContent) o;
-		return Objects.equals(this.id, that.id) && Objects.equals(this.content, that.content)
+		return Objects.equals(this.id, that.id) && Objects.equals(this.text, that.text)
 				&& Objects.equals(this.metadata, that.metadata) && Arrays.equals(this.embedding, that.embedding);
 	}
 
 	@Override
 	public int hashCode() {
 		int result = Objects.hashCode(this.id);
-		result = 31 * result + Objects.hashCode(this.content);
+		result = 31 * result + Objects.hashCode(this.text);
 		result = 31 * result + Objects.hashCode(this.metadata);
 		result = 31 * result + Arrays.hashCode(this.embedding);
 		return result;
@@ -167,8 +169,8 @@ public final class SimpleVectorStoreContent implements Content {
 
 	@Override
 	public String toString() {
-		return "SimpleVectorStoreContent{" + "id='" + this.id + '\'' + ", content='" + this.content + '\''
-				+ ", metadata=" + this.metadata + ", embedding=" + Arrays.toString(this.embedding) + '}';
+		return "SimpleVectorStoreContent{" + "id='" + this.id + '\'' + ", content='" + this.text + '\'' + ", metadata="
+				+ this.metadata + ", embedding=" + Arrays.toString(this.embedding) + '}';
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/ChatModelTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/ChatModelTests.java
@@ -53,7 +53,7 @@ class ChatModelTests {
 		ChatModel mockClient = Mockito.mock(ChatModel.class);
 
 		AssistantMessage mockAssistantMessage = Mockito.mock(AssistantMessage.class);
-		given(mockAssistantMessage.getContent()).willReturn(responseMessage);
+		given(mockAssistantMessage.getText()).willReturn(responseMessage);
 
 		// Create a mock Generation
 		Generation generation = Mockito.mock(Generation.class);
@@ -84,7 +84,7 @@ class ChatModelTests {
 		verify(mockClient, times(1)).call(isA(Prompt.class));
 		verify(response, times(1)).getResult();
 		verify(generation, times(1)).getOutput();
-		verify(mockAssistantMessage, times(1)).getContent();
+		verify(mockAssistantMessage, times(1)).getText();
 		verifyNoMoreInteractions(mockClient, generation, response);
 	}
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientAdvisorTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientAdvisorTests.java
@@ -85,11 +85,11 @@ public class ChatClientAdvisorTests {
 
 		ChatResponse chatResponse = chatClient.prompt().user("my name is John").call().chatResponse();
 
-		String content = chatResponse.getResult().getOutput().getContent();
+		String content = chatResponse.getResult().getOutput().getText();
 		assertThat(content).isEqualTo("Hello John");
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+		assertThat(systemMessage.getText()).isEqualToIgnoringWhitespace("""
 				Default system text.
 
 				Use the conversation memory from the MEMORY section to provide accurate answers.
@@ -101,14 +101,14 @@ public class ChatClientAdvisorTests {
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("my name is John");
+		assertThat(userMessage.getText()).isEqualToIgnoringWhitespace("my name is John");
 
 		content = chatClient.prompt().user("What is my name?").call().content();
 
 		assertThat(content).isEqualTo("Your name is John");
 
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+		assertThat(systemMessage.getText()).isEqualToIgnoringWhitespace("""
 				Default system text.
 
 				Use the conversation memory from the MEMORY section to provide accurate answers.
@@ -122,7 +122,7 @@ public class ChatClientAdvisorTests {
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("What is my name?");
+		assertThat(userMessage.getText()).isEqualToIgnoringWhitespace("What is my name?");
 	}
 
 	@Test
@@ -154,7 +154,7 @@ public class ChatClientAdvisorTests {
 		assertThat(content).isEqualTo("Hello John");
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+		assertThat(systemMessage.getText()).isEqualToIgnoringWhitespace("""
 				Default system text.
 
 				Use the conversation memory from the MEMORY section to provide accurate answers.
@@ -166,14 +166,14 @@ public class ChatClientAdvisorTests {
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("my name is John");
+		assertThat(userMessage.getText()).isEqualToIgnoringWhitespace("my name is John");
 
 		content = join(chatClient.prompt().user("What is my name?").stream().content());
 
 		assertThat(content).isEqualTo("Your name is John");
 
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+		assertThat(systemMessage.getText()).isEqualToIgnoringWhitespace("""
 				Default system text.
 
 				Use the conversation memory from the MEMORY section to provide accurate answers.
@@ -187,7 +187,7 @@ public class ChatClientAdvisorTests {
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("What is my name?");
+		assertThat(userMessage.getText()).isEqualToIgnoringWhitespace("What is my name?");
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientResponseEntityTests.java
@@ -77,7 +77,7 @@ public class ChatClientResponseEntityTests {
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).contains("Tell me about John");
+		assertThat(userMessage.getText()).contains("Tell me about John");
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class ChatClientResponseEntityTests {
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).contains("Tell me about them");
+		assertThat(userMessage.getText()).contains("Tell me about them");
 	}
 
 	@Test
@@ -132,7 +132,7 @@ public class ChatClientResponseEntityTests {
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).contains("Tell me about Max");
+		assertThat(userMessage.getText()).contains("Tell me about Max");
 	}
 
 	record MyBean(String name, int age) {

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/ChatClientTest.java
@@ -91,7 +91,7 @@ public class ChatClientTest {
 		assertThat(content).isEqualTo("response");
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		content = join(chatClient.prompt("What's Spring AI?").stream().content());
@@ -99,7 +99,7 @@ public class ChatClientTest {
 		assertThat(content).isEqualTo("response");
 
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		// Override the default system text with prompt system
@@ -107,7 +107,7 @@ public class ChatClientTest {
 
 		assertThat(content).isEqualTo("response");
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Override default system text");
+		assertThat(systemMessage.getText()).isEqualTo("Override default system text");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		// Streaming
@@ -116,7 +116,7 @@ public class ChatClientTest {
 
 		assertThat(content).isEqualTo("response");
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Override default system text");
+		assertThat(systemMessage.getText()).isEqualTo("Override default system text");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -144,7 +144,7 @@ public class ChatClientTest {
 		assertThat(content).isEqualTo("response");
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text value1, value2");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		// Streaming
@@ -153,7 +153,7 @@ public class ChatClientTest {
 		assertThat(content).isEqualTo("response");
 
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text value1, value2");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		// Override single default system parameter
@@ -161,7 +161,7 @@ public class ChatClientTest {
 
 		assertThat(content).isEqualTo("response");
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text value1New, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text value1New, value2");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		// streaming
@@ -170,7 +170,7 @@ public class ChatClientTest {
 
 		assertThat(content).isEqualTo("response");
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text value1New, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text value1New, value2");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		// Override default system text
@@ -181,7 +181,7 @@ public class ChatClientTest {
 
 		assertThat(content).isEqualTo("response");
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Override default system text value3");
+		assertThat(systemMessage.getText()).isEqualTo("Override default system text value3");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		// Streaming
@@ -192,7 +192,7 @@ public class ChatClientTest {
 
 		assertThat(content).isEqualTo("response");
 		systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("Override default system text value3");
+		assertThat(systemMessage.getText()).isEqualTo("Override default system text value3");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -239,11 +239,11 @@ public class ChatClientTest {
 
 		Message systemMessage = prompt.getInstructions().get(0);
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text value1, value2");
 
 		UserMessage userMessage = (UserMessage) prompt.getInstructions().get(1);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).isEqualTo("Default user text value1, value2");
+		assertThat(userMessage.getText()).isEqualTo("Default user text value1, value2");
 		assertThat(userMessage.getMedia()).hasSize(1);
 		assertThat(userMessage.getMedia().iterator().next().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_JPEG);
 
@@ -261,11 +261,11 @@ public class ChatClientTest {
 
 		systemMessage = prompt.getInstructions().get(0);
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
-		assertThat(systemMessage.getContent()).isEqualTo("Default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Default system text value1, value2");
 
 		userMessage = (UserMessage) prompt.getInstructions().get(1);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).isEqualTo("Default user text value1, value2");
+		assertThat(userMessage.getText()).isEqualTo("Default user text value1, value2");
 		assertThat(userMessage.getMedia()).hasSize(1);
 		assertThat(userMessage.getMedia().iterator().next().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_JPEG);
 
@@ -291,11 +291,11 @@ public class ChatClientTest {
 
 		systemMessage = prompt.getInstructions().get(0);
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
-		assertThat(systemMessage.getContent()).isEqualTo("Mutated default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Mutated default system text value1, value2");
 
 		userMessage = (UserMessage) prompt.getInstructions().get(1);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).isEqualTo("Mutated default user text value1, value2");
+		assertThat(userMessage.getText()).isEqualTo("Mutated default user text value1, value2");
 		assertThat(userMessage.getMedia()).hasSize(1);
 		assertThat(userMessage.getMedia().iterator().next().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_JPEG);
 
@@ -313,11 +313,11 @@ public class ChatClientTest {
 
 		systemMessage = prompt.getInstructions().get(0);
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
-		assertThat(systemMessage.getContent()).isEqualTo("Mutated default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("Mutated default system text value1, value2");
 
 		userMessage = (UserMessage) prompt.getInstructions().get(1);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).isEqualTo("Mutated default user text value1, value2");
+		assertThat(userMessage.getText()).isEqualTo("Mutated default user text value1, value2");
 		assertThat(userMessage.getMedia()).hasSize(1);
 		assertThat(userMessage.getMedia().iterator().next().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_JPEG);
 
@@ -377,11 +377,11 @@ public class ChatClientTest {
 
 		Message systemMessage = prompt.getInstructions().get(0);
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
-		assertThat(systemMessage.getContent()).isEqualTo("New default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("New default system text value1, value2");
 
 		UserMessage userMessage = (UserMessage) prompt.getInstructions().get(1);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).isEqualTo("Default user text userValue1, userValue2");
+		assertThat(userMessage.getText()).isEqualTo("Default user text userValue1, userValue2");
 		assertThat(userMessage.getMedia()).hasSize(1);
 		assertThat(userMessage.getMedia().iterator().next().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_JPEG);
 
@@ -408,11 +408,11 @@ public class ChatClientTest {
 
 		systemMessage = prompt.getInstructions().get(0);
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
-		assertThat(systemMessage.getContent()).isEqualTo("New default system text value1, value2");
+		assertThat(systemMessage.getText()).isEqualTo("New default system text value1, value2");
 
 		userMessage = (UserMessage) prompt.getInstructions().get(1);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).isEqualTo("Default user text userValue1, userValue2");
+		assertThat(userMessage.getText()).isEqualTo("Default user text userValue1, userValue2");
 		assertThat(userMessage.getMedia()).hasSize(1);
 		assertThat(userMessage.getMedia().iterator().next().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_JPEG);
 
@@ -435,7 +435,7 @@ public class ChatClientTest {
 		assertThat(content).isEqualTo("response");
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(userMessage.getContent()).isEqualTo("Default user text");
+		assertThat(userMessage.getText()).isEqualTo("Default user text");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 
 		// Override the default system text with prompt system
@@ -443,7 +443,7 @@ public class ChatClientTest {
 
 		assertThat(content).isEqualTo("response");
 		userMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(userMessage.getContent()).isEqualTo("Override default user text");
+		assertThat(userMessage.getText()).isEqualTo("Override default user text");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -456,7 +456,7 @@ public class ChatClientTest {
 			.isEqualTo("response");
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(userMessage.getContent()).isEqualTo("User prompt");
+		assertThat(userMessage.getText()).isEqualTo("User prompt");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -469,7 +469,7 @@ public class ChatClientTest {
 			.isEqualTo("response");
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(userMessage.getContent()).isEqualTo("User prompt");
+		assertThat(userMessage.getText()).isEqualTo("User prompt");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -488,7 +488,7 @@ public class ChatClientTest {
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(1);
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getContent()).isEqualTo("User prompt");
+		assertThat(userMessage.getText()).isEqualTo("User prompt");
 		assertThat(((UserMessage) userMessage).getMedia()).hasSize(1);
 	}
 
@@ -509,7 +509,7 @@ public class ChatClientTest {
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(2);
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("System prompt");
+		assertThat(systemMessage.getText()).isEqualTo("System prompt");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -539,11 +539,11 @@ public class ChatClientTest {
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(2);
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("System text");
+		assertThat(systemMessage.getText()).isEqualTo("System text");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		UserMessage userMessage = (UserMessage) this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualTo("User text Rock");
+		assertThat(userMessage.getText()).isEqualTo("User text Rock");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getMedia()).hasSize(1);
 		assertThat(userMessage.getMedia().iterator().next().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_PNG);
@@ -598,7 +598,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(1);
 		var userMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(userMessage.getContent()).isEqualTo("my question");
+		assertThat(userMessage.getText()).isEqualTo("my question");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -615,7 +615,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(2);
 		var userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualTo("my question");
+		assertThat(userMessage.getText()).isEqualTo("my question");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -631,7 +631,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(2);
 		var userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualTo("another question");
+		assertThat(userMessage.getText()).isEqualTo("another question");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -648,7 +648,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(3);
 		var userMessage = this.promptCaptor.getValue().getInstructions().get(2);
-		assertThat(userMessage.getContent()).isEqualTo("another question");
+		assertThat(userMessage.getText()).isEqualTo("another question");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -665,7 +665,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(2);
 		var userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualTo("another question");
+		assertThat(userMessage.getText()).isEqualTo("another question");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -682,7 +682,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(3);
 		var userMessage = this.promptCaptor.getValue().getInstructions().get(2);
-		assertThat(userMessage.getContent()).isEqualTo("another question");
+		assertThat(userMessage.getText()).isEqualTo("another question");
 	}
 
 	@Test
@@ -698,7 +698,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(2);
 		var userMessage = this.promptCaptor.getValue().getInstructions().get(1);
-		assertThat(userMessage.getContent()).isEqualTo("another question");
+		assertThat(userMessage.getText()).isEqualTo("another question");
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 	}
 
@@ -717,7 +717,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(4);
 		var systemMessage = this.promptCaptor.getValue().getInstructions().get(2);
-		assertThat(systemMessage.getContent()).isEqualTo("instructions");
+		assertThat(systemMessage.getText()).isEqualTo("instructions");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -734,7 +734,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(3);
 		var systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("instructions");
+		assertThat(systemMessage.getText()).isEqualTo("instructions");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -751,7 +751,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(4);
 		var systemMessage = this.promptCaptor.getValue().getInstructions().get(2);
-		assertThat(systemMessage.getContent()).isEqualTo("other instructions");
+		assertThat(systemMessage.getText()).isEqualTo("other instructions");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -773,7 +773,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(4);
 		var systemMessage = this.promptCaptor.getValue().getInstructions().get(2);
-		assertThat(systemMessage.getContent()).isEqualTo("instructions");
+		assertThat(systemMessage.getText()).isEqualTo("instructions");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -790,7 +790,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(3);
 		var systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(systemMessage.getContent()).isEqualTo("instructions");
+		assertThat(systemMessage.getText()).isEqualTo("instructions");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 
@@ -812,7 +812,7 @@ public class ChatClientTest {
 
 		assertThat(this.promptCaptor.getValue().getInstructions()).hasSize(4);
 		var systemMessage = this.promptCaptor.getValue().getInstructions().get(2);
-		assertThat(systemMessage.getContent()).isEqualTo("other instructions");
+		assertThat(systemMessage.getText()).isEqualTo("other instructions");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 	}
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -97,7 +97,7 @@ class DefaultChatClientTests {
 		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
 			.prompt("my question");
 		assertThat(spec.getMessages()).hasSize(1);
-		assertThat(spec.getMessages().get(0).getContent()).isEqualTo("my question");
+		assertThat(spec.getMessages().get(0).getText()).isEqualTo("my question");
 	}
 
 	@Test
@@ -107,8 +107,8 @@ class DefaultChatClientTests {
 		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
 			.prompt(prompt);
 		assertThat(spec.getMessages()).hasSize(2);
-		assertThat(spec.getMessages().get(0).getContent()).isEqualTo("instructions");
-		assertThat(spec.getMessages().get(1).getContent()).isEqualTo("my question");
+		assertThat(spec.getMessages().get(0).getText()).isEqualTo("instructions");
+		assertThat(spec.getMessages().get(1).getText()).isEqualTo("my question");
 		assertThat(spec.getChatOptions()).isNull();
 	}
 
@@ -627,11 +627,11 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(1);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("my question");
 	}
 
 	@Test
@@ -650,12 +650,12 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(2);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("instructions");
-		assertThat(actualPrompt.getInstructions().get(1).getContent()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("instructions");
+		assertThat(actualPrompt.getInstructions().get(1).getText()).isEqualTo("my question");
 	}
 
 	@Test
@@ -675,13 +675,13 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(3);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("instructions");
-		assertThat(actualPrompt.getInstructions().get(1).getContent()).isEqualTo("my question");
-		assertThat(actualPrompt.getInstructions().get(2).getContent()).isEqualTo("another question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("instructions");
+		assertThat(actualPrompt.getInstructions().get(1).getText()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(2).getText()).isEqualTo("another question");
 	}
 
 	@Test
@@ -702,13 +702,13 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(3);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("instructions");
-		assertThat(actualPrompt.getInstructions().get(1).getContent()).isEqualTo("my question");
-		assertThat(actualPrompt.getInstructions().get(2).getContent()).isEqualTo("another question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("instructions");
+		assertThat(actualPrompt.getInstructions().get(1).getText()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(2).getText()).isEqualTo("another question");
 	}
 
 	@Test
@@ -1090,11 +1090,11 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse().blockLast();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(1);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("my question");
 	}
 
 	@Test
@@ -1113,12 +1113,12 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse().blockLast();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(2);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("instructions");
-		assertThat(actualPrompt.getInstructions().get(1).getContent()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("instructions");
+		assertThat(actualPrompt.getInstructions().get(1).getText()).isEqualTo("my question");
 	}
 
 	@Test
@@ -1138,13 +1138,13 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse().blockLast();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(3);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("instructions");
-		assertThat(actualPrompt.getInstructions().get(1).getContent()).isEqualTo("my question");
-		assertThat(actualPrompt.getInstructions().get(2).getContent()).isEqualTo("another question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("instructions");
+		assertThat(actualPrompt.getInstructions().get(1).getText()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(2).getText()).isEqualTo("another question");
 	}
 
 	@Test
@@ -1165,13 +1165,13 @@ class DefaultChatClientTests {
 
 		ChatResponse chatResponse = spec.chatResponse().blockLast();
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("response");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("response");
 
 		Prompt actualPrompt = promptCaptor.getValue();
 		assertThat(actualPrompt.getInstructions()).hasSize(3);
-		assertThat(actualPrompt.getInstructions().get(0).getContent()).isEqualTo("instructions");
-		assertThat(actualPrompt.getInstructions().get(1).getContent()).isEqualTo("my question");
-		assertThat(actualPrompt.getInstructions().get(2).getContent()).isEqualTo("another question");
+		assertThat(actualPrompt.getInstructions().get(0).getText()).isEqualTo("instructions");
+		assertThat(actualPrompt.getInstructions().get(1).getText()).isEqualTo("my question");
+		assertThat(actualPrompt.getInstructions().get(2).getText()).isEqualTo("another question");
 	}
 
 	@Test

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisorTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisorTests.java
@@ -148,22 +148,22 @@ public class QuestionAnswerAdvisorTests {
 		assertThat(response.getMetadata().get("key6").toString()).isEqualTo("value6");
 		assertThat(response.getMetadata().get("key1").toString()).isEqualTo("value1");
 
-		String content = response.getResult().getOutput().getContent();
+		String content = response.getResult().getOutput().getText();
 
 		assertThat(content).isEqualTo("Your answer is ZXY");
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
 
-		System.out.println(systemMessage.getContent());
+		System.out.println(systemMessage.getText());
 
-		assertThat(systemMessage.getContent()).isEqualToIgnoringWhitespace("""
+		assertThat(systemMessage.getText()).isEqualToIgnoringWhitespace("""
 				Default system text.
 				""");
 		assertThat(systemMessage.getMessageType()).isEqualTo(MessageType.SYSTEM);
 
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(1);
 
-		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("""
+		assertThat(userMessage.getText()).isEqualToIgnoringWhitespace("""
 			Please answer my question XYZ
 			Context information is below, surrounded by ---------------------
 
@@ -204,7 +204,7 @@ public class QuestionAnswerAdvisorTests {
 		//formatter:on
 
 		var expectedQuery = "Please answer my question XYZ";
-		var userPrompt = this.promptCaptor.getValue().getInstructions().get(0).getContent();
+		var userPrompt = this.promptCaptor.getValue().getInstructions().get(0).getText();
 		assertThat(userPrompt).doesNotContain(userTextTemplate);
 		assertThat(userPrompt).contains(expectedQuery);
 		assertThat(this.vectorSearchCaptor.getValue().getQuery()).isEqualTo(expectedQuery);
@@ -233,7 +233,7 @@ public class QuestionAnswerAdvisorTests {
 		//formatter:on
 
 		var expectedQuery = "Please answer my question XYZ";
-		var userPrompt = this.promptCaptor.getValue().getInstructions().get(0).getContent();
+		var userPrompt = this.promptCaptor.getValue().getInstructions().get(0).getText();
 		assertThat(userPrompt).doesNotContain(userTextTemplate);
 		assertThat(userPrompt).contains(expectedQuery);
 		assertThat(this.vectorSearchCaptor.getValue().getQuery()).isEqualTo(expectedQuery);

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisorTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisorTests.java
@@ -70,8 +70,8 @@ class RetrievalAugmentationAdvisorTests {
 			.build());
 
 		// Document Retriever
-		var documentContext = List.of(Document.builder().id("1").content("doc1").build(),
-				Document.builder().id("2").content("doc2").build());
+		var documentContext = List.of(Document.builder().id("1").text("doc1").build(),
+				Document.builder().id("2").text("doc2").build());
 		var documentRetriever = mock(DocumentRetriever.class);
 		var queryCaptor = ArgumentCaptor.forClass(Query.class);
 		given(documentRetriever.retrieve(queryCaptor.capture())).willReturn(documentContext);
@@ -94,7 +94,7 @@ class RetrievalAugmentationAdvisorTests {
 			.chatResponse();
 
 		// Verify
-		assertThat(chatResponse.getResult().getOutput().getContent()).isEqualTo("Felix Felicis");
+		assertThat(chatResponse.getResult().getOutput().getText()).isEqualTo("Felix Felicis");
 		assertThat(chatResponse.getMetadata().<List<Document>>get(RetrievalAugmentationAdvisor.DOCUMENT_CONTEXT))
 			.containsAll(documentContext);
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/SimpleLoggerAdvisorTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/SimpleLoggerAdvisorTests.java
@@ -101,7 +101,7 @@ public class SimpleLoggerAdvisorTests {
 		assertThat(content).isEqualTo("Your answer is ZXY");
 
 		UserMessage userMessage = (UserMessage) this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(userMessage.getContent()).isEqualToIgnoringWhitespace("Please answer my question XYZ");
+		assertThat(userMessage.getText()).isEqualToIgnoringWhitespace("Please answer my question XYZ");
 
 		assertThat(output.getOut()).contains("request: AdvisedRequest", "userText=Please answer my question XYZ");
 		assertThat(output.getOut()).contains("response:", "finishReason");

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/model/GenerationTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/model/GenerationTests.java
@@ -52,7 +52,7 @@ public class GenerationTests {
 		AssistantMessage assistantMessage = new AssistantMessage(expectedText);
 		Generation generation = new Generation(assistantMessage);
 
-		assertEquals(expectedText, generation.getOutput().getContent());
+		assertEquals(expectedText, generation.getOutput().getText());
 	}
 
 	@Test

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
@@ -61,35 +61,5 @@ public class ContentFormatterTests {
 			.isEqualTo(defaultConfigFormatter.format(this.document, MetadataMode.ALL));
 	}
 
-	@Test
-	public void customTextFormatter() {
-
-		DefaultContentFormatter textFormatter = DefaultContentFormatter.builder()
-			.withExcludedEmbedMetadataKeys("embedKey2", "embedKey3")
-			.withExcludedInferenceMetadataKeys("llmKey2")
-			.withTextTemplate("Metadata:\n{metadata_string}\n\nText:{content}")
-			.withMetadataTemplate("Key/Value {key}={value}")
-			.build();
-
-		assertThat(this.document.getFormattedContent(textFormatter, MetadataMode.EMBED)).isEqualTo("""
-				Metadata:
-				Key/Value llmKey2=value4
-				Key/Value embedKey1=value1
-
-				Text:The World is Big and Salvation Lurks Around the Corner""");
-
-		assertThat(this.document.getContent()).isEqualTo("""
-				The World is Big and Salvation Lurks Around the Corner""");
-
-		assertThat(this.document.getFormattedContent(textFormatter, MetadataMode.EMBED))
-			.isEqualTo(textFormatter.format(this.document, MetadataMode.EMBED));
-
-		var documentWithCustomFormatter = new Document(this.document.getId(), this.document.getContent(),
-				this.document.getMetadata());
-		documentWithCustomFormatter.setContentFormatter(textFormatter);
-
-		assertThat(this.document.getFormattedContent(textFormatter, MetadataMode.ALL))
-			.isEqualTo(documentWithCustomFormatter.getFormattedContent());
-	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/ContentFormatterTests.java
@@ -61,5 +61,4 @@ public class ContentFormatterTests {
 			.isEqualTo(defaultConfigFormatter.format(this.document, MetadataMode.ALL));
 	}
 
-
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentBuilderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentBuilderTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.document;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -36,13 +35,11 @@ public class DocumentBuilderTests {
 
 	private Document.Builder builder;
 
-	private static List<Media> getMediaList() {
+	private static Media getMedia() {
 		try {
 			URL mediaUrl1 = new URL("http://type1");
-			URL mediaUrl2 = new URL("http://type2");
 			Media media1 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl1);
-			Media media2 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl2);
-			return List.of(media1, media2);
+			return media1;
 		}
 		catch (MalformedURLException e) {
 			throw new RuntimeException(e);
@@ -75,7 +72,7 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithId() {
-		Document.Builder result = this.builder.id("testId");
+		Document.Builder result = this.builder.text("text").id("testId");
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getId()).isEqualTo("testId");
@@ -83,10 +80,10 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithIdNullOrEmpty() {
-		assertThatThrownBy(() -> this.builder.id(null).build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> this.builder.text("text").id(null).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("id cannot be null or empty");
 
-		assertThatThrownBy(() -> this.builder.id("").build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> this.builder.text("text").id("").build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("id cannot be null or empty");
 	}
 
@@ -98,27 +95,6 @@ public class DocumentBuilderTests {
 		assertThat(result.build().getContent()).isEqualTo("Test content");
 	}
 
-	@Test
-	void testWithContentNull() {
-		assertThatThrownBy(() -> this.builder.content(null).build()).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("content cannot be null");
-	}
-
-	@Test
-	void testWithMediaList() {
-		List<Media> mediaList = getMediaList();
-		Document.Builder result = this.builder.media(mediaList);
-
-		assertThat(result).isSameAs(this.builder);
-		assertThat(result.build().getMedia()).isEqualTo(mediaList);
-	}
-
-	@Test
-	void testWithMediaListNull() {
-		assertThatThrownBy(() -> this.builder.media((List<Media>) null).build())
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("media cannot be null");
-	}
 
 	@Test
 	void testWithMediaSingle() throws MalformedURLException {
@@ -128,13 +104,7 @@ public class DocumentBuilderTests {
 		Document.Builder result = this.builder.media(media);
 
 		assertThat(result).isSameAs(this.builder);
-		assertThat(result.build().getMedia()).contains(media);
-	}
-
-	@Test
-	void testWithMediaSingleNull() {
-		assertThatThrownBy(() -> this.builder.media((Media) null).build()).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("media cannot contain null elements");
+		assertThat(result.build().getMedia()).isEqualTo(media);
 	}
 
 	@Test
@@ -142,7 +112,7 @@ public class DocumentBuilderTests {
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key1", "value1");
 		metadata.put("key2", 2);
-		Document.Builder result = this.builder.metadata(metadata);
+		Document.Builder result = this.builder.text("text").metadata(metadata);
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getMetadata()).isEqualTo(metadata);
@@ -150,7 +120,7 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithMetadataMapNull() {
-		assertThatThrownBy(() -> this.builder.metadata(null).build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> this.builder.text("text").metadata(null).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("metadata cannot be null");
 	}
 
@@ -159,26 +129,26 @@ public class DocumentBuilderTests {
 		Document.Builder result = this.builder.metadata("key", "value");
 
 		assertThat(result).isSameAs(this.builder);
-		assertThat(result.build().getMetadata()).containsEntry("key", "value");
+		assertThat(result.text("text").build().getMetadata()).containsEntry("key", "value");
 	}
 
 	@Test
 	void testWithMetadataKeyNull() {
-		assertThatThrownBy(() -> this.builder.metadata(null, "value").build())
+		assertThatThrownBy(() -> this.builder.text("text").metadata(null, "value").build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("metadata cannot have null keys");
 	}
 
 	@Test
 	void testWithMetadataValueNull() {
-		assertThatThrownBy(() -> this.builder.metadata("key", null).build())
+		assertThatThrownBy(() -> this.builder.text("text").metadata("key", null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("metadata cannot have null values");
 	}
 
 	@Test
 	void testBuildWithoutId() {
-		Document document = this.builder.content("Test content").build();
+		Document document = this.builder.text("text").content("Test content").build();
 
 		assertThat(document.getId()).isNotNull().isNotEmpty();
 		assertThat(document.getContent()).isEqualTo("Test content");
@@ -187,19 +157,17 @@ public class DocumentBuilderTests {
 	@Test
 	void testBuildWithAllProperties() {
 
-		List<Media> mediaList = getMediaList();
+		Media media = getMedia();
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key", "value");
 
 		Document document = this.builder.id("customId")
-			.content("Test content")
-			.media(mediaList)
+			.text("Test content")
 			.metadata(metadata)
 			.build();
 
 		assertThat(document.getId()).isEqualTo("customId");
-		assertThat(document.getContent()).isEqualTo("Test content");
-		assertThat(document.getMedia()).isEqualTo(mediaList);
+		assertThat(document.getText()).isEqualTo("Test content");
 		assertThat(document.getMetadata()).isEqualTo(metadata);
 	}
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentBuilderTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentBuilderTests.java
@@ -59,7 +59,7 @@ public class DocumentBuilderTests {
 
 		assertThat(result).isSameAs(this.builder);
 
-		Document document = result.content("Test content").metadata("key", "value").build();
+		Document document = result.text("Test content").metadata("key", "value").build();
 
 		assertThat(document.getId()).isEqualTo("mockedId");
 	}
@@ -80,7 +80,8 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithIdNullOrEmpty() {
-		assertThatThrownBy(() -> this.builder.text("text").id(null).build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> this.builder.text("text").id(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("id cannot be null or empty");
 
 		assertThatThrownBy(() -> this.builder.text("text").id("").build()).isInstanceOf(IllegalArgumentException.class)
@@ -89,12 +90,11 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithContent() {
-		Document.Builder result = this.builder.content("Test content");
+		Document.Builder result = this.builder.text("Test content");
 
 		assertThat(result).isSameAs(this.builder);
 		assertThat(result.build().getContent()).isEqualTo("Test content");
 	}
-
 
 	@Test
 	void testWithMediaSingle() throws MalformedURLException {
@@ -120,7 +120,8 @@ public class DocumentBuilderTests {
 
 	@Test
 	void testWithMetadataMapNull() {
-		assertThatThrownBy(() -> this.builder.text("text").metadata(null).build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> this.builder.text("text").metadata(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("metadata cannot be null");
 	}
 
@@ -136,19 +137,19 @@ public class DocumentBuilderTests {
 	void testWithMetadataKeyNull() {
 		assertThatThrownBy(() -> this.builder.text("text").metadata(null, "value").build())
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("metadata cannot have null keys");
+			.hasMessageContaining("metadata key cannot be null");
 	}
 
 	@Test
 	void testWithMetadataValueNull() {
 		assertThatThrownBy(() -> this.builder.text("text").metadata("key", null).build())
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("metadata cannot have null values");
+			.hasMessageContaining("metadata value cannot be null");
 	}
 
 	@Test
 	void testBuildWithoutId() {
-		Document document = this.builder.text("text").content("Test content").build();
+		Document document = this.builder.text("text").text("Test content").build();
 
 		assertThat(document.getId()).isNotNull().isNotEmpty();
 		assertThat(document.getContent()).isEqualTo("Test content");
@@ -161,10 +162,7 @@ public class DocumentBuilderTests {
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key", "value");
 
-		Document document = this.builder.id("customId")
-			.text("Test content")
-			.metadata(metadata)
-			.build();
+		Document document = this.builder.id("customId").text("Test content").metadata(metadata).build();
 
 		assertThat(document.getId()).isEqualTo("customId");
 		assertThat(document.getText()).isEqualTo("Test content");

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DocumentTests {
 
@@ -46,29 +47,8 @@ public class DocumentTests {
 	}
 
 	@Test
-	void testMediaBuilderIsAdditive() {
-		try {
-			URL mediaUrl1 = new URL("http://type1");
-			URL mediaUrl2 = new URL("http://type2");
-			URL mediaUrl3 = new URL("http://type3");
-
-			Media media1 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl1);
-			Media media2 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl2);
-			Media media3 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl3);
-
-			Document document = Document.builder().media(media1).media(media2).media(List.of(media3)).build();
-
-			assertThat(document.getMedia()).hasSize(3).containsExactly(media1, media2, media3);
-
-		}
-		catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@Test
 	void testMutate() {
-		List<Media> mediaList = getMediaList();
+		Media media = getMedia();
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key", "value");
 		Double score = 0.95;
@@ -76,7 +56,7 @@ public class DocumentTests {
 		Document original = Document.builder()
 			.id("customId")
 			.content("Test content")
-			.media(mediaList)
+			.media(null)
 			.metadata(metadata)
 			.score(score)
 			.build();
@@ -88,23 +68,21 @@ public class DocumentTests {
 
 	@Test
 	void testEquals() {
-		List<Media> mediaList = getMediaList();
+		Media media = getMedia();
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key", "value");
 		Double score = 0.95;
 
 		Document doc1 = Document.builder()
 			.id("customId")
-			.content("Test content")
-			.media(mediaList)
+			.text("Test text")
 			.metadata(metadata)
 			.score(score)
 			.build();
 
 		Document doc2 = Document.builder()
 			.id("customId")
-			.content("Test content")
-			.media(mediaList)
+			.text("Test text")
 			.metadata(metadata)
 			.score(score)
 			.build();
@@ -112,7 +90,6 @@ public class DocumentTests {
 		Document differentDoc = Document.builder()
 			.id("differentId")
 			.content("Different content")
-			.media(mediaList)
 			.metadata(metadata)
 			.score(score)
 			.build();
@@ -124,17 +101,12 @@ public class DocumentTests {
 
 	@Test
 	void testEmptyDocument() {
-		Document emptyDoc = Document.builder().build();
-
-		assertThat(emptyDoc.getContent()).isEqualTo(Document.EMPTY_TEXT).isEmpty();
-		assertThat(emptyDoc.getMedia()).isEmpty();
-		assertThat(emptyDoc.getMetadata()).isEmpty();
-		assertThat(emptyDoc.getScore()).isNull();
+		assertThrows(IllegalArgumentException.class, () -> Document.builder().build());
 	}
 
 	@Test
 	void testToString() {
-		List<Media> mediaList = getMediaList();
+		Media media = getMedia();
 		Map<String, Object> metadata = new HashMap<>();
 		metadata.put("key", "value");
 		Double score = 0.95;
@@ -142,7 +114,7 @@ public class DocumentTests {
 		Document document = Document.builder()
 			.id("customId")
 			.content("Test content")
-			.media(mediaList)
+			.media(null)
 			.metadata(metadata)
 			.score(score)
 			.build();
@@ -151,27 +123,16 @@ public class DocumentTests {
 
 		assertThat(toString).contains("id='customId'")
 			.contains("content='Test content'")
-			.contains("media=" + mediaList)
 			.contains("metadata=" + metadata)
 			.contains("score=" + score);
 	}
 
-	@Test
-	void testToStringWithEmptyDocument() {
-		Document emptyDoc = Document.builder().build();
 
-		String toString = emptyDoc.toString();
-
-		assertThat(toString).contains("content=''").contains("media=[]").contains("metadata={}").contains("score=null");
-	}
-
-	private static List<Media> getMediaList() {
+	private static Media getMedia() {
 		try {
 			URL mediaUrl1 = new URL("http://type1");
-			URL mediaUrl2 = new URL("http://type2");
 			Media media1 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl1);
-			Media media2 = new Media(MimeTypeUtils.IMAGE_JPEG, mediaUrl2);
-			return List.of(media1, media2);
+			return media1;
 		}
 		catch (MalformedURLException e) {
 			throw new RuntimeException(e);

--- a/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
@@ -115,7 +115,7 @@ public class PromptTemplateTest {
 		// don't normalize EOLs.
 		// It should be fine on Unix systems. In addition, Git will replace CRLF by LF by
 		// default.
-		assertEqualsWithNormalizedEOLs(expected, message.getContent());
+		assertEqualsWithNormalizedEOLs(expected, message.getText());
 
 		PromptTemplate unfilledPromptTemplate = new PromptTemplate(templateString);
 		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(unfilledPromptTemplate::render)

--- a/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreTests.java
@@ -62,7 +62,7 @@ class SimpleVectorStoreTests {
 
 	@Test
 	void shouldAddAndRetrieveDocument() {
-		Document doc = Document.builder().id("1").content("test content").metadata(Map.of("key", "value")).build();
+		Document doc = Document.builder().id("1").text("test content").metadata(Map.of("key", "value")).build();
 
 		this.vectorStore.add(List.of(doc));
 
@@ -76,8 +76,8 @@ class SimpleVectorStoreTests {
 
 	@Test
 	void shouldAddMultipleDocuments() {
-		List<Document> docs = Arrays.asList(Document.builder().id("1").content("first").build(),
-				Document.builder().id("2").content("second").build());
+		List<Document> docs = Arrays.asList(Document.builder().id("1").text("first").build(),
+				Document.builder().id("2").text("second").build());
 
 		this.vectorStore.add(docs);
 
@@ -100,7 +100,7 @@ class SimpleVectorStoreTests {
 
 	@Test
 	void shouldDeleteDocuments() {
-		Document doc = Document.builder().id("1").content("test content").build();
+		Document doc = Document.builder().id("1").text("test content").build();
 
 		this.vectorStore.add(List.of(doc));
 		assertThat(this.vectorStore.similaritySearch("test")).hasSize(1);
@@ -121,7 +121,7 @@ class SimpleVectorStoreTests {
 		// Configure mock to return different embeddings for different queries
 		when(this.mockEmbeddingModel.embed("query")).thenReturn(new float[] { 0.9f, 0.9f, 0.9f });
 
-		Document doc = Document.builder().id("1").content("test content").build();
+		Document doc = Document.builder().id("1").text("test content").build();
 
 		this.vectorStore.add(List.of(doc));
 
@@ -135,7 +135,7 @@ class SimpleVectorStoreTests {
 	void shouldSaveAndLoadVectorStore() throws IOException {
 		Document doc = Document.builder()
 			.id("1")
-			.content("test content")
+			.text("test content")
 			.metadata(new HashMap<>(Map.of("key", "value")))
 			.build();
 
@@ -181,7 +181,7 @@ class SimpleVectorStoreTests {
 		for (int i = 0; i < numThreads; i++) {
 			final String id = String.valueOf(i);
 			threads[i] = new Thread(() -> {
-				Document doc = Document.builder().id(id).content("content " + id).build();
+				Document doc = Document.builder().id(id).text("content " + id).build();
 				this.vectorStore.add(List.of(doc));
 			});
 			threads[i].start();

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
@@ -96,7 +96,7 @@ class RetrievalAugmentationAdvisorIT {
 
 		assertThat(chatResponse).isNotNull();
 
-		String response = chatResponse.getResult().getOutput().getContent();
+		String response = chatResponse.getResult().getOutput().getText();
 		System.out.println(response);
 		assertThat(response).containsIgnoringCase("Highlands");
 
@@ -126,7 +126,7 @@ class RetrievalAugmentationAdvisorIT {
 
 		assertThat(chatResponse).isNotNull();
 
-		String response = chatResponse.getResult().getOutput().getContent();
+		String response = chatResponse.getResult().getOutput().getText();
 		System.out.println(response);
 		assertThat(response.toLowerCase()).containsAnyOf("highlands", "højland");
 
@@ -154,7 +154,7 @@ class RetrievalAugmentationAdvisorIT {
 
 		assertThat(chatResponse).isNotNull();
 
-		String response = chatResponse.getResult().getOutput().getContent();
+		String response = chatResponse.getResult().getOutput().getText();
 		System.out.println(response);
 		assertThat(response).containsIgnoringCase("Highlands");
 
@@ -164,7 +164,7 @@ class RetrievalAugmentationAdvisorIT {
 	private void evaluateRelevancy(String question, ChatResponse chatResponse) {
 		EvaluationRequest evaluationRequest = new EvaluationRequest(question,
 				chatResponse.getMetadata().get(RetrievalAugmentationAdvisor.DOCUMENT_CONTEXT),
-				chatResponse.getResult().getOutput().getContent());
+				chatResponse.getResult().getOutput().getText());
 		RelevancyEvaluator evaluator = new RelevancyEvaluator(ChatClient.builder(this.openAiChatModel));
 		EvaluationResponse evaluationResponse = evaluator.evaluate(evaluationRequest);
 		assertThat(evaluationResponse.isPass()).isTrue();

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/vectorstore/SimpleVectorStoreIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/vectorstore/SimpleVectorStoreIT.java
@@ -51,17 +51,17 @@ public class SimpleVectorStoreIT {
 	List<Document> documents = List.of(
 			Document.builder()
 				.id("471a8c78-549a-4b2c-bce5-ef3ae6579be3")
-				.content(getText("classpath:/test/data/spring.ai.txt"))
+				.text(getText("classpath:/test/data/spring.ai.txt"))
 				.metadata(Map.of("meta1", "meta1"))
 				.build(),
 			Document.builder()
 				.id("bc51d7f7-627b-4ba6-adf4-f0bcd1998f8f")
-				.content(getText("classpath:/test/data/time.shelter.txt"))
+				.text(getText("classpath:/test/data/time.shelter.txt"))
 				.metadata(Map.of())
 				.build(),
 			Document.builder()
 				.id("d0237682-1150-44ff-b4d2-1be9b1731ee5")
-				.content(getText("classpath:/test/data/great.depression.txt"))
+				.text(getText("classpath:/test/data/great.depression.txt"))
 				.metadata(Map.of("meta2", "meta2"))
 				.build());
 
@@ -84,7 +84,7 @@ public class SimpleVectorStoreIT {
 	public void searchWithThreshold() {
 		Document document = Document.builder()
 			.id(UUID.randomUUID().toString())
-			.content("Spring AI rocks!!")
+			.text("Spring AI rocks!!")
 			.metadata("meta1", "meta1")
 			.build();
 
@@ -101,7 +101,7 @@ public class SimpleVectorStoreIT {
 
 		Document sameIdDocument = Document.builder()
 			.id(document.getId())
-			.content("The World is Big and Salvation Lurks Around the Corner")
+			.text("The World is Big and Salvation Lurks Around the Corner")
 			.metadata("meta2", "meta2")
 			.build();
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/AnthropicAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/AnthropicAutoConfigurationIT.java
@@ -66,7 +66,7 @@ public class AnthropicAutoConfigurationIT {
 				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);
 				var optoins = AnthropicChatOptions.builder().withMaxTokens(8192).build();
 				var response = chatModel.call(new Prompt("Tell me a joke", optoins));
-				assertThat(response.getResult().getOutput().getContent()).isNotEmpty();
+				assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 				logger.info("Response: " + response);
 			});
 	}
@@ -83,7 +83,7 @@ public class AnthropicAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithFunctionBeanIT.java
@@ -70,14 +70,14 @@ class FunctionCallWithFunctionBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
 						AnthropicChatOptions.builder().withFunction("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			});
 	}
@@ -100,7 +100,7 @@ class FunctionCallWithFunctionBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithPromptFunctionIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/anthropic/tool/FunctionCallWithPromptFunctionIT.java
@@ -69,7 +69,7 @@ public class FunctionCallWithPromptFunctionIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiAutoConfigurationIT.java
@@ -98,7 +98,7 @@ class AzureOpenAiAutoConfigurationIT {
 		this.contextRunner.run(context -> {
 			AzureOpenAiChatModel chatModel = context.getBean(AzureOpenAiChatModel.class);
 			ChatResponse response = chatModel.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 
@@ -144,7 +144,7 @@ class AzureOpenAiAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiDirectOpenAiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/AzureOpenAiDirectOpenAiAutoConfigurationIT.java
@@ -77,7 +77,7 @@ public class AzureOpenAiDirectOpenAiAutoConfigurationIT {
 		this.contextRunner.run(context -> {
 			AzureOpenAiChatModel chatModel = context.getBean(AzureOpenAiChatModel.class);
 			ChatResponse response = chatModel.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 
@@ -96,7 +96,7 @@ public class AzureOpenAiDirectOpenAiAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionBeanIT.java
@@ -71,14 +71,14 @@ class FunctionCallWithFunctionBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
 						AzureOpenAiChatOptions.builder().withFunction("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			});
 	}
@@ -100,7 +100,7 @@ class FunctionCallWithFunctionBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			});
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionWrapperIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionWrapperIT.java
@@ -68,7 +68,7 @@ public class FunctionCallWithFunctionWrapperIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).containsAnyOf("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).containsAnyOf("30", "10", "15");
 
 			});
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithPromptFunctionIT.java
@@ -72,7 +72,7 @@ public class FunctionCallWithPromptFunctionIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/anthropic/BedrockAnthropicChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/anthropic/BedrockAnthropicChatAutoConfigurationIT.java
@@ -71,7 +71,7 @@ public class BedrockAnthropicChatAutoConfigurationIT {
 		this.contextRunner.run(context -> {
 			BedrockAnthropicChatModel anthropicChatModel = context.getBean(BedrockAnthropicChatModel.class);
 			ChatResponse response = anthropicChatModel.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 
@@ -91,7 +91,7 @@ public class BedrockAnthropicChatAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/anthropic3/BedrockAnthropic3ChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/anthropic3/BedrockAnthropic3ChatAutoConfigurationIT.java
@@ -70,7 +70,7 @@ public class BedrockAnthropic3ChatAutoConfigurationIT {
 		this.contextRunner.run(context -> {
 			BedrockAnthropic3ChatModel anthropicChatModel = context.getBean(BedrockAnthropic3ChatModel.class);
 			ChatResponse response = anthropicChatModel.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 
@@ -90,7 +90,7 @@ public class BedrockAnthropic3ChatAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/cohere/BedrockCohereChatAutoConfigurationIT.java
@@ -74,7 +74,7 @@ public class BedrockCohereChatAutoConfigurationIT {
 		this.contextRunner.run(context -> {
 			BedrockCohereChatModel cohereChatModel = context.getBean(BedrockCohereChatModel.class);
 			ChatResponse response = cohereChatModel.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 
@@ -94,7 +94,7 @@ public class BedrockCohereChatAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/BedrockConverseProxyChatAutoConfigurationIT.java
@@ -70,7 +70,7 @@ public class BedrockConverseProxyChatAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/tool/FunctionCallWithFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/tool/FunctionCallWithFunctionBeanIT.java
@@ -69,14 +69,14 @@ class FunctionCallWithFunctionBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
 						FunctionCallingOptions.builder().withFunction("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 			});
 	}
 
@@ -100,7 +100,7 @@ class FunctionCallWithFunctionBeanIT {
 					.block()
 					.stream()
 					.filter(cr -> cr.getResult() != null)
-					.map(cr -> cr.getResult().getOutput().getContent())
+					.map(cr -> cr.getResult().getOutput().getText())
 					.collect(Collectors.joining());
 
 				logger.info("Response: {}", content);

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/tool/FunctionCallWithPromptFunctionIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/converse/tool/FunctionCallWithPromptFunctionIT.java
@@ -68,7 +68,7 @@ public class FunctionCallWithPromptFunctionIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/jurassic2/BedrockAi21Jurassic2ChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/jurassic2/BedrockAi21Jurassic2ChatAutoConfigurationIT.java
@@ -71,7 +71,7 @@ public class BedrockAi21Jurassic2ChatAutoConfigurationIT {
 			BedrockAi21Jurassic2ChatModel ai21Jurassic2ChatModel = context.getBean(BedrockAi21Jurassic2ChatModel.class);
 			ChatResponse response = ai21Jurassic2ChatModel
 				.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/llama/BedrockLlamaChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/llama/BedrockLlamaChatAutoConfigurationIT.java
@@ -73,7 +73,7 @@ public class BedrockLlamaChatAutoConfigurationIT {
 		this.contextRunner.run(context -> {
 			BedrockLlamaChatModel llamaChatModel = context.getBean(BedrockLlamaChatModel.class);
 			ChatResponse response = llamaChatModel.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 
@@ -93,7 +93,7 @@ public class BedrockLlamaChatAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanChatAutoConfigurationIT.java
@@ -72,7 +72,7 @@ public class BedrockTitanChatAutoConfigurationIT {
 		this.contextRunner.run(context -> {
 			BedrockTitanChatModel chatModel = context.getBean(BedrockTitanChatModel.class);
 			ChatResponse response = chatModel.call(new Prompt(List.of(this.userMessage, this.systemMessage)));
-			assertThat(response.getResult().getOutput().getContent()).contains("Blackbeard");
+			assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 		});
 	}
 
@@ -91,7 +91,7 @@ public class BedrockTitanChatAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Blackbeard");

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/memory/cassandra/CassandraChatMemoryAutoConfigurationIT.java
@@ -71,7 +71,7 @@ class CassandraChatMemoryAutoConfigurationIT {
 				assertThat(memory.get(sessionId, Integer.MAX_VALUE)).hasSize(1);
 				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(0).getMessageType())
 					.isEqualTo(MessageType.USER);
-				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(0).getContent()).isEqualTo("test question");
+				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(0).getText()).isEqualTo("test question");
 
 				memory.clear(sessionId);
 				assertThat(memory.get(sessionId, Integer.MAX_VALUE)).isEmpty();
@@ -81,10 +81,10 @@ class CassandraChatMemoryAutoConfigurationIT {
 				assertThat(memory.get(sessionId, Integer.MAX_VALUE)).hasSize(2);
 				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(1).getMessageType())
 					.isEqualTo(MessageType.USER);
-				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(1).getContent()).isEqualTo("test question");
+				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(1).getText()).isEqualTo("test question");
 				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(0).getMessageType())
 					.isEqualTo(MessageType.ASSISTANT);
-				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(0).getContent()).isEqualTo("test answer");
+				assertThat(memory.get(sessionId, Integer.MAX_VALUE).get(0).getText()).isEqualTo("test answer");
 
 				CassandraChatMemoryProperties properties = context.getBean(CassandraChatMemoryProperties.class);
 				assertThat(properties.getTimeToLive()).isEqualTo(getTimeToLive());

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/huggingface/HuggingfaceChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/huggingface/HuggingfaceChatAutoConfigurationIT.java
@@ -73,7 +73,7 @@ public class HuggingfaceChatAutoConfigurationIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/FunctionCallbackInPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/FunctionCallbackInPromptIT.java
@@ -74,7 +74,7 @@ public class FunctionCallbackInPromptIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		});
 	}
 
@@ -104,7 +104,7 @@ public class FunctionCallbackInPromptIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -75,7 +75,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			// Test weatherFunctionTwo
 			response = chatModel.call(new Prompt(List.of(userMessage),
@@ -83,7 +83,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -128,7 +128,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 
@@ -146,7 +146,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/MiniMaxAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/MiniMaxAutoConfigurationIT.java
@@ -69,7 +69,7 @@ public class MiniMaxAutoConfigurationIT {
 			String response = responseFlux.collectList()
 				.block()
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/MiniMaxFunctionCallbackIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/minimax/MiniMaxFunctionCallbackIT.java
@@ -70,7 +70,7 @@ public class MiniMaxFunctionCallbackIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -93,7 +93,7 @@ public class MiniMaxFunctionCallbackIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/MistralAiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/MistralAiAutoConfigurationIT.java
@@ -67,7 +67,7 @@ public class MistralAiAutoConfigurationIT {
 			String response = responseFlux.collectList()
 				.block()
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/PaymentStatusBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/PaymentStatusBeanIT.java
@@ -74,8 +74,8 @@ class PaymentStatusBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("T1001");
-				assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("paid");
+				assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("T1001");
+				assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("paid");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/PaymentStatusBeanOpenAiIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/PaymentStatusBeanOpenAiIT.java
@@ -81,8 +81,8 @@ class PaymentStatusBeanOpenAiIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("T1001");
-				assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("paid");
+				assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("T1001");
+				assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("paid");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/PaymentStatusPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/PaymentStatusPromptIT.java
@@ -76,8 +76,8 @@ public class PaymentStatusPromptIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("T1001");
-				assertThat(response.getResult().getOutput().getContent()).containsIgnoringCase("paid");
+				assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("T1001");
+				assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("paid");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/WeatherServicePromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/mistralai/tool/WeatherServicePromptIT.java
@@ -84,7 +84,7 @@ public class WeatherServicePromptIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15", "15.0");
+				assertThat(response.getResult().getOutput().getText()).containsAnyOf("15", "15.0");
 			});
 	}
 
@@ -111,7 +111,7 @@ public class WeatherServicePromptIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).containsAnyOf("15", "15.0");
+				assertThat(response.getResult().getOutput().getText()).containsAnyOf("15", "15.0");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/MoonshotAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/MoonshotAutoConfigurationIT.java
@@ -66,7 +66,7 @@ public class MoonshotAutoConfigurationIT {
 			Flux<ChatResponse> responseFlux = client.stream(new Prompt(new UserMessage("Hello")));
 			String response = Objects.requireNonNull(responseFlux.collectList().block())
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/tool/FunctionCallbackInPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/tool/FunctionCallbackInPromptIT.java
@@ -75,7 +75,7 @@ public class FunctionCallbackInPromptIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		});
 	}
 
@@ -105,7 +105,7 @@ public class FunctionCallbackInPromptIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -75,7 +75,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			// Test weatherFunctionTwo
 			response = chatModel.call(new Prompt(List.of(userMessage),
@@ -83,7 +83,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -127,7 +127,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 
@@ -145,7 +145,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/tool/MoonshotFunctionCallbackIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/moonshot/tool/MoonshotFunctionCallbackIT.java
@@ -72,7 +72,7 @@ public class MoonshotFunctionCallbackIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -95,7 +95,7 @@ public class MoonshotFunctionCallbackIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.filter(Objects::nonNull)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaChatAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/OllamaChatAutoConfigurationIT.java
@@ -69,7 +69,7 @@ public class OllamaChatAutoConfigurationIT extends BaseOllamaIT {
 		this.contextRunner.run(context -> {
 			OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);
 			ChatResponse response = chatModel.call(new Prompt(this.userMessage));
-			assertThat(response.getResult().getOutput().getContent()).contains("Copenhagen");
+			assertThat(response.getResult().getOutput().getText()).contains("Copenhagen");
 		});
 	}
 
@@ -88,7 +88,7 @@ public class OllamaChatAutoConfigurationIT extends BaseOllamaIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 
 			assertThat(stitchedResponseContent).contains("Copenhagen");
@@ -107,7 +107,7 @@ public class OllamaChatAutoConfigurationIT extends BaseOllamaIT {
 
 				OllamaChatModel chatModel = context.getBean(OllamaChatModel.class);
 				ChatResponse response = chatModel.call(new Prompt(this.userMessage));
-				assertThat(response.getResult().getOutput().getContent()).contains("Copenhagen");
+				assertThat(response.getResult().getOutput().getText()).contains("Copenhagen");
 				modelManager.deleteModel(model);
 			});
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackInPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackInPromptIT.java
@@ -83,7 +83,7 @@ public class FunctionCallbackInPromptIT extends BaseOllamaIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		});
 	}
 
@@ -114,7 +114,7 @@ public class FunctionCallbackInPromptIT extends BaseOllamaIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/OllamaFunctionCallbackIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/OllamaFunctionCallbackIT.java
@@ -80,7 +80,7 @@ public class OllamaFunctionCallbackIT extends BaseOllamaIT {
 
 			logger.info("Response: " + response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		});
 	}
 
@@ -103,7 +103,7 @@ public class OllamaFunctionCallbackIT extends BaseOllamaIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: " + content);
 
@@ -127,9 +127,9 @@ public class OllamaFunctionCallbackIT extends BaseOllamaIT {
 
 			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), functionOptions));
 
-			logger.info("Response: " + response.getResult().getOutput().getContent());
+			logger.info("Response: " + response.getResult().getOutput().getText());
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfigurationIT.java
@@ -129,7 +129,7 @@ public class OpenAiAutoConfigurationIT {
 			String response = responseFlux.collectList()
 				.block()
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();
@@ -147,7 +147,7 @@ public class OpenAiAutoConfigurationIT {
 			Usage[] streamingTokenUsage = new Usage[1];
 			String response = responseFlux.collectList().block().stream().map(chatResponse -> {
 				streamingTokenUsage[0] = chatResponse.getMetadata().getUsage();
-				return (chatResponse.getResult() != null) ? chatResponse.getResult().getOutput().getContent() : "";
+				return (chatResponse.getResult() != null) ? chatResponse.getResult().getOutput().getText() : "";
 			}).collect(Collectors.joining());
 
 			assertThat(streamingTokenUsage[0].getPromptTokens()).isGreaterThan(0);

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackInPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackInPromptIT.java
@@ -73,7 +73,7 @@ public class FunctionCallbackInPromptIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 			});
 	}
 
@@ -106,7 +106,7 @@ public class FunctionCallbackInPromptIT {
 					.map(ChatResponse::getResults)
 					.flatMap(List::stream)
 					.map(Generation::getOutput)
-					.map(AssistantMessage::getContent)
+					.map(AssistantMessage::getText)
 					.collect(Collectors.joining());
 				logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -162,7 +162,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), functionOptions));
 
-			logger.info("Response: {}", response.getResult().getOutput().getContent());
+			logger.info("Response: {}", response.getResult().getOutput().getText());
 		});
 	}
 
@@ -193,7 +193,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -225,7 +225,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -245,7 +245,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			// Test weatherFunctionTwo
 			response = chatModel.call(new Prompt(List.of(userMessage),
@@ -253,7 +253,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -273,9 +273,9 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), functionOptions));
 
-			logger.info("Response: {}", response.getResult().getOutput().getContent());
+			logger.info("Response: {}", response.getResult().getOutput().getText());
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		});
 	}
 
@@ -298,7 +298,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 
@@ -314,7 +314,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/OpenAiFunctionCallbackIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/openai/tool/OpenAiFunctionCallbackIT.java
@@ -66,7 +66,7 @@ public class OpenAiFunctionCallbackIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -89,7 +89,7 @@ public class OpenAiFunctionCallbackIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/qianfan/QianFanAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/qianfan/QianFanAutoConfigurationIT.java
@@ -75,7 +75,7 @@ public class QianFanAutoConfigurationIT {
 			Flux<ChatResponse> responseFlux = client.stream(new Prompt(new UserMessage("Hello")));
 			String response = Objects.requireNonNull(responseFlux.collectList().block())
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 			assertThat(response).isNotEmpty();
 			logger.info("Response: " + response);

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/VertexAiGeminiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/VertexAiGeminiAutoConfigurationIT.java
@@ -62,7 +62,7 @@ public class VertexAiGeminiAutoConfigurationIT {
 			String response = responseFlux.collectList()
 				.block()
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/tool/FunctionCallWithFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/tool/FunctionCallWithFunctionBeanIT.java
@@ -73,21 +73,21 @@ class FunctionCallWithFunctionBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
 						VertexAiGeminiChatOptions.builder().withFunction("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel
 					.call(new Prompt(List.of(userMessage), VertexAiGeminiChatOptions.builder().build()));
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).doesNotContain("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).doesNotContain("30", "10", "15");
 
 			});
 	}
@@ -113,14 +113,14 @@ class FunctionCallWithFunctionBeanIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
 						VertexAiGeminiChatOptions.builder().withFunction("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			});
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/tool/FunctionCallWithFunctionWrapperIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/tool/FunctionCallWithFunctionWrapperIT.java
@@ -69,7 +69,7 @@ public class FunctionCallWithFunctionWrapperIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 			});
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/tool/FunctionCallWithPromptFunctionIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vertexai/gemini/tool/FunctionCallWithPromptFunctionIT.java
@@ -80,7 +80,7 @@ public class FunctionCallWithPromptFunctionIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				// Verify that no function call is made.
 				response = chatModel
@@ -88,7 +88,7 @@ public class FunctionCallWithPromptFunctionIT {
 
 				logger.info("Response: {}", response);
 
-				assertThat(response.getResult().getOutput().getContent()).doesNotContain("30", "10", "15");
+				assertThat(response.getResult().getOutput().getText()).doesNotContain("30", "10", "15");
 
 			});
 	}

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/ZhiPuAiAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/ZhiPuAiAutoConfigurationIT.java
@@ -72,7 +72,7 @@ public class ZhiPuAiAutoConfigurationIT {
 			String response = responseFlux.collectList()
 				.block()
 				.stream()
-				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getContent())
+				.map(chatResponse -> chatResponse.getResults().get(0).getOutput().getText())
 				.collect(Collectors.joining());
 
 			assertThat(response).isNotEmpty();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/tool/FunctionCallbackInPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/tool/FunctionCallbackInPromptIT.java
@@ -77,7 +77,7 @@ public class FunctionCallbackInPromptIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 		});
 	}
 
@@ -107,7 +107,7 @@ public class FunctionCallbackInPromptIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -75,7 +75,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 			// Test weatherFunctionTwo
 			response = chatModel.call(new Prompt(List.of(userMessage),
@@ -83,7 +83,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -127,7 +127,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 
@@ -145,7 +145,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/tool/ZhipuAiFunctionCallbackIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/zhipuai/tool/ZhipuAiFunctionCallbackIT.java
@@ -71,7 +71,7 @@ public class ZhipuAiFunctionCallbackIT {
 
 			logger.info("Response: {}", response);
 
-			assertThat(response.getResult().getOutput().getContent()).contains("30", "10", "15");
+			assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 		});
 	}
@@ -94,7 +94,7 @@ public class ZhipuAiFunctionCallbackIT {
 				.map(ChatResponse::getResults)
 				.flatMap(List::stream)
 				.map(Generation::getOutput)
-				.map(AssistantMessage::getContent)
+				.map(AssistantMessage::getText)
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackContextKotlinIT.kt
+++ b/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackContextKotlinIT.kt
@@ -74,7 +74,7 @@ class FunctionCallbackResolverKotlinIT : BaseOllamaIT() {
 
 			logger.info("Response: " + response)
 
-			assertThat(response.getResult().output.content).contains("30", "10", "15")
+			assertThat(response.getResult().output.text).contains("30", "10", "15")
 		}
 	}
 
@@ -94,9 +94,9 @@ class FunctionCallbackResolverKotlinIT : BaseOllamaIT() {
 
 			val response = chatModel.call(Prompt(listOf(userMessage), functionOptions));
 
-			logger.info("Response: " + response.getResult().getOutput().getContent());
+			logger.info("Response: " + response.getResult().getOutput().getText());
 
-			assertThat(response.getResult().output.content).contains("30", "10", "15");
+			assertThat(response.getResult().output.text).contains("30", "10", "15");
 		}
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackKotlinIT.kt
+++ b/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackKotlinIT.kt
@@ -74,7 +74,7 @@ class FunctionCallbackKotlinIT : BaseOllamaIT() {
 
 			logger.info("Response: " + response)
 
-			assertThat(response.getResult().output.content).contains("30", "10", "15")
+			assertThat(response.getResult().output.text).contains("30", "10", "15")
 		}
 	}
 
@@ -94,9 +94,9 @@ class FunctionCallbackKotlinIT : BaseOllamaIT() {
 
 			val response = chatModel.call(Prompt(listOf(userMessage), functionOptions));
 
-			logger.info("Response: " + response.getResult().getOutput().getContent());
+			logger.info("Response: " + response.getResult().getOutput().getText());
 
-			assertThat(response.getResult().output.content).contains("30", "10", "15");
+			assertThat(response.getResult().output.text).contains("30", "10", "15");
 		}
 	}
 

--- a/spring-ai-test/src/main/java/org/springframework/ai/evaluation/BasicEvaluationTest.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/evaluation/BasicEvaluationTest.java
@@ -69,12 +69,12 @@ public class BasicEvaluationTest {
 		}
 		Message userMessage = userPromptTemplate.createMessage();
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
-		String yesOrNo = this.openAiChatModel.call(prompt).getResult().getOutput().getContent();
+		String yesOrNo = this.openAiChatModel.call(prompt).getResult().getOutput().getText();
 		logger.info("Is Answer related to question: " + yesOrNo);
 		if (yesOrNo.equalsIgnoreCase("no")) {
 			SystemMessage notRelatedSystemMessage = new SystemMessage(this.qaEvaluatorNotRelatedResource);
 			prompt = new Prompt(List.of(userMessage, notRelatedSystemMessage));
-			String reasonForFailure = this.openAiChatModel.call(prompt).getResult().getOutput().getContent();
+			String reasonForFailure = this.openAiChatModel.call(prompt).getResult().getOutput().getText();
 			fail(reasonForFailure);
 		}
 		else {

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/CosmosDBVectorStore.java
@@ -340,7 +340,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 				.block();
 			// Convert JsonNode to Document
 			List<Document> docs = documents.stream()
-				.map(doc -> Document.builder().id(doc.get("id").asText()).content(doc.get("content").asText()).build())
+				.map(doc -> Document.builder().id(doc.get("id").asText()).text(doc.get("content").asText()).build())
 				.collect(Collectors.toList());
 
 			return docs != null ? docs : List.of();

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -325,7 +325,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 
 				return Document.builder()
 					.id(entry.id())
-					.content(entry.content)
+					.text(entry.content)
 					.metadata(metadata)
 					.score(result.getScore())
 					.build();

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/chat/memory/CassandraChatMemory.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/chat/memory/CassandraChatMemory.java
@@ -108,7 +108,7 @@ public final class CassandraChatMemory implements ChatMemory {
 		Instant instant = (Instant) msg.getMetadata().get(CONVERSATION_TS);
 
 		builder = builder.setInstant(CassandraChatMemoryConfig.DEFAULT_EXCHANGE_ID_NAME, instant)
-			.setString("message", msg.getContent());
+			.setString("message", msg.getText());
 
 		this.conf.session.execute(builder.build());
 	}

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/CassandraVectorStore.java
@@ -262,7 +262,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 			}
 			Document doc = Document.builder()
 				.id(getDocumentId(row))
-				.content(row.getString(this.conf.schema.content()))
+				.text(row.getString(this.conf.schema.content()))
 				.metadata(docFields)
 				.score((double) score)
 				.build();

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
@@ -218,7 +218,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 				metadata.put(DocumentMetadata.DISTANCE.value(), distance);
 				Document document = Document.builder()
 					.id(id)
-					.content(content)
+					.text(content)
 					.metadata(metadata)
 					.score(1.0 - distance)
 					.build();

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStoreIT.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStoreIT.java
@@ -102,7 +102,7 @@ public class ChromaVectorStoreIT {
 
 			var document = Document.builder()
 				.id("simpleDoc")
-				.content("The sky is blue because of Rayleigh scattering.")
+				.text("The sky is blue because of Rayleigh scattering.")
 				.build();
 
 			vectorStore.add(List.of(document));

--- a/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/CoherenceVectorStore.java
+++ b/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/CoherenceVectorStore.java
@@ -216,7 +216,7 @@ public class CoherenceVectorStore implements VectorStore, InitializingBean {
 				chunk.metadata().put(DocumentMetadata.DISTANCE.value(), r.getDistance());
 				documents.add(Document.builder()
 					.id(id.docId())
-					.content(chunk.text())
+					.text(chunk.text())
 					.metadata(chunk.metadata())
 					.score(1 - r.getDistance())
 					.build());

--- a/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/GemFireVectorStore.java
@@ -273,7 +273,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 				}
 				metadata.put(DocumentMetadata.DISTANCE.value(), 1 - r.score);
 				String content = (String) metadata.remove(DOCUMENT_FIELD);
-				return Document.builder().id(r.key).content(content).metadata(metadata).score((double) r.score).build();
+				return Document.builder().id(r.key).text(content).metadata(metadata).score((double) r.score).build();
 			})
 			.collectList()
 			.onErrorMap(WebClientException.class, this::handleHttpClientException)

--- a/vector-stores/spring-ai-hanadb-store/src/test/java/org/springframework/ai/vectorstore/CricketWorldCupHanaController.java
+++ b/vector-stores/spring-ai-hanadb-store/src/test/java/org/springframework/ai/vectorstore/CricketWorldCupHanaController.java
@@ -90,7 +90,7 @@ public class CricketWorldCupHanaController {
 
 		var userMessage = new UserMessage(message);
 		Prompt prompt = new Prompt(List.of(similarDocsMessage, userMessage));
-		String generation = this.chatModel.call(prompt).getResult().getOutput().getContent();
+		String generation = this.chatModel.call(prompt).getResult().getOutput().getText();
 		logger.info("Generation: {}", generation);
 		return Map.of("generation", generation);
 	}

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/MilvusVectorStore.java
@@ -268,7 +268,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 				}
 				return Document.builder()
 					.id(docId)
-					.content(content)
+					.text(content)
 					.metadata((metadata != null) ? metadata.getInnerMap() : Map.of())
 					.score((double) getResultSimilarity(rowRecord))
 					.build();

--- a/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/MongoDBAtlasVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/MongoDBAtlasVectorStore.java
@@ -182,7 +182,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		// @formatter:off
 		return Document.builder()
 			.id(id)
-			.content(content)
+			.text(content)
 			.metadata(metadata)
 			.score(score)
 			.build(); // @formatter:on

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/Neo4jVectorStore.java
@@ -236,7 +236,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 
 		return Document.builder()
 			.id(node.get(this.config.idProperty).asString())
-			.content(node.get("text").asString())
+			.text(node.get("text").asString())
 			.metadata(Map.copyOf(metaData))
 			.score((double) score)
 			.build();

--- a/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/OracleVectorStore.java
+++ b/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/OracleVectorStore.java
@@ -656,7 +656,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 
 			return Document.builder()
 				.id(rs.getString(1))
-				.content(rs.getString(2))
+				.text(rs.getString(2))
 				.metadata(metadata)
 				.score(1 - rs.getDouble(5))
 				.build();

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/PgVectorStore.java
@@ -508,7 +508,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 			// @formatter:off
 			return Document.builder()
 				.id(id)
-				.content(content)
+				.text(content)
 				.metadata(metadata)
 				.score(1.0 - distance)
 				.build(); // @formatter:on

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
@@ -104,7 +104,7 @@ class PgVectorStoreWithChatMemoryAdvisorIT {
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		verify(chatModel).call(promptCaptor.capture());
 		assertThat(promptCaptor.getValue().getInstructions().get(0)).isInstanceOf(SystemMessage.class);
-		assertThat(promptCaptor.getValue().getInstructions().get(0).getContent()).isEqualTo("""
+		assertThat(promptCaptor.getValue().getInstructions().get(0).getText()).isEqualTo("""
 
 				Use the long term conversation memory from the LONG_TERM_MEMORY section to provide accurate answers.
 

--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/PineconeVectorStore.java
@@ -239,7 +239,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 				metadata.put(this.pineconeDistanceMetadataFieldName, 1 - scoredVector.getScore());
 				return Document.builder()
 					.id(id)
-					.content(content)
+					.text(content)
 					.metadata(metadata)
 					.score((double) scoredVector.getScore())
 					.build();

--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -214,12 +214,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 
 			var content = (String) metadata.remove(CONTENT_FIELD_NAME);
 
-			return Document.builder()
-				.id(id)
-				.content(content)
-				.metadata(metadata)
-				.score((double) point.getScore())
-				.build();
+			return Document.builder().id(id).text(content).metadata(metadata).score((double) point.getScore()).build();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/RedisVectorStore.java
@@ -250,12 +250,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		// distance. Can we remove this after standardizing the metadata?
 		metadata.put(DISTANCE_FIELD_NAME, 1 - similarityScore(doc));
 		metadata.put(DocumentMetadata.DISTANCE.value(), 1 - similarityScore(doc));
-		return Document.builder()
-			.id(id)
-			.content(content)
-			.metadata(metadata)
-			.score((double) similarityScore(doc))
-			.build();
+		return Document.builder().id(id).text(content).metadata(metadata).score((double) similarityScore(doc)).build();
 	}
 
 	private float similarityScore(redis.clients.jedis.search.Document doc) {

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/TypesenseVectorStore.java
@@ -218,7 +218,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 					metadata.put(DocumentMetadata.DISTANCE.value(), hit.getVectorDistance());
 					return Document.builder()
 						.id(docId)
-						.content(content)
+						.text(content)
 						.metadata(metadata)
 						.score(1.0 - hit.getVectorDistance())
 						.build();

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/WeaviateVectorStore.java
@@ -387,7 +387,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		// @formatter:off
 		return Document.builder()
 			.id(id)
-			.content(content)
+			.text(content)
 			.metadata(metadata)
 			.score(certainty)
 			.build(); // @formatter:on


### PR DESCRIPTION
The Document class previously allowed multiple media entries while also having a
text field, leading to ambiguity in content handling. This change enforces a
clear separation between text and media documents to prevent content type
confusion and simplify document processing.

A Document now must contain either text content or a single media entry, but
never both. This aligns with the class's primary use in ETL pipelines where
clear content type boundaries are essential for proper embedding generation and
vector database storage.

Additional architectural changes:
- Document now implements a cleaner API by removing deprecated methods
- Removed MediaContent interface implementation from Document class
- Document.getMedia() now returns a single Media object instead of Collection
- Removed EMPTY_TEXT constant in favor of proper null handling
- Constructor signatures simplified and streamlined
- Builder pattern improved to enforce single content type constraint

The breaking changes include:
- Media is now a single entry instead of a collection
- Content field renamed to text for clarity
- Removed support for mixed content types
- Simplified builder API to prevent ambiguous construction

Prefer using text-related methods over deprecated content methods to
better reflect the actual content type being handled and improve API clarity.