### PR TITLE
refactor: move PgVectorStore to dedicated package and update builder …

### DIFF
--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
@@ -38,7 +38,7 @@ import org.springframework.ai.rag.preretrieval.query.transformation.TranslationQ
 import org.springframework.ai.rag.retrieval.search.VectorStoreDocumentRetriever;
 import org.springframework.ai.reader.markdown.MarkdownDocumentReader;
 import org.springframework.ai.reader.markdown.config.MarkdownDocumentReaderConfig;
-import org.springframework.ai.vectorstore.PgVectorStore;
+import org.springframework.ai.pg.vectorstore.PgVectorStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/rag/retrieval/search/VectorStoreDocumentRetrieverIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/rag/retrieval/search/VectorStoreDocumentRetrieverIT.java
@@ -29,7 +29,7 @@ import org.springframework.ai.integration.tests.TestApplication;
 import org.springframework.ai.rag.Query;
 import org.springframework.ai.rag.retrieval.search.DocumentRetriever;
 import org.springframework.ai.rag.retrieval.search.VectorStoreDocumentRetriever;
-import org.springframework.ai.vectorstore.PgVectorStore;
+import org.springframework.ai.pg.vectorstore.PgVectorStore;
 import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfiguration.java
@@ -62,7 +62,8 @@ public class PgVectorStoreAutoConfiguration {
 
 		var initializeSchema = properties.isInitializeSchema();
 
-		return PgVectorStore.builder(jdbcTemplate)
+		return PgVectorStore.builder()
+			.jdbcTemplate(jdbcTemplate)
 			.embeddingModel(embeddingModel)
 			.schemaName(properties.getSchemaName())
 			.vectorTableName(properties.getTableName())

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfiguration.java
@@ -23,7 +23,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.TokenCountBatchingStrategy;
-import org.springframework.ai.vectorstore.PgVectorStore;
+import org.springframework.ai.pg.vectorstore.PgVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -62,18 +62,20 @@ public class PgVectorStoreAutoConfiguration {
 
 		var initializeSchema = properties.isInitializeSchema();
 
-		return new PgVectorStore.Builder(jdbcTemplate, embeddingModel).withSchemaName(properties.getSchemaName())
-			.withVectorTableName(properties.getTableName())
-			.withVectorTableValidationsEnabled(properties.isSchemaValidation())
-			.withDimensions(properties.getDimensions())
-			.withDistanceType(properties.getDistanceType())
-			.withRemoveExistingVectorStoreTable(properties.isRemoveExistingVectorStoreTable())
-			.withIndexType(properties.getIndexType())
-			.withInitializeSchema(initializeSchema)
-			.withObservationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.withSearchObservationConvention(customObservationConvention.getIfAvailable(() -> null))
-			.withBatchingStrategy(batchingStrategy)
-			.withMaxDocumentBatchSize(properties.getMaxDocumentBatchSize())
+		return PgVectorStore.builder(jdbcTemplate)
+			.embeddingModel(embeddingModel)
+			.schemaName(properties.getSchemaName())
+			.vectorTableName(properties.getTableName())
+			.vectorTableValidationsEnabled(properties.isSchemaValidation())
+			.dimensions(properties.getDimensions())
+			.distanceType(properties.getDistanceType())
+			.removeExistingVectorStoreTable(properties.isRemoveExistingVectorStoreTable())
+			.indexType(properties.getIndexType())
+			.initializeSchema(initializeSchema)
+			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))
+			.batchingStrategy(batchingStrategy)
+			.maxDocumentBatchSize(properties.getMaxDocumentBatchSize())
 			.build();
 	}
 

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreProperties.java
@@ -17,9 +17,9 @@
 package org.springframework.ai.autoconfigure.vectorstore.pgvector;
 
 import org.springframework.ai.autoconfigure.vectorstore.CommonVectorStoreProperties;
-import org.springframework.ai.vectorstore.PgVectorStore;
-import org.springframework.ai.vectorstore.PgVectorStore.PgDistanceType;
-import org.springframework.ai.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.pg.vectorstore.PgVectorStore;
+import org.springframework.ai.pg.vectorstore.PgVectorStore.PgDistanceType;
+import org.springframework.ai.pg.vectorstore.PgVectorStore.PgIndexType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfigurationIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStoreAutoConfigurationIT.java
@@ -33,7 +33,7 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.transformers.TransformersEmbeddingModel;
-import org.springframework.ai.vectorstore.PgVectorStore;
+import org.springframework.ai.pg.vectorstore.PgVectorStore;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
 import org.springframework.boot.autoconfigure.AutoConfigurations;

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStorePropertiesTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/vectorstore/pgvector/PgVectorStorePropertiesTests.java
@@ -18,9 +18,9 @@ package org.springframework.ai.autoconfigure.vectorstore.pgvector;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.ai.vectorstore.PgVectorStore;
-import org.springframework.ai.vectorstore.PgVectorStore.PgDistanceType;
-import org.springframework.ai.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.pg.vectorstore.PgVectorStore;
+import org.springframework.ai.pg.vectorstore.PgVectorStore.PgDistanceType;
+import org.springframework.ai.pg.vectorstore.PgVectorStore.PgIndexType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorFilterExpressionConverter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.util.List;
 

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorSchemaValidator.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorSchemaValidator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorStore.java
@@ -125,60 +125,54 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private final int maxDocumentBatchSize;
 
-	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
-	// public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
-	// this(jdbcTemplate, embeddingModel, INVALID_EMBEDDING_DIMENSION,
-	// PgDistanceType.COSINE_DISTANCE, false,
-	// PgIndexType.NONE, false);
-	// }
-	//
-	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
-	// public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int
-	// dimensions) {
-	// this(jdbcTemplate, embeddingModel, dimensions, PgDistanceType.COSINE_DISTANCE,
-	// false, PgIndexType.NONE, false);
-	// }
-	//
-	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
-	// public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int
-	// dimensions,
-	// PgDistanceType distanceType, boolean removeExistingVectorStoreTable, PgIndexType
-	// createIndexMethod,
-	// boolean initializeSchema) {
-	//
-	// this(DEFAULT_TABLE_NAME, jdbcTemplate, embeddingModel, dimensions, distanceType,
-	// removeExistingVectorStoreTable,
-	// createIndexMethod, initializeSchema);
-	// }
-	//
-	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
-	// public PgVectorStore(String vectorTableName, JdbcTemplate jdbcTemplate,
-	// EmbeddingModel embeddingModel,
-	// int dimensions, PgDistanceType distanceType, boolean
-	// removeExistingVectorStoreTable,
-	// PgIndexType createIndexMethod, boolean initializeSchema) {
-	//
-	//
-	// this(builder(jdbcTemplate).schemaName(DEFAULT_SCHEMA_NAME)
-	// .vectorTableName(vectorTableName)
-	// .vectorTableValidationsEnabled(DEFAULT_SCHEMA_VALIDATION)
-	// .dimensions(dimensions)
-	// .distanceType(distanceType)
-	// .removeExistingVectorStoreTable(removeExistingVectorStoreTable)
-	// .indexType(createIndexMethod)
-	// .initializeSchema(initializeSchema));
-	// }
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
+	public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
+		this(jdbcTemplate, embeddingModel, INVALID_EMBEDDING_DIMENSION, PgDistanceType.COSINE_DISTANCE, false,
+				PgIndexType.NONE, false);
+	}
+
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
+	public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int dimensions) {
+		this(jdbcTemplate, embeddingModel, dimensions, PgDistanceType.COSINE_DISTANCE, false, PgIndexType.NONE, false);
+	}
+
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
+	public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int dimensions,
+			PgDistanceType distanceType, boolean removeExistingVectorStoreTable, PgIndexType createIndexMethod,
+			boolean initializeSchema) {
+
+		this(DEFAULT_TABLE_NAME, jdbcTemplate, embeddingModel, dimensions, distanceType, removeExistingVectorStoreTable,
+				createIndexMethod, initializeSchema);
+	}
+
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
+	public PgVectorStore(String vectorTableName, JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
+			int dimensions, PgDistanceType distanceType, boolean removeExistingVectorStoreTable,
+			PgIndexType createIndexMethod, boolean initializeSchema) {
+
+		this(builder().jdbcTemplate(jdbcTemplate)
+			.schemaName(DEFAULT_SCHEMA_NAME)
+			.vectorTableName(vectorTableName)
+			.vectorTableValidationsEnabled(DEFAULT_SCHEMA_VALIDATION)
+			.dimensions(dimensions)
+			.distanceType(distanceType)
+			.removeExistingVectorStoreTable(removeExistingVectorStoreTable)
+			.indexType(createIndexMethod)
+			.initializeSchema(initializeSchema));
+	}
 
 	/**
 	 * @param builder {@link VectorStore.Builder} for pg vector store
 	 */
-	private PgVectorStore(PgVectorStoreBuilder builder) {
+	protected PgVectorStore(PgVectorStoreBuilder builder) {
 		super(builder);
+
+		Assert.notNull(builder.jdbcTemplate, "JdbcTemplate must not be null");
+
 		this.objectMapper = JsonMapper.builder().addModules(JacksonUtils.instantiateAvailableModules()).build();
 
-		String vectorTableName1 = builder.vectorTableName;
-		this.vectorTableName = (null == vectorTableName1 || vectorTableName1.isEmpty()) ? DEFAULT_TABLE_NAME
-				: vectorTableName1.trim();
+		String vectorTable = builder.vectorTableName;
+		this.vectorTableName = (null == vectorTable || vectorTable.isEmpty()) ? DEFAULT_TABLE_NAME : vectorTable.trim();
 		logger.info("Using the vector table name: {}. Is empty: {}", this.vectorTableName,
 				(this.vectorTableName == null || this.vectorTableName.isEmpty()));
 
@@ -203,8 +197,8 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		return this.distanceType;
 	}
 
-	public static PgVectorStoreBuilder builder(JdbcTemplate jdbcTemplate) {
-		return new PgVectorStoreBuilder(jdbcTemplate);
+	public static PgVectorStoreBuilder builder() {
+		return new PgVectorStoreBuilder();
 	}
 
 	@Override
@@ -542,7 +536,7 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	public static class PgVectorStoreBuilder extends AbstractVectorStoreBuilder<PgVectorStoreBuilder> {
 
-		private final JdbcTemplate jdbcTemplate;
+		private JdbcTemplate jdbcTemplate;
 
 		private String schemaName = PgVectorStore.DEFAULT_SCHEMA_NAME;
 
@@ -564,9 +558,10 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 		private int maxDocumentBatchSize = MAX_DOCUMENT_BATCH_SIZE;
 
-		public PgVectorStoreBuilder(JdbcTemplate jdbcTemplate) {
+		public PgVectorStoreBuilder jdbcTemplate(JdbcTemplate jdbcTemplate) {
 			Assert.notNull(jdbcTemplate, "JdbcTemplate must not be null");
 			this.jdbcTemplate = jdbcTemplate;
+			return this;
 		}
 
 		public PgVectorStoreBuilder schemaName(String schemaName) {
@@ -727,7 +722,8 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		}
 
 		public PgVectorStore build() {
-			return PgVectorStore.builder(this.jdbcTemplate)
+			return PgVectorStore.builder()
+				.jdbcTemplate(this.jdbcTemplate)
 				.embeddingModel(this.embeddingModel)
 				.schemaName(this.schemaName)
 				.vectorTableName(this.vectorTableName)

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/PgVectorStore.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -43,6 +43,9 @@ import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
 import org.springframework.ai.util.JacksonUtils;
+import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
 import org.springframework.ai.vectorstore.observation.AbstractObservationVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
@@ -54,6 +57,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SqlTypeValue;
 import org.springframework.jdbc.core.StatementCreatorUtils;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -99,8 +103,6 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private final JdbcTemplate jdbcTemplate;
 
-	private final EmbeddingModel embeddingModel;
-
 	private final String schemaName;
 
 	private final boolean schemaValidation;
@@ -123,75 +125,86 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	private final int maxDocumentBatchSize;
 
-	public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
-		this(jdbcTemplate, embeddingModel, INVALID_EMBEDDING_DIMENSION, PgDistanceType.COSINE_DISTANCE, false,
-				PgIndexType.NONE, false);
-	}
+	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
+	// public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
+	// this(jdbcTemplate, embeddingModel, INVALID_EMBEDDING_DIMENSION,
+	// PgDistanceType.COSINE_DISTANCE, false,
+	// PgIndexType.NONE, false);
+	// }
+	//
+	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
+	// public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int
+	// dimensions) {
+	// this(jdbcTemplate, embeddingModel, dimensions, PgDistanceType.COSINE_DISTANCE,
+	// false, PgIndexType.NONE, false);
+	// }
+	//
+	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
+	// public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int
+	// dimensions,
+	// PgDistanceType distanceType, boolean removeExistingVectorStoreTable, PgIndexType
+	// createIndexMethod,
+	// boolean initializeSchema) {
+	//
+	// this(DEFAULT_TABLE_NAME, jdbcTemplate, embeddingModel, dimensions, distanceType,
+	// removeExistingVectorStoreTable,
+	// createIndexMethod, initializeSchema);
+	// }
+	//
+	// @Deprecated(forRemoval = true, since = "1.0.0-M5")
+	// public PgVectorStore(String vectorTableName, JdbcTemplate jdbcTemplate,
+	// EmbeddingModel embeddingModel,
+	// int dimensions, PgDistanceType distanceType, boolean
+	// removeExistingVectorStoreTable,
+	// PgIndexType createIndexMethod, boolean initializeSchema) {
+	//
+	//
+	// this(builder(jdbcTemplate).schemaName(DEFAULT_SCHEMA_NAME)
+	// .vectorTableName(vectorTableName)
+	// .vectorTableValidationsEnabled(DEFAULT_SCHEMA_VALIDATION)
+	// .dimensions(dimensions)
+	// .distanceType(distanceType)
+	// .removeExistingVectorStoreTable(removeExistingVectorStoreTable)
+	// .indexType(createIndexMethod)
+	// .initializeSchema(initializeSchema));
+	// }
 
-	public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int dimensions) {
-		this(jdbcTemplate, embeddingModel, dimensions, PgDistanceType.COSINE_DISTANCE, false, PgIndexType.NONE, false);
-	}
-
-	public PgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int dimensions,
-			PgDistanceType distanceType, boolean removeExistingVectorStoreTable, PgIndexType createIndexMethod,
-			boolean initializeSchema) {
-
-		this(DEFAULT_TABLE_NAME, jdbcTemplate, embeddingModel, dimensions, distanceType, removeExistingVectorStoreTable,
-				createIndexMethod, initializeSchema);
-	}
-
-	public PgVectorStore(String vectorTableName, JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
-			int dimensions, PgDistanceType distanceType, boolean removeExistingVectorStoreTable,
-			PgIndexType createIndexMethod, boolean initializeSchema) {
-
-		this(DEFAULT_SCHEMA_NAME, vectorTableName, DEFAULT_SCHEMA_VALIDATION, jdbcTemplate, embeddingModel, dimensions,
-				distanceType, removeExistingVectorStoreTable, createIndexMethod, initializeSchema);
-	}
-
-	private PgVectorStore(String schemaName, String vectorTableName, boolean vectorTableValidationsEnabled,
-			JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int dimensions, PgDistanceType distanceType,
-			boolean removeExistingVectorStoreTable, PgIndexType createIndexMethod, boolean initializeSchema) {
-
-		this(schemaName, vectorTableName, vectorTableValidationsEnabled, jdbcTemplate, embeddingModel, dimensions,
-				distanceType, removeExistingVectorStoreTable, createIndexMethod, initializeSchema,
-				ObservationRegistry.NOOP, null, new TokenCountBatchingStrategy(), MAX_DOCUMENT_BATCH_SIZE);
-	}
-
-	private PgVectorStore(String schemaName, String vectorTableName, boolean vectorTableValidationsEnabled,
-			JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel, int dimensions, PgDistanceType distanceType,
-			boolean removeExistingVectorStoreTable, PgIndexType createIndexMethod, boolean initializeSchema,
-			ObservationRegistry observationRegistry, VectorStoreObservationConvention customObservationConvention,
-			BatchingStrategy batchingStrategy, int maxDocumentBatchSize) {
-
-		super(observationRegistry, customObservationConvention);
-
+	/**
+	 * @param builder {@link VectorStore.Builder} for pg vector store
+	 */
+	private PgVectorStore(PgVectorStoreBuilder builder) {
+		super(builder);
 		this.objectMapper = JsonMapper.builder().addModules(JacksonUtils.instantiateAvailableModules()).build();
 
-		this.vectorTableName = (null == vectorTableName || vectorTableName.isEmpty()) ? DEFAULT_TABLE_NAME
-				: vectorTableName.trim();
+		String vectorTableName1 = builder.vectorTableName;
+		this.vectorTableName = (null == vectorTableName1 || vectorTableName1.isEmpty()) ? DEFAULT_TABLE_NAME
+				: vectorTableName1.trim();
 		logger.info("Using the vector table name: {}. Is empty: {}", this.vectorTableName,
-				(vectorTableName == null || vectorTableName.isEmpty()));
+				(this.vectorTableName == null || this.vectorTableName.isEmpty()));
 
 		this.vectorIndexName = this.vectorTableName.equals(DEFAULT_TABLE_NAME) ? DEFAULT_VECTOR_INDEX_NAME
 				: this.vectorTableName + "_index";
 
-		this.schemaName = schemaName;
-		this.schemaValidation = vectorTableValidationsEnabled;
+		this.schemaName = builder.schemaName;
+		this.schemaValidation = builder.vectorTableValidationsEnabled;
 
-		this.jdbcTemplate = jdbcTemplate;
-		this.embeddingModel = embeddingModel;
-		this.dimensions = dimensions;
-		this.distanceType = distanceType;
-		this.removeExistingVectorStoreTable = removeExistingVectorStoreTable;
-		this.createIndexMethod = createIndexMethod;
-		this.initializeSchema = initializeSchema;
-		this.schemaValidator = new PgVectorSchemaValidator(jdbcTemplate);
-		this.batchingStrategy = batchingStrategy;
-		this.maxDocumentBatchSize = maxDocumentBatchSize;
+		this.jdbcTemplate = builder.jdbcTemplate;
+		this.dimensions = builder.dimensions;
+		this.distanceType = builder.distanceType;
+		this.removeExistingVectorStoreTable = builder.removeExistingVectorStoreTable;
+		this.createIndexMethod = builder.indexType;
+		this.initializeSchema = builder.initializeSchema;
+		this.schemaValidator = new PgVectorSchemaValidator(this.jdbcTemplate);
+		this.batchingStrategy = builder.batchingStrategy;
+		this.maxDocumentBatchSize = builder.maxDocumentBatchSize;
 	}
 
 	public PgDistanceType getDistanceType() {
 		return this.distanceType;
+	}
+
+	public static PgVectorStoreBuilder builder(JdbcTemplate jdbcTemplate) {
+		return new PgVectorStoreBuilder(jdbcTemplate);
 	}
 
 	@Override
@@ -527,6 +540,93 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	}
 
+	public static class PgVectorStoreBuilder extends AbstractVectorStoreBuilder<PgVectorStoreBuilder> {
+
+		private final JdbcTemplate jdbcTemplate;
+
+		private String schemaName = PgVectorStore.DEFAULT_SCHEMA_NAME;
+
+		private String vectorTableName = PgVectorStore.DEFAULT_TABLE_NAME;
+
+		private boolean vectorTableValidationsEnabled = PgVectorStore.DEFAULT_SCHEMA_VALIDATION;
+
+		private int dimensions = PgVectorStore.INVALID_EMBEDDING_DIMENSION;
+
+		private PgDistanceType distanceType = PgDistanceType.COSINE_DISTANCE;
+
+		private boolean removeExistingVectorStoreTable = false;
+
+		private PgIndexType indexType = PgIndexType.HNSW;
+
+		private boolean initializeSchema;
+
+		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
+
+		private int maxDocumentBatchSize = MAX_DOCUMENT_BATCH_SIZE;
+
+		public PgVectorStoreBuilder(JdbcTemplate jdbcTemplate) {
+			Assert.notNull(jdbcTemplate, "JdbcTemplate must not be null");
+			this.jdbcTemplate = jdbcTemplate;
+		}
+
+		public PgVectorStoreBuilder schemaName(String schemaName) {
+			this.schemaName = schemaName;
+			return this;
+		}
+
+		public PgVectorStoreBuilder vectorTableName(String vectorTableName) {
+			this.vectorTableName = vectorTableName;
+			return this;
+		}
+
+		public PgVectorStoreBuilder vectorTableValidationsEnabled(boolean vectorTableValidationsEnabled) {
+			this.vectorTableValidationsEnabled = vectorTableValidationsEnabled;
+			return this;
+		}
+
+		public PgVectorStoreBuilder dimensions(int dimensions) {
+			this.dimensions = dimensions;
+			return this;
+		}
+
+		public PgVectorStoreBuilder distanceType(PgDistanceType distanceType) {
+			this.distanceType = distanceType;
+			return this;
+		}
+
+		public PgVectorStoreBuilder removeExistingVectorStoreTable(boolean removeExistingVectorStoreTable) {
+			this.removeExistingVectorStoreTable = removeExistingVectorStoreTable;
+			return this;
+		}
+
+		public PgVectorStoreBuilder indexType(PgIndexType indexType) {
+			this.indexType = indexType;
+			return this;
+		}
+
+		public PgVectorStoreBuilder initializeSchema(boolean initializeSchema) {
+			this.initializeSchema = initializeSchema;
+			return this;
+		}
+
+		public PgVectorStoreBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+			this.batchingStrategy = batchingStrategy;
+			return this;
+		}
+
+		public PgVectorStoreBuilder maxDocumentBatchSize(int maxDocumentBatchSize) {
+			this.maxDocumentBatchSize = maxDocumentBatchSize;
+			return this;
+		}
+
+		public PgVectorStore build() {
+			validate();
+			return new PgVectorStore(this);
+		}
+
+	}
+
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public static class Builder {
 
 		private final JdbcTemplate jdbcTemplate;
@@ -558,7 +658,6 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		@Nullable
 		private VectorStoreObservationConvention searchObservationConvention;
 
-		// Builder constructor with mandatory parameters
 		public Builder(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
 			if (jdbcTemplate == null || embeddingModel == null) {
 				throw new IllegalArgumentException("JdbcTemplate and EmbeddingModel must not be null");
@@ -628,11 +727,19 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 		}
 
 		public PgVectorStore build() {
-			return new PgVectorStore(this.schemaName, this.vectorTableName, this.vectorTableValidationsEnabled,
-					this.jdbcTemplate, this.embeddingModel, this.dimensions, this.distanceType,
-					this.removeExistingVectorStoreTable, this.indexType, this.initializeSchema,
-					this.observationRegistry, this.searchObservationConvention, this.batchingStrategy,
-					this.maxDocumentBatchSize);
+			return PgVectorStore.builder(this.jdbcTemplate)
+				.embeddingModel(this.embeddingModel)
+				.schemaName(this.schemaName)
+				.vectorTableName(this.vectorTableName)
+				.vectorTableValidationsEnabled(this.vectorTableValidationsEnabled)
+				.dimensions(this.dimensions)
+				.distanceType(this.distanceType)
+				.removeExistingVectorStoreTable(this.removeExistingVectorStoreTable)
+				.indexType(this.indexType)
+				.initializeSchema(this.initializeSchema)
+				.batchingStrategy(this.batchingStrategy)
+				.maxDocumentBatchSize(this.maxDocumentBatchSize)
+				.build();
 		}
 
 	}

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/package-info.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/pg/vectorstore/package-info.java
@@ -14,19 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
-
-import org.testcontainers.utility.DockerImageName;
-
 /**
- * @author Thomas Vitale
+ * Provides the API for embedding observations.
  */
-public final class PgVectorImage {
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.pg.vectorstore;
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("pgvector/pgvector:pg17");
-
-	private PgVectorImage() {
-
-	}
-
-}
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorEmbeddingDimensionsTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorEmbeddingDimensionsTests.java
@@ -47,7 +47,8 @@ public class PgVectorEmbeddingDimensionsTests {
 
 		final int explicitDimensions = 696;
 
-		PgVectorStore pgVectorStore = PgVectorStore.builder(this.jdbcTemplate)
+		PgVectorStore pgVectorStore = PgVectorStore.builder()
+			.jdbcTemplate(this.jdbcTemplate)
 			.embeddingModel(this.embeddingModel)
 			.dimensions(explicitDimensions)
 			.build();
@@ -61,7 +62,8 @@ public class PgVectorEmbeddingDimensionsTests {
 	public void embeddingModelDimensions() {
 		given(this.embeddingModel.dimensions()).willReturn(969);
 
-		PgVectorStore pgVectorStore = PgVectorStore.builder(this.jdbcTemplate)
+		PgVectorStore pgVectorStore = PgVectorStore.builder()
+			.jdbcTemplate(this.jdbcTemplate)
 			.embeddingModel(this.embeddingModel)
 			.build();
 		var dim = pgVectorStore.embeddingDimensions();
@@ -76,7 +78,8 @@ public class PgVectorEmbeddingDimensionsTests {
 
 		given(this.embeddingModel.dimensions()).willThrow(new RuntimeException());
 
-		PgVectorStore pgVectorStore = PgVectorStore.builder(this.jdbcTemplate)
+		PgVectorStore pgVectorStore = PgVectorStore.builder()
+			.jdbcTemplate(this.jdbcTemplate)
 			.embeddingModel(this.embeddingModel)
 			.build();
 		var dim = pgVectorStore.embeddingDimensions();

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorEmbeddingDimensionsTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorEmbeddingDimensionsTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +47,11 @@ public class PgVectorEmbeddingDimensionsTests {
 
 		final int explicitDimensions = 696;
 
-		var dim = new PgVectorStore(this.jdbcTemplate, this.embeddingModel, explicitDimensions).embeddingDimensions();
+		PgVectorStore pgVectorStore = PgVectorStore.builder(this.jdbcTemplate)
+			.embeddingModel(this.embeddingModel)
+			.dimensions(explicitDimensions)
+			.build();
+		var dim = pgVectorStore.embeddingDimensions();
 
 		assertThat(dim).isEqualTo(explicitDimensions);
 		verify(this.embeddingModel, never()).dimensions();
@@ -57,7 +61,10 @@ public class PgVectorEmbeddingDimensionsTests {
 	public void embeddingModelDimensions() {
 		given(this.embeddingModel.dimensions()).willReturn(969);
 
-		var dim = new PgVectorStore(this.jdbcTemplate, this.embeddingModel).embeddingDimensions();
+		PgVectorStore pgVectorStore = PgVectorStore.builder(this.jdbcTemplate)
+			.embeddingModel(this.embeddingModel)
+			.build();
+		var dim = pgVectorStore.embeddingDimensions();
 
 		assertThat(dim).isEqualTo(969);
 
@@ -69,7 +76,10 @@ public class PgVectorEmbeddingDimensionsTests {
 
 		given(this.embeddingModel.dimensions()).willThrow(new RuntimeException());
 
-		var dim = new PgVectorStore(this.jdbcTemplate, this.embeddingModel).embeddingDimensions();
+		PgVectorStore pgVectorStore = PgVectorStore.builder(this.jdbcTemplate)
+			.embeddingModel(this.embeddingModel)
+			.build();
+		var dim = pgVectorStore.embeddingDimensions();
 
 		assertThat(dim).isEqualTo(PgVectorStore.OPENAI_EMBEDDING_DIMENSION_SIZE);
 		verify(this.embeddingModel, only()).dimensions();

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorFilterExpressionConverterTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.util.List;
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorImage.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorImage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.pg.vectorstore;
+
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * @author Thomas Vitale
+ */
+public final class PgVectorImage {
+
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("pgvector/pgvector:pg17");
+
+	private PgVectorImage() {
+
+	}
+
+}

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreCustomNamesIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreCustomNamesIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.util.Random;
 
@@ -30,7 +30,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.ai.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.pg.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -195,14 +196,16 @@ public class PgVectorStoreCustomNamesIT {
 		@Bean
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
 
-			return new PgVectorStore.Builder(jdbcTemplate, embeddingModel).withSchemaName(this.schemaName)
-				.withVectorTableName(this.vectorTableName)
-				.withVectorTableValidationsEnabled(this.schemaValidation)
-				.withDimensions(this.dimensions)
-				.withDistanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
-				.withRemoveExistingVectorStoreTable(true)
-				.withIndexType(PgIndexType.HNSW)
-				.withInitializeSchema(true)
+			return PgVectorStore.builder(jdbcTemplate)
+				.embeddingModel(embeddingModel)
+				.schemaName(this.schemaName)
+				.vectorTableName(this.vectorTableName)
+				.vectorTableValidationsEnabled(this.schemaValidation)
+				.dimensions(this.dimensions)
+				.distanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
+				.removeExistingVectorStoreTable(true)
+				.indexType(PgIndexType.HNSW)
+				.initializeSchema(true)
 				.build();
 		}
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreCustomNamesIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreCustomNamesIT.java
@@ -196,7 +196,8 @@ public class PgVectorStoreCustomNamesIT {
 		@Bean
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
 
-			return PgVectorStore.builder(jdbcTemplate)
+			return PgVectorStore.builder()
+				.jdbcTemplate(jdbcTemplate)
 				.embeddingModel(embeddingModel)
 				.schemaName(this.schemaName)
 				.vectorTableName(this.vectorTableName)

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -43,7 +43,9 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.ai.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.pg.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser.FilterExpressionParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
@@ -354,8 +356,14 @@ public class PgVectorStoreIT {
 
 		@Bean
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
-			return new PgVectorStore(jdbcTemplate, embeddingModel, PgVectorStore.INVALID_EMBEDDING_DIMENSION,
-					this.distanceType, true, PgIndexType.HNSW, true);
+			return PgVectorStore.builder(jdbcTemplate)
+				.embeddingModel(embeddingModel)
+				.dimensions(PgVectorStore.INVALID_EMBEDDING_DIMENSION)
+				.distanceType(this.distanceType)
+				.initializeSchema(true)
+				.indexType(PgIndexType.HNSW)
+				.removeExistingVectorStoreTable(true)
+				.build();
 		}
 
 		@Bean

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreIT.java
@@ -356,7 +356,8 @@ public class PgVectorStoreIT {
 
 		@Bean
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
-			return PgVectorStore.builder(jdbcTemplate)
+			return PgVectorStore.builder()
+				.jdbcTemplate(jdbcTemplate)
 				.embeddingModel(embeddingModel)
 				.dimensions(PgVectorStore.INVALID_EMBEDDING_DIMENSION)
 				.distanceType(this.distanceType)

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreObservationIT.java
@@ -187,7 +187,8 @@ public class PgVectorStoreObservationIT {
 		@Bean
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 				ObservationRegistry observationRegistry) {
-			return PgVectorStore.builder(jdbcTemplate)
+			return PgVectorStore.builder()
+				.jdbcTemplate(jdbcTemplate)
 				.embeddingModel(embeddingModel)
 				.distanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
 				.indexType(PgIndexType.HNSW)

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreObservationIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,7 +41,9 @@ import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetri
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.ai.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.pg.vectorstore.PgVectorStore.PgIndexType;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.observation.DefaultVectorStoreObservationConvention;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationDocumentation.HighCardinalityKeyNames;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationDocumentation.LowCardinalityKeyNames;
@@ -185,11 +187,12 @@ public class PgVectorStoreObservationIT {
 		@Bean
 		public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 				ObservationRegistry observationRegistry) {
-			return new PgVectorStore.Builder(jdbcTemplate, embeddingModel)
-				.withDistanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
-				.withIndexType(PgIndexType.HNSW)
-				.withObservationRegistry(observationRegistry)
-				.withInitializeSchema(true)
+			return PgVectorStore.builder(jdbcTemplate)
+				.embeddingModel(embeddingModel)
+				.distanceType(PgVectorStore.PgDistanceType.COSINE_DISTANCE)
+				.indexType(PgIndexType.HNSW)
+				.observationRegistry(observationRegistry)
+				.initializeSchema(true)
 				.build();
 		}
 

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreTests.java
@@ -79,7 +79,8 @@ public class PgVectorStoreTests {
 		// Given
 		var jdbcTemplate = mock(JdbcTemplate.class);
 		var embeddingModel = mock(EmbeddingModel.class);
-		var pgVectorStore = PgVectorStore.builder(jdbcTemplate)
+		var pgVectorStore = PgVectorStore.builder()
+			.jdbcTemplate(jdbcTemplate)
 			.embeddingModel(embeddingModel)
 			.maxDocumentBatchSize(1000)
 			.build();

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.util.Collections;
 
@@ -79,7 +79,9 @@ public class PgVectorStoreTests {
 		// Given
 		var jdbcTemplate = mock(JdbcTemplate.class);
 		var embeddingModel = mock(EmbeddingModel.class);
-		var pgVectorStore = new PgVectorStore.Builder(jdbcTemplate, embeddingModel).withMaxDocumentBatchSize(1000)
+		var pgVectorStore = PgVectorStore.builder(jdbcTemplate)
+			.embeddingModel(embeddingModel)
+			.maxDocumentBatchSize(1000)
 			.build();
 
 		// Testing with 9989 documents

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/pg/vectorstore/PgVectorStoreWithChatMemoryAdvisorIT.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.vectorstore;
+package org.springframework.ai.pg.vectorstore;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
…pattern

 - Move PgVectorStore and related classes to org.springframework.ai.pg.vectorstore package
 - Update builder pattern to use more idiomatic method names (e.g. withSchemaName -> schemaName)
 - Deprecate existing constructors and old Builder class in favor of new static builder() method
 - Update tests to reflect the new builder style usage


