### PR TITLE
Fix HTML document title on main page to "Introduction"  (again)

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 [[introduction]]
+= Introduction
 
 image::spring_ai_logo_with_text.svg[Integration Problem, width=300, align="left"]
 


### PR DESCRIPTION
This is simply a restoration of #1615. The HTML document title was removed in commit 0b00e6f, and unless there is a specific reason for its removal, it would be better to re-add it.