### PR TITLE
Added Line Separator Override Feature to ExtractedTextFormatter

### DIFF
--- a/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
+++ b/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
@@ -44,6 +44,7 @@ class PagePdfDocumentReaderTests {
 						.withNumberOfTopTextLinesToDelete(0)
 						.withNumberOfBottomTextLinesToDelete(3)
 						.withNumberOfTopPagesToSkipBeforeDelete(0)
+						.overrideLineSeparator("\n")
 						.build())
 					.withPagesPerDocument(1)
 					.build());

--- a/spring-ai-core/src/main/java/org/springframework/ai/reader/ExtractedTextFormatter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/reader/ExtractedTextFormatter.java
@@ -47,6 +47,9 @@ public final class ExtractedTextFormatter {
 	/** Number of bottom text lines to delete from a page */
 	private final int numberOfBottomTextLinesToDelete;
 
+	/** Line separator */
+	private final String lineSeparator;
+
 	/**
 	 * Private constructor to initialize the formatter from the builder.
 	 * @param builder Builder used to initialize the formatter.
@@ -56,6 +59,7 @@ public final class ExtractedTextFormatter {
 		this.numberOfBottomTextLinesToDelete = builder.numberOfBottomTextLinesToDelete;
 		this.numberOfTopPagesToSkipBeforeDelete = builder.numberOfTopPagesToSkipBeforeDelete;
 		this.numberOfTopTextLinesToDelete = builder.numberOfTopTextLinesToDelete;
+		this.lineSeparator = builder.lineSeparator;
 	}
 
 	/**
@@ -95,9 +99,10 @@ public final class ExtractedTextFormatter {
 	 * Removes the specified number of lines from the bottom part of the text.
 	 * @param pageText Text to remove lines from.
 	 * @param numberOfLines Number of lines to remove.
+	 * @param lineSeparator The line separator to use when identifying lines in the text.
 	 * @return Returns the text striped from last lines.
 	 */
-	public static String deleteBottomTextLines(String pageText, int numberOfLines) {
+	public static String deleteBottomTextLines(String pageText, int numberOfLines, String lineSeparator) {
 		if (!StringUtils.hasText(pageText)) {
 			return pageText;
 		}
@@ -106,7 +111,7 @@ public final class ExtractedTextFormatter {
 		int truncateIndex = pageText.length();
 		int nextTruncateIndex = truncateIndex;
 		while (lineCount < numberOfLines && nextTruncateIndex >= 0) {
-			nextTruncateIndex = pageText.lastIndexOf(System.lineSeparator(), truncateIndex - 1);
+			nextTruncateIndex = pageText.lastIndexOf(lineSeparator, truncateIndex - 1);
 			truncateIndex = nextTruncateIndex < 0 ? truncateIndex : nextTruncateIndex;
 			lineCount++;
 		}
@@ -132,9 +137,10 @@ public final class ExtractedTextFormatter {
 	 * @param numberOfLines The number of lines to remove from the top of the text. If
 	 * this exceeds the actual number of lines in the text, an empty string will be
 	 * returned.
+	 * @param lineSeparator The line separator to use when identifying lines in the text.
 	 * @return The text with the specified number of lines removed from the top.
 	 */
-	public static String deleteTopTextLines(String pageText, int numberOfLines) {
+	public static String deleteTopTextLines(String pageText, int numberOfLines, String lineSeparator) {
 		if (!StringUtils.hasText(pageText)) {
 			return pageText;
 		}
@@ -143,7 +149,7 @@ public final class ExtractedTextFormatter {
 		int truncateIndex = 0;
 		int nextTruncateIndex = truncateIndex;
 		while (lineCount < numberOfLines && nextTruncateIndex >= 0) {
-			nextTruncateIndex = pageText.indexOf(System.lineSeparator(), truncateIndex + 1);
+			nextTruncateIndex = pageText.indexOf(lineSeparator, truncateIndex + 1);
 			truncateIndex = nextTruncateIndex < 0 ? truncateIndex : nextTruncateIndex;
 			lineCount++;
 		}
@@ -171,8 +177,8 @@ public final class ExtractedTextFormatter {
 		var text = trimAdjacentBlankLines(pageText);
 
 		if (pageNumber >= this.numberOfTopPagesToSkipBeforeDelete) {
-			text = deleteTopTextLines(text, this.numberOfTopTextLinesToDelete);
-			text = deleteBottomTextLines(text, this.numberOfBottomTextLinesToDelete);
+			text = deleteTopTextLines(text, this.numberOfTopTextLinesToDelete, this.lineSeparator);
+			text = deleteBottomTextLines(text, this.numberOfBottomTextLinesToDelete, this.lineSeparator);
 		}
 
 		if (this.leftAlignment) {
@@ -222,6 +228,7 @@ public final class ExtractedTextFormatter {
 
 		private int numberOfBottomTextLinesToDelete = 0;
 
+		private String lineSeparator = System.lineSeparator();
 		/**
 		 * Align the document text to the left. Defaults to false.
 		 * @param leftAlignment Flag to align the text to the left.
@@ -260,6 +267,17 @@ public final class ExtractedTextFormatter {
 		 */
 		public Builder withNumberOfBottomTextLinesToDelete(int numberOfBottomTextLinesToDelete) {
 			this.numberOfBottomTextLinesToDelete = numberOfBottomTextLinesToDelete;
+			return this;
+		}
+
+		/**
+		 * Set the line separator to use when formatting the text. Defaults to the system
+		 * line separator.
+		 * @param lineSeparator The line separator to use.
+		 * @return this builder
+		 */
+		public Builder overrideLineSeparator(String lineSeparator) {
+			this.lineSeparator = lineSeparator;
 			return this;
 		}
 


### PR DESCRIPTION
about #1913 

**Changes**
Added the ability to override the Line Separator in ExtractedTextFormatter. The default remains System.lineSeparator() to ensure backward compatibility.

**Background**
Relying on System.lineSeparator() has caused unexpected behavior in different environments. Specifically, while PDF files generally use \n as a line separator regardless of the operating system, Windows environments use \r\n as the default System.lineSeparator(). This discrepancy could lead to formatting failures.

**My Thoughts**
I reviewed related issues and noticed that Line Separator behavior varies significantly depending on the operating system and environment.
To provide a flexible solution that maintains backward compatibility, I implemented an override option to let developers customize the Line Separator based on their needs.

If you have other better ideas, I’d love to discuss them together.