### PR TITLE
Bug Fix: Correct Parameter Type for KnnSearch$Builder.k Method in ElasticsearchVectorStore.java

### DIFF
--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/ElasticsearchVectorStore.java
@@ -193,7 +193,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 					sr -> sr.index(this.options.getIndexName())
 						.knn(knn -> knn.queryVector(EmbeddingUtils.toList(vectors))
 							.similarity(finalThreshold)
-							.k((long) searchRequest.getTopK())
+							.k(searchRequest.getTopK())
 							.field("embedding")
 							.numCandidates((long) (1.5 * searchRequest.getTopK()))
 							.filter(fl -> fl.queryString(


### PR DESCRIPTION
## Bug Fix

Correct Parameter Type for KnnSearch$Builder.k Method in ElasticsearchVectorStore.java

## Description

This PR addresses a bug in ElasticsearchVectorStore.java where an incorrect parameter type was passed to the `KnnSearch$Builder.k` method of the ElasticSearchClient during the execution of similaritySearch. The issue caused the following error:

```
Handler dispatch failed: java.lang.NoSuchMethodError: 'co.elastic.clients.elasticsearch._types.KnnSearch$Builder co.elastic.clients.elasticsearch._types.KnnSearch$Builder.k(java.lang.Long)'
```

## Root Cause
The `KnnSearch$Builder.k` method in `elasticsearch-rest-client:8.15.4` requires an Integer parameter, but the code passed a long value, leading to the NoSuchMethodError.
```java
SearchResponse<Document> res = this.elasticsearchClient.search(
					sr -> sr.index(this.options.getIndexName())
						.knn(knn -> knn.queryVector(EmbeddingUtils.toList(vectors))
							.similarity(finalThreshold)
							.k((long) searchRequest.getTopK())
							.field("embedding")
							.numCandidates((long) (1.5 * searchRequest.getTopK()))
							.filter(fl -> fl.queryString(
									qs -> qs.query(getElasticsearchQueryString(searchRequest.getFilterExpression()))))),
					Document.class);
```

## Fix
The fix involves changing the parameter type from long to Integer when calling the `KnnSearch$Builder.k` method.

## Changes
Updated ElasticsearchVectorStore.java to pass an Integer parameter to the `KnnSearch$Builder.k` method.
