### PR TITLE
Update Anthropic3ChatOptions.java

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/Anthropic3ChatOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/Anthropic3ChatOptions.java
@@ -74,7 +74,7 @@ public class Anthropic3ChatOptions implements ChatOptions {
 	private @JsonProperty("anthropic_version") String anthropicVersion;
 	// @formatter:on
 
-	Anthropic3ChatOptions() {
+	public Anthropic3ChatOptions() {
 	}
 
 	/**


### PR DESCRIPTION
The constructor needs to be public so that the options can be correctly copied over to the runtime call.