### PR TITLE
chore: replace all instances of 'final static' with 'static final'

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageOptions.java
@@ -255,7 +255,7 @@ public class AzureOpenAiImageOptions implements ImageOptions {
 
 	}
 
-	public final static class Builder {
+	public static final class Builder {
 
 		private final AzureOpenAiImageOptions options;
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -483,7 +483,7 @@ public final class ConverseApiUtils {
 			return new Builder();
 		}
 
-		public final static class Builder {
+		public static final class Builder {
 
 			private String role;
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
@@ -55,7 +55,7 @@ import org.springframework.util.Assert;
  */
 public class OpenAiImageModel implements ImageModel {
 
-	private final static Logger logger = LoggerFactory.getLogger(OpenAiImageModel.class);
+	private static final Logger logger = LoggerFactory.getLogger(OpenAiImageModel.class);
 
 	private static final ImageModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultImageModelObservationConvention();
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiPaymentTransactionIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiPaymentTransactionIT.java
@@ -58,7 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
 public class OpenAiPaymentTransactionIT {
 
-	private final static Logger logger = LoggerFactory.getLogger(OpenAiPaymentTransactionIT.class);
+	private static final Logger logger = LoggerFactory.getLogger(OpenAiPaymentTransactionIT.class);
 
 	private static final Map<Transaction, Status> DATASET = Map.of(new Transaction("001"), new Status("pending"),
 			new Transaction("002"), new Status("approved"), new Transaction("003"), new Status("rejected"));

--- a/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanImageModel.java
+++ b/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanImageModel.java
@@ -50,7 +50,7 @@ import org.springframework.util.Assert;
  */
 public class QianFanImageModel implements ImageModel {
 
-	private final static Logger logger = LoggerFactory.getLogger(QianFanImageModel.class);
+	private static final Logger logger = LoggerFactory.getLogger(QianFanImageModel.class);
 
 	private static final ImageModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultImageModelObservationConvention();
 

--- a/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
+++ b/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
@@ -81,19 +81,19 @@ import org.springframework.util.StringUtils;
 public class TransformersEmbeddingModel extends AbstractEmbeddingModel implements InitializingBean {
 
 	// ONNX tokenizer for the all-MiniLM-L6-v2 generative
-	public final static String DEFAULT_ONNX_TOKENIZER_URI = "https://raw.githubusercontent.com/spring-projects/spring-ai/main/models/spring-ai-transformers/src/main/resources/onnx/all-MiniLM-L6-v2/tokenizer.json";
+	public static final String DEFAULT_ONNX_TOKENIZER_URI = "https://raw.githubusercontent.com/spring-projects/spring-ai/main/models/spring-ai-transformers/src/main/resources/onnx/all-MiniLM-L6-v2/tokenizer.json";
 
 	// ONNX generative for all-MiniLM-L6-v2 pre-trained transformer:
 	// https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2
-	public final static String DEFAULT_ONNX_MODEL_URI = "https://github.com/spring-projects/spring-ai/raw/main/models/spring-ai-transformers/src/main/resources/onnx/all-MiniLM-L6-v2/model.onnx";
+	public static final String DEFAULT_ONNX_MODEL_URI = "https://github.com/spring-projects/spring-ai/raw/main/models/spring-ai-transformers/src/main/resources/onnx/all-MiniLM-L6-v2/model.onnx";
 
-	public final static String DEFAULT_MODEL_OUTPUT_NAME = "last_hidden_state";
+	public static final String DEFAULT_MODEL_OUTPUT_NAME = "last_hidden_state";
 
 	private static final Log logger = LogFactory.getLog(TransformersEmbeddingModel.class);
 
 	private static final EmbeddingModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultEmbeddingModelObservationConvention();
 
-	private final static int EMBEDDING_AXIS = 1;
+	private static final int EMBEDDING_AXIS = 1;
 
 	/**
 	 * Specifies what parts of the {@link Document}'s content and metadata will be used

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/function/VertexAiGeminiPaymentTransactionIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/function/VertexAiGeminiPaymentTransactionIT.java
@@ -57,7 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "VERTEX_AI_GEMINI_LOCATION", matches = ".*")
 public class VertexAiGeminiPaymentTransactionIT {
 
-	private final static Logger logger = LoggerFactory.getLogger(VertexAiGeminiPaymentTransactionIT.class);
+	private static final Logger logger = LoggerFactory.getLogger(VertexAiGeminiPaymentTransactionIT.class);
 
 	private static final Map<Transaction, Status> DATASET = Map.of(new Transaction("001"), new Status("pending"),
 			new Transaction("002"), new Status("approved"), new Transaction("003"), new Status("rejected"));

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageModel.java
@@ -43,7 +43,7 @@ import org.springframework.util.Assert;
  */
 public class ZhiPuAiImageModel implements ImageModel {
 
-	private final static Logger logger = LoggerFactory.getLogger(ZhiPuAiImageModel.class);
+	private static final Logger logger = LoggerFactory.getLogger(ZhiPuAiImageModel.class);
 
 	public final RetryTemplate retryTemplate;
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/SafeGuardAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/SafeGuardAdvisor.java
@@ -41,9 +41,9 @@ import org.springframework.util.CollectionUtils;
  */
 public class SafeGuardAdvisor implements CallAroundAdvisor, StreamAroundAdvisor {
 
-	private final static String DEFAULT_FAILURE_RESPONSE = "I'm unable to respond to that due to sensitive content. Could we rephrase or discuss something else?";
+	private static final String DEFAULT_FAILURE_RESPONSE = "I'm unable to respond to that due to sensitive content. Could we rephrase or discuss something else?";
 
-	private final static int DEFAULT_ORDER = 0;
+	private static final int DEFAULT_ORDER = 0;
 
 	private final String failureResponse;
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/ChatResponseMetadata.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/metadata/ChatResponseMetadata.java
@@ -35,7 +35,7 @@ import org.springframework.ai.model.ResponseMetadata;
  */
 public class ChatResponseMetadata extends AbstractResponseMetadata implements ResponseMetadata {
 
-	private final static Logger logger = LoggerFactory.getLogger(ChatResponseMetadata.class);
+	private static final Logger logger = LoggerFactory.getLogger(ChatResponseMetadata.class);
 
 	private String id = ""; // Set to blank to preserve backward compat with previous
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/model/AbstractToolCallSupport.java
@@ -47,7 +47,7 @@ import org.springframework.util.CollectionUtils;
  */
 public abstract class AbstractToolCallSupport {
 
-	protected final static boolean IS_RUNTIME_CALL = true;
+	protected static final boolean IS_RUNTIME_CALL = true;
 
 	/**
 	 * The function callback register is used to resolve the function callbacks by name.

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptionsBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptionsBuilder.java
@@ -77,7 +77,7 @@ public final class ChatOptionsBuilder {
 		return this.options;
 	}
 
-	private final static class DefaultChatOptions implements ChatOptions {
+	private static final class DefaultChatOptions implements ChatOptions {
 
 		private String model;
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallbackBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallbackBuilder.java
@@ -45,7 +45,7 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultFunctionCallbackBuilder implements FunctionCallback.Builder {
 
-	private final static Logger logger = LoggerFactory.getLogger(DefaultFunctionCallbackBuilder.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultFunctionCallbackBuilder.class);
 
 	@Override
 	public <I, O> FunctionInvokingSpec<I, O> function(String name, Function<I, O> function) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/rag/orchestration/routing/AllRetrieversQueryRouter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/rag/orchestration/routing/AllRetrieversQueryRouter.java
@@ -55,7 +55,7 @@ public class AllRetrieversQueryRouter implements QueryRouter {
 		return new Builder();
 	}
 
-	public final static class Builder {
+	public static final class Builder {
 
 		private List<DocumentRetriever> documentRetrievers;
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -36,15 +36,15 @@ import org.springframework.util.Assert;
  */
 public class TokenTextSplitter extends TextSplitter {
 
-	private final static int DEFAULT_CHUNK_SIZE = 800;
+	private static final int DEFAULT_CHUNK_SIZE = 800;
 
-	private final static int MIN_CHUNK_SIZE_CHARS = 350;
+	private static final int MIN_CHUNK_SIZE_CHARS = 350;
 
-	private final static int MIN_CHUNK_LENGTH_TO_EMBED = 5;
+	private static final int MIN_CHUNK_LENGTH_TO_EMBED = 5;
 
-	private final static int MAX_NUM_CHUNKS = 10000;
+	private static final int MAX_NUM_CHUNKS = 10000;
 
-	private final static boolean KEEP_SEPARATOR = true;
+	private static final boolean KEEP_SEPARATOR = true;
 
 	private final EncodingRegistry registry = Encodings.newLazyEncodingRegistry();
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/FilterHelper.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/FilterHelper.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  */
 public final class FilterHelper {
 
-	private final static Map<ExpressionType, ExpressionType> TYPE_NEGATION_MAP = Map.of(ExpressionType.AND,
+	private static final Map<ExpressionType, ExpressionType> TYPE_NEGATION_MAP = Map.of(ExpressionType.AND,
 			ExpressionType.OR, ExpressionType.OR, ExpressionType.AND, ExpressionType.EQ, ExpressionType.NE,
 			ExpressionType.NE, ExpressionType.EQ, ExpressionType.GT, ExpressionType.LTE, ExpressionType.GTE,
 			ExpressionType.LT, ExpressionType.LT, ExpressionType.GTE, ExpressionType.LTE, ExpressionType.GT,

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/watsonx-ai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/watsonx-ai-chat.adoc
@@ -102,7 +102,7 @@ NOTE: For more information go to https://dataplatform.cloud.ibm.com/docs/content
 ----
 public class MyClass {
 
-    private final static String MODEL = "google/flan-ul2";
+    private static final String MODEL = "google/flan-ul2";
     private final WatsonxAiChatModel chatModel;
 
     @Autowired

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiAutoConfiguration.java
@@ -62,7 +62,7 @@ import org.springframework.util.StringUtils;
 		AzureOpenAiAudioTranscriptionProperties.class })
 public class AzureOpenAiAutoConfiguration {
 
-	private final static String APPLICATION_ID = "spring-ai";
+	private static final String APPLICATION_ID = "spring-ai";
 
 	@Bean
 	@ConditionalOnMissingBean // ({ OpenAIClient.class, TokenCredential.class })

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/azure/AzureVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/azure/AzureVectorStoreAutoConfiguration.java
@@ -50,7 +50,7 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnProperty(prefix = "spring.ai.vectorstore.azure", value = { "url", "api-key", "index-name" })
 public class AzureVectorStoreAutoConfiguration {
 
-	private final static String APPLICATION_ID = "spring-ai";
+	private static final String APPLICATION_ID = "spring-ai";
 
 	@Bean
 	@ConditionalOnMissingBean


### PR DESCRIPTION
Standardized the order of modifiers in variable declarations by replacing all instances of `final static` with `static final` across the codebase.

## Why?
The conventional order of modifiers in Java is `static` followed by `final`. Adhering to this order ensures consistency and meets standard coding practices.

