### PR TITLE
Fix code examples in prompt.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/prompt.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/prompt.adoc
@@ -202,7 +202,7 @@ A simple example taken from the https://github.com/Azure-Samples/spring-ai-azure
 
 PromptTemplate promptTemplate = new PromptTemplate("Tell me a {adjective} joke about {topic}");
 
-Prompt prompt = this.promptTemplate.create(Map.of("adjective", adjective, "topic", topic));
+Prompt prompt = promptTemplate.create(Map.of("adjective", adjective, "topic", topic));
 
 return chatModel.call(prompt).getResult();
 ```
@@ -215,7 +215,7 @@ String userText = """
     Write at least a sentence for each pirate.
     """;
 
-Message userMessage = new UserMessage(this.userText);
+Message userMessage = new UserMessage(userText);
 
 String systemText = """
   You are a helpful AI assistant that helps people find information.
@@ -223,12 +223,12 @@ String systemText = """
   You should reply to the user's request with your name and also in the style of a {voice}.
   """;
 
-SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(this.systemText);
-Message systemMessage = this.systemPromptTemplate.createMessage(Map.of("name", name, "voice", voice));
+SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(systemText);
+Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", name, "voice", voice));
 
-Prompt prompt = new Prompt(List.of(this.userMessage, this.systemMessage));
+Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 
-List<Generation> response = chatModel.call(this.prompt).getResults();
+List<Generation> response = chatModel.call(prompt).getResults();
 
 ```
 


### PR DESCRIPTION
Remove `this.` in code example as it's local variables and not fields

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
