### PR TITLE
Refactor builder methods of Moderation package

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/moderation/Categories.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/moderation/Categories.java
@@ -24,6 +24,7 @@ import java.util.Objects;
  * false (indicating that the content does not belong to the category).
  *
  * @author Ahmed Yousri
+ * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
 public final class Categories {
@@ -168,56 +169,155 @@ public final class Categories {
 
 		private boolean violence;
 
+		public Builder sexual(boolean sexual) {
+			this.sexual = sexual;
+			return this;
+		}
+
+		public Builder hate(boolean hate) {
+			this.hate = hate;
+			return this;
+		}
+
+		public Builder harassment(boolean harassment) {
+			this.harassment = harassment;
+			return this;
+		}
+
+		public Builder selfHarm(boolean selfHarm) {
+			this.selfHarm = selfHarm;
+			return this;
+		}
+
+		public Builder sexualMinors(boolean sexualMinors) {
+			this.sexualMinors = sexualMinors;
+			return this;
+		}
+
+		public Builder hateThreatening(boolean hateThreatening) {
+			this.hateThreatening = hateThreatening;
+			return this;
+		}
+
+		public Builder violenceGraphic(boolean violenceGraphic) {
+			this.violenceGraphic = violenceGraphic;
+			return this;
+		}
+
+		public Builder selfHarmIntent(boolean selfHarmIntent) {
+			this.selfHarmIntent = selfHarmIntent;
+			return this;
+		}
+
+		public Builder selfHarmInstructions(boolean selfHarmInstructions) {
+			this.selfHarmInstructions = selfHarmInstructions;
+			return this;
+		}
+
+		public Builder harassmentThreatening(boolean harassmentThreatening) {
+			this.harassmentThreatening = harassmentThreatening;
+			return this;
+		}
+
+		public Builder violence(boolean violence) {
+			this.violence = violence;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #sexual(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSexual(boolean sexual) {
 			this.sexual = sexual;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #hate(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHate(boolean hate) {
 			this.hate = hate;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #harassment(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHarassment(boolean harassment) {
 			this.harassment = harassment;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #selfHarm(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSelfHarm(boolean selfHarm) {
 			this.selfHarm = selfHarm;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #sexualMinors(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSexualMinors(boolean sexualMinors) {
 			this.sexualMinors = sexualMinors;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #hateThreatening(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHateThreatening(boolean hateThreatening) {
 			this.hateThreatening = hateThreatening;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #violenceGraphic(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withViolenceGraphic(boolean violenceGraphic) {
 			this.violenceGraphic = violenceGraphic;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #selfHarmIntent(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSelfHarmIntent(boolean selfHarmIntent) {
 			this.selfHarmIntent = selfHarmIntent;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #selfHarmInstructions(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSelfHarmInstructions(boolean selfHarmInstructions) {
 			this.selfHarmInstructions = selfHarmInstructions;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #harassmentThreatening(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHarassmentThreatening(boolean harassmentThreatening) {
 			this.harassmentThreatening = harassmentThreatening;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #violence(boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withViolence(boolean violence) {
 			this.violence = violence;
 			return this;

--- a/spring-ai-core/src/main/java/org/springframework/ai/moderation/CategoryScores.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/moderation/CategoryScores.java
@@ -24,6 +24,7 @@ import java.util.Objects;
  * content in each respective category.
  *
  * @author Ahmed Yousri
+ * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
 public final class CategoryScores {
@@ -173,56 +174,155 @@ public final class CategoryScores {
 
 		private double violence;
 
+		public Builder sexual(double sexual) {
+			this.sexual = sexual;
+			return this;
+		}
+
+		public Builder hate(double hate) {
+			this.hate = hate;
+			return this;
+		}
+
+		public Builder harassment(double harassment) {
+			this.harassment = harassment;
+			return this;
+		}
+
+		public Builder selfHarm(double selfHarm) {
+			this.selfHarm = selfHarm;
+			return this;
+		}
+
+		public Builder sexualMinors(double sexualMinors) {
+			this.sexualMinors = sexualMinors;
+			return this;
+		}
+
+		public Builder hateThreatening(double hateThreatening) {
+			this.hateThreatening = hateThreatening;
+			return this;
+		}
+
+		public Builder violenceGraphic(double violenceGraphic) {
+			this.violenceGraphic = violenceGraphic;
+			return this;
+		}
+
+		public Builder selfHarmIntent(double selfHarmIntent) {
+			this.selfHarmIntent = selfHarmIntent;
+			return this;
+		}
+
+		public Builder selfHarmInstructions(double selfHarmInstructions) {
+			this.selfHarmInstructions = selfHarmInstructions;
+			return this;
+		}
+
+		public Builder harassmentThreatening(double harassmentThreatening) {
+			this.harassmentThreatening = harassmentThreatening;
+			return this;
+		}
+
+		public Builder violence(double violence) {
+			this.violence = violence;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #sexual(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSexual(double sexual) {
 			this.sexual = sexual;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #hate(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHate(double hate) {
 			this.hate = hate;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #harassment(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHarassment(double harassment) {
 			this.harassment = harassment;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #selfHarm(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSelfHarm(double selfHarm) {
 			this.selfHarm = selfHarm;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #sexualMinors(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSexualMinors(double sexualMinors) {
 			this.sexualMinors = sexualMinors;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #hateThreatening(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHateThreatening(double hateThreatening) {
 			this.hateThreatening = hateThreatening;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #violenceGraphic(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withViolenceGraphic(double violenceGraphic) {
 			this.violenceGraphic = violenceGraphic;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #selfHarmIntent(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSelfHarmIntent(double selfHarmIntent) {
 			this.selfHarmIntent = selfHarmIntent;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #selfHarmInstructions(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSelfHarmInstructions(double selfHarmInstructions) {
 			this.selfHarmInstructions = selfHarmInstructions;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #harassmentThreatening(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHarassmentThreatening(double harassmentThreatening) {
 			this.harassmentThreatening = harassmentThreatening;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #violence(double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withViolence(double violence) {
 			this.violence = violence;
 			return this;

--- a/spring-ai-core/src/main/java/org/springframework/ai/moderation/Generation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/moderation/Generation.java
@@ -45,6 +45,15 @@ public class Generation implements ModelResult<Moderation> {
 		this.moderationGenerationMetadata = moderationGenerationMetadata;
 	}
 
+	public Generation generationMetadata(@Nullable ModerationGenerationMetadata moderationGenerationMetadata) {
+		this.moderationGenerationMetadata = moderationGenerationMetadata;
+		return this;
+	}
+
+	/**
+	 * @deprecated use {@link #generationMetadata(ModerationGenerationMetadata)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public Generation withGenerationMetadata(@Nullable ModerationGenerationMetadata moderationGenerationMetadata) {
 		this.moderationGenerationMetadata = moderationGenerationMetadata;
 		return this;

--- a/spring-ai-core/src/main/java/org/springframework/ai/moderation/Moderation.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/moderation/Moderation.java
@@ -26,6 +26,7 @@ import java.util.Objects;
  * Moderation, use the Builder class.
  *
  * @author Ahmed Yousri
+ * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
 public final class Moderation {
@@ -90,16 +91,43 @@ public final class Moderation {
 
 		private List<ModerationResult> moderationResultList;
 
+		public Builder id(String id) {
+			this.id = id;
+			return this;
+		}
+
+		public Builder model(String model) {
+			this.model = model;
+			return this;
+		}
+
+		public Builder results(List<ModerationResult> results) {
+			this.moderationResultList = results;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #id(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withId(String id) {
 			this.id = id;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #model(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withModel(String model) {
 			this.model = model;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #results(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withResults(List<ModerationResult> results) {
 			this.moderationResultList = results;
 			return this;

--- a/spring-ai-core/src/main/java/org/springframework/ai/moderation/ModerationOptionsBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/moderation/ModerationOptionsBuilder.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.moderation;
 
+import java.util.List;
+
 /**
  * A builder class for creating instances of ModerationOptions. Use the builder() method
  * to obtain a new instance of ModerationOptionsBuilder. Use the withModel() method to set
@@ -37,6 +39,15 @@ public final class ModerationOptionsBuilder {
 		return new ModerationOptionsBuilder();
 	}
 
+	public ModerationOptionsBuilder model(String model) {
+		this.options.setModel(model);
+		return this;
+	}
+
+	/**
+	 * @deprecated use {@link #model(String)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public ModerationOptionsBuilder withModel(String model) {
 		this.options.setModel(model);
 		return this;


### PR DESCRIPTION
 - Update Moderation, Generation, Categories, CategoryScores' builder method
   - deprecate the existing builder methods with the prefix `with` and replace them without the prefix

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
