### PR TITLE
Refactor Azure model options builder methods

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionOptions.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  * Options for audio transcription using Azure Open AI.
  *
  * @author Piotr Olaszewski
+ * @author Ilayaperumal Gopinathan
  */
 @JsonInclude(Include.NON_NULL)
 public class AzureOpenAiAudioTranscriptionOptions implements AudioTranscriptionOptions {
@@ -266,36 +267,99 @@ public class AzureOpenAiAudioTranscriptionOptions implements AudioTranscriptionO
 			this.options = options;
 		}
 
+		public Builder model(String model) {
+			this.options.model = model;
+			return this;
+		}
+
+		public Builder deploymentName(String deploymentName) {
+			this.options.setDeploymentName(deploymentName);
+			return this;
+		}
+
+		public Builder language(String language) {
+			this.options.language = language;
+			return this;
+		}
+
+		public Builder prompt(String prompt) {
+			this.options.prompt = prompt;
+			return this;
+		}
+
+		public Builder responseFormat(TranscriptResponseFormat responseFormat) {
+			this.options.responseFormat = responseFormat;
+			return this;
+		}
+
+		public Builder temperature(Float temperature) {
+			this.options.temperature = temperature;
+			return this;
+		}
+
+		public Builder granularityType(List<GranularityType> granularityType) {
+			this.options.granularityType = granularityType;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #model(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withModel(String model) {
 			this.options.model = model;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #deploymentName(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withDeploymentName(String deploymentName) {
 			this.options.setDeploymentName(deploymentName);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #language(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withLanguage(String language) {
 			this.options.language = language;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #prompt(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withPrompt(String prompt) {
 			this.options.prompt = prompt;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #responseFormat(TranscriptResponseFormat)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withResponseFormat(TranscriptResponseFormat responseFormat) {
 			this.options.responseFormat = responseFormat;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #temperature(Float)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTemperature(Float temperature) {
 			this.options.temperature = temperature;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #granularityType(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withGranularityType(List<GranularityType> granularityType) {
 			this.options.granularityType = granularityType;
 			return this;

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -145,8 +145,8 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 	public AzureOpenAiChatModel(OpenAIClientBuilder openAIClientBuilder) {
 		this(openAIClientBuilder,
 				AzureOpenAiChatOptions.builder()
-					.withDeploymentName(DEFAULT_DEPLOYMENT_NAME)
-					.withTemperature(DEFAULT_TEMPERATURE)
+					.deploymentName(DEFAULT_DEPLOYMENT_NAME)
+					.temperature(DEFAULT_TEMPERATURE)
 					.build());
 	}
 

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Soby Chacko
+ * @author Ilayaperumal Gopinathan
  */
 @JsonInclude(Include.NON_NULL)
 public class AzureOpenAiChatOptions implements FunctionCallingOptions {
@@ -205,25 +206,25 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions {
 	}
 
 	public static AzureOpenAiChatOptions fromOptions(AzureOpenAiChatOptions fromOptions) {
-		return builder().withDeploymentName(fromOptions.getDeploymentName())
-			.withFrequencyPenalty(fromOptions.getFrequencyPenalty() != null ? fromOptions.getFrequencyPenalty() : null)
-			.withLogitBias(fromOptions.getLogitBias())
-			.withMaxTokens(fromOptions.getMaxTokens())
-			.withN(fromOptions.getN())
-			.withPresencePenalty(fromOptions.getPresencePenalty() != null ? fromOptions.getPresencePenalty() : null)
-			.withStop(fromOptions.getStop())
-			.withTemperature(fromOptions.getTemperature())
-			.withTopP(fromOptions.getTopP())
-			.withUser(fromOptions.getUser())
-			.withFunctionCallbacks(fromOptions.getFunctionCallbacks())
-			.withFunctions(fromOptions.getFunctions())
-			.withResponseFormat(fromOptions.getResponseFormat())
-			.withSeed(fromOptions.getSeed())
-			.withLogprobs(fromOptions.isLogprobs())
-			.withTopLogprobs(fromOptions.getTopLogProbs())
-			.withEnhancements(fromOptions.getEnhancements())
-			.withToolContext(fromOptions.getToolContext())
-			.withStreamOptions(fromOptions.getStreamOptions())
+		return builder().deploymentName(fromOptions.getDeploymentName())
+			.frequencyPenalty(fromOptions.getFrequencyPenalty() != null ? fromOptions.getFrequencyPenalty() : null)
+			.logitBias(fromOptions.getLogitBias())
+			.maxTokens(fromOptions.getMaxTokens())
+			.N(fromOptions.getN())
+			.presencePenalty(fromOptions.getPresencePenalty() != null ? fromOptions.getPresencePenalty() : null)
+			.stop(fromOptions.getStop())
+			.temperature(fromOptions.getTemperature())
+			.topP(fromOptions.getTopP())
+			.user(fromOptions.getUser())
+			.functionCallbacks(fromOptions.getFunctionCallbacks())
+			.functions(fromOptions.getFunctions())
+			.responseFormat(fromOptions.getResponseFormat())
+			.seed(fromOptions.getSeed())
+			.logprobs(fromOptions.isLogprobs())
+			.topLogprobs(fromOptions.getTopLogProbs())
+			.enhancements(fromOptions.getEnhancements())
+			.toolContext(fromOptions.getToolContext())
+			.streamOptions(fromOptions.getStreamOptions())
 			.build();
 	}
 
@@ -442,103 +443,296 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions {
 			this.options = options;
 		}
 
+		public Builder deploymentName(String deploymentName) {
+			this.options.deploymentName = deploymentName;
+			return this;
+		}
+
+		public Builder frequencyPenalty(Double frequencyPenalty) {
+			this.options.frequencyPenalty = frequencyPenalty;
+			return this;
+		}
+
+		public Builder logitBias(Map<String, Integer> logitBias) {
+			this.options.logitBias = logitBias;
+			return this;
+		}
+
+		public Builder maxTokens(Integer maxTokens) {
+			this.options.maxTokens = maxTokens;
+			return this;
+		}
+
+		public Builder N(Integer n) {
+			this.options.n = n;
+			return this;
+		}
+
+		public Builder presencePenalty(Double presencePenalty) {
+			this.options.presencePenalty = presencePenalty;
+			return this;
+		}
+
+		public Builder stop(List<String> stop) {
+			this.options.stop = stop;
+			return this;
+		}
+
+		public Builder temperature(Double temperature) {
+			this.options.temperature = temperature;
+			return this;
+		}
+
+		public Builder topP(Double topP) {
+			this.options.topP = topP;
+			return this;
+		}
+
+		public Builder user(String user) {
+			this.options.user = user;
+			return this;
+		}
+
+		public Builder functionCallbacks(List<FunctionCallback> functionCallbacks) {
+			this.options.functionCallbacks = functionCallbacks;
+			return this;
+		}
+
+		public Builder functions(Set<String> functionNames) {
+			Assert.notNull(functionNames, "Function names must not be null");
+			this.options.functions = functionNames;
+			return this;
+		}
+
+		public Builder function(String functionName) {
+			Assert.hasText(functionName, "Function name must not be empty");
+			this.options.functions.add(functionName);
+			return this;
+		}
+
+		public Builder responseFormat(AzureOpenAiResponseFormat responseFormat) {
+			this.options.responseFormat = responseFormat;
+			return this;
+		}
+
+		public Builder proxyToolCalls(Boolean proxyToolCalls) {
+			this.options.proxyToolCalls = proxyToolCalls;
+			return this;
+		}
+
+		public Builder seed(Long seed) {
+			this.options.seed = seed;
+			return this;
+		}
+
+		public Builder logprobs(Boolean logprobs) {
+			this.options.logprobs = logprobs;
+			return this;
+		}
+
+		public Builder topLogprobs(Integer topLogprobs) {
+			this.options.topLogProbs = topLogprobs;
+			return this;
+		}
+
+		public Builder enhancements(AzureChatEnhancementConfiguration enhancements) {
+			this.options.enhancements = enhancements;
+			return this;
+		}
+
+		public Builder toolContext(Map<String, Object> toolContext) {
+			if (this.options.toolContext == null) {
+				this.options.toolContext = toolContext;
+			}
+			else {
+				this.options.toolContext.putAll(toolContext);
+			}
+			return this;
+		}
+
+		public Builder streamOptions(ChatCompletionStreamOptions streamOptions) {
+			this.options.streamOptions = streamOptions;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #deploymentName(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withDeploymentName(String deploymentName) {
 			this.options.deploymentName = deploymentName;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #frequencyPenalty(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withFrequencyPenalty(Double frequencyPenalty) {
 			this.options.frequencyPenalty = frequencyPenalty;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #logitBias(Map)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withLogitBias(Map<String, Integer> logitBias) {
 			this.options.logitBias = logitBias;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #maxTokens(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withMaxTokens(Integer maxTokens) {
 			this.options.maxTokens = maxTokens;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #N(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withN(Integer n) {
 			this.options.n = n;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #presencePenalty(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withPresencePenalty(Double presencePenalty) {
 			this.options.presencePenalty = presencePenalty;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #stop(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withStop(List<String> stop) {
 			this.options.stop = stop;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #temperature(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTemperature(Double temperature) {
 			this.options.temperature = temperature;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #topP(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTopP(Double topP) {
 			this.options.topP = topP;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #user(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withUser(String user) {
 			this.options.user = user;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #functionCallbacks(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withFunctionCallbacks(List<FunctionCallback> functionCallbacks) {
 			this.options.functionCallbacks = functionCallbacks;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #functions(Set)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withFunctions(Set<String> functionNames) {
 			Assert.notNull(functionNames, "Function names must not be null");
 			this.options.functions = functionNames;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #function(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withFunction(String functionName) {
 			Assert.hasText(functionName, "Function name must not be empty");
 			this.options.functions.add(functionName);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #responseFormat(AzureOpenAiResponseFormat)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withResponseFormat(AzureOpenAiResponseFormat responseFormat) {
 			this.options.responseFormat = responseFormat;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #proxyToolCalls(Boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withProxyToolCalls(Boolean proxyToolCalls) {
 			this.options.proxyToolCalls = proxyToolCalls;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #seed(Long)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withSeed(Long seed) {
 			this.options.seed = seed;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #logprobs(Boolean)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withLogprobs(Boolean logprobs) {
 			this.options.logprobs = logprobs;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #topLogprobs(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTopLogprobs(Integer topLogprobs) {
 			this.options.topLogProbs = topLogprobs;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #enhancements(AzureChatEnhancementConfiguration)} )}
+		 * instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withEnhancements(AzureChatEnhancementConfiguration enhancements) {
 			this.options.enhancements = enhancements;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #toolContext(Map)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withToolContext(Map<String, Object> toolContext) {
 			if (this.options.toolContext == null) {
 				this.options.toolContext = toolContext;
@@ -549,6 +743,10 @@ public class AzureOpenAiChatOptions implements FunctionCallingOptions {
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #streamOptions(ChatCompletionStreamOptions)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withStreamOptions(ChatCompletionStreamOptions streamOptions) {
 			this.options.streamOptions = streamOptions;
 			return this;

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
@@ -80,7 +80,7 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	public AzureOpenAiEmbeddingModel(OpenAIClient azureOpenAiClient, MetadataMode metadataMode) {
 		this(azureOpenAiClient, metadataMode,
-				AzureOpenAiEmbeddingOptions.builder().withDeploymentName("text-embedding-ada-002").build());
+				AzureOpenAiEmbeddingOptions.builder().deploymentName("text-embedding-ada-002").build());
 	}
 
 	public AzureOpenAiEmbeddingModel(OpenAIClient azureOpenAiClient, MetadataMode metadataMode,

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingOptions.java
@@ -27,6 +27,7 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
  * @since 0.8.0
  */
 public class AzureOpenAiEmbeddingOptions implements EmbeddingOptions {
@@ -156,21 +157,57 @@ public class AzureOpenAiEmbeddingOptions implements EmbeddingOptions {
 			return this;
 		}
 
+		public Builder user(String user) {
+			this.options.setUser(user);
+			return this;
+		}
+
+		public Builder deploymentName(String model) {
+			this.options.setDeploymentName(model);
+			return this;
+		}
+
+		public Builder inputType(String inputType) {
+			this.options.inputType = inputType;
+			return this;
+		}
+
+		public Builder dimensions(Integer dimensions) {
+			this.options.dimensions = dimensions;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #user(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withUser(String user) {
 			this.options.setUser(user);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #deploymentName(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withDeploymentName(String model) {
 			this.options.setDeploymentName(model);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #inputType(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withInputType(String inputType) {
 			this.options.inputType = inputType;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #dimensions(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withDimensions(Integer dimensions) {
 			this.options.dimensions = dimensions;
 			return this;

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageModel.java
@@ -67,7 +67,7 @@ public class AzureOpenAiImageModel implements ImageModel {
 	private final ObjectMapper objectMapper;
 
 	public AzureOpenAiImageModel(OpenAIClient openAIClient) {
-		this(openAIClient, AzureOpenAiImageOptions.builder().withDeploymentName(DEFAULT_DEPLOYMENT_NAME).build());
+		this(openAIClient, AzureOpenAiImageOptions.builder().deploymentName(DEFAULT_DEPLOYMENT_NAME).build());
 	}
 
 	public AzureOpenAiImageModel(OpenAIClient microsoftOpenAiClient, AzureOpenAiImageOptions options) {

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageOptions.java
@@ -28,6 +28,7 @@ import org.springframework.ai.image.ImageOptions;
  *
  * @author Benoit Moussaud
  * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
  * @since 1.0.0 M1
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -263,48 +264,120 @@ public class AzureOpenAiImageOptions implements ImageOptions {
 			this.options = new AzureOpenAiImageOptions();
 		}
 
+		public Builder N(Integer n) {
+			this.options.setN(n);
+			return this;
+		}
+
+		public Builder model(String model) {
+			this.options.setModel(model);
+			return this;
+		}
+
+		public Builder deploymentName(String deploymentName) {
+			this.options.setDeploymentName(deploymentName);
+			return this;
+		}
+
+		public Builder responseFormat(String responseFormat) {
+			this.options.setResponseFormat(responseFormat);
+			return this;
+		}
+
+		public Builder width(Integer width) {
+			this.options.setWidth(width);
+			return this;
+		}
+
+		public Builder height(Integer height) {
+			this.options.setHeight(height);
+			return this;
+		}
+
+		public Builder user(String user) {
+			this.options.setUser(user);
+			return this;
+		}
+
+		public Builder style(String style) {
+			this.options.setStyle(style);
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #N(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withN(Integer n) {
 			this.options.setN(n);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #model(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withModel(String model) {
 			this.options.setModel(model);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #deploymentName(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withDeploymentName(String deploymentName) {
 			this.options.setDeploymentName(deploymentName);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #responseFormat(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withResponseFormat(String responseFormat) {
 			this.options.setResponseFormat(responseFormat);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #width(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withWidth(Integer width) {
 			this.options.setWidth(width);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #height(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withHeight(Integer height) {
 			this.options.setHeight(height);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #user(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withUser(String user) {
 			this.options.setUser(user);
 			return this;
 		}
 
-		public AzureOpenAiImageOptions build() {
-			return this.options;
-		}
-
+		/**
+		 * @deprecated use {@link #style(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withStyle(String style) {
 			this.options.setStyle(style);
 			return this;
+		}
+
+		public AzureOpenAiImageOptions build() {
+			return this.options;
 		}
 
 	}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
@@ -54,21 +54,21 @@ public class AzureChatCompletionsOptionsTests {
 			.mock(AzureChatEnhancementConfiguration.class);
 
 		var defaultOptions = AzureOpenAiChatOptions.builder()
-			.withDeploymentName("DEFAULT_MODEL")
-			.withTemperature(66.6)
-			.withFrequencyPenalty(696.9)
-			.withPresencePenalty(969.6)
-			.withLogitBias(Map.of("foo", 1))
-			.withMaxTokens(969)
-			.withN(69)
-			.withStop(List.of("foo", "bar"))
-			.withTopP(0.69)
-			.withUser("user")
-			.withSeed(123L)
-			.withLogprobs(true)
-			.withTopLogprobs(5)
-			.withEnhancements(mockAzureChatEnhancementConfiguration)
-			.withResponseFormat(AzureOpenAiResponseFormat.TEXT)
+			.deploymentName("DEFAULT_MODEL")
+			.temperature(66.6)
+			.frequencyPenalty(696.9)
+			.presencePenalty(969.6)
+			.logitBias(Map.of("foo", 1))
+			.maxTokens(969)
+			.N(69)
+			.stop(List.of("foo", "bar"))
+			.topP(0.69)
+			.user("user")
+			.seed(123L)
+			.logprobs(true)
+			.topLogprobs(5)
+			.enhancements(mockAzureChatEnhancementConfiguration)
+			.responseFormat(AzureOpenAiResponseFormat.TEXT)
 			.build();
 
 		var client = new AzureOpenAiChatModel(mockClient, defaultOptions);
@@ -97,21 +97,21 @@ public class AzureChatCompletionsOptionsTests {
 			.mock(AzureChatEnhancementConfiguration.class);
 
 		var runtimeOptions = AzureOpenAiChatOptions.builder()
-			.withDeploymentName("PROMPT_MODEL")
-			.withTemperature(99.9)
-			.withFrequencyPenalty(100.0)
-			.withPresencePenalty(100.0)
-			.withLogitBias(Map.of("foo", 2))
-			.withMaxTokens(100)
-			.withN(100)
-			.withStop(List.of("foo", "bar"))
-			.withTopP(0.111)
-			.withUser("user2")
-			.withSeed(1234L)
-			.withLogprobs(true)
-			.withTopLogprobs(4)
-			.withEnhancements(anotherMockAzureChatEnhancementConfiguration)
-			.withResponseFormat(AzureOpenAiResponseFormat.JSON)
+			.deploymentName("PROMPT_MODEL")
+			.temperature(99.9)
+			.frequencyPenalty(100.0)
+			.presencePenalty(100.0)
+			.logitBias(Map.of("foo", 2))
+			.maxTokens(100)
+			.N(100)
+			.stop(List.of("foo", "bar"))
+			.topP(0.111)
+			.user("user2")
+			.seed(1234L)
+			.logprobs(true)
+			.topLogprobs(4)
+			.enhancements(anotherMockAzureChatEnhancementConfiguration)
+			.responseFormat(AzureOpenAiResponseFormat.JSON)
 			.build();
 
 		requestOptions = client.toAzureChatCompletionsOptions(new Prompt("Test message content", runtimeOptions));
@@ -140,11 +140,11 @@ public class AzureChatCompletionsOptionsTests {
 	public void createChatOptionsWithPresencePenaltyAndFrequencyPenalty(Double presencePenalty,
 			Double frequencyPenalty) {
 		var options = AzureOpenAiChatOptions.builder()
-			.withMaxTokens(800)
-			.withTemperature(0.7)
-			.withTopP(0.95)
-			.withPresencePenalty(presencePenalty)
-			.withFrequencyPenalty(frequencyPenalty)
+			.maxTokens(800)
+			.temperature(0.7)
+			.topP(0.95)
+			.presencePenalty(presencePenalty)
+			.frequencyPenalty(frequencyPenalty)
 			.build();
 
 		if (presencePenalty == null) {

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureEmbeddingsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureEmbeddingsOptionsTests.java
@@ -38,10 +38,7 @@ public class AzureEmbeddingsOptionsTests {
 
 		OpenAIClient mockClient = Mockito.mock(OpenAIClient.class);
 		var client = new AzureOpenAiEmbeddingModel(mockClient, MetadataMode.EMBED,
-				AzureOpenAiEmbeddingOptions.builder()
-					.withDeploymentName("DEFAULT_MODEL")
-					.withUser("USER_TEST")
-					.build());
+				AzureOpenAiEmbeddingOptions.builder().deploymentName("DEFAULT_MODEL").user("USER_TEST").build());
 
 		var requestOptions = client.toEmbeddingOptions(new EmbeddingRequest(List.of("Test message content"), null));
 
@@ -51,10 +48,7 @@ public class AzureEmbeddingsOptionsTests {
 		assertThat(requestOptions.getUser()).isEqualTo("USER_TEST");
 
 		requestOptions = client.toEmbeddingOptions(new EmbeddingRequest(List.of("Test message content"),
-				AzureOpenAiEmbeddingOptions.builder()
-					.withDeploymentName("PROMPT_MODEL")
-					.withUser("PROMPT_USER")
-					.build()));
+				AzureOpenAiEmbeddingOptions.builder().deploymentName("PROMPT_MODEL").user("PROMPT_USER").build()));
 
 		assertThat(requestOptions.getInput()).hasSize(1);
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModelIT.java
@@ -54,8 +54,8 @@ class AzureOpenAiAudioTranscriptionModelIT {
 	@Test
 	void transcriptionTest() {
 		AzureOpenAiAudioTranscriptionOptions transcriptionOptions = AzureOpenAiAudioTranscriptionOptions.builder()
-			.withResponseFormat(AzureOpenAiAudioTranscriptionOptions.TranscriptResponseFormat.TEXT)
-			.withTemperature(0f)
+			.responseFormat(AzureOpenAiAudioTranscriptionOptions.TranscriptResponseFormat.TEXT)
+			.temperature(0f)
 			.build();
 		AudioTranscriptionPrompt transcriptionRequest = new AudioTranscriptionPrompt(this.audioFile,
 				transcriptionOptions);
@@ -69,10 +69,10 @@ class AzureOpenAiAudioTranscriptionModelIT {
 		AzureOpenAiAudioTranscriptionOptions.TranscriptResponseFormat responseFormat = AzureOpenAiAudioTranscriptionOptions.TranscriptResponseFormat.VTT;
 
 		AzureOpenAiAudioTranscriptionOptions transcriptionOptions = AzureOpenAiAudioTranscriptionOptions.builder()
-			.withLanguage("en")
-			.withPrompt("Ask not this, but ask that")
-			.withTemperature(0f)
-			.withResponseFormat(responseFormat)
+			.language("en")
+			.prompt("Ask not this, but ask that")
+			.temperature(0f)
+			.responseFormat(responseFormat)
 			.build();
 		AudioTranscriptionPrompt transcriptionRequest = new AudioTranscriptionPrompt(this.audioFile,
 				transcriptionOptions);
@@ -101,7 +101,7 @@ class AzureOpenAiAudioTranscriptionModelIT {
 		@Bean
 		public AzureOpenAiAudioTranscriptionModel azureOpenAiChatModel(OpenAIClient openAIClient) {
 			return new AzureOpenAiAudioTranscriptionModel(openAIClient,
-					AzureOpenAiAudioTranscriptionOptions.builder().withDeploymentName("whisper").build());
+					AzureOpenAiAudioTranscriptionOptions.builder().deploymentName("whisper").build());
 		}
 
 	}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatClientIT.java
@@ -162,7 +162,7 @@ public class AzureOpenAiChatClientIT {
 		@Bean
 		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClientBuilder openAIClientBuilder) {
 			return new AzureOpenAiChatModel(openAIClientBuilder,
-					AzureOpenAiChatOptions.builder().withDeploymentName("gpt-4o").withMaxTokens(1000).build());
+					AzureOpenAiChatOptions.builder().deploymentName("gpt-4o").maxTokens(1000).build());
 
 		}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
@@ -221,7 +221,7 @@ class AzureOpenAiChatModelIT {
 
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
-				.options(AzureOpenAiChatOptions.builder().withDeploymentName("gpt-4o").build())
+				.options(AzureOpenAiChatOptions.builder().deploymentName("gpt-4o").build())
 				.user(u -> u.text("Explain what do you see on this picture?").media(MimeTypeUtils.IMAGE_PNG, url))
 				.call()
 				.content();
@@ -239,7 +239,7 @@ class AzureOpenAiChatModelIT {
 
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()
-				.options(AzureOpenAiChatOptions.builder().withDeploymentName("gpt-4o").build())
+				.options(AzureOpenAiChatOptions.builder().deploymentName("gpt-4o").build())
 				.user(u -> u.text("Explain what do you see on this picture?").media(MimeTypeUtils.IMAGE_PNG, resource))
 				.call()
 				.content();
@@ -271,7 +271,7 @@ class AzureOpenAiChatModelIT {
 		@Bean
 		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClientBuilder openAIClientBuilder) {
 			return new AzureOpenAiChatModel(openAIClientBuilder,
-					AzureOpenAiChatOptions.builder().withDeploymentName("gpt-4o").withMaxTokens(1000).build());
+					AzureOpenAiChatOptions.builder().deploymentName("gpt-4o").maxTokens(1000).build());
 
 		}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelObservationIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelObservationIT.java
@@ -65,12 +65,12 @@ class AzureOpenAiChatModelObservationIT {
 	void observationForImperativeChatOperation() {
 
 		var options = AzureOpenAiChatOptions.builder()
-			.withFrequencyPenalty(0.0)
-			.withMaxTokens(2048)
-			.withPresencePenalty(0.0)
-			.withStop(List.of("this-is-the-end"))
-			.withTemperature(0.7)
-			.withTopP(1.0)
+			.frequencyPenalty(0.0)
+			.maxTokens(2048)
+			.presencePenalty(0.0)
+			.stop(List.of("this-is-the-end"))
+			.temperature(0.7)
+			.topP(1.0)
 			.build();
 
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
@@ -88,13 +88,13 @@ class AzureOpenAiChatModelObservationIT {
 	void observationForStreamingChatOperation() {
 
 		var options = AzureOpenAiChatOptions.builder()
-			.withFrequencyPenalty(0.0)
-			.withDeploymentName("gpt-4o")
-			.withMaxTokens(2048)
-			.withPresencePenalty(0.0)
-			.withStop(List.of("this-is-the-end"))
-			.withTemperature(0.7)
-			.withTopP(1.0)
+			.frequencyPenalty(0.0)
+			.deploymentName("gpt-4o")
+			.maxTokens(2048)
+			.presencePenalty(0.0)
+			.stop(List.of("this-is-the-end"))
+			.temperature(0.7)
+			.topP(1.0)
 			.build();
 
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
@@ -195,8 +195,8 @@ class AzureOpenAiChatModelObservationIT {
 		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClientBuilder openAIClientBuilder,
 				TestObservationRegistry observationRegistry) {
 			return new AzureOpenAiChatModel(openAIClientBuilder,
-					AzureOpenAiChatOptions.builder().withDeploymentName("gpt-4o").withMaxTokens(1000).build(), null,
-					List.of(), observationRegistry);
+					AzureOpenAiChatOptions.builder().deploymentName("gpt-4o").maxTokens(1000).build(), null, List.of(),
+					observationRegistry);
 		}
 
 	}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelTests.java
@@ -45,7 +45,7 @@ public class AzureOpenAiChatModelTests {
 		String callbackFromConstructorParam = "callbackFromConstructorParam";
 
 		AzureOpenAiChatOptions chatOptions = AzureOpenAiChatOptions.builder()
-			.withFunctionCallbacks(List.of(new TestFunctionCallback(callbackFromChatOptions)))
+			.functionCallbacks(List.of(new TestFunctionCallback(callbackFromChatOptions)))
 			.build();
 
 		List<FunctionCallback> functionCallbacks = List.of(new TestFunctionCallback(callbackFromConstructorParam));

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModelIT.java
@@ -76,7 +76,7 @@ class AzureOpenAiEmbeddingModelIT {
 		@Bean
 		public AzureOpenAiEmbeddingModel azureEmbeddingModel(OpenAIClient openAIClient) {
 			return new AzureOpenAiEmbeddingModel(openAIClient, MetadataMode.EMBED,
-					AzureOpenAiEmbeddingOptions.builder().withDeploymentName("text-embedding-ada-002").build());
+					AzureOpenAiEmbeddingOptions.builder().deploymentName("text-embedding-ada-002").build());
 		}
 
 	}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModelObservationIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModelObservationIT.java
@@ -59,7 +59,7 @@ public class AzureOpenAiEmbeddingModelObservationIT {
 	@Test
 	void observationForEmbeddingOperation() {
 		var options = AzureOpenAiEmbeddingOptions.builder()
-			.withDeploymentName("text-embedding-ada-002")
+			.deploymentName("text-embedding-ada-002")
 			// should not send dimension value?
 			// https://github.com/SciPhi-AI/R2R/issues/354
 			// .withDimensions(1536)
@@ -111,7 +111,7 @@ public class AzureOpenAiEmbeddingModelObservationIT {
 		public AzureOpenAiEmbeddingModel azureEmbeddingModel(OpenAIClient openAIClient,
 				TestObservationRegistry observationRegistry) {
 			return new AzureOpenAiEmbeddingModel(openAIClient, MetadataMode.EMBED,
-					AzureOpenAiEmbeddingOptions.builder().withDeploymentName("text-embedding-ada-002").build(),
+					AzureOpenAiEmbeddingOptions.builder().deploymentName("text-embedding-ada-002").build(),
 					observationRegistry);
 		}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -68,8 +68,8 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-			.withDeploymentName(this.selectedModel)
-			.withFunctionCallbacks(List.of(FunctionCallback.builder()
+			.deploymentName(this.selectedModel)
+			.functionCallbacks(List.of(FunctionCallback.builder()
 				.function("getCurrentWeather", new MockWeatherService())
 				.description("Get the current weather in a given location")
 				.inputType(MockWeatherService.Request.class)
@@ -92,8 +92,8 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-			.withDeploymentName(this.selectedModel)
-			.withFunctionCallbacks(List.of(FunctionCallback.builder()
+			.deploymentName(this.selectedModel)
+			.functionCallbacks(List.of(FunctionCallback.builder()
 				.function("getCurrentWeather", new MockWeatherService())
 				.description("Get the current weather in a given location")
 				.inputType(MockWeatherService.Request.class)
@@ -114,8 +114,8 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-			.withDeploymentName(this.selectedModel)
-			.withFunctionCallbacks(List.of(FunctionCallback.builder()
+			.deploymentName(this.selectedModel)
+			.functionCallbacks(List.of(FunctionCallback.builder()
 				.function("getCurrentWeather", new MockWeatherService())
 				.description("Get the current weather in a given location")
 				.inputType(MockWeatherService.Request.class)
@@ -151,8 +151,8 @@ class AzureOpenAiChatModelFunctionCallIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AzureOpenAiChatOptions.builder()
-			.withDeploymentName(this.selectedModel)
-			.withFunctionCallbacks(List.of(FunctionCallback.builder()
+			.deploymentName(this.selectedModel)
+			.functionCallbacks(List.of(FunctionCallback.builder()
 				.function("getCurrentWeather", new MockWeatherService())
 				.description("Get the current weather in a given location")
 				.inputType(MockWeatherService.Request.class)
@@ -200,7 +200,7 @@ class AzureOpenAiChatModelFunctionCallIT {
 		@Bean
 		public AzureOpenAiChatModel azureOpenAiChatModel(OpenAIClientBuilder openAIClient, String selectedModel) {
 			return new AzureOpenAiChatModel(openAIClient,
-					AzureOpenAiChatOptions.builder().withDeploymentName(selectedModel).withMaxTokens(500).build());
+					AzureOpenAiChatOptions.builder().deploymentName(selectedModel).maxTokens(500).build());
 		}
 
 		@Bean

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/image/AzureOpenAiImageModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/image/AzureOpenAiImageModelIT.java
@@ -101,7 +101,7 @@ public class AzureOpenAiImageModelIT {
 		@Bean
 		public AzureOpenAiImageModel azureOpenAiImageModel(OpenAIClient openAIClient) {
 			return new AzureOpenAiImageModel(openAIClient,
-					AzureOpenAiImageOptions.builder().withDeploymentName("dall-e-3").build());
+					AzureOpenAiImageOptions.builder().deploymentName("dall-e-3").build());
 
 		}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/azure-openai-transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/azure-openai-transcriptions.adoc
@@ -63,10 +63,10 @@ For example:
 AzureOpenAiAudioTranscriptionOptions.TranscriptResponseFormat responseFormat = AzureOpenAiAudioTranscriptionOptions.TranscriptResponseFormat.VTT;
 
 AzureOpenAiAudioTranscriptionOptions transcriptionOptions = AzureOpenAiAudioTranscriptionOptions.builder()
-    .withLanguage("en")
-    .withPrompt("Ask not this, but ask that")
-    .withTemperature(0f)
-    .withResponseFormat(this.responseFormat)
+    .language("en")
+    .prompt("Ask not this, but ask that")
+    .temperature(0f)
+    .responseFormat(this.responseFormat)
     .build();
 AudioTranscriptionPrompt transcriptionRequest = new AudioTranscriptionPrompt(audioFile, this.transcriptionOptions);
 AudioTranscriptionResponse response = azureOpenAiTranscriptionModel.call(this.transcriptionRequest);
@@ -107,8 +107,8 @@ var openAIClient = new OpenAIClientBuilder()
 var azureOpenAiAudioTranscriptionModel = new AzureOpenAiAudioTranscriptionModel(this.openAIClient, null);
 
 var transcriptionOptions = AzureOpenAiAudioTranscriptionOptions.builder()
-    .withResponseFormat(TranscriptResponseFormat.TEXT)
-    .withTemperature(0f)
+    .responseFormat(TranscriptResponseFormat.TEXT)
+    .temperature(0f)
     .build();
 
 var audioFile = new FileSystemResource("/path/to/your/resource/speech/jfk.flac");

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -168,8 +168,8 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         AzureOpenAiChatOptions.builder()
-            .withDeploymentName("gpt-4o")
-            .withTemperature(0.4)
+            .deploymentName("gpt-4o")
+            .temperature(0.4)
         .build()
     ));
 ----
@@ -198,7 +198,7 @@ Below is a code example excerpted from link:https://github.com/spring-projects/s
 ----
 URL url = new URL("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png");
 String response = ChatClient.create(chatModel).prompt()
-        .options(AzureOpenAiChatOptions.builder().withDeploymentName("gpt-4o").build())
+        .options(AzureOpenAiChatOptions.builder().deploymentName("gpt-4o").build())
         .user(u -> u.text("Explain what do you see on this picture?").media(MimeTypeUtils.IMAGE_PNG, this.url))
         .call()
         .content();
@@ -229,7 +229,7 @@ Resource resource = new ClassPathResource("multimodality/multimodal.test.png");
 
 String response = ChatClient.create(chatModel).prompt()
     .options(AzureOpenAiChatOptions.builder()
-    .withDeploymentName("gpt-4o").build())
+    .deploymentName("gpt-4o").build())
     .user(u -> u.text("Explain what do you see on this picture?")
     .media(MimeTypeUtils.IMAGE_PNG, this.resource))
     .call()
@@ -317,9 +317,9 @@ var openAIClient = new OpenAIClientBuilder()
   .buildClient();
 
 var openAIChatOptions = AzureOpenAiChatOptions.builder()
-  .withDeploymentName("gpt-4o")
-  .withTemperature(0.4)
-  .withMaxTokens(200)
+  .deploymentName("gpt-4o")
+  .temperature(0.4)
+  .maxTokens(200)
   .build();
 
 var chatModel = new AzureOpenAiChatModel(this.openAIClient, this.openAIChatOptions);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/azure-open-ai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/azure-open-ai-chat-functions.adoc
@@ -150,7 +150,7 @@ AzureOpenAiChatModel chatModel = ...
 UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");
 
 ChatResponse response = this.chatModel.call(new Prompt(List.of(this.userMessage),
-		AzureOpenAiChatOptions.builder().withFunction("CurrentWeather").build())); // (1) Enable the function
+		AzureOpenAiChatOptions.builder().function("CurrentWeather").build())); // (1) Enable the function
 
 logger.info("Response: {}", response);
 ----
@@ -180,7 +180,7 @@ AzureOpenAiChatModel chatModel = ...
 UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?  Use Multi-turn function calling.");
 
 var promptOptions = AzureOpenAiChatOptions.builder()
-	.withFunctionCallbacks(List.of(FunctionCallback.builder()
+	.functionCallbacks(List.of(FunctionCallback.builder()
 			.function("CurrentWeather", new MockWeatherService()) // (1) function name and instance
 			.description("Get the current weather in a given location") // (2) function description
 			.inputType(MockWeatherService.Request.class) // (3) function input type

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
@@ -126,7 +126,7 @@ For example to override the default model name for a specific request:
 EmbeddingResponse embeddingResponse = embeddingModel.call(
     new EmbeddingRequest(List.of("Hello World", "World is big and salvation is near"),
         AzureOpenAiEmbeddingOptions.builder()
-        .withModel("Different-Embedding-Model-Deployment-Name")
+        .model("Different-Embedding-Model-Deployment-Name")
         .build()));
 ----
 
@@ -199,8 +199,8 @@ var openAIClient = OpenAIClientBuilder()
 
 var embeddingModel = new AzureOpenAiEmbeddingModel(this.openAIClient)
     .withDefaultOptions(AzureOpenAiEmbeddingOptions.builder()
-        .withModel("text-embedding-ada-002")
-        .withUser("user-6")
+        .model("text-embedding-ada-002")
+        .user("user-6")
         .build());
 
 EmbeddingResponse embeddingResponse = this.embeddingModel

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/azure-openai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/azure-openai-image.adoc
@@ -118,10 +118,10 @@ For example to override the OpenAI specific options such as quality and the numb
 ImageResponse response = azureOpenaiImageModel.call(
         new ImagePrompt("A light cream colored mini golden doodle",
         OpenAiImageOptions.builder()
-                .withQuality("hd")
-                .withN(4)
-                .withHeight(1024)
-                .withWidth(1024).build())
+                .quality("hd")
+                .N(4)
+                .height(1024)
+                .width(1024).build())
 
 );
 ----

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiChatProperties.java
@@ -36,8 +36,8 @@ public class AzureOpenAiChatProperties {
 
 	@NestedConfigurationProperty
 	private AzureOpenAiChatOptions options = AzureOpenAiChatOptions.builder()
-		.withDeploymentName(DEFAULT_DEPLOYMENT_NAME)
-		.withTemperature(DEFAULT_TEMPERATURE)
+		.deploymentName(DEFAULT_DEPLOYMENT_NAME)
+		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public AzureOpenAiChatOptions getOptions() {

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiEmbeddingProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/azure/openai/AzureOpenAiEmbeddingProperties.java
@@ -34,7 +34,7 @@ public class AzureOpenAiEmbeddingProperties {
 
 	@NestedConfigurationProperty
 	private AzureOpenAiEmbeddingOptions options = AzureOpenAiEmbeddingOptions.builder()
-		.withDeploymentName("text-embedding-ada-002")
+		.deploymentName("text-embedding-ada-002")
 		.build();
 
 	private MetadataMode metadataMode = MetadataMode.EMBED;

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionBeanIT.java
@@ -67,14 +67,14 @@ class FunctionCallWithFunctionBeanIT {
 						"What's the weather like in San Francisco, Paris and in Tokyo? Use Multi-turn function calling.");
 
 				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						AzureOpenAiChatOptions.builder().withFunction("weatherFunction").build()));
+						AzureOpenAiChatOptions.builder().function("weatherFunction").build()));
 
 				logger.info("Response: {}", response);
 
 				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
-						AzureOpenAiChatOptions.builder().withFunction("weatherFunction3").build()));
+						AzureOpenAiChatOptions.builder().function("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionWrapperIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithFunctionWrapperIT.java
@@ -64,7 +64,7 @@ public class FunctionCallWithFunctionWrapperIT {
 						"What's the weather like in San Francisco, Paris and in Tokyo?");
 
 				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						AzureOpenAiChatOptions.builder().withFunction("WeatherInfo").build()));
+						AzureOpenAiChatOptions.builder().function("WeatherInfo").build()));
 
 				logger.info("Response: {}", response);
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/azure/tool/FunctionCallWithPromptFunctionIT.java
@@ -61,7 +61,7 @@ public class FunctionCallWithPromptFunctionIT {
 						"What's the weather like in San Francisco, in Paris and in Tokyo? Use Multi-turn function calling.");
 
 				var promptOptions = AzureOpenAiChatOptions.builder()
-					.withFunctionCallbacks(List.of(FunctionCallback.builder()
+					.functionCallbacks(List.of(FunctionCallback.builder()
 						.function("CurrentWeatherService", new MockWeatherService())
 						.description("Get the weather in location")
 						.inputType(MockWeatherService.Request.class)


### PR DESCRIPTION
 - Deprecate builder methods with the prefix `with` and add them without the prefix
 - Update references and docs
