### PR TITLE
Refactor Ollama options builder methods

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -76,6 +76,7 @@ import org.springframework.util.StringUtils;
  * @author luocongqiu
  * @author Thomas Vitale
  * @author Jihoon Kim
+ * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
 public class OllamaChatModel extends AbstractToolCallSupport implements ChatModel {
@@ -316,7 +317,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 		List<OllamaApi.Message> ollamaMessages = prompt.getInstructions().stream().map(message -> {
 			if (message instanceof UserMessage userMessage) {
-				var messageBuilder = OllamaApi.Message.builder(Role.USER).withContent(message.getText());
+				var messageBuilder = OllamaApi.Message.builder(Role.USER).content(message.getText());
 				if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 					messageBuilder.images(
 							userMessage.getMedia().stream().map(media -> this.fromMediaData(media.getData())).toList());
@@ -324,7 +325,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 				return List.of(messageBuilder.build());
 			}
 			else if (message instanceof SystemMessage systemMessage) {
-				return List.of(OllamaApi.Message.builder(Role.SYSTEM).withContent(systemMessage.getText()).build());
+				return List.of(OllamaApi.Message.builder(Role.SYSTEM).content(systemMessage.getText()).build());
 			}
 			else if (message instanceof AssistantMessage assistantMessage) {
 				List<ToolCall> toolCalls = null;
@@ -336,8 +337,8 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 					}).toList();
 				}
 				return List.of(OllamaApi.Message.builder(Role.ASSISTANT)
-					.withContent(assistantMessage.getText())
-					.withToolCalls(toolCalls)
+					.content(assistantMessage.getText())
+					.toolCalls(toolCalls)
 					.build());
 			}
 			else if (message instanceof ToolResponseMessage toolMessage) {
@@ -377,21 +378,21 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 		String model = mergedOptions.getModel();
 		OllamaApi.ChatRequest.Builder requestBuilder = OllamaApi.ChatRequest.builder(model)
-			.withStream(stream)
-			.withMessages(ollamaMessages)
-			.withOptions(mergedOptions);
+			.stream(stream)
+			.messages(ollamaMessages)
+			.options(mergedOptions);
 
 		if (mergedOptions.getFormat() != null) {
-			requestBuilder.withFormat(mergedOptions.getFormat());
+			requestBuilder.format(mergedOptions.getFormat());
 		}
 
 		if (mergedOptions.getKeepAlive() != null) {
-			requestBuilder.withKeepAlive(mergedOptions.getKeepAlive());
+			requestBuilder.keepAlive(mergedOptions.getKeepAlive());
 		}
 
 		// Add the enabled functions definitions to the request's tools parameter.
 		if (!CollectionUtils.isEmpty(functionsForThisRequest)) {
-			requestBuilder.withTools(this.getFunctionTools(functionsForThisRequest));
+			requestBuilder.tools(this.getFunctionTools(functionsForThisRequest));
 		}
 
 		return requestBuilder.build();
@@ -459,7 +460,7 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 
 		private OllamaApi ollamaApi;
 
-		private OllamaOptions defaultOptions = OllamaOptions.create().withModel(OllamaModel.MISTRAL.id());
+		private OllamaOptions defaultOptions = OllamaOptions.create().model(OllamaModel.MISTRAL.id());
 
 		private FunctionCallbackResolver functionCallbackResolver;
 
@@ -472,18 +473,18 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 		private Builder() {
 		}
 
-		public Builder withOllamaApi(OllamaApi ollamaApi) {
+		public Builder ollamaApi(OllamaApi ollamaApi) {
 			this.ollamaApi = ollamaApi;
 			return this;
 		}
 
-		public Builder withDefaultOptions(OllamaOptions defaultOptions) {
+		public Builder defaultOptions(OllamaOptions defaultOptions) {
 			this.defaultOptions = defaultOptions;
 			return this;
 		}
 
 		/**
-		 * @deprecated use the {@link functionCallbackResolver(FunctionCallbackResolver)}
+		 * @deprecated use the {@link #functionCallbackResolver(FunctionCallbackResolver)}
 		 * instead
 		 */
 		@Deprecated
@@ -497,16 +498,62 @@ public class OllamaChatModel extends AbstractToolCallSupport implements ChatMode
 			return this;
 		}
 
+		public Builder toolFunctionCallbacks(List<FunctionCallback> toolFunctionCallbacks) {
+			this.toolFunctionCallbacks = toolFunctionCallbacks;
+			return this;
+		}
+
+		public Builder observationRegistry(ObservationRegistry observationRegistry) {
+			this.observationRegistry = observationRegistry;
+			return this;
+		}
+
+		public Builder modelManagementOptions(ModelManagementOptions modelManagementOptions) {
+			this.modelManagementOptions = modelManagementOptions;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #ollamaApi(OllamaApi)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
+		public Builder withOllamaApi(OllamaApi ollamaApi) {
+			this.ollamaApi = ollamaApi;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #defaultOptions(OllamaOptions)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
+		public Builder withDefaultOptions(OllamaOptions defaultOptions) {
+			this.defaultOptions = defaultOptions;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #toolFunctionCallbacks(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withToolFunctionCallbacks(List<FunctionCallback> toolFunctionCallbacks) {
 			this.toolFunctionCallbacks = toolFunctionCallbacks;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #observationRegistry(ObservationRegistry)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withObservationRegistry(ObservationRegistry observationRegistry) {
 			this.observationRegistry = observationRegistry;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #modelManagementOptions(ModelManagementOptions)}
+		 * instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withModelManagementOptions(ModelManagementOptions modelManagementOptions) {
 			this.modelManagementOptions = modelManagementOptions;
 			return this;

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
@@ -58,6 +58,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
  * @since 0.8.0
  */
 public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
@@ -215,7 +216,7 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 
 		private OllamaApi ollamaApi;
 
-		private OllamaOptions defaultOptions = OllamaOptions.create().withModel(OllamaModel.MXBAI_EMBED_LARGE.id());
+		private OllamaOptions defaultOptions = OllamaOptions.create().model(OllamaModel.MXBAI_EMBED_LARGE.id());
 
 		private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
@@ -224,21 +225,58 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 		private Builder() {
 		}
 
+		public Builder ollamaApi(OllamaApi ollamaApi) {
+			this.ollamaApi = ollamaApi;
+			return this;
+		}
+
+		public Builder defaultOptions(OllamaOptions defaultOptions) {
+			this.defaultOptions = defaultOptions;
+			return this;
+		}
+
+		public Builder observationRegistry(ObservationRegistry observationRegistry) {
+			this.observationRegistry = observationRegistry;
+			return this;
+		}
+
+		public Builder modelManagementOptions(ModelManagementOptions modelManagementOptions) {
+			this.modelManagementOptions = modelManagementOptions;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #ollamaApi(OllamaApi)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withOllamaApi(OllamaApi ollamaApi) {
 			this.ollamaApi = ollamaApi;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #defaultOptions(OllamaOptions)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withDefaultOptions(OllamaOptions defaultOptions) {
 			this.defaultOptions = defaultOptions;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #observationRegistry(ObservationRegistry)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withObservationRegistry(ObservationRegistry observationRegistry) {
 			this.observationRegistry = observationRegistry;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #modelManagementOptions(ModelManagementOptions)}
+		 * instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withModelManagementOptions(ModelManagementOptions modelManagementOptions) {
 			this.modelManagementOptions = modelManagementOptions;
 			return this;

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -25,11 +25,9 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonFormat.Feature;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Flux;
@@ -517,31 +515,93 @@ public class OllamaApi {
 				this.model = model;
 			}
 
+			public Builder messages(List<Message> messages) {
+				this.messages = messages;
+				return this;
+			}
+
+			public Builder stream(boolean stream) {
+				this.stream = stream;
+				return this;
+			}
+
+			public Builder format(String format) {
+				this.format = format;
+				return this;
+			}
+
+			public Builder keepAlive(String keepAlive) {
+				this.keepAlive = keepAlive;
+				return this;
+			}
+
+			public Builder tools(List<Tool> tools) {
+				this.tools = tools;
+				return this;
+			}
+
+			public Builder options(Map<String, Object> options) {
+				Objects.requireNonNull(options, "The options can not be null.");
+
+				this.options = OllamaOptions.filterNonSupportedFields(options);
+				return this;
+			}
+
+			public Builder options(OllamaOptions options) {
+				Objects.requireNonNull(options, "The options can not be null.");
+				this.options = OllamaOptions.filterNonSupportedFields(options.toMap());
+				return this;
+			}
+
+			/**
+			 * @deprecated use {@link #messages( List)} instead.
+			 */
+			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withMessages(List<Message> messages) {
 				this.messages = messages;
 				return this;
 			}
 
+			/**
+			 * @deprecated use {@link #stream(boolean)} instead.
+			 */
+			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withStream(boolean stream) {
 				this.stream = stream;
 				return this;
 			}
 
+			/**
+			 * @deprecated use {@link #format( String)} instead.
+			 */
+			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withFormat(String format) {
 				this.format = format;
 				return this;
 			}
 
+			/**
+			 * @deprecated use {@link #keepAlive( String)} instead.
+			 */
+			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withKeepAlive(String keepAlive) {
 				this.keepAlive = keepAlive;
 				return this;
 			}
 
+			/**
+			 * @deprecated use {@link #tools( List)} instead.
+			 */
+			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withTools(List<Tool> tools) {
 				this.tools = tools;
 				return this;
 			}
 
+			/**
+			 * @deprecated use {@link #options( Map)} instead.
+			 */
+			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withOptions(Map<String, Object> options) {
 				Objects.requireNonNull(options, "The options can not be null.");
 
@@ -549,6 +609,10 @@ public class OllamaApi {
 				return this;
 			}
 
+			/**
+			 * @deprecated use {@link #options( OllamaOptions)} instead.
+			 */
+			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withOptions(OllamaOptions options) {
 				Objects.requireNonNull(options, "The options can not be null.");
 				this.options = OllamaOptions.filterNonSupportedFields(options.toMap());

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
  * @since 0.8.0
  * @see <a href=
  * "https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values">Ollama
@@ -355,43 +356,43 @@ public class OllamaOptions implements FunctionCallingOptions, EmbeddingOptions {
 
 	public static OllamaOptions fromOptions(OllamaOptions fromOptions) {
 		return new OllamaOptions()
-			.withModel(fromOptions.getModel())
-			.withFormat(fromOptions.getFormat())
-			.withKeepAlive(fromOptions.getKeepAlive())
-			.withTruncate(fromOptions.getTruncate())
-			.withUseNUMA(fromOptions.getUseNUMA())
-			.withNumCtx(fromOptions.getNumCtx())
-			.withNumBatch(fromOptions.getNumBatch())
-			.withNumGPU(fromOptions.getNumGPU())
-			.withMainGPU(fromOptions.getMainGPU())
-			.withLowVRAM(fromOptions.getLowVRAM())
-			.withF16KV(fromOptions.getF16KV())
-			.withLogitsAll(fromOptions.getLogitsAll())
-			.withVocabOnly(fromOptions.getVocabOnly())
-			.withUseMMap(fromOptions.getUseMMap())
-			.withUseMLock(fromOptions.getUseMLock())
-			.withNumThread(fromOptions.getNumThread())
-			.withNumKeep(fromOptions.getNumKeep())
-			.withSeed(fromOptions.getSeed())
-			.withNumPredict(fromOptions.getNumPredict())
-			.withTopK(fromOptions.getTopK())
-			.withTopP(fromOptions.getTopP())
-			.withTfsZ(fromOptions.getTfsZ())
-			.withTypicalP(fromOptions.getTypicalP())
-			.withRepeatLastN(fromOptions.getRepeatLastN())
-			.withTemperature(fromOptions.getTemperature())
-			.withRepeatPenalty(fromOptions.getRepeatPenalty())
-			.withPresencePenalty(fromOptions.getPresencePenalty())
-			.withFrequencyPenalty(fromOptions.getFrequencyPenalty())
-			.withMirostat(fromOptions.getMirostat())
-			.withMirostatTau(fromOptions.getMirostatTau())
-			.withMirostatEta(fromOptions.getMirostatEta())
-			.withPenalizeNewline(fromOptions.getPenalizeNewline())
-			.withStop(fromOptions.getStop())
-			.withFunctions(fromOptions.getFunctions())
-			.withProxyToolCalls(fromOptions.getProxyToolCalls())
-			.withFunctionCallbacks(fromOptions.getFunctionCallbacks())
-			.withToolContext(fromOptions.getToolContext());
+			.model(fromOptions.getModel())
+			.format(fromOptions.getFormat())
+			.keepAlive(fromOptions.getKeepAlive())
+			.truncate(fromOptions.getTruncate())
+			.useNUMA(fromOptions.getUseNUMA())
+			.numCtx(fromOptions.getNumCtx())
+			.numBatch(fromOptions.getNumBatch())
+			.numGPU(fromOptions.getNumGPU())
+			.mainGPU(fromOptions.getMainGPU())
+			.lowVRAM(fromOptions.getLowVRAM())
+			.f16KV(fromOptions.getF16KV())
+			.logitsAll(fromOptions.getLogitsAll())
+			.vocabOnly(fromOptions.getVocabOnly())
+			.useMMap(fromOptions.getUseMMap())
+			.useMLock(fromOptions.getUseMLock())
+			.numThread(fromOptions.getNumThread())
+			.numKeep(fromOptions.getNumKeep())
+			.seed(fromOptions.getSeed())
+			.numPredict(fromOptions.getNumPredict())
+			.topK(fromOptions.getTopK())
+			.topP(fromOptions.getTopP())
+			.tfsZ(fromOptions.getTfsZ())
+			.typicalP(fromOptions.getTypicalP())
+			.repeatLastN(fromOptions.getRepeatLastN())
+			.temperature(fromOptions.getTemperature())
+			.repeatPenalty(fromOptions.getRepeatPenalty())
+			.presencePenalty(fromOptions.getPresencePenalty())
+			.frequencyPenalty(fromOptions.getFrequencyPenalty())
+			.mirostat(fromOptions.getMirostat())
+			.mirostatTau(fromOptions.getMirostatTau())
+			.mirostatEta(fromOptions.getMirostatEta())
+			.penalizeNewline(fromOptions.getPenalizeNewline())
+			.stop(fromOptions.getStop())
+			.functions(fromOptions.getFunctions())
+			.proxyToolCalls(fromOptions.getProxyToolCalls())
+			.functionCallbacks(fromOptions.getFunctionCallbacks())
+			.toolContext(fromOptions.getToolContext());
 	}
 
 	public OllamaOptions build() {
@@ -401,197 +402,554 @@ public class OllamaOptions implements FunctionCallingOptions, EmbeddingOptions {
 	/**
 	 * @param model The ollama model names to use. See the {@link OllamaModel} for the common models.
 	 */
+	public OllamaOptions model(String model) {
+		this.model = model;
+		return this;
+	}
+
+	public OllamaOptions model(OllamaModel model) {
+		this.model = model.getName();
+		return this;
+	}
+
+	public OllamaOptions format(String format) {
+		this.format = format;
+		return this;
+	}
+
+	public OllamaOptions keepAlive(String keepAlive) {
+		this.keepAlive = keepAlive;
+		return this;
+	}
+
+	public OllamaOptions truncate(Boolean truncate) {
+		this.truncate = truncate;
+		return this;
+	}
+
+	public OllamaOptions useNUMA(Boolean useNUMA) {
+		this.useNUMA = useNUMA;
+		return this;
+	}
+
+	public OllamaOptions numCtx(Integer numCtx) {
+		this.numCtx = numCtx;
+		return this;
+	}
+
+	public OllamaOptions numBatch(Integer numBatch) {
+		this.numBatch = numBatch;
+		return this;
+	}
+
+	public OllamaOptions numGPU(Integer numGPU) {
+		this.numGPU = numGPU;
+		return this;
+	}
+
+	public OllamaOptions mainGPU(Integer mainGPU) {
+		this.mainGPU = mainGPU;
+		return this;
+	}
+
+	public OllamaOptions lowVRAM(Boolean lowVRAM) {
+		this.lowVRAM = lowVRAM;
+		return this;
+	}
+
+	public OllamaOptions f16KV(Boolean f16KV) {
+		this.f16KV = f16KV;
+		return this;
+	}
+
+	public OllamaOptions logitsAll(Boolean logitsAll) {
+		this.logitsAll = logitsAll;
+		return this;
+	}
+
+	public OllamaOptions vocabOnly(Boolean vocabOnly) {
+		this.vocabOnly = vocabOnly;
+		return this;
+	}
+
+	public OllamaOptions useMMap(Boolean useMMap) {
+		this.useMMap = useMMap;
+		return this;
+	}
+
+	public OllamaOptions useMLock(Boolean useMLock) {
+		this.useMLock = useMLock;
+		return this;
+	}
+
+	public OllamaOptions numThread(Integer numThread) {
+		this.numThread = numThread;
+		return this;
+	}
+
+	public OllamaOptions numKeep(Integer numKeep) {
+		this.numKeep = numKeep;
+		return this;
+	}
+
+	public OllamaOptions seed(Integer seed) {
+		this.seed = seed;
+		return this;
+	}
+
+	public OllamaOptions numPredict(Integer numPredict) {
+		this.numPredict = numPredict;
+		return this;
+	}
+
+	public OllamaOptions topK(Integer topK) {
+		this.topK = topK;
+		return this;
+	}
+
+	public OllamaOptions topP(Double topP) {
+		this.topP = topP;
+		return this;
+	}
+
+	public OllamaOptions tfsZ(Float tfsZ) {
+		this.tfsZ = tfsZ;
+		return this;
+	}
+
+	public OllamaOptions typicalP(Float typicalP) {
+		this.typicalP = typicalP;
+		return this;
+	}
+
+	public OllamaOptions repeatLastN(Integer repeatLastN) {
+		this.repeatLastN = repeatLastN;
+		return this;
+	}
+
+	public OllamaOptions temperature(Double temperature) {
+		this.temperature = temperature;
+		return this;
+	}
+
+	public OllamaOptions repeatPenalty(Double repeatPenalty) {
+		this.repeatPenalty = repeatPenalty;
+		return this;
+	}
+
+	public OllamaOptions presencePenalty(Double presencePenalty) {
+		this.presencePenalty = presencePenalty;
+		return this;
+	}
+
+	public OllamaOptions frequencyPenalty(Double frequencyPenalty) {
+		this.frequencyPenalty = frequencyPenalty;
+		return this;
+	}
+
+	public OllamaOptions mirostat(Integer mirostat) {
+		this.mirostat = mirostat;
+		return this;
+	}
+
+	public OllamaOptions mirostatTau(Float mirostatTau) {
+		this.mirostatTau = mirostatTau;
+		return this;
+	}
+
+	public OllamaOptions mirostatEta(Float mirostatEta) {
+		this.mirostatEta = mirostatEta;
+		return this;
+	}
+
+	public OllamaOptions penalizeNewline(Boolean penalizeNewline) {
+		this.penalizeNewline = penalizeNewline;
+		return this;
+	}
+
+	public OllamaOptions stop(List<String> stop) {
+		this.stop = stop;
+		return this;
+	}
+
+	public OllamaOptions functionCallbacks(List<FunctionCallback> functionCallbacks) {
+		this.functionCallbacks = functionCallbacks;
+		return this;
+	}
+
+	public OllamaOptions functions(Set<String> functions) {
+		this.functions = functions;
+		return this;
+	}
+
+	public OllamaOptions function(String functionName) {
+		Assert.hasText(functionName, "Function name must not be empty");
+		this.functions.add(functionName);
+		return this;
+	}
+
+	public OllamaOptions proxyToolCalls(Boolean proxyToolCalls) {
+		this.proxyToolCalls = proxyToolCalls;
+		return this;
+	}
+
+	public OllamaOptions toolContext(Map<String, Object> toolContext) {
+		if (this.toolContext == null) {
+			this.toolContext = toolContext;
+		}
+		else {
+			this.toolContext.putAll(toolContext);
+		}
+		return this;
+	}
+
+	/**
+	 * @deprecated use {@link #model( String)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withModel(String model) {
 		this.model = model;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #model( OllamaModel)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withModel(OllamaModel model) {
 		this.model = model.getName();
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #format( String)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withFormat(String format) {
 		this.format = format;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #keepAlive( String)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withKeepAlive(String keepAlive) {
 		this.keepAlive = keepAlive;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #truncate( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withTruncate(Boolean truncate) {
 		this.truncate = truncate;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #useNUMA( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withUseNUMA(Boolean useNUMA) {
 		this.useNUMA = useNUMA;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #numCtx( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withNumCtx(Integer numCtx) {
 		this.numCtx = numCtx;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #numBatch( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withNumBatch(Integer numBatch) {
 		this.numBatch = numBatch;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #numGPU( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withNumGPU(Integer numGPU) {
 		this.numGPU = numGPU;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #mainGPU( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withMainGPU(Integer mainGPU) {
 		this.mainGPU = mainGPU;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #lowVRAM( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withLowVRAM(Boolean lowVRAM) {
 		this.lowVRAM = lowVRAM;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #f16KV( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withF16KV(Boolean f16KV) {
 		this.f16KV = f16KV;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #logitsAll( Boolean)}  instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withLogitsAll(Boolean logitsAll) {
 		this.logitsAll = logitsAll;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #vocabOnly( Boolean)}  instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withVocabOnly(Boolean vocabOnly) {
 		this.vocabOnly = vocabOnly;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #useMMap( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withUseMMap(Boolean useMMap) {
 		this.useMMap = useMMap;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #useMLock( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withUseMLock(Boolean useMLock) {
 		this.useMLock = useMLock;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #numThread( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withNumThread(Integer numThread) {
 		this.numThread = numThread;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #numKeep( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withNumKeep(Integer numKeep) {
 		this.numKeep = numKeep;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #seed( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withSeed(Integer seed) {
 		this.seed = seed;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #numPredict( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withNumPredict(Integer numPredict) {
 		this.numPredict = numPredict;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #topK( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withTopK(Integer topK) {
 		this.topK = topK;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #topP( Double)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withTopP(Double topP) {
 		this.topP = topP;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #tfsZ( Float)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withTfsZ(Float tfsZ) {
 		this.tfsZ = tfsZ;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #typicalP( Float)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withTypicalP(Float typicalP) {
 		this.typicalP = typicalP;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #repeatLastN( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withRepeatLastN(Integer repeatLastN) {
 		this.repeatLastN = repeatLastN;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #temperature( Double)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withTemperature(Double temperature) {
 		this.temperature = temperature;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #repeatPenalty( Double)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withRepeatPenalty(Double repeatPenalty) {
 		this.repeatPenalty = repeatPenalty;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #presencePenalty( Double)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withPresencePenalty(Double presencePenalty) {
 		this.presencePenalty = presencePenalty;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #frequencyPenalty( Double)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withFrequencyPenalty(Double frequencyPenalty) {
 		this.frequencyPenalty = frequencyPenalty;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #mirostat( Integer)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withMirostat(Integer mirostat) {
 		this.mirostat = mirostat;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #mirostatTau( Float)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withMirostatTau(Float mirostatTau) {
 		this.mirostatTau = mirostatTau;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #mirostatEta( Float)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withMirostatEta(Float mirostatEta) {
 		this.mirostatEta = mirostatEta;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #penalizeNewline( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withPenalizeNewline(Boolean penalizeNewline) {
 		this.penalizeNewline = penalizeNewline;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #stop( List)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withStop(List<String> stop) {
 		this.stop = stop;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #functionCallbacks( List)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withFunctionCallbacks(List<FunctionCallback> functionCallbacks) {
 		this.functionCallbacks = functionCallbacks;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #functions( Set)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withFunctions(Set<String> functions) {
 		this.functions = functions;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #function( String)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withFunction(String functionName) {
 		Assert.hasText(functionName, "Function name must not be empty");
 		this.functions.add(functionName);
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #proxyToolCalls( Boolean)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withProxyToolCalls(Boolean proxyToolCalls) {
 		this.proxyToolCalls = proxyToolCalls;
 		return this;
 	}
 
+	/**
+	 * @deprecated use {@link #toolContext( Map)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public OllamaOptions withToolContext(Map<String, Object> toolContext) {
 		if (this.toolContext == null) {
 			this.toolContext = toolContext;

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/management/ModelManagementOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/management/ModelManagementOptions.java
@@ -27,6 +27,7 @@ import java.util.List;
  * @param timeout the timeout for managing models
  * @param maxRetries the maximum number of retries
  * @author Thomas Vitale
+ * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
 public record ModelManagementOptions(PullModelStrategy pullModelStrategy, List<String> additionalModels,
@@ -50,21 +51,57 @@ public record ModelManagementOptions(PullModelStrategy pullModelStrategy, List<S
 
 		private Integer maxRetries = 0;
 
+		public Builder pullModelStrategy(PullModelStrategy pullModelStrategy) {
+			this.pullModelStrategy = pullModelStrategy;
+			return this;
+		}
+
+		public Builder additionalModels(List<String> additionalModels) {
+			this.additionalModels = additionalModels;
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.timeout = timeout;
+			return this;
+		}
+
+		public Builder maxRetries(Integer maxRetries) {
+			this.maxRetries = maxRetries;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #pullModelStrategy(PullModelStrategy)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withPullModelStrategy(PullModelStrategy pullModelStrategy) {
 			this.pullModelStrategy = pullModelStrategy;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #additionalModels(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withAdditionalModels(List<String> additionalModels) {
 			this.additionalModels = additionalModels;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #timeout(Duration)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTimeout(Duration timeout) {
 			this.timeout = timeout;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #maxRetries(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withMaxRetries(Integer maxRetries) {
 			this.maxRetries = maxRetries;
 			return this;

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/BaseOllamaIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/BaseOllamaIT.java
@@ -93,8 +93,8 @@ public abstract class BaseOllamaIT {
 
 	private static void ensureModelIsPresent(final OllamaApi ollamaApi, final String model) {
 		final var modelManagementOptions = ModelManagementOptions.builder()
-			.withMaxRetries(DEFAULT_MAX_RETRIES)
-			.withTimeout(DEFAULT_TIMEOUT)
+			.maxRetries(DEFAULT_MAX_RETRIES)
+			.timeout(DEFAULT_TIMEOUT)
 			.build();
 		final var ollamaModelManager = new OllamaModelManager(ollamaApi, modelManagementOptions);
 		ollamaModelManager.pullModel(model, PullModelStrategy.WHEN_MISSING);

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +61,8 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = OllamaOptions.builder()
-			.withModel(MODEL)
-			.withFunctionCallbacks(List.of(FunctionCallback.builder()
+			.model(MODEL)
+			.functionCallbacks(List.of(FunctionCallback.builder()
 				.function("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Find the weather conditions, forecasts, and temperatures for a location, like a city or state.")
@@ -86,8 +85,8 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = OllamaOptions.builder()
-			.withModel(MODEL)
-			.withFunctionCallbacks(List.of(FunctionCallback.builder()
+			.model(MODEL)
+			.functionCallbacks(List.of(FunctionCallback.builder()
 				.function("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Find the weather conditions, forecasts, and temperatures for a location, like a city or state.")
@@ -121,8 +120,8 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 		@Bean
 		public OllamaChatModel ollamaChat(OllamaApi ollamaApi) {
 			return OllamaChatModel.builder()
-				.withOllamaApi(ollamaApi)
-				.withDefaultOptions(OllamaOptions.create().withModel(MODEL).withTemperature(0.9))
+				.ollamaApi(ollamaApi)
+				.defaultOptions(OllamaOptions.create().model(MODEL).temperature(0.9))
 				.build();
 		}
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
@@ -70,7 +70,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 
 		String joke = ChatClient.create(this.chatModel)
 			.prompt("Tell me a joke")
-			.options(OllamaOptions.builder().withModel(ADDITIONAL_MODEL).build())
+			.options(OllamaOptions.builder().model(ADDITIONAL_MODEL).build())
 			.call()
 			.content();
 
@@ -99,7 +99,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
 
 		// ollama specific options
-		var ollamaOptions = new OllamaOptions().withLowVRAM(true);
+		var ollamaOptions = new OllamaOptions().lowVRAM(true);
 
 		response = this.chatModel.call(new Prompt(List.of(systemMessage, userMessage), ollamaOptions));
 		assertThat(response.getResult().getOutput().getText()).contains("Blackbeard");
@@ -243,11 +243,11 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		@Bean
 		public OllamaChatModel ollamaChat(OllamaApi ollamaApi) {
 			return OllamaChatModel.builder()
-				.withOllamaApi(ollamaApi)
-				.withDefaultOptions(OllamaOptions.create().withModel(MODEL).withTemperature(0.9))
-				.withModelManagementOptions(ModelManagementOptions.builder()
-					.withPullModelStrategy(PullModelStrategy.WHEN_MISSING)
-					.withAdditionalModels(List.of(ADDITIONAL_MODEL))
+				.ollamaApi(ollamaApi)
+				.defaultOptions(OllamaOptions.create().model(MODEL).temperature(0.9))
+				.modelManagementOptions(ModelManagementOptions.builder()
+					.pullModelStrategy(PullModelStrategy.WHEN_MISSING)
+					.additionalModels(List.of(ADDITIONAL_MODEL))
 					.build())
 				.build();
 		}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMultimodalIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMultimodalIT.java
@@ -82,8 +82,8 @@ class OllamaChatModelMultimodalIT extends BaseOllamaIT {
 		@Bean
 		public OllamaChatModel ollamaChat(OllamaApi ollamaApi) {
 			return OllamaChatModel.builder()
-				.withOllamaApi(ollamaApi)
-				.withDefaultOptions(OllamaOptions.create().withModel(MODEL).withTemperature(0.9))
+				.ollamaApi(ollamaApi)
+				.defaultOptions(OllamaOptions.create().model(MODEL).temperature(0.9))
 				.build();
 		}
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
@@ -67,14 +67,14 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 	@Test
 	void observationForChatOperation() {
 		var options = OllamaOptions.builder()
-			.withModel(MODEL)
-			.withFrequencyPenalty(0.0)
-			.withNumPredict(2048)
-			.withPresencePenalty(0.0)
-			.withStop(List.of("this-is-the-end"))
-			.withTemperature(0.7)
-			.withTopK(1)
-			.withTopP(1.0)
+			.model(MODEL)
+			.frequencyPenalty(0.0)
+			.numPredict(2048)
+			.presencePenalty(0.0)
+			.stop(List.of("this-is-the-end"))
+			.temperature(0.7)
+			.topK(1)
+			.topP(1.0)
 			.build();
 
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
@@ -91,14 +91,14 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 	@Test
 	void observationForStreamingChatOperation() {
 		var options = OllamaOptions.builder()
-			.withModel(MODEL)
-			.withFrequencyPenalty(0.0)
-			.withNumPredict(2048)
-			.withPresencePenalty(0.0)
-			.withStop(List.of("this-is-the-end"))
-			.withTemperature(0.7)
-			.withTopK(1)
-			.withTopP(1.0)
+			.model(MODEL)
+			.frequencyPenalty(0.0)
+			.numPredict(2048)
+			.presencePenalty(0.0)
+			.stop(List.of("this-is-the-end"))
+			.temperature(0.7)
+			.topK(1)
+			.topP(1.0)
 			.build();
 
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
@@ -169,10 +169,7 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 
 		@Bean
 		public OllamaChatModel openAiChatModel(OllamaApi ollamaApi, TestObservationRegistry observationRegistry) {
-			return OllamaChatModel.builder()
-				.withOllamaApi(ollamaApi)
-				.withObservationRegistry(observationRegistry)
-				.build();
+			return OllamaChatModel.builder().ollamaApi(ollamaApi).observationRegistry(observationRegistry).build();
 		}
 
 	}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
@@ -51,9 +51,9 @@ public class OllamaChatModelTests {
 	public void buildOllamaChatModel() {
 		Exception exception = assertThrows(IllegalArgumentException.class,
 				() -> OllamaChatModel.builder()
-					.withOllamaApi(this.ollamaApi)
-					.withDefaultOptions(OllamaOptions.create().withModel(OllamaModel.LLAMA2))
-					.withModelManagementOptions(null)
+					.ollamaApi(this.ollamaApi)
+					.defaultOptions(OllamaOptions.create().model(OllamaModel.LLAMA2))
+					.modelManagementOptions(null)
 					.build());
 		assertEquals("modelManagementOptions must not be null", exception.getMessage());
 	}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
@@ -32,9 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OllamaChatRequestTests {
 
 	OllamaChatModel chatModel = OllamaChatModel.builder()
-		.withOllamaApi(new OllamaApi())
-		.withDefaultOptions(
-				OllamaOptions.create().withModel("MODEL_NAME").withTopK(99).withTemperature(66.6).withNumGPU(1))
+		.ollamaApi(new OllamaApi())
+		.defaultOptions(OllamaOptions.create().model("MODEL_NAME").topK(99).temperature(66.6).numGPU(1))
 		.build();
 
 	@Test
@@ -56,7 +55,7 @@ public class OllamaChatRequestTests {
 	public void createRequestWithPromptOllamaOptions() {
 
 		// Runtime options should override the default options.
-		OllamaOptions promptOptions = new OllamaOptions().withTemperature(0.8).withTopP(0.5).withNumGPU(2);
+		OllamaOptions promptOptions = new OllamaOptions().temperature(0.8).topP(0.5).numGPU(2);
 
 		var request = this.chatModel.ollamaChatRequest(new Prompt("Test message content", promptOptions), true);
 
@@ -95,7 +94,7 @@ public class OllamaChatRequestTests {
 	public void createRequestWithPromptOptionsModelOverride() {
 
 		// Ollama runtime options.
-		OllamaOptions promptOptions = new OllamaOptions().withModel("PROMPT_MODEL");
+		OllamaOptions promptOptions = new OllamaOptions().model("PROMPT_MODEL");
 
 		var request = this.chatModel.ollamaChatRequest(new Prompt("Test message content", promptOptions), true);
 
@@ -106,8 +105,8 @@ public class OllamaChatRequestTests {
 	public void createRequestWithDefaultOptionsModelOverride() {
 
 		OllamaChatModel chatModel = OllamaChatModel.builder()
-			.withOllamaApi(new OllamaApi())
-			.withDefaultOptions(OllamaOptions.create().withModel("DEFAULT_OPTIONS_MODEL"))
+			.ollamaApi(new OllamaApi())
+			.defaultOptions(OllamaOptions.create().model("DEFAULT_OPTIONS_MODEL"))
 			.build();
 
 		var request = chatModel.ollamaChatRequest(new Prompt("Test message content"), true);
@@ -115,7 +114,7 @@ public class OllamaChatRequestTests {
 		assertThat(request.model()).isEqualTo("DEFAULT_OPTIONS_MODEL");
 
 		// Prompt options should override the default options.
-		OllamaOptions promptOptions = new OllamaOptions().withModel("PROMPT_MODEL");
+		OllamaOptions promptOptions = new OllamaOptions().model("PROMPT_MODEL");
 
 		request = chatModel.ollamaChatRequest(new Prompt("Test message content", promptOptions), true);
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelIT.java
@@ -52,7 +52,7 @@ class OllamaEmbeddingModelIT extends BaseOllamaIT {
 	void embeddings() {
 		assertThat(this.embeddingModel).isNotNull();
 		EmbeddingResponse embeddingResponse = this.embeddingModel.call(new EmbeddingRequest(
-				List.of("Hello World", "Something else"), OllamaOptions.builder().withTruncate(false).build()));
+				List.of("Hello World", "Something else"), OllamaOptions.builder().truncate(false).build()));
 		assertThat(embeddingResponse.getResults()).hasSize(2);
 		assertThat(embeddingResponse.getResults().get(0).getIndex()).isEqualTo(0);
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
@@ -75,7 +75,7 @@ class OllamaEmbeddingModelIT extends BaseOllamaIT {
 
 		EmbeddingResponse embeddingResponse = this.embeddingModel
 			.call(new EmbeddingRequest(List.of("Hello World", "Something else"),
-					OllamaOptions.builder().withModel(model).withTruncate(false).build()));
+					OllamaOptions.builder().model(model).truncate(false).build()));
 
 		assertThat(embeddingResponse.getResults()).hasSize(2);
 		assertThat(embeddingResponse.getResults().get(0).getIndex()).isEqualTo(0);
@@ -102,11 +102,11 @@ class OllamaEmbeddingModelIT extends BaseOllamaIT {
 		@Bean
 		public OllamaEmbeddingModel ollamaEmbedding(OllamaApi ollamaApi) {
 			return OllamaEmbeddingModel.builder()
-				.withOllamaApi(ollamaApi)
-				.withDefaultOptions(OllamaOptions.create().withModel(MODEL))
-				.withModelManagementOptions(ModelManagementOptions.builder()
-					.withPullModelStrategy(PullModelStrategy.WHEN_MISSING)
-					.withAdditionalModels(List.of(ADDITIONAL_MODEL))
+				.ollamaApi(ollamaApi)
+				.defaultOptions(OllamaOptions.create().model(MODEL))
+				.modelManagementOptions(ModelManagementOptions.builder()
+					.pullModelStrategy(PullModelStrategy.WHEN_MISSING)
+					.additionalModels(List.of(ADDITIONAL_MODEL))
 					.build())
 				.build();
 		}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelObservationIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelObservationIT.java
@@ -58,7 +58,7 @@ public class OllamaEmbeddingModelObservationIT extends BaseOllamaIT {
 
 	@Test
 	void observationForEmbeddingOperation() {
-		var options = OllamaOptions.builder().withModel(OllamaModel.NOMIC_EMBED_TEXT.getName()).build();
+		var options = OllamaOptions.builder().model(OllamaModel.NOMIC_EMBED_TEXT.getName()).build();
 
 		EmbeddingRequest embeddingRequest = new EmbeddingRequest(List.of("Here comes the sun"), options);
 
@@ -104,10 +104,7 @@ public class OllamaEmbeddingModelObservationIT extends BaseOllamaIT {
 		@Bean
 		public OllamaEmbeddingModel openAiEmbeddingModel(OllamaApi ollamaApi,
 				TestObservationRegistry observationRegistry) {
-			return OllamaEmbeddingModel.builder()
-				.withOllamaApi(ollamaApi)
-				.withObservationRegistry(observationRegistry)
-				.build();
+			return OllamaEmbeddingModel.builder().ollamaApi(ollamaApi).observationRegistry(observationRegistry).build();
 		}
 
 	}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingModelTests.java
@@ -63,11 +63,11 @@ public class OllamaEmbeddingModelTests {
 					List.of(new float[] { 7f, 8f, 9f }, new float[] { 10f, 11f, 12f }), 0L, 0L, 0));
 
 		// Tests default options
-		var defaultOptions = OllamaOptions.builder().withModel("DEFAULT_MODEL").build();
+		var defaultOptions = OllamaOptions.builder().model("DEFAULT_MODEL").build();
 
 		var embeddingModel = OllamaEmbeddingModel.builder()
-			.withOllamaApi(this.ollamaApi)
-			.withDefaultOptions(defaultOptions)
+			.ollamaApi(this.ollamaApi)
+			.defaultOptions(defaultOptions)
 			.build();
 
 		EmbeddingResponse response = embeddingModel.call(
@@ -90,10 +90,10 @@ public class OllamaEmbeddingModelTests {
 
 		// Tests runtime options
 		var runtimeOptions = OllamaOptions.builder()
-			.withModel("RUNTIME_MODEL")
-			.withKeepAlive("10m")
-			.withTruncate(false)
-			.withMainGPU(666)
+			.model("RUNTIME_MODEL")
+			.keepAlive("10m")
+			.truncate(false)
+			.mainGPU(666)
 			.build();
 
 		response = embeddingModel.call(new EmbeddingRequest(List.of("Input4", "Input5", "Input6"), runtimeOptions));

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingRequestTests.java
@@ -32,9 +32,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OllamaEmbeddingRequestTests {
 
 	OllamaEmbeddingModel embeddingModel = OllamaEmbeddingModel.builder()
-		.withOllamaApi(new OllamaApi())
-		.withDefaultOptions(
-				OllamaOptions.create().withModel("DEFAULT_MODEL").withMainGPU(11).withUseMMap(true).withNumGPU(1))
+		.ollamaApi(new OllamaApi())
+		.defaultOptions(OllamaOptions.create().model("DEFAULT_MODEL").mainGPU(11).useMMap(true).numGPU(1))
 		.build();
 
 	@Test
@@ -53,10 +52,10 @@ public class OllamaEmbeddingRequestTests {
 	public void ollamaEmbeddingRequestRequestOptions() {
 
 		var promptOptions = new OllamaOptions()//
-			.withModel("PROMPT_MODEL")//
-			.withMainGPU(22)//
-			.withUseMMap(true)//
-			.withNumGPU(2);
+			.model("PROMPT_MODEL")//
+			.mainGPU(22)//
+			.useMMap(true)//
+			.numGPU(2);
 
 		var request = this.embeddingModel.ollamaEmbeddingRequest(List.of("Hello"), promptOptions);
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
@@ -50,16 +50,16 @@ public class OllamaApiIT extends BaseOllamaIT {
 	@Test
 	public void chat() {
 		var request = ChatRequest.builder(MODEL)
-			.withStream(false)
-			.withMessages(List.of(
+			.stream(false)
+			.messages(List.of(
 					Message.builder(Role.SYSTEM)
-						.withContent("You are geography teacher. You are talking to a student.")
+						.content("You are geography teacher. You are talking to a student.")
 						.build(),
 					Message.builder(Role.USER)
-						.withContent("What is the capital of Bulgaria and what is the size? "
+						.content("What is the capital of Bulgaria and what is the size? "
 								+ "What it the national anthem?")
 						.build()))
-			.withOptions(OllamaOptions.create().withTemperature(0.9))
+			.options(OllamaOptions.create().temperature(0.9))
 			.build();
 
 		ChatResponse response = getOllamaApi().chat(request);
@@ -76,11 +76,11 @@ public class OllamaApiIT extends BaseOllamaIT {
 	@Test
 	public void streamingChat() {
 		var request = ChatRequest.builder(MODEL)
-			.withStream(true)
-			.withMessages(List.of(Message.builder(Role.USER)
-				.withContent("What is the capital of Bulgaria and what is the size? " + "What it the national anthem?")
+			.stream(true)
+			.messages(List.of(Message.builder(Role.USER)
+				.content("What is the capital of Bulgaria and what is the size? " + "What it the national anthem?")
 				.build()))
-			.withOptions(OllamaOptions.create().withTemperature(0.9).toMap())
+			.options(OllamaOptions.create().temperature(0.9).toMap())
 			.build();
 
 		Flux<ChatResponse> response = getOllamaApi().streamingChat(request);

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaModelOptionsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaModelOptionsTests.java
@@ -29,7 +29,7 @@ public class OllamaModelOptionsTests {
 
 	@Test
 	public void testOptions() {
-		var options = OllamaOptions.create().withTemperature(3.14).withTopK(30).withStop(List.of("a", "b", "c"));
+		var options = OllamaOptions.create().temperature(3.14).topK(30).stop(List.of("a", "b", "c"));
 
 		var optionsMap = options.toMap();
 		System.out.println(optionsMap);

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/OllamaApiToolFunctionCallIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/OllamaApiToolFunctionCallIT.java
@@ -60,7 +60,7 @@ public class OllamaApiToolFunctionCallIT extends BaseOllamaIT {
 	public void toolFunctionCall() {
 		// Step 1: send the conversation and available functions to the model
 		var message = Message.builder(Role.USER)
-			.withContent(
+			.content(
 					"What's the weather like in San Francisco, Tokyo, and Paris? Return a list with the temperature in Celsius for each of the three locations.")
 			.build();
 
@@ -86,8 +86,8 @@ public class OllamaApiToolFunctionCallIT extends BaseOllamaIT {
 		List<Message> messages = new ArrayList<>(List.of(message));
 
 		OllamaApi.ChatRequest chatCompletionRequest = OllamaApi.ChatRequest.builder(MODEL)
-			.withMessages(messages)
-			.withTools(List.of(functionTool))
+			.messages(messages)
+			.tools(List.of(functionTool))
 			.build();
 
 		ChatResponse chatCompletion = ollamaApi.chat(chatCompletionRequest);
@@ -117,12 +117,12 @@ public class OllamaApiToolFunctionCallIT extends BaseOllamaIT {
 
 				// extend conversation with function response.
 				messages.add(Message.builder(Role.TOOL)
-					.withContent("" + weatherResponse.temp() + weatherRequest.unit())
+					.content("" + weatherResponse.temp() + weatherRequest.unit())
 					.build());
 			}
 		}
 
-		var functionResponseRequest = OllamaApi.ChatRequest.builder(MODEL).withMessages(messages).build();
+		var functionResponseRequest = OllamaApi.ChatRequest.builder(MODEL).messages(messages).build();
 
 		ChatResponse chatCompletion2 = ollamaApi.chat(functionResponseRequest);
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/ollama-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/ollama-chat-functions.adoc
@@ -155,7 +155,7 @@ OllamaChatModel chatModel = ...
 UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");
 
 ChatResponse response = this.chatModel.call(new Prompt(this.userMessage,
-		OllamaOptions.builder().withFunction("CurrentWeather").build())); // Enable the function
+		OllamaOptions.builder().function("CurrentWeather").build())); // Enable the function
 
 logger.info("Response: {}", response);
 ----
@@ -184,7 +184,7 @@ OllamaChatModel chatModel = ...
 UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");
 
 var promptOptions = OllamaOptions.builder()
-	.withFunctionCallbacks(List.of(FunctionCallback.builder()
+	.functionCallbacks(List.of(FunctionCallback.builder()
 		.function("CurrentWeather", new MockWeatherService()) // (1) function name and instance        
         .description("Get the weather in location") // (2) function description
 		.inputType(MockWeatherService.Request.class) // (3) function signature

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -152,8 +152,8 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         OllamaOptions.builder()
-            .withModel(OllamaModel.LLAMA3_1)
-            .withTemperature(0.4)
+            .model(OllamaModel.LLAMA3_1)
+            .temperature(0.4)
             .build()
     ));
 ----
@@ -252,7 +252,7 @@ var userMessage = new UserMessage("Explain what do you see on this picture?",
         new Media(MimeTypeUtils.IMAGE_PNG, this.imageResource));
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage,
-        OllamaOptions.builder().withModel(OllamaModel.LLAVA)).build());
+        OllamaOptions.builder().model(OllamaModel.LLAVA)).build());
 ----
 
 The example shows a model taking as an input the `multimodal.test.png` image:
@@ -384,8 +384,8 @@ var ollamaApi = new OllamaApi();
 
 var chatModel = new OllamaChatModel(this.ollamaApi,
             OllamaOptions.create()
-                .withModel(OllamaOptions.DEFAULT_MODEL)
-                .withTemperature(0.9));
+                .model(OllamaOptions.DEFAULT_MODEL)
+                .temperature(0.9));
 
 ChatResponse response = this.chatModel.call(
     new Prompt("Generate the names of 5 famous pirates."));
@@ -415,27 +415,27 @@ OllamaApi ollamaApi = new OllamaApi("YOUR_HOST:YOUR_PORT");
 
 // Sync request
 var request = ChatRequest.builder("orca-mini")
-    .withStream(false) // not streaming
-    .withMessages(List.of(
+    .stream(false) // not streaming
+    .messages(List.of(
             Message.builder(Role.SYSTEM)
-                .withContent("You are a geography teacher. You are talking to a student.")
+                .content("You are a geography teacher. You are talking to a student.")
                 .build(),
             Message.builder(Role.USER)
-                .withContent("What is the capital of Bulgaria and what is the size? "
+                .content("What is the capital of Bulgaria and what is the size? "
                         + "What is the national anthem?")
                 .build()))
-    .withOptions(OllamaOptions.create().withTemperature(0.9))
+    .options(OllamaOptions.create().temperature(0.9))
     .build();
 
 ChatResponse response = this.ollamaApi.chat(this.request);
 
 // Streaming request
 var request2 = ChatRequest.builder("orca-mini")
-    .withStream(true) // streaming
-    .withMessages(List.of(Message.builder(Role.USER)
-        .withContent("What is the capital of Bulgaria and what is the size? " + "What is the national anthem?")
+    .ttream(true) // streaming
+    .messages(List.of(Message.builder(Role.USER)
+        .content("What is the capital of Bulgaria and what is the size? " + "What is the national anthem?")
         .build()))
-    .withOptions(OllamaOptions.create().withTemperature(0.9).toMap())
+    .options(OllamaOptions.create().temperature(0.9).toMap())
     .build();
 
 Flux<ChatResponse> streamingResponse = this.ollamaApi.streamingChat(this.request2);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
@@ -156,8 +156,8 @@ For example to override the default model name for a specific request:
 EmbeddingResponse embeddingResponse = embeddingModel.call(
     new EmbeddingRequest(List.of("Hello World", "World is big and salvation is near"),
         OllamaOptions.builder()
-            .withModel("Different-Embedding-Model-Deployment-Name"))
-            .withtTuncates(false)
+            .model("Different-Embedding-Model-Deployment-Name"))
+            .truncates(false)
             .build());
 ----
 
@@ -303,14 +303,14 @@ var ollamaApi = new OllamaApi();
 
 var embeddingModel = new OllamaEmbeddingModel(this.ollamaApi,
         OllamaOptions.builder()
-			.withModel(OllamaModel.MISTRAL.id())
+			.model(OllamaModel.MISTRAL.id())
             .build());
 
 EmbeddingResponse embeddingResponse = this.embeddingModel.call(
     new EmbeddingRequest(List.of("Hello World", "World is big and salvation is near"),
         OllamaOptions.builder()
-            .withModel("chroma/all-minilm-l6-v2-f32"))
-            .withTruncate(false)
+            .model("chroma/all-minilm-l6-v2-f32"))
+            .truncate(false)
             .build());
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testing.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testing.adoc
@@ -129,7 +129,7 @@ void testFactChecking() {
   OllamaApi ollamaApi = new OllamaApi("http://localhost:11434");
 
   ChatModel chatModel = new OllamaChatModel(ollamaApi,
-				OllamaOptions.builder().withModel(BESPOKE_MINICHECK).withNumPredict(2).withTemperature(0.0d).build())
+				OllamaOptions.builder().model(BESPOKE_MINICHECK).numPredict(2).temperature(0.0d).build())
 
 
   // Create the FactCheckingEvaluator

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaAutoConfiguration.java
@@ -87,12 +87,12 @@ public class OllamaAutoConfiguration {
 				: PullModelStrategy.NEVER;
 
 		var chatModel = OllamaChatModel.builder()
-			.withOllamaApi(ollamaApi)
-			.withDefaultOptions(properties.getOptions())
+			.ollamaApi(ollamaApi)
+			.defaultOptions(properties.getOptions())
 			.functionCallbackResolver(functionCallbackResolver)
-			.withToolFunctionCallbacks(toolFunctionCallbacks)
-			.withObservationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.withModelManagementOptions(
+			.toolFunctionCallbacks(toolFunctionCallbacks)
+			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+			.modelManagementOptions(
 					new ModelManagementOptions(chatModelPullStrategy, initProperties.getChat().getAdditionalModels(),
 							initProperties.getTimeout(), initProperties.getMaxRetries()))
 			.build();
@@ -113,10 +113,10 @@ public class OllamaAutoConfiguration {
 				? initProperties.getPullModelStrategy() : PullModelStrategy.NEVER;
 
 		var embeddingModel = OllamaEmbeddingModel.builder()
-			.withOllamaApi(ollamaApi)
-			.withDefaultOptions(properties.getOptions())
-			.withObservationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.withModelManagementOptions(new ModelManagementOptions(embeddingModelPullStrategy,
+			.ollamaApi(ollamaApi)
+			.defaultOptions(properties.getOptions())
+			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+			.modelManagementOptions(new ModelManagementOptions(embeddingModelPullStrategy,
 					initProperties.getEmbedding().getAdditionalModels(), initProperties.getTimeout(),
 					initProperties.getMaxRetries()))
 			.build();

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaChatProperties.java
@@ -43,7 +43,7 @@ public class OllamaChatProperties {
 	 * generative's defaults.
 	 */
 	@NestedConfigurationProperty
-	private OllamaOptions options = OllamaOptions.create().withModel(OllamaModel.MISTRAL.id());
+	private OllamaOptions options = OllamaOptions.create().model(OllamaModel.MISTRAL.id());
 
 	public String getModel() {
 		return this.options.getModel();

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaEmbeddingProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/ollama/OllamaEmbeddingProperties.java
@@ -43,7 +43,7 @@ public class OllamaEmbeddingProperties {
 	 * generative's defaults.
 	 */
 	@NestedConfigurationProperty
-	private OllamaOptions options = OllamaOptions.create().withModel(OllamaModel.MXBAI_EMBED_LARGE.id());
+	private OllamaOptions options = OllamaOptions.create().model(OllamaModel.MXBAI_EMBED_LARGE.id());
 
 	public String getModel() {
 		return this.options.getModel();

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/BaseOllamaIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/BaseOllamaIT.java
@@ -105,8 +105,8 @@ public abstract class BaseOllamaIT {
 
 	private static void ensureModelIsPresent(final OllamaApi ollamaApi, final String model) {
 		final var modelManagementOptions = ModelManagementOptions.builder()
-			.withMaxRetries(DEFAULT_MAX_RETRIES)
-			.withTimeout(DEFAULT_TIMEOUT)
+			.maxRetries(DEFAULT_MAX_RETRIES)
+			.timeout(DEFAULT_TIMEOUT)
 			.build();
 		final var ollamaModelManager = new OllamaModelManager(ollamaApi, modelManagementOptions);
 		ollamaModelManager.pullModel(model, PullModelStrategy.WHEN_MISSING);

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackInPromptIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackInPromptIT.java
@@ -70,7 +70,7 @@ public class FunctionCallbackInPromptIT extends BaseOllamaIT {
 					"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.");
 
 			var promptOptions = OllamaOptions.builder()
-				.withFunctionCallbacks(List.of(FunctionCallback.builder()
+				.functionCallbacks(List.of(FunctionCallback.builder()
 					.function("CurrentWeatherService", new MockWeatherService())
 					.description(
 							"Find the weather conditions, forecasts, and temperatures for a location, like a city or state.")
@@ -96,7 +96,7 @@ public class FunctionCallbackInPromptIT extends BaseOllamaIT {
 					"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.");
 
 			var promptOptions = OllamaOptions.builder()
-				.withFunctionCallbacks(List.of(FunctionCallback.builder()
+				.functionCallbacks(List.of(FunctionCallback.builder()
 					.function("CurrentWeatherService", new MockWeatherService())
 					.description(
 							"Find the weather conditions, forecasts, and temperatures for a location, like a city or state.")

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/OllamaFunctionCallbackIT.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/ollama/tool/OllamaFunctionCallbackIT.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +75,7 @@ public class OllamaFunctionCallbackIT extends BaseOllamaIT {
 					"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.");
 
 			ChatResponse response = chatModel
-				.call(new Prompt(List.of(userMessage), OllamaOptions.builder().withFunction("WeatherInfo").build()));
+				.call(new Prompt(List.of(userMessage), OllamaOptions.builder().function("WeatherInfo").build()));
 
 			logger.info("Response: " + response);
 
@@ -94,7 +93,7 @@ public class OllamaFunctionCallbackIT extends BaseOllamaIT {
 					"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.");
 
 			Flux<ChatResponse> response = chatModel
-				.stream(new Prompt(List.of(userMessage), OllamaOptions.builder().withFunction("WeatherInfo").build()));
+				.stream(new Prompt(List.of(userMessage), OllamaOptions.builder().function("WeatherInfo").build()));
 
 			String content = response.collectList()
 				.block()

--- a/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackContextKotlinIT.kt
+++ b/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackContextKotlinIT.kt
@@ -70,7 +70,7 @@ class FunctionCallbackResolverKotlinIT : BaseOllamaIT() {
 				"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.")
 
 			val response = chatModel
-					.call(Prompt(listOf(userMessage), OllamaOptions.builder().withFunction("weatherInfo").build()))
+					.call(Prompt(listOf(userMessage), OllamaOptions.builder().function("weatherInfo").build()))
 
 			logger.info("Response: " + response)
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackKotlinIT.kt
+++ b/spring-ai-spring-boot-autoconfigure/src/test/kotlin/org/springframework/ai/autoconfigure/ollama/tool/FunctionCallbackKotlinIT.kt
@@ -70,7 +70,7 @@ class FunctionCallbackKotlinIT : BaseOllamaIT() {
 				"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.")
 
 			val response = chatModel
-					.call(Prompt(listOf(userMessage), OllamaOptions.builder().withFunction("WeatherInfo").build()))
+					.call(Prompt(listOf(userMessage), OllamaOptions.builder().function("WeatherInfo").build()))
 
 			logger.info("Response: " + response)
 

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStoreWithOllamaIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStoreWithOllamaIT.java
@@ -91,8 +91,8 @@ class OpenSearchVectorStoreWithOllamaIT {
 	private static void ensureModelIsPresent(final String model) {
 		final OllamaApi api = new OllamaApi(OLLAMA_LOCAL_URL);
 		final var modelManagementOptions = ModelManagementOptions.builder()
-			.withMaxRetries(DEFAULT_MAX_RETRIES)
-			.withTimeout(DEFAULT_TIMEOUT)
+			.maxRetries(DEFAULT_MAX_RETRIES)
+			.timeout(DEFAULT_TIMEOUT)
 			.build();
 		final var ollamaModelManager = new OllamaModelManager(api, modelManagementOptions);
 		ollamaModelManager.pullModel(model, PullModelStrategy.WHEN_MISSING);
@@ -204,12 +204,9 @@ class OpenSearchVectorStoreWithOllamaIT {
 		@Bean
 		public EmbeddingModel embeddingModel() {
 			return OllamaEmbeddingModel.builder()
-				.withOllamaApi(new OllamaApi())
-				.withDefaultOptions(OllamaOptions.create()
-					.withModel(OllamaModel.MXBAI_EMBED_LARGE)
-					.withMainGPU(11)
-					.withUseMMap(true)
-					.withNumGPU(1))
+				.ollamaApi(new OllamaApi())
+				.defaultOptions(
+						OllamaOptions.create().model(OllamaModel.MXBAI_EMBED_LARGE).mainGPU(11).useMMap(true).numGPU(1))
 				.build();
 		}
 


### PR DESCRIPTION
 - Refactor Ollama related options builder methods
   - Deprecate builder methods with the prefix `with`
   - Update docs and references
