### PR TITLE
Refactor OCI Gen AI builder methods

### DIFF
--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingOptions.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingOptions.java
@@ -26,6 +26,7 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  * The configuration information for OCI embedding requests
  *
  * @author Anders Swanson
+ * @author Ilayaperumal Gopinathan
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OCIEmbeddingOptions implements EmbeddingOptions {
@@ -87,21 +88,57 @@ public class OCIEmbeddingOptions implements EmbeddingOptions {
 
 		private final OCIEmbeddingOptions options = new OCIEmbeddingOptions();
 
+		public Builder model(String model) {
+			this.options.setModel(model);
+			return this;
+		}
+
+		public Builder compartment(String compartment) {
+			this.options.setCompartment(compartment);
+			return this;
+		}
+
+		public Builder servingMode(String servingMode) {
+			this.options.setServingMode(servingMode);
+			return this;
+		}
+
+		public Builder truncate(EmbedTextDetails.Truncate truncate) {
+			this.options.truncate = truncate;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #model(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withModel(String model) {
 			this.options.setModel(model);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #compartment(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withCompartment(String compartment) {
 			this.options.setCompartment(compartment);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #servingMode(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withServingMode(String servingMode) {
 			this.options.setServingMode(servingMode);
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #truncate(EmbedTextDetails.Truncate)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTruncate(EmbedTextDetails.Truncate truncate) {
 			this.options.truncate = truncate;
 			return this;

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatOptions.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatOptions.java
@@ -25,9 +25,10 @@ import com.oracle.bmc.generativeaiinference.model.CohereTool;
 import org.springframework.ai.chat.prompt.ChatOptions;
 
 /**
- * The configuration information for OCI chat requests
+ * The configuration information for OCI chat requests.
  *
  * @author Anders Swanson
+ * @author Ilayaperumal Gopinathan
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OCICohereChatOptions implements ChatOptions {
@@ -115,19 +116,19 @@ public class OCICohereChatOptions implements ChatOptions {
 	private List<CohereTool> tools;
 
 	public static OCICohereChatOptions fromOptions(OCICohereChatOptions fromOptions) {
-		return builder().withModel(fromOptions.model)
-			.withMaxTokens(fromOptions.maxTokens)
-			.withCompartment(fromOptions.compartment)
-			.withServingMode(fromOptions.servingMode)
-			.withPreambleOverride(fromOptions.preambleOverride)
-			.withTemperature(fromOptions.temperature)
-			.withTopP(fromOptions.topP)
-			.withTopK(fromOptions.topK)
-			.withStop(fromOptions.stop)
-			.withFrequencyPenalty(fromOptions.frequencyPenalty)
-			.withPresencePenalty(fromOptions.presencePenalty)
-			.withDocuments(fromOptions.documents)
-			.withTools(fromOptions.tools)
+		return builder().model(fromOptions.model)
+			.maxTokens(fromOptions.maxTokens)
+			.compartment(fromOptions.compartment)
+			.servingMode(fromOptions.servingMode)
+			.preambleOverride(fromOptions.preambleOverride)
+			.temperature(fromOptions.temperature)
+			.topP(fromOptions.topP)
+			.topK(fromOptions.topK)
+			.stop(fromOptions.stop)
+			.frequencyPenalty(fromOptions.frequencyPenalty)
+			.presencePenalty(fromOptions.presencePenalty)
+			.documents(fromOptions.documents)
+			.tools(fromOptions.tools)
 			.build();
 	}
 
@@ -272,66 +273,183 @@ public class OCICohereChatOptions implements ChatOptions {
 			this.chatOptions = chatOptions;
 		}
 
+		public Builder model(String model) {
+			this.chatOptions.model = model;
+			return this;
+		}
+
+		public Builder maxTokens(Integer maxTokens) {
+			this.chatOptions.maxTokens = maxTokens;
+			return this;
+		}
+
+		public Builder compartment(String compartment) {
+			this.chatOptions.compartment = compartment;
+			return this;
+		}
+
+		public Builder servingMode(String servingMode) {
+			this.chatOptions.servingMode = servingMode;
+			return this;
+		}
+
+		public Builder preambleOverride(String preambleOverride) {
+			this.chatOptions.preambleOverride = preambleOverride;
+			return this;
+		}
+
+		public Builder temperature(Double temperature) {
+			this.chatOptions.temperature = temperature;
+			return this;
+		}
+
+		public Builder topP(Double topP) {
+			this.chatOptions.topP = topP;
+			return this;
+		}
+
+		public Builder topK(Integer topK) {
+			this.chatOptions.topK = topK;
+			return this;
+		}
+
+		public Builder frequencyPenalty(Double frequencyPenalty) {
+			this.chatOptions.frequencyPenalty = frequencyPenalty;
+			return this;
+		}
+
+		public Builder presencePenalty(Double presencePenalty) {
+			this.chatOptions.presencePenalty = presencePenalty;
+			return this;
+		}
+
+		public Builder stop(List<String> stop) {
+			this.chatOptions.stop = stop;
+			return this;
+		}
+
+		public Builder documents(List<Object> documents) {
+			this.chatOptions.documents = documents;
+			return this;
+		}
+
+		public Builder tools(List<CohereTool> tools) {
+			this.chatOptions.tools = tools;
+			return this;
+		}
+
+		/**
+		 * @deprecated use {@link #model(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withModel(String model) {
 			this.chatOptions.model = model;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #maxTokens(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withMaxTokens(Integer maxTokens) {
 			this.chatOptions.maxTokens = maxTokens;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #compartment(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withCompartment(String compartment) {
 			this.chatOptions.compartment = compartment;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #servingMode(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withServingMode(String servingMode) {
 			this.chatOptions.servingMode = servingMode;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #preambleOverride(String)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withPreambleOverride(String preambleOverride) {
 			this.chatOptions.preambleOverride = preambleOverride;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #temperature(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTemperature(Double temperature) {
 			this.chatOptions.temperature = temperature;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #topP(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTopP(Double topP) {
 			this.chatOptions.topP = topP;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #topK(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTopK(Integer topK) {
 			this.chatOptions.topK = topK;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #frequencyPenalty(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withFrequencyPenalty(Double frequencyPenalty) {
 			this.chatOptions.frequencyPenalty = frequencyPenalty;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #presencePenalty(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withPresencePenalty(Double presencePenalty) {
 			this.chatOptions.presencePenalty = presencePenalty;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #stop(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withStop(List<String> stop) {
 			this.chatOptions.stop = stop;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #documents(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withDocuments(List<Object> documents) {
 			this.chatOptions.documents = documents;
 			return this;
 		}
 
+		/**
+		 * @deprecated use {@link #tools(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M5")
 		public Builder withTools(List<CohereTool> tools) {
 			this.chatOptions.tools = tools;
 			return this;

--- a/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/BaseEmbeddingModelTest.java
+++ b/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/BaseEmbeddingModelTest.java
@@ -28,9 +28,9 @@ public class BaseEmbeddingModelTest extends BaseOCIGenAITest {
 	 */
 	public static OCIEmbeddingModel getEmbeddingModel() {
 		OCIEmbeddingOptions options = OCIEmbeddingOptions.builder()
-			.withModel(EMBEDDING_MODEL_V2)
-			.withCompartment(COMPARTMENT_ID)
-			.withServingMode("on-demand")
+			.model(EMBEDDING_MODEL_V2)
+			.compartment(COMPARTMENT_ID)
+			.servingMode("on-demand")
 			.build();
 		return new OCIEmbeddingModel(getGenerativeAIClient(), options);
 	}

--- a/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/BaseOCIGenAITest.java
+++ b/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/BaseOCIGenAITest.java
@@ -54,10 +54,7 @@ public class BaseOCIGenAITest {
 	}
 
 	public static OCICohereChatOptions.Builder options() {
-		return OCICohereChatOptions.builder()
-			.withModel(CHAT_MODEL_ID)
-			.withCompartment(COMPARTMENT_ID)
-			.withServingMode("on-demand");
+		return OCICohereChatOptions.builder().model(CHAT_MODEL_ID).compartment(COMPARTMENT_ID).servingMode("on-demand");
 	}
 
 }

--- a/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/OCIEmbeddingModelIT.java
+++ b/models/spring-ai-oci-genai/src/test/java/org/springframework/ai/oci/OCIEmbeddingModelIT.java
@@ -51,8 +51,8 @@ class OCIEmbeddingModelIT extends BaseEmbeddingModelTest {
 
 	@Test
 	void callWithOptions() {
-		EmbeddingResponse response = this.embeddingModel.call(new EmbeddingRequest(this.content,
-				OCIEmbeddingOptions.builder().withModel(EMBEDDING_MODEL_V3).build()));
+		EmbeddingResponse response = this.embeddingModel
+			.call(new EmbeddingRequest(this.content, OCIEmbeddingOptions.builder().model(EMBEDDING_MODEL_V3).build()));
 		assertThat(response).isNotNull();
 		assertThat(response.getResults()).hasSize(2);
 		assertThat(response.getMetadata().getModel()).isEqualTo(EMBEDDING_MODEL_V3);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/oci-genai/cohere-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/oci-genai/cohere-chat.adoc
@@ -102,9 +102,9 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         OCICohereChatOptions.builder()
-            .withModel("my-model-ocid")
-            .withCompartment("my-compartment-ocid")
-            .withTemperature(0.5)
+            .model("my-model-ocid")
+            .compartment("my-compartment-ocid")
+            .temperature(0.5)
         .build()
     ));
 ----
@@ -195,9 +195,9 @@ var genAi = GenerativeAiInferenceClient.builder()
         .build(authProvider);
 
 var chatModel = new OCICohereChatModel(genAi, OCICohereChatOptions.builder()
-        .withModel(MODEL_ID)
-        .withCompartment(COMPARTMENT_ID)
-        .withServingMode("on-demand")
+        .model(MODEL_ID)
+        .compartment(COMPARTMENT_ID)
+        .servingMode("on-demand")
         .build());
 
 ChatResponse response = chatModel.call(

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/oci-genai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/oci-genai-embeddings.adoc
@@ -88,7 +88,7 @@ For example to override the default model name for a specific request:
 EmbeddingResponse embeddingResponse = embeddingModel.call(
     new EmbeddingRequest(List.of("Hello World", "World is big and salvation is near"),
         OCIEmbeddingOptions.builder()
-            .withModel("my-other-embedding-model")
+            .model("my-other-embedding-model")
             .build()
 ));
 ----
@@ -164,9 +164,9 @@ var aiClient = GenerativeAiInferenceClient.builder()
     .region(Region.valueOf(this.REGION))
     .build(this.authProvider);
 var options = OCIEmbeddingOptions.builder()
-    .withModel(this.EMBEDDING_MODEL)
-    .withCompartment(this.COMPARTMENT_ID)
-    .withServingMode("on-demand")
+    .model(this.EMBEDDING_MODEL)
+    .compartment(this.COMPARTMENT_ID)
+    .servingMode("on-demand")
     .build();
 var embeddingModel = new OCIEmbeddingModel(this.aiClient, this.options);
 List<Double> embedding = this.embeddingModel.embed(new Document("How many provinces are in Canada?"));

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/oci/genai/OCICohereChatModelProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/oci/genai/OCICohereChatModelProperties.java
@@ -38,8 +38,8 @@ public class OCICohereChatModelProperties {
 
 	@NestedConfigurationProperty
 	private OCICohereChatOptions options = OCICohereChatOptions.builder()
-		.withServingMode(DEFAULT_SERVING_MODE)
-		.withTemperature(DEFAULT_TEMPERATURE)
+		.servingMode(DEFAULT_SERVING_MODE)
+		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public boolean isEnabled() {

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/oci/genai/OCIEmbeddingModelProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/oci/genai/OCIEmbeddingModelProperties.java
@@ -43,10 +43,10 @@ public class OCIEmbeddingModelProperties {
 
 	public OCIEmbeddingOptions getEmbeddingOptions() {
 		return OCIEmbeddingOptions.builder()
-			.withCompartment(this.compartment)
-			.withModel(this.model)
-			.withServingMode(this.servingMode.getMode())
-			.withTruncate(this.truncate)
+			.compartment(this.compartment)
+			.model(this.model)
+			.servingMode(this.servingMode.getMode())
+			.truncate(this.truncate)
 			.build();
 	}
 


### PR DESCRIPTION
 - Deprecate the builder methods with the prefix `with`
   - Fix OCI cohere chat model options and OCI Embedding model options
 - Update references and docs
