### PR TITLE
Add builder pattern to SimpleVectorStore

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
@@ -43,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
-import org.springframework.ai.document.DocumentMetadata;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
@@ -79,20 +78,36 @@ public class SimpleVectorStore extends AbstractObservationVectorStore {
 
 	protected Map<String, SimpleVectorStoreContent> store = new ConcurrentHashMap<>();
 
-	protected EmbeddingModel embeddingModel;
-
+	/**
+	 * use {@link #SimpleVectorStore(SimpleVectorStoreBuilder)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public SimpleVectorStore(EmbeddingModel embeddingModel) {
 		this(embeddingModel, ObservationRegistry.NOOP, null);
 	}
 
+	/**
+	 * use {@link #SimpleVectorStore(SimpleVectorStoreBuilder)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "1.0.0-M5")
 	public SimpleVectorStore(EmbeddingModel embeddingModel, ObservationRegistry observationRegistry,
 			VectorStoreObservationConvention customObservationConvention) {
+		this(builder().embeddingModel(embeddingModel)
+			.observationRegistry(observationRegistry)
+			.customObservationConvention(customObservationConvention));
+	}
 
-		super(observationRegistry, customObservationConvention);
-
-		Objects.requireNonNull(embeddingModel, "EmbeddingModel must not be null");
-		this.embeddingModel = embeddingModel;
+	protected SimpleVectorStore(SimpleVectorStoreBuilder builder) {
+		super(builder);
 		this.objectMapper = JsonMapper.builder().addModules(JacksonUtils.instantiateAvailableModules()).build();
+	}
+
+	/**
+	 * Creates an instance of SimpleVectorStore builder.
+	 * @return the SimpleVectorStore builder.
+	 */
+	public static SimpleVectorStoreBuilder builder() {
+		return new SimpleVectorStoreBuilder();
 	}
 
 	@Override
@@ -276,6 +291,16 @@ public class SimpleVectorStore extends AbstractObservationVectorStore {
 
 		public static float norm(float[] vector) {
 			return dotProduct(vector, vector);
+		}
+
+	}
+
+	public static final class SimpleVectorStoreBuilder extends AbstractVectorStoreBuilder<SimpleVectorStoreBuilder> {
+
+		@Override
+		public SimpleVectorStore build() {
+			validate();
+			return new SimpleVectorStore(this);
 		}
 
 	}

--- a/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreTests.java
@@ -57,7 +57,7 @@ class SimpleVectorStoreTests {
 		when(this.mockEmbeddingModel.dimensions()).thenReturn(3);
 		when(this.mockEmbeddingModel.embed(any(String.class))).thenReturn(new float[] { 0.1f, 0.2f, 0.3f });
 		when(this.mockEmbeddingModel.embed(any(Document.class))).thenReturn(new float[] { 0.1f, 0.2f, 0.3f });
-		this.vectorStore = new SimpleVectorStore(this.mockEmbeddingModel);
+		this.vectorStore = new SimpleVectorStore(SimpleVectorStore.builder().embeddingModel(this.mockEmbeddingModel));
 	}
 
 	@Test


### PR DESCRIPTION
 - Create SimpleVectorStoreBuilder which can be used to create the SimpleVectorStore instance
 - Remove the field embeddingModel from SimpleVectorStore as it can be retrieved from AbstractObservationVectorStore
 - Deprecate the existing SimpleVectorStore constructors and use the builder to instantiate it
 - Fix the tests
