### PR TITLE
Remove embedding from Document

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/document/Document.java
@@ -123,12 +123,6 @@ public class Document {
 	private final Double score;
 
 	/**
-	 * Embedding of the document. Note: ephemeral field.
-	 */
-	@JsonProperty(index = 100)
-	private float[] embedding = new float[0];
-
-	/**
 	 * Mutable, ephemeral, content to text formatter. Defaults to Document text.
 	 */
 	@JsonIgnore
@@ -258,22 +252,6 @@ public class Document {
 	@Nullable
 	public Double getScore() {
 		return this.score;
-	}
-
-	/**
-	 * Return the embedding that were calculated.
-	 * @deprecated We are considering getting rid of this, please comment on
-	 * https://github.com/spring-projects/spring-ai/issues/1781
-	 * @return the embeddings
-	 */
-	@Deprecated(since = "1.0.0-M4")
-	public float[] getEmbedding() {
-		return this.embedding;
-	}
-
-	public void setEmbedding(float[] embedding) {
-		Assert.notNull(embedding, "embedding must not be null");
-		this.embedding = embedding;
 	}
 
 	/**
@@ -436,9 +414,7 @@ public class Document {
 			if (!StringUtils.hasText(this.id)) {
 				this.id = this.idGenerator.generateId(this.text, this.metadata);
 			}
-			var document = new Document(this.id, this.text, this.media, this.metadata, this.score);
-			document.setEmbedding(this.embedding);
-			return document;
+			return new Document(this.id, this.text, this.media, this.metadata, this.score);
 		}
 
 	}

--- a/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/document/DocumentTests.java
@@ -16,17 +16,16 @@
 
 package org.springframework.ai.document;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.document.id.IdGenerator;
 import org.springframework.ai.model.Media;
 import org.springframework.util.MimeTypeUtils;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -209,15 +208,6 @@ public class DocumentTests {
 			.build();
 
 		assertThat(document.getMetadata()).containsEntry("key1", "value1").containsEntry("key2", "value2");
-	}
-
-	@Test
-	void testEmbeddingOperations() {
-		float[] embedding = new float[] { 0.1f, 0.2f, 0.3f };
-
-		Document document = Document.builder().text("test").embedding(embedding).build();
-
-		assertThat(document.getEmbedding()).isEqualTo(embedding);
 	}
 
 	@Test


### PR DESCRIPTION
 - This PR removes the reference of `embedding` from the `Document` object.
   - The Document is designed to contain the content and its metadata but not the embedding representation of its content. This provides clear separation of concern.
   - Prior to this change, all the vector stores are updated by not depending on the embedding from Document. Instead, use the embedding values returned by the Embedding Models directly: https://github.com/spring-projects/spring-ai/issues/1826

Resolves #1781
