### PR TITLE
feat(bedrock): deprecate InvokeModel API Chat modes in favor of Converse API

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic/BedrockAnthropicChatModel.java
@@ -40,7 +40,10 @@ import org.springframework.ai.model.ModelOptionsUtils;
  *
  * @author Christian Tzolov
  * @since 0.8.0
+ * @deprecated in favor of the
+ * {@link org.springframework.ai.bedrock.converse.BedrockProxyChatModel}.
  */
+@Deprecated
 public class BedrockAnthropicChatModel implements ChatModel, StreamingChatModel {
 
 	private final AnthropicChatBedrockApi anthropicChatApi;

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/anthropic3/BedrockAnthropic3ChatModel.java
@@ -57,7 +57,10 @@ import org.springframework.util.CollectionUtils;
  * @author Wei Jiang
  * @author Alexandros Pappas
  * @since 1.0.0
+ * @deprecated in favor of the
+ * {@link org.springframework.ai.bedrock.converse.BedrockProxyChatModel}.
  */
+@Deprecated
 public class BedrockAnthropic3ChatModel implements ChatModel, StreamingChatModel {
 
 	private final Anthropic3ChatBedrockApi anthropicChatApi;

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereChatModel.java
@@ -42,7 +42,10 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @since 0.8.0
+ * @deprecated in favor of the
+ * {@link org.springframework.ai.bedrock.converse.BedrockProxyChatModel}.
  */
+@Deprecated
 public class BedrockCohereChatModel implements ChatModel, StreamingChatModel {
 
 	private final CohereChatBedrockApi chatApi;

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModel.java
@@ -34,7 +34,10 @@ import org.springframework.util.Assert;
  *
  * @author Ahmed Yousri
  * @since 1.0.0
+ * @deprecated in favor of the
+ * {@link org.springframework.ai.bedrock.converse.BedrockProxyChatModel}.
  */
+@Deprecated
 public class BedrockAi21Jurassic2ChatModel implements ChatModel {
 
 	private final Ai21Jurassic2ChatBedrockApi chatApi;

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/llama/BedrockLlamaChatModel.java
@@ -43,7 +43,10 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Wei Jiang
  * @since 0.8.0
+ * @deprecated in favor of the
+ * {@link org.springframework.ai.bedrock.converse.BedrockProxyChatModel}.
  */
+@Deprecated
 public class BedrockLlamaChatModel implements ChatModel, StreamingChatModel {
 
 	private final LlamaChatBedrockApi chatApi;

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
@@ -43,7 +43,10 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @since 0.8.0
+ * @deprecated in favor of the
+ * {@link org.springframework.ai.bedrock.converse.BedrockProxyChatModel}.
  */
+@Deprecated
 public class BedrockTitanChatModel implements ChatModel, StreamingChatModel {
 
 	private final TitanChatBedrockApi chatApi;


### PR DESCRIPTION
Following Amazon Bedrock's recommendations, deprecate individual model chat implementations (Anthropic, Cohere, Llama, Titan, etc.) in favor of the unified BedrockProxyChatModel. This change promotes the use of Bedrock's Converse API which offers benefits like model flexibility, extended functionality, and native tool support.

The Converse API does not support embedding operations, so these will remain in the current API and the embedding model functionality in the existing InvokeModel API will be maintained

