### PR TITLE
Standardize builder class names in vector stores

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/apache-cassandra.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/apache-cassandra.adoc
@@ -163,9 +163,7 @@ For more complex scenarios, the builder pattern offers extensive configuration o
 ----
 @Bean
 public VectorStore vectorStore(CqlSession session, EmbeddingModel embeddingModel) {
-    return CassandraVectorStore.builder()
-        .session(session)
-        .embeddingModel(embeddingModel)
+    return CassandraVectorStore.builder(embeddingModel)
         .keyspace("my_keyspace")
         .table("my_vectors")
         .partitionKeys(List.of(new SchemaColumn("id", DataTypes.TEXT)))

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure-cosmos-db.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure-cosmos-db.adoc
@@ -203,11 +203,6 @@ public class DemoApplication implements CommandLineRunner {
 
     @Bean
     public VectorStore vectorStore(ObservationRegistry observationRegistry) {
-        CosmosDBVectorStoreConfig config = new CosmosDBVectorStoreConfig();
-        config.setDatabaseName("spring-ai-sample");
-        config.setContainerName("container");
-        config.setMetadataFields("country,city");
-        config.setVectorStoreThroughput(400);
 
         CosmosAsyncClient cosmosClient = new CosmosClientBuilder()
                 .endpoint(System.getenv("COSMOSDB_AI_ENDPOINT"))
@@ -216,7 +211,13 @@ public class DemoApplication implements CommandLineRunner {
                 .gatewayMode()
                 .buildAsyncClient();
 
-        return new CosmosDBVectorStore(observationRegistry, null, cosmosClient, config, this.embeddingModel);
+		return CosmosDBVectorStore.builder(cosmosClient, this.embeddingModel)
+				.databaseName("test-database")
+				.containerName("test-container")
+				.metadataFields(List.of("country", "year", "city"))
+				.vectorStoreThroughput(1000)
+                .observationRegistry(observationRegistry)
+				.build();
     }
 
     @Bean

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure.adoc
@@ -131,12 +131,14 @@ To create a vector store, you can use the following code by injecting the `Searc
 ----
 @Bean
 public VectorStore vectorStore(SearchIndexClient searchIndexClient, EmbeddingModel embeddingModel) {
-  return new AzureVectorStore(searchIndexClient, embeddingModel,
+
+  return AzureVectorStore.builder(searchIndexClient, embeddingModel)
+    .initializeSchema(true)
     // Define the metadata fields to be used
     // in the similarity search filters.
-    List.of(MetadataField.text("country"),
-            MetadataField.int64("year"),
-            MetadataField.bool("active")));
+    .filterMetadataFields(List.of(MetadataField.text("country"), MetadataField.int64("year"),
+            MetadataField.date("activationDate")))
+    .build();
 }
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
@@ -231,7 +231,10 @@ Integrate with OpenAI's embeddings by adding the Spring Boot OpenAI starter to y
 ----
 @Bean
 public VectorStore chromaVectorStore(EmbeddingModel embeddingModel, ChromaApi chromaApi) {
- return new ChromaVectorStore(embeddingModel, chromaApi, "TestCollection", false);
+ return ChromaVectorStore.builder(chromaApi, embeddingModel)
+				.collectionName("TestCollection")
+				.initializeSchema(true)
+				.build();
 }
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -256,9 +256,7 @@ public VectorStore vectorStore(RestClient restClient, EmbeddingModel embeddingMo
     options.setSimilarity(COSINE);           // Optional: defaults to COSINE
     options.setDimensions(1536);             // Optional: defaults to model dimensions or 1536
 
-    return ElasticsearchVectorStore.builder()
-        .restClient(restClient)
-        .embeddingModel(embeddingModel)
+    return ElasticsearchVectorStore.builder(restClient, embeddingModel)
         .options(options)                     // Optional: use custom options
         .initializeSchema(true)               // Optional: defaults to false
         .batchingStrategy(new TokenCountBatchingStrategy()) // Optional: defaults to TokenCountBatchingStrategy

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/gemfire.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/gemfire.adoc
@@ -83,10 +83,13 @@ Here is a sample that creates an instance of the `GemfireVectorStore` instead of
 [source,java]
 ----
 @Bean
-public VectorStore vectorStore(EmbeddingModel embeddingModel) {
-    return new GemFireVectorStore(new GemFireVectorStoreConfig()
-                                    .setIndexName("my-vector-index")
-                                    .setPort(7071), embeddingClient);
+public GemFireVectorStore vectorStore(EmbeddingModel embeddingModel) {
+    return GemFireVectorStore.builder(embeddingModel)
+        .host("localhost")
+        .port(7071)
+        .indexName("my-vector-index")
+        .initializeSchema(true)
+        .build();
 }
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mariadb.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mariadb.adoc
@@ -149,8 +149,7 @@ Then create the `MariaDBVectorStore` bean using the builder pattern:
 ----
 @Bean
 public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
-    return MariaDBVectorStore.builder(jdbcTemplate)
-        .embeddingModel(embeddingModel)
+    return MariaDBVectorStore.builder(jdbcTemplate, embeddingModel)
         .dimensions(1536)                      // Optional: defaults to 1536
         .distanceType(MariaDBDistanceType.COSINE) // Optional: defaults to COSINE
         .schemaName("mydb")                    // Optional: defaults to null

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
@@ -109,13 +109,14 @@ To configure MilvusVectorStore in your application, you can use the following se
 ----
 	@Bean
 	public VectorStore vectorStore(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
-		MilvusVectorStoreConfig config = MilvusVectorStoreConfig.builder()
-			.withCollectionName("test_vector_store")
-			.withDatabaseName("default")
-			.withIndexType(IndexType.IVF_FLAT)
-			.withMetricType(MetricType.COSINE)
-			.build();
-		return new MilvusVectorStore(milvusClient, embeddingModel, config);
+		return MilvusVectorStore.builder(milvusClient, embeddingModel)
+				.collectionName("test_vector_store")
+				.databaseName("default")
+				.indexType(IndexType.IVF_FLAT)
+				.metricType(MetricType.COSINE)
+				.batchingStrategy(new TokenCountBatchingStrategy())
+				.initializeSchema(true)
+				.build();
 	}
 
 	@Bean

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mongodb.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mongodb.adoc
@@ -146,9 +146,7 @@ Then create the `MongoDBAtlasVectorStore` bean using the builder pattern:
 ----
 @Bean
 public VectorStore vectorStore(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel) {
-    return MongoDBAtlasVectorStore.builder()
-        .mongoTemplate(mongoTemplate)
-        .embeddingModel(embeddingModel)
+    return MongoDBAtlasVectorStore.builder(mongoTemplate, embeddingModel)
         .collectionName("custom_vector_store")           // Optional: defaults to "vector_store"
         .vectorIndexName("custom_vector_index")          // Optional: defaults to "vector_index"
         .pathName("custom_embedding")                    // Optional: defaults to "embedding"

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
@@ -172,9 +172,7 @@ Then create the `Neo4jVectorStore` bean using the builder pattern:
 ----
 @Bean
 public VectorStore vectorStore(Driver driver, EmbeddingModel embeddingModel) {
-    return Neo4jVectorStore.builder()
-        .driver(driver)
-        .embeddingModel(embeddingModel)
+    return Neo4jVectorStore.builder(driver, embeddingModel)
         .databaseName("neo4j")                // Optional: defaults to "neo4j"
         .distanceType(Neo4jDistanceType.COSINE) // Optional: defaults to COSINE
         .dimensions(1536)                      // Optional: defaults to 1536

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
@@ -177,9 +177,7 @@ Then create the `OpenSearchVectorStore` bean using the builder pattern:
 ----
 @Bean
 public VectorStore vectorStore(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
-    return OpenSearchVectorStore.builder()
-        .openSearchClient(openSearchClient)
-        .embeddingModel(embeddingModel)
+    return OpenSearchVectorStore.builder(openSearchClient, embeddingModel)
         .index("custom-index")                // Optional: defaults to "spring-ai-document-index"
         .similarityFunction("l2")             // Optional: defaults to "cosinesimil"
         .initializeSchema(true)               // Optional: defaults to false

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pgvector.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pgvector.adoc
@@ -220,9 +220,7 @@ To configure PgVector in your application, you can use the following setup:
 ----
 @Bean
 public VectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
-    return PgVectorStore.builder()
-        .jdbcTemplate(jdbcTemplate)
-        .embeddingModel(embeddingModel)
+    return PgVectorStore.builder(jdbcTemplate, embeddingModel)
         .dimensions(1536)                    // Optional: defaults to model dimensions or 1536
         .distanceType(COSINE_DISTANCE)       // Optional: defaults to COSINE_DISTANCE
         .indexType(HNSW)                     // Optional: defaults to HNSW

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
@@ -188,27 +188,12 @@ To configure Pinecone in your application, you can use the following setup:
 [source,java]
 ----
 @Bean
-public PineconeVectorStoreConfig pineconeVectorStoreConfig() {
-
-    return PineconeVectorStoreConfig.builder()
-        .withApiKey(<PINECONE_API_KEY>)
-        .withEnvironment("gcp-starter")
-        .withProjectId("89309e6")
-        .withIndexName("spring-ai-test-index")
-        .withNamespace("") // the free tier doesn't support namespaces.
-        .withContentFieldName("my_content") // optional field to store the original content. Defaults to `document_content`
+public VectorStore pineconeVectorStore(EmbeddingModel embeddingModel) {
+    return PineconeVectorStore
+        .builder(embeddingModel, PINECONE_API_KEY, PINECONE_PROJECT_ID, PINECONE_ENVIRONMENT, PINECONE_INDEX_NAME)
+        .namespace(PINECONE_NAMESPACE) // the free tier doesn't support namespaces.
+        .contentFieldName(CUSTOM_CONTENT_FIELD_NAME) // optional field to store the original content. Defaults to `document_content`
         .build();
-}
-----
-
-Integrate with OpenAI's embeddings by adding the Spring Boot OpenAI starter to your project.
-This provides you with an implementation of the Embeddings client:
-
-[source,java]
-----
-@Bean
-public VectorStore vectorStore(PineconeVectorStoreConfig config, EmbeddingModel embeddingModel) {
-    return new PineconeVectorStore(config, embeddingModel);
 }
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/qdrant.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/qdrant.adoc
@@ -148,8 +148,7 @@ Then create the `QdrantVectorStore` bean using the builder pattern:
 ----
 @Bean
 public VectorStore vectorStore(QdrantClient qdrantClient, EmbeddingModel embeddingModel) {
-    return QdrantVectorStore.builder(qdrantClient)
-        .embeddingModel(embeddingModel)
+    return QdrantVectorStore.builder(qdrantClient, embeddingModel)
         .collectionName("custom-collection")     // Optional: defaults to "vector_store"
         .initializeSchema(true)                  // Optional: defaults to false
         .batchingStrategy(new TokenCountBatchingStrategy()) // Optional: defaults to TokenCountBatchingStrategy

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
@@ -189,9 +189,7 @@ Then create the `RedisVectorStore` bean using the builder pattern:
 ----
 @Bean
 public VectorStore vectorStore(JedisPooled jedisPooled, EmbeddingModel embeddingModel) {
-    return RedisVectorStore.builder()
-        .jedis(jedisPooled)
-        .embeddingModel(embeddingModel)
+    return RedisVectorStore.builder(jedisPooled, embeddingModel)
         .indexName("custom-index")                // Optional: defaults to "spring-ai-index"
         .prefix("custom-prefix")                  // Optional: defaults to "embedding:"
         .metadataFields(                         // Optional: define metadata fields for filtering

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/typesense.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/typesense.adoc
@@ -161,9 +161,7 @@ Then create the `TypesenseVectorStore` bean using the builder pattern:
 ----
 @Bean
 public VectorStore vectorStore(Client client, EmbeddingModel embeddingModel) {
-    return TypesenseVectorStore.builder()
-        .client(client)
-        .embeddingModel(embeddingModel)
+    return TypesenseVectorStore.builder(client, embeddingModel)
         .collectionName("custom_vectors")     // Optional: defaults to "vector_store"
         .embeddingDimension(1536)            // Optional: defaults to 1536
         .initializeSchema(true)              // Optional: defaults to false

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
@@ -119,10 +119,8 @@ public WeaviateClient weaviateClient() {
 }
 
 @Bean
-public VectorStore vectorStore(EmbeddingModel embeddingModel, WeaviateClient weaviateClient) {
-    return WeaviateVectorStore.builder()
-        .weaviateClient(weaviateClient)
-        .embeddingModel(embeddingModel)
+public VectorStore vectorStore(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
+    return WeaviateVectorStore.builder(weaviateClient, embeddingModel)
         .objectClass("CustomClass")                    // Optional: defaults to "SpringAiWeaviate"
         .consistencyLevel(ConsistentLevel.QUORUM)      // Optional: defaults to ConsistentLevel.ONE
         .filterMetadataFields(List.of(                 // Optional: fields that can be used in filters

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/mongo/MongoDBAtlasVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/mongo/MongoDBAtlasVectorStoreAutoConfiguration.java
@@ -66,7 +66,7 @@ public class MongoDBAtlasVectorStoreAutoConfiguration {
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
 
-		MongoDBAtlasVectorStore.MongoDBBuilder builder = MongoDBAtlasVectorStore.builder(mongoTemplate, embeddingModel)
+		MongoDBAtlasVectorStore.Builder builder = MongoDBAtlasVectorStore.builder(mongoTemplate, embeddingModel)
 			.initializeSchema(properties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
@@ -151,7 +151,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 	 * create new CosmosDBVectorStore instances.
 	 * @param builder the configured builder instance
 	 */
-	protected CosmosDBVectorStore(CosmosDBBuilder builder) {
+	protected CosmosDBVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.cosmosClient, "CosmosClient must not be null");
@@ -172,8 +172,8 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		initializeContainer(containerName, databaseName, vectorStoreThroughput, vectorDimensions, partitionKeyPath);
 	}
 
-	public static CosmosDBBuilder builder(CosmosAsyncClient cosmosClient, EmbeddingModel embeddingModel) {
-		return new CosmosDBBuilder(cosmosClient, embeddingModel);
+	public static Builder builder(CosmosAsyncClient cosmosClient, EmbeddingModel embeddingModel) {
+		return new Builder(cosmosClient, embeddingModel);
 	}
 
 	private void initializeContainer(String containerName, String databaseName, int vectorStoreThroughput,
@@ -429,7 +429,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 	 *
 	 * @since 1.0.0
 	 */
-	public static class CosmosDBBuilder extends AbstractVectorStoreBuilder<CosmosDBBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final CosmosAsyncClient cosmosClient;
 
@@ -450,7 +450,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 
 		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
 
-		private CosmosDBBuilder(CosmosAsyncClient cosmosClient, EmbeddingModel embeddingModel) {
+		private Builder(CosmosAsyncClient cosmosClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(cosmosClient, "CosmosClient must not be null");
 			this.cosmosClient = cosmosClient;
@@ -462,7 +462,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if containerName is null or empty
 		 */
-		public CosmosDBBuilder containerName(String containerName) {
+		public Builder containerName(String containerName) {
 			Assert.hasText(containerName, "Container name must not be empty");
 			this.containerName = containerName;
 			return this;
@@ -474,7 +474,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if databaseName is null or empty
 		 */
-		public CosmosDBBuilder databaseName(String databaseName) {
+		public Builder databaseName(String databaseName) {
 			Assert.hasText(databaseName, "Database name must not be empty");
 			this.databaseName = databaseName;
 			return this;
@@ -486,7 +486,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if partitionKeyPath is null or empty
 		 */
-		public CosmosDBBuilder partitionKeyPath(String partitionKeyPath) {
+		public Builder partitionKeyPath(String partitionKeyPath) {
 			Assert.hasText(partitionKeyPath, "Partition key path must not be empty");
 			this.partitionKeyPath = partitionKeyPath;
 			return this;
@@ -498,7 +498,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if vectorStoreThroughput is not positive
 		 */
-		public CosmosDBBuilder vectorStoreThroughput(int vectorStoreThroughput) {
+		public Builder vectorStoreThroughput(int vectorStoreThroughput) {
 			Assert.isTrue(vectorStoreThroughput > 0, "Vector store throughput must be positive");
 			this.vectorStoreThroughput = vectorStoreThroughput;
 			return this;
@@ -510,7 +510,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if vectorDimensions is not positive
 		 */
-		public CosmosDBBuilder vectorDimensions(long vectorDimensions) {
+		public Builder vectorDimensions(long vectorDimensions) {
 			Assert.isTrue(vectorDimensions > 0, "Vector dimensions must be positive");
 			this.vectorDimensions = vectorDimensions;
 			return this;
@@ -521,7 +521,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @param metadataFieldsList the list of metadata fields
 		 * @return the builder instance
 		 */
-		public CosmosDBBuilder metadataFields(List<String> metadataFieldsList) {
+		public Builder metadataFields(List<String> metadataFieldsList) {
 			this.metadataFieldsList = metadataFieldsList != null ? new ArrayList<>(metadataFieldsList)
 					: new ArrayList<>();
 			return this;
@@ -533,7 +533,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public CosmosDBBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -190,7 +190,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 	 * create new AzureVectorStore instances.
 	 * @param builder the configured builder instance
 	 */
-	protected AzureVectorStore(AzureBuilder builder) {
+	protected AzureVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.searchIndexClient, "The search index client cannot be null");
@@ -206,15 +206,15 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		this.filterExpressionConverter = new AzureAiSearchFilterExpressionConverter(filterMetadataFields);
 	}
 
-	public static AzureBuilder builder(SearchIndexClient searchIndexClient, EmbeddingModel embeddingModel) {
-		return new AzureBuilder(searchIndexClient, embeddingModel);
+	public static Builder builder(SearchIndexClient searchIndexClient, EmbeddingModel embeddingModel) {
+		return new Builder(searchIndexClient, embeddingModel);
 	}
 
 	/**
 	 * Change the Index Name.
 	 * @param indexName The Azure VectorStore index name to use.
 	 * @deprecated Since 1.0.0-M5, use {@link #builder(SearchIndexClient, EmbeddingModel)}
-	 * ()} with {@link AzureBuilder#indexName(String)} instead
+	 * ()} with {@link Builder#indexName(String)} instead
 	 */
 	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public void setIndexName(String indexName) {
@@ -226,7 +226,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 	 * Sets the a default maximum number of similar documents returned.
 	 * @param topK The default maximum number of similar documents returned.
 	 * @deprecated Since 1.0.0-M5, use {@link #builder(SearchIndexClient, EmbeddingModel)}
-	 * ()} with {@link AzureBuilder#indexName(String)} instead
+	 * ()} with {@link Builder#indexName(String)} instead
 	 */
 	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public void setDefaultTopK(int topK) {
@@ -239,7 +239,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 	 * @param similarityThreshold The a default similarity threshold for returned
 	 * documents.
 	 * @deprecated Since 1.0.0-M5, use {@link #builder(SearchIndexClient, EmbeddingModel)}
-	 * ()} with {@link AzureBuilder#indexName(String)} instead
+	 * ()} with {@link Builder#indexName(String)} instead
 	 */
 	@Deprecated(since = "1.0.0-M5", forRemoval = true)
 	public void setDefaultSimilarityThreshold(Double similarityThreshold) {
@@ -472,7 +472,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 	 *
 	 * @since 1.0.0
 	 */
-	public static class AzureBuilder extends AbstractVectorStoreBuilder<AzureBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final SearchIndexClient searchIndexClient;
 
@@ -488,7 +488,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 
 		private String indexName = DEFAULT_INDEX_NAME;
 
-		private AzureBuilder(SearchIndexClient searchIndexClient, EmbeddingModel embeddingModel) {
+		private Builder(SearchIndexClient searchIndexClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(searchIndexClient, "SearchIndexClient must not be null");
 			this.searchIndexClient = searchIndexClient;
@@ -499,7 +499,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public AzureBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -509,7 +509,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		 * @param filterMetadataFields the list of metadata fields
 		 * @return the builder instance
 		 */
-		public AzureBuilder filterMetadataFields(List<MetadataField> filterMetadataFields) {
+		public Builder filterMetadataFields(List<MetadataField> filterMetadataFields) {
 			this.filterMetadataFields = filterMetadataFields != null ? filterMetadataFields : List.of();
 			return this;
 		}
@@ -519,7 +519,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		 * @param batchingStrategy the strategy to use
 		 * @return the builder instance
 		 */
-		public AzureBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;
@@ -531,7 +531,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if indexName is null or empty
 		 */
-		public AzureBuilder indexName(String indexName) {
+		public Builder indexName(String indexName) {
 			Assert.hasText(indexName, "The index name can not be empty.");
 			this.indexName = indexName;
 			return this;
@@ -543,7 +543,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if defaultTopK is negative
 		 */
-		public AzureBuilder defaultTopK(int defaultTopK) {
+		public Builder defaultTopK(int defaultTopK) {
 			Assert.isTrue(defaultTopK >= 0, "The topK should be positive value.");
 			this.defaultTopK = defaultTopK;
 			return this;
@@ -557,7 +557,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		 * @throws IllegalArgumentException if defaultSimilarityThreshold is not between
 		 * 0.0 and 1.0
 		 */
-		public AzureBuilder defaultSimilarityThreshold(Double defaultSimilarityThreshold) {
+		public Builder defaultSimilarityThreshold(Double defaultSimilarityThreshold) {
 			Assert.isTrue(defaultSimilarityThreshold >= 0.0 && defaultSimilarityThreshold <= 1.0,
 					"The similarity threshold must be in range [0.0:1.00].");
 			this.defaultSimilarityThreshold = defaultSimilarityThreshold;

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
@@ -159,14 +159,13 @@ import org.springframework.util.Assert;
  *
  * When adding documents with the method {@link #add(List<Document>)} it first calls
  * embeddingModel to create the embeddings. This is slow. Configure
- * {@link CassandraVectorStore.CassandraBuilder#fixedThreadPoolExecutorSize(int)}
- * accordingly to improve performance so embeddings are created and the documents are
- * added concurrently. The default concurrency is 16
- * ({@link CassandraVectorStore.CassandraBuilder#DEFAULT_ADD_CONCURRENCY}). Remote
- * transformers probably want higher concurrency, and local transformers may need lower
- * concurrency. This concurrency limit does not need to be higher than the max parallel
- * calls made to the {@link #add(List<Document>)} method multiplied by the list size. This
- * setting can also serve as a protecting throttle against your embedding model.
+ * {@link Builder#fixedThreadPoolExecutorSize(int)} accordingly to improve performance so
+ * embeddings are created and the documents are added concurrently. The default
+ * concurrency is 16 ({@link Builder#DEFAULT_ADD_CONCURRENCY}). Remote transformers
+ * probably want higher concurrency, and local transformers may need lower concurrency.
+ * This concurrency limit does not need to be higher than the max parallel calls made to
+ * the {@link #add(List<Document>)} method multiplied by the list size. This setting can
+ * also serve as a protecting throttle against your embedding model.
  *
  * @author Mick Semb Wever
  * @author Christian Tzolov
@@ -255,7 +254,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 			.batchingStrategy(batchingStrategy));
 	}
 
-	protected CassandraVectorStore(CassandraBuilder builder) {
+	protected CassandraVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.session, "Session must not be null");
@@ -288,8 +287,8 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		this.returnEmbeddings = builder.returnEmbeddings;
 	}
 
-	public static CassandraBuilder builder(EmbeddingModel embeddingModel) {
-		return new CassandraBuilder(embeddingModel);
+	public static Builder builder(EmbeddingModel embeddingModel) {
+		return new Builder(embeddingModel);
 	}
 
 	private static Float[] toFloatArray(float[] embedding) {
@@ -527,7 +526,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 	}
 
 	@VisibleForTesting
-	static void dropKeyspace(CassandraBuilder builder) {
+	static void dropKeyspace(Builder builder) {
 		Preconditions.checkState(builder.keyspace.startsWith("test_"), "Only test keyspaces can be dropped");
 		builder.session.execute(SchemaBuilder.dropKeyspace(builder.keyspace).ifExists().build());
 	}
@@ -782,7 +781,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 	 * https://github.com/apache/cassandra-java-driver/tree/4.x/manual/core/configuration
 	 *
 	 */
-	public static class CassandraBuilder extends AbstractVectorStoreBuilder<CassandraBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private CqlSession session;
 
@@ -826,7 +825,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 
 		private boolean returnEmbeddings = false;
 
-		private CassandraBuilder(EmbeddingModel embeddingModel) {
+		private Builder(EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(session, "Session must not be null");
 		}
@@ -837,7 +836,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if session is null
 		 */
-		public CassandraBuilder session(CqlSession session) {
+		public Builder session(CqlSession session) {
 			Assert.notNull(session, "Session must not be null");
 			this.session = session;
 			return this;
@@ -849,7 +848,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * utilize network. For local transformers you probably want a lower value to
 		 * avoid saturation.
 		 **/
-		public CassandraBuilder fixedThreadPoolExecutorSize(int threads) {
+		public Builder fixedThreadPoolExecutorSize(int threads) {
 			Preconditions.checkArgument(0 < threads);
 			this.fixedThreadPoolExecutorSize = threads;
 			return this;
@@ -861,7 +860,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if keyspace is null or empty
 		 */
-		public CassandraBuilder keyspace(String keyspace) {
+		public Builder keyspace(String keyspace) {
 			Assert.hasText(keyspace, "Keyspace must not be null or empty");
 			this.keyspace = keyspace;
 			return this;
@@ -873,7 +872,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalStateException if session is already set
 		 */
-		public CassandraBuilder contactPoint(InetSocketAddress contactPoint) {
+		public Builder contactPoint(InetSocketAddress contactPoint) {
 			Assert.state(session == null, "Cannot call addContactPoint(..) when session is already set");
 			if (sessionBuilder == null) {
 				sessionBuilder = new CqlSessionBuilder();
@@ -888,7 +887,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalStateException if session is already set
 		 */
-		public CassandraBuilder localDatacenter(String localDatacenter) {
+		public Builder localDatacenter(String localDatacenter) {
 			Assert.state(session == null, "Cannot call withLocalDatacenter(..) when session is already set");
 			if (sessionBuilder == null) {
 				sessionBuilder = new CqlSessionBuilder();
@@ -903,7 +902,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if table is null or empty
 		 */
-		public CassandraBuilder table(String table) {
+		public Builder table(String table) {
 			Assert.hasText(table, "Table must not be null or empty");
 			this.table = table;
 			return this;
@@ -915,7 +914,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if partitionKeys is null or empty
 		 */
-		public CassandraBuilder partitionKeys(List<SchemaColumn> partitionKeys) {
+		public Builder partitionKeys(List<SchemaColumn> partitionKeys) {
 			Assert.notEmpty(partitionKeys, "Partition keys must not be null or empty");
 			this.partitionKeys = partitionKeys;
 			return this;
@@ -926,7 +925,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @param clusteringKeys the clustering keys
 		 * @return the builder instance
 		 */
-		public CassandraBuilder clusteringKeys(List<SchemaColumn> clusteringKeys) {
+		public Builder clusteringKeys(List<SchemaColumn> clusteringKeys) {
 			this.clusteringKeys = clusteringKeys != null ? clusteringKeys : List.of();
 			return this;
 		}
@@ -936,7 +935,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @param indexName the index name
 		 * @return the builder instance
 		 */
-		public CassandraBuilder indexName(String indexName) {
+		public Builder indexName(String indexName) {
 			this.indexName = indexName;
 			return this;
 		}
@@ -946,7 +945,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @param disallowSchemaChanges true to disallow schema changes
 		 * @return the builder instance
 		 */
-		public CassandraBuilder disallowSchemaChanges(boolean disallowSchemaChanges) {
+		public Builder disallowSchemaChanges(boolean disallowSchemaChanges) {
 			this.disallowSchemaChanges = disallowSchemaChanges;
 			return this;
 		}
@@ -957,7 +956,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public CassandraBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;
@@ -969,7 +968,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if converter is null
 		 */
-		public CassandraBuilder filterExpressionConverter(FilterExpressionConverter converter) {
+		public Builder filterExpressionConverter(FilterExpressionConverter converter) {
 			Assert.notNull(converter, "FilterExpressionConverter must not be null");
 			this.filterExpressionConverter = converter;
 			return this;
@@ -981,37 +980,37 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if translator is null
 		 */
-		public CassandraBuilder documentIdTranslator(DocumentIdTranslator translator) {
+		public Builder documentIdTranslator(DocumentIdTranslator translator) {
 			Assert.notNull(translator, "DocumentIdTranslator must not be null");
 			this.documentIdTranslator = translator;
 			return this;
 		}
 
-		public CassandraBuilder contentColumnName(String contentColumnName) {
+		public Builder contentColumnName(String contentColumnName) {
 			this.contentColumnName = contentColumnName;
 			return this;
 		}
 
-		public CassandraBuilder embeddingColumnName(String embeddingColumnName) {
+		public Builder embeddingColumnName(String embeddingColumnName) {
 			this.embeddingColumnName = embeddingColumnName;
 			return this;
 		}
 
-		public CassandraBuilder addMetadataColumns(SchemaColumn... columns) {
-			CassandraBuilder builder = this;
+		public Builder addMetadataColumns(SchemaColumn... columns) {
+			Builder builder = this;
 			for (SchemaColumn f : columns) {
 				builder = builder.addMetadataColumn(f);
 			}
 			return builder;
 		}
 
-		public CassandraBuilder addMetadataColumns(List<SchemaColumn> columns) {
-			CassandraBuilder builder = this;
+		public Builder addMetadataColumns(List<SchemaColumn> columns) {
+			Builder builder = this;
 			this.metadataColumns.addAll(columns);
 			return builder;
 		}
 
-		public CassandraBuilder addMetadataColumn(SchemaColumn column) {
+		public Builder addMetadataColumn(SchemaColumn column) {
 
 			Preconditions.checkArgument(this.metadataColumns.stream().noneMatch(sc -> sc.name().equals(column.name())),
 					"A metadata column with name %s has already been added", column.name());
@@ -1026,13 +1025,13 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if translator is null
 		 */
-		public CassandraBuilder primaryKeyTranslator(PrimaryKeyTranslator translator) {
+		public Builder primaryKeyTranslator(PrimaryKeyTranslator translator) {
 			Assert.notNull(translator, "PrimaryKeyTranslator must not be null");
 			this.primaryKeyTranslator = translator;
 			return this;
 		}
 
-		public CassandraBuilder returnEmbeddings(boolean returnEmbeddings) {
+		public Builder returnEmbeddings(boolean returnEmbeddings) {
 			this.returnEmbeddings = true;
 			return this;
 		}

--- a/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraRichSchemaVectorStoreIT.java
+++ b/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraRichSchemaVectorStoreIT.java
@@ -93,7 +93,7 @@ class CassandraRichSchemaVectorStoreIT {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withUserConfiguration(TestApplication.class);
 
-	static CassandraVectorStore.CassandraBuilder storeBuilder(ApplicationContext context,
+	static CassandraVectorStore.Builder storeBuilder(ApplicationContext context,
 			List<CassandraVectorStore.SchemaColumn> columnOverrides) throws IOException {
 
 		Optional<CassandraVectorStore.SchemaColumn> wikiOverride = columnOverrides.stream()
@@ -572,7 +572,7 @@ class CassandraRichSchemaVectorStoreIT {
 	private CassandraVectorStore createStore(ApplicationContext context, List<SchemaColumn> columnOverrides,
 			boolean disallowSchemaCreation, boolean dropKeyspaceFirst) throws IOException {
 
-		CassandraVectorStore.CassandraBuilder builder = storeBuilder(context, columnOverrides);
+		CassandraVectorStore.Builder builder = storeBuilder(context, columnOverrides);
 		if (disallowSchemaCreation) {
 			builder = builder.disallowSchemaChanges(true);
 		}
@@ -584,11 +584,10 @@ class CassandraRichSchemaVectorStoreIT {
 		return new CassandraVectorStore(builder);
 	}
 
-	private CassandraVectorStore.CassandraBuilder createBuilder(ApplicationContext context,
-			List<SchemaColumn> columnOverrides, boolean disallowSchemaCreation, boolean dropKeyspaceFirst)
-			throws IOException {
+	private CassandraVectorStore.Builder createBuilder(ApplicationContext context, List<SchemaColumn> columnOverrides,
+			boolean disallowSchemaCreation, boolean dropKeyspaceFirst) throws IOException {
 
-		CassandraVectorStore.CassandraBuilder builder = storeBuilder(context, columnOverrides);
+		CassandraVectorStore.Builder builder = storeBuilder(context, columnOverrides);
 		if (disallowSchemaCreation) {
 			builder = builder.disallowSchemaChanges(true);
 		}

--- a/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStoreIT.java
+++ b/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStoreIT.java
@@ -85,15 +85,14 @@ class CassandraVectorStoreIT {
 		}
 	}
 
-	private static CassandraVectorStore.CassandraBuilder storeBuilder(CqlSession cqlSession,
-			EmbeddingModel embeddingModel) {
+	private static CassandraVectorStore.Builder storeBuilder(CqlSession cqlSession, EmbeddingModel embeddingModel) {
 		return CassandraVectorStore.builder(embeddingModel)
 			.session(cqlSession)
 			.keyspace("test_" + CassandraVectorStore.DEFAULT_KEYSPACE_NAME);
 	}
 
 	private static CassandraVectorStore createTestStore(ApplicationContext context, SchemaColumn... metadataFields) {
-		CassandraVectorStore.CassandraBuilder builder = storeBuilder(context.getBean(CqlSession.class),
+		CassandraVectorStore.Builder builder = storeBuilder(context.getBean(CqlSession.class),
 				context.getBean(EmbeddingModel.class))
 			.addMetadataColumns(metadataFields);
 
@@ -101,7 +100,7 @@ class CassandraVectorStoreIT {
 	}
 
 	private static CassandraVectorStore createTestStore(ApplicationContext context,
-			CassandraVectorStore.CassandraBuilder builder) {
+			CassandraVectorStore.Builder builder) {
 		CassandraVectorStore.dropKeyspace(builder);
 		CassandraVectorStore store = builder.build();
 		return store;
@@ -151,7 +150,7 @@ class CassandraVectorStoreIT {
 	@Test
 	void addAndSearchReturnEmbeddings() {
 		this.contextRunner.run(context -> {
-			CassandraVectorStore.CassandraBuilder builder = storeBuilder(context.getBean(CqlSession.class),
+			CassandraVectorStore.Builder builder = storeBuilder(context.getBean(CqlSession.class),
 					context.getBean(EmbeddingModel.class))
 				.returnEmbeddings(true);
 
@@ -425,7 +424,7 @@ class CassandraVectorStoreIT {
 		@Bean
 		public CassandraVectorStore store(CqlSession cqlSession, EmbeddingModel embeddingModel) {
 
-			CassandraVectorStore.CassandraBuilder builder = storeBuilder(cqlSession, embeddingModel).addMetadataColumns(
+			CassandraVectorStore.Builder builder = storeBuilder(cqlSession, embeddingModel).addMetadataColumns(
 					new CassandraVectorStore.SchemaColumn("meta1", DataTypes.TEXT),
 					new CassandraVectorStore.SchemaColumn("meta2", DataTypes.TEXT),
 					new CassandraVectorStore.SchemaColumn("country", DataTypes.TEXT),

--- a/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStoreObservationIT.java
+++ b/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStoreObservationIT.java
@@ -172,7 +172,7 @@ public class CassandraVectorStoreObservationIT {
 		public CassandraVectorStore store(CqlSession cqlSession, EmbeddingModel embeddingModel,
 				ObservationRegistry observationRegistry) {
 
-			CassandraVectorStore.CassandraBuilder builder = CassandraVectorStore.builder(embeddingModel)
+			CassandraVectorStore.Builder builder = CassandraVectorStore.builder(embeddingModel)
 				.session(cqlSession)
 				.session(cqlSession)
 				.keyspace("test_" + CassandraVectorStore.DEFAULT_KEYSPACE_NAME)

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
@@ -110,9 +110,9 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 	}
 
 	/**
-	 * @param builder {@link Builder} for chroma vector store
+	 * @param builder {@link VectorStore.Builder} for chroma vector store
 	 */
-	protected ChromaVectorStore(ChromaBuilder builder) {
+	protected ChromaVectorStore(Builder builder) {
 		super(builder);
 
 		this.chromaApi = builder.chromaApi;
@@ -132,8 +132,8 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		}
 	}
 
-	public static ChromaBuilder builder(ChromaApi chromaApi, EmbeddingModel embeddingModel) {
-		return new ChromaBuilder(chromaApi, embeddingModel);
+	public static Builder builder(ChromaApi chromaApi, EmbeddingModel embeddingModel) {
+		return new Builder(chromaApi, embeddingModel);
 	}
 
 	@Override
@@ -274,7 +274,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 			.collectionName(this.collectionName + ":" + this.collectionId);
 	}
 
-	public static class ChromaBuilder extends AbstractVectorStoreBuilder<ChromaBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final ChromaApi chromaApi;
 
@@ -288,7 +288,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 
 		private boolean initializeImmediately = false;
 
-		private ChromaBuilder(ChromaApi chromaApi, EmbeddingModel embeddingModel) {
+		private Builder(ChromaApi chromaApi, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(chromaApi, "ChromaApi must not be null");
 			this.chromaApi = chromaApi;
@@ -300,7 +300,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if collectionName is null or empty
 		 */
-		public ChromaBuilder collectionName(String collectionName) {
+		public Builder collectionName(String collectionName) {
 			Assert.hasText(collectionName, "collectionName must not be null or empty");
 			this.collectionName = collectionName;
 			return this;
@@ -311,7 +311,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public ChromaBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -322,7 +322,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public ChromaBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "batchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;
@@ -334,7 +334,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if converter is null
 		 */
-		public ChromaBuilder filterExpressionConverter(FilterExpressionConverter converter) {
+		public Builder filterExpressionConverter(FilterExpressionConverter converter) {
 			Assert.notNull(converter, "filterExpressionConverter must not be null");
 			this.filterExpressionConverter = converter;
 			return this;
@@ -345,7 +345,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		 * @param initialize true to initialize immediately, false otherwise
 		 * @return the builder instance
 		 */
-		public ChromaBuilder initializeImmediately(boolean initialize) {
+		public Builder initializeImmediately(boolean initialize) {
 			this.initializeImmediately = initialize;
 			return this;
 		}

--- a/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/coherence/CoherenceVectorStore.java
+++ b/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/coherence/CoherenceVectorStore.java
@@ -156,7 +156,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 	 * create new CoherenceVectorStore instances.
 	 * @param builder the configured builder instance
 	 */
-	protected CoherenceVectorStore(CoherenceBuilder builder) {
+	protected CoherenceVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.session, "Session must not be null");
@@ -173,8 +173,8 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 	 * Creates a new builder for configuring and creating CoherenceVectorStore instances.
 	 * @return a new builder instance
 	 */
-	public static CoherenceBuilder builder(Session session, EmbeddingModel embeddingModel) {
-		return new CoherenceBuilder(session, embeddingModel);
+	public static Builder builder(Session session, EmbeddingModel embeddingModel) {
+		return new Builder(session, embeddingModel);
 	}
 
 	/**
@@ -335,7 +335,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 	 *
 	 * @since 1.0.0
 	 */
-	public static class CoherenceBuilder extends AbstractVectorStoreBuilder<CoherenceBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final Session session;
 
@@ -347,7 +347,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 
 		private IndexType indexType = IndexType.NONE;
 
-		private CoherenceBuilder(Session session, EmbeddingModel embeddingModel) {
+		private Builder(Session session, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(session, "Session must not be null");
 			this.session = session;
@@ -358,7 +358,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 		 * @param mapName the name of the map to use
 		 * @return the builder instance
 		 */
-		public CoherenceBuilder mapName(String mapName) {
+		public Builder mapName(String mapName) {
 			if (StringUtils.hasText(mapName)) {
 				this.mapName = mapName;
 			}
@@ -371,7 +371,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if distanceType is null
 		 */
-		public CoherenceBuilder distanceType(DistanceType distanceType) {
+		public Builder distanceType(DistanceType distanceType) {
 			Assert.notNull(distanceType, "DistanceType must not be null");
 			this.distanceType = distanceType;
 			return this;
@@ -382,7 +382,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 		 * @param forcedNormalization true to force normalization, false otherwise
 		 * @return the builder instance
 		 */
-		public CoherenceBuilder forcedNormalization(boolean forcedNormalization) {
+		public Builder forcedNormalization(boolean forcedNormalization) {
 			this.forcedNormalization = forcedNormalization;
 			return this;
 		}
@@ -393,7 +393,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if indexType is null
 		 */
-		public CoherenceBuilder indexType(IndexType indexType) {
+		public Builder indexType(IndexType indexType) {
 			Assert.notNull(indexType, "IndexType must not be null");
 			this.indexType = indexType;
 			return this;

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
@@ -194,7 +194,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 			.batchingStrategy(batchingStrategy));
 	}
 
-	protected ElasticsearchVectorStore(ElasticsearchBuilder builder) {
+	protected ElasticsearchVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.restClient, "RestClient must not be null");
@@ -387,11 +387,11 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 	 * Creates a new builder instance for ElasticsearchVectorStore.
 	 * @return a new ElasticsearchBuilder instance
 	 */
-	public static ElasticsearchBuilder builder(RestClient restClient, EmbeddingModel embeddingModel) {
-		return new ElasticsearchBuilder(restClient, embeddingModel);
+	public static Builder builder(RestClient restClient, EmbeddingModel embeddingModel) {
+		return new Builder(restClient, embeddingModel);
 	}
 
-	public static class ElasticsearchBuilder extends AbstractVectorStoreBuilder<ElasticsearchBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final RestClient restClient;
 
@@ -409,7 +409,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if restClient is null
 		 */
-		public ElasticsearchBuilder(RestClient restClient, EmbeddingModel embeddingModel) {
+		public Builder(RestClient restClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(restClient, "RestClient must not be null");
 			this.restClient = restClient;
@@ -421,7 +421,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if options is null
 		 */
-		public ElasticsearchBuilder options(ElasticsearchVectorStoreOptions options) {
+		public Builder options(ElasticsearchVectorStoreOptions options) {
 			Assert.notNull(options, "options must not be null");
 			this.options = options;
 			return this;
@@ -432,7 +432,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public ElasticsearchBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -443,7 +443,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public ElasticsearchBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "batchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;
@@ -455,7 +455,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if converter is null
 		 */
-		public ElasticsearchBuilder filterExpressionConverter(FilterExpressionConverter converter) {
+		public Builder filterExpressionConverter(FilterExpressionConverter converter) {
 			Assert.notNull(converter, "filterExpressionConverter must not be null");
 			this.filterExpressionConverter = converter;
 			return this;

--- a/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
@@ -169,7 +169,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 	 * create new GemFireVectorStore instances.
 	 * @param builder the configured builder instance
 	 */
-	protected GemFireVectorStore(GemFireBuilder builder) {
+	protected GemFireVectorStore(Builder builder) {
 		super(builder);
 
 		this.initializeSchema = builder.initializeSchema;
@@ -188,8 +188,8 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		this.objectMapper = JsonMapper.builder().addModules(JacksonUtils.instantiateAvailableModules()).build();
 	}
 
-	public static GemFireBuilder builder(EmbeddingModel embeddingModel) {
-		return new GemFireBuilder(embeddingModel);
+	public static Builder builder(EmbeddingModel embeddingModel) {
+		return new Builder(embeddingModel);
 	}
 
 	public String getIndexName() {
@@ -825,7 +825,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 	 *
 	 * @since 1.0.0
 	 */
-	public static class GemFireBuilder extends AbstractVectorStoreBuilder<GemFireBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private String host = GemFireVectorStore.DEFAULT_HOST;
 
@@ -849,7 +849,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 
 		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
 
-		private GemFireBuilder(EmbeddingModel embeddingModel) {
+		private Builder(EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 		}
 
@@ -859,7 +859,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if host is null or empty
 		 */
-		public GemFireBuilder host(String host) {
+		public Builder host(String host) {
 			Assert.hasText(host, "host must have a value");
 			this.host = host;
 			return this;
@@ -871,7 +871,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if port is not positive
 		 */
-		public GemFireBuilder port(int port) {
+		public Builder port(int port) {
 			Assert.isTrue(port > 0, "port must be positive");
 			this.port = port;
 			return this;
@@ -882,7 +882,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @param sslEnabled true to enable SSL, false otherwise
 		 * @return the builder instance
 		 */
-		public GemFireBuilder sslEnabled(boolean sslEnabled) {
+		public Builder sslEnabled(boolean sslEnabled) {
 			this.sslEnabled = sslEnabled;
 			return this;
 		}
@@ -893,7 +893,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if indexName is null or empty
 		 */
-		public GemFireBuilder indexName(String indexName) {
+		public Builder indexName(String indexName) {
 			Assert.hasText(indexName, "indexName must have a value");
 			this.indexName = indexName;
 			return this;
@@ -905,7 +905,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if beamWidth is not within valid range
 		 */
-		public GemFireBuilder beamWidth(int beamWidth) {
+		public Builder beamWidth(int beamWidth) {
 			Assert.isTrue(beamWidth > 0, "beamWidth must be positive");
 			Assert.isTrue(beamWidth <= GemFireVectorStore.UPPER_BOUND_BEAM_WIDTH,
 					"beamWidth must be less than or equal to " + GemFireVectorStore.UPPER_BOUND_BEAM_WIDTH);
@@ -919,7 +919,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if maxConnections is not within valid range
 		 */
-		public GemFireBuilder maxConnections(int maxConnections) {
+		public Builder maxConnections(int maxConnections) {
 			Assert.isTrue(maxConnections > 0, "maxConnections must be positive");
 			Assert.isTrue(maxConnections <= GemFireVectorStore.UPPER_BOUND_MAX_CONNECTIONS,
 					"maxConnections must be less than or equal to " + GemFireVectorStore.UPPER_BOUND_MAX_CONNECTIONS);
@@ -933,7 +933,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if buckets is negative
 		 */
-		public GemFireBuilder buckets(int buckets) {
+		public Builder buckets(int buckets) {
 			Assert.isTrue(buckets >= 0, "buckets must not be negative");
 			this.buckets = buckets;
 			return this;
@@ -945,7 +945,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if vectorSimilarityFunction is null or empty
 		 */
-		public GemFireBuilder vectorSimilarityFunction(String vectorSimilarityFunction) {
+		public Builder vectorSimilarityFunction(String vectorSimilarityFunction) {
 			Assert.hasText(vectorSimilarityFunction, "vectorSimilarityFunction must have a value");
 			this.vectorSimilarityFunction = vectorSimilarityFunction;
 			return this;
@@ -956,7 +956,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @param fields the fields to use
 		 * @return the builder instance
 		 */
-		public GemFireBuilder fields(String[] fields) {
+		public Builder fields(String[] fields) {
 			this.fields = fields;
 			return this;
 		}
@@ -966,7 +966,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public GemFireBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -977,7 +977,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public GemFireBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-hanadb-store/src/main/java/org/springframework/ai/vectorstore/hanadb/HanaCloudVectorStore.java
+++ b/vector-stores/spring-ai-hanadb-store/src/main/java/org/springframework/ai/vectorstore/hanadb/HanaCloudVectorStore.java
@@ -129,7 +129,7 @@ public class HanaCloudVectorStore extends AbstractObservationVectorStore {
 	 * create new HanaCloudVectorStore instances.
 	 * @param builder the configured builder instance
 	 */
-	protected HanaCloudVectorStore(HanaCloudBuilder builder) {
+	protected HanaCloudVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.repository, "Repository must not be null");
@@ -144,9 +144,9 @@ public class HanaCloudVectorStore extends AbstractObservationVectorStore {
 	 * Creates a new builder for configuring and creating HanaCloudVectorStore instances.
 	 * @return a new builder instance
 	 */
-	public static HanaCloudBuilder builder(HanaVectorRepository<? extends HanaVectorEntity> repository,
+	public static Builder builder(HanaVectorRepository<? extends HanaVectorEntity> repository,
 			EmbeddingModel embeddingModel) {
-		return new HanaCloudBuilder(repository, embeddingModel);
+		return new Builder(repository, embeddingModel);
 	}
 
 	@Override
@@ -233,7 +233,7 @@ public class HanaCloudVectorStore extends AbstractObservationVectorStore {
 	 *
 	 * @since 1.0.0
 	 */
-	public static class HanaCloudBuilder extends AbstractVectorStoreBuilder<HanaCloudBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final HanaVectorRepository<? extends HanaVectorEntity> repository;
 
@@ -248,8 +248,7 @@ public class HanaCloudVectorStore extends AbstractObservationVectorStore {
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if repository is null
 		 */
-		private HanaCloudBuilder(HanaVectorRepository<? extends HanaVectorEntity> repository,
-				EmbeddingModel embeddingModel) {
+		private Builder(HanaVectorRepository<? extends HanaVectorEntity> repository, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(repository, "Repository must not be null");
 			this.repository = repository;
@@ -260,7 +259,7 @@ public class HanaCloudVectorStore extends AbstractObservationVectorStore {
 		 * @param tableName the name of the table to use
 		 * @return the builder instance
 		 */
-		public HanaCloudBuilder tableName(String tableName) {
+		public Builder tableName(String tableName) {
 			this.tableName = tableName;
 			return this;
 		}
@@ -270,7 +269,7 @@ public class HanaCloudVectorStore extends AbstractObservationVectorStore {
 		 * @param topK the number of results
 		 * @return the builder instance
 		 */
-		public HanaCloudBuilder topK(int topK) {
+		public Builder topK(int topK) {
 			this.topK = topK;
 			return this;
 		}

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/milvus/vectorstore/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/milvus/vectorstore/MilvusVectorStore.java
@@ -64,6 +64,7 @@ import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
 import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
 import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
 import org.springframework.ai.vectorstore.observation.AbstractObservationVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
@@ -237,9 +238,9 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 	}
 
 	/**
-	 * @param builder {@link Builder} for chroma vector store
+	 * @param builder {@link VectorStore.Builder} for chroma vector store
 	 */
-	protected MilvusVectorStore(MilvusBuilder builder) {
+	protected MilvusVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.milvusClient, "milvusClient must not be null");
@@ -266,8 +267,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 	 * recommended way to instantiate a MilvusBuilder.
 	 * @return a new MilvusBuilder instance
 	 */
-	public static MilvusBuilder builder(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
-		return new MilvusBuilder(milvusClient, embeddingModel);
+	public static Builder builder(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
+		return new Builder(milvusClient, embeddingModel);
 	}
 
 	@Override
@@ -575,7 +576,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		return SIMILARITY_TYPE_MAPPING.get(this.metricType).value();
 	}
 
-	public static final class MilvusBuilder extends AbstractVectorStoreBuilder<MilvusBuilder> {
+	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final MilvusServiceClient milvusClient;
 
@@ -609,7 +610,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * @param milvusClient the Milvus service client to use for database operations
 		 * @throws IllegalArgumentException if milvusClient is null
 		 */
-		private MilvusBuilder(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
+		private Builder(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(milvusClient, "milvusClient must not be null");
 			this.milvusClient = milvusClient;
@@ -623,7 +624,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * @throws IllegalArgumentException if metricType is null or not one of IP, L2, or
 		 * COSINE
 		 */
-		public MilvusBuilder metricType(MetricType metricType) {
+		public Builder metricType(MetricType metricType) {
 			Assert.notNull(metricType, "Collection Name must not be empty");
 			Assert.isTrue(metricType == MetricType.IP || metricType == MetricType.L2 || metricType == MetricType.COSINE,
 					"Only the text metric types IP and L2 are supported");
@@ -636,7 +637,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * @param indexType the index type to use (defaults to IVF_FLAT if not specified)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder indexType(IndexType indexType) {
+		public Builder indexType(IndexType indexType) {
 			this.indexType = indexType;
 			return this;
 		}
@@ -647,7 +648,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * if not specified)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder indexParameters(String indexParameters) {
+		public Builder indexParameters(String indexParameters) {
 			this.indexParameters = indexParameters;
 			return this;
 		}
@@ -658,7 +659,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * if not specified)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder databaseName(String databaseName) {
+		public Builder databaseName(String databaseName) {
 			this.databaseName = databaseName;
 			return this;
 		}
@@ -669,7 +670,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * DEFAULT_COLLECTION_NAME if not specified)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder collectionName(String collectionName) {
+		public Builder collectionName(String collectionName) {
 			this.collectionName = collectionName;
 			return this;
 		}
@@ -681,7 +682,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if dimension is not between 1 and 32768
 		 */
-		public MilvusBuilder embeddingDimension(int newEmbeddingDimension) {
+		public Builder embeddingDimension(int newEmbeddingDimension) {
 			Assert.isTrue(newEmbeddingDimension >= 1 && newEmbeddingDimension <= 32768,
 					"Dimension has to be withing the boundaries 1 and 32768 (inclusively)");
 			this.embeddingDimension = newEmbeddingDimension;
@@ -693,7 +694,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * @param idFieldName The name for the ID field (defaults to DOC_ID_FIELD_NAME)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder iDFieldName(String idFieldName) {
+		public Builder iDFieldName(String idFieldName) {
 			this.idFieldName = idFieldName;
 			return this;
 		}
@@ -703,7 +704,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * @param isAutoId true to enable auto-generated IDs, false to use provided IDs
 		 * @return this builder instance
 		 */
-		public MilvusBuilder autoId(boolean isAutoId) {
+		public Builder autoId(boolean isAutoId) {
 			this.isAutoId = isAutoId;
 			return this;
 		}
@@ -714,7 +715,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * CONTENT_FIELD_NAME)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder contentFieldName(String contentFieldName) {
+		public Builder contentFieldName(String contentFieldName) {
 			this.contentFieldName = contentFieldName;
 			return this;
 		}
@@ -725,7 +726,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * METADATA_FIELD_NAME)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder metadataFieldName(String metadataFieldName) {
+		public Builder metadataFieldName(String metadataFieldName) {
 			this.metadataFieldName = metadataFieldName;
 			return this;
 		}
@@ -736,7 +737,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * EMBEDDING_FIELD_NAME)
 		 * @return this builder instance
 		 */
-		public MilvusBuilder embeddingFieldName(String embeddingFieldName) {
+		public Builder embeddingFieldName(String embeddingFieldName) {
 			this.embeddingFieldName = embeddingFieldName;
 			return this;
 		}
@@ -747,7 +748,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * existing schema
 		 * @return this builder instance
 		 */
-		public MilvusBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -758,7 +759,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public MilvusBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "batchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
@@ -198,7 +198,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 			.batchingStrategy(batchingStrategy));
 	}
 
-	protected MongoDBAtlasVectorStore(MongoDBBuilder builder) {
+	protected MongoDBAtlasVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.mongoTemplate, "MongoTemplate must not be null");
@@ -352,11 +352,11 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 	 * Creates a new builder instance for MongoDBAtlasVectorStore.
 	 * @return a new MongoDBBuilder instance
 	 */
-	public static MongoDBBuilder builder(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel) {
-		return new MongoDBBuilder(mongoTemplate, embeddingModel);
+	public static Builder builder(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel) {
+		return new Builder(mongoTemplate, embeddingModel);
 	}
 
-	public static class MongoDBBuilder extends AbstractVectorStoreBuilder<MongoDBBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final MongoTemplate mongoTemplate;
 
@@ -379,7 +379,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		/**
 		 * @throws IllegalArgumentException if mongoTemplate is null
 		 */
-		private MongoDBBuilder(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel) {
+		private Builder(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(mongoTemplate, "MongoTemplate must not be null");
 			this.mongoTemplate = mongoTemplate;
@@ -392,7 +392,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if collectionName is null or empty
 		 */
-		public MongoDBBuilder collectionName(String collectionName) {
+		public Builder collectionName(String collectionName) {
 			Assert.hasText(collectionName, "Collection Name must not be null or empty");
 			this.collectionName = collectionName;
 			return this;
@@ -405,7 +405,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if vectorIndexName is null or empty
 		 */
-		public MongoDBBuilder vectorIndexName(String vectorIndexName) {
+		public Builder vectorIndexName(String vectorIndexName) {
 			Assert.hasText(vectorIndexName, "Vector Index Name must not be null or empty");
 			this.vectorIndexName = vectorIndexName;
 			return this;
@@ -418,7 +418,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if pathName is null or empty
 		 */
-		public MongoDBBuilder pathName(String pathName) {
+		public Builder pathName(String pathName) {
 			Assert.hasText(pathName, "Path Name must not be null or empty");
 			this.pathName = pathName;
 			return this;
@@ -429,7 +429,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @param numCandidates the number of candidates
 		 * @return the builder instance
 		 */
-		public MongoDBBuilder numCandidates(int numCandidates) {
+		public Builder numCandidates(int numCandidates) {
 			this.numCandidates = numCandidates;
 			return this;
 		}
@@ -440,7 +440,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if metadataFieldsToFilter is null or empty
 		 */
-		public MongoDBBuilder metadataFieldsToFilter(List<String> metadataFieldsToFilter) {
+		public Builder metadataFieldsToFilter(List<String> metadataFieldsToFilter) {
 			Assert.notEmpty(metadataFieldsToFilter, "Fields list must not be empty");
 			this.metadataFieldsToFilter = metadataFieldsToFilter;
 			return this;
@@ -451,7 +451,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public MongoDBBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -462,7 +462,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public MongoDBBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "batchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;
@@ -474,7 +474,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if converter is null
 		 */
-		public MongoDBBuilder filterExpressionConverter(MongoDBAtlasFilterExpressionConverter converter) {
+		public Builder filterExpressionConverter(MongoDBAtlasFilterExpressionConverter converter) {
 			Assert.notNull(converter, "filterExpressionConverter must not be null");
 			this.filterExpressionConverter = converter;
 			return this;

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
@@ -210,7 +210,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 			.batchingStrategy(batchingStrategy));
 	}
 
-	protected Neo4jVectorStore(Neo4jBuilder builder) {
+	protected Neo4jVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.driver, "Neo4j driver must not be null");
@@ -398,11 +398,11 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 
 	}
 
-	public static Neo4jBuilder builder(Driver driver, EmbeddingModel embeddingModel) {
-		return new Neo4jBuilder(driver, embeddingModel);
+	public static Builder builder(Driver driver, EmbeddingModel embeddingModel) {
+		return new Builder(driver, embeddingModel);
 	}
 
-	public static class Neo4jBuilder extends AbstractVectorStoreBuilder<Neo4jBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final Driver driver;
 
@@ -426,7 +426,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 
 		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
 
-		private Neo4jBuilder(Driver driver, EmbeddingModel embeddingModel) {
+		private Builder(Driver driver, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(driver, "Neo4j driver must not be null");
 			this.driver = driver;
@@ -438,7 +438,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param databaseName the database name to use
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder databaseName(String databaseName) {
+		public Builder databaseName(String databaseName) {
 			if (StringUtils.hasText(databaseName)) {
 				this.sessionConfig = SessionConfig.forDatabase(databaseName);
 			}
@@ -450,7 +450,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param sessionConfig the session configuration to use
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder sessionConfig(SessionConfig sessionConfig) {
+		public Builder sessionConfig(SessionConfig sessionConfig) {
 			this.sessionConfig = sessionConfig;
 			return this;
 		}
@@ -461,7 +461,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if dimension is less than 1
 		 */
-		public Neo4jBuilder embeddingDimension(int dimension) {
+		public Builder embeddingDimension(int dimension) {
 			Assert.isTrue(dimension >= 1, "Dimension has to be positive");
 			this.embeddingDimension = dimension;
 			return this;
@@ -473,7 +473,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if distanceType is null
 		 */
-		public Neo4jBuilder distanceType(Neo4jDistanceType distanceType) {
+		public Builder distanceType(Neo4jDistanceType distanceType) {
 			Assert.notNull(distanceType, "Distance type may not be null");
 			this.distanceType = distanceType;
 			return this;
@@ -484,7 +484,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param label the label to use
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder label(String label) {
+		public Builder label(String label) {
 			if (StringUtils.hasText(label)) {
 				this.label = label;
 			}
@@ -496,7 +496,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param embeddingProperty the property name to use
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder embeddingProperty(String embeddingProperty) {
+		public Builder embeddingProperty(String embeddingProperty) {
 			if (StringUtils.hasText(embeddingProperty)) {
 				this.embeddingProperty = embeddingProperty;
 			}
@@ -508,7 +508,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param indexName the index name to use
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder indexName(String indexName) {
+		public Builder indexName(String indexName) {
 			if (StringUtils.hasText(indexName)) {
 				this.indexName = indexName;
 			}
@@ -520,7 +520,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param idProperty the property name to use
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder idProperty(String idProperty) {
+		public Builder idProperty(String idProperty) {
 			if (StringUtils.hasText(idProperty)) {
 				this.idProperty = idProperty;
 			}
@@ -532,7 +532,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param constraintName the constraint name to use
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder constraintName(String constraintName) {
+		public Builder constraintName(String constraintName) {
 			if (StringUtils.hasText(constraintName)) {
 				this.constraintName = constraintName;
 			}
@@ -544,7 +544,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public Neo4jBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -555,7 +555,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public Neo4jBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -250,7 +250,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 	 * Creates a new OpenSearchVectorStore using the builder pattern.
 	 * @param builder The configured builder instance
 	 */
-	protected OpenSearchVectorStore(OpenSearchBuilder builder) {
+	protected OpenSearchVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.openSearchClient, "OpenSearchClient must not be null");
@@ -270,8 +270,8 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 	 * Creates a new builder instance for configuring an OpenSearchVectorStore.
 	 * @return A new OpenSearchBuilder instance
 	 */
-	public static OpenSearchBuilder builder(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
-		return new OpenSearchBuilder(openSearchClient, embeddingModel);
+	public static Builder builder(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
+		return new Builder(openSearchClient, embeddingModel);
 	}
 
 	public OpenSearchVectorStore withSimilarityFunction(String similarityFunction) {
@@ -446,7 +446,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 	/**
 	 * Builder class for creating OpenSearchVectorStore instances.
 	 */
-	public static class OpenSearchBuilder extends AbstractVectorStoreBuilder<OpenSearchBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final OpenSearchClient openSearchClient;
 
@@ -468,7 +468,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 * @return The builder instance
 		 * @throws IllegalArgumentException if openSearchClient is null
 		 */
-		private OpenSearchBuilder(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
+		private Builder(OpenSearchClient openSearchClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(openSearchClient, "OpenSearchClient must not be null");
 			this.openSearchClient = openSearchClient;
@@ -480,7 +480,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 * @return The builder instance
 		 * @throws IllegalArgumentException if index is null or empty
 		 */
-		public OpenSearchBuilder index(String index) {
+		public Builder index(String index) {
 			Assert.hasText(index, "index must not be null or empty");
 			this.index = index;
 			return this;
@@ -492,7 +492,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 * @return The builder instance
 		 * @throws IllegalArgumentException if mappingJson is null or empty
 		 */
-		public OpenSearchBuilder mappingJson(String mappingJson) {
+		public Builder mappingJson(String mappingJson) {
 			Assert.hasText(mappingJson, "mappingJson must not be null or empty");
 			this.mappingJson = mappingJson;
 			return this;
@@ -503,7 +503,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return The builder instance
 		 */
-		public OpenSearchBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -514,7 +514,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 * @return The builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public OpenSearchBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "batchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;
@@ -526,7 +526,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 * @return The builder instance
 		 * @throws IllegalArgumentException if converter is null
 		 */
-		public OpenSearchBuilder filterExpressionConverter(FilterExpressionConverter converter) {
+		public Builder filterExpressionConverter(FilterExpressionConverter converter) {
 			Assert.notNull(converter, "filterExpressionConverter must not be null");
 			this.filterExpressionConverter = converter;
 			return this;
@@ -540,7 +540,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		 * @return The builder instance
 		 * @throws IllegalArgumentException if similarityFunction is null or empty
 		 */
-		public OpenSearchBuilder similarityFunction(String similarityFunction) {
+		public Builder similarityFunction(String similarityFunction) {
 			Assert.hasText(similarityFunction, "similarityFunction must not be null or empty");
 			this.similarityFunction = similarityFunction;
 			return this;

--- a/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
+++ b/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
@@ -242,7 +242,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 	 * create new OracleVectorStore instances.
 	 * @param builder the configured builder instance
 	 */
-	protected OracleVectorStore(OracleBuilder builder) {
+	protected OracleVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.jdbcTemplate, "JdbcTemplate must not be null");
@@ -259,8 +259,8 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		this.batchingStrategy = builder.batchingStrategy;
 	}
 
-	public static OracleBuilder builder(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
-		return new OracleBuilder(jdbcTemplate, embeddingModel);
+	public static Builder builder(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
+		return new Builder(jdbcTemplate, embeddingModel);
 	}
 
 	@Override
@@ -747,7 +747,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 	 *
 	 * @since 1.0.0
 	 */
-	public static class OracleBuilder extends AbstractVectorStoreBuilder<OracleBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final JdbcTemplate jdbcTemplate;
 
@@ -775,7 +775,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if jdbcTemplate is null
 		 */
-		public OracleBuilder(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
+		public Builder(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(jdbcTemplate, "JdbcTemplate must not be null");
 			this.jdbcTemplate = jdbcTemplate;
@@ -786,7 +786,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @param tableName the name of the table to use
 		 * @return the builder instance
 		 */
-		public OracleBuilder tableName(String tableName) {
+		public Builder tableName(String tableName) {
 			if (StringUtils.hasText(tableName)) {
 				this.tableName = tableName;
 			}
@@ -799,7 +799,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if indexType is null
 		 */
-		public OracleBuilder indexType(OracleVectorStoreIndexType indexType) {
+		public Builder indexType(OracleVectorStoreIndexType indexType) {
 			Assert.notNull(indexType, "Index type must not be null");
 			this.indexType = indexType;
 			return this;
@@ -811,7 +811,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if distanceType is null
 		 */
-		public OracleBuilder distanceType(OracleVectorStoreDistanceType distanceType) {
+		public Builder distanceType(OracleVectorStoreDistanceType distanceType) {
 			Assert.notNull(distanceType, "Distance type must not be null");
 			this.distanceType = distanceType;
 			return this;
@@ -823,7 +823,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if dimensions is not within valid range
 		 */
-		public OracleBuilder dimensions(int dimensions) {
+		public Builder dimensions(int dimensions) {
 			if (dimensions != DEFAULT_DIMENSIONS) {
 				Assert.isTrue(dimensions > 0 && dimensions <= 65535,
 						"Number of dimensions must be between 1 and 65535");
@@ -838,7 +838,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if searchAccuracy is not within valid range
 		 */
-		public OracleBuilder searchAccuracy(int searchAccuracy) {
+		public Builder searchAccuracy(int searchAccuracy) {
 			if (searchAccuracy != DEFAULT_SEARCH_ACCURACY) {
 				Assert.isTrue(searchAccuracy >= 1 && searchAccuracy <= 100,
 						"Search accuracy must be between 1 and 100");
@@ -852,7 +852,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public OracleBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -863,7 +863,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * otherwise
 		 * @return the builder instance
 		 */
-		public OracleBuilder removeExistingVectorStoreTable(boolean removeExistingVectorStoreTable) {
+		public Builder removeExistingVectorStoreTable(boolean removeExistingVectorStoreTable) {
 			this.removeExistingVectorStoreTable = removeExistingVectorStoreTable;
 			return this;
 		}
@@ -873,7 +873,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @param forcedNormalization true to force normalization, false otherwise
 		 * @return the builder instance
 		 */
-		public OracleBuilder forcedNormalization(boolean forcedNormalization) {
+		public Builder forcedNormalization(boolean forcedNormalization) {
 			this.forcedNormalization = forcedNormalization;
 			return this;
 		}
@@ -884,7 +884,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public OracleBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
@@ -127,7 +127,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 	 * Creates a new PineconeVectorStore using the builder pattern.
 	 * @param builder The configured builder instance
 	 */
-	protected PineconeVectorStore(PineconeBuilder builder) {
+	protected PineconeVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.hasText(builder.apiKey, "ApiKey must not be null or empty");
@@ -156,9 +156,9 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 	 * Creates a new builder instance for configuring a PineconeVectorStore.
 	 * @return A new PineconeBuilder instance
 	 */
-	public static PineconeBuilder builder(EmbeddingModel embeddingModel, String apiKey, String projectId,
-			String environment, String indexName) {
-		return new PineconeBuilder(embeddingModel, apiKey, projectId, environment, indexName);
+	public static Builder builder(EmbeddingModel embeddingModel, String apiKey, String projectId, String environment,
+			String indexName) {
+		return new Builder(embeddingModel, apiKey, projectId, environment, indexName);
 	}
 
 	/**
@@ -338,7 +338,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 	/**
 	 * Builder class for creating PineconeVectorStore instances.
 	 */
-	public static class PineconeBuilder extends AbstractVectorStoreBuilder<PineconeBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final String apiKey;
 
@@ -358,7 +358,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 
 		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
 
-		private PineconeBuilder(EmbeddingModel embeddingModel, String apiKey, String projectId, String environment,
+		private Builder(EmbeddingModel embeddingModel, String apiKey, String projectId, String environment,
 				String indexName) {
 			super(embeddingModel);
 
@@ -379,7 +379,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		 * @param namespace The namespace to use (leave empty for free tier)
 		 * @return The builder instance
 		 */
-		public PineconeBuilder namespace(@Nullable String namespace) {
+		public Builder namespace(@Nullable String namespace) {
 			this.namespace = namespace != null ? namespace : "";
 			return this;
 		}
@@ -389,7 +389,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		 * @param contentFieldName The content field name to use
 		 * @return The builder instance
 		 */
-		public PineconeBuilder contentFieldName(@Nullable String contentFieldName) {
+		public Builder contentFieldName(@Nullable String contentFieldName) {
 			this.contentFieldName = contentFieldName != null ? contentFieldName : CONTENT_FIELD_NAME;
 			return this;
 		}
@@ -399,7 +399,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		 * @param distanceMetadataFieldName The distance metadata field name to use
 		 * @return The builder instance
 		 */
-		public PineconeBuilder distanceMetadataFieldName(@Nullable String distanceMetadataFieldName) {
+		public Builder distanceMetadataFieldName(@Nullable String distanceMetadataFieldName) {
 			this.distanceMetadataFieldName = distanceMetadataFieldName != null ? distanceMetadataFieldName
 					: DocumentMetadata.DISTANCE.value();
 			return this;
@@ -410,7 +410,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		 * @param serverSideTimeout The timeout duration to use
 		 * @return The builder instance
 		 */
-		public PineconeBuilder serverSideTimeout(@Nullable Duration serverSideTimeout) {
+		public Builder serverSideTimeout(@Nullable Duration serverSideTimeout) {
 			this.serverSideTimeout = serverSideTimeout != null ? serverSideTimeout : Duration.ofSeconds(20);
 			return this;
 		}
@@ -421,7 +421,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		 * @return The builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public PineconeBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -183,12 +183,12 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 	/**
 	 * Protected constructor for creating a QdrantVectorStore instance using the builder
 	 * pattern.
-	 * @param builder the {@link QdrantBuilder} containing all configuration settings
+	 * @param builder the {@link Builder} containing all configuration settings
 	 * @throws IllegalArgumentException if qdrant client is missing
-	 * @see QdrantBuilder
+	 * @see Builder
 	 * @since 1.0.0
 	 */
-	protected QdrantVectorStore(QdrantBuilder builder) {
+	protected QdrantVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.qdrantClient, "QdrantClient must not be null");
@@ -205,8 +205,8 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 	 * @param qdrantClient the client for interfacing with Qdrant
 	 * @return a new QdrantBuilder instance
 	 */
-	public static QdrantBuilder builder(QdrantClient qdrantClient, EmbeddingModel embeddingModel) {
-		return new QdrantBuilder(qdrantClient, embeddingModel);
+	public static Builder builder(QdrantClient qdrantClient, EmbeddingModel embeddingModel) {
+		return new Builder(qdrantClient, embeddingModel);
 	}
 
 	/**
@@ -369,7 +369,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 	 *
 	 * @since 1.0.0
 	 */
-	public static final class QdrantBuilder extends AbstractVectorStoreBuilder<QdrantBuilder> {
+	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final QdrantClient qdrantClient;
 
@@ -385,7 +385,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		 * @param qdrantClient the client for Qdrant operations
 		 * @throws IllegalArgumentException if qdrantClient is null
 		 */
-		private QdrantBuilder(QdrantClient qdrantClient, EmbeddingModel embeddingModel) {
+		private Builder(QdrantClient qdrantClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(qdrantClient, "QdrantClient must not be null");
 			this.qdrantClient = qdrantClient;
@@ -398,7 +398,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if collectionName is null or empty
 		 */
-		public QdrantBuilder collectionName(String collectionName) {
+		public Builder collectionName(String collectionName) {
 			Assert.hasText(collectionName, "collectionName must not be empty");
 			this.collectionName = collectionName;
 			return this;
@@ -409,7 +409,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		 * @param initializeSchema true to initialize schema automatically
 		 * @return this builder instance
 		 */
-		public QdrantBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -420,7 +420,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public QdrantBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreBuilderTests.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreBuilderTests.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for {@link QdrantVectorStore.QdrantBuilder}.
+ * Tests for {@link QdrantVectorStore.Builder}.
  *
  * @author Mark Pollack
  */

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
@@ -261,7 +261,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 			.batchingStrategy(batchingStrategy));
 	}
 
-	protected RedisVectorStore(RedisBuilder builder) {
+	protected RedisVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.jedis, "JedisPooled must not be null");
@@ -482,11 +482,11 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 	}
 
-	public static RedisBuilder builder(JedisPooled jedis, EmbeddingModel embeddingModel) {
-		return new RedisBuilder(jedis, embeddingModel);
+	public static Builder builder(JedisPooled jedis, EmbeddingModel embeddingModel) {
+		return new Builder(jedis, embeddingModel);
 	}
 
-	public static class RedisBuilder extends AbstractVectorStoreBuilder<RedisBuilder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final JedisPooled jedis;
 
@@ -506,7 +506,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 
 		private BatchingStrategy batchingStrategy = new TokenCountBatchingStrategy();
 
-		private RedisBuilder(JedisPooled jedis, EmbeddingModel embeddingModel) {
+		private Builder(JedisPooled jedis, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(jedis, "JedisPooled must not be null");
 			this.jedis = jedis;
@@ -517,7 +517,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param indexName the index name to use
 		 * @return the builder instance
 		 */
-		public RedisBuilder indexName(String indexName) {
+		public Builder indexName(String indexName) {
 			if (StringUtils.hasText(indexName)) {
 				this.indexName = indexName;
 			}
@@ -529,7 +529,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param prefix the prefix to use
 		 * @return the builder instance
 		 */
-		public RedisBuilder prefix(String prefix) {
+		public Builder prefix(String prefix) {
 			if (StringUtils.hasText(prefix)) {
 				this.prefix = prefix;
 			}
@@ -541,7 +541,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param fieldName the content field name to use
 		 * @return the builder instance
 		 */
-		public RedisBuilder contentFieldName(String fieldName) {
+		public Builder contentFieldName(String fieldName) {
 			if (StringUtils.hasText(fieldName)) {
 				this.contentFieldName = fieldName;
 			}
@@ -553,7 +553,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param fieldName the embedding field name to use
 		 * @return the builder instance
 		 */
-		public RedisBuilder embeddingFieldName(String fieldName) {
+		public Builder embeddingFieldName(String fieldName) {
 			if (StringUtils.hasText(fieldName)) {
 				this.embeddingFieldName = fieldName;
 			}
@@ -565,7 +565,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param algorithm the vector algorithm to use
 		 * @return the builder instance
 		 */
-		public RedisBuilder vectorAlgorithm(@Nullable Algorithm algorithm) {
+		public Builder vectorAlgorithm(@Nullable Algorithm algorithm) {
 			if (algorithm != null) {
 				this.vectorAlgorithm = algorithm;
 			}
@@ -577,7 +577,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param fields the metadata fields to include
 		 * @return the builder instance
 		 */
-		public RedisBuilder metadataFields(MetadataField... fields) {
+		public Builder metadataFields(MetadataField... fields) {
 			return metadataFields(Arrays.asList(fields));
 		}
 
@@ -586,7 +586,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param fields the list of metadata fields to include
 		 * @return the builder instance
 		 */
-		public RedisBuilder metadataFields(@Nullable List<MetadataField> fields) {
+		public Builder metadataFields(@Nullable List<MetadataField> fields) {
 			if (fields != null && !fields.isEmpty()) {
 				this.metadataFields = new ArrayList<>(fields);
 			}
@@ -598,7 +598,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @param initializeSchema true to initialize schema, false otherwise
 		 * @return the builder instance
 		 */
-		public RedisBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -609,7 +609,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public RedisBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "BatchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
@@ -207,13 +207,13 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 	 * Protected constructor for creating a TypesenseVectorStore instance using the
 	 * builder pattern. This constructor initializes the vector store with the configured
 	 * settings from the builder and performs necessary validations.
-	 * @param builder the {@link TypesenseBuilder} containing all configuration settings
+	 * @param builder the {@link Builder} containing all configuration settings
 	 * @throws IllegalArgumentException if the client is null
 	 * @throws IllegalArgumentException if the embeddingModel is null
-	 * @see TypesenseBuilder
+	 * @see Builder
 	 * @since 1.0.0
 	 */
-	protected TypesenseVectorStore(TypesenseBuilder builder) {
+	protected TypesenseVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.client, "Typesense must not be null");
@@ -231,8 +231,8 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 	 * a TypesenseVectorStore.
 	 * @return a new TypesenseBuilder instance
 	 */
-	public static TypesenseBuilder builder(Client client, EmbeddingModel embeddingModel) {
-		return new TypesenseBuilder(client, embeddingModel);
+	public static Builder builder(Client client, EmbeddingModel embeddingModel) {
+		return new Builder(client, embeddingModel);
 	}
 
 	@Override
@@ -449,7 +449,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 			.similarityMetric(VectorStoreSimilarityMetric.COSINE.value());
 	}
 
-	public static final class TypesenseBuilder extends AbstractVectorStoreBuilder<TypesenseBuilder> {
+	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private String collectionName = DEFAULT_COLLECTION_NAME;
 
@@ -468,7 +468,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		 * @param embeddingModel The embedding model used for vector transformations.
 		 * @throws IllegalArgumentException if client is null
 		 */
-		public TypesenseBuilder(Client client, EmbeddingModel embeddingModel) {
+		public Builder(Client client, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(client, "client must not be null");
 			this.client = client;
@@ -480,7 +480,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if collectionName is null or empty
 		 */
-		public TypesenseBuilder collectionName(String collectionName) {
+		public Builder collectionName(String collectionName) {
 			Assert.hasText(collectionName, "collectionName must not be empty");
 			this.collectionName = collectionName;
 			return this;
@@ -492,7 +492,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if dimension is invalid
 		 */
-		public TypesenseBuilder embeddingDimension(int embeddingDimension) {
+		public Builder embeddingDimension(int embeddingDimension) {
 			Assert.isTrue(embeddingDimension > 0, "Embedding dimension must be greater than 0");
 			this.embeddingDimension = embeddingDimension;
 			return this;
@@ -503,7 +503,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		 * @param initializeSchema true to initialize schema automatically
 		 * @return this builder instance
 		 */
-		public TypesenseBuilder initializeSchema(boolean initializeSchema) {
+		public Builder initializeSchema(boolean initializeSchema) {
 			this.initializeSchema = initializeSchema;
 			return this;
 		}
@@ -514,7 +514,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public TypesenseBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "batchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;

--- a/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStoreBuilderTests.java
+++ b/vector-stores/spring-ai-typesense-store/src/test/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStoreBuilderTests.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 /**
- * Tests for {@link TypesenseVectorStore.TypesenseBuilder}.
+ * Tests for {@link TypesenseVectorStore.Builder}.
  *
  * @author Mark Pollack
  */

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
@@ -193,12 +193,12 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 	 * Protected constructor for creating a WeaviateVectorStore instance using the builder
 	 * pattern. This constructor initializes the vector store with the configured settings
 	 * from the builder and performs necessary validations.
-	 * @param builder the {@link WeaviateBuilder} containing all configuration settings
+	 * @param builder the {@link Builder} containing all configuration settings
 	 * @throws IllegalArgumentException if the weaviateClient is null
-	 * @see WeaviateBuilder
+	 * @see Builder
 	 * @since 1.0.0
 	 */
-	protected WeaviateVectorStore(WeaviateBuilder builder) {
+	protected WeaviateVectorStore(Builder builder) {
 		super(builder);
 
 		Assert.notNull(builder.weaviateClient, "WeaviateClient must not be null");
@@ -218,8 +218,8 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 	 * a WeaviateVectorStore.
 	 * @return a new WeaviateBuilder instance
 	 */
-	public static WeaviateBuilder builder(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
-		return new WeaviateBuilder(weaviateClient, embeddingModel);
+	public static Builder builder(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
+		return new Builder(weaviateClient, embeddingModel);
 	}
 
 	private Field[] buildWeaviateSimilaritySearchFields() {
@@ -533,7 +533,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		}
 	}
 
-	public static final class WeaviateBuilder extends AbstractVectorStoreBuilder<WeaviateBuilder> {
+	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private String weaviateObjectClass = "SpringAiWeaviate";
 
@@ -552,7 +552,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		 * @param embeddingModel The embedding model used for vector transformations.
 		 * @throws IllegalArgumentException if weaviateClient is null
 		 */
-		private WeaviateBuilder(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
+		private Builder(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
 			super(embeddingModel);
 			Assert.notNull(weaviateClient, "WeaviateClient must not be null");
 			this.weaviateClient = weaviateClient;
@@ -564,7 +564,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if objectClass is null or empty
 		 */
-		public WeaviateBuilder objectClass(String objectClass) {
+		public Builder objectClass(String objectClass) {
 			Assert.hasText(objectClass, "objectClass must not be empty");
 			this.weaviateObjectClass = objectClass;
 			return this;
@@ -576,7 +576,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if consistencyLevel is null
 		 */
-		public WeaviateBuilder consistencyLevel(ConsistentLevel consistencyLevel) {
+		public Builder consistencyLevel(ConsistentLevel consistencyLevel) {
 			Assert.notNull(consistencyLevel, "consistencyLevel must not be null");
 			this.consistencyLevel = consistencyLevel;
 			return this;
@@ -588,7 +588,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if filterMetadataFields is null
 		 */
-		public WeaviateBuilder filterMetadataFields(List<MetadataField> filterMetadataFields) {
+		public Builder filterMetadataFields(List<MetadataField> filterMetadataFields) {
 			Assert.notNull(filterMetadataFields, "filterMetadataFields must not be null");
 			this.filterMetadataFields = filterMetadataFields;
 			return this;
@@ -600,7 +600,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		 * @return this builder instance
 		 * @throws IllegalArgumentException if batchingStrategy is null
 		 */
-		public WeaviateBuilder batchingStrategy(BatchingStrategy batchingStrategy) {
+		public Builder batchingStrategy(BatchingStrategy batchingStrategy) {
 			Assert.notNull(batchingStrategy, "batchingStrategy must not be null");
 			this.batchingStrategy = batchingStrategy;
 			return this;
@@ -833,8 +833,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 			 * @return this builder
 			 * @throws IllegalArgumentException if filterMetadataFields is null
 			 * @deprecated Use
-			 * {@link WeaviateVectorStore.WeaviateBuilder#filterMetadataFields(List)}
-			 * instead
+			 * {@link WeaviateVectorStore.Builder#filterMetadataFields(List)} instead
 			 */
 			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withFilterableMetadataFields(List<MetadataField> filterMetadataFields) {
@@ -863,8 +862,8 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 			 * @param objectClass objectClass to use
 			 * @return this builder
 			 * @throws IllegalArgumentException if objectClass is empty or null
-			 * @deprecated Use
-			 * {@link WeaviateVectorStore.WeaviateBuilder#objectClass(String)} instead
+			 * @deprecated Use {@link WeaviateVectorStore.Builder#objectClass(String)}
+			 * instead
 			 */
 			@Deprecated(forRemoval = true, since = "1.0.0-M5")
 			public Builder withObjectClass(String objectClass) {
@@ -879,7 +878,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 			 * @return this builder
 			 * @throws IllegalArgumentException if consistencyLevel is null
 			 * @deprecated Use
-			 * {@link WeaviateVectorStore.WeaviateBuilder#consistencyLevel(WeaviateVectorStore.ConsistentLevel)}
+			 * {@link WeaviateVectorStore.Builder#consistencyLevel(WeaviateVectorStore.ConsistentLevel)}
 			 * instead
 			 */
 			@Deprecated(forRemoval = true, since = "1.0.0-M5")

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Tests for {@link WeaviateVectorStore.WeaviateBuilder}.
+ * Tests for {@link WeaviateVectorStore.Builder}.
  *
  * @author Mark Pollack
  */


### PR DESCRIPTION
- Rename all specific builder inner classes (PineconeBuilder, MongoDBBuilder, etc.) to simply Builder for consistency across vector store implementations
- Update code references to use the new standardized Builder class names

The change establishes a consistent naming convention for builder classes across the vector store implementations, improving code uniformity.
