### PR TITLE
Improve inheritance hierarchy of ChatOptions/FunctionCallingOptions

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/ChatOptions.java
@@ -94,14 +94,14 @@ public interface ChatOptions extends ModelOptions {
 	 * {@link ChatOptions}.
 	 * @return Returns a new {@link ChatOptions.Builder}.
 	 */
-	static ChatOptions.Builder<? extends DefaultChatOptionsBuilder> builder() {
+	static ChatOptions.Builder<? extends DefaultChatOptionsBuilder, ChatOptions> builder() {
 		return new DefaultChatOptionsBuilder();
 	}
 
 	/**
 	 * Builder for creating {@link ChatOptions} instance.
 	 */
-	interface Builder<B extends Builder<B>> {
+	interface Builder<B extends Builder<B, C>, C extends ChatOptions> {
 
 		/**
 		 * Builds with the model to use for the chat.
@@ -163,7 +163,7 @@ public interface ChatOptions extends ModelOptions {
 		 * Build the {@link ChatOptions}.
 		 * @return the Chat options.
 		 */
-		ChatOptions build();
+		C build();
 
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
@@ -21,7 +21,8 @@ import java.util.List;
 /**
  * Implementation of {@link ChatOptions.Builder} to create {@link DefaultChatOptions}.
  */
-public class DefaultChatOptionsBuilder<T extends DefaultChatOptionsBuilder<T>> implements ChatOptions.Builder<T> {
+public class DefaultChatOptionsBuilder<T extends DefaultChatOptionsBuilder<T, C>, C extends ChatOptions>
+		implements ChatOptions.Builder<T, C> {
 
 	protected DefaultChatOptions options;
 
@@ -77,8 +78,8 @@ public class DefaultChatOptionsBuilder<T extends DefaultChatOptionsBuilder<T>> i
 		return self();
 	}
 
-	public ChatOptions build() {
-		return this.options;
+	public C build() {
+		return (C) this.options;
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallingOptionsBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallingOptionsBuilder.java
@@ -33,8 +33,8 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  */
 public class DefaultFunctionCallingOptionsBuilder
-		extends DefaultChatOptionsBuilder<DefaultFunctionCallingOptionsBuilder>
-		implements FunctionCallingOptions.Builder<DefaultFunctionCallingOptionsBuilder> {
+		extends DefaultChatOptionsBuilder<DefaultFunctionCallingOptionsBuilder, FunctionCallingOptions>
+		implements FunctionCallingOptions.Builder<DefaultFunctionCallingOptionsBuilder, FunctionCallingOptions> {
 
 	public DefaultFunctionCallingOptionsBuilder() {
 		// Set the options in the parent class to be the same instance

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallingOptions.java
@@ -35,7 +35,7 @@ public interface FunctionCallingOptions extends ChatOptions {
 	 * @return Returns {@link DefaultFunctionCallingOptionsBuilder} to create a new
 	 * instance of {@link FunctionCallingOptions}.
 	 */
-	static FunctionCallingOptions.Builder<? extends FunctionCallingOptions.Builder> builder() {
+	static DefaultFunctionCallingOptionsBuilder builder() {
 		return new DefaultFunctionCallingOptionsBuilder();
 	}
 
@@ -87,7 +87,7 @@ public interface FunctionCallingOptions extends ChatOptions {
 	/**
 	 * Builder for creating {@link FunctionCallingOptions} instance.
 	 */
-	interface Builder<T extends Builder<T>> extends ChatOptions.Builder<T> {
+	interface Builder<T extends Builder<T, F>, F extends FunctionCallingOptions> extends ChatOptions.Builder<T, F> {
 
 		/**
 		 * The list of Function Callbacks to be registered with the Chat model.
@@ -143,7 +143,7 @@ public interface FunctionCallingOptions extends ChatOptions {
 		 * Builds the {@link FunctionCallingOptions}.
 		 * @return the FunctionCalling options.
 		 */
-		FunctionCallingOptions build();
+		F build();
 
 	}
 


### PR DESCRIPTION
 - Convert ChatOptions.Builder to have `Builder<B extends Builder<B, C>, C extends ChatOptions>`
   - This will allow the subclasses which extend this builder to provide their implementation of ChatOptions i.e, in our case FunctionCallingOptions
   - Update the default builder implementations with this change
   - Update FunctionCallingOptions and its default builder impelementation to enforce this hiearchical change