### PR TITLE
Modify SimpleLoggerAdvisor to use PrettyPrinter method for response logging

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/SimpleLoggerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/SimpleLoggerAdvisor.java
@@ -42,7 +42,7 @@ public class SimpleLoggerAdvisor implements CallAroundAdvisor, StreamAroundAdvis
 	public static final Function<AdvisedRequest, String> DEFAULT_REQUEST_TO_STRING = request -> request.toString();
 
 	public static final Function<ChatResponse, String> DEFAULT_RESPONSE_TO_STRING = response -> ModelOptionsUtils
-		.toJsonString(response);
+		.toJsonStringPrettyPrinter(response);
 
 	private static final Logger logger = LoggerFactory.getLogger(SimpleLoggerAdvisor.class);
 


### PR DESCRIPTION

* I have observed that default response logging in simple logger advisor printing the ChatResponse in raw json. This PR changes default print method used in the simpleloggeradvisor to pretty print the response.
