### PR TITLE
Fix generic type in explicit type casting

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallbackBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/DefaultFunctionCallbackBuilder.java
@@ -144,9 +144,9 @@ public class DefaultFunctionCallbackBuilder implements FunctionCallback.Builder 
 			BiFunction<I, ToolContext, O> finalBiFunction = (this.biFunction != null) ? this.biFunction
 					: (request, context) -> this.function.apply(request);
 
-			return new FunctionInvokingFunctionCallback(this.name, this.getDescriptionExt(), this.getInputTypeSchema(),
-					this.inputType, (Function<I, String>) this.getResponseConverter(), this.getObjectMapper(),
-					finalBiFunction);
+			return new FunctionInvokingFunctionCallback<>(this.name, this.getDescriptionExt(),
+					this.getInputTypeSchema(), this.inputType, (Function<O, String>) this.getResponseConverter(),
+					this.getObjectMapper(), finalBiFunction);
 		}
 
 		private String getDescriptionExt() {


### PR DESCRIPTION
Fix generic type of `responseConverter`. This typo was possible due to calling constructor of `FunctionInvokingFunctionCallback` with  raw type, so made it generic too.