### PR TITLE
Refact AdvisedRequest to avoid userText rendering

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -126,7 +126,7 @@ public class DefaultChatClient implements ChatClient {
 			}
 		}
 
-		return new AdvisedRequest(inputRequest.chatModel, userText, inputRequest.systemText, inputRequest.chatOptions,
+		return new AdvisedRequest(inputRequest.chatModel, userText, inputRequest.systemText, inputRequest.advisorText, inputRequest.chatOptions,
 				media, inputRequest.functionNames, inputRequest.functionCallbacks, messages, inputRequest.userParams,
 				inputRequest.systemParams, inputRequest.advisors, inputRequest.advisorParams, advisorContext,
 				inputRequest.toolContext);
@@ -138,7 +138,7 @@ public class DefaultChatClient implements ChatClient {
 		return new DefaultChatClientRequestSpec(advisedRequest.chatModel(), advisedRequest.userText(),
 				advisedRequest.userParams(), advisedRequest.systemText(), advisedRequest.systemParams(),
 				advisedRequest.functionCallbacks(), advisedRequest.messages(), advisedRequest.functionNames(),
-				advisedRequest.media(), advisedRequest.chatOptions(), advisedRequest.advisors(),
+				advisedRequest.media(), advisedRequest.chatOptions(), advisedRequest.advisors(), advisedRequest.advisorText(),
 				advisedRequest.advisorParams(), observationRegistry, customObservationConvention,
 				advisedRequest.toolContext());
 	}
@@ -606,19 +606,22 @@ public class DefaultChatClient implements ChatClient {
 		private String systemText;
 
 		@Nullable
+		private String advisorText;
+
+		@Nullable
 		private ChatOptions chatOptions;
 
 		/* copy constructor */
 		DefaultChatClientRequestSpec(DefaultChatClientRequestSpec ccr) {
 			this(ccr.chatModel, ccr.userText, ccr.userParams, ccr.systemText, ccr.systemParams, ccr.functionCallbacks,
-					ccr.messages, ccr.functionNames, ccr.media, ccr.chatOptions, ccr.advisors, ccr.advisorParams,
+					ccr.messages, ccr.functionNames, ccr.media, ccr.chatOptions, ccr.advisors, ccr.advisorText, ccr.advisorParams,
 					ccr.observationRegistry, ccr.customObservationConvention, ccr.toolContext);
 		}
 
 		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
 				Map<String, Object> userParams, @Nullable String systemText, Map<String, Object> systemParams,
 				List<FunctionCallback> functionCallbacks, List<Message> messages, List<String> functionNames,
-				List<Media> media, @Nullable ChatOptions chatOptions, List<Advisor> advisors,
+				List<Media> media, @Nullable ChatOptions chatOptions, List<Advisor> advisors, @Nullable String advisorText,
 				Map<String, Object> advisorParams, ObservationRegistry observationRegistry,
 				@Nullable ChatClientObservationConvention customObservationConvention,
 				Map<String, Object> toolContext) {
@@ -649,6 +652,7 @@ public class DefaultChatClient implements ChatClient {
 			this.messages.addAll(messages);
 			this.media.addAll(media);
 			this.advisors.addAll(advisors);
+			this.advisorText = advisorText;
 			this.advisorParams.putAll(advisorParams);
 			this.observationRegistry = observationRegistry;
 			this.customObservationConvention = customObservationConvention != null ? customObservationConvention
@@ -776,6 +780,10 @@ public class DefaultChatClient implements ChatClient {
 
 			if (StringUtils.hasText(this.systemText)) {
 				builder.defaultSystem(s -> s.text(this.systemText).params(this.systemParams));
+			}
+
+			if (StringUtils.hasText(this.advisorText)) {
+				builder.defaultSystem(s -> s.text(this.advisorText).params(this.advisorParams));
 			}
 
 			if (this.chatOptions != null) {

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -63,7 +63,7 @@ public class DefaultChatClientBuilder implements Builder {
 		Assert.notNull(chatModel, "the " + ChatModel.class.getName() + " must be non-null");
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), null, Map.of(), List.of(),
-				List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
+				List.of(), List.of(), List.of(), null, List.of(), null, Map.of(), observationRegistry,
 				customObservationConvention, Map.of());
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -94,7 +94,8 @@ public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemo
 		AdvisedRequest advisedRequest = AdvisedRequest.from(request).messages(advisedMessages).build();
 
 		// 4. Add the new user input to the conversation memory.
-		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		String renderedUserText = request.renderUserText();
+		UserMessage userMessage = new UserMessage(renderedUserText, request.media());
 		this.getChatMemoryStore().add(this.doGetConversationId(request.adviseContext()), userMessage);
 
 		return advisedRequest;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
@@ -127,7 +127,8 @@ public class PromptChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemor
 			.build();
 
 		// 4. Add the new user input to the conversation memory.
-		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		String renderedUserText = request.renderUserText();
+		UserMessage userMessage = new UserMessage(renderedUserText, request.media());
 		this.getChatMemoryStore().add(this.doGetConversationId(request.adviseContext()), userMessage);
 
 		return advisedRequest;

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/QuestionAnswerAdvisor.java
@@ -216,7 +216,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 		String advisedUserText = request.userText() + System.lineSeparator() + this.userTextAdvise;
 
 		// 2. Search for similar documents in the vector store.
-		String query = new PromptTemplate(request.userText(), request.userParams()).render();
+		String query = request.renderUserText();
 		var searchRequestToUse = SearchRequest.from(this.searchRequest)
 			.query(query)
 			.filterExpression(doGetFilterExpression(context))
@@ -236,7 +236,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 		advisedUserParams.put("question_answer_context", documentContext);
 
 		AdvisedRequest advisedRequest = AdvisedRequest.from(request)
-			.userText(advisedUserText)
+			.advisorText(advisedUserText)
 			.userParams(advisedUserParams)
 			.adviseContext(context)
 			.build();

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisor.java
@@ -103,7 +103,7 @@ public final class RetrievalAugmentationAdvisor implements BaseAdvisor {
 		Map<String, Object> context = new HashMap<>(request.adviseContext());
 
 		// 0. Create a query from the user text and parameters.
-		Query originalQuery = new Query(new PromptTemplate(request.userText(), request.userParams()).render());
+		Query originalQuery = new Query(request.renderUserText());
 
 		// 1. Transform original user query based on a chain of query transformers.
 		Query transformedQuery = originalQuery;
@@ -129,10 +129,10 @@ public final class RetrievalAugmentationAdvisor implements BaseAdvisor {
 		context.put(DOCUMENT_CONTEXT, documents);
 
 		// 5. Augment user query with the document contextual data.
-		Query augmentedQuery = this.queryAugmenter.augment(originalQuery, documents);
+		Query augmentedQuery = this.queryAugmenter.augment(new Query(request.userText()), documents);
 
 		// 6. Update advised request with augmented prompt.
-		return AdvisedRequest.from(request).userText(augmentedQuery.text()).adviseContext(context).build();
+		return AdvisedRequest.from(request).advisorText(augmentedQuery.text()).adviseContext(context).build();
 	}
 
 	/**

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/SafeGuardAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/SafeGuardAdvisor.java
@@ -74,9 +74,10 @@ public class SafeGuardAdvisor implements CallAroundAdvisor, StreamAroundAdvisor 
 
 	@Override
 	public AdvisedResponse aroundCall(AdvisedRequest advisedRequest, CallAroundAdvisorChain chain) {
+		String renderedUserText = advisedRequest.renderUserText();
 
 		if (!CollectionUtils.isEmpty(this.sensitiveWords)
-				&& this.sensitiveWords.stream().anyMatch(w -> advisedRequest.userText().contains(w))) {
+				&& this.sensitiveWords.stream().anyMatch(renderedUserText::contains)) {
 
 			return createFailureResponse(advisedRequest);
 		}
@@ -86,9 +87,10 @@ public class SafeGuardAdvisor implements CallAroundAdvisor, StreamAroundAdvisor 
 
 	@Override
 	public Flux<AdvisedResponse> aroundStream(AdvisedRequest advisedRequest, StreamAroundAdvisorChain chain) {
+		String renderedUserText = advisedRequest.renderUserText();
 
 		if (!CollectionUtils.isEmpty(this.sensitiveWords)
-				&& this.sensitiveWords.stream().anyMatch(w -> advisedRequest.userText().contains(w))) {
+				&& this.sensitiveWords.stream().anyMatch(renderedUserText::contains)) {
 			return Flux.just(createFailureResponse(advisedRequest));
 		}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/VectorStoreChatMemoryAdvisor.java
@@ -137,9 +137,10 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 		else {
 			advisedSystemText = this.systemTextAdvise;
 		}
+		String renderedUserText = request.renderUserText();
 
 		var searchRequest = SearchRequest.builder()
-			.query(request.userText())
+			.query(renderedUserText)
 			.topK(this.doGetChatMemoryRetrieveSize(request.adviseContext()))
 			.filterExpression(
 					DOCUMENT_METADATA_CONVERSATION_ID + "=='" + this.doGetConversationId(request.adviseContext()) + "'")
@@ -159,7 +160,7 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 			.systemParams(advisedSystemParams)
 			.build();
 
-		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		UserMessage userMessage = new UserMessage(renderedUserText, request.media());
 		this.getChatMemoryStore()
 			.write(toDocuments(List.of(userMessage), this.doGetConversationId(request.adviseContext())));
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1198,14 +1198,14 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
 				chatModel, null, Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(),
-				Map.of(), ObservationRegistry.NOOP, null, Map.of());
+				null, Map.of(), ObservationRegistry.NOOP, null, Map.of());
 		assertThat(spec).isNotNull();
 	}
 
 	@Test
 	void whenChatModelIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), null,
-				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
+				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), null, Map.of(),
 				ObservationRegistry.NOOP, null, Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
@@ -1214,7 +1214,7 @@ class DefaultChatClientTests {
 	@Test
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mock(ChatModel.class), null,
-				Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), null,
+				Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), null, Map.of(), null,
 				null, Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/SimpleLoggerAdvisorTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/SimpleLoggerAdvisorTests.java
@@ -103,7 +103,7 @@ public class SimpleLoggerAdvisorTests {
 		UserMessage userMessage = (UserMessage) this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getText()).isEqualToIgnoringWhitespace("Please answer my question XYZ");
 
-		assertThat(output.getOut()).contains("request: AdvisedRequest", "userText=Please answer my question XYZ");
+		assertThat(output.getOut()).contains("request: AdvisedRequest", "userText={userText}", "userParams={userText=Please answer my question XYZ}");
 		assertThat(output.getOut()).contains("response:", "finishReason");
 	}
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequestTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequestTests.java
@@ -36,14 +36,14 @@ class AdvisedRequestTests {
 
 	@Test
 	void buildAdvisedRequest() {
-		AdvisedRequest request = new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		AdvisedRequest request = new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of());
 		assertThat(request).isNotNull();
 	}
 
 	@Test
 	void whenChatModelIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(null, "user", null, null, List.of(), List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(null, "user", null, null, null, List.of(), List.of(), List.of(),
 				List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
@@ -51,7 +51,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenUserTextIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), null, null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), null, null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage(
@@ -60,7 +60,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenUserTextIsEmptyThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage(
@@ -69,7 +69,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenMediaIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, null, List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("media cannot be null");
@@ -77,7 +77,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenFunctionNamesIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), null,
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), null,
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("functionNames cannot be null");
@@ -85,7 +85,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenFunctionCallbacksIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				null, List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("functionCallbacks cannot be null");
@@ -93,7 +93,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenMessagesIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), null, Map.of(), Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("messages cannot be null");
@@ -101,7 +101,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenUserParamsIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), null, Map.of(), List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("userParams cannot be null");
@@ -109,7 +109,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenSystemParamsIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), null, List.of(), Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("systemParams cannot be null");
@@ -117,7 +117,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenAdvisorsIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), null, Map.of(), Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("advisors cannot be null");
@@ -125,7 +125,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenAdvisorParamsIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), null, Map.of(), Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("advisorParams cannot be null");
@@ -133,7 +133,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenAdviseContextIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), Map.of(), null, Map.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("adviseContext cannot be null");
@@ -141,7 +141,7 @@ class AdvisedRequestTests {
 
 	@Test
 	void whenToolContextIsNullThenThrows() {
-		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, List.of(), List.of(),
+		assertThatThrownBy(() -> new AdvisedRequest(mock(ChatModel.class), "user", null, null, null, List.of(), List.of(),
 				List.of(), List.of(), Map.of(), Map.of(), List.of(), Map.of(), Map.of(), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("toolContext cannot be null");

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientInputContentObservationFilterTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientInputContentObservationFilterTests.java
@@ -61,7 +61,7 @@ class ChatClientInputContentObservationFilterTests {
 		ChatClientObservationConvention customObservationConvention = null;
 
 		var request = new DefaultChatClientRequestSpec(this.chatModel, "", Map.of(), "", Map.of(), List.of(), List.of(),
-				List.of(), List.of(), null, List.of(), Map.of(), observationRegistry, customObservationConvention,
+				List.of(), List.of(), null, List.of(), null, Map.of(), observationRegistry, customObservationConvention,
 				Map.of());
 
 		var expectedContext = ChatClientObservationContext.builder().withRequest(request).build();
@@ -78,7 +78,7 @@ class ChatClientInputContentObservationFilterTests {
 
 		var request = new DefaultChatClientRequestSpec(this.chatModel, "sample user text", Map.of("up1", "upv1"),
 				"sample system text", Map.of("sp1", "sp1v"), List.of(), List.of(), List.of(), List.of(), null,
-				List.of(), Map.of(), observationRegistry, customObservationConvention, Map.of());
+				List.of(), null, Map.of(), observationRegistry, customObservationConvention, Map.of());
 
 		var originalContext = ChatClientObservationContext.builder().withRequest(request).build();
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientObservationContextTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/ChatClientObservationContextTests.java
@@ -46,7 +46,7 @@ class ChatClientObservationContextTests {
 	void whenMandatoryRequestOptionsThenReturn() {
 
 		var request = new DefaultChatClientRequestSpec(this.chatModel, "", Map.of(), "", Map.of(), List.of(), List.of(),
-				List.of(), List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of());
+				List.of(), List.of(), null, List.of(), null, Map.of(), ObservationRegistry.NOOP, null, Map.of());
 
 		var observationContext = ChatClientObservationContext.builder().withRequest(request).withStream(true).build();
 

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConventionTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConventionTests.java
@@ -114,7 +114,7 @@ class DefaultChatClientObservationConventionTests {
 	@BeforeEach
 	public void beforeEach() {
 		this.request = new DefaultChatClientRequestSpec(this.chatModel, "", Map.of(), "", Map.of(), List.of(),
-				List.of(), List.of(), List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of());
+				List.of(), List.of(), List.of(), null, List.of(), null, Map.of(), ObservationRegistry.NOOP, null, Map.of());
 	}
 
 	@Test
@@ -161,7 +161,7 @@ class DefaultChatClientObservationConventionTests {
 		var request = new DefaultChatClientRequestSpec(this.chatModel, "", Map.of(), "", Map.of(),
 				List.of(dummyFunction("functionCallback1"), dummyFunction("functionCallback2")), List.of(),
 				List.of("function1", "function2"), List.of(), null,
-				List.of(dummyAdvisor("advisor1"), dummyAdvisor("advisor2")), Map.of("advParam1", "advisorParam1Value"),
+				List.of(dummyAdvisor("advisor1"), dummyAdvisor("advisor2")), "", Map.of("advParam1", "advisorParam1Value"),
 				ObservationRegistry.NOOP, null, Map.of());
 
 		ChatClientObservationContext observationContext = ChatClientObservationContext.builder()


### PR DESCRIPTION
Hello.

While implementing RAG using spring-ai, I encountered an error during rendering with PromptTemplate when the `userText` contained curly braces (`{}`).

```javascript
// My Request
{
    "prompt": "\"``` \\n suspend fun methodName(prompt: String) { \\n     return RetryUtil.retry( \\n         context = Dispatchers.IO, \\n         retryCount = 3, \\n         predicate = { \\n             logger.info(\\\"RETRY POLICY :: ${it.message}\\\") \\n             return@retry it is RuntimeException \\n         } \\n     ) { \\n         methodGeneratorClient.prompt() \\n             .user(prompt) \\n             .advisors() \\n             .call() \\n             .entity(object : ParameterizedTypeReference<List<MethodGenerateResult>>() {}) ?: emptyList() \\n     } \\n } \\n ``` \\n\\nPlease Recommend Method name\""
}

```

### Configuration

Spring Boot : 3.4.1
jdk : 17
spring-ai : 1.0.0-M5

```kotlin
private var SYSTEM_MESSAGE: String = """
    You are an expert in defining method names by analyzing code. 
    Provide clear and concise method names that match the functionality and purpose of the code snippets provided by the user. 
    Method names should start with a verb, followed by an object or adjective to clearly convey the meaning. 
    If the user requests names for multiple methods, separate each name with a newline. 
    Do not provide unnecessary explanations.
""".trimIndent()

@Configuration
class MethodGeneratorPipeline {

    @Bean
    fun methodGeneratorClient(
        vectorStore: VectorStore,
        ollamaChatModel: OllamaChatModel,
    ): ChatClient {
        return ChatClient.builder(ollamaChatModel)
            .defaultSystem(SYSTEM_MESSAGE)
            .defaultAdvisors(methodGeneratorPipeline(vectorStore))
            .build()
    }

    private fun methodGeneratorPipeline(vectorStore: VectorStore): BaseAdvisor {
        val retriever = VectorStoreDocumentRetriever.builder()
            .vectorStore(vectorStore)
            .similarityThreshold(0.73)
            .topK(5)
            .build()

        val queryAugmenter = ContextualQueryAugmenter.builder()
            .allowEmptyContext(true)
            .build()

        return RetrievalAugmentationAdvisor.builder()
            .documentRetriever(retriever)
            .documentJoiner(ConcatenationDocumentJoiner())
            .queryAugmenter(queryAugmenter)
            .build()
    }
}

@RestController
@RequestMapping("/methods")
class MethodController(
    private val methodGeneratorClient: ChatClient,
) {
    private val logger = logger<MethodController>()

    @PostMapping(value = [""], produces = [MediaType.APPLICATION_JSON_VALUE])
    suspend fun generateMethodNames(
        @RequestBody request: MethodGenerateRequest,
    ): List<MethodGenerateResult> {

        return retry(
            context = Dispatchers.IO,
            retryCount = 1,
            predicate = {
                logger.info("RETRY POLICY :: ${it.message}")
                return@retry it is RuntimeException
            }
        ) {
            methodGeneratorClient.prompt()
                .user(request.prompt)
                .call()
                .entity(object : ParameterizedTypeReference<List<MethodGenerateResult>>() {}) ?: emptyList()
        }
    }
}
```

```
== error log ==
1:49: invalid character '\'
1:56: 'return' came as a complete surprise to me

// Json Response
{
    "error": {
        "status": "400",
        "title": "ERROR",
        "message": "The template string is not valid."
    }
}
```

Looking through the history, I found many related issues concerning StringTemplate.  https://github.com/spring-projects/spring-ai/issues/355

When I implemented it using custom templates without the RetrievalAugmentationAdvisor, the error did not occur. However, the error started appearing after using RetrievalAugmentationAdvisor. 

After investigating the cause, I discovered that the Advisor was treating userText as if it were a template and rendering it.

```java
Query originalQuery = new Query(new PromptTemplate(request.userText(), request.userParams()).render());
```

Therefore, I propose a solution to manage the text generated by the Advisor separately as a variable called `advisorText` instead of replacing the `userText`.

`userText` should provide the rendered string only when direct rendering is required, such as in `DocumentRetrieval` or `ChatMemory`. 

I envisioned a scenario where the actual rendering of `userText` happens in the `toPrompt()` method of `CallAroundAdvisor`, which is created by default in `DefaultChatClientRequestSpec`.

```java
		public DefaultChatClientRequestSpec(...) {
                         ...
			this.advisors.add(new CallAroundAdvisor() {

				@Override
				public String getName() {
					return CallAroundAdvisor.class.getSimpleName();
				}

				@Override
				public int getOrder() {
					return Ordered.LOWEST_PRECEDENCE;
				}

				@Override
				public AdvisedResponse aroundCall(AdvisedRequest advisedRequest, CallAroundAdvisorChain chain) {
					return new AdvisedResponse(chatModel.call(advisedRequest.toPrompt()), Collections.unmodifiableMap(advisedRequest.adviseContext()));
				}
			});
                         ...
		}
```