### PR TITLE
docs: fix grammatical issue in API provider description

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can find more details in the [Reference Documentation](https://docs.spring.i
   - [Audio Transcription](https://docs.spring.io/spring-ai/reference/api/audio/transcriptions.html)
   - [Text to Speech](https://docs.spring.io/spring-ai/reference/api/audio/speech.html)
   - [Moderation](https://docs.spring.io/spring-ai/reference/api/index.html#api/moderation)
-* Portable API support across AI providers for both synchronous and streaming API options are supported. Access to [model-specific features](https://docs.spring.io/spring-ai/reference/api/chatmodel.html#_chat_options) is also available.
+* Portable API support across AI providers for both synchronous and streaming options. Access to [model-specific features](https://docs.spring.io/spring-ai/reference/api/chatmodel.html#_chat_options) is also available.
 * [Structured Outputs](https://docs.spring.io/spring-ai/reference/api/structured-output-converter.html) - Mapping of AI Model output to POJOs.
 * Support for all major [Vector Database providers](https://docs.spring.io/spring-ai/reference/api/vectordbs.html) such as *Apache Cassandra, Azure Vector Search, Chroma, Milvus, MongoDB Atlas, MariaDB, Neo4j, Oracle, PostgreSQL/PGVector, PineCone, Qdrant, Redis, and Weaviate*.
 * Portable API across Vector Store providers, including a novel SQL-like [metadata filter API](https://docs.spring.io/spring-ai/reference/api/vectordbs.html#metadata-filters).


### PR DESCRIPTION
Fix grammatical issue in API provider documentation

- Simplify redundant wording around API provider support
- Remove duplicate terms ('support')

Before:
Portable API support across AI providers for both synchronous and streaming API options are supported.

After:
Portable API support across AI providers for both synchronous and streaming options.