### PR TITLE
Gemini response can contains text and function call.

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -396,7 +396,7 @@ public class VertexAiGeminiChatModel extends AbstractToolCallSupport implements 
 			.finishReason(candidateFinishReason.name())
 			.build();
 
-		boolean isFunctionCall = candidate.getContent().getPartsList().stream().allMatch(Part::hasFunctionCall);
+		boolean isFunctionCall = candidate.getContent().getPartsList().stream().anyMatch(Part::hasFunctionCall);
 
 		if (isFunctionCall) {
 			List<AssistantMessage.ToolCall> assistantToolCalls = candidate.getContent()


### PR DESCRIPTION
The function call feature can result in gemini respond multiple part like

 - part 1: message: " I understand what you want to do, I will check ..."
 - part 2:  function call  
 - part 3:  message "if it is not enough you will need to check yourself  .... "

Today, the response via spring-ai is the message will not launch the function because the code want every part to be a function call to do it.  There will be 3 outputs on the response  (1 message,  1 empty string, 1 message)

It seems it is ok to switch to 'anyMatch' instead of 'allMatch' on this subject, because after the function call, another call will be made to the model and a return like 

- part 1:  message "I understand what you want, I get the result and you can do .... " 

