### PR TITLE
Make FunctionCallback.Builder customizable

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionInvokingFunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionInvokingFunctionCallback.java
@@ -34,12 +34,13 @@ import org.springframework.util.Assert;
  * @param <I> the input type
  * @param <O> the output type
  * @author Christian Tzolov
+ * @author Thomas Vitale
  */
 public final class FunctionInvokingFunctionCallback<I, O> extends AbstractFunctionCallback<I, O> {
 
 	private final BiFunction<I, ToolContext, O> biFunction;
 
-	FunctionInvokingFunctionCallback(String name, String description, String inputTypeSchema, Type inputType,
+	public FunctionInvokingFunctionCallback(String name, String description, String inputTypeSchema, Type inputType,
 			Function<O, String> responseConverter, ObjectMapper objectMapper, BiFunction<I, ToolContext, O> function) {
 		super(name, description, inputTypeSchema, inputType, responseConverter, objectMapper);
 		Assert.notNull(function, "Function must not be null");


### PR DESCRIPTION
* Make constructor in MethodInvokingFunctionCallback public.
* Make constructor in FunctionInvokingFunctionCallback public.
* Make JSON Schema Generation strategy in MethodInvokingFunctionCallback more customizable.

Fixes gh-2032