### PR TITLE
Do not autoconfigure ChatClient.Builder if a bean exists already

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/client/ChatClientAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/chat/client/ChatClientAutoConfiguration.java
@@ -46,6 +46,7 @@ import org.springframework.context.annotation.Scope;
  * @author Mark Pollack
  * @author Josh Long
  * @author Arjen Poutsma
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 @AutoConfiguration
@@ -67,6 +68,7 @@ public class ChatClientAutoConfiguration {
 
 	@Bean
 	@Scope("prototype")
+	@ConditionalOnMissingBean
 	ChatClient.Builder chatClientBuilder(ChatClientBuilderConfigurer chatClientBuilderConfigurer, ChatModel chatModel,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<ChatClientObservationConvention> observationConvention) {


### PR DESCRIPTION
Fix the ChatClient.Builder auto-configuration so that it's only autoconfigured when there is no bean defined yet.

Fixes gh-2034