### PR TITLE
Introduce LoggingMarkers marker for logging sensitive data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
 
 		<!-- production dependencies -->
 		<spring-boot.version>3.3.6</spring-boot.version>
@@ -344,6 +345,10 @@
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-maven-plugin</artifactId>
 				<version>${kotlin.version}</version>
+				<configuration>
+					<jvmTarget>${java.version}</jvmTarget>
+					<javaParameters>true</javaParameters>
+				</configuration>
 				<executions>
 					<execution>
 						<id>compile</id>

--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -145,7 +145,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 			this.jsonSchema = objectWriter.writeValueAsString(jsonNode);
 		}
 		catch (JsonProcessingException e) {
-			logger.error("Could not pretty print json schema for jsonNode: " + jsonNode);
+			logger.error("Could not pretty print json schema for jsonNode: {}", jsonNode);
 			throw new RuntimeException("Could not pretty print json schema for " + this.type, e);
 		}
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -41,6 +41,8 @@ import org.springframework.ai.util.JacksonUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.lang.NonNull;
 
+import static org.springframework.ai.util.LoggingMarkers.PII_MARKER;
+
 /**
  * An implementation of {@link StructuredOutputConverter} that transforms the LLM output
  * to a specific object type using JSON schema. This converter works by generating a JSON
@@ -180,7 +182,8 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 			return (T) this.objectMapper.readValue(text, this.objectMapper.constructType(this.type));
 		}
 		catch (JsonProcessingException e) {
-			logger.error("Could not parse the given text to the desired target type:" + text + " into " + this.type);
+			logger.error(PII_MARKER,
+					"Could not parse the given text to the desired target type:" + text + " into " + this.type);
 			throw new RuntimeException(e);
 		}
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -41,7 +41,7 @@ import org.springframework.ai.util.JacksonUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.lang.NonNull;
 
-import static org.springframework.ai.util.LoggingMarkers.PII_MARKER;
+import static org.springframework.ai.util.LoggingMarkers.SENSITIVE_DATA_MARKER;
 
 /**
  * An implementation of {@link StructuredOutputConverter} that transforms the LLM output
@@ -182,8 +182,8 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 			return (T) this.objectMapper.readValue(text, this.objectMapper.constructType(this.type));
 		}
 		catch (JsonProcessingException e) {
-			logger.error(PII_MARKER,
-					"Could not parse the given text to the desired target type:" + text + " into " + this.type);
+			logger.error(SENSITIVE_DATA_MARKER,
+					"Could not parse the given text to the desired target type: \"{}\" into {}", text, this.type);
 			throw new RuntimeException(e);
 		}
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/util/LoggingMarkers.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/util/LoggingMarkers.java
@@ -1,0 +1,25 @@
+package org.springframework.ai.util;
+
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+/**
+ * Utility class that provides predefined SLF4J {@link Marker} instances used in logging
+ * operations within the application. <br>
+ * This class is not intended to be instantiated.
+ */
+public class LoggingMarkers {
+
+	/**
+	 * Marker instance representing Personally Identifiable Information (PII) used in
+	 * logging operations to classify or tag log entries for sensitive data. This can be
+	 * utilized to allow selective filtering, handling, or analysis of log messages
+	 * containing PII.
+	 */
+	public static final Marker PII_MARKER = MarkerFactory.getMarker("PII");
+
+	private LoggingMarkers() {
+		// Prevent instantiation of this utility class
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/util/LoggingMarkers.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/util/LoggingMarkers.java
@@ -20,7 +20,7 @@ public class LoggingMarkers {
 	 * <li>Business processes and logic</li>
 	 * <li>etc.</li>
 	 * </ul>
-	 * Typically, logging this information should be avoided
+	 * Typically, logging this information should be avoided.
 	 */
 	public static final Marker SENSITIVE_DATA_MARKER = MarkerFactory.getMarker("SENSITIVE");
 
@@ -35,7 +35,7 @@ public class LoggingMarkers {
 	 * <li>Trade secrets</li>
 	 * <li>etc.</li>
 	 * </ul>
-	 * Logging of such information is usually prohibited in any circumstances
+	 * Logging of such information is usually prohibited in any circumstances.
 	 */
 	public static final Marker RESTRICTED_DATA_MARKER = MarkerFactory.getMarker("RESTRICTED");
 
@@ -50,7 +50,7 @@ public class LoggingMarkers {
 	 * <li>Compliance-controlled data</li>
 	 * <li>etc.</li>
 	 * </ul>
-	 * Logging of such information should be avoided
+	 * Logging of such information should be avoided.
 	 */
 	public static final Marker REGULATED_DATA_MARKER = MarkerFactory.getMarker("REGULATED");
 
@@ -62,7 +62,7 @@ public class LoggingMarkers {
 	 * <li>Marketing materials</li>
 	 * <li>etc.</li>
 	 * </ul>
-	 * There are no restriction for
+	 * There are no restriction for logging such information.
 	 */
 	public static final Marker PUBLIC_DATA_MARKER = MarkerFactory.getMarker("PUBLIC");
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/util/LoggingMarkers.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/util/LoggingMarkers.java
@@ -6,20 +6,64 @@ import org.slf4j.MarkerFactory;
 /**
  * Utility class that provides predefined SLF4J {@link Marker} instances used in logging
  * operations within the application. <br>
- * This class is not intended to be instantiated.
+ * This class is not intended to be instantiated, but is open for extension.
  */
 public class LoggingMarkers {
 
 	/**
-	 * Marker instance representing Personally Identifiable Information (PII) used in
-	 * logging operations to classify or tag log entries for sensitive data. This can be
-	 * utilized to allow selective filtering, handling, or analysis of log messages
-	 * containing PII.
+	 * Marker used to identify log statements associated with <strong>sensitive
+	 * data</strong>, such as:
+	 * <ul>
+	 * <li>Internal business information</li>
+	 * <li>Employee data</li>
+	 * <li>Customer non-regulated data</li>
+	 * <li>Business processes and logic</li>
+	 * <li>etc.</li>
+	 * </ul>
+	 * Typically, logging this information should be avoided
 	 */
-	public static final Marker PII_MARKER = MarkerFactory.getMarker("PII");
+	public static final Marker SENSITIVE_DATA_MARKER = MarkerFactory.getMarker("SENSITIVE");
 
-	private LoggingMarkers() {
-		// Prevent instantiation of this utility class
-	}
+	/**
+	 * Marker used to identify log statements associated with <strong>restricted
+	 * data</strong>, such as:
+	 * <ul>
+	 * <li>Authentication credentials</li>
+	 * <li>Keys and secrets</li>
+	 * <li>Core intellectual property</li>
+	 * <li>Critical security configs</li>
+	 * <li>Trade secrets</li>
+	 * <li>etc.</li>
+	 * </ul>
+	 * Logging of such information is usually prohibited in any circumstances
+	 */
+	public static final Marker RESTRICTED_DATA_MARKER = MarkerFactory.getMarker("RESTRICTED");
+
+	/**
+	 * Marker used to identify log statements associated with <strong>regulated
+	 * data</strong>, such as:
+	 * <ul>
+	 * <li>PCI (credit card data)</li>
+	 * <li>PHI (health information)</li>
+	 * <li>PII (personally identifiable info)</li>
+	 * <li>Financial records</li>
+	 * <li>Compliance-controlled data</li>
+	 * <li>etc.</li>
+	 * </ul>
+	 * Logging of such information should be avoided
+	 */
+	public static final Marker REGULATED_DATA_MARKER = MarkerFactory.getMarker("REGULATED");
+
+	/**
+	 * Marker used to identify log statements associated with <strong>public
+	 * data</strong>, such as:
+	 * <ul>
+	 * <li>Public documentation</li>
+	 * <li>Marketing materials</li>
+	 * <li>etc.</li>
+	 * </ul>
+	 * There are no restriction for
+	 */
+	public static final Marker PUBLIC_DATA_MARKER = MarkerFactory.getMarker("PUBLIC");
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
@@ -158,7 +158,8 @@ class BeanOutputConverterTest {
 		void failToConvertInvalidJson() {
 			var converter = new BeanOutputConverter<>(TestClass.class);
 			assertThatThrownBy(() -> converter.convert("{invalid json")).hasCauseInstanceOf(JsonParseException.class);
-			final var loggingEvent = logAppender.list.getFirst();
+			assertThat(logAppender.list).hasSize(1);
+			final var loggingEvent = logAppender.list.get(0);
 			assertThat(loggingEvent.getMessage()).isEqualTo(
 					"Could not parse the given text to the desired target type:{invalid json into " + TestClass.class);
 			assertThat(loggingEvent.getMarkerList()).contains(PII_MARKER);

--- a/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
@@ -16,25 +16,32 @@
 
 package org.springframework.ai.converter;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.ai.util.LoggingMarkers.PII_MARKER;
 
 /**
  * @author Sebastian Ullrich
@@ -45,8 +52,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 class BeanOutputConverterTest {
 
+	private ListAppender<ILoggingEvent> logAppender;
+
 	@Mock
 	private ObjectMapper objectMapperMock;
+
+	@BeforeEach
+	void beforeEach() {
+
+		var logger = (Logger) LoggerFactory.getLogger(BeanOutputConverter.class);
+
+		logAppender = new ListAppender<>();
+		logAppender.start();
+		logger.addAppender(logAppender);
+	}
 
 	@Test
 	void shouldHavePreConfiguredDefaultObjectMapper() {
@@ -133,6 +152,16 @@ class BeanOutputConverterTest {
 			var converter = new BeanOutputConverter<>(TestClass.class);
 			var testClass = converter.convert("{ \"someString\": \"some value\" }");
 			assertThat(testClass.getSomeString()).isEqualTo("some value");
+		}
+
+		@Test
+		void failToConvertInvalidJson() {
+			var converter = new BeanOutputConverter<>(TestClass.class);
+			assertThatThrownBy(() -> converter.convert("{invalid json")).hasCauseInstanceOf(JsonParseException.class);
+			final var loggingEvent = logAppender.list.getFirst();
+			assertThat(loggingEvent.getMessage()).isEqualTo(
+					"Could not parse the given text to the desired target type:{invalid json into " + TestClass.class);
+			assertThat(loggingEvent.getMarkerList()).contains(PII_MARKER);
 		}
 
 		@Test

--- a/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/converter/BeanOutputConverterTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.springframework.ai.util.LoggingMarkers.PII_MARKER;
+import static org.springframework.ai.util.LoggingMarkers.SENSITIVE_DATA_MARKER;
 
 /**
  * @author Sebastian Ullrich
@@ -160,9 +160,11 @@ class BeanOutputConverterTest {
 			assertThatThrownBy(() -> converter.convert("{invalid json")).hasCauseInstanceOf(JsonParseException.class);
 			assertThat(logAppender.list).hasSize(1);
 			final var loggingEvent = logAppender.list.get(0);
-			assertThat(loggingEvent.getMessage()).isEqualTo(
-					"Could not parse the given text to the desired target type:{invalid json into " + TestClass.class);
-			assertThat(loggingEvent.getMarkerList()).contains(PII_MARKER);
+			assertThat(loggingEvent.getFormattedMessage())
+				.isEqualTo("Could not parse the given text to the desired target type: \"{invalid json\" into "
+						+ TestClass.class);
+
+			assertThat(loggingEvent.getMarkerList()).contains(SENSITIVE_DATA_MARKER);
 		}
 
 		@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/contribution-guidelines.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/contribution-guidelines.adoc
@@ -30,6 +30,7 @@ you'll need to develop a low-level client API class. This often involves utilizi
 Ensure your client conforms to the link:https://docs.spring.io/spring-ai/reference/api/generic-model.html[Generic Model API].
 Use existing request and response classes if your model's inputs and outputs are supported.
 If not, create new classes for the Generic Model API and establish a new Java package.
+Be careful with logging Personally Identifiable Information (PII), mark it with https://github.com/spring-projects/spring-ai/tree/main/spring-ai-core/src/main/java/org/springframework/ai/util/LoggingMarkers.java[`PII_MARKER`] Slf4j marker.
 
 . *Implement Auto-Configuration and a Spring Boot Starter*: This step involves creating the
 necessary auto-configuration and Spring Boot Starter to easily instantiate the new model with


### PR DESCRIPTION
Introduce a utility class `LoggingMarkers` providing an SLF4J marker for tagging log entries with different data security classification, such as:
- SENSITIVE_DATA_MARKER
- RESTRICTED_DATA_MARKER
- REGULATED_DATA_MARKER
- PUBLIC_DATA_MARKER

Update `BeanOutputConverter` to use the `SENSITIVE_DATA_MARKER` in error logs for invalid JSON conversions. Enhance tests to verify SENSITIVE_DATA_MARKER marker usage in logging.

Updated Maven configurations to dynamically reference the Java version using `${java.version}`. Added Kotlin compiler settings, including `jvmTarget` alignment with Java version and enabling `javaParameters` to ensure consistency and better compatibility across builds.