### PR TITLE
Update getting-started.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -93,7 +93,7 @@ Gradle::
 [source,groovy,indent=0,subs="verbatim,quotes"]
 ----
 dependencies {
-  implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+  implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-M5")
   // Replace the following with the starter dependencies of specific modules you wish to use
   implementation 'org.springframework.ai:spring-ai-openai'
 }


### PR DESCRIPTION
Fix to 1.0.0-M5 because 1.0.0-SNAPSHOT is missing and build with Gradle fails. Maven side was not changed because we did not have a Maven environment and could not verify it immediately. If the change to M5 does not cause any problems, I will add the changes accordingly.

If a non-M5 version is better, please point it out to us.
