### PR TITLE
Make vector store builders extensible

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStore.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +48,6 @@ import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetri
 import org.springframework.ai.util.JacksonUtils;
 import org.springframework.ai.vectorstore.observation.AbstractObservationVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
-import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
 import org.springframework.core.io.Resource;
 
 /**

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -40,8 +40,14 @@
 
 	<suppress files="AzureVectorStore.java" checks="FinalClass"/>
 	<suppress files="CassandraVectorStore.java" checks="FinalClass"/>
+	<suppress files="CoherenceVectorStore.java" checks="FinalClass"/>
+	<suppress files="CosmosDBVectorStore.java" checks="FinalClass"/>
+	<suppress files="GemFireVectorStore.java" checks="FinalClass"/>
 	<suppress files="MilvusVectorStore.java" checks="FinalClass"/>
 	<suppress files="HanaCloudVectorStore.java" checks="FinalClass"/>
+	<suppress files="MongoDBAtlasVectorStore.java" checks="FinalClass"/>
+	<suppress files="Neo4jVectorStore.java" checks="FinalClass"/>
+	<suppress files="OpenSearchVectorStore.java" checks="FinalClass"/>
 	<suppress files="PineconeVectorStore.java" checks="FinalClass"/>
 	<suppress files="TypesenseVectorStore.java" checks="FinalClass"/>
 	<suppress files="WeaviateVectorStore.java" checks="FinalClass"/>

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
@@ -385,7 +385,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 	 *
 	 * @since 1.0.0
 	 */
-	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final CosmosAsyncClient cosmosClient;
 

--- a/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/coherence/CoherenceVectorStore.java
+++ b/vector-stores/spring-ai-coherence-store/src/main/java/org/springframework/ai/vectorstore/coherence/CoherenceVectorStore.java
@@ -283,7 +283,7 @@ public class CoherenceVectorStore extends AbstractObservationVectorStore impleme
 	 *
 	 * @since 1.0.0
 	 */
-	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final Session session;
 

--- a/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
@@ -562,7 +562,7 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 	 *
 	 * @since 1.0.0
 	 */
-	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private String host = GemFireVectorStore.DEFAULT_HOST;
 

--- a/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
@@ -321,7 +321,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 		return new Builder(mongoTemplate, embeddingModel);
 	}
 
-	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final MongoTemplate mongoTemplate;
 

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
@@ -369,7 +369,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		return new Builder(driver, embeddingModel);
 	}
 
-	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final Driver driver;
 

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -368,7 +368,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 	/**
 	 * Builder class for creating OpenSearchVectorStore instances.
 	 */
-	public static final class Builder extends AbstractVectorStoreBuilder<Builder> {
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
 
 		private final OpenSearchClient openSearchClient;
 


### PR DESCRIPTION
 - The VectorStore builders shouldn't be final as they are meant to be extensible
 - Suppress the `FinalClass` checkstyle errors on VectorStore classes
