### PR TITLE
Remove the name field from ToolMessage

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -548,7 +548,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 					.forEach(response -> Assert.isTrue(response.id() != null, "ToolResponseMessage must have an id"));
 				return toolMessage.getResponses()
 					.stream()
-					.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
+					.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, null,
 							tr.id(), null, null, null))
 					.toList();
 			}


### PR DESCRIPTION
Modify the code because there is no name in ToolMessage in openai api specification.
- https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages