### PR TITLE
feat(minimax): add support for MiniMax-Text-01 model

### DIFF
--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -219,6 +219,7 @@ public class MiniMaxApi {
 	 * <a href="https://www.minimaxi.com/document/algorithm-concept">MiniMax Model</a>.
 	 */
 	public enum ChatModel implements ChatModelDescription {
+		MINIMAX_TEXT_01("minimax-text-01"),
 		ABAB_7_Chat_Preview("abab7-chat-preview"),
 		ABAB_6_5_Chat("abab6.5-chat"),
 		ABAB_6_5_S_Chat("abab6.5s-chat"),


### PR DESCRIPTION
This commit adds support for the MiniMax-Text-01 model, which is recommended for general scenarios due to its longer context window. [MiniMax Chat Completion documentation](https://intl.minimaxi.com/document/ChatCompletion%20v2?key=66701d281d57f38758d581d0)

The new model is added to the ChatModel enum as MiniMax_Text_01.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
