### PR TITLE
Add filter-based deletion to VectorStore implementations, Chroma, Elastic, PGVector

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/observation/AbstractObservationVectorStore.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/observation/AbstractObservationVectorStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.ai.vectorstore.observation;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.micrometer.observation.ObservationRegistry;
 
@@ -27,6 +28,7 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.lang.Nullable;
 
 /**
@@ -100,6 +102,18 @@ public abstract class AbstractObservationVectorStore implements VectorStore {
 	}
 
 	@Override
+	public void delete(Filter.Expression filterExpression) {
+		VectorStoreObservationContext observationContext = this
+			.createObservationContextBuilder(VectorStoreObservationContext.Operation.DELETE.value())
+			.build();
+
+		VectorStoreObservationDocumentation.AI_VECTOR_STORE
+			.observation(this.customObservationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
+					this.observationRegistry)
+			.observe(() -> this.doDelete(filterExpression));
+	}
+
+	@Override
 	@Nullable
 	public List<Document> similaritySearch(SearchRequest request) {
 
@@ -130,6 +144,19 @@ public abstract class AbstractObservationVectorStore implements VectorStore {
 	 * @return true if the documents were successfully deleted
 	 */
 	public abstract Optional<Boolean> doDelete(List<String> idList);
+
+	/**
+	 * Template method for concrete implementations to provide filter-based deletion
+	 * logic.
+	 * @param filterExpression Filter expression to identify documents to delete
+	 */
+	@Nullable
+	protected void doDelete(Filter.Expression filterExpression) {
+		// this is temporary until we implement this method in all concrete vector stores,
+		// at which point
+		// this method will become an abstract method.
+		throw new UnsupportedOperationException();
+	}
 
 	/**
 	 * Perform the actual similarity search operation.

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaApi.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaApi.java
@@ -338,7 +338,7 @@ public class ChromaApi {
 	 */
 	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public record DeleteEmbeddingsRequest(// @formatter:off
-		@JsonProperty("ids") List<String> ids,
+		@Nullable @JsonProperty("ids") List<String> ids,
 		@Nullable @JsonProperty("where") Map<String, Object> where) { // @formatter:on
 
 		public DeleteEmbeddingsRequest(List<String> ids) {

--- a/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,11 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.ExpressionType;
+import org.springframework.ai.vectorstore.filter.Filter.Key;
+import org.springframework.ai.vectorstore.filter.Filter.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -140,6 +145,90 @@ class ElasticsearchVectorStoreIT {
 				.indices()
 				.get("spring-ai-document-index");
 			assertThat(stats.total().docs().count()).isEqualTo(0L);
+		});
+	}
+
+	@Test
+	public void deleteDocumentsByFilterExpressionTest() {
+		getContextRunner().run(context -> {
+			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_cosine",
+					ElasticsearchVectorStore.class);
+			ElasticsearchClient elasticsearchClient = context.getBean(ElasticsearchClient.class);
+
+			IndicesStats stats = elasticsearchClient.indices()
+				.stats(s -> s.index("spring-ai-document-index"))
+				.indices()
+				.get("spring-ai-document-index");
+
+			assertThat(stats.total().docs().count()).isEqualTo(0L);
+
+			// Add documents with metadata
+			List<Document> documents = List.of(
+					new Document("1", getText("classpath:/test/data/spring.ai.txt"), Map.of("meta1", "meta1")),
+					new Document("2", getText("classpath:/test/data/time.shelter.txt"), Map.of()),
+					new Document("3", getText("classpath:/test/data/great.depression.txt"), Map.of("meta2", "meta2")));
+
+			vectorStore.add(documents);
+			elasticsearchClient.indices().refresh();
+
+			stats = elasticsearchClient.indices()
+				.stats(s -> s.index("spring-ai-document-index"))
+				.indices()
+				.get("spring-ai-document-index");
+			assertThat(stats.total().docs().count()).isEqualTo(3L);
+
+			// Delete documents with meta1 using filter expression
+			Expression filterExpression = new Expression(ExpressionType.EQ, new Key("meta1"), new Value("meta1"));
+
+			vectorStore.delete(filterExpression);
+			elasticsearchClient.indices().refresh();
+
+			stats = elasticsearchClient.indices()
+				.stats(s -> s.index("spring-ai-document-index"))
+				.indices()
+				.get("spring-ai-document-index");
+			assertThat(stats.total().docs().count()).isEqualTo(2L);
+
+			// Clean up remaining documents
+			vectorStore.delete(List.of("2", "3"));
+			elasticsearchClient.indices().refresh();
+
+			stats = elasticsearchClient.indices()
+				.stats(s -> s.index("spring-ai-document-index"))
+				.indices()
+				.get("spring-ai-document-index");
+			assertThat(stats.total().docs().count()).isEqualTo(0L);
+		});
+	}
+
+	@Test
+	public void deleteWithStringFilterExpressionTest() {
+		getContextRunner().run(context -> {
+			ElasticsearchVectorStore vectorStore = context.getBean("vectorStore_cosine",
+					ElasticsearchVectorStore.class);
+			ElasticsearchClient elasticsearchClient = context.getBean(ElasticsearchClient.class);
+
+			List<Document> documents = List.of(
+					new Document("1", getText("classpath:/test/data/spring.ai.txt"), Map.of("meta1", "meta1")),
+					new Document("2", getText("classpath:/test/data/time.shelter.txt"), Map.of()),
+					new Document("3", getText("classpath:/test/data/great.depression.txt"), Map.of("meta2", "meta2")));
+
+			vectorStore.add(documents);
+			elasticsearchClient.indices().refresh();
+
+			// Delete documents with meta1 using string filter
+			vectorStore.delete("meta1 == 'meta1'");
+			elasticsearchClient.indices().refresh();
+
+			IndicesStats stats = elasticsearchClient.indices()
+				.stats(s -> s.index("spring-ai-document-index"))
+				.indices()
+				.get("spring-ai-document-index");
+			assertThat(stats.total().docs().count()).isEqualTo(2L);
+
+			// Clean up
+			vectorStore.delete(List.of("2", "3"));
+			elasticsearchClient.indices().refresh();
 		});
 	}
 


### PR DESCRIPTION
Add the ability to delete documents from vector stores using filter expressions. This allows for more flexible document deletion based on metadata criteria rather than just document IDs.

Key changes:
- Add delete(Filter.Expression) method to VectorStore interface
- Implement filter-based deletion in ChromaVectorStore using where clauses
- Implement filter-based deletion in ElasticsearchVectorStore using deleteByQuery
- Implement filter-based deletion in PgVectorStore using jsonpath filters
- Add integration tests for filter-based deletion across all implementations
- Add default implementation in AbstractObservationVectorStore

This extends the VectorStore API to support more sophisticated document management capabilities while maintaining consistent behavior across different backend implementations.

