### PR TITLE
Refactor Amazon Bedrock builder methods

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModel.java
@@ -54,7 +54,7 @@ public class BedrockTitanChatModel implements ChatModel, StreamingChatModel {
 	private final BedrockTitanChatOptions defaultOptions;
 
 	public BedrockTitanChatModel(TitanChatBedrockApi chatApi) {
-		this(chatApi, BedrockTitanChatOptions.builder().withTemperature(0.8).build());
+		this(chatApi, BedrockTitanChatOptions.builder().temperature(0.8).build());
 	}
 
 	public BedrockTitanChatModel(TitanChatBedrockApi chatApi, BedrockTitanChatOptions defaultOptions) {

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanChatOptions.java
@@ -62,10 +62,10 @@ public class BedrockTitanChatOptions implements ChatOptions {
 	}
 
 	public static BedrockTitanChatOptions fromOptions(BedrockTitanChatOptions fromOptions) {
-		return builder().withTemperature(fromOptions.getTemperature())
-			.withTopP(fromOptions.getTopP())
-			.withMaxTokenCount(fromOptions.getMaxTokenCount())
-			.withStopSequences(fromOptions.getStopSequences())
+		return builder().temperature(fromOptions.getTemperature())
+			.topP(fromOptions.getTopP())
+			.maxTokenCount(fromOptions.getMaxTokenCount())
+			.stopSequences(fromOptions.getStopSequences())
 			.build();
 	}
 
@@ -148,21 +148,57 @@ public class BedrockTitanChatOptions implements ChatOptions {
 
 		private BedrockTitanChatOptions options = new BedrockTitanChatOptions();
 
+		public Builder temperature(Double temperature) {
+			this.options.temperature = temperature;
+			return this;
+		}
+
+		public Builder topP(Double topP) {
+			this.options.topP = topP;
+			return this;
+		}
+
+		public Builder maxTokenCount(Integer maxTokenCount) {
+			this.options.maxTokenCount = maxTokenCount;
+			return this;
+		}
+
+		public Builder stopSequences(List<String> stopSequences) {
+			this.options.stopSequences = stopSequences;
+			return this;
+		}
+
+		/**
+		 * @deprecated see {@link #temperature(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M6")
 		public Builder withTemperature(Double temperature) {
 			this.options.temperature = temperature;
 			return this;
 		}
 
+		/**
+		 * @deprecated see {@link #topP(Double)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M6")
 		public Builder withTopP(Double topP) {
 			this.options.topP = topP;
 			return this;
 		}
 
+		/**
+		 * @deprecated see {@link #maxTokenCount(Integer)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M6")
 		public Builder withMaxTokenCount(Integer maxTokenCount) {
 			this.options.maxTokenCount = maxTokenCount;
 			return this;
 		}
 
+		/**
+		 * @deprecated see {@link #stopSequences(List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M6")
 		public Builder withStopSequences(List<String> stopSequences) {
 			this.options.stopSequences = stopSequences;
 			return this;

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.bedrock.titan;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -66,6 +68,17 @@ public class BedrockTitanEmbeddingOptions implements EmbeddingOptions {
 
 		private BedrockTitanEmbeddingOptions options = new BedrockTitanEmbeddingOptions();
 
+		public Builder inputType(InputType inputType) {
+			Assert.notNull(inputType, "input type can not be null.");
+
+			this.options.setInputType(inputType);
+			return this;
+		}
+
+		/**
+		 * @deprecated see {@link #inputType(InputType)} (List)} instead.
+		 */
+		@Deprecated(forRemoval = true, since = "1.0.0-M6")
 		public Builder withInputType(InputType inputType) {
 			Assert.notNull(inputType, "input type can not be null.");
 

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/jurassic2/BedrockAi21Jurassic2ChatModelIT.java
@@ -171,7 +171,7 @@ class BedrockAi21Jurassic2ChatModelIT {
 					BedrockAi21Jurassic2ChatOptions.builder()
 						.temperature(0.5)
 						.maxTokens(500)
-						// .withTopP(0.9)
+						// .topP(0.9)
 						.build());
 		}
 

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModelCreateRequestTests.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanChatModelCreateRequestTests.java
@@ -44,10 +44,10 @@ public class BedrockTitanChatModelCreateRequestTests {
 
 		var model = new BedrockTitanChatModel(this.api,
 				BedrockTitanChatOptions.builder()
-					.withTemperature(66.6)
-					.withTopP(0.66)
-					.withMaxTokenCount(666)
-					.withStopSequences(List.of("stop1", "stop2"))
+					.temperature(66.6)
+					.topP(0.66)
+					.maxTokenCount(666)
+					.stopSequences(List.of("stop1", "stop2"))
 					.build());
 
 		var request = model.createRequest(new Prompt("Test message content"));
@@ -60,10 +60,10 @@ public class BedrockTitanChatModelCreateRequestTests {
 
 		request = model.createRequest(new Prompt("Test message content",
 				BedrockTitanChatOptions.builder()
-					.withTemperature(99.9)
-					.withTopP(0.99)
-					.withMaxTokenCount(999)
-					.withStopSequences(List.of("stop3", "stop4"))
+					.temperature(99.9)
+					.topP(0.99)
+					.maxTokenCount(999)
+					.stopSequences(List.of("stop3", "stop4"))
 					.build()
 
 		));

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModelIT.java
@@ -51,7 +51,7 @@ class BedrockTitanEmbeddingModelIT {
 	void singleEmbedding() {
 		assertThat(this.embeddingModel).isNotNull();
 		EmbeddingResponse embeddingResponse = this.embeddingModel.call(new EmbeddingRequest(List.of("Hello World"),
-				BedrockTitanEmbeddingOptions.builder().withInputType(InputType.TEXT).build()));
+				BedrockTitanEmbeddingOptions.builder().inputType(InputType.TEXT).build()));
 		assertThat(embeddingResponse.getResults()).hasSize(1);
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);
@@ -65,7 +65,7 @@ class BedrockTitanEmbeddingModelIT {
 
 		EmbeddingResponse embeddingResponse = this.embeddingModel
 			.call(new EmbeddingRequest(List.of(Base64.getEncoder().encodeToString(image)),
-					BedrockTitanEmbeddingOptions.builder().withInputType(InputType.IMAGE).build()));
+					BedrockTitanEmbeddingOptions.builder().inputType(InputType.IMAGE).build()));
 		assertThat(embeddingResponse.getResults()).hasSize(1);
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/anthropic3/BedrockAnthropic3ChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/anthropic3/BedrockAnthropic3ChatProperties.java
@@ -51,7 +51,7 @@ public class BedrockAnthropic3ChatProperties {
 		.maxTokens(300)
 		.topK(10)
 		.anthropicVersion(Anthropic3ChatBedrockApi.DEFAULT_ANTHROPIC_VERSION)
-		// .withStopSequences(List.of("\n\nHuman:"))
+		// .stopSequences(List.of("\n\nHuman:"))
 		.build();
 
 	public boolean isEnabled() {

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanChatProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/bedrock/titan/BedrockTitanChatProperties.java
@@ -43,7 +43,7 @@ public class BedrockTitanChatProperties {
 	private String model = TitanChatModel.TITAN_TEXT_EXPRESS_V1.id();
 
 	@NestedConfigurationProperty
-	private BedrockTitanChatOptions options = BedrockTitanChatOptions.builder().withTemperature(0.7).build();
+	private BedrockTitanChatOptions options = BedrockTitanChatOptions.builder().temperature(0.7).build();
 
 	public boolean isEnabled() {
 		return this.enabled;


### PR DESCRIPTION
 - Rename builder methods by removing `with` prefix
 - Deprecate the existing methods and mark them for removal post M6