### PR TITLE
Add filter-based deletion to Neo4j and OpenSearch vector stores

### DIFF
--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
@@ -25,17 +25,18 @@ import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentMetadata;
-import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
-import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
 import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
 import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.neo4j.filter.Neo4jVectorFilterExpressionConverter;
 import org.springframework.ai.vectorstore.observation.AbstractObservationVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
@@ -132,6 +133,8 @@ import org.springframework.util.StringUtils;
  * @since 1.0.0
  */
 public class Neo4jVectorStore extends AbstractObservationVectorStore implements InitializingBean {
+
+	private static final Logger logger = LoggerFactory.getLogger(Neo4jVectorStore.class);
 
 	public static final int DEFAULT_EMBEDDING_DIMENSION = 1536;
 
@@ -232,6 +235,31 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 						Map.of("ids", idList, "transactionSize", DEFAULT_TRANSACTION_SIZE))
 				.consume();
 			return Optional.of(idList.size() == summary.counters().nodesDeleted());
+		}
+	}
+
+	@Override
+	protected void doDelete(Filter.Expression filterExpression) {
+		Assert.notNull(filterExpression, "Filter expression must not be null");
+
+		try (var session = this.driver.session(this.sessionConfig)) {
+			String whereClause = this.filterExpressionConverter.convertExpression(filterExpression);
+
+			// Create Cypher query with transaction batching
+			String cypher = """
+            MATCH (node:%s) WHERE %s
+            CALL { WITH node DETACH DELETE node } IN TRANSACTIONS OF $transactionSize ROWS
+            """.formatted(this.label, whereClause);
+
+			var summary = session.run(cypher,
+							Map.of("transactionSize", DEFAULT_TRANSACTION_SIZE))
+					.consume();
+
+			logger.debug("Deleted {} nodes matching filter expression", summary.counters().nodesDeleted());
+		}
+		catch (Exception e) {
+			logger.error("Failed to delete nodes by filter: {}", e.getMessage(), e);
+			throw new IllegalStateException("Failed to delete nodes by filter", e);
 		}
 	}
 

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
@@ -247,13 +247,11 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 
 			// Create Cypher query with transaction batching
 			String cypher = """
-            MATCH (node:%s) WHERE %s
-            CALL { WITH node DETACH DELETE node } IN TRANSACTIONS OF $transactionSize ROWS
-            """.formatted(this.label, whereClause);
+					MATCH (node:%s) WHERE %s
+					CALL { WITH node DETACH DELETE node } IN TRANSACTIONS OF $transactionSize ROWS
+					""".formatted(this.label, whereClause);
 
-			var summary = session.run(cypher,
-							Map.of("transactionSize", DEFAULT_TRANSACTION_SIZE))
-					.consume();
+			var summary = session.run(cypher, Map.of("transactionSize", DEFAULT_TRANSACTION_SIZE)).consume();
 
 			logger.debug("Deleted {} nodes matching filter expression", summary.counters().nodesDeleted());
 		}

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStoreIT.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,7 @@ import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -53,6 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Michael Simons
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Soby Chacko
  */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -299,6 +302,110 @@ class Neo4jVectorStoreIT {
 			.get(0)
 			.asBoolean()) // get returned result
 			.isTrue());
+	}
+
+	@Test
+	void deleteByFilter() {
+		this.contextRunner.run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			var bgDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2020));
+			var nlDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "NL", "year", 2021));
+			var bgDocument2 = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2023));
+
+			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+			SearchRequest searchRequest = SearchRequest.builder()
+					.query("The World")
+					.topK(5)
+					.similarityThresholdAll()
+					.build();
+
+			List<Document> results = vectorStore.similaritySearch(searchRequest);
+			assertThat(results).hasSize(3);
+
+			Filter.Expression filterExpression = new Filter.Expression(Filter.ExpressionType.EQ,
+					new Filter.Key("country"), new Filter.Value("BG"));
+
+			vectorStore.delete(filterExpression);
+
+			results = vectorStore.similaritySearch(searchRequest);
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getMetadata()).containsEntry("country", "NL");
+		});
+	}
+
+	@Test
+	void deleteWithStringFilterExpression() {
+		this.contextRunner.run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			var bgDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2020));
+			var nlDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "NL", "year", 2021));
+			var bgDocument2 = new Document("The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2023));
+
+			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+			var searchRequest = SearchRequest.builder()
+					.query("The World")
+					.topK(5)
+					.similarityThresholdAll()
+					.build();
+
+			List<Document> results = vectorStore.similaritySearch(searchRequest);
+			assertThat(results).hasSize(3);
+
+			vectorStore.delete("country == 'BG'");
+
+			results = vectorStore.similaritySearch(searchRequest);
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getMetadata()).containsEntry("country", "NL");
+		});
+	}
+
+	@Test
+	void deleteWithComplexFilterExpression() {
+		this.contextRunner.run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			var doc1 = new Document("Content 1", Map.of("type", "A", "priority", 1L));
+			var doc2 = new Document("Content 2", Map.of("type", "A", "priority", 2L));
+			var doc3 = new Document("Content 3", Map.of("type", "B", "priority", 1L));
+
+			vectorStore.add(List.of(doc1, doc2, doc3));
+
+			// Complex filter expression: (type == 'A' AND priority > 1)
+			Filter.Expression priorityFilter = new Filter.Expression(Filter.ExpressionType.GT,
+					new Filter.Key("priority"), new Filter.Value(1));
+			Filter.Expression typeFilter = new Filter.Expression(Filter.ExpressionType.EQ,
+					new Filter.Key("type"), new Filter.Value("A"));
+			Filter.Expression complexFilter = new Filter.Expression(Filter.ExpressionType.AND,
+					typeFilter, priorityFilter);
+
+			vectorStore.delete(complexFilter);
+
+			var results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("Content")
+					.topK(5)
+					.similarityThresholdAll()
+					.build());
+
+			assertThat(results).hasSize(2);
+			assertThat(results.stream()
+					.map(doc -> doc.getMetadata().get("type"))
+					.collect(Collectors.toList()))
+					.containsExactlyInAnyOrder("A", "B");
+			assertThat(results.stream()
+					.map(doc -> doc.getMetadata().get("priority"))
+					.collect(Collectors.toList()))
+					.containsExactlyInAnyOrder(1L, 1L);
+		});
 	}
 
 	@SpringBootConfiguration

--- a/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStoreIT.java
+++ b/vector-stores/spring-ai-neo4j-store/src/test/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStoreIT.java
@@ -319,10 +319,10 @@ class Neo4jVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			SearchRequest searchRequest = SearchRequest.builder()
-					.query("The World")
-					.topK(5)
-					.similarityThresholdAll()
-					.build();
+				.query("The World")
+				.topK(5)
+				.similarityThresholdAll()
+				.build();
 
 			List<Document> results = vectorStore.similaritySearch(searchRequest);
 			assertThat(results).hasSize(3);
@@ -352,11 +352,7 @@ class Neo4jVectorStoreIT {
 
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
-			var searchRequest = SearchRequest.builder()
-					.query("The World")
-					.topK(5)
-					.similarityThresholdAll()
-					.build();
+			var searchRequest = SearchRequest.builder().query("The World").topK(5).similarityThresholdAll().build();
 
 			List<Document> results = vectorStore.similaritySearch(searchRequest);
 			assertThat(results).hasSize(3);
@@ -383,28 +379,21 @@ class Neo4jVectorStoreIT {
 			// Complex filter expression: (type == 'A' AND priority > 1)
 			Filter.Expression priorityFilter = new Filter.Expression(Filter.ExpressionType.GT,
 					new Filter.Key("priority"), new Filter.Value(1));
-			Filter.Expression typeFilter = new Filter.Expression(Filter.ExpressionType.EQ,
-					new Filter.Key("type"), new Filter.Value("A"));
-			Filter.Expression complexFilter = new Filter.Expression(Filter.ExpressionType.AND,
-					typeFilter, priorityFilter);
+			Filter.Expression typeFilter = new Filter.Expression(Filter.ExpressionType.EQ, new Filter.Key("type"),
+					new Filter.Value("A"));
+			Filter.Expression complexFilter = new Filter.Expression(Filter.ExpressionType.AND, typeFilter,
+					priorityFilter);
 
 			vectorStore.delete(complexFilter);
 
-			var results = vectorStore.similaritySearch(SearchRequest.builder()
-					.query("Content")
-					.topK(5)
-					.similarityThresholdAll()
-					.build());
+			var results = vectorStore
+				.similaritySearch(SearchRequest.builder().query("Content").topK(5).similarityThresholdAll().build());
 
 			assertThat(results).hasSize(2);
-			assertThat(results.stream()
-					.map(doc -> doc.getMetadata().get("type"))
-					.collect(Collectors.toList()))
-					.containsExactlyInAnyOrder("A", "B");
-			assertThat(results.stream()
-					.map(doc -> doc.getMetadata().get("priority"))
-					.collect(Collectors.toList()))
-					.containsExactlyInAnyOrder(1L, 1L);
+			assertThat(results.stream().map(doc -> doc.getMetadata().get("type")).collect(Collectors.toList()))
+				.containsExactlyInAnyOrder("A", "B");
+			assertThat(results.stream().map(doc -> doc.getMetadata().get("priority")).collect(Collectors.toList()))
+				.containsExactlyInAnyOrder(1L, 1L);
 		});
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -242,20 +242,16 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 			String filterStr = this.filterExpressionConverter.convertExpression(filterExpression);
 
 			// Create delete by query request
-			DeleteByQueryRequest request = new DeleteByQueryRequest.Builder()
-					.index(this.index)
-					.query(q -> q
-							.queryString(qs -> qs
-									.query(filterStr)
-							))
-					.build();
+			DeleteByQueryRequest request = new DeleteByQueryRequest.Builder().index(this.index)
+				.query(q -> q.queryString(qs -> qs.query(filterStr)))
+				.build();
 
-				DeleteByQueryResponse response = this.openSearchClient.deleteByQuery(request);
-				logger.debug("Deleted {} documents matching filter expression", response.deleted());
+			DeleteByQueryResponse response = this.openSearchClient.deleteByQuery(request);
+			logger.debug("Deleted {} documents matching filter expression", response.deleted());
 
-				if (!response.failures().isEmpty()) {
-					throw new IllegalStateException("Failed to delete some documents: " + response.failures());
-				}
+			if (!response.failures().isEmpty()) {
+				throw new IllegalStateException("Failed to delete some documents: " + response.failures());
+			}
 		}
 		catch (Exception e) {
 			logger.error("Failed to delete documents by filter: {}", e.getMessage(), e);

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -32,17 +32,19 @@ import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.CreateIndexResponse;
 import org.opensearch.client.transport.endpoints.BooleanResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentMetadata;
-import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
-import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
 import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
@@ -139,6 +141,8 @@ import org.springframework.util.Assert;
  */
 public class OpenSearchVectorStore extends AbstractObservationVectorStore implements InitializingBean {
 
+	private static final Logger logger = LoggerFactory.getLogger(OpenSearchVectorStore.class);
+
 	public static final String COSINE_SIMILARITY_FUNCTION = "cosinesimil";
 
 	public static final String DEFAULT_INDEX_NAME = "spring-ai-document-index";
@@ -227,6 +231,35 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	protected void doDelete(Filter.Expression filterExpression) {
+		Assert.notNull(filterExpression, "Filter expression must not be null");
+
+		try {
+			String filterStr = this.filterExpressionConverter.convertExpression(filterExpression);
+
+			// Create delete by query request
+			DeleteByQueryRequest request = new DeleteByQueryRequest.Builder()
+					.index(this.index)
+					.query(q -> q
+							.queryString(qs -> qs
+									.query(filterStr)
+							))
+					.build();
+
+				DeleteByQueryResponse response = this.openSearchClient.deleteByQuery(request);
+				logger.debug("Deleted {} documents matching filter expression", response.deleted());
+
+				if (!response.failures().isEmpty()) {
+					throw new IllegalStateException("Failed to delete some documents: " + response.failures());
+				}
+		}
+		catch (Exception e) {
+			logger.error("Failed to delete documents by filter: {}", e.getMessage(), e);
+			throw new IllegalStateException("Failed to delete documents by filter", e);
 		}
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStoreIT.java
@@ -432,8 +432,8 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
-							hasSize(3));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+						hasSize(3));
 
 			Filter.Expression filterExpression = new Filter.Expression(Filter.ExpressionType.EQ,
 					new Filter.Key("country"), new Filter.Value("BG"));
@@ -441,14 +441,11 @@ class OpenSearchVectorStoreIT {
 			vectorStore.delete(filterExpression);
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
-							hasSize(1));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+						hasSize(1));
 
-			List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
-					.query("The World")
-					.topK(5)
-					.similarityThresholdAll()
-					.build());
+			List<Document> results = vectorStore
+				.similaritySearch(SearchRequest.builder().query("The World").topK(5).similarityThresholdAll().build());
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getMetadata()).containsEntry("country", "NL");
@@ -470,20 +467,17 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
-							hasSize(3));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+						hasSize(3));
 
 			vectorStore.delete("country == 'BG'");
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
-							hasSize(1));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+						hasSize(1));
 
-			List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
-					.query("The World")
-					.topK(5)
-					.similarityThresholdAll()
-					.build());
+			List<Document> results = vectorStore
+				.similaritySearch(SearchRequest.builder().query("The World").topK(5).similarityThresholdAll().build());
 
 			assertThat(results).hasSize(1);
 			assertThat(results.get(0).getMetadata()).containsEntry("country", "NL");
@@ -502,38 +496,31 @@ class OpenSearchVectorStoreIT {
 			vectorStore.add(List.of(doc1, doc2, doc3));
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("Content").topK(5).build()),
-							hasSize(3));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("Content").topK(5).build()),
+						hasSize(3));
 
 			// Complex filter expression: (type == 'A' AND priority > 1)
 			Filter.Expression priorityFilter = new Filter.Expression(Filter.ExpressionType.GT,
 					new Filter.Key("priority"), new Filter.Value(1));
-			Filter.Expression typeFilter = new Filter.Expression(Filter.ExpressionType.EQ,
-					new Filter.Key("type"), new Filter.Value("A"));
-			Filter.Expression complexFilter = new Filter.Expression(Filter.ExpressionType.AND,
-					typeFilter, priorityFilter);
+			Filter.Expression typeFilter = new Filter.Expression(Filter.ExpressionType.EQ, new Filter.Key("type"),
+					new Filter.Value("A"));
+			Filter.Expression complexFilter = new Filter.Expression(Filter.ExpressionType.AND, typeFilter,
+					priorityFilter);
 
 			vectorStore.delete(complexFilter);
 
 			Awaitility.await()
-					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("Content").topK(5).build()),
-							hasSize(2));
+				.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("Content").topK(5).build()),
+						hasSize(2));
 
-			var results = vectorStore.similaritySearch(SearchRequest.builder()
-					.query("Content")
-					.topK(5)
-					.similarityThresholdAll()
-					.build());
+			var results = vectorStore
+				.similaritySearch(SearchRequest.builder().query("Content").topK(5).similarityThresholdAll().build());
 
 			assertThat(results).hasSize(2);
-			assertThat(results.stream()
-					.map(doc -> doc.getMetadata().get("type"))
-					.collect(Collectors.toList()))
-					.containsExactlyInAnyOrder("A", "B");
-			assertThat(results.stream()
-					.map(doc -> doc.getMetadata().get("priority"))
-					.collect(Collectors.toList()))
-					.containsExactlyInAnyOrder(1, 1);
+			assertThat(results.stream().map(doc -> doc.getMetadata().get("type")).collect(Collectors.toList()))
+				.containsExactlyInAnyOrder("A", "B");
+			assertThat(results.stream().map(doc -> doc.getMetadata().get("priority")).collect(Collectors.toList()))
+				.containsExactlyInAnyOrder(1, 1);
 		});
 	}
 

--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStoreIT.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,16 @@ package org.springframework.ai.vectorstore.opensearch;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.hc.core5.http.HttpHost;
 import org.awaitility.Awaitility;
@@ -49,6 +52,7 @@ import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -410,6 +414,126 @@ class OpenSearchVectorStoreIT {
 
 			assertThat(resultInIndex2).hasSize(1);
 			assertThat(resultInIndex2.get(0).getId()).isEqualTo(docInIndex2.getId());
+		});
+	}
+
+	@Test
+	void deleteByFilter() {
+		getContextRunner().run(context -> {
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore", OpenSearchVectorStore.class);
+
+			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
+			var nlDocument = new Document("2", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "NL", "activationDate", new Date(2000)));
+			var bgDocument2 = new Document("3", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2023, "activationDate", new Date(3000)));
+
+			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+							hasSize(3));
+
+			Filter.Expression filterExpression = new Filter.Expression(Filter.ExpressionType.EQ,
+					new Filter.Key("country"), new Filter.Value("BG"));
+
+			vectorStore.delete(filterExpression);
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+							hasSize(1));
+
+			List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("The World")
+					.topK(5)
+					.similarityThresholdAll()
+					.build());
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getMetadata()).containsEntry("country", "NL");
+		});
+	}
+
+	@Test
+	void deleteWithStringFilterExpression() {
+		getContextRunner().run(context -> {
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore", OpenSearchVectorStore.class);
+
+			var bgDocument = new Document("1", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2020, "activationDate", new Date(1000)));
+			var nlDocument = new Document("2", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "NL", "activationDate", new Date(2000)));
+			var bgDocument2 = new Document("3", "The World is Big and Salvation Lurks Around the Corner",
+					Map.of("country", "BG", "year", 2023, "activationDate", new Date(3000)));
+
+			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+							hasSize(3));
+
+			vectorStore.delete("country == 'BG'");
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("The World").topK(5).build()),
+							hasSize(1));
+
+			List<Document> results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("The World")
+					.topK(5)
+					.similarityThresholdAll()
+					.build());
+
+			assertThat(results).hasSize(1);
+			assertThat(results.get(0).getMetadata()).containsEntry("country", "NL");
+		});
+	}
+
+	@Test
+	void deleteWithComplexFilterExpression() {
+		getContextRunner().run(context -> {
+			OpenSearchVectorStore vectorStore = context.getBean("vectorStore", OpenSearchVectorStore.class);
+
+			var doc1 = new Document("1", "Content 1", Map.of("type", "A", "priority", 1));
+			var doc2 = new Document("2", "Content 2", Map.of("type", "A", "priority", 2));
+			var doc3 = new Document("3", "Content 3", Map.of("type", "B", "priority", 1));
+
+			vectorStore.add(List.of(doc1, doc2, doc3));
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("Content").topK(5).build()),
+							hasSize(3));
+
+			// Complex filter expression: (type == 'A' AND priority > 1)
+			Filter.Expression priorityFilter = new Filter.Expression(Filter.ExpressionType.GT,
+					new Filter.Key("priority"), new Filter.Value(1));
+			Filter.Expression typeFilter = new Filter.Expression(Filter.ExpressionType.EQ,
+					new Filter.Key("type"), new Filter.Value("A"));
+			Filter.Expression complexFilter = new Filter.Expression(Filter.ExpressionType.AND,
+					typeFilter, priorityFilter);
+
+			vectorStore.delete(complexFilter);
+
+			Awaitility.await()
+					.until(() -> vectorStore.similaritySearch(SearchRequest.builder().query("Content").topK(5).build()),
+							hasSize(2));
+
+			var results = vectorStore.similaritySearch(SearchRequest.builder()
+					.query("Content")
+					.topK(5)
+					.similarityThresholdAll()
+					.build());
+
+			assertThat(results).hasSize(2);
+			assertThat(results.stream()
+					.map(doc -> doc.getMetadata().get("type"))
+					.collect(Collectors.toList()))
+					.containsExactlyInAnyOrder("A", "B");
+			assertThat(results.stream()
+					.map(doc -> doc.getMetadata().get("priority"))
+					.collect(Collectors.toList()))
+					.containsExactlyInAnyOrder(1, 1);
 		});
 	}
 


### PR DESCRIPTION
Add string-based filter deletion alongside the Filter.Expression-based deletion for Neo4j and OpenSearch vector stores, providing consistent deletion capabilities with other vector store implementations.

Key changes:
- Add delete(Filter.Expression) implementation for Neo4j store using Cypher queries
- Add delete(Filter.Expression) implementation for OpenSearch store using query_string
- Leverage existing filter expression converters for both stores
- Use Neo4j's transaction batching for efficient large-scale deletions
- Use OpenSearch's delete_by_query API for metadata-based deletion
- Add comprehensive integration tests for both stores covering:
  * Simple equality filters
  * String-based filter expressions
  * Complex filter expressions with multiple conditions

This maintains consistency with other vector store implementations while utilizing store-specific features for efficient metadata-based deletion.

