### PR TITLE
Add filter-based deletion to Oracle vector store

### DIFF
--- a/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
+++ b/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
@@ -39,14 +39,13 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentMetadata;
-import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingOptionsBuilder;
-import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.observation.conventions.VectorStoreProvider;
 import org.springframework.ai.observation.conventions.VectorStoreSimilarityMetric;
 import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
 import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionConverter;
 import org.springframework.ai.vectorstore.observation.AbstractObservationVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
@@ -309,6 +308,25 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 		}
 
 		return Optional.of(deleteCount == idList.size());
+	}
+
+	@Override
+	protected void doDelete(Filter.Expression filterExpression) {
+		Assert.notNull(filterExpression, "Filter expression must not be null");
+
+		try {
+			String jsonPath = this.filterExpressionConverter.convertExpression(filterExpression);
+			String sql = String.format("DELETE FROM %s WHERE JSON_EXISTS(metadata, '%s')", this.tableName, jsonPath);
+
+			logger.debug("Executing delete with filter: {}", sql);
+
+			int deletedCount = this.jdbcTemplate.update(sql);
+			logger.debug("Deleted {} documents matching filter expression", deletedCount);
+		}
+		catch (Exception e) {
+			logger.error("Failed to delete documents by filter: {}", e.getMessage(), e);
+			throw new IllegalStateException("Failed to delete documents by filter", e);
+		}
 	}
 
 	@Override

--- a/vector-stores/spring-ai-oracle-store/src/test/java/org/springframework/ai/vectorstore/oracle/OracleVectorStoreIT.java
+++ b/vector-stores/spring-ai-oracle-store/src/test/java/org/springframework/ai/vectorstore/oracle/OracleVectorStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
 import oracle.jdbc.pool.OracleDataSource;
 import org.junit.Assert;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -43,6 +45,7 @@ import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.transformers.TransformersEmbeddingModel;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
@@ -308,6 +311,110 @@ public class OracleVectorStoreIT {
 				Document resultDoc = results.get(0);
 				assertThat(resultDoc.getId()).isEqualTo(this.documents.get(1).getId());
 				assertThat(resultDoc.getScore()).isGreaterThanOrEqualTo(similarityThreshold);
+
+				dropTable(context, ((OracleVectorStore) vectorStore).getTableName());
+			});
+	}
+
+	@Test
+	void deleteByFilter() {
+		this.contextRunner
+			.withPropertyValues("test.spring.ai.vectorstore.oracle.distanceType=COSINE",
+					"test.spring.ai.vectorstore.oracle.searchAccuracy=" + OracleVectorStore.DEFAULT_SEARCH_ACCURACY)
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				var bgDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "BG", "year", 2020));
+				var nlDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "NL"));
+				var bgDocument2 = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "BG", "year", 2023));
+
+				vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+				Filter.Expression filterExpression = new Filter.Expression(Filter.ExpressionType.EQ,
+						new Filter.Key("country"), new Filter.Value("BG"));
+
+				vectorStore.delete(filterExpression);
+
+				List<Document> results = vectorStore.similaritySearch(
+						SearchRequest.builder().query("The World").topK(5).similarityThresholdAll().build());
+
+				assertThat(results).hasSize(1);
+				assertThat(results.get(0).getMetadata()).containsKey("country")
+					.hasEntrySatisfying("country",
+							value -> assertThat(value.toString().replace("\"", "")).isEqualTo("NL"));
+
+				dropTable(context, ((OracleVectorStore) vectorStore).getTableName());
+			});
+	}
+
+	@Test
+	void deleteWithStringFilterExpression() {
+		this.contextRunner
+			.withPropertyValues("test.spring.ai.vectorstore.oracle.distanceType=COSINE",
+					"test.spring.ai.vectorstore.oracle.searchAccuracy=" + OracleVectorStore.DEFAULT_SEARCH_ACCURACY)
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				var bgDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "BG", "year", 2020));
+				var nlDocument = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "NL"));
+				var bgDocument2 = new Document("The World is Big and Salvation Lurks Around the Corner",
+						Map.of("country", "BG", "year", 2023));
+
+				vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
+
+				vectorStore.delete("country == 'BG'");
+
+				List<Document> results = vectorStore.similaritySearch(
+						SearchRequest.builder().query("The World").topK(5).similarityThresholdAll().build());
+
+				assertThat(results).hasSize(1);
+				assertThat(results.get(0).getMetadata()).containsKey("country")
+					.hasEntrySatisfying("country",
+							value -> assertThat(value.toString().replace("\"", "")).isEqualTo("NL"));
+
+				dropTable(context, ((OracleVectorStore) vectorStore).getTableName());
+			});
+	}
+
+	@Test
+	void deleteWithComplexFilterExpression() {
+		this.contextRunner
+			.withPropertyValues("test.spring.ai.vectorstore.oracle.distanceType=COSINE",
+					"test.spring.ai.vectorstore.oracle.searchAccuracy=" + OracleVectorStore.DEFAULT_SEARCH_ACCURACY)
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				var doc1 = new Document("Content 1", Map.of("type", "A", "priority", 1));
+				var doc2 = new Document("Content 2", Map.of("type", "A", "priority", 2));
+				var doc3 = new Document("Content 3", Map.of("type", "B", "priority", 1));
+
+				vectorStore.add(List.of(doc1, doc2, doc3));
+
+				// Complex filter expression: (type == 'A' AND priority > 1)
+				Filter.Expression priorityFilter = new Filter.Expression(Filter.ExpressionType.GT,
+						new Filter.Key("priority"), new Filter.Value(1));
+				Filter.Expression typeFilter = new Filter.Expression(Filter.ExpressionType.EQ, new Filter.Key("type"),
+						new Filter.Value("A"));
+				Filter.Expression complexFilter = new Filter.Expression(Filter.ExpressionType.AND, typeFilter,
+						priorityFilter);
+
+				vectorStore.delete(complexFilter);
+
+				var results = vectorStore.similaritySearch(
+						SearchRequest.builder().query("Content").topK(5).similarityThresholdAll().build());
+
+				assertThat(results).hasSize(2);
+				assertThat(results.stream()
+					.map(doc -> doc.getMetadata().get("type").toString().replace("\"", ""))
+					.collect(Collectors.toList())).containsExactlyInAnyOrder("A", "B");
+				assertThat(results.stream()
+					.map(doc -> Integer.parseInt(doc.getMetadata().get("priority").toString()))
+					.collect(Collectors.toList())).containsExactlyInAnyOrder(1, 1);
 
 				dropTable(context, ((OracleVectorStore) vectorStore).getTableName());
 			});


### PR DESCRIPTION
Add string-based filter deletion alongside the Filter.Expression-based deletion for Oracle vector store, providing consistent deletion capabilities with other vector store implementations.

Key changes:
- Add delete(Filter.Expression) implementation using Oracle JSON_EXISTS
- Leverage existing SqlJsonPathFilterExpressionConverter for JSON path expressions
- Add comprehensive integration tests for filter deletion
- Support both simple and complex filter expressions
- Handle Oracle-specific JSON types in test assertions

This maintains consistency with other vector store implementations while utilizing Oracle's JSON path capabilities for efficient metadata-based deletion.
