### PR TITLE
Fix typo in deepseek model name in deepseek-chat.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
@@ -1,6 +1,6 @@
 = DeepSeek Chat
 
-https://www.deepseek.com/[DeepSeek AI] provides the open-source DeepSeek R3 model, renowned for its cutting-edge reasoning and problem-solving capabilities.
+https://www.deepseek.com/[DeepSeek AI] provides the open-source DeepSeek V3 model, renowned for its cutting-edge reasoning and problem-solving capabilities.
 
 Spring AI integrates with DeepSeek AI by reusing the existing xref::api/chat/openai-chat.adoc[OpenAI] client. To get started, you'll need to obtain a https://api-docs.deepseek.com/[DeepSeek API Key], configure the base URL, and select one of the supported models.
 


### PR DESCRIPTION
DeepSeek does not currently have an R3 model.
This appears to be a mislabeling of the V3 model.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
