### PR TITLE
Fix spell error and updated gemma model name

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
@@ -10,7 +10,7 @@ provided https://console.groq.com/docs/models[Groq models].
 image::spring-ai-groq-integration.jpg[w=800,align="center"]
 
 NOTE: The Groq API is not fully compatible with the OpenAI API. 
-Be aware for the following https://console.groq.com/docs/openai[compatability constrains].
+Be aware for the following https://console.groq.com/docs/openai[compatibility constrains].
 Additionally, currently Groq doesn't support multimodal messages.
 
 Check the https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/GroqWithOpenAiChatModelIT.java[GroqWithOpenAiChatModelIT.java] tests 
@@ -24,7 +24,7 @@ The Spring AI project defines a configuration property named `spring.ai.openai.a
 * Set the Groq URL. 
 You have to set the `spring.ai.openai.base-url` property to `https://api.groq.com/openai`.
 * Select a https://console.groq.com/docs/models[Groq Model].
-Use the `spring.ai.openai.chat.model=<model name>` property to set the Model.
+Use the `spring.ai.openai.chat.options.model=<model name>` property to set the Model.
 
 Exporting an environment variable is one way to set that configuration property:
 
@@ -115,7 +115,7 @@ The prefix `spring.ai.openai.chat` is the property prefix that lets you configur
 | spring.ai.openai.chat.enabled | Enable OpenAI chat model.  | true
 | spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://api.groq.com/openai` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
-| spring.ai.openai.chat.options.model | The avalable https://console.groq.com/docs/models[model] names are `llama3-8b-8192`, `llama3-70b-8192`, `mixtral-8x7b-32768`, `gemma-7b-it`. | -
+| spring.ai.openai.chat.options.model | The https://console.groq.com/docs/models[available model] names are `llama3-8b-8192`, `llama3-70b-8192`, `mixtral-8x7b-32768`, `gemma2-9b-it`. | -
 | spring.ai.openai.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8
 | spring.ai.openai.chat.options.frequencyPenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. | 0.0f
 | spring.ai.openai.chat.options.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -


### PR DESCRIPTION
The `chat.model` property snippet was missing correct `.options` hierarchy, fixed it. Also fixed couple of spell-errors.