### PR TITLE
Update to Spring Boot 3.4.2 for dependency management

### DIFF
--- a/models/spring-ai-ollama/pom.xml
+++ b/models/spring-ai-ollama/pom.xml
@@ -60,13 +60,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
 		<kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
 
 		<!-- production dependencies -->
-		<spring-boot.version>3.3.6</spring-boot.version>
+		<spring-boot.version>3.4.2</spring-boot.version>
 		<ST4.version>4.3.4</ST4.version>
 		<azure-open-ai-client.version>1.0.0-beta.13</azure-open-ai-client.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
@@ -207,7 +207,6 @@
 		<sap.hanadb.version>2.20.11</sap.hanadb.version>
 		<coherence.version>24.09</coherence.version>
 		<milvus.version>2.3.5</milvus.version>
-		<oracle.free.version>1.19.8</oracle.free.version>
 		<gemfire.testcontainers.version>2.3.0</gemfire.testcontainers.version>
 		<pinecone.version>0.8.0</pinecone.version>
 		<fastjson.version>2.0.46</fastjson.version>
@@ -223,40 +222,15 @@
 		<mariadb.version>3.5.1</mariadb.version>
 		<commonmark.version>0.22.0</commonmark.version>
 
-		<!-- also managed by boot bom -->
-		<oracle.version>23.4.0.24.05</oracle.version>
-		<postgresql.version>42.7.2</postgresql.version>
-		<cassandra.java-driver.version>4.18.1</cassandra.java-driver.version>
-		<elasticsearch-java.version>8.13.3</elasticsearch-java.version>
-		<spring-retry.version>2.0.9</spring-retry.version>
-		<jackson.version>2.16.1</jackson.version>
-		<!-- not sure if jsonSchema is also managed by boot bom -->
-		<jackson-module-jsonSchema.version>2.17.2</jackson-module-jsonSchema.version>
-		<!-- check on kotlin version as managed by boot bom -->
-		<kotlin.version>1.9.25</kotlin.version>
-
-
-		<!-- testing dependencies also managed by boot bom-->
-		<httpclient5.version>5.3.1</httpclient5.version>
-		<testcontainers.version>1.20.1</testcontainers.version>
-
 
 		<!-- testing dependencies -->
-		<testcontainers.opensearch.version>2.0.1</testcontainers.opensearch.version>
 		<okhttp3.version>4.12.0</okhttp3.version>
-
-		<!-- documentation dependencies -->
-		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>
-		<org.maven.antora-version>1.0.0-alpha.4</org.maven.antora-version>
-		<asciidoctorj-pdf.version>1.6.2</asciidoctorj-pdf.version>		<!-- FIXME build failure with
-		version 2.3.9 -->
-		<asciidoctorj-epub.version>1.5.1</asciidoctorj-epub.version>
-		<spring-asciidoctor-backends.version>0.0.6</spring-asciidoctor-backends.version>
 
 		<!-- MCP-->
 		<mcp.sdk.version>0.7.0-SNAPSHOT</mcp.sdk.version>
 
 		<!-- plugin versions -->
+		<antlr.version>4.13.1</antlr.version>
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
@@ -268,7 +242,6 @@
 		<asciidoctor-maven-plugin.version>2.2.3</asciidoctor-maven-plugin.version>
 		<maven-assembly-plugin.version>3.7.0</maven-assembly-plugin.version>
 		<maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
-		<!-- <maven-site-plugin.version>3.12.1</maven-site-plugin.version> -->
 		<maven-site-plugin.version>4.0.0-M13</maven-site-plugin.version>
 		<maven-project-info-reports-plugin.version>3.4.5</maven-project-info-reports-plugin.version>
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>

--- a/spring-ai-core/pom.xml
+++ b/spring-ai-core/pom.xml
@@ -36,16 +36,11 @@
 		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-		<antlr.version>4.13.1</antlr.version>
-	</properties>
-
 	<dependencies>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-jsonSchema</artifactId>
-			<version>${jackson-module-jsonSchema.version}</version>
 		</dependency>
 
 		<dependency>
@@ -128,26 +123,22 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-stdlib</artifactId>
-			<version>${kotlin.version}</version>
 			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-reflect</artifactId>
-			<version>${kotlin.version}</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -161,7 +152,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-kotlin</artifactId>
-			<version>${jackson.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-ai-docs/pom.xml
+++ b/spring-ai-docs/pom.xml
@@ -38,7 +38,6 @@
 			<plugin>
 				<groupId>org.antora</groupId>
 				<artifactId>antora-maven-plugin</artifactId>
-				<version>${org.maven.antora-version}</version>
 				<extensions>true</extensions>
 				<configuration>
 					<options>
@@ -61,7 +60,6 @@
 			<plugin>
 				<groupId>io.spring.maven.antora</groupId>
 				<artifactId>antora-component-version-maven-plugin</artifactId>
-				<version>${io.spring.maven.antora-version}</version>
 				<executions>
 					<execution>
 						<goals>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -55,6 +55,14 @@ All the Amazon Bedrock Chat models are removed except the Embedding models for C
 
 NOTE: Refer to xref:api/chat/bedrock-converse.adoc[Bedrock Converse] documentation for using the chat models.
 
+=== Changes to use Spring Boot 3.4.2 for dependency management
+
+Spring AI updates to use Spring Boot 3.4.2 for the dependency management. You can refer https://github.com/spring-projects/spring-boot/blob/v3.4.2/spring-boot-project/spring-boot-dependencies/build.gradle[here] for the dependencies which Spring Boot 3.4.2
+
+==== Required Actions
+
+* If you are upgrading to Spring Boot 3.4.2, please make sure to refer to https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes#upgrading-from-spring-boot-33[this] documentation for the changes required to configure the REST Client. Notably, if you don’t have an HTTP client library on the classpath, this will likely result in the use of `JdkClientHttpRequestFactory` where `SimpleClientHttpRequestFactory` would have been used previously. To switch to use `SimpleClientHttpRequestFactory`, you need to set `spring.http.client.factory=simple`.
+* If you are using a different version of Spring Boot (say Spring Boot 3.3.x) and need a specific version of a dependency, you can override it in your build configuration.
 
 
 == Upgrading to 1.0.0.M5

--- a/spring-ai-retry/pom.xml
+++ b/spring-ai-retry/pom.xml
@@ -50,7 +50,6 @@
 		<dependency>
 			<groupId>org.springframework.retry</groupId>
 			<artifactId>spring-retry</artifactId>
-			<version>${spring-retry.version}</version>
 		</dependency>
 		
 		<dependency>

--- a/spring-ai-spring-boot-autoconfigure/pom.xml
+++ b/spring-ai-spring-boot-autoconfigure/pom.xml
@@ -155,19 +155,16 @@
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc11</artifactId>
-			<version>${oracle.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ucp</artifactId>
-			<version>${oracle.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.ha</groupId>
 			<artifactId>simplefan</artifactId>
-			<version>${oracle.version}</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -197,7 +194,6 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>${postgresql.version}</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -211,7 +207,6 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
-			<version>${mariadb.version}</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -490,7 +485,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>oracle-free</artifactId>
-			<version>${oracle.free.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-ai-spring-boot-starters/spring-ai-starter-oracle-store/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-oracle-store/pom.xml
@@ -58,17 +58,14 @@
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc11</artifactId>
-			<version>${oracle.version}</version>
 		</dependency>
 			<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ucp</artifactId>
-			<version>${oracle.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.ha</groupId>
 			<artifactId>simplefan</artifactId>
-			<version>${oracle.version}</version>
 		</dependency>
     </dependencies>
 

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -187,7 +187,6 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>${postgresql.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-cassandra-store/pom.xml
+++ b/vector-stores/spring-ai-cassandra-store/pom.xml
@@ -51,7 +51,6 @@
 		<dependency>
 			<groupId>org.apache.cassandra</groupId>
 			<artifactId>java-driver-query-builder</artifactId>
-			<version>${cassandra.java-driver.version}</version>
 		</dependency>
 
 		<!-- TESTING -->

--- a/vector-stores/spring-ai-elasticsearch-store/pom.xml
+++ b/vector-stores/spring-ai-elasticsearch-store/pom.xml
@@ -53,7 +53,6 @@
 		<dependency>
 			<groupId>co.elastic.clients</groupId>
 			<artifactId>elasticsearch-java</artifactId>
-			<version>${elasticsearch-java.version}</version>
 		</dependency>
 
 		<!-- TESTING -->

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
@@ -263,9 +263,9 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 			SearchResponse<Document> res = this.elasticsearchClient.search(sr -> sr.index(this.options.getIndexName())
 				.knn(knn -> knn.queryVector(EmbeddingUtils.toList(vectors))
 					.similarity(finalThreshold)
-					.k((long) searchRequest.getTopK())
+					.k(searchRequest.getTopK())
 					.field("embedding")
-					.numCandidates((long) (1.5 * searchRequest.getTopK()))
+					.numCandidates((int) (1.5 * searchRequest.getTopK()))
 					.filter(fl -> fl
 						.queryString(qs -> qs.query(getElasticsearchQueryString(searchRequest.getFilterExpression())))))
 				.size(searchRequest.getTopK()), Document.class);

--- a/vector-stores/spring-ai-opensearch-store/pom.xml
+++ b/vector-stores/spring-ai-opensearch-store/pom.xml
@@ -57,7 +57,6 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>${httpclient5.version}</version>
 		</dependency>
 
 		<!-- TESTING -->
@@ -99,7 +98,6 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-oracle-store/pom.xml
+++ b/vector-stores/spring-ai-oracle-store/pom.xml
@@ -56,19 +56,16 @@
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc11</artifactId>
-			<version>${oracle.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ucp</artifactId>
-			<version>${oracle.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.oracle.database.ha</groupId>
 			<artifactId>simplefan</artifactId>
-			<version>${oracle.version}</version>
 		</dependency>
 
 		<dependency>

--- a/vector-stores/spring-ai-pgvector-store/pom.xml
+++ b/vector-stores/spring-ai-pgvector-store/pom.xml
@@ -61,7 +61,6 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>${postgresql.version}</version>
 		</dependency>
 
 		<dependency>

--- a/vector-stores/spring-ai-typesense-store/pom.xml
+++ b/vector-stores/spring-ai-typesense-store/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.typesense</groupId>
             <artifactId>typesense-java</artifactId>
-            <version>${typesense.version}</version>
+			<version>${typesense.version}</version>
         </dependency>
 
         <!-- TESTING -->


### PR DESCRIPTION
  - Spring AI's dependencies management to derive from Spring Boot 3.4.2
    - Remove explicit versioning of dependencies
  - Update upgrade notes for Spring Boot 3.4.2
  - Fix ElasticSearch client changes with the latest dependency derived from Spring Boot 3.4.2