### PR TITLE
Add merge for missing Ollama options

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -18,6 +18,7 @@ package org.springframework.ai.ollama.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -331,7 +332,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 	private Set<String> toolNames = new HashSet<>();
 
 	@JsonIgnore
-	private Map<String, Object> toolContext;
+	private Map<String, Object> toolContext = new HashMap<>();
 
 	public static Builder builder() {
 		return new Builder();

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
@@ -24,6 +24,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -202,6 +203,17 @@ public interface ToolCallingChatOptions extends FunctionCallingOptions {
 		var mergedToolCallbacks = new ArrayList<>(runtimeToolCallbacks);
 		mergedToolCallbacks.addAll(defaultToolCallbacks);
 		return mergedToolCallbacks;
+	}
+
+	static Map<String, Object> mergeToolContext(Map<String, Object> runtimeToolContext,
+			Map<String, Object> defaultToolContext) {
+		Assert.notNull(runtimeToolContext, "runtimeToolContext cannot be null");
+		Assert.noNullElements(runtimeToolContext.keySet(), "runtimeToolContext keys cannot be null");
+		Assert.notNull(defaultToolContext, "defaultToolContext cannot be null");
+		Assert.noNullElements(defaultToolContext.keySet(), "defaultToolContext keys cannot be null");
+		var mergedToolContext = new HashMap<>(defaultToolContext);
+		mergedToolContext.putAll(runtimeToolContext);
+		return mergedToolContext;
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/model/tool/ToolCallingChatOptionsTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/model/tool/ToolCallingChatOptionsTests.java
@@ -22,6 +22,7 @@ import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -139,6 +140,47 @@ class ToolCallingChatOptionsTests {
 		List<FunctionCallback> mergedToolCallbacks = ToolCallingChatOptions.mergeToolCallbacks(runtimeToolCallbacks,
 				defaultToolCallbacks);
 		assertThat(mergedToolCallbacks).hasSize(0);
+	}
+
+	@Test
+	void whenMergeRuntimeAndDefaultToolContext() {
+		Map<String, Object> runtimeToolContext = Map.of("key1", "value1", "key2", "value2");
+		Map<String, Object> defaultToolContext = Map.of("key1", "valueA", "key3", "value3");
+		Map<String, Object> mergedToolContext = ToolCallingChatOptions.mergeToolContext(runtimeToolContext,
+				defaultToolContext);
+		assertThat(mergedToolContext).hasSize(3);
+		assertThat(mergedToolContext).containsEntry("key1", "value1")
+			.containsEntry("key2", "value2")
+			.containsEntry("key3", "value3");
+	}
+
+	@Test
+	void whenMergeRuntimeAndEmptyDefaultToolContext() {
+		Map<String, Object> runtimeToolContext = Map.of("key1", "value1", "key2", "value2");
+		Map<String, Object> defaultToolContext = Map.of();
+		Map<String, Object> mergedToolContext = ToolCallingChatOptions.mergeToolContext(runtimeToolContext,
+				defaultToolContext);
+		assertThat(mergedToolContext).hasSize(2);
+		assertThat(mergedToolContext).containsEntry("key1", "value1").containsEntry("key2", "value2");
+	}
+
+	@Test
+	void whenMergeEmptyRuntimeAndDefaultToolContext() {
+		Map<String, Object> runtimeToolContext = Map.of();
+		Map<String, Object> defaultToolContext = Map.of("key1", "value1", "key2", "value2");
+		Map<String, Object> mergedToolContext = ToolCallingChatOptions.mergeToolContext(runtimeToolContext,
+				defaultToolContext);
+		assertThat(mergedToolContext).hasSize(2);
+		assertThat(mergedToolContext).containsEntry("key1", "value1").containsEntry("key2", "value2");
+	}
+
+	@Test
+	void whenMergeEmptyRuntimeAndEmptyDefaultToolContext() {
+		Map<String, Object> runtimeToolContext = Map.of();
+		Map<String, Object> defaultToolContext = Map.of();
+		Map<String, Object> mergedToolContext = ToolCallingChatOptions.mergeToolContext(runtimeToolContext,
+				defaultToolContext);
+		assertThat(mergedToolContext).hasSize(0);
 	}
 
 	static class TestToolCallback implements ToolCallback {


### PR DESCRIPTION
When fields in OllamaOptions are marked as ignored in Jackson, they require explicit merge of runtime and default options. Added tests to validate the different merge combinations for all tool-related options.