### PR TITLE
Add Reasoning Content support to OpenAiChatModel and related classes (For deepseek-reasoner)

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -258,7 +258,8 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 							"role", choice.message().role() != null ? choice.message().role().name() : "",
 							"index", choice.index(),
 							"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "",
-							"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "");
+							"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
+							"reasoningContent", StringUtils.hasText(choice.message().reasoningContent()) ? choice.message().reasoningContent() : "");
 					// @formatter:on
 					return buildGeneration(choice, metadata, request);
 				}).toList();
@@ -346,7 +347,8 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 									"role", roleMap.getOrDefault(id, ""),
 									"index", choice.index(),
 									"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "",
-									"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "");
+									"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
+									"reasoningContent", StringUtils.hasText(choice.message().reasoningContent()) ? choice.message().reasoningContent() : "");
 
 							return buildGeneration(choice, metadata, request);
 						}).toList();
@@ -543,7 +545,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 
 				}
 				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
-						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null, audioOutput));
+						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null, audioOutput, null));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;
@@ -553,7 +555,7 @@ public class OpenAiChatModel extends AbstractToolCallSupport implements ChatMode
 				return toolMessage.getResponses()
 					.stream()
 					.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
-							tr.id(), null, null, null))
+							tr.id(), null, null, null, null))
 					.toList();
 			}
 			else {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -1138,8 +1138,11 @@ public class OpenAiApi {
 	 * {@link Role#ASSISTANT} role and null otherwise.
 	 * @param audioOutput Audio response from the model. >>>>>>> bdb66e577 (OpenAI -
 	 * Support audio input modality)
+	 * @param reasoningContent For deepseek-reasoner model only. The reasoning contents of
+	 * the assistant message, before the final answer.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionMessage(// @formatter:off
 			@JsonProperty("content") Object rawContent,
 			@JsonProperty("role") Role role,
@@ -1148,7 +1151,8 @@ public class OpenAiApi {
 			@JsonProperty("tool_calls")
 			@JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) List<ToolCall> toolCalls,
 			@JsonProperty("refusal") String refusal,
-			@JsonProperty("audio") AudioOutput audioOutput) { // @formatter:on
+			@JsonProperty("audio") AudioOutput audioOutput,
+			@JsonProperty("reasoning_content") String reasoningContent) { // @formatter:on
 
 		/**
 		 * Create a chat completion message with the given content and role. All other
@@ -1157,7 +1161,7 @@ public class OpenAiApi {
 		 * @param role The role of the author of this message.
 		 */
 		public ChatCompletionMessage(Object content, Role role) {
-			this(content, role, null, null, null, null, null);
+			this(content, role, null, null, null, null, null, null);
 
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
@@ -39,6 +39,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Alexandros Pappas
  * @since 0.8.1
  */
 public class OpenAiStreamFunctionCallingHelper {
@@ -97,6 +98,8 @@ public class OpenAiStreamFunctionCallingHelper {
 		String refusal = (current.refusal() != null ? current.refusal() : previous.refusal());
 		ChatCompletionMessage.AudioOutput audioOutput = (current.audioOutput() != null ? current.audioOutput()
 				: previous.audioOutput());
+		String reasoningContent = (current.reasoningContent() != null ? current.reasoningContent()
+				: previous.reasoningContent());
 
 		List<ToolCall> toolCalls = new ArrayList<>();
 		ToolCall lastPreviousTooCall = null;
@@ -126,7 +129,8 @@ public class OpenAiStreamFunctionCallingHelper {
 				toolCalls.add(lastPreviousTooCall);
 			}
 		}
-		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, refusal, audioOutput);
+		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, refusal, audioOutput,
+				reasoningContent);
 	}
 
 	private ToolCall merge(ToolCall previous, ToolCall current) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Alexandros Pappas
  */
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 public class OpenAiApiToolFunctionCallIT {
@@ -129,7 +130,7 @@ public class OpenAiApiToolFunctionCallIT {
 
 				// extend conversation with function response.
 				messages.add(new ChatCompletionMessage("" + weatherResponse.temp() + weatherRequest.unit(), Role.TOOL,
-						functionName, toolCall.id(), null, null, null));
+						functionName, toolCall.id(), null, null, null, null));
 			}
 		}
 


### PR DESCRIPTION
This PR resolves: https://github.com/spring-projects/spring-ai/issues/2283 by adding reasoning content support to OpenAiChatModel and related classes, following the approach of this https://github.com/spring-projects/spring-ai/commit/45421b1c93bbf19f5d7c5871f5064c9a4df8b067 .

Reasoning Content Details
```
reasoning_content : string / nullable  
For DeepSeek-Reasoner model only. Represents the reasoning contents of the assistant's message before the final answer.  
```

Refer to the DeepSeek API documentation for more details: [API Docs](https://api-docs.deepseek.com/api/create-chat-completion).

Changes in This PR
	•	Added reasoningContent field to metadata in OpenAiChatModel.
	•	Updated ChatCompletionMessage to include reasoningContent.
	
With this implementation, we can build projects like [DeepClaude](https://github.com/getAsterisk/deepclaude), enabling the integration of DeepSeek R1’s logical reasoning capabilities with Anthropic Claude’s (or any other model’s) creative and coding prowess. This will provide a powerful, combined language model experience.