### PR TITLE
feat(mistral-schema): allow custom structured output with json schema

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -633,9 +633,11 @@ public class MistralAiApi {
 	 * @param stop A list of tokens that the model should stop generating after. If set,
 	 * @param randomSeed The seed to use for random sampling. If set, different calls will
 	 * generate deterministic results.
-	 * @param responseFormat An object specifying the format that the model must output.
-	 * Setting to { "type": "json_object" } enables JSON mode, which guarantees the
-	 * message the model generates is valid JSON.
+	 * @param responseFormat An object specifying the format or schema that the model must
+	 * output. Setting to { "type": "json_object" } enables JSON mode, which guarantees
+	 * the message the model generates is valid JSON. Setting to { "type": "json_object" ,
+	 * "json_schema": schema} allows you to ensure the model provides an answer in a very
+	 * specific JSON format by supplying a clear JSON schema.
 	 */
 	@JsonInclude(Include.NON_NULL)
 	public record ChatCompletionRequest(
@@ -738,11 +740,12 @@ public class MistralAiApi {
 		 * An object specifying the format that the model must output.
 		 *
 		 * @param type Must be one of 'text' or 'json_object'.
+		 * @param jsonSchema A specific JSON schema to match, if 'type' is 'json_object'.
 		 */
 		@JsonInclude(Include.NON_NULL)
-		public record ResponseFormat(@JsonProperty("type") String type) {
+		public record ResponseFormat(@JsonProperty("type") String type,
+                               @JsonProperty("json_schema") Map<String, Object> jsonSchema) {
 
-		}
 
 	}
 


### PR DESCRIPTION
- Add Mistral [Custom Structured Output Support](https://docs.mistral.ai/capabilities/structured-output/custom_structured_output/). [On January 28th](https://docs.mistral.ai/getting-started/changelog/), 2025 Mistral added this feature.