### PR TITLE
Deprecate redundant field in ModelObservationContext

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
@@ -45,6 +45,10 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 		return new Builder();
 	}
 
+	/**
+	 * @deprecated Use {@link #getRequest().getOptions()} instead.
+	 */
+	@Deprecated(forRemoval = true)
 	public ChatOptions getRequestOptions() {
 		return this.requestOptions;
 	}
@@ -70,6 +74,11 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 			return this;
 		}
 
+		/**
+		 * @deprecated ChatOptions are passed in the Prompt object and should not be set
+		 * separately anymore.
+		 */
+		@Deprecated(forRemoval = true)
 		public Builder requestOptions(ChatOptions requestOptions) {
 			this.requestOptions = requestOptions;
 			return this;

--- a/spring-ai-core/src/main/java/org/springframework/ai/embedding/observation/EmbeddingModelObservationContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/embedding/observation/EmbeddingModelObservationContext.java
@@ -49,6 +49,10 @@ public class EmbeddingModelObservationContext extends ModelObservationContext<Em
 		return new Builder();
 	}
 
+	/**
+	 * @deprecated Use {@link #getRequest().getOptions()} instead.
+	 */
+	@Deprecated(forRemoval = true)
 	public EmbeddingOptions getRequestOptions() {
 		return this.requestOptions;
 	}
@@ -74,6 +78,11 @@ public class EmbeddingModelObservationContext extends ModelObservationContext<Em
 			return this;
 		}
 
+		/**
+		 * @deprecated EmbeddingOptions are passed in the EmbeddingRequest object and
+		 * should not be set separately anymore.
+		 */
+		@Deprecated(forRemoval = true)
 		public Builder requestOptions(EmbeddingOptions requestOptions) {
 			this.requestOptions = requestOptions;
 			return this;

--- a/spring-ai-core/src/main/java/org/springframework/ai/image/observation/ImageModelObservationContext.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/image/observation/ImageModelObservationContext.java
@@ -45,6 +45,10 @@ public class ImageModelObservationContext extends ModelObservationContext<ImageP
 		return new Builder();
 	}
 
+	/**
+	 * @deprecated Use {@link #getRequest().getOptions()} instead.
+	 */
+	@Deprecated(forRemoval = true)
 	public ImageOptions getRequestOptions() {
 		return this.requestOptions;
 	}
@@ -74,6 +78,11 @@ public class ImageModelObservationContext extends ModelObservationContext<ImageP
 			return this;
 		}
 
+		/**
+		 * @deprecated ImageOptions are passed in the ImagePrompt object and should not be
+		 * set separately anymore.
+		 */
+		@Deprecated(forRemoval = true)
 		public Builder requestOptions(ImageOptions requestOptions) {
 			this.requestOptions = requestOptions;
 			return this;


### PR DESCRIPTION
Each `ModelObservationContext` takes both a request object (e.g. `Prompt`) and an options object (e.g. `ChatOptions`). However, the options are already included in the request object. This PR deprecates the additional field, which will be removed in a subsequent release.

The reason why the extra field was there in the first place was due to the model implementations not handling request options correctly, requiring a dedicated setter. We started fixing the model implementations now, so we are deprecating the extra field, and we'll remove it in the next release, once we have completed the implementation of a fix for all model implementations.