### PR TITLE
Update MCP Java SDK link

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
@@ -5,7 +5,7 @@ It supports multiple transport mechanisms to provide flexibility across differen
 
 == MCP Java SDK
 
-The link:https://modelcontextprotocol.github.io/sdk/java[MCP Java SDK] provides a Java implementation of the Model Context Protocol, enabling standardized interaction with AI models and tools through both synchronous and asynchronous communication patterns.
+The link:https://github.com/spring-projects-experimental/spring-ai-mcp[MCP Java SDK] provides a Java implementation of the Model Context Protocol, enabling standardized interaction with AI models and tools through both synchronous and asynchronous communication patterns.
 
 The Java MCP implementation follows a three-layer architecture:
 


### PR DESCRIPTION
The link to the original MCP Java SDK no longer exists.
![image](https://github.com/user-attachments/assets/b03e1d2c-91e8-4c10-8fed-b7f9b314a35b)
