### PR TITLE
feat(autoconfigure): Support both FunctionCallback and ToolCallback in ToolCallingAutoConfiguration

### DIFF
--- a/auto-configurations/spring-ai-mcp-client/src/main/java/org/springframework/ai/autoconfigure/mcp/client/McpClientAutoConfiguration.java
+++ b/auto-configurations/spring-ai-mcp-client/src/main/java/org/springframework/ai/autoconfigure/mcp/client/McpClientAutoConfiguration.java
@@ -27,9 +27,11 @@ import io.modelcontextprotocol.spec.McpSchema;
 import org.springframework.ai.autoconfigure.mcp.client.configurer.McpAsyncClientConfigurer;
 import org.springframework.ai.autoconfigure.mcp.client.configurer.McpSyncClientConfigurer;
 import org.springframework.ai.autoconfigure.mcp.client.properties.McpClientCommonProperties;
-import org.springframework.ai.mcp.McpToolUtils;
+import org.springframework.ai.mcp.AsyncMcpToolCallbackProvider;
+import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
 import org.springframework.ai.mcp.customizer.McpAsyncClientCustomizer;
 import org.springframework.ai.mcp.customizer.McpSyncClientCustomizer;
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -178,7 +180,20 @@ public class McpClientAutoConfiguration {
 			matchIfMissing = true)
 	public ToolCallbackProvider toolCallbacks(ObjectProvider<List<McpSyncClient>> mcpClientsProvider) {
 		List<McpSyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
-		return ToolCallbackProvider.from(McpToolUtils.getToolCallbacksFromSyncClients(mcpClients));
+		return new SyncMcpToolCallbackProvider(mcpClients);
+	}
+
+	/**
+	 * @deprecated replaced by {@link #toolCallbacks(ObjectProvider)} that returns a
+	 * {@link ToolCallbackProvider} instead of a list of {@link ToolCallback}
+	 */
+	@Deprecated
+	@Bean
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
+			matchIfMissing = true)
+	public List<ToolCallback> toolCallbacksDeprecated(ObjectProvider<List<McpSyncClient>> mcpClientsProvider) {
+		List<McpSyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
+		return List.of(new SyncMcpToolCallbackProvider(mcpClients).getToolCallbacks());
 	}
 
 	/**
@@ -189,7 +204,7 @@ public class McpClientAutoConfiguration {
 	 * This class is responsible for closing all MCP sync clients when the application
 	 * context is closed, preventing resource leaks.
 	 */
-	public record ClosebleMcpSyncClients(List<McpSyncClient> clients) implements AutoCloseable {
+	public record CloseableMcpSyncClients(List<McpSyncClient> clients) implements AutoCloseable {
 
 		@Override
 		public void close() {
@@ -205,8 +220,8 @@ public class McpClientAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
-	public ClosebleMcpSyncClients makeSyncClientsClosable(List<McpSyncClient> clients) {
-		return new ClosebleMcpSyncClients(clients);
+	public CloseableMcpSyncClients makeSyncClientsClosable(List<McpSyncClient> clients) {
+		return new CloseableMcpSyncClients(clients);
 	}
 
 	/**
@@ -263,14 +278,26 @@ public class McpClientAutoConfiguration {
 		return mcpSyncClients;
 	}
 
+	/**
+	 * @deprecated replaced by {@link #asyncToolCallbacks(ObjectProvider)} that returns a
+	 * {@link ToolCallbackProvider} instead of a list of {@link ToolCallback}
+	 */
+	@Deprecated
+	@Bean
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
+	public List<ToolCallback> asyncToolCallbacksDeprecated(ObjectProvider<List<McpAsyncClient>> mcpClientsProvider) {
+		List<McpAsyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
+		return List.of(new AsyncMcpToolCallbackProvider(mcpClients).getToolCallbacks());
+	}
+
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	public ToolCallbackProvider asyncToolCallbacks(ObjectProvider<List<McpAsyncClient>> mcpClientsProvider) {
 		List<McpAsyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
-		return ToolCallbackProvider.from(McpToolUtils.getToolCallbacksFromAsyncClinents(mcpClients));
+		return new AsyncMcpToolCallbackProvider(mcpClients);
 	}
 
-	public record ClosebleMcpAsyncClients(List<McpAsyncClient> clients) implements AutoCloseable {
+	public record CloseableMcpAsyncClients(List<McpAsyncClient> clients) implements AutoCloseable {
 		@Override
 		public void close() {
 			this.clients.forEach(McpAsyncClient::close);
@@ -279,8 +306,8 @@ public class McpClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public ClosebleMcpAsyncClients makeAsynClientsClosable(List<McpAsyncClient> clients) {
-		return new ClosebleMcpAsyncClients(clients);
+	public CloseableMcpAsyncClients makeAsynClientsClosable(List<McpAsyncClient> clients) {
+		return new CloseableMcpAsyncClients(clients);
 	}
 
 	@Bean

--- a/auto-configurations/spring-ai-mcp-client/src/main/java/org/springframework/ai/autoconfigure/mcp/client/McpClientAutoConfiguration.java
+++ b/auto-configurations/spring-ai-mcp-client/src/main/java/org/springframework/ai/autoconfigure/mcp/client/McpClientAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.ai.autoconfigure.mcp.client.properties.McpClientCommo
 import org.springframework.ai.mcp.McpToolUtils;
 import org.springframework.ai.mcp.customizer.McpAsyncClientCustomizer;
 import org.springframework.ai.mcp.customizer.McpSyncClientCustomizer;
-import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -176,9 +176,9 @@ public class McpClientAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
-	public List<ToolCallback> toolCallbacks(ObjectProvider<List<McpSyncClient>> mcpClientsProvider) {
+	public ToolCallbackProvider toolCallbacks(ObjectProvider<List<McpSyncClient>> mcpClientsProvider) {
 		List<McpSyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
-		return McpToolUtils.getToolCallbacksFromSyncClients(mcpClients);
+		return ToolCallbackProvider.from(McpToolUtils.getToolCallbacksFromSyncClients(mcpClients));
 	}
 
 	/**
@@ -265,9 +265,9 @@ public class McpClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public List<ToolCallback> asyncToolCallbacks(ObjectProvider<List<McpAsyncClient>> mcpClientsProvider) {
+	public ToolCallbackProvider asyncToolCallbacks(ObjectProvider<List<McpAsyncClient>> mcpClientsProvider) {
 		List<McpAsyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
-		return McpToolUtils.getToolCallbacksFromAsyncClinents(mcpClients);
+		return ToolCallbackProvider.from(McpToolUtils.getToolCallbacksFromAsyncClinents(mcpClients));
 	}
 
 	public record ClosebleMcpAsyncClients(List<McpAsyncClient> clients) implements AutoCloseable {

--- a/auto-configurations/spring-ai-mcp-client/src/test/java/org/springframework/ai/autoconfigure/mcp/client/McpClientAutoConfigurationIT.java
+++ b/auto-configurations/spring-ai-mcp-client/src/test/java/org/springframework/ai/autoconfigure/mcp/client/McpClientAutoConfigurationIT.java
@@ -122,7 +122,7 @@ public class McpClientAutoConfigurationIT {
 	@Test
 	void closeableWrappersCreation() {
 		this.contextRunner.withUserConfiguration(TestTransportConfiguration.class).run(context -> {
-			assertThat(context).hasSingleBean(McpClientAutoConfiguration.ClosebleMcpSyncClients.class);
+			assertThat(context).hasSingleBean(McpClientAutoConfiguration.CloseableMcpSyncClients.class);
 		});
 	}
 

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -211,10 +211,7 @@ public final class McpToolUtils {
 		if (CollectionUtils.isEmpty(mcpClients)) {
 			return List.of();
 		}
-		return mcpClients.stream()
-			.map(mcpClient -> List.of((new SyncMcpToolCallbackProvider(mcpClient).getToolCallbacks())))
-			.flatMap(List::stream)
-			.toList();
+		return List.of((new SyncMcpToolCallbackProvider(mcpClients).getToolCallbacks()));
 	}
 
 	/**
@@ -247,10 +244,7 @@ public final class McpToolUtils {
 		if (CollectionUtils.isEmpty(asynMcpClients)) {
 			return List.of();
 		}
-		return asynMcpClients.stream()
-			.map(mcpClient -> List.of((new AsyncMcpToolCallbackProvider(mcpClient).getToolCallbacks())))
-			.flatMap(List::stream)
-			.toList();
+		return List.of((new AsyncMcpToolCallbackProvider(asynMcpClients).getToolCallbacks()));
 	}
 
 }

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/tool/VertexAiGeminiPaymentTransactionMethodIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/tool/VertexAiGeminiPaymentTransactionMethodIT.java
@@ -38,7 +38,7 @@ import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain;
 import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.model.tool.ToolCallingManager;
-import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.ToolCallbacks;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.execution.DefaultToolExecutionExceptionProcessor;
@@ -183,9 +183,8 @@ public class VertexAiGeminiPaymentTransactionMethodIT {
 	public static class TestConfiguration {
 
 		@Bean
-		public List<ToolCallback> paymentServiceTools() {
-			var tools = List.of(ToolCallbacks.from(new PaymentService()));
-			return tools;
+		public ToolCallbackProvider paymentServiceTools() {
+			return ToolCallbackProvider.from(List.of(ToolCallbacks.from(new PaymentService())));
 		}
 
 		@Bean
@@ -221,11 +220,11 @@ public class VertexAiGeminiPaymentTransactionMethodIT {
 
 		@Bean
 		ToolCallingManager toolCallingManager(GenericApplicationContext applicationContext,
-				List<ToolCallback> toolCallbacks, List<FunctionCallback> functionCallbacks,
+				List<ToolCallbackProvider> tcps, List<FunctionCallback> functionCallbacks,
 				ObjectProvider<ObservationRegistry> observationRegistry) {
 
 			List<FunctionCallback> allFunctionCallbacks = new ArrayList(functionCallbacks);
-			allFunctionCallbacks.addAll(toolCallbacks.stream().map(tc -> (FunctionCallback) tc).toList());
+			tcps.stream().map(pr -> List.of(pr.getToolCallbacks())).forEach(allFunctionCallbacks::addAll);
 
 			var staticToolCallbackResolver = new StaticToolCallbackResolver(allFunctionCallbacks);
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -36,6 +36,7 @@ import org.springframework.ai.converter.StructuredOutputConverter;
 import org.springframework.ai.model.Media;
 import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.Resource;
 import org.springframework.lang.Nullable;
@@ -223,6 +224,8 @@ public interface ChatClient {
 
 		ChatClientRequestSpec tools(Object... toolObjects);
 
+		ChatClientRequestSpec tools(ToolCallbackProvider... toolCallbackProvider);
+
 		@Deprecated
 		<I, O> ChatClientRequestSpec functions(FunctionCallback... functionCallbacks);
 
@@ -289,6 +292,8 @@ public interface ChatClient {
 		Builder defaultTools(List<ToolCallback> toolCallbacks);
 
 		Builder defaultTools(Object... toolObjects);
+
+		Builder defaultTools(ToolCallbackProvider... toolCallbackProvider);
 
 		/**
 		 * @deprecated in favor of {@link #defaultTools(String...)}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -224,7 +224,7 @@ public interface ChatClient {
 
 		ChatClientRequestSpec tools(Object... toolObjects);
 
-		ChatClientRequestSpec tools(ToolCallbackProvider... toolCallbackProvider);
+		ChatClientRequestSpec tools(ToolCallbackProvider... toolCallbackProviders);
 
 		@Deprecated
 		<I, O> ChatClientRequestSpec functions(FunctionCallback... functionCallbacks);
@@ -293,7 +293,7 @@ public interface ChatClient {
 
 		Builder defaultTools(Object... toolObjects);
 
-		Builder defaultTools(ToolCallbackProvider... toolCallbackProvider);
+		Builder defaultTools(ToolCallbackProvider... toolCallbackProviders);
 
 		/**
 		 * @deprecated in favor of {@link #defaultTools(String...)}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -35,6 +35,7 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.ToolCallbacks;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
@@ -868,6 +869,16 @@ public class DefaultChatClient implements ChatClient {
 			Assert.notNull(toolObjects, "toolObjects cannot be null");
 			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
 			this.functionCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects)));
+			return this;
+		}
+
+		@Override
+		public ChatClientRequestSpec tools(ToolCallbackProvider... toolCallbackProviders) {
+			Assert.notNull(toolCallbackProviders, "toolCallbackProviders cannot be null");
+			Assert.noNullElements(toolCallbackProviders, "toolCallbackProviders cannot contain null elements");
+			for (ToolCallbackProvider toolCallbackProvider : toolCallbackProviders) {
+				this.functionCallbacks.addAll(List.of(toolCallbackProvider.getToolCallbacks()));
+			}
 			return this;
 		}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -36,6 +36,7 @@ import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.core.io.Resource;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -170,6 +171,12 @@ public class DefaultChatClientBuilder implements Builder {
 	@Override
 	public Builder defaultTools(Object... toolObjects) {
 		this.defaultRequest.tools(toolObjects);
+		return this;
+	}
+
+	@Override
+	public Builder defaultTools(ToolCallbackProvider... toolCallbackProviders) {
+		this.defaultRequest.tools(toolCallbackProviders);
 		return this;
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
@@ -34,7 +34,7 @@ public class StaticToolCallbackProvider implements ToolCallbackProvider {
 	}
 
 	public StaticToolCallbackProvider(List<? extends FunctionCallback> toolCallbacks) {
-		Assert.notNull(toolCallbacks, "ToolCallbacks must not be null");
+		Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
 		this.toolCallbacks = toolCallbacks.toArray(new FunctionCallback[0]);
 	}
 

--- a/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
@@ -1,0 +1,46 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.tool;
+
+import java.util.List;
+
+import org.springframework.ai.model.function.FunctionCallback;
+import org.springframework.util.Assert;
+
+/**
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+public class StaticToolCallbackProvider implements ToolCallbackProvider {
+
+	private final FunctionCallback[] toolCallbacks;
+
+	public StaticToolCallbackProvider(FunctionCallback... toolCallbacks) {
+		Assert.notNull(toolCallbacks, "ToolCallbacks must not be null");
+		this.toolCallbacks = toolCallbacks;
+	}
+
+	public StaticToolCallbackProvider(List<? extends FunctionCallback> toolCallbacks) {
+		Assert.notNull(toolCallbacks, "ToolCallbacks must not be null");
+		this.toolCallbacks = toolCallbacks.toArray(new FunctionCallback[0]);
+	}
+
+	@Override
+	public FunctionCallback[] getToolCallbacks() {
+		return this.toolCallbacks;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
@@ -21,23 +21,67 @@ import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.util.Assert;
 
 /**
+ * A simple implementation of {@link ToolCallbackProvider} that maintains a static array
+ * of {@link FunctionCallback} objects. This provider is immutable after construction and
+ * provides a straightforward way to supply a fixed set of tool callbacks to AI models.
+ *
+ * <p>
+ * This implementation is thread-safe as it maintains an immutable array of callbacks that
+ * is set during construction and cannot be modified afterwards.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * FunctionCallback callback1 = new MyFunctionCallback();
+ * FunctionCallback callback2 = new AnotherFunctionCallback();
+ *
+ * // Create provider with varargs constructor
+ * ToolCallbackProvider provider1 = new StaticToolCallbackProvider(callback1, callback2);
+ *
+ * // Or create provider with List constructor
+ * List<FunctionCallback> callbacks = Arrays.asList(callback1, callback2);
+ * ToolCallbackProvider provider2 = new StaticToolCallbackProvider(callbacks);
+ * }</pre>
+ *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @see ToolCallbackProvider
+ * @see FunctionCallback
  */
 public class StaticToolCallbackProvider implements ToolCallbackProvider {
 
 	private final FunctionCallback[] toolCallbacks;
 
+	/**
+	 * Constructs a new StaticToolCallbackProvider with the specified array of function
+	 * callbacks.
+	 * @param toolCallbacks the array of function callbacks to be provided by this
+	 * provider. Must not be null, though an empty array is permitted.
+	 * @throws IllegalArgumentException if the toolCallbacks array is null
+	 */
 	public StaticToolCallbackProvider(FunctionCallback... toolCallbacks) {
 		Assert.notNull(toolCallbacks, "ToolCallbacks must not be null");
 		this.toolCallbacks = toolCallbacks;
 	}
 
+	/**
+	 * Constructs a new StaticToolCallbackProvider with the specified list of function
+	 * callbacks. The list is converted to an array internally.
+	 * @param toolCallbacks the list of function callbacks to be provided by this
+	 * provider. Must not be null and must not contain null elements.
+	 * @throws IllegalArgumentException if the toolCallbacks list is null or contains null
+	 * elements
+	 */
 	public StaticToolCallbackProvider(List<? extends FunctionCallback> toolCallbacks) {
 		Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
 		this.toolCallbacks = toolCallbacks.toArray(new FunctionCallback[0]);
 	}
 
+	/**
+	 * Returns the array of function callbacks held by this provider.
+	 * @return an array containing all function callbacks provided during construction.
+	 * The returned array is a direct reference to the internal array, as the callbacks
+	 * are expected to be immutable.
+	 */
 	@Override
 	public FunctionCallback[] getToolCallbacks() {
 		return this.toolCallbacks;

--- a/spring-ai-core/src/main/java/org/springframework/ai/tool/ToolCallbackProvider.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tool/ToolCallbackProvider.java
@@ -16,6 +16,10 @@
 
 package org.springframework.ai.tool;
 
+import java.util.List;
+
+import org.springframework.ai.model.function.FunctionCallback;
+
 /**
  * Provides {@link ToolCallback} instances for tools defined in different sources.
  *
@@ -24,6 +28,14 @@ package org.springframework.ai.tool;
  */
 public interface ToolCallbackProvider {
 
-	ToolCallback[] getToolCallbacks();
+	FunctionCallback[] getToolCallbacks();
+
+	public static ToolCallbackProvider from(List<? extends FunctionCallback> toolCallbacks) {
+		return new StaticToolCallbackProvider(toolCallbacks);
+	}
+
+	public static ToolCallbackProvider from(FunctionCallback... toolCallbacks) {
+		return new StaticToolCallbackProvider(toolCallbacks);
+	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -351,12 +351,14 @@ private List<McpSyncClient> mcpSyncClients;  // For sync client
 private List<McpAsyncClient> mcpAsyncClients;  // For async client
 ----
 
-Additionally, the registered MCP Tools with all MCP clients are provided as a list of ToolCallback instances:
+Additionally, the registered MCP Tools with all MCP clients are provided as a list of ToolCallback 
+throurgh a ToolCallbackProvider instance:
 
 [source,java]
 ----
 @Autowired
-private List<ToolCallback> toolCallbacks;
+private SyncMcpToolCallbackProvider toolCallbackProvider;
+ToolCallback[] toolCallbacks = toolCallbackProvider.getToolCallbacks();
 ----
 
 == Example Applications

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -352,7 +352,7 @@ private List<McpAsyncClient> mcpAsyncClients;  // For async client
 ----
 
 Additionally, the registered MCP Tools with all MCP clients are provided as a list of ToolCallback 
-throurgh a ToolCallbackProvider instance:
+through a ToolCallbackProvider instance:
 
 [source,java]
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -126,9 +126,9 @@ Allows servers to expose tools that can be invoked by language models. The MCP S
 [source,java]
 ----
 @Bean
-public List<ToolCallback> myTools(...) {
+public ToolCallbackProvier myTools(...) {
     List<ToolCallback> tools = ...
-    return tools;
+    return ToolCallbackProvier.from(tools);
 }
 ----
 
@@ -284,15 +284,15 @@ public class McpServerApplication {
         SpringApplication.run(McpServerApplication.class, args);
     }
 
-    @Bean
-    public List<ToolCallback> tools(WeatherService weatherService) {
-        return ToolCallbacks.from(weatherService);
-    }
+	@Bean
+	public ToolCallbackProvider weatherTools(WeatherService weatherService) {
+		return MethodToolCallbackProvider.builder().toolObjects(weatherService).build();
+	}
 }
 ----
 
 The auto-configuration will automatically register the tool callbacks as MCP tools.
-You can have multiple beans producing lists of ToolCallbacks. The auto-configuration will merge them.
+You can have multiple beans producing ToolCallbacks. The auto-configuration will merge them.
 
 == Example Applications
 * link:https://github.com/spring-projects/spring-ai-examples/tree/main/model-context-protocol/weather/starter-webflux-server[Weather Server (WebFlux)] - Spring AI MCP Server Boot Starter with WebFlux transport.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -126,9 +126,9 @@ Allows servers to expose tools that can be invoked by language models. The MCP S
 [source,java]
 ----
 @Bean
-public ToolCallbackProvier myTools(...) {
+public ToolCallbackProvider myTools(...) {
     List<ToolCallback> tools = ...
-    return ToolCallbackProvier.from(tools);
+    return ToolCallbackProvider.from(tools);
 }
 ----
 

--- a/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/model/ToolCallingAutoConfigurationTests.java
+++ b/spring-ai-spring-boot-autoconfigure/src/test/java/org/springframework/ai/autoconfigure/chat/model/ToolCallingAutoConfigurationTests.java
@@ -16,15 +16,30 @@
 
 package org.springframework.ai.autoconfigure.chat.model;
 
+import java.util.List;
+import java.util.function.Function;
+
 import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.model.tool.DefaultToolCallingManager;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbacks;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.DefaultToolExecutionExceptionProcessor;
 import org.springframework.ai.tool.execution.ToolExecutionExceptionProcessor;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.ai.tool.method.MethodToolCallback;
 import org.springframework.ai.tool.resolution.DelegatingToolCallbackResolver;
 import org.springframework.ai.tool.resolution.ToolCallbackResolver;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for {@link ToolCallingAutoConfiguration}.
  *
  * @author Thomas Vitale
+ * @author Christian Tzolov
  */
 class ToolCallingAutoConfigurationTests {
 
@@ -48,6 +64,114 @@ class ToolCallingAutoConfigurationTests {
 				var toolCallingManager = context.getBean(ToolCallingManager.class);
 				assertThat(toolCallingManager).isInstanceOf(DefaultToolCallingManager.class);
 			});
+	}
+
+	@Test
+	void resolveMultipleFuncitonAndToolCallbacks() {
+		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(ToolCallingAutoConfiguration.class))
+			.withUserConfiguration(Config.class)
+			.run(context -> {
+				var toolCallbackResolver = context.getBean(ToolCallbackResolver.class);
+				assertThat(toolCallbackResolver).isInstanceOf(DelegatingToolCallbackResolver.class);
+
+				assertThat(toolCallbackResolver.resolve("getForecast")).isNotNull();
+				assertThat(toolCallbackResolver.resolve("getForecast").getName()).isEqualTo("getForecast");
+
+				assertThat(toolCallbackResolver.resolve("getAlert")).isNotNull();
+				assertThat(toolCallbackResolver.resolve("getAlert").getName()).isEqualTo("getAlert");
+
+				assertThat(toolCallbackResolver.resolve("weatherFunction1")).isNotNull();
+				assertThat(toolCallbackResolver.resolve("weatherFunction1").getName()).isEqualTo("weatherFunction1");
+
+				assertThat(toolCallbackResolver.resolve("getCurrentWeather3")).isNotNull();
+				assertThat(toolCallbackResolver.resolve("getCurrentWeather3").getName())
+					.isEqualTo("getCurrentWeather3");
+
+				assertThat(toolCallbackResolver.resolve("getCurrentWeather4")).isNotNull();
+				assertThat(toolCallbackResolver.resolve("getCurrentWeather4").getName())
+					.isEqualTo("getCurrentWeather4");
+
+				assertThat(toolCallbackResolver.resolve("getCurrentWeather5")).isNotNull();
+				assertThat(toolCallbackResolver.resolve("getCurrentWeather5").getName())
+					.isEqualTo("getCurrentWeather5");
+			});
+	}
+
+	static class WeatherService {
+
+		@Tool(description = "Get the weather in location. Return temperature in 36°F or 36°C format.")
+		public String getForecast(String location) {
+			return "30";
+		}
+
+		public String getAlert(String usState) {
+			return "Alergt";
+		}
+
+	}
+
+	@Configuration
+	static class Config {
+
+		// Note: Currently we do not have ToolCallbackResolver implementation that can
+		// resolve the ToolCallback from the Tool annotation.
+		// Therefore we need to provide the ToolCallback instances explicitly using the
+		// ToolCallbacks.from(...) utility method.
+		@Bean
+		public List<ToolCallback> toolCallbacks() {
+			return List.of(ToolCallbacks.from(new WeatherService()));
+		}
+
+		public record Request(String location) {
+		}
+
+		public record Response(String temperature) {
+		}
+
+		@Bean
+		@Description("Get the weather in location. Return temperature in 36°F or 36°C format.")
+		public Function<Request, Response> weatherFunction1() {
+			return request -> new Response("30");
+		}
+
+		@Bean
+		public List<FunctionCallback> functionCallbacks3() {
+			return List.of(FunctionCallback.builder()
+				.function("getCurrentWeather3", (Request request) -> "15.0°C")
+				.description("Gets the weather in location")
+				.inputType(Request.class)
+				.build());
+		}
+
+		@Bean
+		public List<FunctionCallback> functionCallbacks4() {
+			return List.of(FunctionCallback.builder()
+				.function("getCurrentWeather4", (Request request) -> "15.0°C")
+				.description("Gets the weather in location")
+				.inputType(Request.class)
+				.build());
+
+		}
+
+		@Bean
+		public List<ToolCallback> toolCallbacks5() {
+			return List.of(FunctionToolCallback.builder("getCurrentWeather5", (Request request) -> "15.0°C")
+				.description("Gets the weather in location")
+				.inputType(Request.class)
+				.build());
+
+		}
+
+		@Bean
+		public List<ToolCallback> toolCallbacks6() {
+			var toolMethod = ReflectionUtils.findMethod(WeatherService.class, "getAlert", String.class);
+			return List.of(MethodToolCallback.builder()
+				.toolDefinition(ToolDefinition.builder(toolMethod).build())
+				.toolMethod(toolMethod)
+				.toolObject(new WeatherService())
+				.build());
+		}
+
 	}
 
 }


### PR DESCRIPTION
- Extends the ToolCallingAutoConfiguration to support both FunctionCallback and ToolCallback types.
- The toolCallbackResolver bean now handles both callback types through ObjectProvider injection.
- Added comprehensive tests to verify the resolution of multiple function and tool callbacks.