### PR TITLE
Update MCP Java SDK link in documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
@@ -5,7 +5,7 @@ It supports multiple transport mechanisms to provide flexibility across differen
 
 == MCP Java SDK
 
-The link:https://modelcontextprotocol.github.io/sdk/java[MCP Java SDK] provides a Java implementation of the Model Context Protocol, enabling standardized interaction with AI models and tools through both synchronous and asynchronous communication patterns.
+The link:https://docs.spring.io/spring-ai-mcp/reference/mcp.html[MCP Java SDK] provides a Java implementation of the Model Context Protocol, enabling standardized interaction with AI models and tools through both synchronous and asynchronous communication patterns.
 
 The Java MCP implementation follows a three-layer architecture:
 


### PR DESCRIPTION
Changed the MCP Java SDK link in the `mcp-overview.adoc` file to point to Spring AI documentation as the previous link does not exist (404).
