### PR TITLE
fix(spring-ai-azure-openai): last chat completions can have null deltas

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -353,7 +353,11 @@ public class AzureOpenAiChatModel extends AbstractToolCallSupport implements Cha
 						|| chatCompletions.getUsage() != null)
 				.map(chatCompletions -> {
 					if (!chatCompletions.getChoices().isEmpty()) {
-						final var toolCalls = chatCompletions.getChoices().get(0).getDelta().getToolCalls();
+						ChatChoice chatChoice = chatCompletions.getChoices().get(0);
+						List<ChatCompletionsToolCall> toolCalls = null;
+						if (chatChoice.getDelta() != null) {
+							toolCalls = chatChoice.getDelta().getToolCalls();
+						}
 						isFunctionCall.set(toolCalls != null && !toolCalls.isEmpty());
 					}
 					return chatCompletions;


### PR DESCRIPTION
This PR fixes a null pointer exception that can happen when models check for profanity, selfHarm etc... the last chat completions does not contain any delta and therefor fails at this step. 

To reproduce the issue one can just try a simple : 
```
@GetMapping("/ai/generateStream")
    fun generateStream(
        @RequestParam(
            value = "message",
            defaultValue = "Tell me a joke"
        ) message: String?
    ): Flux<ChatResponse> {
        val prompt = Prompt(UserMessage(message))
        return chatModel.stream(prompt)
    }
```

that will fail with a : 
```
There was an unexpected error (type=Internal Server Error, status=500).
Cannot invoke "com.azure.ai.openai.models.ChatResponseMessage.getToolCalls()" because the return value of "com.azure.ai.openai.models.ChatChoice.getDelta()" is null
java.lang.NullPointerException: Cannot invoke "com.azure.ai.openai.models.ChatResponseMessage.getToolCalls()" because the return value of "com.azure.ai.openai.models.ChatChoice.getDelta()" is null
	at org.springframework.ai.azure.openai.AzureOpenAiChatModel.lambda$internalStream$4(AzureOpenAiChatModel.java:297)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:113)
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onNext(FluxFilterFuseable.java:118)
	at reactor.core.publisher.FluxReplay$UnboundedReplayBuffer.replayNormal(FluxReplay.java:618)
	at reactor.core.publisher.FluxReplay$UnboundedReplayBuffer.replay(FluxReplay.java:709)
	at reactor.core.publisher.FluxReplay$ReplaySubscriber.onNext(FluxReplay.java:1345)
	at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.innerNext(FluxConcatMapNoPrefetch.java:259)
	at reactor.core.publisher.FluxConcatMap$ConcatMapInner.onNext(FluxConcatMap.java:865)
	at reactor.core.publisher.FluxIterable$IterableSubscription.slowPath(FluxIterable.java:335)
	at reactor.core.publisher.FluxIterable$IterableSubscription.request(FluxIterable.java:294)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2367)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2241)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:201)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:83)
	at reactor.core.publisher.Flux.subscribe(Flux.java:8891)
	at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.onNext(FluxConcatMapNoPrefetch.java:207)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.runAsync(FluxPublishOn.java:446)
	at reactor.core.publisher.FluxPublishOn$PublishOnSubscriber.run(FluxPublishOn.java:533)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```