### PR TITLE
Make allow negative keep alive value with OllamaEmbeddingModel

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Jonghoon Park
  * @since 0.8.0
  */
 public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
@@ -188,7 +189,7 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 
 	public static class DurationParser {
 
-		private static final Pattern PATTERN = Pattern.compile("(\\d+)(ms|s|m|h)");
+		private static final Pattern PATTERN = Pattern.compile("(-?\\d+)(ms|s|m|h)");
 
 		public static Duration parse(String input) {
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaEmbeddingRequestTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.ollama;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Jonghoon Park
  */
 public class OllamaEmbeddingRequestTests {
 
@@ -65,6 +67,16 @@ public class OllamaEmbeddingRequestTests {
 		assertThat(request.options().get("main_gpu")).isEqualTo(22);
 		assertThat(request.options().get("use_mmap")).isEqualTo(true);
 		assertThat(request.input()).isEqualTo(List.of("Hello"));
+	}
+
+	@Test
+	public void ollamaEmbeddingRequestWithNegativeKeepAlive() {
+
+		var promptOptions = OllamaOptions.builder().model("PROMPT_MODEL").keepAlive("-1m").build();
+
+		var request = this.embeddingModel.ollamaEmbeddingRequest(List.of("Hello"), promptOptions);
+
+		assertThat(request.keepAlive()).isEqualTo(Duration.ofMinutes(-1));
 	}
 
 }


### PR DESCRIPTION
### Motivation:
In issue https://github.com/spring-projects/spring-ai/issues/2197, it was identified that the keep-alive option for embedding models did not allow negative values. This limitation restricted certain configurations as described in the documentation.

### Modification:
Updated the regex to enable the keep-alive option for embedding models to accept negative values.

### Result:
Users can now configure negative values for the keep-alive option in embedding models, addressing the issue mentioned.
This resolves https://github.com/spring-projects/spring-ai/issues/2197.

### Verification:

#### When set to 1m:
The keep-alive duration is correctly set to 1 minute.

Logs:
```
[GIN] 2025/02/17 - 07:45:12 | 200 |   53.186102ms |   192.168.88.61 | POST     "/api/embed"
time=2025-02-17T07:45:12.956Z level=DEBUG source=sched.go:407 msg="context for request finished"
time=2025-02-17T07:45:12.956Z level=DEBUG source=sched.go:339 msg="runner with non-zero duration has gone idle, adding timer" modelPath=/root/.ollama/models/blobs/sha256-819c2adf5ce6df2b6bd2ae4ca90d2a69f060afeb438d0c171db57daa02e39c3d duration=1m0s
```

#### When set to -1m:
The keep-alive duration is correctly interpreted as infinite, as [documented](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-do-i-keep-a-model-loaded-in-memory-or-make-it-unload-immediately).

Logs:
```
[GIN] 2025/02/17 - 07:40:34 | 200 |   1.04253822s |        10.8.0.3 | POST     "/api/embed"
time=2025-02-17T07:40:34.201Z level=DEBUG source=sched.go:466 msg="context for request finished"
time=2025-02-17T07:40:34.201Z level=DEBUG source=sched.go:339 msg="runner with non-zero duration has gone idle, adding timer" modelPath=/root/.ollama/models/blobs/sha256-819c2adf5ce6df2b6bd2ae4ca90d2a69f060afeb438d0c171db57daa02e39c3d duration=2562047h47m16.854775807s
```