### PR TITLE
Fix issue with CosmosDBVectorStore.Builder - "... must not be empty"

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cosmosdb/CosmosDBVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/cosmosdb/CosmosDBVectorStoreAutoConfiguration.java
@@ -77,6 +77,7 @@ public class CosmosDBVectorStoreAutoConfiguration {
 			.metadataFields(List.of(properties.getMetadataFields()))
 			.vectorStoreThroughput(properties.getVectorStoreThroughput())
 			.vectorDimensions(properties.getVectorDimensions())
+			.partitionKeyPath(properties.getPartitionKeyPath())
 			.build();
 
 	}

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
@@ -416,7 +416,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @throws IllegalArgumentException if containerName is null or empty
 		 */
 		public Builder containerName(String containerName) {
-			Assert.hasText(this.containerName, "Container name must not be empty");
+			Assert.hasText(containerName, "Container name must not be empty");
 			this.containerName = containerName;
 			return this;
 		}
@@ -428,7 +428,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @throws IllegalArgumentException if databaseName is null or empty
 		 */
 		public Builder databaseName(String databaseName) {
-			Assert.hasText(this.databaseName, "Database name must not be empty");
+			Assert.hasText(databaseName, "Database name must not be empty");
 			this.databaseName = databaseName;
 			return this;
 		}
@@ -440,7 +440,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @throws IllegalArgumentException if partitionKeyPath is null or empty
 		 */
 		public Builder partitionKeyPath(String partitionKeyPath) {
-			Assert.hasText(this.partitionKeyPath, "Partition key path must not be empty");
+			Assert.hasText(partitionKeyPath, "Partition key path must not be empty");
 			this.partitionKeyPath = partitionKeyPath;
 			return this;
 		}
@@ -452,7 +452,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @throws IllegalArgumentException if vectorStoreThroughput is not positive
 		 */
 		public Builder vectorStoreThroughput(int vectorStoreThroughput) {
-			Assert.isTrue(this.vectorStoreThroughput > 0, "Vector store throughput must be positive");
+			Assert.isTrue(vectorStoreThroughput > 0, "Vector store throughput must be positive");
 			this.vectorStoreThroughput = vectorStoreThroughput;
 			return this;
 		}
@@ -464,7 +464,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 		 * @throws IllegalArgumentException if vectorDimensions is not positive
 		 */
 		public Builder vectorDimensions(long vectorDimensions) {
-			Assert.isTrue(this.vectorDimensions > 0, "Vector dimensions must be positive");
+			Assert.isTrue(vectorDimensions > 0, "Vector dimensions must be positive");
 			this.vectorDimensions = vectorDimensions;
 			return this;
 		}


### PR DESCRIPTION
Each CosmosDBVectorStore.Builder function evaluates `this.PROPERTY_NAME` rather than the new argument passed to each function resulting in it not being possible to instantiate an instance of CosmosDBVectorStore. 