### PR TITLE
Update FunctionCallback.java

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java
@@ -79,8 +79,8 @@ public interface FunctionCallback {
 	 * model.
 	 * @return String containing the function call response.
 	 */
-	default String call(String functionInput, ToolContext tooContext) {
-		if (tooContext != null && !tooContext.getContext().isEmpty()) {
+	default String call(String functionInput, ToolContext toolContext) {
+		if (toolContext != null && !toolContext.getContext().isEmpty()) {
 			throw new UnsupportedOperationException("Function context is not supported!");
 		}
 		return call(functionInput);


### PR DESCRIPTION
This pull request includes a minor change to the `FunctionCallback` interface in the `spring-ai-core` module. The change corrects a typo in the parameter name of the `call` method.

* [`spring-ai-core/src/main/java/org/springframework/ai/model/function/FunctionCallback.java`](diffhunk://#diff-294e6cbbd49e177226d29f542a5b0d29ebad1e4cf0093589fa2ca32f7cd326e9L82-R83): Corrected the parameter name from `tooContext` to `toolContext` in the `call` method.
