### PR TITLE
Fix typos @ConditionalOnMissingClass in WebFluxSseClientTransport

### DIFF
--- a/auto-configurations/spring-ai-mcp-client/src/main/java/org/springframework/ai/autoconfigure/mcp/client/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/spring-ai-mcp-client/src/main/java/org/springframework/ai/autoconfigure/mcp/client/SseHttpClientTransportAutoConfiguration.java
@@ -63,7 +63,7 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration(after = SseWebFluxTransportAutoConfiguration.class)
 @ConditionalOnClass({ McpSchema.class, McpSyncClient.class })
-@ConditionalOnMissingClass("io.modelcontextprotocol.client.transport.public class WebFluxSseClientTransport")
+@ConditionalOnMissingClass("io.modelcontextprotocol.client.transport.WebFluxSseClientTransport")
 @EnableConfigurationProperties({ McpSseClientProperties.class, McpClientCommonProperties.class })
 @ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 		matchIfMissing = true)


### PR DESCRIPTION
- fix bug @ConditionalOnMissingClass class declaration 
- change from "public class WebFluxSseClientTransport" to "WebFluxSseClientTransport"

Signed-off-by: yudai <jiangyufeng.0918@gmail.com>

