### PR TITLE
Add Context Support to Query in RetrievalAugmentationAdvisor

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisor.java
@@ -106,6 +106,7 @@ public final class RetrievalAugmentationAdvisor implements BaseAdvisor {
 		Query originalQuery = Query.builder()
 			.text(new PromptTemplate(request.userText(), request.userParams()).render())
 			.history(request.messages())
+			.context(context)
 			.build();
 
 		// 1. Transform original user query based on a chain of query transformers.


### PR DESCRIPTION
Currently, the Query object originalQuery in `RetrievalAugmentationAdvisor` only includes `text` and `history` fields. I wish to add context into originalQuery. By adding context support, downstream transformers and retrievers would be able to access more runtime information to enhance their processing capabilities.

> RetrievalAugmentationAdvisor

``` 
public AdvisedRequest before(AdvisedRequest request) {
		Map<String, Object> context = new HashMap<>(request.adviseContext());

		// 0. Create a query from the user text, parameters, and conversation history.
		Query originalQuery = Query.builder()
			.text(new PromptTemplate(request.userText(), request.userParams()).render())
			.history(request.messages())
			.build();

		// 1. Transform original user query based on a chain of query transformers.
		Query transformedQuery = originalQuery;
		for (var queryTransformer : this.queryTransformers) {
			transformedQuery = queryTransformer.apply(transformedQuery);
		}
...
}
```
