### PR TITLE
Update OpenAI Chat documentation to maintain 'with' prefix consistency

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -154,8 +154,8 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         OpenAiChatOptions.builder()
-            .model("gpt-4-o")
-            .temperature(0.4)
+            .withModel("gpt-4-o")
+            .withTemperature(0.4)
         .build()
     ));
 ----
@@ -192,7 +192,7 @@ var userMessage = new UserMessage("Explain what do you see on this picture?",
         new Media(MimeTypeUtils.IMAGE_PNG, this.imageResource));
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage,
-        OpenAiChatOptions.builder().model(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));
+        OpenAiChatOptions.builder().withModel(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));
 ----
 
 TIP: GPT_4_VISION_PREVIEW will continue to be available only to existing users of this model starting June 17, 2024. If you are not an existing user, please use the GPT_4_O or GPT_4_TURBO models. More details https://platform.openai.com/docs/deprecations/2024-06-06-gpt-4-32k-and-vision-preview-models[here]
@@ -206,7 +206,7 @@ var userMessage = new UserMessage("Explain what do you see on this picture?",
                 "https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png"));
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage,
-        OpenAiChatOptions.builder().model(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));
+        OpenAiChatOptions.builder().withModel(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));
 ----
 
 TIP: You can pass multiple images as well.
@@ -246,7 +246,7 @@ var userMessage = new UserMessage("What is this recording about?",
         List.of(new Media(MimeTypeUtils.parseMimeType("audio/mp3"), audioResource)));
 
 ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-        OpenAiChatOptions.builder().model(OpenAiApi.ChatModel.GPT_4_O_AUDIO_PREVIEW).build()));
+        OpenAiChatOptions.builder().withModel(OpenAiApi.ChatModel.GPT_4_O_AUDIO_PREVIEW).build()));
 ----
 
 TIP: You can pass multiple audio files as well.
@@ -269,7 +269,7 @@ var userMessage = new UserMessage("Tell me joke about Spring Framework");
 
 ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
         OpenAiChatOptions.builder()
-            .model(OpenAiApi.ChatModel.GPT_4_O_AUDIO_PREVIEW)
+            .withModel(OpenAiApi.ChatModel.GPT_4_O_AUDIO_PREVIEW)
             .outputModalities(List.of("text", "audio"))
             .outputAudio(new AudioParameters(Voice.ALLOY, AudioResponseFormat.WAV))
             .build()));
@@ -324,8 +324,8 @@ String jsonSchema = """
 
 Prompt prompt = new Prompt("how can I solve 8x + 7 = -23",
         OpenAiChatOptions.builder()
-            .model(ChatModel.GPT_4_O_MINI)
-            .responseFormat(new ResponseFormat(ResponseFormat.Type.JSON_SCHEMA, this.jsonSchema))
+            .withModel(ChatModel.GPT_4_O_MINI)
+            .withResponseFormat(new ResponseFormat(ResponseFormat.Type.JSON_SCHEMA, this.jsonSchema))
             .build());
 
 ChatResponse response = this.openAiChatModel.call(this.prompt);
@@ -364,8 +364,8 @@ var jsonSchema = this.outputConverter.getJsonSchema();
 
 Prompt prompt = new Prompt("how can I solve 8x + 7 = -23",
         OpenAiChatOptions.builder()
-            .model(ChatModel.GPT_4_O_MINI)
-            .responseFormat(new ResponseFormat(ResponseFormat.Type.JSON_SCHEMA, this.jsonSchema))
+            .withModel(ChatModel.GPT_4_O_MINI)
+            .withResponseFormat(new ResponseFormat(ResponseFormat.Type.JSON_SCHEMA, this.jsonSchema))
             .build());
 
 ChatResponse response = this.openAiChatModel.call(this.prompt);
@@ -395,8 +395,8 @@ val jsonSchema = outputConverter.jsonSchema;
 
 val prompt = Prompt("how can I solve 8x + 7 = -23",
 	OpenAiChatOptions.builder()
-		.model(ChatModel.GPT_4_O_MINI)
-		.responseFormat(ResponseFormat(ResponseFormat.Type.JSON_SCHEMA, jsonSchema))
+		.withModel(ChatModel.GPT_4_O_MINI)
+		.withResponseFormat(ResponseFormat(ResponseFormat.Type.JSON_SCHEMA, jsonSchema))
 		.build())
 
 val response = openAiChatModel.call(prompt)
@@ -498,9 +498,9 @@ Next, create an `OpenAiChatModel` and use it for text generations:
 ----
 var openAiApi = new OpenAiApi(System.getenv("OPENAI_API_KEY"));
 var openAiChatOptions = OpenAiChatOptions.builder()
-            .model("gpt-3.5-turbo")
-            .temperature(0.4)
-            .maxTokens(200)
+            .withModel("gpt-3.5-turbo")
+            .withTemperature(0.4F)
+            .withMaxTokens(200)
             .build();
 var chatModel = new OpenAiChatModel(this.openAiApi, this.openAiChatOptions);
 


### PR DESCRIPTION
This update ensures all builder method calls in the OpenAI Chat documentation use the 'with' prefix consistently to match the actual implementation in the OpenAiChatOptions class. The audio-related methods (.outputModalities and .outputAudio) have been kept as is.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
