### PR TITLE
feat(mcp): add support for custom MIME types in tool responses

### DIFF
--- a/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerAutoConfiguration.java
+++ b/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerAutoConfiguration.java
@@ -54,6 +54,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.MimeType;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for the Model Context Protocol (MCP)
@@ -127,9 +128,21 @@ public class McpServerAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
-	public List<McpServerFeatures.SyncToolRegistration> syncTools(ObjectProvider<List<ToolCallback>> toolCalls) {
-		var tools = toolCalls.stream().flatMap(List::stream).toList();
-		return McpToolUtils.toSyncToolRegistration(tools);
+	public List<McpServerFeatures.SyncToolRegistration> syncTools(ObjectProvider<List<ToolCallback>> toolCalls,
+			McpServerProperties serverProperties) {
+		List<ToolCallback> tools = toolCalls.stream().flatMap(List::stream).toList();
+
+		return this.toSyncToolRegistration(tools, serverProperties);
+	}
+
+	private List<McpServerFeatures.SyncToolRegistration> toSyncToolRegistration(List<ToolCallback> tools,
+			McpServerProperties serverProperties) {
+		return tools.stream().map(tool -> {
+			String toolName = tool.getToolDefinition().name();
+			MimeType mimeType = (serverProperties.getToolResponseMimeType().containsKey(toolName))
+					? MimeType.valueOf(serverProperties.getToolResponseMimeType().get(toolName)) : null;
+			return McpToolUtils.toSyncToolRegistration(tool, mimeType);
+		}).toList();
 	}
 
 	@Bean
@@ -149,13 +162,16 @@ public class McpServerAutoConfiguration {
 		SyncSpec serverBuilder = McpServer.sync(transport).serverInfo(serverInfo);
 
 		List<SyncToolRegistration> toolResgistrations = new ArrayList<>(tools.stream().flatMap(List::stream).toList());
+
 		List<ToolCallback> providerToolCallbacks = toolCallbackProvider.stream()
 			.map(pr -> List.of(pr.getToolCallbacks()))
 			.flatMap(List::stream)
 			.filter(fc -> fc instanceof ToolCallback)
 			.map(fc -> (ToolCallback) fc)
 			.toList();
-		toolResgistrations.addAll(McpToolUtils.toSyncToolRegistration(providerToolCallbacks));
+
+		toolResgistrations.addAll(this.toSyncToolRegistration(providerToolCallbacks, serverProperties));
+
 		if (!CollectionUtils.isEmpty(toolResgistrations)) {
 			serverBuilder.tools(toolResgistrations);
 			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
@@ -191,9 +207,21 @@ public class McpServerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public List<McpServerFeatures.AsyncToolRegistration> asyncTools(ObjectProvider<List<ToolCallback>> toolCalls) {
+	public List<McpServerFeatures.AsyncToolRegistration> asyncTools(ObjectProvider<List<ToolCallback>> toolCalls,
+			McpServerProperties serverProperties) {
 		var tools = toolCalls.stream().flatMap(List::stream).toList();
-		return McpToolUtils.toAsyncToolRegistration(tools);
+
+		return this.toAsyncToolRegistration(tools, serverProperties);
+	}
+
+	private List<McpServerFeatures.AsyncToolRegistration> toAsyncToolRegistration(List<ToolCallback> tools,
+			McpServerProperties serverProperties) {
+		return tools.stream().map(tool -> {
+			String toolName = tool.getToolDefinition().name();
+			MimeType mimeType = (serverProperties.getToolResponseMimeType().containsKey(toolName))
+					? MimeType.valueOf(serverProperties.getToolResponseMimeType().get(toolName)) : null;
+			return McpToolUtils.toAsyncToolRegistration(tool, mimeType);
+		}).toList();
 	}
 
 	@Bean
@@ -219,7 +247,9 @@ public class McpServerAutoConfiguration {
 			.filter(fc -> fc instanceof ToolCallback)
 			.map(fc -> (ToolCallback) fc)
 			.toList();
-		toolResgistrations.addAll(McpToolUtils.toAsyncToolRegistration(providerToolCallbacks));
+
+		toolResgistrations.addAll(this.toAsyncToolRegistration(providerToolCallbacks, serverProperties));
+
 		if (!CollectionUtils.isEmpty(toolResgistrations)) {
 			serverBilder.tools(toolResgistrations);
 			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());

--- a/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerProperties.java
+++ b/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.autoconfigure.mcp.server;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.Assert;
 
@@ -130,6 +133,11 @@ public class McpServerProperties {
 
 	}
 
+	/**
+	 * (Optinal) response MIME type per tool name.
+	 */
+	private Map<String, String> toolResponseMimeType = new HashMap<>();
+
 	public boolean isStdio() {
 		return this.stdio;
 	}
@@ -204,6 +212,10 @@ public class McpServerProperties {
 	public void setType(ServerType serverType) {
 		Assert.notNull(serverType, "Server type must not be null");
 		this.type = serverType;
+	}
+
+	public Map<String, String> getToolResponseMimeType() {
+		return this.toolResponseMimeType;
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -87,8 +87,9 @@ All properties are prefixed with `spring.ai.mcp.server`:
 |`version` |Server version |`1.0.0`
 |`type` |Server type (SYNC/ASYNC) |`SYNC`
 |`resource-change-notification` |Enable resource change notifications |`true`
-|`tool-change-notification` |Enable tool change notifications |`true`
 |`prompt-change-notification` |Enable prompt change notifications |`true`
+|`tool-change-notification` |Enable tool change notifications |`true`
+|`tool-response-mime-type` |(optinal) response MIME type per tool name. For example `spring.ai.mcp.server.tool-response-mime-type.generateImage=image/png` will assosiate the `image/png` mime type with the `generateImage()` tool name |`-`
 |`sse-message-endpoint` |SSE endpoint path for web transport |`/mcp/message`
 |===
 


### PR DESCRIPTION
Add capability to specify MIME types for MCP tool responses, with special handling for image content.

This enhancement allows tools to return different content types, particularly images, by:
- Adding a new toolResponseMimeType map property to configure response MIME types per tool
- Extending tool registration methods to accept and use MIME type information
- Adding special handling for image content in tool responses
- Updating documentation with the new configuration options
