### PR TITLE
Typo in example code

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -154,7 +154,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         OpenAiChatOptions.builder()
-            .model("gpt-4-o")
+            .model("gpt-4o")
             .temperature(0.4)
         .build()
     ));


### PR DESCRIPTION
Existing code for **Runtime Options** displays a typo where the model is `gpt-4-o` and should be `gpt-4o`:

```
ChatResponse response = chatModel.call(
    new Prompt(
        "Generate the names of 5 famous pirates.",
        OpenAiChatOptions.builder()
            .model("gpt-4-o")
            .temperature(0.4)
        .build()
    ));
```

Using `gpt-4-o` generates this error:
```
org.springframework.ai.retry.NonTransientAiException: 404 - {
    "error": {
        "message": "The model `gpt-4-o` does not exist or you do not have access to it.",
        "type": "invalid_request_error",
        "param": null,
        "code": "model_not_found"
    }
}
```

Changing the `model` parameter in the example to `gpt-4o` resolves this.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
