### PR TITLE
Adding @ConditionalOnProperty configuration for OpenAiModerationModel.

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/openai/OpenAiAutoConfiguration.java
@@ -253,6 +253,8 @@ public class OpenAiAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = OpenAiModerationProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+			matchIfMissing = true)
 	public OpenAiModerationModel openAiModerationClient(OpenAiConnectionProperties commonProperties,
 			OpenAiModerationProperties moderationProperties, RetryTemplate retryTemplate,
 			ObjectProvider<RestClient.Builder> restClientBuilderProvider, ResponseErrorHandler responseErrorHandler) {


### PR DESCRIPTION
Added the ability to disable auto configuration of the OpenAiModerationModel bean.  Addresses reported bug [2373](https://github.com/spring-projects/spring-ai/issues/2373)

