### PR TITLE
update anthropic model version in example code from Documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -102,7 +102,7 @@ The prefix `spring.ai.anthropic.chat` is the property prefix that lets you confi
 | Property | Description | Default
 
 | spring.ai.anthropic.chat.enabled | Enable Anthropic chat model.  | true
-| spring.ai.anthropic.chat.options.model | This is the Anthropic Chat model to use. Supports: `claude-3-7-sonnet-latest`, `claude-3-5-sonnet-latest`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307` and the legacy `claude-2.1`, `claude-2.0` and `claude-instant-1.2` models. | `claude-3-7-sonnet-latest`
+| spring.ai.anthropic.chat.options.model | This is the Anthropic Chat model to use. Supports: `claude-3-7-sonnet-latest`, `claude-3-5-sonnet-latest`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307` | `claude-3-7-sonnet-latest`
 | spring.ai.anthropic.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8
 | spring.ai.anthropic.chat.options.max-tokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | 500
 | spring.ai.anthropic.chat.options.stop-sequence | Custom text sequences that will cause the model to stop generating. Our models will normally stop when they have naturally completed their turn, which will result in a response stop_reason of "end_turn". If you want the model to stop generating when it encounters custom strings of text, you can use the stop_sequences parameter. If the model encounters one of the custom sequences, the response stop_reason value will be "stop_sequence" and the response stop_sequence value will contain the matched stop sequence. | -
@@ -134,7 +134,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         AnthropicChatOptions.builder()
-            .model("claude-2.1")
+            .model("claude-3-7-sonnet-latest")
             .temperature(0.4)
         .build()
     ));


### PR DESCRIPTION
Update Anthropics Model Version in Example Code from [Documentation](https://docs.spring.io/spring-ai/reference/api/chat/anthropic-chat.html)

The legacy model is no longer supported, and attempting to use it results in an error.
The Anthropic API now returns a 404 error:
```log
org.springframework.ai.retry.NonTransientAiException: 404 - {"type":"error","error":{"type":"not_found_error","message":"model: claude-2.1"}}
```

According to the [documentation](https://docs.anthropic.com/en/docs/resources/model-deprecations), the model was scheduled for retirement on July 21, 2025. However, it appears to have already been retired.

Even if the 404 error occurs only for me, it seems there is no issue in upgrading the version since it was already deprecated on January 21, 2025.