### PR TITLE
chore: Remove unnecessary public modifier in ToolCallbackProvider.

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/tool/ToolCallbackProvider.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tool/ToolCallbackProvider.java
@@ -30,11 +30,11 @@ public interface ToolCallbackProvider {
 
 	FunctionCallback[] getToolCallbacks();
 
-	public static ToolCallbackProvider from(List<? extends FunctionCallback> toolCallbacks) {
+	static ToolCallbackProvider from(List<? extends FunctionCallback> toolCallbacks) {
 		return new StaticToolCallbackProvider(toolCallbacks);
 	}
 
-	public static ToolCallbackProvider from(FunctionCallback... toolCallbacks) {
+	static ToolCallbackProvider from(FunctionCallback... toolCallbacks) {
 		return new StaticToolCallbackProvider(toolCallbacks);
 	}
 


### PR DESCRIPTION
Motivication:
Remove unnecessary public modifier in ToolCallbackProvider.