### PR TITLE
feat: Add helper method to ToolCallbackProvider for ToolCallback.

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tool/StaticToolCallbackProvider.java
@@ -15,6 +15,7 @@
 */
 package org.springframework.ai.tool;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.ai.model.function.FunctionCallback;
@@ -72,6 +73,19 @@ public class StaticToolCallbackProvider implements ToolCallbackProvider {
 	 * elements
 	 */
 	public StaticToolCallbackProvider(List<? extends FunctionCallback> toolCallbacks) {
+		Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
+		this.toolCallbacks = toolCallbacks.toArray(new FunctionCallback[0]);
+	}
+
+	/**
+	 * Constructs a new StaticToolCallbackProvider with the specified list of function
+	 * callbacks. The list is converted to an array internally.
+	 * @param toolCallbacks the list of function callbacks to be provided by this
+	 * provider. Must not be null and must not contain null elements.
+	 * @throws IllegalArgumentException if the toolCallbacks list is null or contains null
+	 * elements
+	 */
+	public StaticToolCallbackProvider(Collection<? extends ToolCallback> toolCallbacks) {
 		Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
 		this.toolCallbacks = toolCallbacks.toArray(new FunctionCallback[0]);
 	}

--- a/spring-ai-core/src/main/java/org/springframework/ai/tool/ToolCallbackProvider.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/tool/ToolCallbackProvider.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.tool;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.ai.model.function.FunctionCallback;
@@ -30,12 +31,23 @@ public interface ToolCallbackProvider {
 
 	FunctionCallback[] getToolCallbacks();
 
+	@Deprecated
 	public static ToolCallbackProvider from(List<? extends FunctionCallback> toolCallbacks) {
 		return new StaticToolCallbackProvider(toolCallbacks);
 	}
 
+	@Deprecated
 	public static ToolCallbackProvider from(FunctionCallback... toolCallbacks) {
 		return new StaticToolCallbackProvider(toolCallbacks);
 	}
+
+	static ToolCallbackProvider from(Collection<? extends ToolCallback> toolCallbacks) {
+		return new StaticToolCallbackProvider(toolCallbacks);
+	}
+
+	static ToolCallbackProvider from(ToolCallback... toolCallbacks) {
+		return new StaticToolCallbackProvider(toolCallbacks);
+	}
+
 
 }


### PR DESCRIPTION
Motivation：
Drop the deprecated `FunctionCallback` usage