### PR TITLE
fix typo in rag doc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -123,7 +123,7 @@ String answer = chatClient.prompt()
 [source,java]
 ----
 Advisor retrievalAugmentationAdvisor = RetrievalAugmentationAdvisor.builder()
-        .queryTransformer(RewriteQueryTransformer.builder()
+        .queryTransformers(RewriteQueryTransformer.builder()
                 .chatClientBuilder(chatClientBuilder.build().mutate())
                 .build())
         .documentRetriever(VectorStoreDocumentRetriever.builder()


### PR DESCRIPTION
docs: https://docs.spring.io/spring-ai/reference/api/retrieval-augmented-generation.html#_advanced_rag

- Fix typo: `queryTransformer` → `queryTransformers`
  - Identified in https://github.com/spring-projects/spring-ai/issues/2296