### PR TITLE
fix vertordbs opensearch.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
@@ -77,7 +77,7 @@ List<Document> documents = List.of(
 vectorStore.add(documents);
 
 // Retrieve documents similar to a query
-List<Document> results = vectorStore.similaritySearch(SearchRequest.build().query("Spring").topK(5).build());
+List<Document> results = vectorStore.similaritySearch(SearchRequest.builder().query("Spring").topK(5).build());
 ----
 
 === Configuration Properties


### PR DESCRIPTION
docs: [spring-ai/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc](https://github.com/spring-projects/spring-ai/blob/ff287a54573cf8330253eab8a8c3e089447b8760/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc?plain=1#L80)

- fix typo: `List<Document> results = vectorStore.similaritySearch(SearchRequest.build().query("Spring").topK(5).build());`
-> `List<Document> results = vectorStore.similaritySearch(SearchRequest.builder().query("Spring").topK(5).build());`
  - Identified in #2147 