### PR TITLE
Fix typo in spring-ai-mcp-server autoconfiguration

### DIFF
--- a/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerAutoConfiguration.java
+++ b/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerAutoConfiguration.java
@@ -173,7 +173,7 @@ public class McpServerAutoConfiguration {
 		if (!CollectionUtils.isEmpty(toolRegistrations)) {
 			serverBuilder.tools(toolRegistrations);
 			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
-			logger.info("Registered tools" + toolRegistrations.size() + " notification: "
+			logger.info("Registered tools: " + toolRegistrations.size() + ", notification: "
 					+ serverProperties.isToolChangeNotification());
 		}
 
@@ -181,7 +181,7 @@ public class McpServerAutoConfiguration {
 		if (!CollectionUtils.isEmpty(resourceRegistrations)) {
 			serverBuilder.resources(resourceRegistrations);
 			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
-			logger.info("Registered resources" + resourceRegistrations.size() + " notification: "
+			logger.info("Registered resources: " + resourceRegistrations.size() + ", notification: "
 					+ serverProperties.isResourceChangeNotification());
 		}
 
@@ -189,7 +189,7 @@ public class McpServerAutoConfiguration {
 		if (!CollectionUtils.isEmpty(promptRegistrations)) {
 			serverBuilder.prompts(promptRegistrations);
 			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
-			logger.info("Registered prompts" + promptRegistrations.size() + " notification: "
+			logger.info("Registered prompts: " + promptRegistrations.size() + ", notification: "
 					+ serverProperties.isPromptChangeNotification());
 		}
 
@@ -251,7 +251,7 @@ public class McpServerAutoConfiguration {
 		if (!CollectionUtils.isEmpty(toolRegistrations)) {
 			serverBuilder.tools(toolRegistrations);
 			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
-			logger.info("Registered tools" + toolRegistrations.size() + " notification: "
+			logger.info("Registered tools: " + toolRegistrations.size() + ", notification: "
 					+ serverProperties.isToolChangeNotification());
 		}
 
@@ -259,7 +259,7 @@ public class McpServerAutoConfiguration {
 		if (!CollectionUtils.isEmpty(resourceRegistrations)) {
 			serverBuilder.resources(resourceRegistrations);
 			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
-			logger.info("Registered resources" + resourceRegistrations.size() + " notification: "
+			logger.info("Registered resources: " + resourceRegistrations.size() + ", notification: "
 					+ serverProperties.isResourceChangeNotification());
 		}
 
@@ -267,7 +267,7 @@ public class McpServerAutoConfiguration {
 		if (!CollectionUtils.isEmpty(promptRegistrations)) {
 			serverBuilder.prompts(promptRegistrations);
 			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
-			logger.info("Registered prompts" + promptRegistrations.size() + " notification: "
+			logger.info("Registered prompts: " + promptRegistrations.size() + ", notification: "
 					+ serverProperties.isPromptChangeNotification());
 		}
 

--- a/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerProperties.java
+++ b/auto-configurations/spring-ai-mcp-server/src/main/java/org/springframework/ai/autoconfigure/mcp/server/McpServerProperties.java
@@ -134,7 +134,7 @@ public class McpServerProperties {
 	}
 
 	/**
-	 * (Optinal) response MIME type per tool name.
+	 * (Optional) response MIME type per tool name.
 	 */
 	private Map<String, String> toolResponseMimeType = new HashMap<>();
 


### PR DESCRIPTION
This pull request includes fixing minor typos from `McpServerAutoConfiguration` and `McpServerProperties`.
- in `McpServerProperties`
  - fixed `Optinal` to `Optional`
- in `McpServerAutoConfiguration`
  - added delimiter on logging
  - AS-IS: `Registered resources1 notification: true`
  - TO-BE: `Registered resources: 1, notification: true`