### PR TITLE
Request-time filter expressions for RAG

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/RetrievalAugmentationAdvisor.java
@@ -106,6 +106,7 @@ public final class RetrievalAugmentationAdvisor implements BaseAdvisor {
 		Query originalQuery = Query.builder()
 			.text(new PromptTemplate(request.userText(), request.userParams()).render())
 			.history(request.messages())
+			.context(context)
 			.build();
 
 		// 1. Transform original user query based on a chain of query transformers.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -39,14 +39,11 @@ This filter expression can be configured when creating the `QuestionAnswerAdviso
 
 Here is how to create an instance of `QuestionAnswerAdvisor` where the threshold is `0.8` and to return the top `6` reulsts.
 
-
 [source,java]
 ----
 var qaAdvisor = new QuestionAnswerAdvisor(this.vectorStore,
         SearchRequest.builder().similarityThreshold(0.8d).topK(6).build());
 ----
-
-
 
 ==== Dynamic Filter Expressions
 
@@ -117,6 +114,29 @@ String answer = chatClient.prompt()
         .call()
         .content();
 ----
+
+The `VectorStoreDocumentRetriever` accepts a `FilterExpression` to filter the search results based on metadata.
+You can provide one when instantiating the `VectorStoreDocumentRetriever` or at runtime per request,
+using the `FILTER_EXPRESSION` advisor context parameter.
+
+[source,java]
+----
+Advisor retrievalAugmentationAdvisor = RetrievalAugmentationAdvisor.builder()
+        .documentRetriever(VectorStoreDocumentRetriever.builder()
+                .similarityThreshold(0.50)
+                .vectorStore(vectorStore)
+                .build())
+        .build();
+
+String answer = chatClient.prompt()
+        .advisors(retrievalAugmentationAdvisor)
+        .advisors(a -> a.param(VectorStoreDocumentRetriever.FILTER_EXPRESSION, "type == 'Spring'"))
+        .user(question)
+        .call()
+        .content();
+----
+
+See xref:api/retrieval-augmented-generation.adoc#_vectorstoredocumentretriever for more information.
 
 ===== Advanced RAG
 
@@ -296,6 +316,18 @@ DocumentRetriever retriever = VectorStoreDocumentRetriever.builder()
         .build())
     .build();
 List<Document> documents = retriever.retrieve(new Query("What are the KPIs for the next semester?"));
+----
+
+You can also provide a request-specific filter expression via the `Query` API, using the `FILTER_EXPRESSION` parameter.
+If both the request-specific and the retriever-specific filter expressions are provided, the request-specific filter expression takes precedence.
+
+[source,java]
+----
+Query query = Query.builder()
+    .text("Who is Anacletus?")
+    .context(Map.of(VectorStoreDocumentRetriever.FILTER_EXPRESSION, "location == 'Whispering Woods'"))
+    .build();
+List<Document> retrievedDocuments = documentRetriever.retrieve(query);
 ----
 
 ==== Document Join

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
@@ -109,6 +109,29 @@ class RetrievalAugmentationAdvisorIT {
 	}
 
 	@Test
+	void ragWithRequestFilter() {
+		String question = "Where does the adventure of Anacletus and Birba take place?";
+
+		RetrievalAugmentationAdvisor ragAdvisor = RetrievalAugmentationAdvisor.builder()
+			.documentRetriever(VectorStoreDocumentRetriever.builder().vectorStore(this.pgVectorStore).build())
+			.build();
+
+		ChatResponse chatResponse = ChatClient.builder(this.openAiChatModel)
+			.build()
+			.prompt(question)
+			.advisors(ragAdvisor)
+			.advisors(a -> a.param(VectorStoreDocumentRetriever.FILTER_EXPRESSION, "location == 'Italy'"))
+			.call()
+			.chatResponse();
+
+		assertThat(chatResponse).isNotNull();
+		// No documents retrieved since the filter expression matches none of the
+		// documents in the vector store.
+		assertThat((String) chatResponse.getResult().getMetadata().get(RetrievalAugmentationAdvisor.DOCUMENT_CONTEXT))
+			.isNull();
+	}
+
+	@Test
 	void ragWithCompression() {
 		MessageChatMemoryAdvisor memoryAdvisor = MessageChatMemoryAdvisor.builder(new InMemoryChatMemory()).build();
 

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/rag/preretrieval/query/transformation/RewriteQueryTransformerIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/rag/preretrieval/query/transformation/RewriteQueryTransformerIT.java
@@ -43,7 +43,7 @@ class RewriteQueryTransformerIT {
 
 	@Test
 	void whenTransformerWithDefaults() {
-		Query query = new Query("I'm studying machine learning. What is an LLM?");
+		Query query = new Query("What are the main tourist attractions in L.A.?");
 		QueryTransformer queryTransformer = RewriteQueryTransformer.builder()
 			.chatClientBuilder(ChatClient.builder(this.openAiChatModel))
 			.build();
@@ -52,7 +52,7 @@ class RewriteQueryTransformerIT {
 
 		assertThat(transformedQuery).isNotNull();
 		System.out.println(transformedQuery);
-		assertThat(transformedQuery.text()).containsIgnoringCase("model");
+		assertThat(transformedQuery.text()).containsIgnoringCase("Angeles");
 	}
 
 }


### PR DESCRIPTION
When using the RetrievalAugmentationAdvisor with the VectorStoreDocumentRetriever, it’s now possible to provide a filter expression at request-time as an advisor context variable with key VectorStoreDocumentRetriever.FILTER_EXPRESSION.

Fixes gh-1776