### PR TITLE
Fix property name in Redis documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
@@ -84,7 +84,7 @@ A simple configuration can be provided via Spring Boot's `application.yml`,
 spring:
   data:
     redis:
-      uri: <redis instance uri>
+      url: <redis instance url>
   ai:
     vectorstore:
       redis:


### PR DESCRIPTION
Fixes #2414

resolves: https://github.com/spring-projects/spring-ai/issues/2414

Current implementation of RedisProperties: https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/data/redis/RedisProperties.java#L49