### PR TITLE
feat(mcp): handle ToolContext in MCP tool callbacks

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
@@ -22,6 +22,7 @@ import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -108,6 +109,12 @@ public class AsyncMcpToolCallback implements ToolCallback {
 		return this.asyncMcpClient.callTool(new CallToolRequest(this.getToolDefinition().name(), arguments))
 			.map(response -> ModelOptionsUtils.toJsonString(response.content()))
 			.block();
+	}
+
+	@Override
+	public String call(String toolArguments, ToolContext toolContext) {
+		// ToolContext is not supported by the MCP tools
+		return this.call(toolArguments);
 	}
 
 }

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
@@ -23,6 +23,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
@@ -109,6 +110,12 @@ public class SyncMcpToolCallback implements ToolCallback {
 		CallToolResult response = this.mcpClient
 			.callTool(new CallToolRequest(this.getToolDefinition().name(), arguments));
 		return ModelOptionsUtils.toJsonString(response.content());
+	}
+
+	@Override
+	public String call(String toolArguments, ToolContext toolContext) {
+		// ToolContext is not supported by the MCP tools
+		return this.call(toolArguments);
 	}
 
 }

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.mcp;
 
+import java.util.Map;
+
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -24,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.model.ToolContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,6 +70,22 @@ class SyncMcpToolCallbackTests {
 
 		// Act
 		String response = callback.call("{\"param\":\"value\"}");
+
+		// Assert
+		assertThat(response).isNotNull();
+	}
+
+	@Test
+	void callShoulIngroeToolContext() {
+		// Arrange
+		when(tool.name()).thenReturn("testTool");
+		CallToolResult callResult = mock(CallToolResult.class);
+		when(mcpClient.callTool(any(CallToolRequest.class))).thenReturn(callResult);
+
+		SyncMcpToolCallback callback = new SyncMcpToolCallback(mcpClient, tool);
+
+		// Act
+		String response = callback.call("{\"param\":\"value\"}", new ToolContext(Map.of("foo", "bar")));
 
 		// Assert
 		assertThat(response).isNotNull();


### PR DESCRIPTION
- Implement the new ToolCallback.call(String, ToolContext) method in both Sync and Async MCP tool callbacks.
- Since MCP tools don't support tool context, the implementation ignores the context parameter and delegates to the existing call(String) method. Added test to verify the behavior.

Resolves #2378