### PR TITLE
Fix PgVectorStore doDelete function as batch update

### DIFF
--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorStore.java
@@ -319,12 +319,21 @@ public class PgVectorStore extends AbstractObservationVectorStore implements Ini
 
 	@Override
 	public void doDelete(List<String> idList) {
-		int updateCount = 0;
-		for (String id : idList) {
-			int count = this.jdbcTemplate.update("DELETE FROM " + getFullyQualifiedTableName() + " WHERE id = ?",
-					UUID.fromString(id));
-			updateCount = updateCount + count;
-		}
+		String sql = "DELETE FROM " + getFullyQualifiedTableName() + " WHERE id = ?";
+
+		this.jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+
+			@Override
+			public void setValues(PreparedStatement ps, int i) throws SQLException {
+				var id = idList.get(i);
+				StatementCreatorUtils.setParameterValue(ps, 1, SqlTypeValue.TYPE_UNKNOWN, convertIdToPgType(id));
+			}
+
+			@Override
+			public int getBatchSize() {
+				return idList.size();
+			}
+		});
 	}
 
 	@Override

--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorStoreIT.java
@@ -75,6 +75,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Jihoon Kim
+ * @author CChuYong
  */
 @Testcontainers
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -227,6 +228,47 @@ public class PgVectorStoreIT extends BaseVectorStoreTests {
 				initSchema(context);
 
 				vectorStore.add(List.of(new Document("NOT_UUID", "TEXT", new HashMap<>())));
+
+				dropTable(context);
+			});
+	}
+
+	@Test
+	public void testBulkOperationWithUuidIdType() {
+		this.contextRunner.withPropertyValues("test.spring.ai.vectorstore.pgvector.distanceType=" + "COSINE_DISTANCE")
+			.run(context -> {
+
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+
+				List<Document> documents = List.of(
+						new Document(new RandomIdGenerator().generateId(), "TEXT", new HashMap<>()),
+						new Document(new RandomIdGenerator().generateId(), "TEXT", new HashMap<>()),
+						new Document(new RandomIdGenerator().generateId(), "TEXT", new HashMap<>()));
+				vectorStore.add(documents);
+
+				List<String> idList = documents.stream().map(Document::getId).toList();
+				vectorStore.delete(idList);
+
+				dropTable(context);
+			});
+	}
+
+	@Test
+	public void testBulkOperationWithNonUuidIdType() {
+		this.contextRunner.withPropertyValues("test.spring.ai.vectorstore.pgvector.distanceType=" + "COSINE_DISTANCE")
+			.withPropertyValues("test.spring.ai.vectorstore.pgvector.initializeSchema=" + false)
+			.withPropertyValues("test.spring.ai.vectorstore.pgvector.idType=" + "TEXT")
+			.run(context -> {
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+				initSchema(context);
+
+				List<Document> documents = List.of(new Document("NON_UUID_1", "TEXT", new HashMap<>()),
+						new Document("NON_UUID_2", "TEXT", new HashMap<>()),
+						new Document("NON_UUID_3", "TEXT", new HashMap<>()));
+				vectorStore.add(documents);
+
+				List<String> idList = documents.stream().map(Document::getId).toList();
+				vectorStore.delete(idList);
 
 				dropTable(context);
 			});
@@ -436,6 +478,8 @@ public class PgVectorStoreIT extends BaseVectorStoreTests {
 			PgVectorStore vectorStore = context.getBean(PgVectorStore.class);
 			Optional<JdbcTemplate> nativeClient = vectorStore.getNativeClient();
 			assertThat(nativeClient).isPresent();
+
+			dropTable(context);
 		});
 	}
 


### PR DESCRIPTION
This pull request includes fixing minor issues on `PgVectorStore.doDelete()`.

- handling different types of id
  - `PgVectorStore` can handle different kind of IdTypes from #2111.
  - but `doDelete()` function only accepts UUID, so method will throw `IllegalArgumentException` when id type isn't UUID.
  - so used `convertIdToPgType()` function to correctly map id types.
- used `JdbcTemplate.batchUpdate()` to delete bulk of ids.