### PR TITLE
minor fix azure openai chat model doc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -121,7 +121,7 @@ A customizer might be used for example to change the default response timeout:
 public class AzureOpenAiConfig {
 
 	@Bean
-	public OpenAIClientBuilderCustomizer responseTimeoutCustomizer() {
+	public AzureOpenAIClientBuilderCustomizer responseTimeoutCustomizer() {
 		return openAiClientBuilder -> {
 			HttpClientOptions clientOptions = new HttpClientOptions()
 					.setResponseTimeout(Duration.ofMinutes(5));


### PR DESCRIPTION
This fixes a minor issue in the azure openai chat model doc `OpenAIClientBuilderCustomizer` usage example

When I created https://github.com/spring-projects/spring-ai/pull/2224 I used an old code version that I had locally where the class name was outdated.

This fixes the documentation.

ping @sobychacko 