### PR TITLE
Fixed the issue where using built-in functions in PromptTemplate caused validation failures, and added a method:skipValidate() to skip validation for PromptTemplate.

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
@@ -109,13 +109,29 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 		}
 	}
 
+	public PromptTemplate(Resource resource, boolean skipRenderValidate) {
+		this(resource);
+		this.skipRenderValidate = skipRenderValidate;
+	}
+
+	public PromptTemplate(String template, boolean skipRenderValidate) {
+		this(template);
+		this.skipRenderValidate = skipRenderValidate;
+	}
+
+	public PromptTemplate(String template, Map<String, Object> model, boolean skipRenderValidate) {
+		this(template, model);
+		this.skipRenderValidate = skipRenderValidate;
+	}
+
+	public PromptTemplate(Resource resource, Map<String, Object> model, boolean skipRenderValidate) {
+		this(resource, model);
+		this.skipRenderValidate = skipRenderValidate;
+	}
+
 	public void add(String name, Object value) {
 		this.st.add(name, value);
 		this.dynamicModel.put(name, value);
-	}
-
-	public void skipValidate() {
-		this.skipRenderValidate = true;
 	}
 
 	public String getTemplate() {

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
@@ -48,7 +48,7 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 
 	private Map<String, Object> dynamicModel = new HashMap<>();
 
-	private boolean skipRenderValidate = false;
+	private boolean skipRenderValidate = true;
 
 	public PromptTemplate(Resource resource) {
 		try (InputStream inputStream = resource.getInputStream()) {

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.prompt;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit Tests for {@link PromptTemplateTests}.
+ *
+ * @author Sun Yuhan
+ */
+public class PromptTemplateTests {
+	@Test
+	void buildPromptTemplateWithBuiltInFunctions() {
+		String chatMemoryPrompt = """
+                {if(strlen(memory))}
+
+                Hello World!
+
+                ---------------------
+                {memory}
+                ---------------------
+                {endif}
+                """;
+
+		PromptTemplate promptTemplate = new PromptTemplate(chatMemoryPrompt);
+		promptTemplate.add("memory", "you are a helpful assistant");
+		System.out.println(promptTemplate.render());
+	}
+
+	@Test
+	void buildPromptTemplateSkipRenderValidate() {
+		String chatMemoryPrompt = """
+                {if(strlen(memory))}
+
+                Hello World!
+
+                ---------------------
+                {memory}
+                ---------------------
+                {endif}
+                """;
+
+		PromptTemplate promptTemplate = new PromptTemplate(chatMemoryPrompt);
+		promptTemplate.add("memory", "you are a helpful assistant");
+		promptTemplate.skipValidate();
+		System.out.println(promptTemplate.render());
+	}
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
@@ -55,9 +55,8 @@ public class PromptTemplateTests {
                 {endif}
                 """;
 
-		PromptTemplate promptTemplate = new PromptTemplate(chatMemoryPrompt);
+		PromptTemplate promptTemplate = new PromptTemplate(chatMemoryPrompt, true);
 		promptTemplate.add("memory", "you are a helpful assistant");
-		promptTemplate.skipValidate();
 		System.out.println(promptTemplate.render());
 	}
 }


### PR DESCRIPTION
As mentioned in https://github.com/spring-projects/spring-ai/issues/2456, when using `PromptTemplate`, if the template contains certain built-in functions, it fails validation during `render()`. I made the following two fixes and optimizations:

1. By comparing the function names in `org.stringtemplate.v4.compiler.Compiler#funcs`, I skip the validation of these built-in functions.
2. Added a `skipValidate()` method to allow users to actively skip this validation.