### PR TITLE
feat(ESvectorstore): Custom ES filed name

### DIFF
--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreAutoConfiguration.java
@@ -72,6 +72,9 @@ public class ElasticsearchVectorStoreAutoConfiguration {
 		if (properties.getSimilarity() != null) {
 			elasticsearchVectorStoreOptions.setSimilarity(properties.getSimilarity());
 		}
+		if (properties.getFiledName() != null) {
+			elasticsearchVectorStoreOptions.setFiledName(properties.getFiledName());
+		}
 
 		return ElasticsearchVectorStore.builder(restClient, embeddingModel)
 			.options(elasticsearchVectorStoreOptions)

--- a/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreProperties.java
+++ b/spring-ai-spring-boot-autoconfigure/src/main/java/org/springframework/ai/autoconfigure/vectorstore/elasticsearch/ElasticsearchVectorStoreProperties.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.autoconfigure.vectorstore.elasticsearch;
 
 import org.springframework.ai.autoconfigure.vectorstore.CommonVectorStoreProperties;
+import org.springframework.ai.vectorstore.elasticsearch.ElasticsearchVectorStoreOptions;
 import org.springframework.ai.vectorstore.elasticsearch.SimilarityFunction;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -46,6 +47,11 @@ public class ElasticsearchVectorStoreProperties extends CommonVectorStorePropert
 	 */
 	private SimilarityFunction similarity;
 
+	/**
+	 * The field name to store the vector.
+	 */
+	private String filedName = "embedding";
+
 	public String getIndexName() {
 		return this.indexName;
 	}
@@ -68,6 +74,14 @@ public class ElasticsearchVectorStoreProperties extends CommonVectorStorePropert
 
 	public void setSimilarity(SimilarityFunction similarity) {
 		this.similarity = similarity;
+	}
+
+	public String getFiledName() {
+		return filedName;
+	}
+
+	public void setFiledName(String filedName) {
+		this.filedName = filedName;
 	}
 
 }

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
@@ -263,7 +263,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 				.knn(knn -> knn.queryVector(EmbeddingUtils.toList(vectors))
 					.similarity(finalThreshold)
 					.k(searchRequest.getTopK())
-					.field("embedding")
+					.field(this.options.getFiledName())
 					.numCandidates((int) (1.5 * searchRequest.getTopK()))
 					.filter(fl -> fl
 						.queryString(qs -> qs.query(getElasticsearchQueryString(searchRequest.getFilterExpression())))))
@@ -321,7 +321,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 		try {
 			this.elasticsearchClient.indices()
 				.create(cr -> cr.index(this.options.getIndexName())
-					.mappings(map -> map.properties("embedding",
+					.mappings(map -> map.properties(this.options.getFiledName(),
 							p -> p.denseVector(dv -> dv.similarity(this.options.getSimilarity().toString())
 								.dims(this.options.getDimensions())))));
 		}

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStoreOptions.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStoreOptions.java
@@ -40,6 +40,11 @@ public class ElasticsearchVectorStoreOptions {
 	 */
 	private SimilarityFunction similarity = SimilarityFunction.cosine;
 
+	/**
+	 * The field name to store the vector.
+	 */
+	private String filedName = "embedding";
+
 	public String getIndexName() {
 		return this.indexName;
 	}
@@ -62,6 +67,14 @@ public class ElasticsearchVectorStoreOptions {
 
 	public void setSimilarity(SimilarityFunction similarity) {
 		this.similarity = similarity;
+	}
+
+	public String getFiledName() {
+		return filedName;
+	}
+
+	public void setFiledName(String filedName) {
+		this.filedName = filedName;
 	}
 
 }


### PR DESCRIPTION
- added in the ElasticsearchVectorStoreOptions and ElasticsearchVectorStoreProperties filedName properties
- Allows the user to customize the field name of the storage vector, default is "embedding"
- Update related methods in ElasticsearchVectorStore to support custom field names
- in ElasticsearchVectorStoreAutoConfiguration add support for a custom field name