### PR TITLE
Support userText rendering strategy in RetrievalAugmentationAdvisor

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/NoOpUserTextProcessor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/NoOpUserTextProcessor.java
@@ -1,0 +1,18 @@
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.Map;
+
+/**
+ * A {@link UserTextProcessor} that returns the user text as is.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public class NoOpUserTextProcessor implements UserTextProcessor {
+
+	@Override
+	public String process(String userText, Map<String, Object> userParams) {
+		return userText;
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptTemplateUserTextProcessor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/PromptTemplateUserTextProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.util.Assert;
+
+import java.util.Map;
+
+/**
+ * Processes the advised user text with the given user parameters using a
+ * {@link PromptTemplate}.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public class PromptTemplateUserTextProcessor implements UserTextProcessor {
+
+	@Override
+	public String process(String userText, Map<String, Object> userParams) {
+		Assert.hasText(userText, "userText cannot be null or empty");
+		Assert.notNull(userParams, "userParams cannot be null");
+		Assert.noNullElements(userParams.keySet(), "userParams keys cannot be null");
+
+		return new PromptTemplate(userText, userParams).render();
+	}
+
+}

--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/UserTextProcessor.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/UserTextProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * Processes the advised user text with the given user parameters.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+@FunctionalInterface
+public interface UserTextProcessor extends BiFunction<String, Map<String, Object>, String> {
+
+	String process(String userText, Map<String, Object> userParams);
+
+	@Override
+	default String apply(String userText, Map<String, Object> userParams) {
+		return process(userText, userParams);
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/NoOpUserTextProcessorTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/NoOpUserTextProcessorTests.java
@@ -1,0 +1,22 @@
+package org.springframework.ai.chat.client.advisor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link NoOpUserTextProcessor}.
+ *
+ * @author Thomas Vitale
+ */
+class NoOpUserTextProcessorTests {
+
+	@Test
+	void process() {
+		NoOpUserTextProcessor processor = new NoOpUserTextProcessor();
+		String userText = "Hello, {World}!";
+		String processedText = processor.process(userText, null);
+		assertEquals(userText, processedText);
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/PromptTemplateUserTextProcessorTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/PromptTemplateUserTextProcessorTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Unit tests for {@link PromptTemplateUserTextProcessor}.
+ *
+ * @author Thomas Vitale
+ */
+class PromptTemplateUserTextProcessorTests {
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	void processWithNullOrEmptyUserText(String userText) {
+		PromptTemplateUserTextProcessor processor = new PromptTemplateUserTextProcessor();
+		Map<String, Object> userParams = Map.of("name", "William");
+		assertThatIllegalArgumentException().isThrownBy(() -> processor.process(userText, userParams))
+			.withMessage("userText cannot be null or empty");
+	}
+
+	@Test
+	void processWithNullUserParams() {
+		PromptTemplateUserTextProcessor processor = new PromptTemplateUserTextProcessor();
+		String userText = "Hello, {name}!";
+		Map<String, Object> userParams = null;
+		assertThatIllegalArgumentException().isThrownBy(() -> processor.process(userText, userParams))
+			.withMessage("userParams cannot be null");
+	}
+
+	@Test
+	void processWithNullUserParamsKeys() {
+		PromptTemplateUserTextProcessor processor = new PromptTemplateUserTextProcessor();
+		String userText = "Hello, {name}!";
+		Map<String, Object> userParams = new HashMap<>();
+		userParams.put(null, "William");
+		assertThatIllegalArgumentException().isThrownBy(() -> processor.process(userText, userParams))
+			.withMessage("userParams keys cannot be null");
+	}
+
+	@Test
+	void process() {
+		PromptTemplateUserTextProcessor processor = new PromptTemplateUserTextProcessor();
+		String userText = "Hello, {name}!";
+		Map<String, Object> userParams = Map.of("name", "William");
+		String processedText = processor.process(userText, userParams);
+		assertThat(processedText).isEqualTo("Hello, William!");
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -138,6 +138,24 @@ String answer = chatClient.prompt()
 
 See xref:api/retrieval-augmented-generation.adoc#_vectorstoredocumentretriever for more information.
 
+By default, the `RetrievalAugmentationAdvisor` process the input user text with a `PromptTemplate`, ensuring that any template placeholder is correctly rendered before using the text for the retrieval process.
+If you want to customize the processing logic, you can provide a custom `UserTextProcessor` to the advisor, either as a lambda or a class.
+For example, in case you want to skip the rendering step, you can provide a `NoOpUserTextProcessor`. That is useful if you're planning to use the templating special characters in the user text for other purposes.
+
+[source,java]
+----
+Advisor retrievalAugmentationAdvisor = RetrievalAugmentationAdvisor.builder()
+			.documentRetriever(VectorStoreDocumentRetriever.builder().vectorStore().build())
+			.userTextProcessor(new NoOpUserTextProcessor())
+			.build();
+
+String answer = chatClient.prompt()
+        .advisors(retrievalAugmentationAdvisor)
+        .user(question)
+        .call()
+        .content();
+----
+
 ===== Advanced RAG
 
 [source,java]


### PR DESCRIPTION
The input `userText` to the advisor might contain the templating special characters for other purposes than templating (e.g. when including source code). A new `UserTextProcessor` functional interface allows to customize how the `userText` is processed when taken as input to the `RetrievalAugmentationAdvisor`.  By default, the `PromptTemplateUserTextProcessor` implementation is used. If you want to disable the rendering step altogether, you can use the `NoOpUserTextProcessor` implementation.