### PR TITLE
allow null usage for OpenAI embedding model

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.metadata.EmptyUsage;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
@@ -167,8 +169,9 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 					return new EmbeddingResponse(List.of());
 				}
 
-				var metadata = new EmbeddingResponseMetadata(apiEmbeddingResponse.model(),
-						getDefaultUsage(apiEmbeddingResponse.usage()));
+				OpenAiApi.Usage usage = apiEmbeddingResponse.usage();
+				Usage embeddingResponseUsage = usage != null ? getDefaultUsage(usage) : new EmptyUsage();
+				var metadata = new EmbeddingResponseMetadata(apiEmbeddingResponse.model(), embeddingResponseUsage);
 
 				List<Embedding> embeddings = apiEmbeddingResponse.data()
 					.stream()


### PR DESCRIPTION
The issue described in https://github.com/spring-projects/spring-ai/issues/2485, where a NullPointerException (NPE) occurs when the `usage` field is null in OpenAI-compatible models, has been fixed.