### PR TITLE
Update tools.adoc Corrected incorrect punctuation usage

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -970,7 +970,7 @@ ToolCallback[] customerTools = ToolCallbacks.from(new CustomerTools());
 ChatOptions chatOptions = ToolCallingChatOptions.builder()
     .toolCallbacks(customerTools)
     .toolContext(Map.of("tenantId", "acme"))
-    .build():
+    .build();
 Prompt prompt = new Prompt("Tell me more about the customer with ID 42", chatOptions);
 chatModel.call(prompt);
 ----


### PR DESCRIPTION
Original:
ChatOptions chatOptions = ToolCallingChatOptions.builder()
    .toolCallbacks(customerTools)
    .toolContext(Map.of("tenantId", "acme"))
    .build():

After Change:
ChatOptions chatOptions = ToolCallingChatOptions.builder()
    .toolCallbacks(customerTools)
    .toolContext(Map.of("tenantId", "acme"))
    .build();

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
