### PR TITLE
fix: Update testNonExistingUrl to use not exist classpath resource

### DIFF
--- a/document-readers/jsoup-reader/src/test/java/org/springframework/ai/reader/jsoup/JsoupDocumentReaderTests.java
+++ b/document-readers/jsoup-reader/src/test/java/org/springframework/ai/reader/jsoup/JsoupDocumentReaderTests.java
@@ -177,8 +177,8 @@ class JsoupDocumentReaderTests {
 	}
 
 	@Test
-	void testNonExistingUrl() {
-		JsoupDocumentReader reader = new JsoupDocumentReader("https://nonexistingurl.com",
+	void testNonExistingHtmlResource() {
+		JsoupDocumentReader reader = new JsoupDocumentReader("classpath:/non-existing.html",
 				JsoupDocumentReaderConfig.builder().build());
 		assertThatThrownBy(reader::get).isInstanceOf(RuntimeException.class);
 	}


### PR DESCRIPTION
Becaue of the url : [nonexistingurl.com](https://nonexistingurl.com),return the normal page. It makes the UT fails(https://github.com/spring-projects/spring-ai/actions/runs/13921835150/job/38956712217?pr=2507#step:4:7588).


Related PR: https://github.com/spring-projects/spring-ai/pull/2507
