### PR TITLE
Fix: Add missing placeholder for TABLE_NAME in MariaDB table existence check

### DIFF
--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
@@ -45,7 +45,7 @@ public class MariaDBSchemaValidator {
 
 	private boolean isTableExists(String schemaName, String tableName) {
 		// schema and table are expected to be escaped
-		String sql = String.format("SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = ",
+		String sql = String.format("SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s",
 				(schemaName == null) ? "SCHEMA()" : schemaName, tableName);
 		try {
 			// Query for a single integer value, if it exists, table exists


### PR DESCRIPTION
Fix table existence check in MariaDBSchemaValidator

Issue:
The SQL query in the isTableExists method of MariaDBSchemaValidator class has a syntax error. The original query is missing a placeholder for TABLE_NAME, which results in an incomplete SQL statement and affects the table existence check functionality.

Changes:
- Added %s placeholder for TABLE_NAME in the SQL query
- Ensured String.format method correctly uses both schemaName and tableName parameters

This fix ensures the table existence check functionality works properly in the MariaDB vector store implementation.