### PR TITLE
Refactor Redis vector store property: index to indexName

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
@@ -74,7 +74,7 @@ public class RedisVectorStoreAutoConfiguration {
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))
 			.batchingStrategy(batchingStrategy)
-			.indexName(properties.getIndex())
+			.indexName(properties.getIndexName())
 			.prefix(properties.getPrefix())
 			.build();
 	}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreProperties.java
@@ -30,16 +30,16 @@ public class RedisVectorStoreProperties extends CommonVectorStoreProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.redis";
 
-	private String index = "default-index";
+	private String indexName = "default-index";
 
 	private String prefix = "default:";
 
-	public String getIndex() {
-		return this.index;
+	public String getIndexName() {
+		return this.indexName;
 	}
 
-	public void setIndex(String name) {
-		this.index = name;
+	public void setIndexName(String indexName) {
+		this.indexName = indexName;
 	}
 
 	public String getPrefix() {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStorePropertiesTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/test/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStorePropertiesTests.java
@@ -29,17 +29,17 @@ class RedisVectorStorePropertiesTests {
 	@Test
 	void defaultValues() {
 		var props = new RedisVectorStoreProperties();
-		assertThat(props.getIndex()).isEqualTo("default-index");
+		assertThat(props.getIndexName()).isEqualTo("default-index");
 		assertThat(props.getPrefix()).isEqualTo("default:");
 	}
 
 	@Test
 	void customValues() {
 		var props = new RedisVectorStoreProperties();
-		props.setIndex("myIdx");
+		props.setIndexName("myIdx");
 		props.setPrefix("doc:");
 
-		assertThat(props.getIndex()).isEqualTo("myIdx");
+		assertThat(props.getIndexName()).isEqualTo("myIdx");
 		assertThat(props.getPrefix()).isEqualTo("doc:");
 	}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bf8b14fb-d0db-47b7-b185-67fdfa2897fd)

The [documentation](https://docs.spring.io/spring-ai/reference/api/vectordbs/redis.html) states that the index name can be configured using `index-name`, but it was actually configured using `index`.

This has now been corrected to use `index-name`.