### PR TITLE
refact: sort by descending score In ConcatenationDocumentJoiner

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoiner.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoiner.java
@@ -35,7 +35,8 @@ import org.springframework.util.Assert;
  * by concatenating them into a single collection of documents. In case of duplicate
  * documents, the first occurrence is kept. The score of each document is kept as is.
  *
- * @author Thomas Vitale, ghdcksgml1
+ * @author Thomas Vitale
+ * @author ghdcksgml1
  * @since 1.0.0
  */
 public class ConcatenationDocumentJoiner implements DocumentJoiner {

--- a/spring-ai-core/src/main/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoiner.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoiner.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.rag.retrieval.join;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -34,7 +35,7 @@ import org.springframework.util.Assert;
  * by concatenating them into a single collection of documents. In case of duplicate
  * documents, the first occurrence is kept. The score of each document is kept as is.
  *
- * @author Thomas Vitale
+ * @author Thomas Vitale, ghdcksgml1
  * @since 1.0.0
  */
 public class ConcatenationDocumentJoiner implements DocumentJoiner {
@@ -54,7 +55,10 @@ public class ConcatenationDocumentJoiner implements DocumentJoiner {
 			.flatMap(List::stream)
 			.flatMap(List::stream)
 			.collect(Collectors.toMap(Document::getId, Function.identity(), (existing, duplicate) -> existing))
-			.values());
+			.values()
+			.stream()
+			.sorted(Comparator.comparing((Document d1) -> (d1.getScore() != null) ? d1.getScore() : 0.0).reversed())
+			.toList());
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoinerTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoinerTests.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link ConcatenationDocumentJoiner}.
  *
- * @author Thomas Vitale
+ * @author Thomas Vitale, ghdcksgml1
  */
 class ConcatenationDocumentJoinerTests {
 
@@ -90,6 +90,24 @@ class ConcatenationDocumentJoinerTests {
 		assertThat(result).hasSize(4);
 		assertThat(result).extracting(Document::getId).containsExactlyInAnyOrder("1", "2", "3", "4");
 		assertThat(result).extracting(Document::getText).containsOnlyOnce("Content 2");
+	}
+
+	@Test
+	void whenSeveralQueryExistsInMapThenDocumentsAreJoinedInDescendingScoreOrder() {
+		DocumentJoiner documentJoiner = new ConcatenationDocumentJoiner();
+		var documentsForQuery = new HashMap<Query, List<List<Document>>>();
+		documentsForQuery.put(new Query("query1"),
+				List.of(List.of(Document.builder().id("1").text("Content 1").score(0.9).build(),
+						Document.builder().id("4").text("Content 4").score(0.6).build()),
+						List.of(Document.builder().id("2").text("Content 2").score(0.8).build())));
+		documentsForQuery.put(new Query("query2"),
+				List.of(List.of(Document.builder().id("3").text("Content 3").score(0.7).build())));
+
+		List<Document> result = documentJoiner.join(documentsForQuery);
+
+		assertThat(result).hasSize(4);
+		assertThat(result).extracting(Document::getId).containsExactly("1", "2", "3", "4");
+		assertThat(result).extracting(Document::getScore).containsExactly(0.9, 0.8, 0.7, 0.6);
 	}
 
 }

--- a/spring-ai-core/src/test/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoinerTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/rag/retrieval/join/ConcatenationDocumentJoinerTests.java
@@ -31,7 +31,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link ConcatenationDocumentJoiner}.
  *
- * @author Thomas Vitale, ghdcksgml1
+ * @author Thomas Vitale
+ * @author ghdcksgml1
  */
 class ConcatenationDocumentJoinerTests {
 


### PR DESCRIPTION
I noticed in the `RetrievalAugmentationAdvisor` code that when joining expanded query results from `QueryExpander` using `DocumentJoiner`, shouldn't the results be sorted by Score in descending order to prioritize documents relevant to the prompt?