### PR TITLE
Add Missing Audio Formats (WAV, PCM)

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
@@ -378,7 +378,7 @@ public class OpenAiAudioApi {
 		}
 
 		/**
-		 * The format to audio in. Supported formats are mp3, opus, aac, and flac.
+		 * The format to audio in. Supported formats are mp3, opus, aac, wav, pcm and flac.
 		 * Defaults to mp3.
 		 */
 		public enum AudioResponseFormat {
@@ -391,7 +391,11 @@ public class OpenAiAudioApi {
 			@JsonProperty("aac")
 			AAC("aac"),
 			@JsonProperty("flac")
-			FLAC("flac");
+			FLAC("flac"),
+			@JsonProperty("wav")
+			WAV("wav"),
+			@JsonProperty("pcm")
+			PCM("pcm");
 			// @formatter:on
 
 			public final String value;

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/speech/OpenAiSpeechModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/speech/OpenAiSpeechModelIT.java
@@ -73,6 +73,24 @@ class OpenAiSpeechModelIT extends AbstractIT {
 	}
 
 	@Test
+	void shouldGenerateNonEmptyWavAudioFromSpeechPrompt() {
+		OpenAiAudioSpeechOptions speechOptions = OpenAiAudioSpeechOptions.builder()
+				.voice(OpenAiAudioApi.SpeechRequest.Voice.ALLOY)
+				.speed(SPEED)
+				.responseFormat(OpenAiAudioApi.SpeechRequest.AudioResponseFormat.WAV)
+				.model(OpenAiAudioApi.TtsModel.TTS_1.value)
+				.build();
+		SpeechPrompt speechPrompt = new SpeechPrompt("Today is a wonderful day to build something people love!",
+				speechOptions);
+		SpeechResponse response = this.speechModel.call(speechPrompt);
+		byte[] audioBytes = response.getResult().getOutput();
+		assertThat(response.getResults()).hasSize(1);
+		assertThat(response.getResults().get(0).getOutput()).isNotEmpty();
+		assertThat(audioBytes).hasSizeGreaterThan(0);
+
+	}
+
+	@Test
 	void speechRateLimitTest() {
 		OpenAiAudioSpeechOptions speechOptions = OpenAiAudioSpeechOptions.builder()
 			.voice(OpenAiAudioApi.SpeechRequest.Voice.ALLOY)


### PR DESCRIPTION
Current code does not support all the audio formats that OAI returns. My company needs WAV and PCM formats for our use case (anyone using telephony will want this).
