### PR TITLE
Fix: Duplicate example in Vector Databases documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
@@ -389,7 +389,7 @@ Consider the following example:
 
 [source,java]
 ----
-Expression exp = b.and(b.eq("genre", "drama"), b.gte("year", 2020)).build();
+Expression exp = b.and(b.in("genre", "drama", "documentary"), b.not(b.lt("year", 2020))).build();
 ----
 
 == Deleting Documents from Vector Store


### PR DESCRIPTION
## Issue 
(Fixes #2562)

I noticed a duplicate example in the Vector Databases documentation. In the section about filter operators (IN, NIN, NOT), the example shown is identical to an earlier example and doesn't actually demonstrate these operators.

## Changes

Replace the duplicate example with one that properly demonstrates the IN, NOT, and other operators:

```java
Expression exp = b.and(b.in("genre", "drama", "documentary"), b.not(b.lt("year", 2020))).build();
