### PR TITLE
Update/remove autoconfiguration enable/disable configurations

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatProperties.java
@@ -34,11 +34,6 @@ public class AnthropicChatProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.anthropic.chat";
 
 	/**
-	 * Enable Anthropic chat model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Client lever Ollama options. Use this property to configure generative temperature,
 	 * topK and topP and alike parameters. The null values are ignored defaulting to the
 	 * generative's defaults.
@@ -52,14 +47,6 @@ public class AnthropicChatProperties {
 
 	public AnthropicChatOptions getOptions() {
 		return this.options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicPropertiesTests.java
@@ -56,8 +56,6 @@ public class AnthropicPropertiesTests {
 
 				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
 				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
-				// enabled is true by default
-				assertThat(chatProperties.isEnabled()).isTrue();
 			});
 	}
 
@@ -111,7 +109,7 @@ public class AnthropicPropertiesTests {
 			});
 
 		// Explicitly enable the chat auto-configuration.
-		new ApplicationContextRunner().withPropertyValues("spring.ai.anthropic.chat.enabled=true")
+		new ApplicationContextRunner().withPropertyValues("spring.ai.model.chat=anthropic")
 			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
 					RestClientAutoConfiguration.class, AnthropicChatAutoConfiguration.class))
 			.run(context -> {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiAudioTranscriptionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiAudioTranscriptionProperties.java
@@ -30,21 +30,8 @@ public class AzureOpenAiAudioTranscriptionProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.audio.transcription";
 
-	/**
-	 * Enable AzureOpenAI audio transcription model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private AzureOpenAiAudioTranscriptionOptions options = AzureOpenAiAudioTranscriptionOptions.builder().build();
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
 
 	public AzureOpenAiAudioTranscriptionOptions getOptions() {
 		return this.options;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiChatProperties.java
@@ -29,11 +29,6 @@ public class AzureOpenAiChatProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
-	/**
-	 * Enable Azure OpenAI chat model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private AzureOpenAiChatOptions options = AzureOpenAiChatOptions.builder()
 		.deploymentName(DEFAULT_DEPLOYMENT_NAME)
@@ -46,14 +41,6 @@ public class AzureOpenAiChatProperties {
 
 	public void setOptions(AzureOpenAiChatOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiEmbeddingProperties.java
@@ -27,11 +27,6 @@ public class AzureOpenAiEmbeddingProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.embedding";
 
-	/**
-	 * Enable Azure OpenAI embedding model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private AzureOpenAiEmbeddingOptions options = AzureOpenAiEmbeddingOptions.builder()
 		.deploymentName("text-embedding-ada-002")
@@ -55,14 +50,6 @@ public class AzureOpenAiEmbeddingProperties {
 	public void setMetadataMode(MetadataMode metadataMode) {
 		Assert.notNull(metadataMode, "Metadata mode must not be null");
 		this.metadataMode = metadataMode;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiImageOptionsProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiImageOptionsProperties.java
@@ -31,11 +31,6 @@ public class AzureOpenAiImageOptionsProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.image";
 
-	/**
-	 * Enable Azure OpenAI chat client.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private AzureOpenAiImageOptions options = AzureOpenAiImageOptions.builder().build();
 
@@ -45,14 +40,6 @@ public class AzureOpenAiImageOptionsProperties {
 
 	public void setOptions(AzureOpenAiImageOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingProperties.java
@@ -35,11 +35,6 @@ public class BedrockCohereEmbeddingProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.bedrock.cohere.embedding";
 
 	/**
-	 * Enable Bedrock Cohere Embedding Model. False by default.
-	 */
-	private boolean enabled = false;
-
-	/**
 	 * Bedrock Cohere Embedding generative name. Defaults to
 	 * 'cohere.embed-multilingual-v3'.
 	 */
@@ -50,14 +45,6 @@ public class BedrockCohereEmbeddingProperties {
 		.inputType(InputType.SEARCH_DOCUMENT)
 		.truncate(CohereEmbeddingRequest.Truncate.NONE)
 		.build();
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
 
 	public String getModel() {
 		return this.model;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
@@ -32,25 +32,12 @@ public class BedrockConverseProxyChatProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.bedrock.converse.chat";
 
-	/**
-	 * Enable Bedrock Converse chat model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private ToolCallingChatOptions options = ToolCallingChatOptions.builder()
 		.temperature(0.7)
 		.maxTokens(300)
 		.topK(10)
 		.build();
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
 
 	public ToolCallingChatOptions getOptions() {
 		return this.options;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingProperties.java
@@ -32,11 +32,6 @@ public class BedrockTitanEmbeddingProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.bedrock.titan.embedding";
 
 	/**
-	 * Enable Bedrock Titan Embedding Model. False by default.
-	 */
-	private boolean enabled = false;
-
-	/**
 	 * Bedrock Titan Embedding generative name. Defaults to 'amazon.titan-embed-image-v1'.
 	 */
 	private String model = TitanEmbeddingModel.TITAN_EMBED_IMAGE_V1.id();
@@ -49,14 +44,6 @@ public class BedrockTitanEmbeddingProperties {
 
 	public static String getConfigPrefix() {
 		return CONFIG_PREFIX;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 	public String getModel() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingAutoConfigurationIT.java
@@ -85,7 +85,7 @@ public class BedrockCohereEmbeddingAutoConfigurationIT {
 	public void propertiesTest() {
 
 		BedrockTestUtils.getContextRunnerWithUserConfiguration()
-			.withPropertyValues("spring.ai.bedrock.cohere.embedding.enabled=true",
+			.withPropertyValues("spring.ai.model.embedding=bedrock-cohere",
 					"spring.ai.bedrock.aws.access-key=ACCESS_KEY", "spring.ai.bedrock.aws.secret-key=SECRET_KEY",
 					"spring.ai.bedrock.aws.region=" + Region.US_EAST_1.id(),
 					"spring.ai.bedrock.cohere.embedding.model=MODEL_XYZ",
@@ -96,7 +96,6 @@ public class BedrockCohereEmbeddingAutoConfigurationIT {
 				var properties = context.getBean(BedrockCohereEmbeddingProperties.class);
 				var awsProperties = context.getBean(BedrockAwsConnectionProperties.class);
 
-				assertThat(properties.isEnabled()).isTrue();
 				assertThat(awsProperties.getRegion()).isEqualTo(Region.US_EAST_1.id());
 				assertThat(properties.getModel()).isEqualTo("MODEL_XYZ");
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
@@ -51,8 +51,6 @@ public class BedrockConverseProxyChatPropertiesTests {
 			.run(context -> {
 				var chatProperties = context.getBean(BedrockConverseProxyChatProperties.class);
 
-				assertThat(chatProperties.isEnabled()).isTrue();
-
 				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
 				assertThat(chatProperties.getOptions().getMaxTokens()).isEqualTo(123);
 				assertThat(chatProperties.getOptions().getStopSequences()).contains("boza", "koza");

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/titan/autoconfigure/BedrockTitanEmbeddingAutoConfigurationIT.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BedrockTitanEmbeddingAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = BedrockTestUtils.getContextRunner()
-		.withPropertyValues("spring.ai.bedrock.titan.embedding.enabled=true",
+		.withPropertyValues("spring.ai.model.embedding=bedrock-titan",
 				"spring.ai.bedrock.aws.access-key=" + System.getenv("AWS_ACCESS_KEY_ID"),
 				"spring.ai.bedrock.aws.secret-key=" + System.getenv("AWS_SECRET_ACCESS_KEY"),
 				"spring.ai.bedrock.aws.region=" + Region.US_EAST_1.id(),
@@ -86,7 +86,7 @@ public class BedrockTitanEmbeddingAutoConfigurationIT {
 	public void propertiesTest() {
 
 		BedrockTestUtils.getContextRunnerWithUserConfiguration()
-			.withPropertyValues("spring.ai.bedrock.titan.embedding.enabled=true",
+			.withPropertyValues("spring.ai.model.embedding=bedrock-titan",
 					"spring.ai.bedrock.aws.access-key=ACCESS_KEY", "spring.ai.bedrock.aws.secret-key=SECRET_KEY",
 					"spring.ai.bedrock.aws.region=" + Region.US_EAST_1.id(),
 					"spring.ai.bedrock.titan.embedding.model=MODEL_XYZ",
@@ -96,7 +96,6 @@ public class BedrockTitanEmbeddingAutoConfigurationIT {
 				var properties = context.getBean(BedrockTitanEmbeddingProperties.class);
 				var awsProperties = context.getBean(BedrockAwsConnectionProperties.class);
 
-				assertThat(properties.isEnabled()).isTrue();
 				assertThat(awsProperties.getRegion()).isEqualTo(Region.US_EAST_1.id());
 				assertThat(properties.getModel()).isEqualTo("MODEL_XYZ");
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-huggingface/src/main/java/org/springframework/ai/model/huggingface/autoconfigure/HuggingfaceChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-huggingface/src/main/java/org/springframework/ai/model/huggingface/autoconfigure/HuggingfaceChatProperties.java
@@ -41,11 +41,6 @@ public class HuggingfaceChatProperties {
 	 */
 	private String url;
 
-	/**
-	 * Enable Hugging Face chat model.
-	 */
-	private boolean enabled = true;
-
 	public String getApiKey() {
 		return this.apiKey;
 	}
@@ -60,14 +55,6 @@ public class HuggingfaceChatProperties {
 
 	public void setUrl(String url) {
 		this.url = url;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatProperties.java
@@ -35,11 +35,6 @@ public class MiniMaxChatProperties extends MiniMaxParentProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
-	/**
-	 * Enable MiniMax chat model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private MiniMaxChatOptions options = MiniMaxChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
@@ -52,14 +47,6 @@ public class MiniMaxChatProperties extends MiniMaxParentProperties {
 
 	public void setOptions(MiniMaxChatOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxEmbeddingProperties.java
@@ -34,11 +34,6 @@ public class MiniMaxEmbeddingProperties extends MiniMaxParentProperties {
 
 	public static final String DEFAULT_EMBEDDING_MODEL = MiniMaxApi.EmbeddingModel.Embo_01.value;
 
-	/**
-	 * Enable MiniMax embedding model.
-	 */
-	private boolean enabled = true;
-
 	private MetadataMode metadataMode = MetadataMode.EMBED;
 
 	@NestedConfigurationProperty
@@ -58,14 +53,6 @@ public class MiniMaxEmbeddingProperties extends MiniMaxParentProperties {
 
 	public void setMetadataMode(MetadataMode metadataMode) {
 		this.metadataMode = metadataMode;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxPropertiesTests.java
@@ -281,7 +281,7 @@ public class MiniMaxPropertiesTests {
 
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.minimax.api-key=API_KEY", "spring.ai.minimax.base-url=TEST_BASE_URL",
-					"spring.ai.minimax.embedding.enabled=true")
+					"spring.ai.model.embedding=minimax")
 			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
 					RestClientAutoConfiguration.class, MiniMaxEmbeddingAutoConfiguration.class))
 			.run(context -> {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiChatProperties.java
@@ -43,11 +43,6 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 
 	private static final Boolean IS_ENABLED = false;
 
-	/**
-	 * Enable OpenAI chat model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private MistralAiChatOptions options = MistralAiChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
@@ -66,14 +61,6 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 
 	public void setOptions(MistralAiChatOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiEmbeddingProperties.java
@@ -39,11 +39,6 @@ public class MistralAiEmbeddingProperties extends MistralAiParentProperties {
 
 	public MetadataMode metadataMode = MetadataMode.EMBED;
 
-	/**
-	 * Enable MistralAI embedding model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private MistralAiEmbeddingOptions options = MistralAiEmbeddingOptions.builder()
 		.withModel(DEFAULT_EMBEDDING_MODEL)
@@ -68,14 +63,6 @@ public class MistralAiEmbeddingProperties extends MistralAiParentProperties {
 
 	public void setMetadataMode(MetadataMode metadataMode) {
 		this.metadataMode = metadataMode;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-moonshot/src/main/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-moonshot/src/main/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotChatProperties.java
@@ -36,11 +36,6 @@ public class MoonshotChatProperties extends MoonshotParentProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
-	/**
-	 * Enable Moonshot chat client.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private MoonshotChatOptions options = MoonshotChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
@@ -53,14 +48,6 @@ public class MoonshotChatProperties extends MoonshotParentProperties {
 
 	public void setOptions(MoonshotChatOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java
@@ -34,21 +34,11 @@ public class OCICohereChatModelProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
-	private boolean enabled;
-
 	@NestedConfigurationProperty
 	private OCICohereChatOptions options = OCICohereChatOptions.builder()
 		.servingMode(DEFAULT_SERVING_MODE)
 		.temperature(DEFAULT_TEMPERATURE)
 		.build();
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
 
 	public OCICohereChatOptions getOptions() {
 		return this.options;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIEmbeddingModelProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIEmbeddingModelProperties.java
@@ -39,8 +39,6 @@ public class OCIEmbeddingModelProperties {
 
 	private String model;
 
-	private boolean enabled;
-
 	public OCIEmbeddingOptions getEmbeddingOptions() {
 		return OCIEmbeddingOptions.builder()
 			.compartment(this.compartment)
@@ -72,14 +70,6 @@ public class OCIEmbeddingModelProperties {
 
 	public void setModel(String model) {
 		this.model = model;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 	public EmbedTextDetails.Truncate getTruncate() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatProperties.java
@@ -33,11 +33,6 @@ public class OllamaChatProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.ollama.chat";
 
 	/**
-	 * Enable Ollama chat model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Client lever Ollama options. Use this property to configure generative temperature,
 	 * topK and topP and alike parameters. The null values are ignored defaulting to the
 	 * generative's defaults.
@@ -55,14 +50,6 @@ public class OllamaChatProperties {
 
 	public OllamaOptions getOptions() {
 		return this.options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaEmbeddingProperties.java
@@ -33,11 +33,6 @@ public class OllamaEmbeddingProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.ollama.embedding";
 
 	/**
-	 * Enable Ollama embedding model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Client lever Ollama options. Use this property to configure generative temperature,
 	 * topK and topP and alike parameters. The null values are ignored defaulting to the
 	 * generative's defaults.
@@ -55,14 +50,6 @@ public class OllamaEmbeddingProperties {
 
 	public OllamaOptions getOptions() {
 		return this.options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaEmbeddingAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaEmbeddingAutoConfigurationIT.java
@@ -94,7 +94,7 @@ public class OllamaEmbeddingAutoConfigurationIT extends BaseOllamaIT {
 			assertThat(context.getBeansOfType(OllamaEmbeddingModel.class)).isNotEmpty();
 		});
 
-		this.contextRunner.withPropertyValues("spring.ai.ollama.embedding.enabled=true").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.model.embedding=ollama").run(context -> {
 			assertThat(context.getBeansOfType(OllamaEmbeddingProperties.class)).isNotEmpty();
 			assertThat(context.getBeansOfType(OllamaEmbeddingModel.class)).isNotEmpty();
 		});

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechProperties.java
@@ -43,11 +43,6 @@ public class OpenAiAudioSpeechProperties extends OpenAiParentProperties {
 
 	private static final OpenAiAudioApi.SpeechRequest.AudioResponseFormat DEFAULT_RESPONSE_FORMAT = OpenAiAudioApi.SpeechRequest.AudioResponseFormat.MP3;
 
-	/**
-	 * Enable OpenAI audio speech model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private OpenAiAudioSpeechOptions options = OpenAiAudioSpeechOptions.builder()
 		.model(DEFAULT_SPEECH_MODEL)
@@ -62,14 +57,6 @@ public class OpenAiAudioSpeechProperties extends OpenAiParentProperties {
 
 	public void setOptions(OpenAiAudioSpeechOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionProperties.java
@@ -32,11 +32,6 @@ public class OpenAiAudioTranscriptionProperties extends OpenAiParentProperties {
 
 	private static final OpenAiAudioApi.TranscriptResponseFormat DEFAULT_RESPONSE_FORMAT = OpenAiAudioApi.TranscriptResponseFormat.TEXT;
 
-	/**
-	 * Enable OpenAI audio transcription model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
 		.model(DEFAULT_TRANSCRIPTION_MODEL)
@@ -50,14 +45,6 @@ public class OpenAiAudioTranscriptionProperties extends OpenAiParentProperties {
 
 	public void setOptions(OpenAiAudioTranscriptionOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
@@ -31,11 +31,6 @@ public class OpenAiChatProperties extends OpenAiParentProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
-	/**
-	 * Enable OpenAI chat model.
-	 */
-	private boolean enabled = true;
-
 	private String completionsPath = DEFAULT_COMPLETIONS_PATH;
 
 	@NestedConfigurationProperty
@@ -50,14 +45,6 @@ public class OpenAiChatProperties extends OpenAiParentProperties {
 
 	public void setOptions(OpenAiChatOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 	public String getCompletionsPath() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingProperties.java
@@ -30,11 +30,6 @@ public class OpenAiEmbeddingProperties extends OpenAiParentProperties {
 
 	public static final String DEFAULT_EMBEDDINGS_PATH = "/v1/embeddings";
 
-	/**
-	 * Enable OpenAI embedding model.
-	 */
-	private boolean enabled = true;
-
 	private MetadataMode metadataMode = MetadataMode.EMBED;
 
 	private String embeddingsPath = DEFAULT_EMBEDDINGS_PATH;
@@ -56,14 +51,6 @@ public class OpenAiEmbeddingProperties extends OpenAiParentProperties {
 
 	public void setMetadataMode(MetadataMode metadataMode) {
 		this.metadataMode = metadataMode;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 	public String getEmbeddingsPath() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageProperties.java
@@ -35,11 +35,6 @@ public class OpenAiImageProperties extends OpenAiParentProperties {
 	public static final String DEFAULT_IMAGE_MODEL = OpenAiImageApi.ImageModel.DALL_E_3.getValue();
 
 	/**
-	 * Enable OpenAI image model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Options for OpenAI Image API.
 	 */
 	@NestedConfigurationProperty
@@ -51,14 +46,6 @@ public class OpenAiImageProperties extends OpenAiParentProperties {
 
 	public void setOptions(OpenAiImageOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingProperties.java
@@ -37,11 +37,6 @@ public class PostgresMlEmbeddingProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.postgresml.embedding";
 
 	/**
-	 * Enable Postgres ML embedding model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Create the extensions required for embedding
 	 */
 	private boolean createExtension;
@@ -66,14 +61,6 @@ public class PostgresMlEmbeddingProperties {
 		Assert.notNull(options.getMetadataMode(), "metadataMode must not be null.");
 
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 	public boolean isCreateExtension() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/test/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/test/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingAutoConfigurationIT.java
@@ -84,15 +84,14 @@ public class PostgresMlEmbeddingAutoConfigurationIT {
 	void embeddingActivation() {
 		new ApplicationContextRunner().withBean(JdbcTemplate.class, () -> this.jdbcTemplate)
 			.withConfiguration(AutoConfigurations.of(PostgresMlEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.postgresml.embedding.enabled=false")
+			.withPropertyValues("spring.ai.model.embedding=none")
 			.run(context -> {
-				assertThat(context.getBeansOfType(PostgresMlEmbeddingProperties.class)).isNotEmpty();
+				assertThat(context.getBeansOfType(PostgresMlEmbeddingProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(PostgresMlEmbeddingModel.class)).isEmpty();
 			});
 
 		new ApplicationContextRunner().withBean(JdbcTemplate.class, () -> this.jdbcTemplate)
-			.withConfiguration(AutoConfigurations.of(PostgresMlEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.postgresml.embedding.enabled=true")
+			.withPropertyValues("spring.ai.model.embedding=postgresml")
 			.run(context -> {
 				assertThat(context.getBeansOfType(PostgresMlEmbeddingProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(PostgresMlEmbeddingModel.class)).isNotEmpty();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/main/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/main/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanChatProperties.java
@@ -35,11 +35,6 @@ public class QianFanChatProperties extends QianFanParentProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
-	/**
-	 * Enable QianFan chat client.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private QianFanChatOptions options = QianFanChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
@@ -52,14 +47,6 @@ public class QianFanChatProperties extends QianFanParentProperties {
 
 	public void setOptions(QianFanChatOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/main/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/main/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanEmbeddingProperties.java
@@ -32,11 +32,6 @@ public class QianFanEmbeddingProperties extends QianFanParentProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.qianfan.embedding";
 
-	/**
-	 * Enable QianFan embedding client.
-	 */
-	private boolean enabled = true;
-
 	private MetadataMode metadataMode = MetadataMode.EMBED;
 
 	@NestedConfigurationProperty
@@ -58,14 +53,6 @@ public class QianFanEmbeddingProperties extends QianFanParentProperties {
 
 	public void setMetadataMode(MetadataMode metadataMode) {
 		this.metadataMode = metadataMode;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/main/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/main/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanImageProperties.java
@@ -34,11 +34,6 @@ public class QianFanImageProperties extends QianFanParentProperties {
 	public static final String DEFAULT_IMAGE_MODEL = QianFanImageApi.ImageModel.Stable_Diffusion_XL.getValue();
 
 	/**
-	 * Enable QianFan image model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Options for QianFan Image API.
 	 */
 	@NestedConfigurationProperty
@@ -50,14 +45,6 @@ public class QianFanImageProperties extends QianFanParentProperties {
 
 	public void setOptions(QianFanImageOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/test/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-qianfan/src/test/java/org/springframework/ai/model/qianfan/autoconfigure/QianFanPropertiesTests.java
@@ -286,7 +286,7 @@ public class QianFanPropertiesTests {
 
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.qianfan.api-key=API_KEY", "spring.ai.qianfan.secret-key=SECRET_KEY",
-					"spring.ai.qianfan.base-url=TEST_BASE_URL", "spring.ai.qianfan.chat.enabled=true")
+					"spring.ai.qianfan.base-url=TEST_BASE_URL", "spring.ai.model.chat=qianfan")
 			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
 					RestClientAutoConfiguration.class, QianFanChatAutoConfiguration.class))
 			.run(context -> {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageProperties.java
@@ -32,11 +32,6 @@ public class StabilityAiImageProperties extends StabilityAiParentProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.stabilityai.image";
 
-	/**
-	 * Enable Stability image model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private StabilityAiImageOptions options = StabilityAiImageOptions.builder().build(); // stable-diffusion-v1-6
 
@@ -50,14 +45,6 @@ public class StabilityAiImageProperties extends StabilityAiParentProperties {
 
 	public void setOptions(StabilityAiImageOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-transformers/src/main/java/org/springframework/ai/model/transformers/autoconfigure/TransformersEmbeddingModelProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-transformers/src/main/java/org/springframework/ai/model/transformers/autoconfigure/TransformersEmbeddingModelProperties.java
@@ -56,11 +56,6 @@ public class TransformersEmbeddingModelProperties {
 	private final Onnx onnx = new Onnx();
 
 	/**
-	 * Enable the Transformer Embedding model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Specifies what parts of the {@link Document}'s content and metadata will be used
 	 * for computing the embeddings. Applicable for the
 	 * {@link TransformersEmbeddingModel#embed(Document)} method only. Has no effect on
@@ -69,14 +64,6 @@ public class TransformersEmbeddingModelProperties {
 	 * {@link MetadataMode#NONE}.
 	 */
 	private MetadataMode metadataMode = MetadataMode.NONE;
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
 
 	public Cache getCache() {
 		return this.cache;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultimodalEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultimodalEmbeddingProperties.java
@@ -30,8 +30,6 @@ public class VertexAiMultimodalEmbeddingProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vertex.ai.embedding.multimodal";
 
-	private boolean enabled = true;
-
 	/**
 	 * Vertex AI Text Embedding API options.
 	 */
@@ -45,14 +43,6 @@ public class VertexAiMultimodalEmbeddingProperties {
 
 	public void setOptions(VertexAiMultimodalEmbeddingOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingProperties.java
@@ -30,8 +30,6 @@ public class VertexAiTextEmbeddingProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.vertex.ai.embedding.text";
 
-	private boolean enabled = true;
-
 	/**
 	 * Vertex AI Text Embedding API options.
 	 */
@@ -46,14 +44,6 @@ public class VertexAiTextEmbeddingProperties {
 
 	public void setOptions(VertexAiTextEmbeddingOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingModelAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingModelAutoConfigurationIT.java
@@ -58,7 +58,6 @@ public class VertexAiTextEmbeddingModelAutoConfigurationIT {
 				var textEmbeddingProperties = context.getBean(VertexAiTextEmbeddingProperties.class);
 
 				assertThat(conntectionProperties).isNotNull();
-				assertThat(textEmbeddingProperties.isEnabled()).isTrue();
 
 				VertexAiTextEmbeddingModel embeddingModel = context.getBean(VertexAiTextEmbeddingModel.class);
 				assertThat(embeddingModel).isInstanceOf(VertexAiTextEmbeddingModel.class);
@@ -73,14 +72,14 @@ public class VertexAiTextEmbeddingModelAutoConfigurationIT {
 	@Test
 	void textEmbeddingActivation() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(VertexAiTextEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.text.embedding=none")
+			.withPropertyValues("spring.ai.model.embedding.text=none")
 			.run(context -> {
 				assertThat(context.getBeansOfType(VertexAiTextEmbeddingProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(VertexAiTextEmbeddingModel.class)).isEmpty();
 			});
 
 		this.contextRunner.withConfiguration(AutoConfigurations.of(VertexAiTextEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.text.embedding=vertexai")
+			.withPropertyValues("spring.ai.model.embedding.text=vertexai")
 			.run(context -> {
 				assertThat(context.getBeansOfType(VertexAiTextEmbeddingProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(VertexAiTextEmbeddingModel.class)).isNotEmpty();
@@ -102,7 +101,6 @@ public class VertexAiTextEmbeddingModelAutoConfigurationIT {
 				var multimodalEmbeddingProperties = context.getBean(VertexAiMultimodalEmbeddingProperties.class);
 
 				assertThat(conntectionProperties).isNotNull();
-				assertThat(multimodalEmbeddingProperties.isEnabled()).isTrue();
 
 				VertexAiMultimodalEmbeddingModel multiModelEmbeddingModel = context
 					.getBean(VertexAiMultimodalEmbeddingModel.class);
@@ -132,14 +130,14 @@ public class VertexAiTextEmbeddingModelAutoConfigurationIT {
 	@Test
 	void multimodalEmbeddingActivation() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(VertexAiMultiModalEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.multi-modal.embedding=none")
+			.withPropertyValues("spring.ai.model.embedding.multimodal=none")
 			.run(context -> {
 				assertThat(context.getBeansOfType(VertexAiMultimodalEmbeddingProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(VertexAiMultimodalEmbeddingModel.class)).isEmpty();
 			});
 
 		this.contextRunner.withConfiguration(AutoConfigurations.of(VertexAiMultiModalEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.multi-modal.embedding=vertexai")
+			.withPropertyValues("spring.ai.model.embedding.multimodal=vertexai")
 			.run(context -> {
 				assertThat(context.getBeansOfType(VertexAiMultimodalEmbeddingProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(VertexAiMultimodalEmbeddingModel.class)).isNotEmpty();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springframework/ai/model/watsonxai/autoconfigure/WatsonxAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springframework/ai/model/watsonxai/autoconfigure/WatsonxAiChatProperties.java
@@ -35,11 +35,6 @@ public class WatsonxAiChatProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.watsonx.ai.chat";
 
 	/**
-	 * Enable Watsonx.AI chat model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Watsonx AI generative options.
 	 */
 	@NestedConfigurationProperty
@@ -54,14 +49,6 @@ public class WatsonxAiChatProperties {
 		.repetitionPenalty(1.0)
 		.stopSequences(List.of())
 		.build();
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
 
 	public WatsonxAiChatOptions getOptions() {
 		return this.options;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springframework/ai/model/watsonxai/autoconfigure/WatsonxAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-watsonx-ai/src/main/java/org/springframework/ai/model/watsonxai/autoconfigure/WatsonxAiEmbeddingProperties.java
@@ -32,11 +32,6 @@ public class WatsonxAiEmbeddingProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.watsonx.ai.embedding";
 
 	/**
-	 * Enable Watsonx.ai embedding model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Client lever Watsonx.ai embedding options. Use this property to configure the
 	 * model. The null values are ignored defaulting to the defaults.
 	 */
@@ -54,14 +49,6 @@ public class WatsonxAiEmbeddingProperties {
 
 	public WatsonxAiEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatProperties.java
@@ -35,11 +35,6 @@ public class ZhiPuAiChatProperties extends ZhiPuAiParentProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
-	/**
-	 * Enable ZhiPuAI chat model.
-	 */
-	private boolean enabled = true;
-
 	@NestedConfigurationProperty
 	private ZhiPuAiChatOptions options = ZhiPuAiChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
@@ -52,14 +47,6 @@ public class ZhiPuAiChatProperties extends ZhiPuAiParentProperties {
 
 	public void setOptions(ZhiPuAiChatOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingProperties.java
@@ -34,11 +34,6 @@ public class ZhiPuAiEmbeddingProperties extends ZhiPuAiParentProperties {
 
 	public static final String DEFAULT_EMBEDDING_MODEL = ZhiPuAiApi.EmbeddingModel.Embedding_2.value;
 
-	/**
-	 * Enable ZhiPuAI embedding model.
-	 */
-	private boolean enabled = true;
-
 	private MetadataMode metadataMode = MetadataMode.EMBED;
 
 	@NestedConfigurationProperty
@@ -58,14 +53,6 @@ public class ZhiPuAiEmbeddingProperties extends ZhiPuAiParentProperties {
 
 	public void setMetadataMode(MetadataMode metadataMode) {
 		this.metadataMode = metadataMode;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageProperties.java
@@ -31,11 +31,6 @@ public class ZhiPuAiImageProperties extends ZhiPuAiParentProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.zhipuai.image";
 
 	/**
-	 * Enable ZhiPuAI image model.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * Options for ZhiPuAI Image API.
 	 */
 	@NestedConfigurationProperty
@@ -47,14 +42,6 @@ public class ZhiPuAiImageProperties extends ZhiPuAiParentProperties {
 
 	public void setOptions(ZhiPuAiImageOptions options) {
 		this.options = options;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/spring-ai-core/src/main/java/org/springframework/ai/model/SpringAIModelProperties.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/model/SpringAIModelProperties.java
@@ -24,9 +24,9 @@ public class SpringAIModelProperties {
 
 	public static final String EMBEDDING_MODEL = MODEL_PREFIX + ".embedding";
 
-	public static final String TEXT_EMBEDDING_MODEL = MODEL_PREFIX + ".text.embedding";
+	public static final String TEXT_EMBEDDING_MODEL = MODEL_PREFIX + ".embedding.text";
 
-	public static final String MULTI_MODAL_EMBEDDING_MODEL = MODEL_PREFIX + ".multi-modal.embedding";
+	public static final String MULTI_MODAL_EMBEDDING_MODEL = MODEL_PREFIX + ".embedding.multimodal";
 
 	public static final String IMAGE_MODEL = MODEL_PREFIX + ".image";
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
@@ -15,6 +15,12 @@ The Audio API provides a speech endpoint based on OpenAI's TTS (text-to-speech) 
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Text-to-Speech Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -57,12 +63,24 @@ Usage from these API requests will count as usage for the specified organization
 
 === Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.audio.speech=openai (It is enabled by default)
+
+To disable, spring.ai.model.audio.speech=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.audio.speech` is used as the property prefix that lets you configure the OpenAI Text-to-Speech client.
 
 [cols="3,5,2"]
 |====
 | Property | Description | Default
 
+| spring.ai.model.audio.speech   | Enable Audio Speech Model |  openai
 | spring.ai.openai.audio.speech.base-url   | The URL to connect to |  https://api.openai.com
 | spring.ai.openai.audio.speech.api-key    | The API Key           |  -
 | spring.ai.openai.audio.speech.organization-id | Optionally you can specify which organization  used for an API request. |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/azure-openai-transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/azure-openai-transcriptions.adoc
@@ -11,6 +11,12 @@ Exporting an environment variable is one way to set that configuration property:
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure OpenAI Transcription Generation Client.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 
@@ -35,13 +41,25 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 
 === Transcription Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.audio.transcription=azure-openai (It is enabled by default)
+
+To disable, spring.ai.model.audio.transcription=none (or any value which doesn't match azure-openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.audio.transcription` is used as the property prefix that lets you configure the retry mechanism for the OpenAI image model.
 
 [cols="3,5,2"]
 |====
 | Property | Description | Default
 
-| spring.ai.azure.openai.audio.transcription.enabled  | Enable Azure OpenAI transcription model. | true
+| spring.ai.azure.openai.audio.transcription.enabled (Removed and no longer valid)  | Enable Azure OpenAI transcription model. | true
+| spring.ai.model.audio.transcription  | Enable Azure OpenAI transcription model. | azure-openai
 | spring.ai.azure.openai.audio.transcription.options.model  | ID of the model to use. Only whisper is currently available. | whisper
 | spring.ai.azure.openai.audio.transcription.options.deployment-name  | The deployment name under which the model is deployed. |
 | spring.ai.azure.openai.audio.transcription.options.response-format | The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt. | json

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
@@ -13,6 +13,12 @@ Exporting an environment variable is one way to set that configuration property:
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Transcription Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -55,12 +61,24 @@ Usage from these API requests will count as usage for the specified organization
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.audio.transcription=openai (It is enabled by default)
+
+To disable, spring.ai.model.audio.transcription=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.audio.transcription` is used as the property prefix that lets you configure the retry mechanism for the OpenAI transcription model.
 
 [cols="3,5,2"]
 |====
 | Property | Description | Default
 
+| spring.ai.model.audio.transcription   | Enable OpenAI Audio Transcription Model |  openai
 | spring.ai.openai.audio.transcription.base-url   | The URL to connect to |  https://api.openai.com
 | spring.ai.openai.audio.transcription.api-key    | The API Key           |  -
 | spring.ai.openai.audio.transcription.organization-id | Optionally you can specify which organization  used for an API request. |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -30,6 +30,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Anthropic Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` file:
 
@@ -95,13 +101,25 @@ the output tokens limit is increased from `4096` to `8192` tokens (for claude-3-
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=anthropic (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match anthropic)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.anthropic.chat` is the property prefix that lets you configure the chat model implementation for Anthropic.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.anthropic.chat.enabled | Enable Anthropic chat model.  | true
+| spring.ai.anthropic.chat.enabled (Removed and no longer valid) | Enable Anthropic chat model.  | true
+| spring.ai.model.chat | Enable Anthropic chat model.  | anthropic
 | spring.ai.anthropic.chat.options.model | This is the Anthropic Chat model to use. Supports: `claude-3-7-sonnet-latest`, `claude-3-5-sonnet-latest`, `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307` | `claude-3-7-sonnet-latest`
 | spring.ai.anthropic.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8
 | spring.ai.anthropic.chat.options.max-tokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | 500

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc
@@ -84,6 +84,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure OpenAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -150,14 +156,26 @@ With this configuration the `spring.ai.azure.openai.chat.options.deployment-name
 | spring.ai.azure.openai.custom-headers | A map of custom headers to be included in the API requests. Each entry in the map represents a header, where the key is the header name and the value is the header value. | Empty map
 |====
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=azure-openai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match azure-openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.azure.openai.chat` is the property prefix that configures the `ChatModel` implementation for Azure OpenAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.azure.openai.chat.enabled | Enable Azure OpenAI chat model.  | true
-| spring.ai.azure.openai.chat.options.deployment-name | In use with Azure, this refers to the "Deployment Name" of your model, which you can find at https://oai.azure.com/portal. 
+| spring.ai.azure.openai.chat.enabled (Removed and no longer valid) | Enable Azure OpenAI chat model.  | true
+| spring.ai.model.chat | Enable Azure OpenAI chat model.  | azure-openai
+| spring.ai.azure.openai.chat.options.deployment-name | In use with Azure, this refers to the "Deployment Name" of your model, which you can find at https://oai.azure.com/portal.
 It's important to note that within an Azure OpenAI deployment, the "Deployment Name" is distinct from the model itself. 
 The confusion around these terms stems from the intention to make the Azure OpenAI client library compatible with the original OpenAI endpoint. 
 The deployment structures offered by Azure OpenAI and Sam Altman's OpenAI differ significantly.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -32,6 +32,12 @@ Refer to https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.ht
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Add the `spring-ai-starter-model-bedrock-converse` dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
 [tabs]
@@ -74,13 +80,25 @@ The prefix `spring.ai.bedrock.aws` is the property prefix to configure the conne
 | spring.ai.bedrock.aws.session-token | AWS session token for temporary credentials. | -
 |====
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=bedrock-converse (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match bedrock-converse)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.bedrock.converse.chat` is the property prefix that configures the chat model implementation for the Converse API.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.bedrock.converse.chat.enabled | Enable Bedrock Converse chat model. | true
+| spring.ai.bedrock.converse.chat.enabled (Removed and no longer valid) | Enable Bedrock Converse chat model. | true
+| spring.ai.model.chat | Enable Bedrock Converse chat model. | bedrock-converse
 | spring.ai.bedrock.converse.chat.options.model | The model ID to use. You can use the https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html[Supported models and model features]  | None. Select your https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/models[modelId] from the AWS Bedrock console.
 | spring.ai.bedrock.converse.chat.options.temperature | Controls the randomness of the output. Values can range over [0.0,1.0] | 0.8
 | spring.ai.bedrock.converse.chat.options.top-p | The maximum cumulative probability of tokens to consider when sampling. | AWS Bedrock default

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
@@ -41,6 +41,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -102,12 +108,25 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=openai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
+
 The prefix `spring.ai.openai.chat` is the property prefix that lets you configure the chat model implementation for OpenAI.
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.openai.chat.enabled | Enable OpenAI chat model.  | true
+| spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
+| spring.ai.model.chat | Enable OpenAI chat model.  | openai
 | spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://api.deepseek.com` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.options.model | The link:https://api-docs.deepseek.com/quick_start/pricing[DeepSeek LLM model] to use | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
@@ -45,6 +45,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -106,13 +112,25 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=openai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.chat` is the property prefix that lets you configure the chat model implementation for OpenAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.openai.chat.enabled | Enable OpenAI chat model.  | true
+| spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
+| spring.ai.openai.chat | Enable OpenAI chat model.  | openai
 | spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://api.groq.com/openai` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.options.model | The https://console.groq.com/docs/models[available model] names are `llama3-8b-8192`, `llama3-70b-8192`, `mixtral-8x7b-32768`, `gemma2-9b-it`. | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/huggingface.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/huggingface.adoc
@@ -30,6 +30,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Hugging Face Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -54,6 +60,17 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 
 === Chat Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=huggingface (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match huggingface)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.huggingface` is the property prefix that lets you configure the chat model implementation for Hugging Face.
 
 [cols="3,5,1", stripes=even]
@@ -61,7 +78,8 @@ The prefix `spring.ai.huggingface` is the property prefix that lets you configur
 | Property | Description | Default
 | spring.ai.huggingface.chat.api-key    | API Key to authenticate with the Inference Endpoint.  |  -
 | spring.ai.huggingface.chat.url        | URL of the Inference Endpoint to connect to           |  -
-| spring.ai.huggingface.chat.enabled    | Enable Hugging Face chat model.                       | true
+| spring.ai.huggingface.chat.enabled (Removed and no longer valid)   | Enable Hugging Face chat model.                       | true
+| spring.ai.model.chat (Removed and no longer valid)   | Enable Hugging Face chat model.                       | huggingface
 |====
 
 == Sample Controller (Auto-configuration)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/minimax-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/minimax-chat.adoc
@@ -26,6 +26,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the MiniMax Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -81,13 +87,26 @@ The prefix `spring.ai.minimax` is used as the property prefix that lets you conn
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=minimax (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match minimax)
+
+This change is done to allow configuration of multiple models.
+====
+
+
 The prefix `spring.ai.minimax.chat` is the property prefix that lets you configure the chat model implementation for MiniMax.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.minimax.chat.enabled | Enable MiniMax chat model.  | true
+| spring.ai.minimax.chat.enabled (Removed and no longer valid) | Enable MiniMax chat model.  | true
+| spring.ai.model.chat | Enable MiniMax chat model.  | minimax
 | spring.ai.minimax.chat.base-url | Optional overrides the spring.ai.minimax.base-url to provide chat specific url |  https://api.minimax.chat
 | spring.ai.minimax.chat.api-key | Optional overrides the spring.ai.minimax.api-key to provide chat specific api-key |  -
 | spring.ai.minimax.chat.options.model | This is the MiniMax Chat model to use | `abab6.5g-chat` (the `abab5.5-chat`, `abab5.5s-chat`, `abab6.5-chat`, `abab6.5g-chat`, `abab6.5t-chat` and `abab6.5s-chat` point to the latest model versions)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -26,6 +26,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Mistral AI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -81,13 +87,25 @@ The prefix `spring.ai.mistralai` is used as the property prefix that lets you co
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=mistral (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match mistral)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.mistralai.chat` is the property prefix that lets you configure the chat model implementation for Mistral AI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.mistralai.chat.enabled | Enable Mistral AI chat model.  | true
+| spring.ai.mistralai.chat.enabled (Removed and no longer valid) | Enable Mistral AI chat model.  | true
+| spring.ai.model.chat | Enable Mistral AI chat model.  | mistral
 | spring.ai.mistralai.chat.base-url   | Optional override for the `spring.ai.mistralai.base-url` property to provide chat-specific URL. |  -
 | spring.ai.mistralai.chat.api-key   | Optional override for the `spring.ai.mistralai.api-key` to provide chat-specific API Key. |  -
 | spring.ai.mistralai.chat.options.model | This is the Mistral AI Chat model to use | `open-mistral-7b`, `open-mixtral-8x7b`, `open-mixtral-8x22b`, `mistral-small-latest`, `mistral-large-latest`

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/moonshot-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/moonshot-chat.adoc
@@ -25,6 +25,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Moonshot Chat Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -80,13 +86,25 @@ The prefix `spring.ai.moonshot` is used as the property prefix that lets you con
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=moonshot (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match moonshot)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.moonshot.chat` is the property prefix that lets you configure the chat model implementation for Moonshot.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.moonshot.chat.enabled | Enable Moonshot chat model.  | true
+| spring.ai.moonshot.chat.enabled (Removed and no longer valid) | Enable Moonshot chat model.  | true
+| spring.ai.model.chat | Enable Moonshot chat model.  | moonshot
 | spring.ai.moonshot.chat.base-url | Optional overrides the spring.ai.moonshot.base-url to provide chat specific url |  -
 | spring.ai.moonshot.chat.api-key | Optional overrides the spring.ai.moonshot.api-key to provide chat specific api-key |  -
 | spring.ai.moonshot.chat.options.model | This is the Moonshot Chat model to use | `moonshot-v1-8k` (the `moonshot-v1-8k`, `moonshot-v1-32k`, and `moonshot-v1-128k` point to the latest model versions)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/nvidia-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/nvidia-chat.adoc
@@ -22,6 +22,12 @@ image::spring-ai-nvidia-registration.jpg[w=800,align="center"]
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -77,13 +83,25 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=openai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.chat` is the property prefix that lets you configure the chat model implementation for OpenAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.openai.chat.enabled | Enable OpenAI chat model.  | true
+| spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
+| spring.ai.model.chat | Enable OpenAI chat model.  | openai
 | spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://integrate.api.nvidia.com` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.options.model | The link:https://docs.api.nvidia.com/nim/reference/llm-apis#models[NVIDIA LLM model] to use | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/oci-genai/cohere-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/oci-genai/cohere-chat.adoc
@@ -17,6 +17,11 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
 Spring AI provides Spring Boot auto-configuration for the OCI GenAI Cohere Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -65,13 +70,22 @@ The prefix `spring.ai.oci.genai` is the property prefix to configure the connect
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+To enable, spring.ai.model.chat=oci-genai (It is enabled by default)
+To disable, spring.ai.model.chat=none (or any value which doesn't match oci-genai)
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.oci.genai.chat.cohere` is the property prefix that configures the `ChatModel` implementation for OCI GenAI Cohere Chat.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.oci.genai.chat.cohere.enabled | Enable OCI GenAI Cohere chat model.  | true
+| spring.ai.model.chat | Enable OCI GenAI Cohere chat model.  | oci-genai
+| spring.ai.oci.genai.chat.cohere.enabled (no longer valid) | Enable OCI GenAI Cohere chat model.  | true
 | spring.ai.oci.genai.chat.cohere.options.model | Model OCID or endpoint | -
 | spring.ai.oci.genai.chat.cohere.options.compartment | Model compartment OCID.  | -
 | spring.ai.oci.genai.chat.cohere.options.servingMode | The model serving mode to be used. May be `on-demand`, or `dedicated`.  | on-demand

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -32,6 +32,12 @@ Alternatively, you can enable the option to download automatically any needed mo
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Ollama chat integration.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -83,6 +89,17 @@ Here are the properties for initializing the Ollama integration and xref:auto-pu
 
 === Chat Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=ollama (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match ollama)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.ollama.chat.options` is the property prefix that configures the Ollama chat model.
 It includes the Ollama request (advanced) parameters such as the `model`, `keep-alive`, and `format` as well as the Ollama model `options` properties.
 
@@ -91,7 +108,8 @@ Here are the advanced request parameter for the Ollama chat model:
 [cols="3,6,1", stripes=even]
 |====
 | Property | Description | Default
-| spring.ai.ollama.chat.enabled      | Enable Ollama chat model. | true
+| spring.ai.ollama.chat.enabled (Removed and no longer valid)     | Enable Ollama chat model. | true
+| spring.ai.model.chat      | Enable Ollama chat model. | ollama
 | spring.ai.ollama.chat.options.model  | The name of the https://github.com/ollama/ollama?tab=readme-ov-file#model-library[supported model] to use. | mistral
 | spring.ai.ollama.chat.options.format  | The format to return a response in. Currently, the only accepted value is `json` | -
 | spring.ai.ollama.chat.options.keep_alive  | Controls how long the model will stay loaded into memory following the request | 5m

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -23,6 +23,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -88,13 +94,25 @@ Usage from these API requests will count as usage for the specified organization
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=openai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.chat` is the property prefix that lets you configure the chat model implementation for OpenAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.openai.chat.enabled | Enable OpenAI chat model.  | true
+| spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
+| spring.ai.model.chat | Enable OpenAI chat model.  | openai
 | spring.ai.openai.chat.base-url   | Optional override for the `spring.ai.openai.base-url` property to provide a chat-specific URL. |  -
 | spring.ai.openai.chat.completions-path   | The path to append to the base URL. |  `/v1/chat/completions`
 | spring.ai.openai.chat.api-key   | Optional override for the `spring.ai.openai.api-key` to provide a chat-specific API Key. |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/perplexity-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/perplexity-chat.adoc
@@ -47,6 +47,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -108,11 +114,23 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=openai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.chat` is the property prefix that lets you configure the chat model implementation for OpenAI.
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
+| spring.ai.model.chat | Enable OpenAI chat model.  | openai
 | spring.ai.openai.chat.model      | One of the supported https://docs.perplexity.ai/guides/model-cards[Perplexity models]. Example: `llama-3.1-sonar-small-128k-online`. | -
 | spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://api.perplexity.ai` |  -
 | spring.ai.openai.chat.completions-path | Must be set to `/chat/completions` | `/v1/chat/completions`

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/qianfan-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/qianfan-chat.adoc
@@ -28,6 +28,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the QianFan Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -84,13 +90,25 @@ The prefix `spring.ai.qianfan` is used as the property prefix that lets you conn
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=qianfan (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match qianfan)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.qianfan.chat` is the property prefix that lets you configure the chat client implementation for QianFan.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.qianfan.chat.enabled | Enable QianFan chat client.  | true
+| spring.ai.qianfan.chat.enabled (Removed and no longer valid) | Enable QianFan chat client.  | true
+| spring.ai.model.chat  | Enable QianFan chat client.  | qianfan
 | spring.ai.qianfan.chat.base-url | Optional overrides the spring.ai.qianfan.base-url to provide chat specific url |  https://api.qianfan.chat
 | spring.ai.qianfan.chat.api-key | Optional overrides the spring.ai.qianfan.api-key to provide chat specific api-key |  -
 | spring.ai.qianfan.chat.secret-key | Optional overrides the spring.ai.qianfan.secret-key to provide chat specific secret-key |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/vertexai-gemini-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/vertexai-gemini-chat.adoc
@@ -22,6 +22,12 @@ gcloud auth application-default login <ACCOUNT>
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the VertexAI Gemini Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -51,12 +57,24 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 
 === Chat Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=vertexai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match vertexai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.vertex.ai.gemini` is used as the property prefix that lets you connect to VertexAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
+| spring.ai.model.chat   | Enable Chat Model client |  vertexai
 | spring.ai.vertex.ai.gemini.projectId   | Google Cloud Platform project ID |  -
 | spring.ai.vertex.ai.gemini.location    | Region           |  -
 | spring.ai.vertex.ai.gemini.credentialsUri    | URI to Vertex AI Gemini credentials. When provided it is used to create an a `GoogleCredentials` instance to authenticate the `VertexAI`. |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/watsonx-ai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/watsonx-ai-chat.adoc
@@ -14,6 +14,12 @@ TIP: More info can be found https://www.ibm.com/products/watsonx-ai/info/trial[h
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the watsonx.ai Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -53,13 +59,25 @@ The prefix `spring.ai.watsonx.ai` is used as the property prefix that lets you c
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=watsonx (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match watsonx)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.watsonx.ai.chat` is the property prefix that lets you configure the chat model implementation for Watsonx.AI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.watsonx.ai.chat.enabled | Enable Watsonx.AI chat model.  | true
+| spring.ai.watsonx.ai.chat.enabled (Removed and no longer valid) | Enable Watsonx.AI chat model.  | true
+| spring.ai.model.chat | Enable Watsonx.AI chat model.  | watsonx
 | spring.ai.watsonx.ai.chat.options.temperature | The temperature of the model. Increasing the temperature will make the model answer more creatively.  | 0.7
 | spring.ai.watsonx.ai.chat.options.top-p | Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.2) will generate more focused and conservative text.  | 1.0
 | spring.ai.watsonx.ai.chat.options.top-k | Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative.   |  50

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/zhipuai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/zhipuai-chat.adoc
@@ -26,6 +26,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the ZhiPuAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -81,13 +87,25 @@ The prefix `spring.ai.zhiPu` is used as the property prefix that lets you connec
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the chat auto-configurations are now configured via top level properties with the prefix `spring.ai.model.chat`.
+
+To enable, spring.ai.model.chat=zhipuai (It is enabled by default)
+
+To disable, spring.ai.model.chat=none (or any value which doesn't match zhipuai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.zhipuai.chat` is the property prefix that lets you configure the chat model implementation for ZhiPuAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.zhipuai.chat.enabled | Enable ZhiPuAI chat model.  | true
+| spring.ai.zhipuai.chat.enabled (Removed and no longer valid) | Enable ZhiPuAI chat model.  | true
+| spring.ai.model.chat | Enable ZhiPuAI chat model.  | zhipuai
 | spring.ai.zhipuai.chat.base-url | Optional overrides the spring.ai.zhipuai.base-url to provide chat specific url |  https://open.bigmodel.cn/api/paas
 | spring.ai.zhipuai.chat.api-key | Optional overrides the spring.ai.zhipuai.api-key to provide chat specific api-key |  -
 | spring.ai.zhipuai.chat.options.model | This is the ZhiPuAI Chat model to use | `GLM-3-Turbo` (the `GLM-3-Turbo`, `GLM-4`, `GLM-4-Air`, `GLM-4-AirX`, `GLM-4-Flash`, and `GLM-4V` point to the latest model versions)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
@@ -60,6 +60,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure OpenAI Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -98,13 +104,25 @@ With this configuraiton the `spring.ai.azure.openai.embedding.options.deployment
 |====
 
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=azure-openai (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match azure-openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.azure.openai.embedding` is the property prefix that configures the `EmbeddingModel` implementation for Azure OpenAI
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.azure.openai.embedding.enabled | Enable Azure OpenAI embedding model.  | true
+| spring.ai.azure.openai.embedding.enabled (Removed and no longer valid) | Enable Azure OpenAI embedding model.  | true
+| spring.ai.model.embedding | Enable Azure OpenAI embedding model.  | azure-openai
 | spring.ai.azure.openai.embedding.metadata-mode | Document content extraction mode    | EMBED
 | spring.ai.azure.openai.embedding.options.deployment-name | This is the value of the 'Deployment Name' as presented in the Azure AI Portal | text-embedding-ada-002
 | spring.ai.azure.openai.embedding.options.user | An identifier for the caller or end user of the operation. This may be used for tracking or rate-limiting purposes. | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-cohere-embedding.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-cohere-embedding.adoc
@@ -18,6 +18,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Add the `spring-ai-starter-model-bedrock` dependency to your project's Maven `pom.xml` file:
 
 [source,xml]
@@ -63,12 +69,24 @@ The prefix `spring.ai.bedrock.aws` is the property prefix to configure the conne
 | spring.ai.bedrock.aws.secret-key | AWS secret key.  | -
 |====
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=bedrock-cohere (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match bedrock-cohere)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.bedrock.cohere.embedding` (defined in `BedrockCohereEmbeddingProperties`) is the property prefix that configures the embedding model implementation for Cohere.
 
 [cols="3,4,1", stripes=even]
 |====
 | Property | Description | Default
-| spring.ai.bedrock.cohere.embedding.enabled              | Enable or disable support for Cohere  | false
+| spring.ai.bedrock.cohere.embedding.enabled (Removed and no longer valid)             | Enable or disable support for Cohere  | false
+| spring.ai.model.embedding           | Enable or disable support for Cohere  | bedrock-cohere
 | spring.ai.bedrock.cohere.embedding.model                | The model id to use. See the https://github.com/spring-projects/spring-ai/blob/056b95a00efa5b014a1f488329fbd07a46c02378/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java#L150[CohereEmbeddingModel] for the supported models.  | cohere.embed-multilingual-v3
 | spring.ai.bedrock.cohere.embedding.options.input-type  | Prepends special tokens to differentiate each type from one another. You should not mix different types together, except when mixing types for search and retrieval. In this case, embed your corpus with the search_document type and embedded queries with type search_query type.  | SEARCH_DOCUMENT
 | spring.ai.bedrock.cohere.embedding.options.truncate  | Specifies how the API handles inputs longer than the maximum token length. If you specify LEFT or RIGHT, the model discards the input until the remaining input is exactly the maximum input token length for the model.  | NONE

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
@@ -25,6 +25,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Add the `spring-ai-starter-model-bedrock` dependency to your project's Maven `pom.xml` file:
 
 [source,xml]
@@ -70,12 +76,24 @@ The prefix `spring.ai.bedrock.aws` is the property prefix to configure the conne
 | spring.ai.bedrock.aws.secret-key | AWS secret key.  | -
 |====
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=bedrock-titan (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match bedrock-titan)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.bedrock.titan.embedding` (defined in `BedrockTitanEmbeddingProperties`) is the property prefix that configures the embedding model implementation for Titan.
 
 [cols="3,4,1", stripes=even]
 |====
 | Property | Description | Default
-| spring.ai.bedrock.titan.embedding.enabled              | Enable or disable support for Titan  embedding | false
+| spring.ai.bedrock.titan.embedding.enabled (Removed and no longer valid)             | Enable or disable support for Titan  embedding | false
+| spring.ai.model.embedding              | Enable or disable support for Titan  embedding | bedrock-titan
 | spring.ai.bedrock.titan.embedding.model                | The model id to use. See the `TitanEmbeddingModel` for the supported models.  | amazon.titan-embed-image-v1
 |====
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/minimax-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/minimax-embeddings.adoc
@@ -26,6 +26,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure MiniMax Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -81,13 +87,26 @@ The prefix `spring.ai.minimax` is used as the property prefix that lets you conn
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=minimax (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match minimax)
+
+This change is done to allow configuration of multiple models.
+====
+
+
 The prefix `spring.ai.minimax.embedding` is property prefix that configures the `EmbeddingModel` implementation for MiniMax.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.minimax.embedding.enabled | Enable MiniMax embedding model.  | true
+| spring.ai.minimax.embedding.enabled (Removed and no longer valid) | Enable MiniMax embedding model.  | true
+| spring.ai.model.embedding | Enable MiniMax embedding model.  | minimax
 | spring.ai.minimax.embedding.base-url   | Optional overrides the spring.ai.minimax.base-url to provide embedding specific url | -
 | spring.ai.minimax.embedding.api-key    | Optional overrides the spring.ai.minimax.api-key to provide embedding specific api-key  | -
 | spring.ai.minimax.embedding.options.model      | The model to use      | embo-01

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/mistralai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/mistralai-embeddings.adoc
@@ -26,6 +26,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the MistralAI Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -81,13 +87,25 @@ The prefix `spring.ai.mistralai` is used as the property prefix that lets you co
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=mistral (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match mistral)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.mistralai.embedding` is property prefix that configures the `EmbeddingModel` implementation for MistralAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.mistralai.embedding.enabled | Enable OpenAI embedding model.  | true
+| spring.ai.mistralai.embedding.enabled (Removed and no longer valid) | Enable OpenAI embedding model.  | true
+| spring.ai.model.embedding | Enable OpenAI embedding model.  | true
 | spring.ai.mistralai.embedding.base-url   | Optional overrides the spring.ai.mistralai.base-url to provide embedding specific url | -
 | spring.ai.mistralai.embedding.api-key    | Optional overrides the spring.ai.mistralai.api-key to provide embedding specific api-key  | -
 | spring.ai.mistralai.embedding.metadata-mode      | Document content extraction mode.      | EMBED

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/oci-genai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/oci-genai-embeddings.adoc
@@ -15,6 +15,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OCI GenAI Embedding Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -58,6 +64,16 @@ The prefix `spring.ai.oci.genai` is the property prefix to configure the connect
 
 |====
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=oci-genai (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match oci-genai)
+
+This change is done to allow configuration of multiple models.
+====
 
 The prefix `spring.ai.oci.genai.embedding` is the property prefix that configures the `EmbeddingModel` implementation for OCI GenAI
 
@@ -65,7 +81,8 @@ The prefix `spring.ai.oci.genai.embedding` is the property prefix that configure
 |====
 | Property | Description | Default
 
-| spring.ai.oci.genai.embedding.enabled | Enable OCI GenAI embedding model.  | true
+| spring.ai.oci.genai.embedding.enabled (Removed and no longer valid) | Enable OCI GenAI embedding model.  | true
+| spring.ai.model.embedding | Enable OCI GenAI embedding model.  | oci-genai
 | spring.ai.oci.genai.embedding.compartment | Model compartment OCID.    | -
 | spring.ai.oci.genai.embedding.servingMode | The model serving mode to be used. May be `on-demand`, or `dedicated`.  | on-demand
 | spring.ai.oci.genai.embedding.truncate | How to truncate text if it overruns the embedding context. May be `START`, or `END`.  | END

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc
@@ -34,6 +34,12 @@ Alternatively, you can enable the option to download automatically any needed mo
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure Ollama Embedding Model.
 To enable it add the following dependency to your Maven `pom.xml` or Gradle `build.gradle` build files:
 
@@ -87,6 +93,17 @@ Here are the properties for initializing the Ollama integration and xref:auto-pu
 
 === Embedding Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=ollama (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match ollama)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.ollama.embedding.options` is the property prefix that configures the Ollama embedding model.
 It includes the Ollama request (advanced) parameters such as the `model`, `keep-alive`, and `truncate` as well as the Ollama model `options` properties.
 
@@ -95,8 +112,9 @@ Here are the advanced request parameter for the Ollama embedding model:
 [cols="4,5,1", stripes=even]
 |====
 | Property | Description | Default
-| spring.ai.ollama.embedding.enabled      | Enables the Ollama embedding model auto-configuration. | true
-| spring.ai.ollama.embedding.options.model  | The name of the https://github.com/ollama/ollama?tab=readme-ov-file#model-library[supported model] to use. 
+| spring.ai.ollama.embedding.enabled (Removed and no longer valid)     | Enables the Ollama embedding model auto-configuration. | true
+| spring.ai.model.embedding      | Enables the Ollama embedding model auto-configuration. | ollama
+| spring.ai.ollama.embedding.options.model  | The name of the https://github.com/ollama/ollama?tab=readme-ov-file#model-library[supported model] to use.
 You can use dedicated https://ollama.com/search?c=embedding[Embedding Model] types | mistral
 | spring.ai.ollama.embedding.options.keep_alive  | Controls how long the model will stay loaded into memory following the request | 5m
 | spring.ai.ollama.embedding.options.truncate  | Truncates the end of each input to fit within context length. Returns error if false and context length is exceeded.  | true

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/onnx.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/onnx.adoc
@@ -30,6 +30,12 @@ In place of the all-MiniLM-L6-v2 you can pick any huggingface transformer identi
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the ONNX Transformer Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -66,11 +72,23 @@ The complete list of supported properties are:
 
 === Embedding Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=transformers (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match transformers)
+
+This change is done to allow configuration of multiple models.
+====
+
 [cols="3*"", stripes=even]
 |===
 | Property    | Description | Default
 
-| spring.ai.embedding.transformer.enabled | Enable the Transformer Embedding model. | true
+| spring.ai.embedding.transformer.enabled (Removed and no longer valid) | Enable the Transformer Embedding model. | true
+| spring.ai.model.embedding | Enable the Transformer Embedding model. | transformers
 | spring.ai.embedding.transformer.tokenizer.uri  | URI of a pre-trained HuggingFaceTokenizer created by the ONNX engine (e.g. tokenizer.json).   | onnx/all-MiniLM-L6-v2/tokenizer.json
 | spring.ai.embedding.transformer.tokenizer.options  | HuggingFaceTokenizer options such as '`addSpecialTokens`', '`modelMaxLength`', '`truncation`', '`padding`', '`maxLength`', '`stride`', '`padToMultipleOf`'. Leave empty to fallback to the defaults. | empty
 | spring.ai.embedding.transformer.cache.enabled  | Enable remote Resource caching.  | true

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
@@ -27,6 +27,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -87,13 +93,25 @@ Usage from these API requests will count as usage for the specified organization
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=openai (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.embedding` is property prefix that configures the `EmbeddingModel` implementation for OpenAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.openai.embedding.enabled | Enable OpenAI embedding model.  | true
+| spring.ai.openai.embedding.enabled (Required and no longer valid) | Enable OpenAI embedding model.  | true
+| spring.ai.model.embedding | Enable OpenAI embedding model.  | openai
 | spring.ai.openai.embedding.base-url   | Optional overrides the spring.ai.openai.base-url to provide embedding specific url | -
 | spring.ai.openai.chat.embeddings-path   | The path to append to the base-url  |  `/v1/embeddings`
 | spring.ai.openai.embedding.api-key    | Optional overrides the spring.ai.openai.api-key to provide embedding specific api-key  | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/postgresml-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/postgresml-embeddings.adoc
@@ -19,6 +19,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure PostgresML Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -45,12 +51,24 @@ Use the `spring.ai.postgresml.embedding.options.*` properties to configure your 
 
 === Embedding Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=postgresml (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match postgresml)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.postgresml.embedding` is property prefix that configures the `EmbeddingModel` implementation for PostgresML embeddings.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
-| spring.ai.postgresml.embedding.enabled | Enable PostgresML embedding model.  | true
+| spring.ai.postgresml.embedding.enabled (Removed and no longer valid) | Enable PostgresML embedding model.  | true
+| spring.ai.model.embedding | Enable PostgresML embedding model.  | postgresml
 | spring.ai.postgresml.embedding.create-extension | Execute the SQL 'CREATE EXTENSION IF NOT EXISTS pgml' to enable the extesnion | false
 | spring.ai.postgresml.embedding.options.transformer  | The Hugging Face transformer model to use for the embedding.  | distilbert-base-uncased
 | spring.ai.postgresml.embedding.options.kwargs   | Additional transformer specific options.  | empty map

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/qianfan-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/qianfan-embeddings.adoc
@@ -28,6 +28,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure QianFan Embedding Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -84,13 +90,25 @@ The prefix `spring.ai.qianfan` is used as the property prefix that lets you conn
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=qianfan (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match qianfan)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.qianfan.embedding` is property prefix that configures the `EmbeddingClient` implementation for QianFan.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.qianfan.embedding.enabled       | Enable QianFan embedding client.  | true
+| spring.ai.qianfan.embedding.enabled (Removed and no longer valid)      | Enable QianFan embedding client.  | true
+| spring.ai.model.embedding       | Enable QianFan embedding client.  | qianfan
 | spring.ai.qianfan.embedding.base-url      | Optional overrides the spring.ai.qianfan.base-url to provide embedding specific url | -
 | spring.ai.qianfan.embedding.api-key       | Optional overrides the spring.ai.qianfan.api-key to provide embedding specific api-key  | -
 | spring.ai.qianfan.embedding.secret-key    | Optional overrides the spring.ai.qianfan.secret-key to provide embedding specific secret-key  | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/vertexai-embeddings-multimodal.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/vertexai-embeddings-multimodal.adoc
@@ -37,6 +37,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the VertexAI Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -73,13 +79,25 @@ The prefix `spring.ai.vertex.ai.embedding` is used as the property prefix that l
 
 |====
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding.multimodal=vertexai (It is enabled by default)
+
+To disable, spring.ai.model.embedding.multimodal=none (or any value which doesn't match vertexai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.vertex.ai.embedding.multimodal` is the property prefix that lets you configure the embedding model implementation for VertexAI Multimodal Embedding.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.vertex.ai.embedding.multimodal.enabled | Enable Vertex AI Embedding API model. | true
+| spring.ai.vertex.ai.embedding.multimodal.enabled (Removed and no longer valid) | Enable Vertex AI Embedding API model. | true
+| spring.ai.model.embedding.multimodal=vertexai | Enable Vertex AI Embedding API model. | vertexai
 | spring.ai.vertex.ai.embedding.multimodal.options.model | You can get multimodal embeddings by using the following model: | multimodalembedding@001
 | spring.ai.vertex.ai.embedding.multimodal.options.dimensions | Specify lower-dimension embeddings. By default, an embedding request returns a 1408 float vector for a data type. You can also specify lower-dimension embeddings (128, 256, or 512 float vectors) for text and image data.  | 1408
 | spring.ai.vertex.ai.embedding.multimodal.options.video-start-offset-sec | The start offset of the video segment in seconds. If not specified, it's calculated with max(0, endOffsetSec - 120).  | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/vertexai-embeddings-text.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/vertexai-embeddings-text.adoc
@@ -29,6 +29,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the VertexAI Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -65,13 +71,25 @@ The prefix `spring.ai.vertex.ai.embedding` is used as the property prefix that l
 
 |====
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding.text=vertexai (It is enabled by default)
+
+To disable, spring.ai.model.embedding.text=none (or any value which doesn't match vertexai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.vertex.ai.embedding.text` is the property prefix that lets you configure the embedding model implementation for VertexAI Text Embedding.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.vertex.ai.embedding.text.enabled | Enable Vertex AI Embedding API model. | true
+| spring.ai.vertex.ai.embedding.text.enabled (Removed and no longer valid) | Enable Vertex AI Embedding API model. | true
+| spring.ai.model.embedding.text | Enable Vertex AI Embedding API model. | vertexai
 | spring.ai.vertex.ai.embedding.text.options.model | This is the link:https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings#supported-models[Vertex Text Embedding model] to use | text-embedding-004
 | spring.ai.vertex.ai.embedding.text.options.task-type | The intended downstream application to help the model produce better quality embeddings. Available link:https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#request_body[task-types]  | `RETRIEVAL_DOCUMENT`
 | spring.ai.vertex.ai.embedding.text.options.title | Optional title, only valid with task_type=RETRIEVAL_DOCUMENT.  | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/watsonx-ai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/watsonx-ai-embeddings.adoc
@@ -25,6 +25,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Watsonx.ai Embedding Model.
 To enable it add the following dependency to your Maven `pom.xml` file:
 
@@ -63,13 +69,25 @@ The prefix `spring.ai.watsonx.ai` is used as the property prefix that lets you c
 | spring.ai.watsonx.ai.iam-token            | The IBM Cloud account IAM token   |  -
 |====
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=watsonx (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match watsonx)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.watsonx.embedding.options` is the property prefix that configures the `EmbeddingModel` implementation for Watsonx.ai.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.watsonx.ai.embedding.enabled       | Enable Watsonx.ai embedding model | true
+| spring.ai.watsonx.ai.embedding.enabled (Removed and no longer valid)      | Enable Watsonx.ai embedding model | true
+| spring.ai.model.embedding       | Enable Watsonx.ai embedding model | watsonx
 | spring.ai.watsonx.ai.embedding.options.model | The embedding model to be used    | ibm/slate-30m-english-rtrvr
 |====
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/zhipuai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/zhipuai-embeddings.adoc
@@ -27,6 +27,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure ZhiPuAI Embedding Model.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -82,13 +88,25 @@ The prefix `spring.ai.zhipuai` is used as the property prefix that lets you conn
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.embedding=zhipuai (It is enabled by default)
+
+To disable, spring.ai.model.embedding=none (or any value which doesn't match zhipuai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.zhipuai.embedding` is property prefix that configures the `EmbeddingModel` implementation for ZhiPuAI.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
-| spring.ai.zhipuai.embedding.enabled | Enable ZhiPuAI embedding model.  | true
+| spring.ai.zhipuai.embedding.enabled (Removed and no longer valid) | Enable ZhiPuAI embedding model.  | true
+| spring.ai.model.embedding | Enable ZhiPuAI embedding model.  | zhipuai
 | spring.ai.zhipuai.embedding.base-url   | Optional overrides the spring.ai.zhipuai.base-url to provide embedding specific url | -
 | spring.ai.zhipuai.embedding.api-key    | Optional overrides the spring.ai.zhipuai.api-key to provide embedding specific api-key  | -
 | spring.ai.zhipuai.embedding.options.model      | The model to use      | embedding-2

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/azure-openai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/azure-openai-image.adoc
@@ -52,6 +52,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Azure OpenAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -76,13 +82,24 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 
 === Image Generation Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.image=azure-openai (It is enabled by default)
+
+To disable, spring.ai.model.image=none (or any value which doesn't match azure-openai)
+
+This change is done to allow configuration of multiple models.
+====
 
 The prefix `spring.ai.openai.image` is the property prefix that lets you configure the `ImageModel` implementation for OpenAI.
 
 [cols="3,5,1"]
 |====
 | Property | Description | Default
-| spring.ai.azure.openai.image.enabled | Enable OpenAI image model.  | true
+| spring.ai.azure.openai.image.enabled (Removed and no longer valid) | Enable OpenAI image model.  | true
+| spring.ai.model.image | Enable OpenAI image model.  | azure-openai
 | spring.ai.azure.openai.image.options.n            | The number of images to generate. Must be between 1 and 10. For dall-e-3, only n=1 is supported.  | -
 | spring.ai.azure.openai.image.options.model        | The model to use for image generation.  | AzureOpenAiImageOptions.DEFAULT_IMAGE_MODEL
 | spring.ai.azure.openai.image.options.quality      | The quality of the image that will be generated. HD creates images with finer details and greater consistency across the image. This parameter is only supported for dall-e-3. | -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/openai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/openai-image.adoc
@@ -17,6 +17,12 @@ export SPRING_AI_OPENAI_API_KEY=<INSERT KEY HERE>
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Image Generation Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -77,12 +83,24 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 
 ==== Configuration Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.image=openai (It is enabled by default)
+
+To disable, spring.ai.model.image=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.openai.image` is the property prefix that lets you configure the `ImageModel` implementation for OpenAI.
 
 [cols="3,5,1"]
 |====
 | Property | Description | Default
-| spring.ai.openai.image.enabled | Enable OpenAI image model.  | true
+| spring.ai.openai.image.enabled (Removed and no longer valid) | Enable OpenAI image model.  | true
+| spring.ai.model.image | Enable OpenAI image model.  | openai
 | spring.ai.openai.image.base-url              | Optional overrides the spring.ai.openai.base-url to provide chat specific url |  -
 | spring.ai.openai.image.api-key               | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.image.organization-id | Optionally you can specify which organization  used for an API request. |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/qianfan-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/qianfan-image.adoc
@@ -26,6 +26,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the QianFan Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -50,12 +56,24 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 
 === Image Generation Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.image=qianfan (It is enabled by default)
+
+To disable, spring.ai.model.image=none (or any value which doesn't match qianfan)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.qianfan.image` is the property prefix that lets you configure the `ImageModel` implementation for QianFan.
 
 [cols="3,5,1"]
 |====
 | Property | Description | Default
-| spring.ai.qianfan.image.enabled           | Enable QianFan image model.  | true
+| spring.ai.qianfan.image.enabled (Removed and no longer valid)           | Enable QianFan image model.  | true
+| spring.ai.model.image          | Enable QianFan image model.  | qianfan
 | spring.ai.qianfan.image.base-url          | Optional overrides the spring.ai.qianfan.base-url to provide chat specific url |  -
 | spring.ai.qianfan.image.api-key           | Optional overrides the spring.ai.qianfan.api-key to provide chat specific api-key |  -
 | spring.ai.qianfan.image.secret-key        | Optional overrides the spring.ai.qianfan.secret-key to provide chat specific secret-key |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/stabilityai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/stabilityai-image.adoc
@@ -16,6 +16,12 @@ export SPRING_AI_STABILITYAI_API_KEY=<INSERT KEY HERE>
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Stability AI Image Generation Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -51,13 +57,25 @@ The prefix `spring.ai.stabilityai` is used as the property prefix that lets you 
 | spring.ai.stabilityai.api-key    | The API Key           |  -
 |====
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.image=stabilityai (It is enabled by default)
+
+To disable, spring.ai.model.image=none (or any value which doesn't match stabilityai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.stabilityai.image` is the property prefix that lets you configure the `ImageModel` implementation for Stability AI.
 
 [cols="2,5,1"]
 |====
 | Property | Description | Default
 
-| spring.ai.stabilityai.image.enabled | Enable Stability AI image model.  | true
+| spring.ai.stabilityai.image.enabled (Removed and no longer valid) | Enable Stability AI image model.  | true
+| spring.ai.model.image | Enable Stability AI image model.  | stabilityai
 | spring.ai.stabilityai.image.base-url              | Optional overrides the spring.ai.openai.base-url to provide a specific url |  `https://api.stability.ai/v1`
 | spring.ai.stabilityai.image.api-key              | Optional overrides the spring.ai.openai.api-key to provide a specific api-key |  -
 | spring.ai.stabilityai.image.option.n               | The number of images to be generated. Must be between 1 and 10.                                                            | 1

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/zhipuai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/zhipuai-image.adoc
@@ -24,6 +24,12 @@ To help with dependency management, Spring AI provides a BOM (bill of materials)
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the ZhiPuAI Chat Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -48,12 +54,24 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 
 === Image Generation Properties
 
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.image=stabilityai (It is enabled by default)
+
+To disable, spring.ai.model.image=none (or any value which doesn't match stabilityai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix `spring.ai.zhipuai.image` is the property prefix that lets you configure the `ImageModel` implementation for ZhiPuAI.
 
 [cols="3,5,1"]
 |====
 | Property | Description | Default
-| spring.ai.zhipuai.image.enabled        | Enable ZhiPuAI image model.  | true
+| spring.ai.zhipuai.image.enabled (Removed and no longer valid)       | Enable ZhiPuAI image model.  | true
+| spring.ai.model.image       | Enable ZhiPuAI image model.  | zhipuai
 | spring.ai.zhipuai.image.base-url       | Optional overrides the spring.ai.zhipuai.base-url to provide chat specific url |  -
 | spring.ai.zhipuai.image.api-key        | Optional overrides the spring.ai.zhipuai.api-key to provide chat specific api-key |  -
 | spring.ai.zhipuai.image.options.model  | The model to use for image generation.  | cogview-3

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -13,6 +13,12 @@ The MCP Client Boot Starter provides:
 
 == Starters
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 === Standard MCP Client
 
 [source,xml]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -12,6 +12,12 @@ The MCP Server Boot Starter offers:
 
 == Starters
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Choose one of the following starters based on your transport requirements:
 
 === Standard MCP Server

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
@@ -13,6 +13,12 @@ Follow this https://platform.openai.com/docs/guides/moderation[guide] to for mor
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenAI Text-to-Speech Client.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 
@@ -52,10 +58,23 @@ TIP: For users that belong to multiple organizations (or are accessing their pro
 Usage from these API requests will count as usage for the specified organization and project.
 
 === Configuration Properties
+
+[NOTE]
+====
+Enabling and disabling of the embedding auto-configurations are now configured via top level properties with the prefix `spring.ai.model.embedding`.
+
+To enable, spring.ai.model.moderation=openai (It is enabled by default)
+
+To disable, spring.ai.model.moderation=none (or any value which doesn't match openai)
+
+This change is done to allow configuration of multiple models.
+====
+
 The prefix spring.ai.openai.moderation is used as the property prefix for configuring the OpenAI moderation model.
 [cols="3,5,2"]
 |====
 | Property | Description | Default
+| spring.ai.model.moderation   | Enable Moderation model |  openai
 | spring.ai.openai.moderation.base-url   | The URL to connect to |  https://api.openai.com
 | spring.ai.openai.moderation.api-key    | The API Key           |  -
 | spring.ai.openai.moderation.organization-id | Optionally you can specify which organization is used for an API request. |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/apache-cassandra.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/apache-cassandra.adoc
@@ -52,6 +52,12 @@ b. For a managed offering https://astra.datastax.com/[Astra DB] offers a healthy
 
 == Dependencies
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 TIP: For dependency management, we recommend using the Spring AI BOM as explained in the xref:getting-started.adoc#dependency-management[Dependency Management] section.
 
 Add these dependencies to your project:

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure-cosmos-db.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure-cosmos-db.adoc
@@ -87,6 +87,12 @@ public class DemoApplication implements CommandLineRunner {
 
 == Auto Configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Add the following dependency to your Maven project:
 
 [source,xml]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure.adoc
@@ -42,6 +42,12 @@ You can replace Azure Open AI implementation with any valid OpenAI implementatio
 
 == Dependencies
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Add these dependencies to your project:
 
 === 1. Select an Embeddings interface implementation. You can choose between:

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/chroma.adoc
@@ -15,6 +15,12 @@ On startup, the `ChromaVectorStore` creates the required collection if one is no
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Chroma Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/couchbase.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/couchbase.adoc
@@ -16,6 +16,12 @@ Couchbase
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Couchbase Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -15,6 +15,12 @@ A running Elasticsearch instance. The following options are available:
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Elasticsearch Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` or Gradle `build.gradle` build files:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/gemfire.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/gemfire.adoc
@@ -16,6 +16,12 @@ An option that runs locally on your machine is xref:api/embeddings/onnx.adoc[ONN
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Add the GemFire VectorStore Spring Boot starter to you project's Maven build file `pom.xml`:
 
 [source, xml]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/hana.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/hana.adoc
@@ -8,6 +8,12 @@
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the SAP Hana Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mariadb.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mariadb.adoc
@@ -15,6 +15,12 @@ It provides efficient vector similarity search capabilities using vector indexes
 
 == Auto-Configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the MariaDB Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
@@ -11,6 +11,12 @@ link:https://milvus.io/[Milvus] is an open-source vector database that has garne
 
 == Dependencies
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Then add the Milvus VectorStore boot starter dependency to your project:
 
 [source,xml]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mongodb.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/mongodb.adoc
@@ -20,6 +20,12 @@ You can use the `$vectorSearch` aggregation operator in a MongoDB aggregation st
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the MongoDB Atlas Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
@@ -22,6 +22,12 @@ Those indexes are powered by Lucene using a Hierarchical Navigable Small World G
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Neo4j Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
@@ -15,6 +15,12 @@ The link:https://opensearch.org/docs/latest/search-plugins/knn/index/[OpenSearch
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the OpenSearch Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/oracle.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/oracle.adoc
@@ -6,6 +6,12 @@ TIP: The <<Run Oracle Database 23ai locally,Run Oracle Database 23ai locally>> a
 
 == Auto-Configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Start by adding the Oracle Vector Store boot starter dependency to your project:
 
 [source,xml]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pgvector.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pgvector.adoc
@@ -36,6 +36,12 @@ Next, if required, an API key for the xref:api/embeddings.adoc#available-impleme
 
 == Auto-Configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Then add the PgVectorStore boot starter dependency to your project:
 
 [source,xml]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc
@@ -25,6 +25,12 @@ The namespace support is not available in the Pinecone free tier.
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Pinecone Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/qdrant.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/qdrant.adoc
@@ -14,6 +14,12 @@ If the collection is not created, the `QdrantVectorStore` will attempt to create
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Qdrant Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
@@ -21,6 +21,12 @@ link:https://redis.io/docs/interact/search-and-query/[Redis Search and Query] ex
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Redis Vector Store.
 To enable it, add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/typesense.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/typesense.adoc
@@ -13,6 +13,12 @@ link:https://typesense.org[Typesense] is an open source typo tolerant search eng
 
 == Auto-configuration
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Spring AI provides Spring Boot auto-configuration for the Typesense Vector Store.
 To enable it add the following dependency to your project's Maven `pom.xml` file:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
@@ -14,6 +14,12 @@ It provides tools to store document embeddings, content, and metadata and to sea
 
 == Dependencies
 
+[NOTE]
+====
+There has been a significant change in the Spring AI auto-configuration, starter modules' artifact names.
+Please refer to the https://docs.spring.io/spring-ai/reference/upgrade-notes.html[upgrade notes] for more information.
+====
+
 Add the Weaviate Vector Store dependency to your project:
 
 [source,xml]


### PR DESCRIPTION
 - Since the model autoconfiguration enable/disable flags are no longer used, remove them

   - Currently, the model autoconfigurations can be enabled/disabled via top level Spring AI properties such as spring.ai.model.chat/embedding/image/moderation=<model-provider-name>

   - Update documentation to add note section about this change

- Update note on the autoconfiguration section to point to the configuration changes

- Align the vertex ai text/multimodal keys in line with the other properties
