### PR TITLE
Fix :: Broken URL link to document

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -136,7 +136,7 @@ String answer = chatClient.prompt()
         .content();
 ----
 
-See xref:api/retrieval-augmented-generation.adoc#_vectorstoredocumentretriever for more information.
+See xref:api/retrieval-augmented-generation.adoc#_vectorstoredocumentretriever[VectorStoreDocumentRetriever] for more information.
 
 ===== Advanced RAG
 


### PR DESCRIPTION
Hello Spring AI Team,

This PR fixes a broken xref link that did not correctly resolve to the intended documentation section. 
The link is now updated to correctly point to the published HTML page.

<img width="903" alt="스크린샷 2025-03-26 오전 9 04 16" src="https://github.com/user-attachments/assets/290eb731-21fb-4a88-98a1-e30232a797a7" />
