### PR TITLE
Encapsulate Advisor Parameters with ChatMemoryAdvisorOptions

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/ChatMemoryAdvisorOptions.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/chat/client/advisor/ChatMemoryAdvisorOptions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import org.springframework.ai.chat.client.ChatClient.AdvisorSpec;
+import org.springframework.util.Assert;
+
+import static org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor.*;
+
+/**
+ * Provides a way to configure an AdvisorSpec with a conversation ID and retrieval size.
+ *
+ * @author Jonghoon Park
+ */
+public class ChatMemoryAdvisorOptions {
+
+	private Object conversationId = DEFAULT_CHAT_MEMORY_CONVERSATION_ID;
+
+	private Integer retrieveSize = DEFAULT_CHAT_MEMORY_RESPONSE_SIZE;
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private final ChatMemoryAdvisorOptions options;
+
+		public Builder() {
+			this.options = new ChatMemoryAdvisorOptions();
+		}
+
+		public Builder conversationId(Object conversationId) {
+			this.options.conversationId = conversationId;
+			return this;
+		}
+
+		public Builder retrieveSize(int retrieveSize) {
+			this.options.retrieveSize = retrieveSize;
+			return this;
+		}
+
+		public ChatMemoryAdvisorOptions build() {
+			return this.options;
+		}
+
+	}
+
+	public void applyTo(AdvisorSpec advisorSpec) {
+		Assert.notNull(advisorSpec, "advisorSpec must not be null");
+
+		advisorSpec.param(CHAT_MEMORY_CONVERSATION_ID_KEY, conversationId);
+		advisorSpec.param(CHAT_MEMORY_RETRIEVE_SIZE_KEY, retrieveSize);
+	}
+
+}

--- a/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/ChatMemoryAdvisorOptionsTests.java
+++ b/spring-ai-core/src/test/java/org/springframework/ai/chat/client/advisor/ChatMemoryAdvisorOptionsTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.DefaultChatClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor.*;
+
+/**
+ * @author Jonghoon Park
+ */
+public class ChatMemoryAdvisorOptionsTests {
+
+	@Test
+	public void testChatMemoryAdvisorConfigurator() {
+		DefaultChatClient.DefaultAdvisorSpec spec = new DefaultChatClient.DefaultAdvisorSpec();
+		spec.param(CHAT_MEMORY_CONVERSATION_ID_KEY, 1);
+		spec.param(CHAT_MEMORY_RETRIEVE_SIZE_KEY, 100);
+
+		DefaultChatClient.DefaultAdvisorSpec spec2 = new DefaultChatClient.DefaultAdvisorSpec();
+		ChatMemoryAdvisorOptions options = ChatMemoryAdvisorOptions.builder()
+			.conversationId(1)
+			.retrieveSize(100)
+			.build();
+		options.applyTo(spec2);
+
+		assertEquals(spec.getParams().get(CHAT_MEMORY_CONVERSATION_ID_KEY),
+				spec2.getParams().get(CHAT_MEMORY_CONVERSATION_ID_KEY));
+		assertEquals(spec.getParams().get(CHAT_MEMORY_RETRIEVE_SIZE_KEY),
+				spec2.getParams().get(CHAT_MEMORY_RETRIEVE_SIZE_KEY));
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
@@ -18,10 +18,14 @@ var chatClient = ChatClient.builder(chatModel)
     )
     .build();
 
+// Set advisor parameters at runtime
+ChatMemoryAdvisorOptions options = ChatMemoryAdvisorOptions.builder()
+    .conversationId("678")
+    .retrieveSize(100)
+    .build();
+
 String response = this.chatClient.prompt()
-    // Set advisor parameters at runtime
-    .advisors(advisor -> advisor.param("chat_memory_conversation_id", "678") 
-            .param("chat_memory_response_size", 100)) 
+    .advisors(options::applyTo)
     .user(userText)
     .call()
 	.content();

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -420,9 +420,6 @@ A sample `@Service` implementation that uses several advisors is shown below.
 
 [source,java]
 ----
-import static org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor.CHAT_MEMORY_CONVERSATION_ID_KEY;
-import static org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor.CHAT_MEMORY_RETRIEVE_SIZE_KEY;
-
 @Service
 public class CustomerSupportAssistant {
 
@@ -452,11 +449,14 @@ public class CustomerSupportAssistant {
 
     public Flux<String> chat(String chatId, String userMessageContent) {
 
+        ChatMemoryAdvisorOptions options = ChatMemoryAdvisorOptions.builder()
+                .conversationId(chatId)
+                .retrieveSize(100)
+                .build();
+
         return this.chatClient.prompt()
                 .user(userMessageContent)
-                .advisors(a -> a
-                        .param(CHAT_MEMORY_CONVERSATION_ID_KEY, chatId)
-                        .param(CHAT_MEMORY_RETRIEVE_SIZE_KEY, 100))
+                .advisors(options::applyTo)
                 .stream().content();
     }
 

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/RetrievalAugmentationAdvisorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.ChatMemoryAdvisorOptions;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.RetrievalAugmentationAdvisor;
 import org.springframework.ai.chat.memory.InMemoryChatMemory;
@@ -147,11 +147,11 @@ class RetrievalAugmentationAdvisorIT {
 			.build();
 
 		String conversationId = "007";
+		ChatMemoryAdvisorOptions options = ChatMemoryAdvisorOptions.builder().conversationId(conversationId).build();
 
 		ChatResponse chatResponse1 = chatClient.prompt()
 			.user("Where does the adventure of Anacletus and Birba take place?")
-			.advisors(advisors -> advisors.param(AbstractChatMemoryAdvisor.CHAT_MEMORY_CONVERSATION_ID_KEY,
-					conversationId))
+			.advisors(options::applyTo)
 			.call()
 			.chatResponse();
 
@@ -161,8 +161,7 @@ class RetrievalAugmentationAdvisorIT {
 
 		ChatResponse chatResponse2 = chatClient.prompt()
 			.user("Did they meet any cow?")
-			.advisors(advisors -> advisors.param(AbstractChatMemoryAdvisor.CHAT_MEMORY_CONVERSATION_ID_KEY,
-					conversationId))
+			.advisors(options::applyTo)
 			.call()
 			.chatResponse();
 


### PR DESCRIPTION
### Changes
This PR introduces the ChatMemoryAdvisorOptions class to encapsulate advisor parameters.

### Background
Previously, CHAT_MEMORY_CONVERSATION_ID_KEY and CHAT_MEMORY_RETRIEVE_SIZE_KEY had to be referenced directly:

```java
import static org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor.CHAT_MEMORY_CONVERSATION_ID_KEY;
import static org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor.CHAT_MEMORY_RETRIEVE_SIZE_KEY;

// ...

this.chatClient.prompt()
        .user(userMessageContent)
        .advisors(a -> a
                .param(CHAT_MEMORY_CONVERSATION_ID_KEY, chatId)
                .param(CHAT_MEMORY_RETRIEVE_SIZE_KEY, 100))
        .stream().content();
```

### Improvements
By introducing ChatMemoryAdvisorOptions, the code is now more structured:

```java 
ChatMemoryAdvisorOptions options = ChatMemoryAdvisorOptions.builder()
        .conversationId(chatId)
        .retrieveSize(100)
        .build();

return this.chatClient.prompt()
        .user(userMessageContent)
        .advisors(options::applyTo)
        .stream().content();
```