### PR TITLE
Fix ChatModel docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatmodel.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatmodel.adoc
@@ -85,7 +85,7 @@ The interface is defined as follows:
 ```java
 public interface Content {
 
-	String getContent();
+	String getText();
 
 	Map<String, Object> getMetadata();
 }


### PR DESCRIPTION
Hello Spring AI Team,

This PR fixes the deprecated `getContent()` to `getText()` in the ChatModel documentation.