### PR TITLE
[ElasticsearchVectorStore] Allowing a custom embedding field by using a record instead of a map

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-elasticsearch/src/main/java/org/springframework/ai/vectorstore/elasticsearch/autoconfigure/ElasticsearchVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-elasticsearch/src/main/java/org/springframework/ai/vectorstore/elasticsearch/autoconfigure/ElasticsearchVectorStoreProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.vectorstore.elasticsearch.autoconfigure;
 
+import org.springframework.ai.vectorstore.elasticsearch.common.ElasticsearchVectorStoreConstants;
 import org.springframework.ai.vectorstore.properties.CommonVectorStoreProperties;
 import org.springframework.ai.vectorstore.elasticsearch.SimilarityFunction;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -50,7 +51,7 @@ public class ElasticsearchVectorStoreProperties extends CommonVectorStorePropert
 	/**
 	 * The name of the vector field to search against
 	 */
-	private String embeddingFieldName = "embedding";
+	private String embeddingFieldName = ElasticsearchVectorStoreConstants.DEFAULT_EMBEDDING_FIELD_NAME;
 
 	public String getIndexName() {
 		return this.indexName;

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStoreOptions.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStoreOptions.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.vectorstore.elasticsearch;
 
+import org.springframework.ai.vectorstore.elasticsearch.common.ElasticsearchVectorStoreConstants;
+
 /**
  * Provided Elasticsearch vector option configuration.
  * https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html
@@ -29,7 +31,7 @@ public class ElasticsearchVectorStoreOptions {
 	/**
 	 * The name of the index to store the vectors.
 	 */
-	private String indexName = "spring-ai-document-index";
+	private String indexName = ElasticsearchVectorStoreConstants.DEFAULT_INDEX_NAME;
 
 	/**
 	 * The number of dimensions in the vector.
@@ -44,7 +46,7 @@ public class ElasticsearchVectorStoreOptions {
 	/**
 	 * The name of the vector field to search against
 	 */
-	private String embeddingFieldName = "embedding";
+	private String embeddingFieldName = ElasticsearchVectorStoreConstants.DEFAULT_EMBEDDING_FIELD_NAME;
 
 	public String getIndexName() {
 		return this.indexName;

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/common/ElasticsearchVectorStoreConstants.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/common/ElasticsearchVectorStoreConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.elasticsearch.common;
+
+/**
+ * Common value constants for Elasticsearch VectorStore.
+ *
+ * @author Jonghoon Park
+ */
+public class ElasticsearchVectorStoreConstants {
+
+	public static final String DEFAULT_INDEX_NAME = "spring-ai-document-index";
+
+	public static final String DEFAULT_EMBEDDING_FIELD_NAME = "embedding";
+
+}


### PR DESCRIPTION
In https://github.com/spring-projects/spring-ai/pull/2175,
we changed from record to Map to allow a custom embedding field.

However, as mentioned in [this comment](https://github.com/spring-projects/spring-ai/issues/1936#issuecomment-2781149848),
There is a suggestion to go back to using record.

Therefore, we should support record again while still allowing a custom embedding field.