### PR TITLE
Update `OpenAiApiToolFunctionCallIT` source

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/functions/openai-chat-functions.adoc
@@ -267,5 +267,5 @@ The following diagram illustrates the flow of the OpenAI API https://platform.op
 
 image:openai-function-calling-flow.jpg[title="OpenAI API Function Calling Flow", width=800, link=https://platform.openai.com/docs/guides/function-calling]
 
-The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/api/tool/OpenAiApiToolFunctionCallIT.java[OpenAiApiToolFunctionCallIT.java] provides a complete example on how to use the OpenAI API function calling.
+The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/tool/OpenAiApiToolFunctionCallIT.java[OpenAiApiToolFunctionCallIT.java] provides a complete example on how to use the OpenAI API function calling.
 It is based on the https://platform.openai.com/docs/guides/function-calling/parallel-function-calling[OpenAI Function Calling tutorial].


### PR DESCRIPTION
# PR Summary
Small PR - Commit 1e3eaec7b9d853e399cb370dfd63e05ccee193ca moved `OpenAiApiToolFunctionCallIT.java`. This PR adjusts sources to changes. Relevant page: https://docs.spring.io/spring-ai/reference/api/chat/functions/openai-chat-functions.html