### PR TITLE
fix typo in ToolCallingAutoConfigurationTests

### DIFF
--- a/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/test/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfigurationTests.java
+++ b/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/test/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfigurationTests.java
@@ -68,7 +68,7 @@ class ToolCallingAutoConfigurationTests {
 	}
 
 	@Test
-	void resolveMultipleFuncitonAndToolCallbacks() {
+	void resolveMultipleFunctionAndToolCallbacks() {
 		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(ToolCallingAutoConfiguration.class))
 			.withUserConfiguration(Config.class)
 			.run(context -> {


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
