### PR TITLE
feat(anthropic): add support for prompt caching

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -42,6 +42,8 @@ import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock;
 import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock.Source;
 import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock.Type;
 import org.springframework.ai.anthropic.api.AnthropicApi.Role;
+import org.springframework.ai.anthropic.api.AnthropicCacheType;
+import org.springframework.ai.chat.messages.AbstractMessage;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
@@ -432,7 +434,16 @@ public class AnthropicChatModel implements ChatModel {
 			.filter(message -> message.getMessageType() != MessageType.SYSTEM)
 			.map(message -> {
 				if (message.getMessageType() == MessageType.USER) {
-					List<ContentBlock> contents = new ArrayList<>(List.of(new ContentBlock(message.getText())));
+					AbstractMessage abstractMessage = (AbstractMessage) message;
+					List<ContentBlock> contents;
+					if (abstractMessage.getCache() != null) {
+						AnthropicCacheType cacheType = AnthropicCacheType.valueOf(abstractMessage.getCache());
+						contents = new ArrayList<>(
+								List.of(new ContentBlock(message.getText(), cacheType.cacheControl())));
+					}
+					else {
+						contents = new ArrayList<>(List.of(new ContentBlock(message.getText())));
+					}
 					if (message instanceof UserMessage userMessage) {
 						if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 							List<ContentBlock> mediaContent = userMessage.getMedia().stream().map(media -> {

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheType.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheType.java
@@ -1,0 +1,21 @@
+package org.springframework.ai.anthropic.api;
+
+import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionRequest.CacheControl;
+
+import java.util.function.Supplier;
+
+public enum AnthropicCacheType {
+
+	EPHEMERAL(() -> new CacheControl("ephemeral"));
+
+	private Supplier<CacheControl> value;
+
+	AnthropicCacheType(Supplier<CacheControl> value) {
+		this.value = value;
+	}
+
+	public CacheControl cacheControl() {
+		return this.value.get();
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
@@ -174,7 +174,9 @@ public class StreamHelper {
 
 			if (messageDeltaEvent.usage() != null) {
 				var totalUsage = new Usage(contentBlockReference.get().usage.inputTokens(),
-						messageDeltaEvent.usage().outputTokens());
+						messageDeltaEvent.usage().outputTokens(),
+						contentBlockReference.get().usage.cacheCreationInputTokens(),
+						contentBlockReference.get().usage.cacheReadInputTokens());
 				contentBlockReference.get().withUsage(totalUsage);
 			}
 		}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiIT.java
@@ -29,6 +29,9 @@ import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock;
 import org.springframework.ai.anthropic.api.AnthropicApi.Role;
 import org.springframework.http.ResponseEntity;
 
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -40,6 +43,34 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class AnthropicApiIT {
 
 	AnthropicApi anthropicApi = new AnthropicApi(System.getenv("ANTHROPIC_API_KEY"));
+
+	@Test
+	void chatWithPromptCache() {
+		String userMessageText = "It could be either a contraction of the full title Quenta Silmarillion (\"Tale of the Silmarils\") or also a plain Genitive which "
+				+ "(as in Ancient Greek) signifies reference. This genitive is translated in English with \"about\" or \"of\" "
+				+ "constructions; the titles of the chapters in The Silmarillion are examples of this genitive in poetic English "
+				+ "(Of the Sindar, Of Men, Of the Darkening of Valinor etc), where \"of\" means \"about\" or \"concerning\". "
+				+ "In the same way, Silmarillion can be taken to mean \"Of/About the Silmarils\"";
+
+		AnthropicMessage chatCompletionMessage = new AnthropicMessage(
+				List.of(new ContentBlock(userMessageText.repeat(20), AnthropicCacheType.EPHEMERAL.cacheControl())),
+				Role.USER);
+
+		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(
+				AnthropicApi.ChatModel.CLAUDE_3_HAIKU.getValue(), List.of(chatCompletionMessage), null, 100, 0.8,
+				false);
+		AnthropicApi.Usage createdCacheToken = anthropicApi.chatCompletionEntity(chatCompletionRequest)
+			.getBody()
+			.usage();
+
+		assertThat(createdCacheToken.cacheCreationInputTokens()).isGreaterThan(0);
+		assertThat(createdCacheToken.cacheReadInputTokens()).isEqualTo(0);
+
+		AnthropicApi.Usage readCacheToken = anthropicApi.chatCompletionEntity(chatCompletionRequest).getBody().usage();
+
+		assertThat(readCacheToken.cacheCreationInputTokens()).isEqualTo(0);
+		assertThat(readCacheToken.cacheReadInputTokens()).isGreaterThan(0);
+	}
 
 	@Test
 	void chatCompletionEntity() {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/UserMessage.java
@@ -36,12 +36,21 @@ public class UserMessage extends AbstractMessage implements MediaContent {
 
 	protected final List<Media> media;
 
+	public UserMessage(String textContent, String cache) {
+		this(MessageType.USER, textContent, new ArrayList<>(), Map.of(), cache);
+	}
+
 	public UserMessage(String textContent) {
 		this(MessageType.USER, textContent, new ArrayList<>(), Map.of());
 	}
 
 	public UserMessage(Resource resource) {
 		super(MessageType.USER, resource, Map.of());
+		this.media = new ArrayList<>();
+	}
+
+	public UserMessage(Resource resource, String cache) {
+		super(MessageType.USER, resource, Map.of(), cache);
 		this.media = new ArrayList<>();
 	}
 
@@ -64,6 +73,17 @@ public class UserMessage extends AbstractMessage implements MediaContent {
 		this.media = new ArrayList<>(media);
 	}
 
+	public UserMessage(MessageType messageType, String textContent, Collection<Media> media,
+			Map<String, Object> metadata, String cache) {
+		super(messageType, textContent, metadata, cache);
+		Assert.notNull(media, "media data must not be null");
+		this.media = new ArrayList<>(media);
+	}
+
+	public List<Media> getMedia(String... dummy) {
+		return this.media;
+	}
+
 	@Override
 	public String toString() {
 		return "UserMessage{" + "content='" + getText() + '\'' + ", properties=" + this.metadata + ", messageType="
@@ -78,6 +98,11 @@ public class UserMessage extends AbstractMessage implements MediaContent {
 	@Override
 	public String getText() {
 		return this.textContent;
+	}
+
+	@Override
+	public String getCache() {
+		return super.getCache();
 	}
 
 }


### PR DESCRIPTION
NOTE: This is a rebased version of the original https://github.com/spring-projects/spring-ai/pull/1413 PR by @Claudio-code. 

@Claudio-code is this the original author for this PR:

Implements Anthropic's prompt caching feature to improve token efficiency.

- Adds cache control support in AnthropicApi and AnthropicChatModel
- Creates AnthropicCacheType enum with EPHEMERAL cache type
- Extends AbstractMessage and UserMessage to support cache parameters
- Updates Usage tracking to include cache-related token metrics
- Adds integration test to verify prompt caching functionality

This implementation follows Anthropic's prompt caching API (beta-2024-07-31) which allows for more efficient token usage by caching frequently used prompts.

