### PR TITLE
Use inline literal in documents

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
@@ -17,7 +17,7 @@ Check the https://github.com/spring-projects/spring-ai/blob/main/models/spring-a
 Visit https://api-docs.deepseek.com/[here] to create an API Key. Configure it using the `spring.ai.openai.api-key` property in your Spring AI project.
 
 * **Set the DeepSeek Base URL**:
-Set the `spring.ai.openai.base-url` property to `https://api.deepseek.com`.
+Set the `spring.ai.openai.base-url` property to `+https://api.deepseek.com+`.
 
 * **Select a DeepSeek Model**:
 Use the `spring.ai.openai.chat.options.model=<model name>` property to specify the model. Refer to https://api-docs.deepseek.com/quick_start/pricing[Supported Models] for available options.
@@ -101,7 +101,7 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 |====
 | Property | Description | Default
 
-| spring.ai.openai.base-url   | The URL to connect to. Must be set to `https://api.deepseek.com` | -
+| spring.ai.openai.base-url   | The URL to connect to. Must be set to `+https://api.deepseek.com+` | -
 | spring.ai.openai.api-key    | Your DeepSeek API Key | -
 |====
 
@@ -127,7 +127,7 @@ The prefix `spring.ai.openai.chat` is the property prefix that lets you configur
 
 | spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
 | spring.ai.model.chat | Enable OpenAI chat model.  | openai
-| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://api.deepseek.com` |  -
+| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `+https://api.deepseek.com+` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.options.model | The link:https://api-docs.deepseek.com/quick_start/pricing[DeepSeek LLM model] to use | -
 | spring.ai.openai.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
@@ -22,7 +22,7 @@ for examples of using Groq with Spring AI.
 Please visit https://console.groq.com/keys[here] to create an API Key.
 The Spring AI project defines a configuration property named `spring.ai.openai.api-key` that you should set to the value of the `API Key` obtained from groq.com.
 * Set the Groq URL. 
-You have to set the `spring.ai.openai.base-url` property to `https://api.groq.com/openai`.
+You have to set the `spring.ai.openai.base-url` property to `+https://api.groq.com/openai+`.
 * Select a https://console.groq.com/docs/models[Groq Model].
 Use the `spring.ai.openai.chat.options.model=<model name>` property to set the Model.
 
@@ -105,7 +105,7 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 |====
 | Property | Description | Default
 
-| spring.ai.openai.base-url   | The URL to connect to. Must be set to `https://api.groq.com/openai` | -
+| spring.ai.openai.base-url   | The URL to connect to. Must be set to `+https://api.groq.com/openai+` | -
 | spring.ai.openai.api-key    | The Groq API Key           |  -
 |====
 
@@ -131,7 +131,7 @@ The prefix `spring.ai.openai.chat` is the property prefix that lets you configur
 
 | spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
 | spring.ai.openai.chat | Enable OpenAI chat model.  | openai
-| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://api.groq.com/openai` |  -
+| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `+https://api.groq.com/openai+` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.options.model | The https://console.groq.com/docs/models[available model] names are `llama3-8b-8192`, `llama3-70b-8192`, `mixtral-8x7b-32768`, `gemma2-9b-it`. | -
 | spring.ai.openai.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/nvidia-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/nvidia-chat.adoc
@@ -3,7 +3,7 @@
 https://docs.api.nvidia.com/nim/reference/llm-apis[NVIDIA LLM API] is a proxy AI Inference Engine offering a wide range of models from link:https://docs.api.nvidia.com/nim/reference/llm-apis#models[various providers].
 
 Spring AI integrates with the NVIDIA LLM API by reusing the existing xref::api/chat/openai-chat.adoc[OpenAI] client. 
-For this you need to set the base-url to `https://integrate.api.nvidia.com`, select one of the provided https://docs.api.nvidia.com/nim/reference/llm-apis#model[LLM models] and get an `api-key` for it.
+For this you need to set the base-url to `+https://integrate.api.nvidia.com+`, select one of the provided https://docs.api.nvidia.com/nim/reference/llm-apis#model[LLM models] and get an `api-key` for it.
 
 image::spring-ai-nvidia-llm-api-1.jpg[w=800,align="center"]
 
@@ -77,7 +77,7 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 |====
 | Property | Description | Default
 
-| spring.ai.openai.base-url   | The URL to connect to. Must be set to `https://integrate.api.nvidia.com` | -
+| spring.ai.openai.base-url   | The URL to connect to. Must be set to `+https://integrate.api.nvidia.com+` | -
 | spring.ai.openai.api-key    | The NVIDIA API Key           |  -
 |====
 
@@ -102,7 +102,7 @@ The prefix `spring.ai.openai.chat` is the property prefix that lets you configur
 
 | spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
 | spring.ai.model.chat | Enable OpenAI chat model.  | openai
-| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://integrate.api.nvidia.com` |  -
+| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `+https://integrate.api.nvidia.com+` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.options.model | The link:https://docs.api.nvidia.com/nim/reference/llm-apis#models[NVIDIA LLM model] to use | -
 | spring.ai.openai.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/perplexity-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/perplexity-chat.adoc
@@ -20,7 +20,7 @@ Check the https://github.com/spring-projects/spring-ai/blob/main/models/spring-a
 Visit https://docs.perplexity.ai/guides/getting-started[here] to create an API Key. Configure it using the `spring.ai.openai.api-key` property in your Spring AI project.
 
 * **Set the Perplexity Base URL**:
-Set the `spring.ai.openai.base-url` property to `https://api.perplexity.ai`.
+Set the `spring.ai.openai.base-url` property to `+https://api.perplexity.ai+`.
 
 * **Select a Perplexity Model**:
 Use the `spring.ai.openai.chat.model=<model name>` property to specify the model. Refer to https://docs.perplexity.ai/guides/model-cards[Supported Models] for available options.
@@ -107,7 +107,7 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 |====
 | Property | Description | Default
 
-| spring.ai.openai.base-url   | The URL to connect to. Must be set to `https://api.perplexity.ai` | -
+| spring.ai.openai.base-url   | The URL to connect to. Must be set to `+https://api.perplexity.ai+` | -
 | spring.ai.openai.chat.api-key    | Your Perplexity API Key | -
 |====
 
@@ -132,7 +132,7 @@ The prefix `spring.ai.openai.chat` is the property prefix that lets you configur
 
 | spring.ai.model.chat | Enable OpenAI chat model.  | openai
 | spring.ai.openai.chat.model      | One of the supported https://docs.perplexity.ai/guides/model-cards[Perplexity models]. Example: `llama-3.1-sonar-small-128k-online`. | -
-| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `https://api.perplexity.ai` |  -
+| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `+https://api.perplexity.ai+` |  -
 | spring.ai.openai.chat.completions-path | Must be set to `/chat/completions` | `/v1/chat/completions`
 | spring.ai.openai.chat.options.temperature | The amount of randomness in the response, valued between 0 inclusive and 2 exclusive. Higher values are more random, and lower values are more deterministic. Required range: `0 < x < 2`. | 0.2
 | spring.ai.openai.chat.options.frequencyPenalty | A multiplicative penalty greater than 0. Values greater than 1.0 penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. A value of 1.0 means no penalty. Incompatible with presence_penalty. Required range: `x > 0`. | 1

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/stabilityai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/stabilityai-image.adoc
@@ -76,7 +76,7 @@ The prefix `spring.ai.stabilityai.image` is the property prefix that lets you co
 
 | spring.ai.stabilityai.image.enabled (Removed and no longer valid) | Enable Stability AI image model.  | true
 | spring.ai.model.image | Enable Stability AI image model.  | stabilityai
-| spring.ai.stabilityai.image.base-url              | Optional overrides the spring.ai.openai.base-url to provide a specific url |  `https://api.stability.ai/v1`
+| spring.ai.stabilityai.image.base-url              | Optional overrides the spring.ai.openai.base-url to provide a specific url |  `+https://api.stability.ai/v1+`
 | spring.ai.stabilityai.image.api-key              | Optional overrides the spring.ai.openai.api-key to provide a specific api-key |  -
 | spring.ai.stabilityai.image.option.n               | The number of images to be generated. Must be between 1 and 10.                                                            | 1
 | spring.ai.stabilityai.image.option.model                 | The engine/model to use in Stability AI. The model is passed in the URL as a path parameter.          | `stable-diffusion-v1-6`


### PR DESCRIPTION
`https://example.com` is rendered to a link which the text is `example.com` without https scheme, we should use literal here.

See https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#literals-and-source-code
