### PR TITLE
MetadataModel moved to AbstractEmbeddingModel.

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
@@ -63,8 +63,6 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private final AzureOpenAiEmbeddingOptions defaultOptions;
 
-	private final MetadataMode metadataMode;
-
 	/**
 	 * Observation registry used for instrumentation.
 	 */
@@ -92,28 +90,14 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	public AzureOpenAiEmbeddingModel(OpenAIClient azureOpenAiClient, MetadataMode metadataMode,
 			AzureOpenAiEmbeddingOptions options, ObservationRegistry observationRegistry) {
 
+		super(metadataMode);
+
 		Assert.notNull(azureOpenAiClient, "com.azure.ai.openai.OpenAIClient must not be null");
-		Assert.notNull(metadataMode, "Metadata mode must not be null");
 		Assert.notNull(options, "Options must not be null");
 		Assert.notNull(observationRegistry, "Observation registry must not be null");
 		this.azureOpenAiClient = azureOpenAiClient;
-		this.metadataMode = metadataMode;
 		this.defaultOptions = options;
 		this.observationRegistry = observationRegistry;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		logger.debug("Retrieving embeddings");
-
-		EmbeddingResponse response = this
-			.call(new EmbeddingRequest(List.of(document.getFormattedContent(this.metadataMode)), null));
-		logger.debug("Embeddings retrieved");
-
-		if (CollectionUtils.isEmpty(response.getResults())) {
-			return new float[0];
-		}
-		return response.getResults().get(0).getOutput();
 	}
 
 	@Override

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
@@ -24,6 +24,7 @@ import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingResponse;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingOptions;
@@ -65,15 +66,19 @@ public class BedrockCohereEmbeddingModel extends AbstractEmbeddingModel {
 
 	public BedrockCohereEmbeddingModel(CohereEmbeddingBedrockApi cohereEmbeddingBedrockApi,
 			BedrockCohereEmbeddingOptions options) {
+
+		this(cohereEmbeddingBedrockApi, MetadataMode.EMBED, options);
+	}
+
+	public BedrockCohereEmbeddingModel(CohereEmbeddingBedrockApi cohereEmbeddingBedrockApi, MetadataMode metadataMode,
+			BedrockCohereEmbeddingOptions options) {
+
+		super(metadataMode);
+
 		Assert.notNull(cohereEmbeddingBedrockApi, "CohereEmbeddingBedrockApi must not be null");
 		Assert.notNull(options, "BedrockCohereEmbeddingOptions must not be null");
 		this.embeddingApi = cohereEmbeddingBedrockApi;
 		this.defaultOptions = options;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		return embed(document.getText());
 	}
 
 	@Override

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModel.java
@@ -27,6 +27,7 @@ import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingRequest;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingResponse;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingOptions;
@@ -57,6 +58,13 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 	private InputType inputType = InputType.TEXT;
 
 	public BedrockTitanEmbeddingModel(TitanEmbeddingBedrockApi titanEmbeddingBedrockApi) {
+		this(titanEmbeddingBedrockApi, MetadataMode.EMBED);
+	}
+
+	public BedrockTitanEmbeddingModel(TitanEmbeddingBedrockApi titanEmbeddingBedrockApi, MetadataMode metadataMode) {
+
+		super(metadataMode);
+
 		this.embeddingApi = titanEmbeddingBedrockApi;
 	}
 
@@ -67,11 +75,6 @@ public class BedrockTitanEmbeddingModel extends AbstractEmbeddingModel {
 	public BedrockTitanEmbeddingModel withInputType(InputType inputType) {
 		this.inputType = inputType;
 		return this;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		return embed(document.getText());
 	}
 
 	@Override

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
@@ -63,8 +63,6 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 
 	private final MiniMaxApi miniMaxApi;
 
-	private final MetadataMode metadataMode;
-
 	/**
 	 * Observation registry used for instrumentation.
 	 */
@@ -128,23 +126,18 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 	 */
 	public MiniMaxEmbeddingModel(MiniMaxApi miniMaxApi, MetadataMode metadataMode, MiniMaxEmbeddingOptions options,
 			RetryTemplate retryTemplate, ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(miniMaxApi, "MiniMaxApi must not be null");
-		Assert.notNull(metadataMode, "metadataMode must not be null");
 		Assert.notNull(options, "options must not be null");
 		Assert.notNull(retryTemplate, "retryTemplate must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
 
 		this.miniMaxApi = miniMaxApi;
-		this.metadataMode = metadataMode;
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		Assert.notNull(document, "Document must not be null");
-		return this.embed(document.getFormattedContent(this.metadataMode));
 	}
 
 	@Override

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
@@ -57,8 +57,6 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private final MistralAiEmbeddingOptions defaultOptions;
 
-	private final MetadataMode metadataMode;
-
 	private final MistralAiApi mistralAiApi;
 
 	private final RetryTemplate retryTemplate;
@@ -94,6 +92,9 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	public MistralAiEmbeddingModel(MistralAiApi mistralAiApi, MetadataMode metadataMode,
 			MistralAiEmbeddingOptions options, RetryTemplate retryTemplate, ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(mistralAiApi, "mistralAiApi must not be null");
 		Assert.notNull(metadataMode, "metadataMode must not be null");
 		Assert.notNull(options, "options must not be null");
@@ -101,7 +102,6 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
 
 		this.mistralAiApi = mistralAiApi;
-		this.metadataMode = metadataMode;
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
@@ -172,12 +172,6 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 		MistralAiEmbeddingOptions requestOptions = (MistralAiEmbeddingOptions) request.getOptions();
 		return new MistralAiApi.EmbeddingRequest<>(request.getInstructions(), requestOptions.getModel(),
 				requestOptions.getEncodingFormat());
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		Assert.notNull(document, "Document must not be null");
-		return this.embed(document.getFormattedContent(this.metadataMode));
 	}
 
 	/**

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingModel.java
@@ -30,6 +30,7 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingOptions;
@@ -72,6 +73,14 @@ public class OCIEmbeddingModel extends AbstractEmbeddingModel {
 
 	public OCIEmbeddingModel(GenerativeAiInference genAi, OCIEmbeddingOptions options,
 			ObservationRegistry observationRegistry) {
+		this(genAi, MetadataMode.EMBED, options, observationRegistry);
+	}
+
+	public OCIEmbeddingModel(GenerativeAiInference genAi, MetadataMode metadataMode, OCIEmbeddingOptions options,
+			ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(genAi, "com.oracle.bmc.generativeaiinference.GenerativeAiInferenceClient must not be null");
 		Assert.notNull(options, "options must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
@@ -96,11 +105,6 @@ public class OCIEmbeddingModel extends AbstractEmbeddingModel {
 			.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> context,
 					this.observationRegistry)
 			.observe(() -> embedAllWithContext(embedTextRequests, context));
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		return embed(document.getText());
 	}
 
 	private EmbeddingResponse embedAllWithContext(List<EmbedTextRequest> embedTextRequests,

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
@@ -27,6 +27,7 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingModel;
@@ -78,6 +79,14 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 
 	public OllamaEmbeddingModel(OllamaApi ollamaApi, OllamaOptions defaultOptions,
 			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions) {
+		this(ollamaApi, MetadataMode.EMBED, defaultOptions, observationRegistry, modelManagementOptions);
+	}
+
+	public OllamaEmbeddingModel(OllamaApi ollamaApi, MetadataMode metadataMode, OllamaOptions defaultOptions,
+			ObservationRegistry observationRegistry, ModelManagementOptions modelManagementOptions) {
+
+		super(metadataMode);
+
 		Assert.notNull(ollamaApi, "ollamaApi must not be null");
 		Assert.notNull(defaultOptions, "options must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
@@ -93,11 +102,6 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 
 	public static Builder builder() {
 		return new Builder();
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		return embed(document.getText());
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -65,8 +65,6 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private final OpenAiApi openAiApi;
 
-	private final MetadataMode metadataMode;
-
 	/**
 	 * Observation registry used for instrumentation.
 	 */
@@ -128,23 +126,18 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 	 */
 	public OpenAiEmbeddingModel(OpenAiApi openAiApi, MetadataMode metadataMode, OpenAiEmbeddingOptions options,
 			RetryTemplate retryTemplate, ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(openAiApi, "openAiApi must not be null");
-		Assert.notNull(metadataMode, "metadataMode must not be null");
 		Assert.notNull(options, "options must not be null");
 		Assert.notNull(retryTemplate, "retryTemplate must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
 
 		this.openAiApi = openAiApi;
-		this.metadataMode = metadataMode;
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		Assert.notNull(document, "Document must not be null");
-		return this.embed(document.getFormattedContent(this.metadataMode));
 	}
 
 	@Override

--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingOptions;
@@ -75,6 +76,21 @@ public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements 
 	 */
 	public PostgresMlEmbeddingModel(JdbcTemplate jdbcTemplate, PostgresMlEmbeddingOptions options,
 			boolean createExtension) {
+		this(jdbcTemplate, MetadataMode.EMBED, options, createExtension);
+	}
+
+	/**
+	 * a PostgresMlEmbeddingModel constructor
+	 * @param jdbcTemplate JdbcTemplate to use to interact with the database.
+	 * @param metadataMode MetadataMode describing what metadata values are included in
+	 * the embedding.
+	 * @param options PostgresMlEmbeddingOptions to configure the client.
+	 */
+	public PostgresMlEmbeddingModel(JdbcTemplate jdbcTemplate, MetadataMode metadataMode,
+			PostgresMlEmbeddingOptions options, boolean createExtension) {
+
+		super(metadataMode);
+
 		Assert.notNull(jdbcTemplate, "jdbc template must not be null.");
 		Assert.notNull(options, "options must not be null.");
 		Assert.notNull(options.getTransformer(), "transformer must not be null.");
@@ -94,11 +110,6 @@ public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements 
 				"SELECT pgml.embed(?, ?, ?::JSONB)" + this.defaultOptions.getVectorType().cast + " AS embedding",
 				this.defaultOptions.getVectorType().rowMapper, this.defaultOptions.getTransformer(), text,
 				ModelOptionsUtils.toJsonString(this.defaultOptions.getKwargs()));
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		return this.embed(document.getFormattedContent(this.defaultOptions.getMetadataMode()));
 	}
 
 	@SuppressWarnings("null")

--- a/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanEmbeddingModel.java
+++ b/models/spring-ai-qianfan/src/main/java/org/springframework/ai/qianfan/QianFanEmbeddingModel.java
@@ -63,8 +63,6 @@ public class QianFanEmbeddingModel extends AbstractEmbeddingModel {
 
 	private final QianFanApi qianFanApi;
 
-	private final MetadataMode metadataMode;
-
 	/**
 	 * Observation registry used for instrumentation.
 	 */
@@ -126,23 +124,18 @@ public class QianFanEmbeddingModel extends AbstractEmbeddingModel {
 	 */
 	public QianFanEmbeddingModel(QianFanApi qianFanApi, MetadataMode metadataMode, QianFanEmbeddingOptions options,
 			RetryTemplate retryTemplate, ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(qianFanApi, "QianFanApi must not be null");
-		Assert.notNull(metadataMode, "metadataMode must not be null");
 		Assert.notNull(options, "options must not be null");
 		Assert.notNull(retryTemplate, "retryTemplate must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
 
 		this.qianFanApi = qianFanApi;
-		this.metadataMode = metadataMode;
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		Assert.notNull(document, "Document must not be null");
-		return this.embed(document.getFormattedContent(this.metadataMode));
 	}
 
 	@Override

--- a/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
+++ b/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
@@ -96,14 +96,6 @@ public class TransformersEmbeddingModel extends AbstractEmbeddingModel implement
 	private static final int EMBEDDING_AXIS = 1;
 
 	/**
-	 * Specifies what parts of the {@link Document}'s content and metadata will be used
-	 * for computing the embeddings. Applicable for the {@link #embed(Document)} method
-	 * only. Has no effect on the {@link #embed(String)} or {@link #embed(List)}. Defaults
-	 * to {@link MetadataMode#NONE}.
-	 */
-	private final MetadataMode metadataMode;
-
-	/**
 	 * Observation registry used for instrumentation.
 	 */
 	private final ObservationRegistry observationRegistry;
@@ -169,9 +161,11 @@ public class TransformersEmbeddingModel extends AbstractEmbeddingModel implement
 	}
 
 	public TransformersEmbeddingModel(MetadataMode metadataMode, ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(metadataMode, "Metadata mode should not be null");
 		Assert.notNull(observationRegistry, "Observation registry should not be null");
-		this.metadataMode = metadataMode;
 		this.observationRegistry = observationRegistry;
 	}
 
@@ -257,11 +251,6 @@ public class TransformersEmbeddingModel extends AbstractEmbeddingModel implement
 	@Override
 	public float[] embed(String text) {
 		return embed(List.of(text)).get(0);
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		return this.embed(document.getFormattedContent(this.metadataMode));
 	}
 
 	@Override

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
@@ -33,6 +33,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingRequest;
@@ -99,6 +100,15 @@ public class VertexAiTextEmbeddingModel extends AbstractEmbeddingModel {
 	public VertexAiTextEmbeddingModel(VertexAiEmbeddingConnectionDetails connectionDetails,
 			VertexAiTextEmbeddingOptions defaultEmbeddingOptions, RetryTemplate retryTemplate,
 			ObservationRegistry observationRegistry) {
+		this(connectionDetails, MetadataMode.EMBED, defaultEmbeddingOptions, retryTemplate, observationRegistry);
+	}
+
+	public VertexAiTextEmbeddingModel(VertexAiEmbeddingConnectionDetails connectionDetails, MetadataMode metadataMode,
+			VertexAiTextEmbeddingOptions defaultEmbeddingOptions, RetryTemplate retryTemplate,
+			ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(defaultEmbeddingOptions, "VertexAiTextEmbeddingOptions must not be null");
 		Assert.notNull(retryTemplate, "retryTemplate must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
@@ -106,12 +116,6 @@ public class VertexAiTextEmbeddingModel extends AbstractEmbeddingModel {
 		this.connectionDetails = connectionDetails;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		Assert.notNull(document, "Document must not be null");
-		return this.embed(document.getFormattedContent());
 	}
 
 	@Override

--- a/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiEmbeddingModel.java
+++ b/models/spring-ai-watsonx-ai/src/main/java/org/springframework/ai/watsonx/WatsonxAiEmbeddingModel.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingModel;
@@ -62,17 +63,21 @@ public class WatsonxAiEmbeddingModel extends AbstractEmbeddingModel {
 		.withModel(WatsonxAiEmbeddingOptions.DEFAULT_MODEL);
 
 	public WatsonxAiEmbeddingModel(WatsonxAiApi watsonxAiApi) {
+		super(MetadataMode.EMBED);
 		this.watsonxAiApi = watsonxAiApi;
 	}
 
 	public WatsonxAiEmbeddingModel(WatsonxAiApi watsonxAiApi, WatsonxAiEmbeddingOptions defaultOptions) {
-		this.watsonxAiApi = watsonxAiApi;
-		this.defaultOptions = defaultOptions;
+		this(watsonxAiApi, MetadataMode.EMBED, defaultOptions);
 	}
 
-	@Override
-	public float[] embed(Document document) {
-		return embed(document.getText());
+	public WatsonxAiEmbeddingModel(WatsonxAiApi watsonxAiApi, MetadataMode metadataMode,
+			WatsonxAiEmbeddingOptions defaultOptions) {
+
+		super(metadataMode);
+
+		this.watsonxAiApi = watsonxAiApi;
+		this.defaultOptions = defaultOptions;
 	}
 
 	@Override

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
@@ -63,8 +63,6 @@ public class ZhiPuAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private final ZhiPuAiApi zhiPuAiApi;
 
-	private final MetadataMode metadataMode;
-
 	/**
 	 * Observation registry used for instrumentation.
 	 */
@@ -127,23 +125,18 @@ public class ZhiPuAiEmbeddingModel extends AbstractEmbeddingModel {
 	 */
 	public ZhiPuAiEmbeddingModel(ZhiPuAiApi zhiPuAiApi, MetadataMode metadataMode, ZhiPuAiEmbeddingOptions options,
 			RetryTemplate retryTemplate, ObservationRegistry observationRegistry) {
+
+		super(metadataMode);
+
 		Assert.notNull(zhiPuAiApi, "ZhiPuAiApi must not be null");
-		Assert.notNull(metadataMode, "metadataMode must not be null");
 		Assert.notNull(options, "options must not be null");
 		Assert.notNull(retryTemplate, "retryTemplate must not be null");
 		Assert.notNull(observationRegistry, "observationRegistry must not be null");
 
 		this.zhiPuAiApi = zhiPuAiApi;
-		this.metadataMode = metadataMode;
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
-	}
-
-	@Override
-	public float[] embed(Document document) {
-		Assert.notNull(document, "Document must not be null");
-		return this.embed(document.getFormattedContent(this.metadataMode));
 	}
 
 	@Override

--- a/spring-ai-model/src/main/java/org/springframework/ai/embedding/AbstractEmbeddingModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/embedding/AbstractEmbeddingModel.java
@@ -29,6 +29,11 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.util.Assert;
+
 /**
  * Abstract implementation of the {@link EmbeddingModel} interface that provides
  * dimensions calculation caching.
@@ -44,6 +49,8 @@ public abstract class AbstractEmbeddingModel implements EmbeddingModel {
 
 	private static final Map<String, Integer> KNOWN_EMBEDDING_DIMENSIONS = loadKnownModelDimensions();
 
+	private final MetadataMode metadataMode;
+
 	static class Hints implements RuntimeHintsRegistrar {
 
 		@Override
@@ -51,6 +58,16 @@ public abstract class AbstractEmbeddingModel implements EmbeddingModel {
 			hints.resources().registerResource(EMBEDDING_MODEL_DIMENSIONS_PROPERTIES);
 		}
 
+	}
+
+	public AbstractEmbeddingModel() {
+		this(MetadataMode.EMBED);
+	}
+
+	public AbstractEmbeddingModel(MetadataMode metadataMode) {
+		Assert.notNull(metadataMode, "metadataMode must not be null");
+
+		this.metadataMode = metadataMode;
 	}
 
 	/**
@@ -104,6 +121,12 @@ public abstract class AbstractEmbeddingModel implements EmbeddingModel {
 			this.embeddingDimensions.set(dimensions(this, "Test", "Hello World"));
 		}
 		return this.embeddingDimensions.get();
+	}
+
+	@Override
+	public float[] embed(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return this.embed(document.getFormattedContent(this.metadataMode));
 	}
 
 }


### PR DESCRIPTION
Embedding models, that didn't have support for a MetadataModel got an additional constructor with MetadataModel as the second argument. I did not include it in all the other constructors since this would break code.

AzureOpenAiEmbeddingModel had special handling for empty results, that got lost in the change. Not sure if that is ok.

TransformersEmbeddingModel has  as default, which differs from the others. Should that be changed to , which seems the most reasonable default to me and is used in the other models?

Closes #2579