### PR TITLE
refactor(docs): improve Berock embedding and RAG documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-cohere-embedding.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-cohere-embedding.adoc
@@ -48,12 +48,12 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 === Enable Cohere Embedding Support
 
 By default the Cohere model is disabled.
-To enable it set the `spring.ai.bedrock.cohere.embedding.enabled` property to `true`.
+To enable it set the `spring.ai.model.embedding` property to `bedrock-cohere`.
 Exporting environment variable is one way to set this configuration property:
 
 [source,shell]
 ----
-export SPRING_AI_BEDROCK_COHERE_EMBEDDING_ENABLED=true
+export SPRING_AI_MODEL_EMBEDDING=bedrock-cohere
 ----
 
 === Embedding Properties
@@ -85,8 +85,8 @@ The prefix `spring.ai.bedrock.cohere.embedding` (defined in `BedrockCohereEmbedd
 [cols="3,4,1", stripes=even]
 |====
 | Property | Description | Default
-| spring.ai.bedrock.cohere.embedding.enabled (Removed and no longer valid)             | Enable or disable support for Cohere  | false
 | spring.ai.model.embedding           | Enable or disable support for Cohere  | bedrock-cohere
+| spring.ai.bedrock.cohere.embedding.enabled (Removed and no longer valid)             | Enable or disable support for Cohere  | false
 | spring.ai.bedrock.cohere.embedding.model                | The model id to use. See the https://github.com/spring-projects/spring-ai/blob/056b95a00efa5b014a1f488329fbd07a46c02378/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java#L150[CohereEmbeddingModel] for the supported models.  | cohere.embed-multilingual-v3
 | spring.ai.bedrock.cohere.embedding.options.input-type  | Prepends special tokens to differentiate each type from one another. You should not mix different types together, except when mixing types for search and retrieval. In this case, embed your corpus with the search_document type and embedded queries with type search_query type.  | SEARCH_DOCUMENT
 | spring.ai.bedrock.cohere.embedding.options.truncate  | Specifies how the API handles inputs longer than the maximum token length. If you specify LEFT or RIGHT, the model discards the input until the remaining input is exactly the maximum input token length for the model.  | NONE
@@ -130,7 +130,7 @@ spring.ai.bedrock.aws.region=eu-central-1
 spring.ai.bedrock.aws.access-key=${AWS_ACCESS_KEY_ID}
 spring.ai.bedrock.aws.secret-key=${AWS_SECRET_ACCESS_KEY}
 
-spring.ai.bedrock.cohere.embedding.enabled=true
+spring.ai.model.embedding=bedrock-cohere
 spring.ai.bedrock.cohere.embedding.options.input-type=search-document
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
@@ -55,12 +55,12 @@ TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Man
 === Enable Titan Embedding Support
 
 By default the Titan embedding model is disabled.
-To enable it set the `spring.ai.bedrock.titan.embedding.enabled` property to `true`.
+To enable it set the `spring.ai.model.embedding` property to `bedrock-titan`.
 Exporting environment variable is one way to set this configuration property:
 
 [source,shell]
 ----
-export SPRING_AI_BEDROCK_TITAN_EMBEDDING_ENABLED=true
+export SPRING_AI_MODEL_EMBEDDING=bedrock-titan
 ----
 
 === Embedding Properties
@@ -129,7 +129,7 @@ spring.ai.bedrock.aws.region=eu-central-1
 spring.ai.bedrock.aws.access-key=${AWS_ACCESS_KEY_ID}
 spring.ai.bedrock.aws.secret-key=${AWS_SECRET_ACCESS_KEY}
 
-spring.ai.bedrock.titan.embedding.enabled=true
+spring.ai.model.embedding=bedrock-titan
 ----
 
 TIP: replace the `regions`, `access-key` and `secret-key` with your AWS credentials.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -13,6 +13,16 @@ NOTE: Learn more about Retrieval Augmented Generation in the xref:concepts.adoc#
 
 Spring AI provides out-of-the-box support for common RAG flows using the `Advisor` API.
 
+To use the `QuestionAnswerAdvisor` or `RetrievalAugmentationAdvisor`, you need to add the `spring-ai-advisors-vector-store` dependency to your project:
+
+[source,xml]
+----
+<dependency>
+   <groupId>org.springframework.ai</groupId>
+   <artifactId>spring-ai-advisors-vector-store</artifactId>
+</dependency>
+----
+
 === QuestionAnswerAdvisor
 
 A vector database stores data that the AI model is unaware of.


### PR DESCRIPTION
- Replace model-specific enabled properties with unified spring.ai.model.embedding property
- Update documentation for Bedrock Cohere and Titan embedding models
- Add missing dependency information for RAG advisors in documentation