### PR TITLE
fix: add userParams to UserMessage before passing to ChatMemoryStore

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -35,6 +35,7 @@ import org.springframework.ai.chat.model.MessageAggregator;
  * Memory is retrieved added as a collection of messages to the prompt
  *
  * @author Christian Tzolov
+ * @author NingNing0111
  * @since 1.0.0
  */
 public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemory> {
@@ -94,7 +95,7 @@ public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemo
 		AdvisedRequest advisedRequest = AdvisedRequest.from(request).messages(advisedMessages).build();
 
 		// 4. Add the new user input to the conversation memory.
-		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		UserMessage userMessage = new UserMessage(request.userText(), request.media(), request.userParams());
 		this.getChatMemoryStore().add(this.doGetConversationId(request.adviseContext()), userMessage);
 
 		return advisedRequest;


### PR DESCRIPTION
This PR addresses the issue I submitted:  #2701  , and it has proven to be feasible in my project.

<img width="1577" alt="image" src="https://github.com/user-attachments/assets/bfc9a32c-8ef8-40c3-bc11-57673dd6eb6c" />



Signed-off-by: NingNing0111 <zdncode@gmail.com>
