### PR TITLE
feat: markdown reader sopport folder reader and multi files

### DIFF
--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -29,8 +29,67 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 /**
  * @author Piotr Olaszewski
+ * @author shown.Ji
  */
 class MarkdownDocumentReaderTest {
+
+	@Test
+	void testDirPathSingle() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/dir-test-1");
+
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(2)
+				.extracting(Document::getMetadata, Document::getText)
+				.containsOnly(tuple(Map.of(),
+								"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
+						tuple(Map.of("category", "blockquote"),
+								"Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit."));
+	}
+
+	@Test
+	void testDirPathMultiple() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/dir-test-2");
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(6)
+				.extracting(Document::getMetadata, Document::getText)
+				.containsOnly(
+						tuple(Map.of("category", "header_1", "title", "This is a fancy header name"),
+								"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim."),
+						tuple(Map.of("category", "header_3", "title", "Header 3"),
+								"Aenean eu leo eu nibh tristique posuere quis quis massa."),
+						tuple(Map.of("category", "header_1", "title", "Header 1a"),
+								"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
+						tuple(Map.of("category", "header_1", "title", "Header 1b"),
+								"Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam lobortis risus libero, sed sollicitudin risus cursus in. Morbi enim metus, ornare vel lacinia eget, venenatis vel nibh."),
+						tuple(Map.of("category", "header_2", "title", "Header 2b"),
+								"Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero."),
+						tuple(Map.of("category", "header_2", "title", "Header 2c"),
+								"Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit."));
+	}
+
+	@Test
+	void testMultipleMarkdownFiles() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader(List.of("classpath:/only-headers.md", "classpath:/with-formatting.md"));
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(6)
+				.extracting(Document::getMetadata, Document::getText)
+				.containsOnly(
+						tuple(Map.of("category", "header_1", "title", "This is a fancy header name"),
+								"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt velit non bibendum gravida. Cras accumsan tincidunt ornare. Donec hendrerit consequat tellus blandit accumsan. Aenean aliquam metus at arcu elementum dignissim."),
+						tuple(Map.of("category", "header_3", "title", "Header 3"),
+								"Aenean eu leo eu nibh tristique posuere quis quis massa."),
+						tuple(Map.of("category", "header_1", "title", "Header 1a"),
+								"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue."),
+						tuple(Map.of("category", "header_1", "title", "Header 1b"),
+								"Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam lobortis risus libero, sed sollicitudin risus cursus in. Morbi enim metus, ornare vel lacinia eget, venenatis vel nibh."),
+						tuple(Map.of("category", "header_2", "title", "Header 2b"),
+								"Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero."),
+						tuple(Map.of("category", "header_2", "title", "Header 2c"),
+								"Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit."));
+	}
 
 	@Test
 	void testOnlyHeadersWithParagraphs() {

--- a/document-readers/markdown-reader/src/test/resources/dir-test-1/blockquote.md
+++ b/document-readers/markdown-reader/src/test/resources/dir-test-1/blockquote.md
@@ -1,0 +1,8 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed
+nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue.
+
+> Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget
+> sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a
+> porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum
+> suscipit.
+

--- a/document-readers/markdown-reader/src/test/resources/dir-test-1/blockquote.txt
+++ b/document-readers/markdown-reader/src/test/resources/dir-test-1/blockquote.txt
@@ -1,0 +1,8 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed
+nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue.
+
+> Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget
+> sapien odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero. Ut rhoncus nec justo a
+> porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum
+> suscipit.
+

--- a/document-readers/markdown-reader/src/test/resources/dir-test-2/only-headers.md
+++ b/document-readers/markdown-reader/src/test/resources/dir-test-2/only-headers.md
@@ -1,0 +1,20 @@
+# Header 1a
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur diam eros, laoreet sit amet cursus vitae, varius sed
+nisi. Cras sit amet quam quis velit commodo porta consectetur id nisi. Phasellus tincidunt pulvinar augue.
+
+# Header 1b
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam lobortis risus libero, sed
+sollicitudin risus cursus in. Morbi enim metus, ornare vel lacinia eget, venenatis vel nibh.
+
+## Header 2b
+
+Proin vel laoreet leo, sed luctus augue. Sed et ligula commodo, commodo lacus at, consequat turpis. Maecenas eget sapien
+odio. Maecenas urna lectus, pellentesque in accumsan aliquam, congue eu libero.
+
+# Header 1c
+
+## Header 2c
+
+Ut rhoncus nec justo a porttitor. Pellentesque auctor pharetra eros, viverra sodales lorem aliquet id. Curabitur semper nisi vel sem interdum suscipit.

--- a/document-readers/markdown-reader/src/test/resources/dir-test-2/with-formatting.md
+++ b/document-readers/markdown-reader/src/test/resources/dir-test-2/with-formatting.md
@@ -1,0 +1,9 @@
+# This is a fancy header name
+
+Lorem ipsum dolor sit amet, **consectetur adipiscing elit**. Donec tincidunt velit non bibendum gravida. Cras accumsan
+tincidunt ornare. Donec hendrerit consequat tellus *blandit* accumsan. Aenean aliquam metus at ***arcu elementum***
+dignissim.
+
+### Header 3
+
+Aenean eu leo eu nibh tristique _posuere quis quis massa_. 


### PR DESCRIPTION
1. Markdown can read directory paths under the classpath and only read files with a `.md` suffix.
2. Supports creating a Reader object using `file1.md file2.md.` 
3. Add tests.