### PR TITLE
Fixed incorrect variable usage in MethodToolCallback.java

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -119,7 +119,7 @@ public class MethodToolCallback implements ToolCallback {
 		var isNonEmptyToolContextProvided = toolContext != null && !CollectionUtils.isEmpty(toolContext.getContext());
 		var isToolContextAcceptedByMethod = Stream.of(toolMethod.getParameterTypes())
 			.anyMatch(type -> ClassUtils.isAssignable(type, ToolContext.class));
-		if (isToolContextAcceptedByMethod && !isNonEmptyToolContextProvided) {
+		if (isNonEmptyToolContextProvided && !isToolContextAcceptedByMethod) {
 			throw new IllegalArgumentException("ToolContext is required by the method as an argument");
 		}
 	}


### PR DESCRIPTION

In version m7, the validateToolContextSupport method should behave as it did in m6, throwing an IllegalArgumentException only when ToolContext is non-null, its context is non-empty, and the method’s parameters do not support the ToolContext type. Currently, m7 incorrectly throws the exception, leading to functional issues.

Relates to: [#2714](https://github.com/spring-projects/spring-ai/issues/2714)

