### PR TITLE
add server instructions

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
@@ -225,6 +225,8 @@ public class McpServerAutoConfiguration {
 
 		serverBuilder.capabilities(capabilitiesBuilder.build());
 
+		serverBuilder.instructions(serverProperties.getInstructions());
+
 		return serverBuilder.build();
 	}
 
@@ -323,6 +325,8 @@ public class McpServerAutoConfiguration {
 		});
 
 		serverBuilder.capabilities(capabilitiesBuilder.build());
+
+		serverBuilder.instructions(serverProperties.getInstructions());
 
 		return serverBuilder.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
@@ -73,6 +73,14 @@ public class McpServerProperties {
 	private String version = "1.0.0";
 
 	/**
+	 * The instructions of the MCP server instance.
+	 * <p>
+	 * These instructions are used to provide guidance to the client on how to interact
+	 * with this server.
+	 */
+	private String instructions = null;
+
+	/**
 	 * Enable/disable notifications for resource changes. Only relevant for MCP servers
 	 * with resource capabilities.
 	 * <p>
@@ -178,6 +186,14 @@ public class McpServerProperties {
 	public void setVersion(String version) {
 		Assert.hasText(version, "Version must not be empty");
 		this.version = version;
+	}
+
+	public String getInstructions() {
+		return this.instructions;
+	}
+
+	public void setInstructions(String instructions) {
+		this.instructions = instructions;
 	}
 
 	public boolean isResourceChangeNotification() {


### PR DESCRIPTION
Adds the ability to set and use MCP Server instructions.

Requires: https://github.com/modelcontextprotocol/java-sdk/pull/148