### PR TITLE
Update anthropic-chat.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -293,13 +293,13 @@ Next, create a `AnthropicChatModel` and use it for text generations:
 [source,java]
 ----
 var anthropicApi = new AnthropicApi(System.getenv("ANTHROPIC_API_KEY"));
-
-var chatModel = new AnthropicChatModel(this.anthropicApi,
-        AnthropicChatOptions.builder()
-            .model("claude-3-opus-20240229")
+var anthropicChatOptions = AnthropicChatOptions.builder()
+            .model("claude-3-7-sonnet-20250219")
             .temperature(0.4)
             .maxTokens(200)
-        .build());
+        .build()
+var chatModel = AnthropicChatModel.builder().anthropicApi(anthropicApi)
+                .defaultOptions(anthropicChatOptions).build();
 
 ChatResponse response = this.chatModel.call(
     new Prompt("Generate the names of 5 famous pirates."));


### PR DESCRIPTION
 In the current version 1.0.0-SNAPSHOT, AnthropicChatModel does not provide a constructor with two parameters. If there are only two parameters, you should use Builder to construct AnthropicChatModel. The current document misleads users and needs to be updated.


