### PR TITLE
mcp: support sseEndpoint config

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -94,8 +94,11 @@ public class SseHttpClientTransportAutoConfiguration {
 
 		for (Map.Entry<String, SseParameters> serverParameters : sseProperties.getConnections().entrySet()) {
 
-			var transport = new HttpClientSseClientTransport(HttpClient.newBuilder(), serverParameters.getValue().url(),
-					objectMapper);
+			var transport = HttpClientSseClientTransport.builder(serverParameters.getValue().url())
+				.sseEndpoint(serverParameters.getValue().sseEndpoint())
+				.clientBuilder(HttpClient.newBuilder())
+				.objectMapper(objectMapper)
+				.build();
 			sseTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/SseWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/SseWebFluxTransportAutoConfiguration.java
@@ -90,7 +90,8 @@ public class SseWebFluxTransportAutoConfiguration {
 
 		for (Map.Entry<String, SseParameters> serverParameters : sseProperties.getConnections().entrySet()) {
 			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(serverParameters.getValue().url());
-			var transport = new WebFluxSseClientTransport(webClientBuilder, objectMapper);
+			var transport = new WebFluxSseClientTransport(webClientBuilder, objectMapper,
+					serverParameters.getValue().sseEndpoint());
 			sseTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpSseClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpSseClientProperties.java
@@ -18,7 +18,10 @@ package org.springframework.ai.mcp.client.autoconfigure.properties;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 
 /**
  * Configuration properties for Server-Sent Events (SSE) based MCP client connections.
@@ -52,10 +55,9 @@ public class McpSseClientProperties {
 	 * @param url the URL endpoint for SSE communication with the MCP server
 	 * @param sseEndpoint the SSE endpoint for SSE communication with the MCP server
 	 */
-	public record SseParameters(String url, String sseEndpoint) {
-		public SseParameters(String url) {
-			this(url, "/sse");
-		}
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
+	public record SseParameters(@JsonProperty("url") String url,
+			@JsonProperty("sse-endpoint") @DefaultValue("/sse") String sseEndpoint) {
 	}
 
 	/**

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpSseClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpSseClientProperties.java
@@ -50,8 +50,12 @@ public class McpSseClientProperties {
 	 * Parameters for configuring an SSE connection to an MCP server.
 	 *
 	 * @param url the URL endpoint for SSE communication with the MCP server
+	 * @param sseEndpoint the SSE endpoint for SSE communication with the MCP server
 	 */
-	public record SseParameters(String url) {
+	public record SseParameters(String url, String sseEndpoint) {
+		public SseParameters(String url) {
+			this(url, "/sse");
+		}
 	}
 
 	/**

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
@@ -77,7 +77,8 @@ public class McpWebFluxServerAutoConfiguration {
 	public WebFluxSseServerTransportProvider webFluxTransport(ObjectProvider<ObjectMapper> objectMapperProvider,
 			McpServerProperties serverProperties) {
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
-		return new WebFluxSseServerTransportProvider(objectMapper, serverProperties.getSseMessageEndpoint());
+		return new WebFluxSseServerTransportProvider(objectMapper, serverProperties.getBaseUrl(),
+				serverProperties.getSseMessageEndpoint(), serverProperties.getSseEndpoint());
 	}
 
 	// Router function for SSE transport used by Spring WebFlux to start an HTTP server.

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
@@ -72,7 +72,8 @@ public class McpWebMvcServerAutoConfiguration {
 	public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider(
 			ObjectProvider<ObjectMapper> objectMapperProvider, McpServerProperties serverProperties) {
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
-		return new WebMvcSseServerTransportProvider(objectMapper, serverProperties.getSseMessageEndpoint());
+		return new WebMvcSseServerTransportProvider(objectMapper, serverProperties.getBaseUrl(),
+				serverProperties.getSseMessageEndpoint(), serverProperties.getSseEndpoint());
 	}
 
 	@Bean


### PR DESCRIPTION
MCP supports configuring sseEndpoint、baseUrl

rel: org.springframework.ai.mcp.server.autoconfigure.McpServerProperties#sseEndpoint


---
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
