### PR TITLE
Fixes #2185 googleSearchRetrieval(true) causes INVALID_ARGUMENT error with Gemini 2.0 (use google_search instead)

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.vertexai.gemini;
 
+import com.google.cloud.vertexai.api.Tool.GoogleSearch;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -713,9 +714,10 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 		}
 
 		if (prompt.getOptions() instanceof VertexAiGeminiChatOptions options && options.getGoogleSearchRetrieval()) {
-			final var googleSearchRetrieval = GoogleSearchRetrieval.newBuilder().getDefaultInstanceForType();
+			// final var googleSearchRetrieval = GoogleSearchRetrieval.newBuilder().getDefaultInstanceForType();
+			var googleSearch = GoogleSearch.newBuilder().getDefaultInstanceForType();
 			final var googleSearchRetrievalTool = Tool.newBuilder()
-				.setGoogleSearchRetrieval(googleSearchRetrieval)
+				.setGoogleSearch(googleSearch)
 				.build();
 			tools.add(googleSearchRetrievalTool);
 		}
@@ -969,7 +971,7 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 
 		GEMINI_2_0_FLASH_LIGHT("gemini-2.0-flash-lite"),
 
-		GEMINI_2_5_PRO("gemini-2.5-pro-exp-03-28");
+		GEMINI_2_5_PRO("gemini-2.5-pro-exp-03-25");
 
 		public final String value;
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -714,11 +714,8 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 		}
 
 		if (prompt.getOptions() instanceof VertexAiGeminiChatOptions options && options.getGoogleSearchRetrieval()) {
-			// final var googleSearchRetrieval = GoogleSearchRetrieval.newBuilder().getDefaultInstanceForType();
 			var googleSearch = GoogleSearch.newBuilder().getDefaultInstanceForType();
-			final var googleSearchRetrievalTool = Tool.newBuilder()
-				.setGoogleSearch(googleSearch)
-				.build();
+			final var googleSearchRetrievalTool = Tool.newBuilder().setGoogleSearch(googleSearch).build();
 			tools.add(googleSearchRetrievalTool);
 		}
 

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
@@ -88,7 +88,7 @@ class VertexAiGeminiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
-	// Disabled until Gemini 2.5 PRO has an official release
+	// Test disabled until Gemini 2.5 PRO has an official release
 	@Disabled
 	@Test
 	void googleSearchToolPro() {

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
@@ -88,15 +88,26 @@ class VertexAiGeminiChatModelIT {
 		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
 	}
 
+	// Disabled until Gemini 2.5 PRO has an official release
+	@Disabled
 	@Test
-	void googleSearchTool() {
+	void googleSearchToolPro() {
 		Prompt prompt = createPrompt(VertexAiGeminiChatOptions.builder()
-			.model(ChatModel.GEMINI_1_5_PRO) // Only the pro model supports the google
-												// search tool
+			.model(ChatModel.GEMINI_2_5_PRO)
 			.googleSearchRetrieval(true)
 			.build());
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
+	}
+
+	@Test
+	void googleSearchToolFlash() {
+		Prompt prompt = createPrompt(VertexAiGeminiChatOptions.builder()
+				.model(ChatModel.GEMINI_2_0_FLASH)
+				.googleSearchRetrieval(true)
+				.build());
+		ChatResponse response = this.chatModel.call(prompt);
+		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew", "Bob");
 	}
 
 	@Test

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModelIT.java
@@ -103,9 +103,9 @@ class VertexAiGeminiChatModelIT {
 	@Test
 	void googleSearchToolFlash() {
 		Prompt prompt = createPrompt(VertexAiGeminiChatOptions.builder()
-				.model(ChatModel.GEMINI_2_0_FLASH)
-				.googleSearchRetrieval(true)
-				.build());
+			.model(ChatModel.GEMINI_2_0_FLASH)
+			.googleSearchRetrieval(true)
+			.build());
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew", "Bob");
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
 		<djl.version>0.30.0</djl.version>
 		<onnxruntime.version>1.19.2</onnxruntime.version>
 		<oci-sdk-version>3.51.0</oci-sdk-version>
-		<com.google.cloud.version>26.48.0</com.google.cloud.version>
+		<com.google.cloud.version>26.59.0</com.google.cloud.version>
 		<ibm.sdk.version>9.20.0</ibm.sdk.version>
 		<jsonschema.version>4.37.0</jsonschema.version>
 		<swagger-annotations.version>2.2.25</swagger-annotations.version>


### PR DESCRIPTION
- Updated the Google Java client library BOM to 26.59, latest version
- Updated the model list for Gemini
- Update the GoogleSearch with the up-to-date search method

cc @tzolov @markpollack 