### PR TITLE
fix(MessageChatMemory) When adding data to Message Chat Memory Data, the actual data was not replaced

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -19,6 +19,8 @@ package org.springframework.ai.chat.client.advisor;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest;
@@ -94,7 +96,12 @@ public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemo
 		AdvisedRequest advisedRequest = AdvisedRequest.from(request).messages(advisedMessages).build();
 
 		// 4. Add the new user input to the conversation memory.
-		UserMessage userMessage = new UserMessage(request.userText(), request.media());
+		String processedUserText = request.userText();
+		if (!CollectionUtils.isEmpty(request.userParams())) {
+			processedUserText = new PromptTemplate(processedUserText, request.userParams()).render();
+		}
+		UserMessage userMessage = new UserMessage(processedUserText, request.media());
+
 		this.getChatMemoryStore().add(this.doGetConversationId(request.adviseContext()), userMessage);
 
 		return advisedRequest;


### PR DESCRIPTION
When I use something like `ReReadingAdvisor`, I will use `{re2_input_query}` for parameter substitution.

![image](https://github.com/user-attachments/assets/944493da-192c-4f4c-b718-633d5c0f8e7e)

However, when `MessageChatMemoryAdvisor` executes `this.getChatMemoryStore().add`, it does not perform replacement and will directly save `{re2_input_query}` to `ChatMemory`. This is incorrect.

```java
// 4. Add the new user input to the conversation memory.
		UserMessage userMessage = new UserMessage(request.userText(), request.media());
		this.getChatMemoryStore().add(this.doGetConversationId(request.adviseContext()), userMessage);
```

![image](https://github.com/user-attachments/assets/0089d4b8-00ca-497f-a0a0-1a34f486336f)

We need to replace `{re2_input_query}` with real content. Modified code:
```java
String processedUserText = request.userText();
		if (!CollectionUtils.isEmpty(request.userParams())) {
			processedUserText = new PromptTemplate(processedUserText, request.userParams()).render();
		}
		UserMessage userMessage = new UserMessage(processedUserText, request.media());

		this.getChatMemoryStore().add(this.doGetConversationId(request.adviseContext()), userMessage);
```