### PR TITLE
Introduce first-class chat memory support

### DIFF
--- a/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryConfig.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryConfig.java
@@ -20,7 +20,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.Assert;
 
 /**
- * Configuration for {@link JdbcChatMemory}.
+ * Configuration for {@link JdbcChatMemoryRepository}.
  *
  * @author Jonathan Leijendekker
  * @since 1.0.0

--- a/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/aot/hint/JdbcChatMemoryRepositoryRuntimeHints.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/aot/hint/JdbcChatMemoryRepositoryRuntimeHints.java
@@ -27,7 +27,7 @@ import org.springframework.aot.hint.RuntimeHintsRegistrar;
  *
  * @author Jonathan Leijendekker
  */
-class JdbcChatMemoryRuntimeHints implements RuntimeHintsRegistrar {
+class JdbcChatMemoryRepositoryRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {

--- a/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/package-info.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.chat.memory.jdbc;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/memory/spring-ai-model-chat-memory-jdbc/src/main/resources/META-INF/spring/aot.factories
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/main/resources/META-INF/spring/aot.factories
@@ -1,2 +1,2 @@
 org.springframework.aot.hint.RuntimeHintsRegistrar=\
-org.springframework.ai.chat.memory.jdbc.aot.hint.JdbcChatMemoryRuntimeHints
+org.springframework.ai.chat.memory.jdbc.aot.hint.JdbcChatMemoryRepositoryRuntimeHints

--- a/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepositoryIT.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepositoryIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.jdbc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+import javax.sql.DataSource;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link JdbcChatMemoryRepository}.
+ *
+ * @author Jonathan Leijendekker
+ * @author Thomas Vitale
+ */
+@Testcontainers
+class JdbcChatMemoryRepositoryIT {
+
+	@Container
+	@SuppressWarnings("resource")
+	static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:17")
+		.withDatabaseName("chat_memory_test")
+		.withUsername("postgres")
+		.withPassword("postgres")
+		.withCopyFileToContainer(
+				MountableFile.forClasspathResource("org/springframework/ai/chat/memory/jdbc/schema-postgresql.sql"),
+				"/docker-entrypoint-initdb.d/schema.sql");
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(JdbcChatMemoryRepositoryIT.TestApplication.class)
+		.withPropertyValues(String.format("myapp.datasource.url=%s", postgresContainer.getJdbcUrl()),
+				String.format("myapp.datasource.username=%s", postgresContainer.getUsername()),
+				String.format("myapp.datasource.password=%s", postgresContainer.getPassword()));
+
+	@Test
+	void correctChatMemoryRepositoryInstance() {
+		this.contextRunner.run(context -> {
+			var chatMemoryRepository = context.getBean(ChatMemoryRepository.class);
+			assertThat(chatMemoryRepository).isInstanceOf(ChatMemoryRepository.class);
+		});
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "Message from assistant,ASSISTANT", "Message from user,USER", "Message from system,SYSTEM" })
+	void saveSingleMessage(String content, MessageType messageType) {
+		this.contextRunner.run(context -> {
+			var chatMemoryRepository = context.getBean(ChatMemoryRepository.class);
+			var conversationId = UUID.randomUUID().toString();
+			var message = switch (messageType) {
+				case ASSISTANT -> new AssistantMessage(content + " - " + conversationId);
+				case USER -> new UserMessage(content + " - " + conversationId);
+				case SYSTEM -> new SystemMessage(content + " - " + conversationId);
+				default -> throw new IllegalArgumentException("Type not supported: " + messageType);
+			};
+
+			chatMemoryRepository.save(conversationId, List.of(message));
+
+			var jdbcTemplate = context.getBean(JdbcTemplate.class);
+			var query = "SELECT conversation_id, content, type, \"timestamp\" FROM ai_chat_memory WHERE conversation_id = ?";
+			var result = jdbcTemplate.queryForMap(query, conversationId);
+
+			assertThat(result.size()).isEqualTo(4);
+			assertThat(result.get("conversation_id")).isEqualTo(conversationId);
+			assertThat(result.get("content")).isEqualTo(message.getText());
+			assertThat(result.get("type")).isEqualTo(messageType.name());
+			assertThat(result.get("timestamp")).isInstanceOf(Timestamp.class);
+		});
+	}
+
+	@Test
+	void saveMultipleMessages() {
+		this.contextRunner.run(context -> {
+			var chatMemoryRepository = context.getBean(ChatMemoryRepository.class);
+			var conversationId = UUID.randomUUID().toString();
+			var messages = List.<Message>of(new AssistantMessage("Message from assistant - " + conversationId),
+					new UserMessage("Message from user - " + conversationId),
+					new SystemMessage("Message from system - " + conversationId));
+
+			chatMemoryRepository.save(conversationId, messages);
+
+			var jdbcTemplate = context.getBean(JdbcTemplate.class);
+			var query = "SELECT conversation_id, content, type, \"timestamp\" FROM ai_chat_memory WHERE conversation_id = ?";
+			var results = jdbcTemplate.queryForList(query, conversationId);
+
+			assertThat(results.size()).isEqualTo(messages.size());
+
+			for (var i = 0; i < messages.size(); i++) {
+				var message = messages.get(i);
+				var result = results.get(i);
+
+				assertThat(result.get("conversation_id")).isNotNull();
+				assertThat(result.get("conversation_id")).isEqualTo(conversationId);
+				assertThat(result.get("content")).isEqualTo(message.getText());
+				assertThat(result.get("type")).isEqualTo(message.getMessageType().name());
+				assertThat(result.get("timestamp")).isInstanceOf(Timestamp.class);
+			}
+		});
+	}
+
+	@Test
+	void findMessagesByConversationId() {
+		this.contextRunner.run(context -> {
+			var chatMemoryRepository = context.getBean(ChatMemoryRepository.class);
+			var conversationId = UUID.randomUUID().toString();
+			var messages = List.<Message>of(new AssistantMessage("Message from assistant 1 - " + conversationId),
+					new AssistantMessage("Message from assistant 2 - " + conversationId),
+					new UserMessage("Message from user - " + conversationId),
+					new SystemMessage("Message from system - " + conversationId));
+
+			chatMemoryRepository.save(conversationId, messages);
+
+			var results = chatMemoryRepository.findById(conversationId);
+
+			assertThat(results.size()).isEqualTo(messages.size());
+			assertThat(results).isEqualTo(messages);
+		});
+	}
+
+	@Test
+	void deleteMessagesByConversationId() {
+		this.contextRunner.run(context -> {
+			var chatMemoryRepository = context.getBean(ChatMemoryRepository.class);
+			var conversationId = UUID.randomUUID().toString();
+			var messages = List.<Message>of(new AssistantMessage("Message from assistant - " + conversationId),
+					new UserMessage("Message from user - " + conversationId),
+					new SystemMessage("Message from system - " + conversationId));
+
+			chatMemoryRepository.save(conversationId, messages);
+
+			chatMemoryRepository.deleteById(conversationId);
+
+			var jdbcTemplate = context.getBean(JdbcTemplate.class);
+			var count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM ai_chat_memory WHERE conversation_id = ?",
+					Integer.class, conversationId);
+
+			assertThat(count).isZero();
+		});
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class })
+	static class TestApplication {
+
+		@Bean
+		ChatMemoryRepository chatMemoryRepository(JdbcTemplate jdbcTemplate) {
+			JdbcChatMemoryConfig config = JdbcChatMemoryConfig.builder().jdbcTemplate(jdbcTemplate).build();
+			return JdbcChatMemoryRepository.create(config);
+		}
+
+		@Bean
+		JdbcTemplate jdbcTemplate(DataSource dataSource) {
+			return new JdbcTemplate(dataSource);
+		}
+
+		@Bean
+		@Primary
+		@ConfigurationProperties("myapp.datasource")
+		DataSourceProperties dataSourceProperties() {
+			return new DataSourceProperties();
+		}
+
+		@Bean
+		public DataSource dataSource(DataSourceProperties dataSourceProperties) {
+			return dataSourceProperties.initializeDataSourceBuilder().build();
+		}
+
+	}
+
+}

--- a/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/aot/hint/JdbcChatMemoryRepositoryRuntimeHintsTest.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/aot/hint/JdbcChatMemoryRepositoryRuntimeHintsTest.java
@@ -38,18 +38,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Jonathan Leijendekker
  */
-class JdbcChatMemoryRuntimeHintsTest {
+class JdbcChatMemoryRepositoryRuntimeHintsTest {
 
 	private final RuntimeHints hints = new RuntimeHints();
 
-	private final JdbcChatMemoryRuntimeHints jdbcChatMemoryRuntimeHints = new JdbcChatMemoryRuntimeHints();
+	private final JdbcChatMemoryRepositoryRuntimeHints jdbcChatMemoryRepositoryRuntimeHints = new JdbcChatMemoryRepositoryRuntimeHints();
 
 	@Test
 	void aotFactoriesContainsRegistrar() {
 		var match = SpringFactoriesLoader.forResourceLocation("META-INF/spring/aot.factories")
 			.load(RuntimeHintsRegistrar.class)
 			.stream()
-			.anyMatch(registrar -> registrar instanceof JdbcChatMemoryRuntimeHints);
+			.anyMatch(registrar -> registrar instanceof JdbcChatMemoryRepositoryRuntimeHints);
 
 		assertThat(match).isTrue();
 	}
@@ -57,7 +57,7 @@ class JdbcChatMemoryRuntimeHintsTest {
 	@ParameterizedTest
 	@MethodSource("getSchemaFileNames")
 	void jdbcSchemasHasHints(String schemaFileName) {
-		this.jdbcChatMemoryRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
+		this.jdbcChatMemoryRepositoryRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
 
 		var predicate = RuntimeHintsPredicates.resource()
 			.forResource("org/springframework/ai/chat/memory/jdbc/" + schemaFileName);
@@ -67,7 +67,7 @@ class JdbcChatMemoryRuntimeHintsTest {
 
 	@Test
 	void dataSourceHasHints() {
-		this.jdbcChatMemoryRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
+		this.jdbcChatMemoryRepositoryRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
 
 		assertThat(RuntimeHintsPredicates.reflection().onType(DataSource.class)).accepts(this.hints);
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -27,6 +27,7 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -247,6 +248,10 @@ public interface ChatClient {
 
 		ChatClientRequestSpec user(Consumer<PromptUserSpec> consumer);
 
+		ChatClientRequestSpec memory(ChatMemory chatMemory);
+
+		ChatClientRequestSpec conversationId(String conversationId);
+
 		CallResponseSpec call();
 
 		StreamResponseSpec stream();
@@ -293,6 +298,8 @@ public interface ChatClient {
 		Builder defaultTools(ToolCallbackProvider... toolCallbackProviders);
 
 		Builder defaultToolContext(Map<String, Object> toolContext);
+
+		Builder defaultMemory(ChatMemory chatMemory);
 
 		Builder clone();
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientResponse.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientResponse.java
@@ -51,7 +51,7 @@ public record ChatClientResponse(@Nullable ChatResponse chatResponse, Map<String
 		private Builder() {
 		}
 
-		public Builder chatResponse(ChatResponse chatResponse) {
+		public Builder chatResponse(@Nullable ChatResponse chatResponse) {
 			this.chatResponse = chatResponse;
 			return this;
 		}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -30,6 +30,7 @@ import org.springframework.ai.chat.client.ChatClient.PromptUserSpec;
 import org.springframework.ai.chat.client.DefaultChatClient.DefaultChatClientRequestSpec;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -64,8 +65,8 @@ public class DefaultChatClientBuilder implements Builder {
 			@Nullable ChatClientObservationConvention customObservationConvention) {
 		Assert.notNull(chatModel, "the " + ChatModel.class.getName() + " must be non-null");
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
-		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), null, Map.of(), List.of(),
-				List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
+		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, null, null, Map.of(), null, Map.of(),
+				List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
 				customObservationConvention, Map.of());
 	}
 
@@ -187,6 +188,13 @@ public class DefaultChatClientBuilder implements Builder {
 
 	public Builder defaultToolContext(Map<String, Object> toolContext) {
 		this.defaultRequest.toolContext(toolContext);
+		return this;
+	}
+
+	@Override
+	public Builder defaultMemory(ChatMemory chatMemory) {
+		Assert.notNull(chatMemory, "chatMemory cannot be null");
+		this.defaultRequest.memory(chatMemory);
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/AbstractChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/AbstractChatMemoryAdvisor.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.client.advisor;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.springframework.ai.chat.memory.ChatMemory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -38,7 +39,10 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
+ * @deprecated in favour of providing the ChatClient directly with a {@link ChatMemory}
+ * instance.
  */
+@Deprecated
 public abstract class AbstractChatMemoryAdvisor<T> implements CallAroundAdvisor, StreamAroundAdvisor {
 
 	/**

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ChatModelCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ChatModelCallAdvisor.java
@@ -20,11 +20,16 @@ import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -45,7 +50,29 @@ public final class ChatModelCallAdvisor implements CallAdvisor {
 	public ChatClientResponse adviseCall(ChatClientRequest chatClientRequest, CallAroundAdvisorChain chain) {
 		Assert.notNull(chatClientRequest, "the chatClientRequest cannot be null");
 
-		ChatResponse chatResponse = chatModel.call(chatClientRequest.prompt());
+		ChatMemory chatMemory = chain.getChatMemory();
+
+		ChatResponse chatResponse;
+		if (chatMemory == null) {
+			chatResponse = chatModel.call(chatClientRequest.prompt());
+		}
+		else {
+			String conversationId = chain.getConversationId();
+			chatMemory.add(conversationId, chatClientRequest.prompt().getInstructions());
+			Prompt prompt = chatClientRequest.prompt().mutate().messages(chatMemory.get(conversationId)).build();
+			chatResponse = chatModel.call(prompt);
+			if (chatResponse != null) {
+				List<Generation> generations = chatResponse.getResults();
+				if (generations != null) {
+					List<Message> assistantMessages = generations.stream()
+						.map(generation -> (Message) generation.getOutput())
+						.toList();
+					chatMemory.add(conversationId, assistantMessages);
+				}
+			}
+
+		}
+
 		return ChatClientResponse.builder()
 			.chatResponse(chatResponse)
 			.context(Map.copyOf(chatClientRequest.context()))

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAroundAdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.MessageAggregator;
@@ -36,7 +37,10 @@ import org.springframework.ai.chat.model.MessageAggregator;
  *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @deprecated in favor of providing the ChatClient directly with a
+ * {@link MessageWindowChatMemory} instance.
  */
+@Deprecated
 public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemory> {
 
 	public MessageChatMemoryAdvisor(ChatMemory chatMemory) {

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/AdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/AdvisorChain.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.api;
+
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.lang.Nullable;
+
+/**
+ * Defines the context for executing a chain of advisors as part of processing a chat
+ * request.
+ */
+public interface AdvisorChain {
+
+	default String getConversationId() {
+		return ChatMemory.DEFAULT_CONVERSATION_ID;
+	}
+
+	@Nullable
+	default ChatMemory getChatMemory() {
+		return null;
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/CallAroundAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/CallAroundAdvisorChain.java
@@ -28,7 +28,7 @@ import org.springframework.ai.chat.client.ChatClientRequest;
  * @deprecated in favor of {@link CallAdvisorChain}
  */
 @Deprecated
-public interface CallAroundAdvisorChain {
+public interface CallAroundAdvisorChain extends AdvisorChain {
 
 	/**
 	 * Invokes the next Around Advisor in the CallAroundAdvisorChain with the given

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/StreamAroundAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/StreamAroundAdvisorChain.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Flux;
  * @deprecated in favor of {@link StreamAdvisorChain}
  */
 @Deprecated
-public interface StreamAroundAdvisorChain {
+public interface StreamAroundAdvisorChain extends AdvisorChain {
 
 	/**
 	 * This method delegates the call to the next StreamAroundAdvisor in the chain and is

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/memory/InMemoryChatMemory.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/memory/InMemoryChatMemory.java
@@ -34,7 +34,10 @@ import org.springframework.ai.chat.messages.Message;
  * @see ChatMemory
  * @author Christian Tzolov
  * @since 1.0.0 M1
+ * @deprecated in favor of {@link MessageWindowChatMemory}, which internally uses
+ * {@link InMemoryChatMemoryRepository}.
  */
+@Deprecated
 public class InMemoryChatMemory implements ChatMemory {
 
 	Map<String, List<Message>> conversationHistory = new ConcurrentHashMap<>();

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
@@ -95,4 +95,11 @@ class DefaultChatClientBuilderTests {
 			.hasMessage("charset cannot be null");
 	}
 
+	@Test
+	void whenChatMemoryIsNullThenThrows() {
+		DefaultChatClientBuilder builder = new DefaultChatClientBuilder(mock(ChatModel.class));
+		assertThatThrownBy(() -> builder.defaultMemory(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("chatMemory cannot be null");
+	}
+
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -94,6 +94,7 @@
 * xref:api/retrieval-augmented-generation.adoc[Retrieval Augmented Generation (RAG)]
 ** xref:api/etl-pipeline.adoc[]
 * xref:api/structured-output-converter.adoc[Structured Output]
+* xref:api/memory.adoc[Memory]
 * xref:api/tools.adoc[Tool Calling]
 ** xref:api/tools-migration.adoc[Migrating to ToolCallback API]
 * xref:api/mcp/mcp-overview.adoc[Model Context Protocol (MCP)]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/memory.adoc
@@ -1,0 +1,152 @@
+[[Memory]]
+= Memory
+
+Large language models (LLMs) are stateless, meaning they do not retain information about previous interactions. This can be a limitation when you want to maintain context or state across multiple interactions. To address this, Spring AI provides a `ChatMemory` abstraction that allows you to store and retrieve information across multiple interactions with the LLM.
+
+WARNING: In previous versions of Spring AI, the way to provide memory to a Chat Client was by using one of the available advisors (e.g. `MessageChatMemoryAdvisor`, `PromptChatMemoryAdvisor`, or `VectorStoreChatMemoryAdvisor`). This approach has been deprecated in favor of a more flexible and extensible memory system. The new system allows you to provide memory directly to the `ChatClient`, making it easier to manage and customize memory behavior. When adopting the new system, make sure to remove any old memory advisors from your configuration to avoid unintended behavior.
+
+== Usage
+
+=== Providing Memory to Chat Client
+
+The `ChatClient` can be configured with a memory implementation to maintain conversation context across multiple interactions. Here's an example of how to set up a `ChatClient` with memory:
+
+[source,java]
+----
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultMemory(MessageWindowChatMemory.builder().build())
+    .build();
+----
+
+When sending a prompt to the model, you can specify a `conversationId` to associate the message with a specific conversation. This allows the model to remember previous interactions within that conversation. All messages with the same `conversationId` are stored together in the memory.
+
+[source,java]
+----
+String conversationId = "007";
+
+// First interaction
+ChatResponse response1 = chatClient.prompt("My name is Bond. James Bond.")
+    .conversationId(conversationId)
+    .call()
+    .chatResponse();
+
+// Second interaction - the model remembers the name from the first interaction
+ChatResponse response2 = chatClient.prompt("What is my name?")
+    .conversationId(conversationId)
+    .call()
+    .chatResponse();
+
+// The response will contain "James Bond"
+----
+
+=== Choosing a Storage for the Memory
+
+A `ChatMemory` implementation typically uses a `ChatMemoryRepository` to store messages. The repository is responsible for persisting the messages and providing retrieval capabilities. You can choose from various repository implementations based on your storage needs, such as in-memory, JDBC, Cassandra, or Neo4j.
+
+Let's consider `MessageWindowChatMemory` as an example. By default, it uses an in-memory repository (`InMemoryChatMemoryRepository`), which is suitable for simple use cases. However, if you need to persist messages across application restarts or share memory between different instances, you can configure it to use a different repository.
+
+[source,java]
+----
+// Create a custom repository
+ChatMemoryRepository repository = new InMemoryChatMemoryRepository();
+
+// Configure the memory with the custom repository
+MessageWindowChatMemory memory = MessageWindowChatMemory.builder()
+    .chatMemoryRepository(repository)
+    .maxMessages(10) // Limit the number of messages stored
+    .build();
+
+// Create a ChatClient with the configured memory
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultMemory(memory)
+    .build();
+----
+
+=== Managing Memory Manually with ChatModel
+
+If you're working directly with a `ChatModel` instead of a `ChatClient`, you can manage the memory manually:
+
+[source,java]
+----
+// Create a memory instance
+ChatMemory memory = MessageWindowChatMemory.builder().build();
+String conversationId = "007";
+
+// First interaction
+UserMessage userMessage1 = new UserMessage("My name is James Bond");
+memory.add(conversationId, userMessage1);
+ChatResponse response1 = chatModel.call(new Prompt(memory.get(conversationId)));
+memory.add(conversationId, response1.getResult().getOutput());
+
+// Second interaction
+UserMessage userMessage2 = new UserMessage("What is my name?");
+memory.add(conversationId, userMessage2);
+ChatResponse response2 = chatModel.call(new Prompt(memory.get(conversationId)));
+memory.add(conversationId, response2.getResult().getOutput());
+
+// The response will contain "James Bond"
+----
+
+== Memory Types
+
+The `ChatMemory` abstraction allows you to implement various types of memory to suit different use cases. The choice of memory type can significantly impact the performance and behavior of your application. This section describes the built-in memory types provided by Spring AI and their characteristics.
+
+=== Message Window Chat Memory
+
+`MessageWindowChatMemory` maintains a window of messages up to a specified maximum size. When the number of messages exceeds the maximum, older messages are removed while preserving system messages. The default window size is 200 messages.
+
+[source,java]
+----
+// Create a memory with a window size of 10 messages
+MessageWindowChatMemory memory = MessageWindowChatMemory.builder()
+    .maxMessages(10)
+    .build();
+----
+
+== Storage
+
+Spring AI offers the `ChatMemoryRepository` abstraction for storing chat memory. This section describes the built-in repositories provided by Spring AI and how to use them, but you can also implement your own repository if needed.
+
+=== In-Memory Repository
+
+`InMemoryChatMemoryRepository` stores messages in memory using a `ConcurrentHashMap`.
+
+[source,java]
+----
+ChatMemoryRepository repository = new InMemoryChatMemoryRepository();
+----
+
+=== JDBC Repository
+
+`JdbcChatMemoryRepository` is a built-in implementation that uses JDBC to store messages in a relational database. It is suitable for applications that require persistent storage of chat memory.
+
+WARNING: When you use the JDBC repository, make sure to size the chat memory appropriately. For example, the `MessageWindowChatMemory` implementation has a default size of 200 messages, which might be too much to retrieve and store in a single database transaction. You can adjust the size using the `maxMessages` property.
+
+[source,java]
+----
+JdbcChatMemoryConfig config = JdbcChatMemoryConfig.builder().jdbcTemplate(jdbcTemplate).build();
+JdbcChatMemoryRepository chatMemoryRepository = JdbcChatMemoryRepository.create(config);
+
+MessageWindowChatMemory memory = MessageWindowChatMemory.builder()
+    .chatMemoryRepository(chatMemoryRepository)
+    .maxMessages(20) // Limit the number of messages stored
+    .build();
+----
+
+Spring AI provides auto-configuration for `JdbcChatMemoryRepository`.
+
+[source,java]
+----
+@RestController
+class AiController {
+
+    private final ChatMemory chatMemory;
+
+    public AiController(JdbcChatMemoryRepository chatMemoryRepository) {
+        this.chatMemory = MessageWindowChatMemory.builder()
+            .chatMemoryRepository(chatMemoryRepository)
+            .maxMessages(20)
+            .build();
+    }
+}
+----

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.util.Assert;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The contract for storing and managing the history of chat conversations.
+ *
+ * @author Christian Tzolov
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public interface ChatMemory {
+
+	String DEFAULT_CONVERSATION_ID = "default";
+
+	/**
+	 * Save the specified message in the chat memory for the specified conversation.
+	 */
+	default void add(String conversationId, Message message) {
+		this.add(conversationId, Collections.singletonList(message));
+	}
+
+	/**
+	 * Save the specified messages in the chat memory for the specified conversation.
+	 */
+	void add(String conversationId, List<Message> messages);
+
+	/**
+	 * Get the messages in the chat memory for the specified conversation.
+	 */
+	default List<Message> get(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		return get(conversationId, Integer.MAX_VALUE);
+	}
+
+	/**
+	 * @deprecated in favor of {@link MessageWindowChatMemory}.
+	 */
+	@Deprecated
+	List<Message> get(String conversationId, int lastN);
+
+	/**
+	 * Clear the chat memory for the specified conversation.
+	 */
+	void clear(String conversationId);
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemoryRepository.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemoryRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.springframework.ai.chat.messages.Message;
+
+import java.util.List;
+
+/**
+ * A repository for storing and retrieving chat messages.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public interface ChatMemoryRepository {
+
+	List<Message> findById(String conversationId);
+
+	void save(String conversationId, List<Message> messages);
+
+	void deleteById(String conversationId);
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/DefaultMessageWindowProcessingPolicy.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/DefaultMessageWindowProcessingPolicy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A policy that adds new messages to the existing history messages and ensures that the
+ * total number of messages does not exceed the specified limit.
+ * <p>
+ * Messages of type {@link SystemMessage} are treated specially: if a new
+ * {@link SystemMessage} is added, all previous {@link SystemMessage} instances are
+ * removed from the history. Also, if the total number of messages exceeds the limit, the
+ * {@link SystemMessage} messages are preserved while removing other types of messages.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public final class DefaultMessageWindowProcessingPolicy implements MessageWindowProcessingPolicy {
+
+	@Override
+	public List<Message> process(List<Message> historyMessages, List<Message> newMessages, int limit) {
+		Assert.notNull(historyMessages, "historyMessages cannot be null");
+		Assert.noNullElements(historyMessages, "historyMessages cannot contain null elements");
+		Assert.notNull(newMessages, "newMessages cannot be null");
+		Assert.noNullElements(newMessages, "newMessages cannot contain null elements");
+		Assert.isTrue(limit > 0, "limit must be greater than 0");
+
+		List<Message> processedMessages = new ArrayList<>(historyMessages);
+
+		for (Message newMessage : newMessages) {
+			if (newMessage instanceof SystemMessage systemMessage && !processedMessages.contains(systemMessage)) {
+				// If a new SystemMessage is added, remove all previous SystemMessages
+				processedMessages.removeIf(m -> m instanceof SystemMessage);
+				break;
+			}
+		}
+
+		processedMessages.addAll(new ArrayList<>(newMessages));
+
+		if (processedMessages.size() <= limit) {
+			return processedMessages;
+		}
+
+		int messagesToRemove = processedMessages.size() - limit;
+		int index = 0;
+
+		while (messagesToRemove > 0 && index < processedMessages.size()) {
+			if (!(processedMessages.get(index) instanceof SystemMessage)) {
+				processedMessages.remove(index);
+				messagesToRemove--;
+			}
+			else {
+				index++;
+			}
+		}
+
+		return processedMessages;
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepository.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepository.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An in-memory implementation of {@link ChatMemoryRepository}.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public final class InMemoryChatMemoryRepository implements ChatMemoryRepository {
+
+	Map<String, List<Message>> chatMemoryStore = new ConcurrentHashMap<>();
+
+	@Override
+	public List<Message> findById(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		List<Message> messages = this.chatMemoryStore.get(conversationId);
+		return messages != null ? new ArrayList<>(messages) : List.of();
+	}
+
+	@Override
+	public void save(String conversationId, List<Message> messages) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		Assert.notNull(messages, "messages cannot be null");
+		Assert.noNullElements(messages, "messages cannot contain null elements");
+
+		this.chatMemoryStore.putIfAbsent(conversationId, new ArrayList<>());
+		this.chatMemoryStore.get(conversationId).addAll(messages);
+	}
+
+	@Override
+	public void deleteById(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		this.chatMemoryStore.remove(conversationId);
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+/**
+ * A chat memory implementation that maintains a message window of a specified size. When
+ * the number of messages exceeds the maximum size, older messages are removed while
+ * preserving SystemMessages.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public final class MessageWindowChatMemory implements ChatMemory {
+
+	private static final int DEFAULT_MAX_MESSAGES = 200;
+
+	private static final ChatMemoryRepository DEFAULT_CHAT_MEMORY_REPOSITORY = new InMemoryChatMemoryRepository();
+
+	private static final MessageWindowProcessingPolicy DEFAULT_MESSAGE_WINDOW_EVICTION_POLICY = new DefaultMessageWindowProcessingPolicy();
+
+	private final ChatMemoryRepository chatMemoryRepository;
+
+	private final MessageWindowProcessingPolicy messageWindowProcessingPolicy;
+
+	private final int maxMessages;
+
+	private MessageWindowChatMemory(ChatMemoryRepository chatMemoryRepository,
+			MessageWindowProcessingPolicy messageWindowProcessingPolicy, int maxMessages) {
+		this.chatMemoryRepository = chatMemoryRepository;
+		this.messageWindowProcessingPolicy = messageWindowProcessingPolicy;
+		this.maxMessages = maxMessages;
+	}
+
+	@Override
+	public void add(String conversationId, List<Message> messages) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		Assert.notNull(messages, "messages cannot be null");
+		Assert.noNullElements(messages, "messages cannot contain null elements");
+
+		List<Message> historyMessages = this.chatMemoryRepository.findById(conversationId);
+		List<Message> processedMessages = this.messageWindowProcessingPolicy.process(historyMessages, messages,
+				this.maxMessages);
+		this.chatMemoryRepository.save(conversationId, processedMessages);
+	}
+
+	@Override
+	public List<Message> get(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		return this.chatMemoryRepository.findById(conversationId);
+	}
+
+	@Override
+	@Deprecated // in favor of get(conversationId)
+	public List<Message> get(String conversationId, int lastN) {
+		return get(conversationId);
+	}
+
+	@Override
+	public void clear(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		this.chatMemoryRepository.deleteById(conversationId);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private ChatMemoryRepository chatMemoryRepository = DEFAULT_CHAT_MEMORY_REPOSITORY;
+
+		private int maxMessages = DEFAULT_MAX_MESSAGES;
+
+		private MessageWindowProcessingPolicy messageWindowProcessingPolicy = DEFAULT_MESSAGE_WINDOW_EVICTION_POLICY;
+
+		private Builder() {
+		}
+
+		public Builder chatMemoryRepository(ChatMemoryRepository chatMemoryRepository) {
+			this.chatMemoryRepository = chatMemoryRepository;
+			return this;
+		}
+
+		public Builder messageWindowEvictionPolicy(MessageWindowProcessingPolicy messageWindowProcessingPolicy) {
+			this.messageWindowProcessingPolicy = messageWindowProcessingPolicy;
+			return this;
+		}
+
+		public Builder maxMessages(int maxMessages) {
+			this.maxMessages = maxMessages;
+			return this;
+		}
+
+		public MessageWindowChatMemory build() {
+			return new MessageWindowChatMemory(chatMemoryRepository, messageWindowProcessingPolicy, maxMessages);
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowProcessingPolicy.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowProcessingPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,25 @@
 
 package org.springframework.ai.chat.memory;
 
-import java.util.List;
-
 import org.springframework.ai.chat.messages.Message;
 
+import java.util.List;
+
 /**
- * The ChatMemory interface represents a storage for chat conversation history. It
- * provides methods to add messages to a conversation, retrieve messages from a
- * conversation, and clear the conversation history.
+ * A policy for processing a message window in a chat memory system. It defines a strategy
+ * for handling the addition of new messages to the existing message history, ensuring
+ * that the total number of messages does not exceed a specified limit.
  *
- * @author Christian Tzolov
+ * @author Thomas Vitale
  * @since 1.0.0
  */
-public interface ChatMemory {
+public interface MessageWindowProcessingPolicy {
 
-	// TODO: consider a non-blocking interface for streaming usages
-
-	default void add(String conversationId, Message message) {
-		this.add(conversationId, List.of(message));
-	}
-
-	void add(String conversationId, List<Message> messages);
-
-	List<Message> get(String conversationId, int lastN);
-
-	void clear(String conversationId);
+	/**
+	 * Processes the message window by adding new messages to the existing history
+	 * messages and ensuring that the total number of messages does not exceed the
+	 * specified limit.
+	 */
+	List<Message> process(List<Message> historyMessages, List<Message> newMessages, int limit);
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/package-info.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.chat.memory;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/DefaultMessageWindowProcessingPolicyTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/DefaultMessageWindowProcessingPolicyTests.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link DefaultMessageWindowProcessingPolicy}.
+ *
+ * @author Thomas Vitale
+ */
+public class DefaultMessageWindowProcessingPolicyTests {
+
+	private final MessageWindowProcessingPolicy processingPolicy = new DefaultMessageWindowProcessingPolicy();
+
+	@Test
+	void noEvictionWhenMessagesWithinLimit() {
+		List<Message> historyMessages = new ArrayList<>(
+				List.of(new UserMessage("Hello"), new AssistantMessage("Hi there")));
+		List<Message> newMessages = new ArrayList<>(List.of(new UserMessage("How are you?")));
+		int limit = 3;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		assertThat(result).hasSize(3);
+		assertThat(result).containsExactly(new UserMessage("Hello"), new AssistantMessage("Hi there"),
+				new UserMessage("How are you?"));
+	}
+
+	@Test
+	void evictionWhenMessagesExceedLimit() {
+		List<Message> historyMessages = new ArrayList<>(
+				List.of(new UserMessage("Message 1"), new AssistantMessage("Response 1")));
+		List<Message> newMessages = new ArrayList<>(
+				List.of(new UserMessage("Message 2"), new AssistantMessage("Response 2")));
+		int limit = 2;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		assertThat(result).hasSize(2);
+		assertThat(result).containsExactly(new UserMessage("Message 2"), new AssistantMessage("Response 2"));
+	}
+
+	@Test
+	void systemMessageIsPreserved() {
+		List<Message> historyMessages = new ArrayList<>(List.of(new SystemMessage("System instruction"),
+				new UserMessage("Message 1"), new AssistantMessage("Response 1")));
+		List<Message> newMessages = new ArrayList<>(
+				List.of(new UserMessage("Message 2"), new AssistantMessage("Response 2")));
+		int limit = 3;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		assertThat(result).hasSize(3);
+		assertThat(result).containsExactly(new SystemMessage("System instruction"), new UserMessage("Message 2"),
+				new AssistantMessage("Response 2"));
+	}
+
+	@Test
+	void multipleSystemMessagesArePreserved() {
+		List<Message> historyMessages = new ArrayList<>(
+				List.of(new SystemMessage("System instruction 1"), new SystemMessage("System instruction 2"),
+						new UserMessage("Message 1"), new AssistantMessage("Response 1")));
+		List<Message> newMessages = new ArrayList<>(
+				List.of(new UserMessage("Message 2"), new AssistantMessage("Response 2")));
+		int limit = 3;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		assertThat(result).hasSize(3);
+		assertThat(result).containsExactly(new SystemMessage("System instruction 1"),
+				new SystemMessage("System instruction 2"), new AssistantMessage("Response 2"));
+	}
+
+	@Test
+	void emptyMessageList() {
+		List<Message> historyMessages = new ArrayList<>();
+		List<Message> newMessages = new ArrayList<>();
+		int limit = 5;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void zeroLimitNotAllowed() {
+		List<Message> historyMessages = new ArrayList<>(List.of(new UserMessage("Message 1")));
+		List<Message> newMessages = new ArrayList<>(List.of(new AssistantMessage("Response 1")));
+
+		assertThatThrownBy(() -> processingPolicy.process(historyMessages, newMessages, 0))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("limit must be greater than 0");
+	}
+
+	@Test
+	void negativeLimitNotAllowed() {
+		List<Message> historyMessages = new ArrayList<>(List.of(new UserMessage("Message 1")));
+		List<Message> newMessages = new ArrayList<>(List.of(new AssistantMessage("Response 1")));
+
+		assertThatThrownBy(() -> processingPolicy.process(historyMessages, newMessages, -1))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("limit must be greater than 0");
+	}
+
+	@Test
+	void oldSystemMessagesAreRemovedEvenWithCountLessThanLimit() {
+		List<Message> historyMessages = new ArrayList<>(
+				List.of(new SystemMessage("System instruction 1"), new SystemMessage("System instruction 2")));
+		List<Message> newMessages = new ArrayList<>(List.of(new SystemMessage("System instruction 3")));
+		int limit = 2;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		// Old system messages are moved if a new one is provided, even if there's room in
+		// the window.
+		assertThat(result).hasSize(1);
+		assertThat(result).containsExactly(new SystemMessage("System instruction 3"));
+	}
+
+	@Test
+	void mixedMessagesWithLimitEqualToSystemMessageCount() {
+		List<Message> historyMessages = new ArrayList<>(
+				List.of(new SystemMessage("System instruction 1"), new SystemMessage("System instruction 2")));
+		List<Message> newMessages = new ArrayList<>(
+				List.of(new UserMessage("Message 1"), new AssistantMessage("Response 1")));
+		int limit = 2;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		assertThat(result).hasSize(2);
+		assertThat(result).containsExactly(new SystemMessage("System instruction 1"),
+				new SystemMessage("System instruction 2"));
+	}
+
+	@Test
+	void originalListIsNotModified() {
+		List<Message> historyMessages = new ArrayList<>(
+				List.of(new UserMessage("Message 1"), new AssistantMessage("Response 1")));
+		List<Message> newMessages = new ArrayList<>(
+				List.of(new UserMessage("Message 2"), new AssistantMessage("Response 2")));
+		List<Message> originalHistoryMessages = new ArrayList<>(historyMessages);
+		List<Message> originalNewMessages = new ArrayList<>(newMessages);
+		int limit = 4;
+
+		List<Message> result = processingPolicy.process(historyMessages, newMessages, limit);
+
+		assertThat(historyMessages).isEqualTo(originalHistoryMessages);
+		assertThat(newMessages).isEqualTo(originalNewMessages);
+		assertThat(result).isNotSameAs(historyMessages);
+		assertThat(result).isNotSameAs(newMessages);
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepositoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/InMemoryChatMemoryRepositoryTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link InMemoryChatMemoryRepository}.
+ *
+ * @author Thomas Vitale
+ */
+public class InMemoryChatMemoryRepositoryTests {
+
+	private final InMemoryChatMemoryRepository chatMemoryRepository = new InMemoryChatMemoryRepository();
+
+	@Test
+	void saveAndFindMultipleMessagesInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new AssistantMessage("I, Robot"), new UserMessage("Hello"));
+
+		chatMemoryRepository.save(conversationId, messages);
+
+		assertThat(chatMemoryRepository.findById(conversationId)).containsAll(messages);
+
+		chatMemoryRepository.deleteById(conversationId);
+
+		assertThat(chatMemoryRepository.findById(conversationId)).isEmpty();
+	}
+
+	@Test
+	void saveAndFindSingleMessageInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		Message message = new UserMessage("Hello");
+		List<Message> messages = List.of(message);
+
+		chatMemoryRepository.save(conversationId, messages);
+
+		assertThat(chatMemoryRepository.findById(conversationId)).contains(message);
+
+		chatMemoryRepository.deleteById(conversationId);
+
+		assertThat(chatMemoryRepository.findById(conversationId)).isEmpty();
+	}
+
+	@Test
+	void findNonExistingConversation() {
+		String conversationId = UUID.randomUUID().toString();
+
+		assertThat(chatMemoryRepository.findById(conversationId)).isEmpty();
+	}
+
+	@Test
+	void saveMultipleMessagesForSameConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> firstMessages = List.of(new UserMessage("Hello"));
+		List<Message> secondMessages = List.of(new AssistantMessage("Hi there"));
+
+		chatMemoryRepository.save(conversationId, firstMessages);
+		chatMemoryRepository.save(conversationId, secondMessages);
+
+		List<Message> allMessages = new ArrayList<>();
+		allMessages.addAll(firstMessages);
+		allMessages.addAll(secondMessages);
+
+		assertThat(chatMemoryRepository.findById(conversationId)).containsExactlyElementsOf(allMessages);
+	}
+
+	@Test
+	void nullConversationIdNotAllowed() {
+		assertThatThrownBy(() -> chatMemoryRepository.save(null, List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemoryRepository.findById(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemoryRepository.deleteById(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void emptyConversationIdNotAllowed() {
+		assertThatThrownBy(() -> chatMemoryRepository.save("", List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemoryRepository.findById("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemoryRepository.deleteById("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void nullMessagesNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		assertThatThrownBy(() -> chatMemoryRepository.save(conversationId, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot be null");
+	}
+
+	@Test
+	void messagesWithNullElementsNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messagesWithNull = new ArrayList<>();
+		messagesWithNull.add(null);
+
+		assertThatThrownBy(() -> chatMemoryRepository.save(conversationId, messagesWithNull))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot contain null elements");
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link MessageWindowChatMemory}.
+ *
+ * @author Thomas Vitale
+ */
+public class MessageWindowChatMemoryTests {
+
+	private final MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder().build();
+
+	@Test
+	void handleMultipleMessagesInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new AssistantMessage("I, Robot"), new UserMessage("Hello"));
+
+		chatMemory.add(conversationId, messages);
+
+		assertThat(chatMemory.get(conversationId)).containsAll(messages);
+
+		chatMemory.clear(conversationId);
+
+		assertThat(chatMemory.get(conversationId)).isEmpty();
+	}
+
+	@Test
+	void handleSingleMessageInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		Message message = new UserMessage("Hello");
+
+		chatMemory.add(conversationId, message);
+
+		assertThat(chatMemory.get(conversationId)).contains(message);
+
+		chatMemory.clear(conversationId);
+
+		assertThat(chatMemory.get(conversationId)).isEmpty();
+	}
+
+	@Test
+	void nullConversationIdNotAllowed() {
+		assertThatThrownBy(() -> chatMemory.add(null, List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemory.add(null, new UserMessage("Hello")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemory.get(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemory.clear(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void emptyConversationIdNotAllowed() {
+		assertThatThrownBy(() -> chatMemory.add("", List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemory.add(null, new UserMessage("Hello")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemory.get("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> chatMemory.clear("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void nullMessagesNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		assertThatThrownBy(() -> chatMemory.add(conversationId, (List<Message>) null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot be null");
+	}
+
+	@Test
+	void nullMessageNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		assertThatThrownBy(() -> chatMemory.add(conversationId, (Message) null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot contain null elements");
+	}
+
+	@Test
+	void messagesWithNullElementsNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messagesWithNull = new ArrayList<>();
+		messagesWithNull.add(null);
+
+		assertThatThrownBy(() -> chatMemory.add(conversationId, messagesWithNull))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot contain null elements");
+	}
+
+	@Test
+	void customMaxMessages() {
+		String conversationId = UUID.randomUUID().toString();
+		int customMaxMessages = 2;
+
+		MessageWindowChatMemory customChatMemory = MessageWindowChatMemory.builder()
+			.maxMessages(customMaxMessages)
+			.build();
+
+		List<Message> messages = List.of(new UserMessage("Message 1"), new AssistantMessage("Response 1"),
+				new UserMessage("Message 2"), new AssistantMessage("Response 2"), new UserMessage("Message 3"));
+
+		customChatMemory.add(conversationId, messages);
+		List<Message> result = customChatMemory.get(conversationId);
+
+		assertThat(result).hasSize(2);
+	}
+
+}


### PR DESCRIPTION
- ChatMemory will become a generic interface to implement different memory management strategies. It’s been moved from the “”spring-ai-client-chat” package to “spring-ai-model” package while retaining the same package, so it’s transparent to users.
- A MessageWindowChatMemory has been introduced to provide support for a chat memory that keeps at most N messages in the memory.
- A MessageWindowProcessingPolicy API has been introduced to customise the processing policy for the message window. A default implementation is provided out-of-the-box.
- A ChatMemoryRepository interface has been introduced to support different storage strategies for the chat memory. It’s meant to be used as part of a ChatMemory implementation. This is different than before, where the storage-specific implementation was directly tied to the ChatMemory. This design is familiar to Spring users since it’s used already in the ecosystem. The goal was to use a programming model similar to Spring Session and Spring Data.
- The JdbcChatMemory has been supersed by JdbcChatMemoryRepository.
- The ChatClient now supports memory as a first-class citizen, superseding the need for an Advisor to manage the chat memory. It also simplifies providing a conversationId. This feature lays the foundation for including the intermediate messages in tool calling in the memory as well.
- All the changes introduced in this PR are backword-compatible.

Usage:

```java
ChatClient chatClient = ChatClient.builder(this.chatModel)
	.defaultMemory(MessageWindowChatMemory.builder().build())
	.build();

String conversationId = "007";

ChatResponse response1 = chatClient.prompt("My name is Bond. James Bond.")
	.conversationId(conversationId)
	.call()
	.chatResponse(); // Hello, James Bond!

ChatResponse response2 = chatClient.prompt("What is my name?")
	.conversationId(conversationId)
	.call()
	.chatResponse(); // Your name is James Bond!
```