### PR TITLE
Add RestClient timeout support via spring-ai-autoconfigure-http-client module

### DIFF
--- a/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/pom.xml
+++ b/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>1.1.0-SNAPSHOT</version>
+		<relativePath>../../../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Http Client Auto Configuration</name>
+	<description>Spring AI Http Client Auto Configuration</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/main/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientAutoConfiguration.java
+++ b/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/main/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.http.client.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
+import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.*;
+import org.springframework.web.client.RestClient;
+
+/**
+ * {@link AutoConfiguration Auto-configuration} for AI rest-client.
+ *
+ * @author Song Jaegeun
+ */
+@AutoConfiguration
+@ConditionalOnClass({ RestClient.class })
+@EnableConfigurationProperties({ SpringAiRestClientProperties.class })
+public class SpringAiRestClientAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(RestClientCustomizer.class)
+	public RestClientCustomizer restClientCustomizer(SpringAiRestClientProperties props) {
+		// RestClient.Builder is not registered as a bean in the context,
+		// so there's no need to use @ConditionalOnMissingBean(RestClient.Builder.class).
+		// Spring Boot will automatically apply this RestClientCustomizer
+		// to any RestClient.Builder instance created via RestClient.create().
+		return restClientBuilder -> {
+			ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.defaults()
+				.withConnectTimeout(props.getConnectionTimeout())
+				.withReadTimeout(props.getReadTimeout());
+
+			ClientHttpRequestFactory factory = ClientHttpRequestFactoryBuilder.detect().build(settings);
+			restClientBuilder.requestFactory(factory);
+		};
+	}
+
+}

--- a/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/main/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientProperties.java
+++ b/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/main/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.http.client.autoconfigure;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Properties for AI rest-client.
+ *
+ * @author Song Jaegeun
+ */
+@ConfigurationProperties(SpringAiRestClientProperties.CONFIG_PREFIX)
+public class SpringAiRestClientProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.rest.client";
+
+	private Duration connectionTimeout = Duration.ofSeconds(10);
+
+	private Duration readTimeout = Duration.ofSeconds(30);
+
+	public Duration getConnectionTimeout() {
+		return connectionTimeout;
+	}
+
+	public void setConnectionTimeout(Duration connectionTimeout) {
+		this.connectionTimeout = connectionTimeout;
+	}
+
+	public Duration getReadTimeout() {
+		return readTimeout;
+	}
+
+	public void setReadTimeout(Duration readTimeout) {
+		this.readTimeout = readTimeout;
+	}
+
+}

--- a/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.springframework.ai.http.client.autoconfigure.SpringAiRestClientAutoConfiguration

--- a/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/test/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientAutoConfigurationIT.java
+++ b/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/test/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientAutoConfigurationIT.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.http.client.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.web.client.RestClientCustomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Song jaegeun
+ */
+public class SpringAiRestClientAutoConfigurationIT {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+			AutoConfigurations.of(SpringAiRestClientAutoConfigurationIT.class, RestClientAutoConfiguration.class));
+
+	@Test
+	void testRestClientAutoConfiguration() {
+		this.contextRunner.run(context -> {
+			assertThat(context).hasSingleBean(RestClientCustomizer.class);
+		});
+	}
+
+}

--- a/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/test/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientPropertiesTests.java
+++ b/auto-configurations/models/http/client/spring-ai-autoconfigure-http-client/src/test/java/org/springframework/ai/http/client/autoconfigure/SpringAiRestClientPropertiesTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.http.client.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit Tests for {@link SpringAiRestClientProperties}.
+ *
+ * @author Song Jaegeun
+ */
+public class SpringAiRestClientPropertiesTests {
+
+	@Test
+	public void restClientDefaultProperties() {
+
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(SpringAiRestClientAutoConfiguration.class))
+			.run(context -> {
+				var httpClientProperties = context.getBean(SpringAiRestClientProperties.class);
+
+				assertThat(httpClientProperties.getConnectionTimeout()).isEqualTo(Duration.ofSeconds(10));
+				assertThat(httpClientProperties.getReadTimeout()).isEqualTo(Duration.ofSeconds(30));
+			});
+	}
+
+	@Test
+	public void restClientCustomProperties() {
+		new ApplicationContextRunner().withPropertyValues(
+		// @formatter:off
+				"spring.ai.rest.client.connection-timeout=10s",
+				"spring.ai.rest.client.read-timeout=30s")
+				// @formatter:on
+			.withConfiguration(AutoConfigurations.of(SpringAiRestClientAutoConfiguration.class))
+			.run(context -> {
+				var httpClientProperties = context.getBean(SpringAiRestClientProperties.class);
+
+				assertThat(httpClientProperties.getConnectionTimeout()).isEqualTo(Duration.ofSeconds(10));
+				assertThat(httpClientProperties.getReadTimeout()).isEqualTo(Duration.ofSeconds(30));
+			});
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
 
 		<module>auto-configurations/common/spring-ai-autoconfigure-retry</module>
 
+		<module>auto-configurations/models/http/client/spring-ai-autoconfigure-http-client</module>
+
 		<module>auto-configurations/models/tool/spring-ai-autoconfigure-model-tool</module>
 
 		<module>auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client</module>
@@ -769,6 +771,8 @@
 								 <exclude>org.springframework.ai.autoconfigure.postgresml/**/**IT.java</exclude>
 
 								 <exclude>org.springframework.ai.autoconfigure.retry/**/**IT.java</exclude>
+
+								 <exclude>org.springframework.ai.http.client.autoconfigure/**/**IT.java</exclude>
 
 								 <exclude>org.springframework.ai.autoconfigure.stabilityai/**/**IT.java</exclude>
 								 <exclude>org.springframework.ai.autoconfigure.transformers/**/**IT.java</exclude>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-anthropic/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-anthropic/pom.xml
@@ -65,6 +65,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-deepseek/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-deepseek/pom.xml
@@ -65,6 +65,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-minimax/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-minimax/pom.xml
@@ -65,6 +65,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-mistral-ai/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-mistral-ai/pom.xml
@@ -65,6 +65,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-ollama/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-ollama/pom.xml
@@ -65,6 +65,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-openai/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-openai/pom.xml
@@ -65,6 +65,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-stability-ai/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-stability-ai/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>spring-ai-stability-ai</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-zhipuai/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-zhipuai/pom.xml
@@ -65,6 +65,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-vector-store-chroma/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-vector-store-chroma/pom.xml
@@ -55,6 +55,12 @@
             <artifactId>spring-ai-chroma-store</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-http-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-template-st/pom.xml
+++ b/spring-ai-template-st/pom.xml
@@ -16,7 +16,7 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>


### PR DESCRIPTION
Hi team,

This PR adds support for configuring `RestClient` timeouts via the new `spring.ai.http.client.connection-timeout` and `spring.ai.http.client.read-timeout` properties.

I understand that some of the previous timeout-related contributions were declined with the reasoning that `RestClientCustomizer` is the recommended way to control low-level HTTP behavior. However, I’d like to offer a slightly different perspective based on real-world usage and Spring Boot developer experience.

Spring AI clients such as `OpenAiChatModel` internally construct `RestClient` using `RestClient.builder()`, which makes it difficult for users to apply timeout settings without defining custom beans. For many users who just want to quickly call ChatGPT or OpenAI endpoints, defining a `RestClientCustomizer` bean solely to apply timeout settings is unexpected ceremony.

This PR follows the Spring Boot philosophy of externalized configuration with reasonable defaults, enabling users to declare timeout values in `application.yml` without writing additional Java code.

A new auto-configuration module (`spring-ai-autoconfigure-http-client`) is introduced to configure `RestClientBuilder` via `RestClientCustomizer`. The customizer is registered only if no other `RestClientCustomizer` is defined, using `@ConditionalOnMissingBean`, so it’s fully overridable. The timeout values are backed by a simple `@ConfigurationProperties` class (`SpringAiHttpClientProperties`) to keep things clean and idiomatic.

While `WebClient` timeout support would be useful as well, we chose not to include it yet because the most elegant and standardized way to configure timeouts (via `ClientHttpConnectorSettings`) is only available in Spring Boot 3.5+. Once Spring AI upgrades its baseline, we plan to extend this same configuration model to support `WebClient` as well.

This PR is designed to:

- Keep configuration consistent with Spring Boot patterns  
- Reduce friction for users who use `RestClient` implicitly via Spring AI models  
- Respect existing extension points (`RestClientCustomizer`) without overriding user-defined beans

Looking forward to your feedback.
