### PR TITLE
Add 'capabilities' field to ShowModelResponse in OllamaApi

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -694,6 +694,7 @@ public class OllamaApi {
 			@JsonProperty("messages") List<Message> messages,
 			@JsonProperty("model_info") Map<String, Object> modelInfo,
 			@JsonProperty("projector_info") Map<String, Object> projectorInfo,
+			@JsonProperty("capabilities") List<String> capabilities,
 			@JsonProperty("modified_at") Instant modifiedAt
 	) { }
 


### PR DESCRIPTION
This update enables deserialization of the 'capabilities' field from the JSON response.

[Ollama Show Model Information](https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information)

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
