### PR TITLE
Fix various typos and casing inconsistencies across the codebase

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpClientAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpClientAutoConfiguration.java
@@ -244,7 +244,7 @@ public class McpClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public CloseableMcpAsyncClients makeAsynClientsClosable(List<McpAsyncClient> clients) {
+	public CloseableMcpAsyncClients makeAsyncClientsClosable(List<McpAsyncClient> clients) {
 		return new CloseableMcpAsyncClients(clients);
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Conditional;
  */
 @AutoConfiguration(after = { McpClientAutoConfiguration.class })
 @EnableConfigurationProperties(McpClientCommonProperties.class)
-@Conditional(McpToolCallbackAutoConfiguration.McpToolCallbackAutoconfigurationCondition.class)
+@Conditional(McpToolCallbackAutoConfiguration.McpToolCallbackAutoConfigurationCondition.class)
 public class McpToolCallbackAutoConfiguration {
 
 	/**
@@ -64,9 +64,9 @@ public class McpToolCallbackAutoConfiguration {
 		return new AsyncMcpToolCallbackProvider(mcpClients);
 	}
 
-	public static class McpToolCallbackAutoconfigurationCondition extends AllNestedConditions {
+	public static class McpToolCallbackAutoConfigurationCondition extends AllNestedConditions {
 
-		public McpToolCallbackAutoconfigurationCondition() {
+		public McpToolCallbackAutoConfigurationCondition() {
 			super(ConfigurationPhase.PARSE_CONFIGURATION);
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/StdioTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/StdioTransportAutoConfiguration.java
@@ -67,21 +67,21 @@ public class StdioTransportAutoConfiguration {
 	 * <li>Server-specific parameters from properties
 	 * <li>Unique connection name for identification
 	 * </ul>
-	 * @param sdioProperties the stdio client properties containing server configurations
+	 * @param stdioProperties the stdio client properties containing server configurations
 	 * @return list of named MCP transports
 	 */
 	@Bean
-	public List<NamedClientMcpTransport> stdioTransports(McpStdioClientProperties sdioProperties) {
+	public List<NamedClientMcpTransport> stdioTransports(McpStdioClientProperties stdioProperties) {
 
-		List<NamedClientMcpTransport> stdoiTransports = new ArrayList<>();
+		List<NamedClientMcpTransport> stdioTransports = new ArrayList<>();
 
-		for (Map.Entry<String, ServerParameters> serverParameters : sdioProperties.toServerParameters().entrySet()) {
+		for (Map.Entry<String, ServerParameters> serverParameters : stdioProperties.toServerParameters().entrySet()) {
 			var transport = new StdioClientTransport(serverParameters.getValue());
-			stdoiTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
+			stdioTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 
 		}
 
-		return stdoiTransports;
+		return stdioTransports;
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationConditionTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationConditionTests.java
@@ -18,7 +18,7 @@ package org.springframework.ai.mcp.client.autoconfigure;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.ai.mcp.client.autoconfigure.McpToolCallbackAutoConfiguration.McpToolCallbackAutoconfigurationCondition;
+import org.springframework.ai.mcp.client.autoconfigure.McpToolCallbackAutoConfiguration.McpToolCallbackAutoConfigurationCondition;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -27,9 +27,9 @@ import org.springframework.context.annotation.Configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link McpToolCallbackAutoconfigurationCondition}.
+ * Tests for {@link McpToolCallbackAutoConfigurationCondition}.
  */
-public class McpToolCallbackAutoconfigurationConditionTests {
+public class McpToolCallbackAutoConfigurationConditionTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withUserConfiguration(TestConfiguration.class);
@@ -78,7 +78,7 @@ public class McpToolCallbackAutoconfigurationConditionTests {
 	}
 
 	@Configuration
-	@Conditional(McpToolCallbackAutoconfigurationCondition.class)
+	@Conditional(McpToolCallbackAutoConfigurationCondition.class)
 	static class TestConfiguration {
 
 		@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationTests.java
@@ -29,7 +29,7 @@ public class McpToolCallbackAutoConfigurationTests {
 		.withConfiguration(AutoConfigurations.of(McpToolCallbackAutoConfiguration.class));
 
 	@Test
-	void disabledByDeafault() {
+	void disabledByDefault() {
 
 		this.applicationContext.run(context -> {
 			assertThat(context).doesNotHaveBean("mcpToolCallbacks");
@@ -52,7 +52,7 @@ public class McpToolCallbackAutoConfigurationTests {
 	}
 
 	@Test
-	void enabledMcpToolCallbackAutoconfiguration() {
+	void enabledMcpToolCallbackAutoConfiguration() {
 
 		// sync
 		this.applicationContext.withPropertyValues("spring.ai.mcp.client.toolcallback.enabled=true").run(context -> {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfigurationIT.java
@@ -64,8 +64,8 @@ public class AnthropicChatAutoConfigurationIT {
 					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_3_5_SONNET.getValue())
 			.run(context -> {
 				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);
-				var optoins = AnthropicChatOptions.builder().maxTokens(8192).build();
-				var response = chatModel.call(new Prompt("Tell me a joke", optoins));
+				var options = AnthropicChatOptions.builder().maxTokens(8192).build();
+				var response = chatModel.call(new Prompt("Tell me a joke", options));
 				assertThat(response.getResult().getOutput().getText()).isNotEmpty();
 				logger.info("Response: " + response);
 			});

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingModelAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingModelAutoConfigurationIT.java
@@ -54,10 +54,10 @@ public class VertexAiTextEmbeddingModelAutoConfigurationIT {
 	public void textEmbedding() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(VertexAiTextEmbeddingAutoConfiguration.class))
 			.run(context -> {
-				var conntectionProperties = context.getBean(VertexAiEmbeddingConnectionProperties.class);
+				var connectionProperties = context.getBean(VertexAiEmbeddingConnectionProperties.class);
 				var textEmbeddingProperties = context.getBean(VertexAiTextEmbeddingProperties.class);
 
-				assertThat(conntectionProperties).isNotNull();
+				assertThat(connectionProperties).isNotNull();
 
 				VertexAiTextEmbeddingModel embeddingModel = context.getBean(VertexAiTextEmbeddingModel.class);
 				assertThat(embeddingModel).isInstanceOf(VertexAiTextEmbeddingModel.class);
@@ -97,10 +97,10 @@ public class VertexAiTextEmbeddingModelAutoConfigurationIT {
 	public void multimodalEmbedding() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(VertexAiMultiModalEmbeddingAutoConfiguration.class))
 			.run(context -> {
-				var conntectionProperties = context.getBean(VertexAiEmbeddingConnectionProperties.class);
+				var connectionProperties = context.getBean(VertexAiEmbeddingConnectionProperties.class);
 				var multimodalEmbeddingProperties = context.getBean(VertexAiMultimodalEmbeddingProperties.class);
 
-				assertThat(conntectionProperties).isNotNull();
+				assertThat(connectionProperties).isNotNull();
 
 				VertexAiMultimodalEmbeddingModel multiModelEmbeddingModel = context
 					.getBean(VertexAiMultimodalEmbeddingModel.class);

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
@@ -98,7 +98,7 @@ class SyncMcpToolCallbackProviderTests {
 	}
 
 	@Test
-	void getSameNameToolsButDifferntClientInfoNamesShouldProduceDifferentToolCallbackNames() {
+	void getSameNameToolsButDifferentClientInfoNamesShouldProduceDifferentToolCallbackNames() {
 
 		Tool tool1 = mock(Tool.class);
 		when(tool1.name()).thenReturn("sameName");

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -97,7 +97,7 @@ class ToolUtilsTests {
 	}
 
 	@Test
-	void toSyncToolSpecificaitonShouldConvertSingleCallback() {
+	void toSyncToolSpecificationShouldConvertSingleCallback() {
 
 		ToolCallback callback = createMockToolCallback("test", "success");
 
@@ -138,7 +138,7 @@ class ToolUtilsTests {
 	}
 
 	@Test
-	void toAsyncToolSpecificaitonShouldConvertSingleCallback() {
+	void toAsyncToolSpecificationShouldConvertSingleCallback() {
 		ToolCallback callback = createMockToolCallback("test", "success");
 
 		AsyncToolSpecification toolSpecification = McpToolUtils.toAsyncToolSpecification(callback);
@@ -160,10 +160,10 @@ class ToolUtilsTests {
 	void toAsyncToolSpecificationShouldHandleError() {
 		ToolCallback callback = createMockToolCallback("test", new RuntimeException("error"));
 
-		AsyncToolSpecification toolSpecificaiton = McpToolUtils.toAsyncToolSpecification(callback);
+		AsyncToolSpecification toolSpecification = McpToolUtils.toAsyncToolSpecification(callback);
 
-		assertThat(toolSpecificaiton).isNotNull();
-		StepVerifier.create(toolSpecificaiton.call().apply(mock(McpAsyncServerExchange.class), Map.of()))
+		assertThat(toolSpecification).isNotNull();
+		StepVerifier.create(toolSpecification.call().apply(mock(McpAsyncServerExchange.class), Map.of()))
 			.assertNext(result -> {
 				TextContent content = (TextContent) result.content().get(0);
 				assertThat(content.text()).isEqualTo("error");

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiResponseFormat.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiResponseFormat.java
@@ -27,7 +27,7 @@ public enum AzureOpenAiResponseFormat {
 	// default value used by OpenAI
 	TEXT,
 	/*
-	 * From the OpenAI API documentation: Compatability: Compatible with GPT-4 Turbo and
+	 * From the OpenAI API documentation: Compatibility: Compatible with GPT-4 Turbo and
 	 * all GPT-3.5 Turbo models newer than gpt-3.5-turbo-1106. Caveats: This enables JSON
 	 * mode, which guarantees the message the model generates is valid JSON. Important:
 	 * when using JSON mode, you must also instruct the model to produce JSON yourself via

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
@@ -84,7 +84,7 @@ class MistralAiChatModelIT {
 	protected Resource qaEvaluatorNotRelatedResource;
 
 	@Value("classpath:/prompts/eval/qa-evaluator-fact-based-answer.st")
-	protected Resource qaEvalutaorFactBasedAnswerResource;
+	protected Resource qaEvaluatorFactBasedAnswerResource;
 
 	@Value("classpath:/prompts/eval/user-evaluator-message.st")
 	protected Resource userEvaluatorResource;

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/VertexAiEmbeddingConnectionDetails.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/VertexAiEmbeddingConnectionDetails.java
@@ -122,7 +122,7 @@ public class VertexAiEmbeddingConnectionDetails {
 		private String publisher;
 
 		/**
-		 * Allows the connection settings to be customised
+		 * Allows the connection settings to be customized
 		 */
 		private PredictionServiceSettings predictionServiceSettings;
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -547,7 +547,7 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 
 	protected List<Generation> responseCandidateToGeneration(Candidate candidate) {
 
-		// TODO - The candidateIndex (e.g. choice must be asigned to the generation).
+		// TODO - The candidateIndex (e.g. choice must be assigned to the generation).
 		int candidateIndex = candidate.getIndex();
 		FinishReason candidateFinishReason = candidate.getFinishReason();
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
@@ -174,7 +174,7 @@ TIP: In addition to the model specific https://github.com/spring-projects/spring
 
 == Function Calling
 
-NOTE: The current version of the deepseek-chat model's Function Calling capabilitity is unstable, which may result in looped calls or empty responses.
+NOTE: The current version of the deepseek-chat model's Function Calling capability is unstable, which may result in looped calls or empty responses.
 
 == Multimodal
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/vertexai-gemini-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/vertexai-gemini-chat.adoc
@@ -10,7 +10,7 @@ link:https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemin
 
 == Prerequisites
 
-- Install the link:https://cloud.google.com/sdk/docs/install[gcloud] CLI, apropriate for you OS.
+- Install the link:https://cloud.google.com/sdk/docs/install[gcloud] CLI, appropriate for you OS.
 - Authenticate by running the following command.
 Replace `PROJECT_ID` with your Google Cloud project ID and `ACCOUNT` with your Google Cloud username.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/cloud-bindings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/cloud-bindings.adoc
@@ -38,7 +38,7 @@ The following are the components for which the cloud binding support is currentl
 [cols="|,|"]
 |====
 | Service Type	 | Binding Type | Source Properties | Target Properties
-| `Chroma Vecor Store`
+| `Chroma Vector Store`
 | `chroma` | `uri`, `username`, `passwor` | `spring.ai.vectorstore.chroma.client.host`, `spring.ai.vectorstore.chroma.client.port`, `spring.ai.vectorstore.chroma.client.username`, `spring.ai.vectorstore.chroma.client.host.password`
 
 | `Mistral AI`

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc
@@ -100,7 +100,7 @@ The prefix `spring.ai.azure.openai` is the property prefix to configure the conn
 | spring.ai.azure.openai.endpoint | The endpoint from the Azure AI OpenAI `Keys and Endpoint` section under `Resource Management` | -
 | spring.ai.azure.openai.openai-api-key |  (non Azure) OpenAI API key. Used to authenticate with the OpenAI service, instead of Azure OpenAI. 
 This automatically sets the endpoint to https://api.openai.com/v1. Use either `api-key` or `openai-api-key` property. 
-With this configuraiton the `spring.ai.azure.openai.embedding.options.deployment-name` is threated as an https://platform.openai.com/docs/models[OpenAi Model] name.| -
+With this configuration the `spring.ai.azure.openai.embedding.options.deployment-name` is threated as an https://platform.openai.com/docs/models[OpenAi Model] name.| -
 |====
 
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/onnx.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/onnx.adoc
@@ -129,7 +129,7 @@ that means that you model is larger than 2GB and is serialized in two files: `mo
 
 The `model.onnx_data` is called link:https://onnx.ai/onnx/repo-docs/ExternalData.html#external-data[External Data] and is expected to be under the same directory of the `model.onnx`.
 
-Currently the only workaround is to copy the large `model.onnx_data` in the folder you run your Boot applicaiton.
+Currently the only workaround is to copy the large `model.onnx_data` in the folder you run your Boot application.
 ====
 
 [NOTE]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-helpers.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-helpers.adoc
@@ -115,7 +115,7 @@ Async::
 [source,java]
 ----
 List<ToolCallback> toolCallbacks = // obtain tool callbacks
-List<AsyncToolSpecification> asyncToolSpecificaitons = McpToolUtils.toAsyncToolSpecifications(toolCallbacks);
+List<AsyncToolSpecification> asyncToolSpecifications = McpToolUtils.toAsyncToolSpecifications(toolCallbacks);
 ----
 +
 then you can use the `McpServer.AsyncSpecification` to register the tool specifications:
@@ -123,7 +123,7 @@ then you can use the `McpServer.AsyncSpecification` to register the tool specifi
 [source,java]
 ----
 McpServer.AsyncSpecification asyncSpec = ...
-asyncSpec.tools(asyncToolSpecificaitons);
+asyncSpec.tools(asyncToolSpecifications);
 ----
 ======
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/EmptyUsage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/EmptyUsage.java
@@ -19,7 +19,7 @@ package org.springframework.ai.chat.metadata;
 import java.util.Map;
 
 /**
- * A EmpytUsage implementation that returns zero for all property getters
+ * A EmptyUsage implementation that returns zero for all property getters
  *
  * @author John Blum
  * @author Ilayaperumal Gopinathan

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/UsageUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/UsageUtils.java
@@ -43,7 +43,7 @@ public final class UsageUtils {
 			usageFromPreviousChatResponse = previousChatResponse.getMetadata().getUsage();
 		}
 		else {
-			// Return the curent usage when the previous chat response usage is empty or
+			// Return the current usage when the previous chat response usage is empty or
 			// null.
 			return currentUsage;
 		}


### PR DESCRIPTION
This pull request fixes numerous minor typos and naming inconsistencies across the codebase.

### Changes included:
- Corrected misspellings such as `optoins` → `options`, `Differnt` → `Different`, `Autoconfiguration` -> `AutoConfiguration` etc.
- Standardized casing in class and file names (e.g., `McpToolCallbackAutoconfigurationConditionTests` → `McpToolCallbackAutoConfigurationConditionTests`)
- Verified all modified files compile and existing tests pass

These changes are limited to non-functional improvements (comments, naming, typos).
Unit test is passes.
Please let me know if you'd prefer these broken into smaller PRs or scoped differently.

Note: The CLA link (https://cla.pivotal.io/sign/spring) appears to be unavailable (`ERR_NAME_NOT_RESOLVED`).  
Is there an updated contributor license agreement process in place?

Please advise how to proceed.