### PR TITLE
Make allow image url for Anthropic Message API

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -88,6 +88,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Vitale
  * @author Claudio Silva Junior
  * @author Alexandros Pappas
+ * @author Jonghoon Park
  * @since 1.0.0
  */
 public class AnthropicChatModel implements ChatModel {
@@ -357,6 +358,18 @@ public class AnthropicChatModel implements ChatModel {
 			.build();
 	}
 
+	private Source getSourceByMedia(Media media) {
+		String data = this.fromMediaData(media.getData());
+
+		// http is not allowed and redirect not allowed
+		if (data.startsWith("https://")) {
+			return new Source(data);
+		}
+		else {
+			return new Source(media.getMimeType().toString(), data);
+		}
+	}
+
 	private String fromMediaData(Object mediaData) {
 		if (mediaData instanceof byte[] bytes) {
 			return Base64.getEncoder().encodeToString(bytes);
@@ -457,8 +470,7 @@ public class AnthropicChatModel implements ChatModel {
 						if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 							List<ContentBlock> mediaContent = userMessage.getMedia().stream().map(media -> {
 								Type contentBlockType = getContentBlockTypeByMedia(media);
-								var source = new Source(media.getMimeType().toString(),
-										this.fromMediaData(media.getData()));
+								var source = getSourceByMedia(media);
 								return new ContentBlock(contentBlockType, source);
 							}).toList();
 							contents.addAll(mediaContent);

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Thomas Vitale
  * @author Jihoon Kim
  * @author Alexandros Pappas
+ * @author Jonghoon Park
  * @since 1.0.0
  */
 public class AnthropicApi {
@@ -1038,13 +1039,15 @@ public class AnthropicApi {
 		 * @param mediaType The media type of the content. For example, "image/png" or
 		 * "image/jpeg".
 		 * @param data The base64-encoded data of the content.
+		 * @param url The url of the content. (image only)
 		 */
 		@JsonInclude(Include.NON_NULL)
 		public record Source(
 		// @formatter:off
 			@JsonProperty("type") String type,
 			@JsonProperty("media_type") String mediaType,
-			@JsonProperty("data") String data) {
+			@JsonProperty("data") String data,
+			@JsonProperty("url") String url) {
 			// @formatter:on
 
 			/**
@@ -1053,7 +1056,11 @@ public class AnthropicApi {
 			 * @param data The content data.
 			 */
 			public Source(String mediaType, String data) {
-				this("base64", mediaType, data);
+				this("base64", mediaType, data, null);
+			}
+
+			public Source(String url) {
+				this("url", null, null, url);
 			}
 
 		}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -301,14 +301,12 @@ class AnthropicChatClientIT {
 		assertThat(response).containsAnyOf("bananas", "apple", "bowl", "basket", "fruit stand");
 	}
 
-	@Disabled("Currently Anthropic API does not support external image URLs")
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "claude-3-opus-latest", "claude-3-5-sonnet-latest", "claude-3-haiku-latest",
-			"claude-3-7-sonnet-latest" })
+	@ValueSource(strings = { "claude-3-opus-latest", "claude-3-5-sonnet-latest", "claude-3-7-sonnet-latest" })
 	void multiModalityImageUrl(String modelName) throws IOException {
 
 		// TODO: add url method that wrapps the checked exception.
-		URL url = new URL("https://docs.spring.io/spring-ai/reference/1.0.0-SNAPSHOT/_images/multimodal.test.png");
+		URL url = new URL("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png");
 
 		// @formatter:off
 		String response = ChatClient.create(this.chatModel).prompt()


### PR DESCRIPTION
related issue: https://github.com/spring-projects/spring-ai/issues/2804

I have improved the Anthropic API to support image URLs.

---

The following areas still need improvement:
- In Spring AI, the `MimeType` is required in the `Media` object, but the Anthropic API does not require the MimeType. Therefore, we need to explicitly provide a MimeType (any value can be used).

example:
```
String response = ChatClient.create(this.chatModel).prompt()
        .options(AnthropicChatOptions.builder().model(modelName).build())
        .user(u -> u.text("Explain what do you see on this picture?").media(MimeTypeUtils.IMAGE_PNG, url))
        .call()
        .content();
```

`MimeTypeUtils.IMAGE_PNG` is not necessary for the Anthropic API, but it must be included to meet the requirements of Spring AI.

I thought that creating a `media(URL url)` method that does not require a `MimeType` could cause confusion with other models that mandate the use of a `MimeType.`