### PR TITLE
Delete non-existing methods

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -142,7 +142,7 @@ public class TokenTextSplitter extends TextSplitter {
 
 	private List<Integer> getEncodedTokens(String text) {
 		Assert.notNull(text, "Text must not be null");
-		return this.encoding.encode(text).boxed();
+		return this.encoding.encode(text);
 	}
 
 	private String decodeTokens(List<Integer> tokens) {


### PR DESCRIPTION
The boxed() method is not a method in List, but a method in Java's IntStream class.

