### PR TITLE
Update dependencies for vector stores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,8 +281,8 @@
 		<pdfbox.version>3.0.3</pdfbox.version>
 		<pgvector.version>0.1.6</pgvector.version>
 		<sap.hanadb.version>2.20.11</sap.hanadb.version>
-		<coherence.version>24.09</coherence.version>
-		<milvus.version>2.5.4</milvus.version>
+		<coherence.version>25.03</coherence.version>
+		<milvus.version>2.5.7</milvus.version>
 		<gemfire.testcontainers.version>2.3.0</gemfire.testcontainers.version>
 
 		<pinecone.version>4.0.1</pinecone.version>
@@ -292,17 +292,17 @@
 		<azure-core.version>1.53.0</azure-core.version>
 		<azure-json.version>1.3.0</azure-json.version>
 		<azure-identity.version>1.14.0</azure-identity.version>
-		<azure-search.version>11.6.1</azure-search.version>
+		<azure-search.version>11.7.6</azure-search.version>
 		<azure-cosmos.version>5.17.1</azure-cosmos.version>
-		<weaviate-client.version>5.0.1</weaviate-client.version>
+		<weaviate-client.version>5.2.0</weaviate-client.version>
 		<qdrant.version>1.13.0</qdrant.version>
-		<typesense.version>0.5.0</typesense.version>
-		<opensearch-client.version>2.10.1</opensearch-client.version>
+		<typesense.version>1.3.0</typesense.version>
+		<opensearch-client.version>2.23.0</opensearch-client.version>
 		<postgresql.version>42.7.5</postgresql.version>
-		<mariadb.version>3.5.1</mariadb.version>
+		<mariadb.version>3.5.3</mariadb.version>
 		<commonmark.version>0.22.0</commonmark.version>
 
-		<couchbase.version>3.7.8</couchbase.version>
+		<couchbase.version>3.8.0</couchbase.version>
 
 		<!-- testing dependencies -->
 		<okhttp3.version>4.12.0</okhttp3.version>

--- a/vector-stores/spring-ai-neo4j-store/pom.xml
+++ b/vector-stores/spring-ai-neo4j-store/pom.xml
@@ -46,7 +46,7 @@
 			<dependency>
 				<groupId>org.neo4j</groupId>
 				<artifactId>neo4j-cypher-dsl-bom</artifactId>
-				<version>2024.0.2</version>
+				<version>2024.5.1</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/vector-stores/spring-ai-redis-store/pom.xml
+++ b/vector-stores/spring-ai-redis-store/pom.xml
@@ -38,7 +38,7 @@
 
 	<properties>
 		<testcontainers-redis.version>2.2.0</testcontainers-redis.version>
-		<jedis.version>5.1.0</jedis.version>
+		<jedis.version>5.2.0</jedis.version>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
 	</properties>

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
@@ -32,6 +32,7 @@ import org.typesense.model.CollectionSchema;
 import org.typesense.model.DeleteDocumentsParameters;
 import org.typesense.model.Field;
 import org.typesense.model.ImportDocumentsParameters;
+import org.typesense.model.IndexAction;
 import org.typesense.model.MultiSearchCollectionParameters;
 import org.typesense.model.MultiSearchResult;
 import org.typesense.model.MultiSearchSearchesParameter;
@@ -154,7 +155,7 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		}).toList();
 
 		ImportDocumentsParameters importDocumentsParameters = new ImportDocumentsParameters();
-		importDocumentsParameters.action("upsert");
+		importDocumentsParameters.action(IndexAction.UPSERT);
 
 		try {
 			this.client.collections(this.collectionName).documents().import_(documentList, importDocumentsParameters);


### PR DESCRIPTION
Update multiple dependency versions including:

- Coherence from 24.09 to 25.03
- Milvus from 2.5.4 to 2.5.7
- Azure Search from 11.6.1 to 11.7.6
- Weaviate client from 5.0.1 to 5.2.0
- Typesense from 0.5.0 to 1.3.0 (with matching code update)
- OpenSearch client from 2.10.1 to 2.23.0
- MariaDB from 3.5.1 to 3.5.3
- Couchbase from 3.7.8 to 3.8.0
- Neo4j Cypher DSL from 2024.0.2 to 2024.5.1
- Jedis from 5.1.0 to 5.2.0

Updates TypesenseVectorStore to use IndexAction enum instead of string literal.

