### PR TITLE
Fix missing table name in exception message in CassandraVectorStore

### DIFF
--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
@@ -546,7 +546,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 			.getKeyspace(this.schema.keyspace)
 			.get()
 			.getTable(this.schema.table)
-			.isPresent(), "table %s does not exist");
+			.isPresent(), "table %s does not exist", this.schema.table);
 
 		TableMetadata tableMetadata = this.session.getMetadata()
 			.getKeyspace(this.schema.keyspace)


### PR DESCRIPTION
Updated the `Preconditions.checkState` call to include `this.schema.table` as an argument.

#2837