### PR TITLE
Remove deprecations post M7

### DIFF
--- a/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
+++ b/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
@@ -26,7 +26,6 @@ import reactor.core.publisher.Flux;
 import org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest;
 import org.springframework.ai.chat.client.advisor.api.AdvisedResponse;
-import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAroundAdvisorChain;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -66,51 +65,6 @@ public class VectorStoreChatMemoryAdvisor extends AbstractChatMemoryAdvisor<Vect
 			""";
 
 	private final String systemTextAdvise;
-
-	@Deprecated(forRemoval = true, since = "1.0.0-M6")
-	/**
-	 * @deprecated use {@link Builder} instead.
-	 */
-	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore) {
-		this(vectorStore, DEFAULT_SYSTEM_TEXT_ADVISE);
-	}
-
-	@Deprecated(forRemoval = true, since = "1.0.0-M6")
-	/**
-	 * @deprecated use {@link Builder} instead.
-	 */
-	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String systemTextAdvise) {
-		super(vectorStore);
-		this.systemTextAdvise = systemTextAdvise;
-	}
-
-	@Deprecated(forRemoval = true, since = "1.0.0-M6")
-	/**
-	 * @deprecated use {@link Builder} instead.
-	 */
-	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String defaultConversationId,
-			int chatHistoryWindowSize) {
-		this(vectorStore, defaultConversationId, chatHistoryWindowSize, DEFAULT_SYSTEM_TEXT_ADVISE);
-	}
-
-	@Deprecated(forRemoval = true, since = "1.0.0-M6")
-	/**
-	 * @deprecated use {@link Builder} instead.
-	 */
-	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String defaultConversationId,
-			int chatHistoryWindowSize, int order) {
-		this(vectorStore, defaultConversationId, chatHistoryWindowSize, DEFAULT_SYSTEM_TEXT_ADVISE, order);
-	}
-
-	@Deprecated(forRemoval = true, since = "1.0.0-M6")
-	/**
-	 * @deprecated use {@link Builder} instead.
-	 */
-	public VectorStoreChatMemoryAdvisor(VectorStore vectorStore, String defaultConversationId,
-			int chatHistoryWindowSize, String systemTextAdvise) {
-		this(vectorStore, defaultConversationId, chatHistoryWindowSize, systemTextAdvise,
-				Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER);
-	}
 
 	/**
 	 * Constructor for VectorStoreChatMemoryAdvisor.

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/tool/FunctionCallWithFunctionBeanIT.java
@@ -69,14 +69,14 @@ class FunctionCallWithFunctionBeanIT {
 						""");
 
 				ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-						VertexAiGeminiChatOptions.builder().function("weatherFunction").build()));
+						VertexAiGeminiChatOptions.builder().toolName("weatherFunction").build()));
 
 				logger.info("Response: {}", response);
 
 				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
-						VertexAiGeminiChatOptions.builder().function("weatherFunction3").build()));
+						VertexAiGeminiChatOptions.builder().toolName("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 
@@ -116,7 +116,7 @@ class FunctionCallWithFunctionBeanIT {
 				assertThat(response.getResult().getOutput().getText()).contains("30", "10", "15");
 
 				response = chatModel.call(new Prompt(List.of(userMessage),
-						VertexAiGeminiChatOptions.builder().function("weatherFunction3").build()));
+						VertexAiGeminiChatOptions.builder().toolName("weatherFunction3").build()));
 
 				logger.info("Response: {}", response);
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -593,26 +593,8 @@ public class AnthropicApi {
 			this.thinking = request.thinking;
 		}
 
-		/**
-		 * @deprecated use {@link #model(ChatModel)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withModel(ChatModel model) {
-			this.model = model.getValue();
-			return this;
-		}
-
 		public ChatCompletionRequestBuilder model(ChatModel model) {
 			this.model = model.getValue();
-			return this;
-		}
-
-		/**
-		 * @deprecated use {@link #model(String)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withModel(String model) {
-			this.model = model;
 			return this;
 		}
 
@@ -621,26 +603,8 @@ public class AnthropicApi {
 			return this;
 		}
 
-		/**
-		 * @deprecated use {@link #messages(List)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withMessages(List<AnthropicMessage> messages) {
-			this.messages = messages;
-			return this;
-		}
-
 		public ChatCompletionRequestBuilder messages(List<AnthropicMessage> messages) {
 			this.messages = messages;
-			return this;
-		}
-
-		/**
-		 * @deprecated use {@link #system(String)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withSystem(String system) {
-			this.system = system;
 			return this;
 		}
 
@@ -649,26 +613,8 @@ public class AnthropicApi {
 			return this;
 		}
 
-		/**
-		 * @deprecated use {@link #maxTokens(Integer)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withMaxTokens(Integer maxTokens) {
-			this.maxTokens = maxTokens;
-			return this;
-		}
-
 		public ChatCompletionRequestBuilder maxTokens(Integer maxTokens) {
 			this.maxTokens = maxTokens;
-			return this;
-		}
-
-		/**
-		 * @deprecated use {@link #metadata(ChatCompletionRequest.Metadata)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withMetadata(ChatCompletionRequest.Metadata metadata) {
-			this.metadata = metadata;
 			return this;
 		}
 
@@ -677,26 +623,8 @@ public class AnthropicApi {
 			return this;
 		}
 
-		/**
-		 * @deprecated use {@link #stopSequences(List)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withStopSequences(List<String> stopSequences) {
-			this.stopSequences = stopSequences;
-			return this;
-		}
-
 		public ChatCompletionRequestBuilder stopSequences(List<String> stopSequences) {
 			this.stopSequences = stopSequences;
-			return this;
-		}
-
-		/**
-		 * @deprecated use {@link #stream(Boolean)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withStream(Boolean stream) {
-			this.stream = stream;
 			return this;
 		}
 
@@ -705,26 +633,8 @@ public class AnthropicApi {
 			return this;
 		}
 
-		/**
-		 * @deprecated use {@link #temperature(Double)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withTemperature(Double temperature) {
-			this.temperature = temperature;
-			return this;
-		}
-
 		public ChatCompletionRequestBuilder temperature(Double temperature) {
 			this.temperature = temperature;
-			return this;
-		}
-
-		/**
-		 * @deprecated use {@link #topP(Double)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withTopP(Double topP) {
-			this.topP = topP;
 			return this;
 		}
 
@@ -733,26 +643,8 @@ public class AnthropicApi {
 			return this;
 		}
 
-		/**
-		 * @deprecated use {@link #topK(Integer)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withTopK(Integer topK) {
-			this.topK = topK;
-			return this;
-		}
-
 		public ChatCompletionRequestBuilder topK(Integer topK) {
 			this.topK = topK;
-			return this;
-		}
-
-		/**
-		 * @deprecated use {@link #tools(List)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withTools(List<Tool> tools) {
-			this.tools = tools;
 			return this;
 		}
 
@@ -761,27 +653,8 @@ public class AnthropicApi {
 			return this;
 		}
 
-		/**
-		 * @deprecated use {@link #thinking(ChatCompletionRequest.ThinkingConfig)}
-		 * instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withThinking(ChatCompletionRequest.ThinkingConfig thinking) {
-			this.thinking = thinking;
-			return this;
-		}
-
 		public ChatCompletionRequestBuilder thinking(ChatCompletionRequest.ThinkingConfig thinking) {
 			this.thinking = thinking;
-			return this;
-		}
-
-		/**
-		 * @deprecated use {@link #thinking(ThinkingType, Integer)} instead.
-		 */
-		@Deprecated(forRemoval = true, since = "1.0.0-M6")
-		public ChatCompletionRequestBuilder withThinking(ThinkingType type, Integer budgetTokens) {
-			this.thinking = new ChatCompletionRequest.ThinkingConfig(type, budgetTokens);
 			return this;
 		}
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
@@ -244,31 +244,6 @@ class BedrockProxyChatModelIT {
 				"fruit stand");
 	}
 
-	@Deprecated
-	@Test
-	void functionCallTestDeprecated() {
-
-		UserMessage userMessage = new UserMessage(
-				"What's the weather like in San Francisco, Tokyo and Paris? Return the result in Celsius.");
-
-		List<Message> messages = new ArrayList<>(List.of(userMessage));
-
-		var promptOptions = ToolCallingChatOptions.builder()
-			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
-				.description(
-						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
-				.inputType(MockWeatherService.Request.class)
-				.build()))
-			.build();
-
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
-
-		logger.info("Response: {}", response);
-
-		Generation generation = response.getResult();
-		assertThat(generation.getOutput().getText()).contains("30", "10", "15");
-	}
-
 	@Test
 	void functionCallTest() {
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -332,31 +332,6 @@ public class OpenAiChatModelIT extends AbstractIT {
 	}
 
 	@Test
-	@Deprecated
-	void functionCallTestDeprecated() {
-
-		UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");
-
-		List<Message> messages = new ArrayList<>(List.of(userMessage));
-
-		var promptOptions = OpenAiChatOptions.builder()
-			.model(OpenAiApi.ChatModel.GPT_4_O.getValue())
-			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
-				.description("Get the weather in location")
-				.inputType(MockWeatherService.Request.class)
-				.build()))
-			.build();
-
-		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
-
-		logger.info("Response: {}", response);
-
-		assertThat(response.getResult().getOutput().getText()).containsAnyOf("30.0", "30");
-		assertThat(response.getResult().getOutput().getText()).containsAnyOf("10.0", "10");
-		assertThat(response.getResult().getOutput().getText()).containsAnyOf("15.0", "15");
-	}
-
-	@Test
 	void functionCallTest() {
 
 		UserMessage userMessage = new UserMessage("What's the weather like in San Francisco, Tokyo, and Paris?");

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -417,20 +417,10 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		@Deprecated
-		public Builder functions(Set<String> functionNames) {
-			return this.toolNames(functionNames);
-		}
-
 		public Builder toolNames(Set<String> toolNames) {
 			Assert.notNull(toolNames, "Function names must not be null");
 			this.options.toolNames = toolNames;
 			return this;
-		}
-
-		@Deprecated
-		public Builder function(String functionName) {
-			return this.toolName(functionName);
 		}
 
 		public Builder toolName(String toolName) {

--- a/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/document/Document.java
@@ -247,12 +247,9 @@ public class Document {
 
 	/**
 	 * Returns the content formatter associated with this document.
-	 * @deprecated We are considering getting rid of this, please comment on
-	 * https://github.com/spring-projects/spring-ai/issues/1782
 	 * @return the current ContentFormatter instance used for formatting the document
 	 * content.
 	 */
-	@Deprecated(since = "1.0.0-M4")
 	public ContentFormatter getContentFormatter() {
 		return this.contentFormatter;
 	}

--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStoreContent.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/SimpleVectorStoreContent.java
@@ -103,19 +103,6 @@ public final class SimpleVectorStoreContent implements Content {
 		this.embedding = Arrays.copyOf(embedding, embedding.length);
 	}
 
-	/**
-	 * Creates a new instance with an updated embedding vector.
-	 * @param embedding the new embedding vector, must not be null
-	 * @return a new instance with the updated embedding
-	 * @throws IllegalArgumentException if embedding is null or empty
-	 */
-	@Deprecated(forRemoval = true, since = "1.0.0-M7")
-	public SimpleVectorStoreContent withEmbedding(float[] embedding) {
-		Assert.notNull(embedding, "embedding must not be null");
-		Assert.isTrue(embedding.length > 0, "embedding vector must not be empty");
-		return new SimpleVectorStoreContent(this.id, this.text, this.metadata, embedding);
-	}
-
 	public String getId() {
 		return this.id;
 	}


### PR DESCRIPTION
 - Remove deprecated constructors from VectorStoreChatMemoryAdvisor
 - Remove deprecated builder methods from AnthropicApi and SimpleVectorStoreContent
 - Remove deprecation annotation from ContentFormatter in Document
 - Remove deprecated test methods

