### PR TITLE
Update getting-started.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -70,6 +70,13 @@ repositories {
   }  
 }
 ----
+**NOTE:** If you're using Maven mirror settings (typically in `settings.xml`), ensure your `<mirrorOf>` configuration excludes Spring repositories:
+```xml
+<mirror>
+    <mirrorOf>*,!spring-snapshots,!central-portal-snapshots</mirrorOf>
+    <!-- other mirror configurations -->
+</mirror>
+```
 ======
 
 [[dependency-management]]


### PR DESCRIPTION
Add documentation about Maven mirror configuration when using Spring AI snapshots, including examples of correct mirrorOf settings to allow access to Spring repositories.


