### PR TITLE
mcp: support auth provider by HTTP basic auth

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
@@ -62,9 +62,11 @@ import org.springframework.web.reactive.function.server.RouterFunction;
  * }</pre>
  *
  * @author Christian Tzolov
+ * @author lambochen
  * @since 1.0.0
  * @see McpServerProperties
  * @see WebFluxSseServerTransportProvider
+ * @see McpServerAuthProvider
  */
 @AutoConfiguration
 @ConditionalOnClass({ WebFluxSseServerTransportProvider.class })

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.McpServerAuthProvider;
 import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 
@@ -75,9 +76,16 @@ public class McpWebFluxServerAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public WebFluxSseServerTransportProvider webFluxTransport(ObjectProvider<ObjectMapper> objectMapperProvider,
+			ObjectProvider<McpServerAuthProvider> mcpServerAuthProviderObjectProvider,
 			McpServerProperties serverProperties) {
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
-		return new WebFluxSseServerTransportProvider(objectMapper, serverProperties.getSseMessageEndpoint());
+		McpServerAuthProvider authProvider = mcpServerAuthProviderObjectProvider.getIfAvailable(() -> null);
+		return WebFluxSseServerTransportProvider.builder()
+			.sseEndpoint(serverProperties.getSseEndpoint())
+			.messageEndpoint(serverProperties.getSseMessageEndpoint())
+			.objectMapper(objectMapper)
+			.authProvider(authProvider)
+			.build();
 	}
 
 	// Router function for SSE transport used by Spring WebFlux to start an HTTP server.

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.McpServerAuthProvider;
 import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 
@@ -70,9 +71,13 @@ public class McpWebMvcServerAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider(
-			ObjectProvider<ObjectMapper> objectMapperProvider, McpServerProperties serverProperties) {
+			ObjectProvider<ObjectMapper> objectMapperProvider,
+			ObjectProvider<McpServerAuthProvider> mcpServerAuthProviderObjectProvider,
+			McpServerProperties serverProperties) {
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
-		return new WebMvcSseServerTransportProvider(objectMapper, serverProperties.getSseMessageEndpoint());
+		McpServerAuthProvider authProvider = mcpServerAuthProviderObjectProvider.getIfAvailable(() -> null);
+		return new WebMvcSseServerTransportProvider(objectMapper, serverProperties.getSseMessageEndpoint(),
+				serverProperties.getSseMessageEndpoint(), serverProperties.getSseEndpoint(), authProvider);
 	}
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
@@ -57,9 +57,11 @@ import org.springframework.web.servlet.function.ServerResponse;
  * }</pre>
  *
  * @author Christian Tzolov
+ * @author lambochen
  * @since 1.0.0
  * @see McpServerProperties
  * @see WebMvcSseServerTransportProvider
+ * @see McpServerAuthProvider
  */
 @AutoConfiguration
 @ConditionalOnClass({ WebMvcSseServerTransportProvider.class })

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
 		<okhttp3.version>4.12.0</okhttp3.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.9.0</mcp.sdk.version>
+		<mcp.sdk.version>0.10.0-SNAPSHOT</mcp.sdk.version>
 
 		<!-- plugin versions -->
 		<antlr.version>4.13.1</antlr.version>


### PR DESCRIPTION

Support a way to auth client-server connection by request params.
I think it's necessary, such as, When using Claude Desktop to connect to a remote MCP Server, only one URL can be filled in. If identity authentication and authorization are implemented, passing information from the request parameters is a good choice.

---
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
