### PR TITLE
fix null systemText in PromptChatMemoryAdvisor

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.advisor.api.AdvisedRequest;
@@ -33,7 +34,6 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.MessageAggregator;
-import org.springframework.ai.content.Content;
 
 /**
  * Memory is retrieved added into the prompt's system text.
@@ -111,14 +111,16 @@ public class PromptChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemor
 
 		String memory = (memoryMessages != null) ? memoryMessages.stream()
 			.filter(m -> m.getMessageType() == MessageType.USER || m.getMessageType() == MessageType.ASSISTANT)
-			.map(m -> m.getMessageType() + ":" + ((Content) m).getText())
+			.map(m -> m.getMessageType() + ":" + m.getText())
 			.collect(Collectors.joining(System.lineSeparator())) : "";
 
 		Map<String, Object> advisedSystemParams = new HashMap<>(request.systemParams());
 		advisedSystemParams.put("memory", memory);
 
 		// 2. Advise the system text.
-		String advisedSystemText = request.systemText() + System.lineSeparator() + this.systemTextAdvise;
+		String systemText = request.systemText();
+		String advisedSystemText = (StringUtils.hasText(systemText) ? systemText + System.lineSeparator() : "")
+				+ this.systemTextAdvise;
 
 		// 3. Create a new request with the advised system text and parameters.
 		AdvisedRequest advisedRequest = AdvisedRequest.from(request)


### PR DESCRIPTION
I started having `null` word in LLM prompts while using PromptChatMemoryAdvisor.

Since `systemText` is `@Nullable`, as a fix I added check for it.

![null in a prompt](https://github.com/user-attachments/assets/87112cdd-002c-43f3-b4ce-a79489e00177)

