### PR TITLE
Fix mutable observation context

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConvention.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConvention.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.client.observation;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import io.micrometer.common.KeyValue;
@@ -115,7 +116,7 @@ public class DefaultChatClientObservationConvention implements ChatClientObserva
 		if (CollectionUtils.isEmpty(context.getRequest().context())) {
 			return keyValues;
 		}
-		var chatClientContext = context.getRequest().context();
+		var chatClientContext = new HashMap<>(context.getRequest().context());
 		Arrays.stream(ChatClientAttributes.values()).forEach(attribute -> chatClientContext.remove(attribute.getKey()));
 		return keyValues.and(
 				ChatClientObservationDocumentation.HighCardinalityKeyNames.CHAT_CLIENT_ADVISOR_PARAMS.asString(),

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConventionTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConventionTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.client.observation;
 import java.util.List;
 
 import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -168,6 +169,26 @@ class DefaultChatClientObservationConventionTests {
 						"[\"tool1\", \"tool2\"]"),
 				KeyValue.of(HighCardinalityKeyNames.CHAT_CLIENT_TOOL_FUNCTION_CALLBACKS.asString(),
 						"[\"toolCallback1\", \"toolCallback2\"]"));
+	}
+
+	@Test
+	void entriesInAdvisorContextAreNotRemoved() {
+		var request = ChatClientRequest.builder()
+			.prompt(new Prompt(""))
+			.context("advParam1", "advisorParam1Value")
+			.context(ChatClientAttributes.ADVISORS.getKey(),
+					List.of(dummyAdvisor("advisor1"), dummyAdvisor("advisor2")))
+			.build();
+
+		ChatClientObservationContext observationContext = ChatClientObservationContext.builder()
+			.request(request)
+			.build();
+
+		assertThat(observationContext.getRequest().context()).hasSize(2);
+
+		this.observationConvention.chatClientAdvisorParams(KeyValues.empty(), observationContext);
+
+		assertThat(observationContext.getRequest().context()).hasSize(2);
 	}
 
 }


### PR DESCRIPTION
The DefaultChatClientObservationConvention is now not removing entries from the observation context, resulting in advisor context entries being removed in the ChatClientRequest.

Fixes gh-2876