### PR TITLE
Fix: Prevent exceptions when disabling MCP Server

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerStdioDisabledCondition.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerStdioDisabledCondition.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * This class defines a condition met when the MCP server is enabled and the STDIO
+ * Transport is disabled.
+ *
+ * @since 1.0.0
+ * @author YunKui Lu
+ */
+public class McpServerStdioDisabledCondition extends AllNestedConditions {
+
+	public McpServerStdioDisabledCondition() {
+		super(ConfigurationPhase.PARSE_CONFIGURATION);
+	}
+
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+			matchIfMissing = true)
+	static class McpServerEnabledCondition {
+
+	}
+
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "stdio", havingValue = "false",
+			matchIfMissing = true)
+	static class StdioDisabledCondition {
+
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfiguration.java
@@ -24,8 +24,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.web.reactive.function.server.RouterFunction;
 
 /**
@@ -68,8 +68,7 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 @AutoConfiguration
 @ConditionalOnClass({ WebFluxSseServerTransportProvider.class })
 @ConditionalOnMissingBean(McpServerTransportProvider.class)
-@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "stdio", havingValue = "false",
-		matchIfMissing = true)
+@Conditional(McpServerStdioDisabledCondition.class)
 public class McpWebFluxServerAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfiguration.java
@@ -24,8 +24,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.ServerResponse;
 
@@ -63,8 +63,7 @@ import org.springframework.web.servlet.function.ServerResponse;
 @AutoConfiguration
 @ConditionalOnClass({ WebMvcSseServerTransportProvider.class })
 @ConditionalOnMissingBean(McpServerTransportProvider.class)
-@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "stdio", havingValue = "false",
-		matchIfMissing = true)
+@Conditional(McpServerStdioDisabledCondition.class)
 public class McpWebMvcServerAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpWebFluxServerAutoConfigurationIT.java
@@ -53,4 +53,12 @@ class McpWebFluxServerAutoConfigurationIT {
 			.run(context -> assertThat(context).doesNotHaveBean(WebFluxSseServerTransportProvider.class));
 	}
 
+	@Test
+	void serverDisableConfiguration() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.enabled=false").run(context -> {
+			assertThat(context).doesNotHaveBean(WebFluxSseServerTransportProvider.class);
+			assertThat(context).doesNotHaveBean(RouterFunction.class);
+		});
+	}
+
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpWebMvcServerAutoConfigurationIT.java
@@ -26,7 +26,7 @@ import org.springframework.web.servlet.function.RouterFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class McpWebMvcServerAutoConfigurationTest {
+class McpWebMvcServerAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
 			AutoConfigurations.of(McpWebMvcServerAutoConfiguration.class, McpServerAutoConfiguration.class));
@@ -51,6 +51,14 @@ class McpWebMvcServerAutoConfigurationTest {
 	void stdioEnabledConfiguration() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.server.stdio=true")
 			.run(context -> assertThat(context).doesNotHaveBean(WebMvcSseServerTransportProvider.class));
+	}
+
+	@Test
+	void serverDisableConfiguration() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.enabled=false").run(context -> {
+			assertThat(context).doesNotHaveBean(WebMvcSseServerTransportProvider.class);
+			assertThat(context).doesNotHaveBean(RouterFunction.class);
+		});
 	}
 
 }


### PR DESCRIPTION
- Prevent projects depending on `mcp-server-webmvc` or `mcp-server-webflux` from exceptions when `spring.ai.mcp.server.enabled` is set to `false`.
- Add unit tests to verify.

When the project depends on the `spring-ai-starter-mcp-server-webmvc` package but attempts to temporarily disable the MCP server (via `spring.ai.mcp.server.enabled=false`), the following exception is thrown:
<img width="1361" alt="image" src="https://github.com/user-attachments/assets/5743f9d5-df8a-4f21-b4cc-15afdadf380d" />

