### PR TITLE
feat(mcp): add support for completion specifications in MCP server

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
@@ -28,9 +28,11 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.SyncSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
@@ -173,6 +175,7 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<SyncToolSpecification>> tools,
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
+			ObjectProvider<List<SyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
 			List<ToolCallbackProvider> toolCallbackProvider) {
 
@@ -214,6 +217,15 @@ public class McpServerAutoConfiguration {
 			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
 			logger.info("Registered prompts: " + promptSpecifications.size() + ", notification: "
 					+ serverProperties.isPromptChangeNotification());
+		}
+
+		List<SyncCompletionSpecification> completionSpecifications = completions.stream()
+			.flatMap(List::stream)
+			.toList();
+		if (!CollectionUtils.isEmpty(completionSpecifications)) {
+			serverBuilder.completions(completionSpecifications);
+			capabilitiesBuilder.completions();
+			logger.info("Registered completions: " + completionSpecifications.size());
 		}
 
 		rootsChangeConsumers.ifAvailable(consumer -> {
@@ -270,6 +282,7 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<AsyncToolSpecification>> tools,
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
+			ObjectProvider<List<AsyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpAsyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumer,
 			List<ToolCallbackProvider> toolCallbackProvider) {
 
@@ -311,6 +324,15 @@ public class McpServerAutoConfiguration {
 			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
 			logger.info("Registered prompts: " + promptSpecifications.size() + ", notification: "
 					+ serverProperties.isPromptChangeNotification());
+		}
+
+		List<AsyncCompletionSpecification> completionSpecifications = completions.stream()
+			.flatMap(List::stream)
+			.toList();
+		if (!CollectionUtils.isEmpty(completionSpecifications)) {
+			serverBuilder.completions(completionSpecifications);
+			capabilitiesBuilder.completions();
+			logger.info("Registered completions: " + completionSpecifications.size());
 		}
 
 		rootsChangeConsumer.ifAvailable(consumer -> {

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
 		<okhttp3.version>4.12.0</okhttp3.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.9.0</mcp.sdk.version>
+		<mcp.sdk.version>0.10.0-SNAPSHOT</mcp.sdk.version>
 
 		<!-- plugin versions -->
 		<antlr.version>4.13.1</antlr.version>


### PR DESCRIPTION
Add support for completion specifications in both sync and async MCP servers by:

- Adding parameters for SyncCompletionSpecification and AsyncCompletionSpecification
- Implementing registration of completion specifications in server builders
- Updating capabilities builders to include completions
- Upgrading MCP SDK version to 0.10.0-SNAPSHOT
