### PR TITLE
Maven build issues fixes

### DIFF
--- a/auto-configurations/common/spring-ai-autoconfigure-retry/pom.xml
+++ b/auto-configurations/common/spring-ai-autoconfigure-retry/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-retry</artifactId>
-			<version>${parent.version}</version>
+			<version>${project.parent.version}</version>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -327,11 +327,13 @@
 		<maven-project-info-reports-plugin.version>3.4.5</maven-project-info-reports-plugin.version>
 		<maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
 		<spring-javaformat-maven-plugin.version>0.0.43</spring-javaformat-maven-plugin.version>
-
+		<antora-maven-plugin.version>1.0.0-alpha.5</antora-maven-plugin.version>
+		<antora-component-version-maven-plugin.version>0.0.4</antora-component-version-maven-plugin.version>
 		<maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
 		<maven-checkstyle-plugin.failsOnError>true</maven-checkstyle-plugin.failsOnError>
 		<maven-checkstyle-plugin.failOnViolation>true</maven-checkstyle-plugin.failOnViolation>
 		<puppycrawl-tools-checkstyle.version>9.3</puppycrawl-tools-checkstyle.version>
+
 		<disable.checks>true</disable.checks>
 
 	</properties>

--- a/spring-ai-docs/pom.xml
+++ b/spring-ai-docs/pom.xml
@@ -38,6 +38,7 @@
 			<plugin>
 				<groupId>org.antora</groupId>
 				<artifactId>antora-maven-plugin</artifactId>
+				<version>${antora-maven-plugin.version}</version>
 				<extensions>true</extensions>
 				<configuration>
 					<options>
@@ -60,6 +61,7 @@
 			<plugin>
 				<groupId>io.spring.maven.antora</groupId>
 				<artifactId>antora-component-version-maven-plugin</artifactId>
+				<version>${antora-component-version-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<goals>

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -38,6 +38,7 @@
 
 	<properties>
 		<spring-ai-testcontainers.skipITs>false</spring-ai-testcontainers.skipITs>
+		<maven.javadoc.skip>true</maven.javadoc.skip>
 	</properties>
 
 	<dependencies>

--- a/vector-stores/spring-ai-couchbase-store/pom.xml
+++ b/vector-stores/spring-ai-couchbase-store/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-vector-store</artifactId>
-			<version>${parent.version}</version>
+			<version>${project.parent.version}</version>
 		</dependency>
 
 
@@ -38,14 +38,14 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-openai</artifactId>
-			<version>${parent.version}</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
-			<version>${parent.version}</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
I have addressed the following warnings and errors that occurred during the Maven build:

```shell
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.springframework.ai:spring-ai-docs:jar:1.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for io.spring.maven.antora:antora-component-version-maven-plugin is missing. @ line 60, column 12
[WARNING] 'build.plugins.plugin.version' for org.antora:antora-maven-plugin is missing. @ line 38, column 12
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.springframework.ai:spring-ai-autoconfigure-retry:jar:1.0.0-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.springframework.ai:spring-ai-couchbase-store:jar:1.0.0-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
…
[ERROR] MavenReportException: Error while generating Javadoc: 
Exit code: 1
error: No public or protected classes found to document.
1 error
Command line was: /Users/my_user/.sdkman/candidates/java/21.0.7-tem/bin/javadoc @options @packages

Refer to the generated Javadoc files in '/Users/my_user/IDE/Personal_Projects/spring-ai/spring-ai-spring-boot-testcontainers/target/apidocs' dir.

org.apache.maven.reporting.MavenReportException: 
Exit code: 1
error: No public or protected classes found to document.
1 error
Command line was: /Users/my_user/.sdkman/candidates/java/21.0.7-tem/bin/javadoc @options @packages

Refer to the generated Javadoc files in '/Users/my_user/IDE/Personal_Projects/spring-ai/spring-ai-spring-boot-testcontainers/target/apidocs' dir.

    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.doExecuteJavadocCommandLine (AbstractJavadocMojo.java:5166)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.executeJavadocCommandLine (AbstractJavadocMojo.java:5051)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.executeReport (AbstractJavadocMojo.java:2022)
    at org.apache.maven.plugins.javadoc.JavadocJar.doExecute (JavadocJar.java:181)
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.execute (AbstractJavadocMojo.java:1818)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
    at org.codehaus.classworlds.Launcher.main (Launcher.java:41)
```
