### PR TITLE
Configure TemplateRenderer in ChatClient

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -34,6 +34,7 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.converter.StructuredOutputConverter;
+import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.core.ParameterizedTypeReference;
@@ -247,6 +248,8 @@ public interface ChatClient {
 
 		ChatClientRequestSpec user(Consumer<PromptUserSpec> consumer);
 
+		ChatClientRequestSpec templateRenderer(TemplateRenderer templateRenderer);
+
 		CallResponseSpec call();
 
 		StreamResponseSpec stream();
@@ -281,6 +284,8 @@ public interface ChatClient {
 		Builder defaultSystem(Resource text);
 
 		Builder defaultSystem(Consumer<PromptSystemSpec> systemSpecConsumer);
+
+		Builder defaultTemplateRenderer(TemplateRenderer templateRenderer);
 
 		Builder defaultTools(String... toolNames);
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -33,6 +33,7 @@ import org.springframework.ai.chat.client.observation.ChatClientObservationConve
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.function.FunctionToolCallback;
@@ -66,7 +67,7 @@ public class DefaultChatClientBuilder implements Builder {
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), null, Map.of(), List.of(),
 				List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
-				customObservationConvention, Map.of());
+				customObservationConvention, Map.of(), null);
 	}
 
 	public ChatClient build() {
@@ -187,6 +188,12 @@ public class DefaultChatClientBuilder implements Builder {
 
 	public Builder defaultToolContext(Map<String, Object> toolContext) {
 		this.defaultRequest.toolContext(toolContext);
+		return this;
+	}
+
+	public Builder defaultTemplateRenderer(TemplateRenderer templateRenderer) {
+		Assert.notNull(templateRenderer, "templateRenderer cannot be null");
+		this.defaultRequest.templateRenderer(templateRenderer);
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequest.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequest.java
@@ -37,6 +37,8 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.template.TemplateRenderer;
+import org.springframework.ai.template.st.StTemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -199,8 +201,12 @@ public record AdvisedRequest(
 	}
 
 	public ChatClientRequest toChatClientRequest() {
+		return toChatClientRequest(StTemplateRenderer.builder().build());
+	}
+
+	public ChatClientRequest toChatClientRequest(TemplateRenderer templateRenderer) {
 		return ChatClientRequest.builder()
-			.prompt(toPrompt())
+			.prompt(toPrompt(templateRenderer))
 			.context(this.adviseContext)
 			.context(ChatClientAttributes.ADVISORS.getKey(), this.advisors)
 			.context(ChatClientAttributes.CHAT_MODEL.getKey(), this.chatModel)
@@ -210,12 +216,21 @@ public record AdvisedRequest(
 	}
 
 	public Prompt toPrompt() {
+		return toPrompt(StTemplateRenderer.builder().build());
+	}
+
+	public Prompt toPrompt(TemplateRenderer templateRenderer) {
 		var messages = new ArrayList<>(this.messages());
 
 		String processedSystemText = this.systemText();
 		if (StringUtils.hasText(processedSystemText)) {
 			if (!CollectionUtils.isEmpty(this.systemParams())) {
-				processedSystemText = new PromptTemplate(processedSystemText, this.systemParams()).render();
+				processedSystemText = PromptTemplate.builder()
+					.template(processedSystemText)
+					.variables(this.systemParams())
+					.renderer(templateRenderer)
+					.build()
+					.render();
 			}
 			messages.add(new SystemMessage(processedSystemText));
 		}
@@ -224,7 +239,12 @@ public record AdvisedRequest(
 			Map<String, Object> userParams = new HashMap<>(this.userParams());
 			String processedUserText = this.userText();
 			if (!CollectionUtils.isEmpty(userParams)) {
-				processedUserText = new PromptTemplate(processedUserText, userParams).render();
+				processedUserText = PromptTemplate.builder()
+					.template(processedUserText)
+					.variables(userParams)
+					.renderer(templateRenderer)
+					.build()
+					.render();
 			}
 			messages.add(new UserMessage(processedUserText, this.media()));
 		}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseAdvisorChain.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.chat.client.advisor.api;
 
+import org.springframework.ai.template.TemplateRenderer;
+import org.springframework.ai.template.st.StTemplateRenderer;
+
 /**
  * A base interface for advisor chains that can be used to chain multiple advisors
  * together, both for call and stream advisors.
@@ -24,5 +27,9 @@ package org.springframework.ai.chat.client.advisor.api;
  * @since 1.0.0
  */
 public interface BaseAdvisorChain extends CallAdvisorChain, StreamAdvisorChain {
+
+	default TemplateRenderer getTemplateRenderer() {
+		return StTemplateRenderer.builder().build();
+	}
 
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
@@ -95,4 +95,11 @@ class DefaultChatClientBuilderTests {
 			.hasMessage("charset cannot be null");
 	}
 
+	@Test
+	void whenTemplateRendererIsNullThenThrows() {
+		DefaultChatClientBuilder builder = new DefaultChatClientBuilder(mock(ChatModel.class));
+		assertThatThrownBy(() -> builder.defaultTemplateRenderer(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("templateRenderer cannot be null");
+	}
+
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1302,7 +1302,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
 				chatModel, null, Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(),
-				Map.of(), ObservationRegistry.NOOP, null, Map.of());
+				Map.of(), ObservationRegistry.NOOP, null, Map.of(), null);
 		assertThat(spec).isNotNull();
 	}
 
@@ -1310,7 +1310,7 @@ class DefaultChatClientTests {
 	void whenChatModelIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), null,
 				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
-				ObservationRegistry.NOOP, null, Map.of()))
+				ObservationRegistry.NOOP, null, Map.of(), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
 	}
@@ -1319,7 +1319,7 @@ class DefaultChatClientTests {
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mock(ChatModel.class), null,
 				Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), null,
-				null, Map.of()))
+				null, Map.of(), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequestTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/api/AdvisedRequestTests.java
@@ -30,6 +30,8 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.template.TemplateRenderer;
+import org.springframework.ai.template.st.StTemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -157,12 +159,12 @@ class AdvisedRequestTests {
 	}
 
 	@Test
-	void whenConvertToAndFromChatClientRequest() {
+	void whenConvertToAndFromChatClientRequestWithDefaultTemplateRenderer() {
 		ChatModel chatModel = mock(ChatModel.class);
 		ChatOptions chatOptions = ToolCallingChatOptions.builder().build();
 		List<Message> messages = List.of(mock(UserMessage.class));
 		SystemMessage systemMessage = new SystemMessage("Instructions {key}");
-		UserMessage userMessage = new UserMessage("Question {key}", mock(Media.class));
+		UserMessage userMessage = UserMessage.builder().text("Question {key}").media(mock(Media.class)).build();
 		Map<String, Object> systemParams = Map.of("key", "value");
 		Map<String, Object> userParams = Map.of("key", "value");
 		List<String> toolNames = List.of("tool1", "tool2");
@@ -208,6 +210,70 @@ class AdvisedRequestTests {
 		AdvisedRequest convertedAdvisedRequest = AdvisedRequest.from(chatClientRequest);
 		assertThat(convertedAdvisedRequest.toPrompt()).isEqualTo(chatClientRequest.prompt());
 		assertThat(convertedAdvisedRequest.adviseContext()).containsAllEntriesOf(chatClientRequest.context());
+		assertThat(chatClientRequest.context().get(ChatClientAttributes.USER_PARAMS.getKey())).isEqualTo(userParams);
+		assertThat(chatClientRequest.context().get(ChatClientAttributes.SYSTEM_PARAMS.getKey()))
+			.isEqualTo(systemParams);
+	}
+
+	@Test
+	void whenConvertToAndFromChatClientRequestWithCustomTemplateRenderer() {
+		ChatModel chatModel = mock(ChatModel.class);
+		ChatOptions chatOptions = ToolCallingChatOptions.builder().build();
+		SystemMessage systemMessage = new SystemMessage("Instructions <name>");
+		UserMessage userMessage = UserMessage.builder().text("Question <name>").media(mock(Media.class)).build();
+		Map<String, Object> systemParams = Map.of("name", "Spring AI");
+		Map<String, Object> userParams = Map.of("name", "Spring AI");
+
+		AdvisedRequest advisedRequest = AdvisedRequest.builder()
+			.chatModel(chatModel)
+			.chatOptions(chatOptions)
+			.systemText(systemMessage.getText())
+			.systemParams(systemParams)
+			.userText(userMessage.getText())
+			.userParams(userParams)
+			.media(userMessage.getMedia())
+			.build();
+
+		TemplateRenderer customRenderer = StTemplateRenderer.builder()
+			.startDelimiterToken('<')
+			.endDelimiterToken('>')
+			.build();
+		ChatClientRequest chatClientRequest = advisedRequest.toChatClientRequest(customRenderer);
+
+		assertThat(chatClientRequest.prompt().getInstructions()).hasSize(2);
+		assertThat(chatClientRequest.prompt().getInstructions().get(0)).isInstanceOf(SystemMessage.class);
+		assertThat(chatClientRequest.prompt().getInstructions().get(1)).isInstanceOf(UserMessage.class);
+		assertThat(chatClientRequest.context().get(ChatClientAttributes.USER_PARAMS.getKey())).isEqualTo(userParams);
+		assertThat(chatClientRequest.context().get(ChatClientAttributes.SYSTEM_PARAMS.getKey()))
+			.isEqualTo(systemParams);
+	}
+
+	@Test
+	void whenUsingToPromptWithCustomTemplateRenderer() {
+		ChatModel chatModel = mock(ChatModel.class);
+		SystemMessage systemMessage = new SystemMessage("Instructions <name>");
+		UserMessage userMessage = UserMessage.builder().text("Question <name>").media(mock(Media.class)).build();
+		Map<String, Object> systemParams = Map.of("name", "Spring AI");
+		Map<String, Object> userParams = Map.of("name", "Spring AI");
+
+		AdvisedRequest advisedRequest = AdvisedRequest.builder()
+			.chatModel(chatModel)
+			.systemText(systemMessage.getText())
+			.systemParams(systemParams)
+			.userText(userMessage.getText())
+			.userParams(userParams)
+			.media(userMessage.getMedia())
+			.build();
+
+		TemplateRenderer customRenderer = StTemplateRenderer.builder()
+			.startDelimiterToken('<')
+			.endDelimiterToken('>')
+			.build();
+		var prompt = advisedRequest.toPrompt(customRenderer);
+
+		assertThat(prompt.getInstructions()).hasSize(2);
+		assertThat(prompt.getInstructions().get(0).getText()).isEqualTo("Instructions Spring AI");
+		assertThat(prompt.getInstructions().get(1).getText()).isEqualTo("Question Spring AI");
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -165,6 +165,37 @@ String content = this.flux.collectList().block().stream().collect(Collectors.joi
 List<ActorFilms> actorFilms = this.converter.convert(this.content);
 ----
 
+== Prompt Templates
+
+The `ChatClient` fluent API lets you provide user and system text as templates with variables that are replaced at runtime.
+
+[source,java]
+----
+String answer = ChatClient.create(chatModel).prompt()
+    .user(u -> u
+            .text("Tell me the names of 5 movies whose soundtrack was composed by {composer}")
+            .param("composer", "John Williams"))
+    .call()
+    .content();
+----
+
+Internally, the ChatClient uses the `PromptTemplate` class to handle the user and system text and replace the variables with the values provided at runtime relying on a given `TemplateRenderer` implementation. By default, Spring AI uses the `StTemplateRenderer` implementation, which is based on the open-source https://www.stringtemplate.org/[StringTemplate] engine developed by Terence Parr.
+
+If you'd rather use a different template engine, you can provide a custom implementation of the `TemplateRenderer` interface directly to the ChatClient. You can also keep using the default `StTemplateRenderer`, but with a custom configuration.
+
+For example, by default, template variables are identified by the `{}` syntax. If you're planning to include JSON in your prompt, you might want to use a different syntax to avoid conflicts with JSON syntax. For example, you can use the `<` and `>` delimiters.
+
+[source,java]
+----
+String answer = ChatClient.create(chatModel).prompt()
+    .user(u -> u
+            .text("Tell me the names of 5 movies whose soundtrack was composed by <composer>")
+            .param("composer", "John Williams"))
+    .templateRenderer(StTemplateRenderer.builder().startDelimiterToken('<').endDelimiterToken('>').build())
+    .call()
+    .content();
+----
+
 == call() return values
 
 After specifying the `call()` method on `ChatClient`, there are a few different options for the response type.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/prompt.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/prompt.adoc
@@ -20,7 +20,6 @@ Initially, prompts were simple strings.
 Over time, they grew to include placeholders for specific inputs, like "USER:", which the AI model recognizes.
 OpenAI have introduced even more structure to prompts by categorizing multiple message strings into distinct roles before they are processed by the AI model.
 
-
 == API Overview
 
 === Prompt
@@ -34,14 +33,15 @@ This arrangement enables intricate and detailed interactions with AI models, as 
 
 Below is a truncated version of the Prompt class, with constructors and utility methods omitted for brevity:
 
-```java
+[source,java]
+----
 public class Prompt implements ModelRequest<List<Message>> {
 
     private final List<Message> messages;
 
     private ChatOptions chatOptions;
 }
-```
+----
 
 === Message
 
@@ -49,7 +49,8 @@ The `Message` interface encapsulates a `Prompt` textual content, a collection of
 
 The interface is defined as follows:
 
-```java
+[source,java]
+----
 public interface Content {
 
 	String getContent();
@@ -61,17 +62,18 @@ public interface Message extends Content {
 
 	MessageType getMessageType();
 }
-```
+----
 
 The multimodal message types implement also the `MediaContent` interface providing a list of `Media` content objects.
 
-```java
+[source,java]
+----
 public interface MediaContent extends Content {
 
 	Collection<Media> getMedia();
 
 }
-```
+----
 
 Various implementations of the `Message` interface correspond to different categories of messages that an AI model can process. 
 The Models distinguish between message categories based on conversational roles. 
@@ -99,7 +101,8 @@ It's like a special feature in the AI, used when needed to perform specific func
 
 Roles are represented as an enumeration in Spring AI as shown below
 
-```java
+[source,java]
+----
 public enum MessageType {
 
 	USER("user"),
@@ -112,20 +115,31 @@ public enum MessageType {
 
     ...
 }
-```
+----
 
 === PromptTemplate
 
-A key component for prompt templating in Spring AI is the `PromptTemplate` class.
-This class uses the OSS https://www.stringtemplate.org/[StringTemplate] engine, developed by Terence Parr, for constructing and managing prompts.
-The `PromptTemplate` class is designed to facilitate the creation of structured prompts that are then sent to the AI model for processing
+A key component for prompt templating in Spring AI is the `PromptTemplate` class, designed to facilitate the creation of structured prompts that are then sent to the AI model for processing
 
-```java
+[source,java]
+----
 public class PromptTemplate implements PromptTemplateActions, PromptTemplateMessageActions {
 
     // Other methods to be discussed later
 }
-```
+----
+
+This class uses the `TemplateRenderer` API to render templates. By default, Spring AI uses the `StTemplateRenderer` implementation, which is based on the open-source https://www.stringtemplate.org/[StringTemplate] engine developed by Terence Parr. Template variables are identified by the `{}` syntax, but you can configure the delimiters to use other syntax as well.
+
+[source,java]
+----
+public interface TemplateRenderer extends BiFunction<String, Map<String, Object>, String> {
+
+	@Override
+	String apply(String template, Map<String, Object> variables);
+
+}
+----
 
 The interfaces implemented by this class support different aspects of prompt creation:
 
@@ -139,7 +153,8 @@ While these interfaces might not be used extensively in many projects, they show
 
 The implemented interfaces are
 
-```java
+[source,java]
+----
 public interface PromptTemplateStringActions {
 
 	String render();
@@ -147,13 +162,14 @@ public interface PromptTemplateStringActions {
 	String render(Map<String, Object> model);
 
 }
-```
+----
 
 The method `String render()`: Renders a prompt template into a final string format without external input, suitable for templates without placeholders or dynamic content.
 
 The method `String render(Map<String, Object> model)`: Enhances rendering functionality to include dynamic content. It uses a `Map<String, Object>` where map keys are placeholder names in the prompt template, and values are the dynamic content to be inserted.
 
-```java
+[source,java]
+----
 public interface PromptTemplateMessageActions {
 
 	Message createMessage();
@@ -163,7 +179,7 @@ public interface PromptTemplateMessageActions {
 	Message createMessage(Map<String, Object> model);
 
 }
-```
+----
 
 The method `Message createMessage()`: Creates a `Message` object without additional data, used for static or predefined message content.
 
@@ -172,7 +188,8 @@ The method `Message createMessage(List<Media> mediaList)`: Creates a `Message` o
 The method `Message createMessage(Map<String, Object> model)`: Extends message creation to integrate dynamic content, accepting a `Map<String, Object>` where each entry represents a placeholder in the message template and its corresponding dynamic value.
 
 
-```java
+[source,java]
+----
 public interface PromptTemplateActions extends PromptTemplateStringActions {
 
 	Prompt create();
@@ -184,7 +201,7 @@ public interface PromptTemplateActions extends PromptTemplateStringActions {
 	Prompt create(Map<String, Object> model, ChatOptions modelOptions);
 
 }
-```
+----
 
 The method `Prompt create()`: Generates a `Prompt` object without external data inputs, ideal for static or predefined prompts.
 
@@ -198,18 +215,19 @@ The method `Prompt create(Map<String, Object> model, ChatOptions modelOptions)`:
 
 A simple example taken from the https://github.com/Azure-Samples/spring-ai-azure-workshop/blob/main/2-README-prompt-templating.md[AI Workshop on PromptTemplates] is shown below.
 
-```java
-
+[source,java]
+----
 PromptTemplate promptTemplate = new PromptTemplate("Tell me a {adjective} joke about {topic}");
 
 Prompt prompt = promptTemplate.create(Map.of("adjective", adjective, "topic", topic));
 
 return chatModel.call(prompt).getResult();
-```
+----
 
 Another example taken from the https://github.com/Azure-Samples/spring-ai-azure-workshop/blob/main/3-README-prompt-roles.md[AI Workshop on Roles] is shown below.
 
-```java
+[source,java]
+----
 String userText = """
     Tell me about three famous pirates from the Golden Age of Piracy and why they did.
     Write at least a sentence for each pirate.
@@ -229,28 +247,47 @@ Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", name, 
 Prompt prompt = new Prompt(List.of(userMessage, systemMessage));
 
 List<Generation> response = chatModel.call(prompt).getResults();
-
-```
+----
 
 This shows how you can build up the `Prompt` instance by using the `SystemPromptTemplate` to create a `Message` with the system role passing in placeholder values.
 The message with the role `user` is then combined with the message of the role `system` to form the prompt.
 The prompt is then passed to the ChatModel to get a generative response.
+
+=== Using a custom template renderer
+
+You can use a custom template renderer by implementing the `TemplateRenderer` interface and passing it to the `PromptTemplate` constructor. You can also keep using the default `StTemplateRenderer`, but with a custom configuration.
+
+By default, template variables are identified by the `{}` syntax. If you're planning to include JSON in your prompt, you might want to use a different syntax to avoid conflicts with JSON syntax. For example, you can use the `<` and `>` delimiters.
+
+[source,java]
+----
+PromptTemplate promptTemplate = PromptTemplate.builder()
+    .renderer(StTemplateRenderer.builder().startDelimiterToken('<').endDelimiterToken('>').build())
+    .template("""
+            Tell me the names of 5 movies whose soundtrack was composed by <composer>.
+            """)
+    .build();
+
+String prompt = promptTemplate.render(Map.of("composer", "John Williams"));
+----
 
 === Using resources instead of raw Strings
 
 Spring AI supports the `org.springframework.core.io.Resource` abstraction, so you can put prompt data in a file that can directly be used in a `PromptTemplate`.
 For example, you can define a field in your Spring managed component to retrieve the `Resource`.
 
-```java
+[source,java]
+----
 @Value("classpath:/prompts/system-message.st")
 private Resource systemResource;
-```
+----
 
 and then pass that resource to the `SystemPromptTemplate` directly.
 
-```java
+[source,java]
+----
 SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(systemResource);
-```
+----
 
 == Prompt Engineering
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -25,8 +25,7 @@ To use the `QuestionAnswerAdvisor` or `RetrievalAugmentationAdvisor`, you need t
 
 === QuestionAnswerAdvisor
 
-A vector database stores data that the AI model is unaware of.
-When a user question is sent to the AI model, a `QuestionAnswerAdvisor` queries the vector database for documents related to the user question.
+A vector database stores data that the AI model is unaware of. When a user question is sent to the AI model, a `QuestionAnswerAdvisor` queries the vector database for documents related to the user question.
 
 The response from the vector database is appended to the user text to provide context for the AI model to generate a response.
 
@@ -42,17 +41,17 @@ ChatResponse response = ChatClient.builder(chatModel)
         .chatResponse();
 ----
 
-In this example, the `QuestionAnswerAdvisor` will perform a similarity search over all documents in the Vector Database.
-To restrict the types of documents that are searched, the `SearchRequest` takes an SQL like filter expression that is portable across all `VectorStores`.
+In this example, the `QuestionAnswerAdvisor` will perform a similarity search over all documents in the Vector Database. To restrict the types of documents that are searched, the `SearchRequest` takes an SQL like filter expression that is portable across all `VectorStores`.
 
-This filter expression can be configured when creating the `QuestionAnswerAdvisor` and hence will always apply to all `ChatClient` requests or it can be provided at runtime per request.
+This filter expression can be configured when creating the `QuestionAnswerAdvisor` and hence will always apply to all `ChatClient` requests, or it can be provided at runtime per request.
 
 Here is how to create an instance of `QuestionAnswerAdvisor` where the threshold is `0.8` and to return the top `6` results.
 
 [source,java]
 ----
-var qaAdvisor = new QuestionAnswerAdvisor(this.vectorStore,
-        SearchRequest.builder().similarityThreshold(0.8d).topK(6).build());
+var qaAdvisor = QuestionAnswerAdvisor.builder(vectorStore)
+        .searchRequest(SearchRequest.builder().similarityThreshold(0.8d).topK(6).build())
+        .build();
 ----
 
 ==== Dynamic Filter Expressions
@@ -62,7 +61,9 @@ Update the `SearchRequest` filter expression at runtime using the `FILTER_EXPRES
 [source,java]
 ----
 ChatClient chatClient = ChatClient.builder(chatModel)
-    .defaultAdvisors(new QuestionAnswerAdvisor(vectorStore, SearchRequest.builder().build()))
+    .defaultAdvisors(QuestionAnswerAdvisor.builder(vectorStore)
+        .searchRequest(SearchRequest.builder().build())
+        .build())
     .build();
 
 // Update filter expression at runtime
@@ -74,6 +75,43 @@ String content = this.chatClient.prompt()
 ----
 
 The `FILTER_EXPRESSION` parameter allows you to dynamically filter the search results based on the provided expression.
+
+==== Custom Template
+
+The `QuestionAnswerAdvisor` uses a default template to augment the user question with the retrieved documents, but you can always customize it by providing your own template as a `PromptTemplate` object. This object can be created using the `PromptTemplate` builder and can use any `TemplateRenderer` implementation to render the actual template (by default, `PromptTemplate` uses the `StPromptTemplate` implementation based on the https://www.stringtemplate.org/[StringTemplate] engine). The important thing to remember is that the template must contain the following placeholder, independently of the templating syntax: `question_answer_context`.
+
+[source,java]
+----
+PromptTemplate customPromptTemplate = PromptTemplate.builder()
+    .renderer(StTemplateRenderer.builder().startDelimiterToken('<').endDelimiterToken('>').build())
+    .template("""
+            Context information is below.
+
+			---------------------
+			<question_answer_context>
+			---------------------
+
+			Given the context information and no prior knowledge, answer the query.
+
+			Follow these rules:
+
+			1. If the answer is not in the context, just say that you don't know.
+			2. Avoid statements like "Based on the context..." or "The provided information...".
+            """)
+    .build();
+
+    String question = "Where does the adventure of Anacletus and Birba take place?";
+
+    QuestionAnswerAdvisor qaAdvisor = QuestionAnswerAdvisor.builder(vectorStore)
+        .promptTemplate(customPromptTemplate)
+        .build();
+
+    String response = ChatClient.builder(chatModel).build()
+        .prompt(question)
+        .advisors(qaAdvisor)
+        .call()
+        .content();
+----
 
 === RetrievalAugmentationAdvisor (Incubating)
 

--- a/spring-ai-integration-tests/pom.xml
+++ b/spring-ai-integration-tests/pom.xml
@@ -63,6 +63,13 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-advisors-vector-store</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-openai</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/QuestionAnswerAdvisorIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/QuestionAnswerAdvisorIT.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.integration.tests.client.advisor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.ai.evaluation.EvaluationRequest;
+import org.springframework.ai.evaluation.EvaluationResponse;
+import org.springframework.ai.evaluation.RelevancyEvaluator;
+import org.springframework.ai.integration.tests.TestApplication;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.reader.markdown.MarkdownDocumentReader;
+import org.springframework.ai.reader.markdown.config.MarkdownDocumentReaderConfig;
+import org.springframework.ai.template.st.StTemplateRenderer;
+import org.springframework.ai.vectorstore.pgvector.PgVectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link QuestionAnswerAdvisor}.
+ *
+ * @author Thomas Vitale
+ */
+@SpringBootTest(classes = TestApplication.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
+public class QuestionAnswerAdvisorIT {
+
+	private List<Document> knowledgeBaseDocuments;
+
+	@Autowired
+	OpenAiChatModel openAiChatModel;
+
+	@Autowired
+	PgVectorStore pgVectorStore;
+
+	@Value("${classpath:documents/knowledge-base.md}")
+	Resource knowledgeBaseResource;
+
+	@BeforeEach
+	void setUp() {
+		DocumentReader markdownReader = new MarkdownDocumentReader(this.knowledgeBaseResource,
+				MarkdownDocumentReaderConfig.defaultConfig());
+		this.knowledgeBaseDocuments = markdownReader.read();
+		this.pgVectorStore.add(this.knowledgeBaseDocuments);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.pgVectorStore.delete(this.knowledgeBaseDocuments.stream().map(Document::getId).toList());
+	}
+
+	@Test
+	void qaBasic() {
+		String question = "Where does the adventure of Anacletus and Birba take place?";
+
+		QuestionAnswerAdvisor qaAdvisor = QuestionAnswerAdvisor.builder(this.pgVectorStore).build();
+
+		ChatResponse chatResponse = ChatClient.builder(this.openAiChatModel)
+			.build()
+			.prompt(question)
+			.advisors(qaAdvisor)
+			.call()
+			.chatResponse();
+
+		assertThat(chatResponse).isNotNull();
+
+		String response = chatResponse.getResult().getOutput().getText();
+		System.out.println(response);
+		assertThat(response).containsIgnoringCase("Highlands");
+
+		evaluateRelevancy(question, chatResponse);
+	}
+
+	@Test
+	void qaCustomTemplateRenderer() {
+		QuestionAnswerAdvisor qaAdvisor = QuestionAnswerAdvisor.builder(this.pgVectorStore).build();
+
+		ChatResponse chatResponse = ChatClient.builder(this.openAiChatModel)
+			.build()
+			.prompt()
+			.user(user -> user.text("Where does the adventure of <character1> and <character2> take place?")
+				.param("character1", "Anacletus")
+				.param("character2", "Birba"))
+			.advisors(qaAdvisor)
+			.templateRenderer(StTemplateRenderer.builder().startDelimiterToken('<').endDelimiterToken('>').build())
+			.call()
+			.chatResponse();
+
+		assertThat(chatResponse).isNotNull();
+
+		String response = chatResponse.getResult().getOutput().getText();
+		System.out.println(response);
+		assertThat(response).containsIgnoringCase("Highlands");
+
+		evaluateRelevancy("Where does the adventure of Anacletus and Birba take place?", chatResponse);
+	}
+
+	@Test
+	void qaCustomPromptTemplate() {
+		PromptTemplate customPromptTemplate = PromptTemplate.builder()
+			.renderer(StTemplateRenderer.builder().startDelimiterToken('$').endDelimiterToken('$').build())
+			.template("""
+
+					Context information is below, surrounded by ---------------------
+
+					---------------------
+					$question_answer_context$
+					---------------------
+
+					Given the context and provided history information and not prior knowledge,
+					reply to the user comment. If the answer is not in the context, inform
+					the user that you can't answer the question.
+					""")
+			.build();
+
+		String question = "Where does the adventure of Anacletus and Birba take place?";
+
+		QuestionAnswerAdvisor qaAdvisor = QuestionAnswerAdvisor.builder(this.pgVectorStore)
+			.promptTemplate(customPromptTemplate)
+			.build();
+
+		ChatResponse chatResponse = ChatClient.builder(this.openAiChatModel)
+			.build()
+			.prompt(question)
+			.advisors(qaAdvisor)
+			.call()
+			.chatResponse();
+
+		assertThat(chatResponse).isNotNull();
+
+		String response = chatResponse.getResult().getOutput().getText();
+		System.out.println(response);
+		assertThat(response).containsIgnoringCase("Highlands");
+
+		evaluateRelevancy(question, chatResponse);
+	}
+
+	private void evaluateRelevancy(String question, ChatResponse chatResponse) {
+		EvaluationRequest evaluationRequest = new EvaluationRequest(question,
+				chatResponse.getMetadata().get(QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS),
+				chatResponse.getResult().getOutput().getText());
+		RelevancyEvaluator evaluator = new RelevancyEvaluator(ChatClient.builder(this.openAiChatModel));
+		EvaluationResponse evaluationResponse = evaluator.evaluate(evaluationRequest);
+		assertThat(evaluationResponse.isPass()).isTrue();
+	}
+
+}


### PR DESCRIPTION
- Extend the ChatClient with a new templateRenderer() method to pass a custom TemplateRenderer object used to render user and system templates.
- Evolve the QuestionAnswerAdvisor to accept a PromptTemplate for customising the RAG prompt and templating logic while maintaining backward compatibility.
- Introduce integration tests for the QuestionAnswerAdvisor.
- Document the TemplateRenderer API and how to use it to build PromptTemplate with custom templating logic.
- Document how to customise the templating logic used internally by the ChatClient via the TemplateRendererAPI.

Fixes gh-355
Fixes gh-1687
Fixes gh-2448
Fixes gh-1849
Fixes gh-1428