### PR TITLE
Add default ChatOptions to Prompt

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -110,7 +110,8 @@ class DefaultChatClientTests {
 		assertThat(spec.getMessages()).hasSize(2);
 		assertThat(spec.getMessages().get(0).getText()).isEqualTo("instructions");
 		assertThat(spec.getMessages().get(1).getText()).isEqualTo("my question");
-		assertThat(spec.getChatOptions()).isNull();
+		assertThat(spec.getChatOptions()).isNotNull();
+		assertThat(spec.getChatOptions()).isInstanceOf(ChatOptions.class);
 	}
 
 	@Test

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -45,7 +45,6 @@ public class Prompt implements ModelRequest<List<Message>> {
 
 	private final List<Message> messages;
 
-	@Nullable
 	private ChatOptions chatOptions;
 
 	public Prompt(String contents) {
@@ -57,24 +56,24 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	public Prompt(List<Message> messages) {
-		this(messages, null);
+		this(messages, ChatOptions.builder().build());
 	}
 
 	public Prompt(Message... messages) {
-		this(Arrays.asList(messages), null);
+		this(Arrays.asList(messages), ChatOptions.builder().build());
 	}
 
-	public Prompt(String contents, @Nullable ChatOptions chatOptions) {
+	public Prompt(String contents, ChatOptions chatOptions) {
 		this(new UserMessage(contents), chatOptions);
 	}
 
-	public Prompt(Message message, @Nullable ChatOptions chatOptions) {
+	public Prompt(Message message, ChatOptions chatOptions) {
 		this(Collections.singletonList(message), chatOptions);
 	}
 
-	public Prompt(List<Message> messages, @Nullable ChatOptions chatOptions) {
+	public Prompt(List<Message> messages, ChatOptions chatOptions) {
 		this.messages = messages;
-		this.chatOptions = chatOptions;
+		this.chatOptions = (chatOptions != null) ? chatOptions : ChatOptions.builder().build();
 	}
 
 	public String getContents() {
@@ -86,7 +85,6 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	@Override
-	@Nullable
 	public ChatOptions getOptions() {
 		return this.chatOptions;
 	}


### PR DESCRIPTION
 - Remove @Nullable on ChatOptions
 - By default, pass the default ChatOptions from the DefaultChatOptionsBuilder

