### PR TITLE
Support URI in Media

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.ai.content;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 
 import org.springframework.core.io.Resource;
@@ -64,6 +65,7 @@ import org.springframework.util.MimeType;
  *
  * @author Christian Tzolov
  * @author Mark Pollack
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 public class Media {
@@ -75,7 +77,7 @@ public class Media {
 	 * media it has been passed.
 	 */
 	@Nullable
-	private String id;
+	private final String id;
 
 	private final MimeType mimeType;
 
@@ -98,13 +100,29 @@ public class Media {
 	 * <li>Square brackets
 	 * </ul>
 	 */
-	private String name;
+	private final String name;
+
+	/**
+	 * Create a new Media instance.
+	 * @param mimeType the media MIME type
+	 * @param uri the URI for the media data
+	 */
+	public Media(MimeType mimeType, URI uri) {
+		Assert.notNull(mimeType, "MimeType must not be null");
+		Assert.notNull(uri, "URI must not be null");
+		this.mimeType = mimeType;
+		this.id = null;
+		this.data = uri.toString();
+		this.name = generateDefaultName(mimeType);
+	}
 
 	/**
 	 * Create a new Media instance.
 	 * @param mimeType the media MIME type
 	 * @param url the URL for the media data
+	 * @deprecated in favour of {@link #Media(MimeType, URI)}
 	 */
+	@Deprecated
 	public Media(MimeType mimeType, URL url) {
 		Assert.notNull(mimeType, "MimeType must not be null");
 		Assert.notNull(url, "URL must not be null");
@@ -138,7 +156,7 @@ public class Media {
 	 * Creates a new Media builder.
 	 * @return a new Media builder instance
 	 */
-	public static final Builder builder() {
+	public static Builder builder() {
 		return new Builder();
 	}
 
@@ -148,7 +166,7 @@ public class Media {
 	 * @param data the media data
 	 * @param id the media id
 	 */
-	private Media(MimeType mimeType, Object data, String id, String name) {
+	private Media(MimeType mimeType, Object data, @Nullable String id, @Nullable String name) {
 		Assert.notNull(mimeType, "MimeType must not be null");
 		Assert.notNull(data, "Data must not be null");
 		this.mimeType = mimeType;
@@ -171,7 +189,7 @@ public class Media {
 
 	/**
 	 * Get the media data object
-	 * @return a java.net.URL.toString() or a byte[]
+	 * @return a java.net.URI.toString() or a byte[]
 	 */
 	public Object getData() {
 		return this.data;
@@ -194,6 +212,7 @@ public class Media {
 	 * Get the media id
 	 * @return the media id
 	 */
+	@Nullable
 	public String getId() {
 		return this.id;
 	}
@@ -261,11 +280,25 @@ public class Media {
 		}
 
 		/**
+		 * Sets the media data from a URI.
+		 * @param uri the media URI, must not be null
+		 * @return the builder instance
+		 * @throws IllegalArgumentException if URI is null
+		 */
+		public Builder data(URI uri) {
+			Assert.notNull(uri, "URI must not be null");
+			this.data = uri.toString();
+			return this;
+		}
+
+		/**
 		 * Sets the media data from a URL.
 		 * @param url the media URL, must not be null
 		 * @return the builder instance
 		 * @throws IllegalArgumentException if url is null
+		 * @deprecated in favour of {@link #data(URI)}
 		 */
+		@Deprecated
 		public Builder data(URL url) {
 			Assert.notNull(url, "URL must not be null");
 			this.data = url.toString();

--- a/spring-ai-commons/src/main/java/org/springframework/ai/content/package-info.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/content/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Core observation abstractions.
+ */
+package org.springframework.ai.content;

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -191,7 +191,7 @@ or the image URL equivalent:
 ----
 var userMessage = new UserMessage("Explain what do you see on this picture?",
         new Media(MimeTypeUtils.IMAGE_PNG,
-                "https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png"));
+                URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png")));
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage,
         ChatOptions.builder().model(MistralAiApi.ChatModel.PIXTRAL_LARGE.getValue()).build()));

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -221,7 +221,7 @@ or the image URL equivalent using the `gpt-4o` model:
 ----
 var userMessage = new UserMessage("Explain what do you see on this picture?",
         new Media(MimeTypeUtils.IMAGE_PNG,
-                "https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png"));
+                URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png")));
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage,
         OpenAiChatOptions.builder().model(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));


### PR DESCRIPTION
Introduce defining Media objects from a URI, deprecating the previous URL support.

Fixes gh-1147