### PR TITLE
Revert the commits which added default chat/image options when creating Prompt

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiRetryTests.java
@@ -34,6 +34,7 @@ import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.image.ImageMessage;
+import org.springframework.ai.image.ImageOptionsBuilder;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionOptions;
@@ -250,7 +251,8 @@ public class OpenAiRetryTests {
 			.willThrow(new TransientAiException("Transient Error 2"))
 			.willReturn(ResponseEntity.of(Optional.of(expectedResponse)));
 
-		var result = this.imageModel.call(new ImagePrompt(List.of(new ImageMessage("Image Message"))));
+		var result = this.imageModel
+			.call(new ImagePrompt(List.of(new ImageMessage("Image Message")), ImageOptionsBuilder.builder().build()));
 
 		assertThat(result).isNotNull();
 		assertThat(result.getResult().getOutput().getUrl()).isEqualTo("url678");
@@ -262,8 +264,8 @@ public class OpenAiRetryTests {
 	public void openAiImageNonTransientError() {
 		given(this.openAiImageApi.createImage(isA(OpenAiImageRequest.class)))
 			.willThrow(new RuntimeException("Transient Error 1"));
-		assertThrows(RuntimeException.class,
-				() -> this.imageModel.call(new ImagePrompt(List.of(new ImageMessage("Image Message")))));
+		assertThrows(RuntimeException.class, () -> this.imageModel
+			.call(new ImagePrompt(List.of(new ImageMessage("Image Message")), ImageOptionsBuilder.builder().build())));
 	}
 
 	private static class TestRetryListener implements RetryListener {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -110,8 +110,7 @@ class DefaultChatClientTests {
 		assertThat(spec.getMessages()).hasSize(2);
 		assertThat(spec.getMessages().get(0).getText()).isEqualTo("instructions");
 		assertThat(spec.getMessages().get(1).getText()).isEqualTo("my question");
-		assertThat(spec.getChatOptions()).isNotNull();
-		assertThat(spec.getChatOptions()).isInstanceOf(ChatOptions.class);
+		assertThat(spec.getChatOptions()).isNull();
 	}
 
 	@Test

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -47,7 +47,8 @@ public class Prompt implements ModelRequest<List<Message>> {
 
 	private final List<Message> messages;
 
-	private final ChatOptions chatOptions;
+	@Nullable
+	private ChatOptions chatOptions;
 
 	public Prompt(String contents) {
 		this(new UserMessage(contents));
@@ -58,26 +59,26 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	public Prompt(List<Message> messages) {
-		this(messages, ChatOptions.builder().build());
+		this(messages, null);
 	}
 
 	public Prompt(Message... messages) {
-		this(Arrays.asList(messages), ChatOptions.builder().build());
+		this(Arrays.asList(messages), null);
 	}
 
-	public Prompt(String contents, ChatOptions chatOptions) {
+	public Prompt(String contents, @Nullable ChatOptions chatOptions) {
 		this(new UserMessage(contents), chatOptions);
 	}
 
-	public Prompt(Message message, ChatOptions chatOptions) {
+	public Prompt(Message message, @Nullable ChatOptions chatOptions) {
 		this(Collections.singletonList(message), chatOptions);
 	}
 
-	public Prompt(List<Message> messages, ChatOptions chatOptions) {
+	public Prompt(List<Message> messages, @Nullable ChatOptions chatOptions) {
 		Assert.notNull(messages, "messages cannot be null");
 		Assert.noNullElements(messages, "messages cannot contain null elements");
 		this.messages = messages;
-		this.chatOptions = (chatOptions != null) ? chatOptions : ChatOptions.builder().build();
+		this.chatOptions = chatOptions;
 	}
 
 	public String getContents() {
@@ -89,6 +90,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	@Override
+	@Nullable
 	public ChatOptions getOptions() {
 		return this.chatOptions;
 	}
@@ -134,7 +136,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	public Prompt copy() {
-		return new Prompt(instructionsCopy(), this.chatOptions.copy());
+		return new Prompt(instructionsCopy(), null == this.chatOptions ? null : this.chatOptions.copy());
 	}
 
 	private List<Message> instructionsCopy() {
@@ -196,7 +198,9 @@ public class Prompt implements ModelRequest<List<Message>> {
 
 	public Builder mutate() {
 		Builder builder = new Builder().messages(instructionsCopy());
-		builder.chatOptions(this.chatOptions.copy());
+		if (this.chatOptions != null) {
+			builder.chatOptions(this.chatOptions.copy());
+		}
 		return builder;
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/image/ImagePrompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/image/ImagePrompt.java
@@ -29,7 +29,12 @@ public class ImagePrompt implements ModelRequest<List<ImageMessage>> {
 	private ImageOptions imageModelOptions;
 
 	public ImagePrompt(List<ImageMessage> messages) {
-		this(messages, ImageOptionsBuilder.builder().build());
+		this.messages = messages;
+	}
+
+	public ImagePrompt(List<ImageMessage> messages, ImageOptions imageModelOptions) {
+		this.messages = messages;
+		this.imageModelOptions = imageModelOptions;
 	}
 
 	public ImagePrompt(ImageMessage imageMessage, ImageOptions imageOptions) {
@@ -42,11 +47,6 @@ public class ImagePrompt implements ModelRequest<List<ImageMessage>> {
 
 	public ImagePrompt(String instructions) {
 		this(new ImageMessage(instructions), ImageOptionsBuilder.builder().build());
-	}
-
-	public ImagePrompt(List<ImageMessage> messages, ImageOptions imageModelOptions) {
-		this.messages = messages;
-		this.imageModelOptions = imageModelOptions != null ? imageModelOptions : ImageOptionsBuilder.builder().build();
 	}
 
 	@Override


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
