### PR TITLE
Fix incorrect ChatMemory initialization example in chat-memory.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -142,7 +142,7 @@ For example, if you want to use `MessageWindowChatMemory` with the `MessageChatM
 
 [source,java]
 ----
-ChatMemory chatMemory = MessageChatMemoryAdvisor.builder().build();
+ChatMemory chatMemory = MessageWindowChatMemory.builder().build();
 
 ChatClient chatClient = ChatClient.builder(chatModel)
     .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())


### PR DESCRIPTION
This pull request updates the example in chat-memory.adoc where ChatMemory was incorrectly initialized using MessageChatMemoryAdvisor.builder().build().
It has been corrected to use MessageWindowChatMemory.builder().build() as intended.