### PR TITLE
Re-enable completionspec features in MCP server

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
@@ -28,11 +28,11 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.SyncSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures;
-// import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
-// import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
@@ -175,7 +175,7 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<SyncToolSpecification>> tools,
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
-			// ObjectProvider<List<SyncCompletionSpecification>> completions,
+			ObjectProvider<List<SyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
 			List<ToolCallbackProvider> toolCallbackProvider) {
 
@@ -219,15 +219,14 @@ public class McpServerAutoConfiguration {
 					+ serverProperties.isPromptChangeNotification());
 		}
 
-		// List<SyncCompletionSpecification> completionSpecifications =
-		// completions.stream()
-		// .flatMap(List::stream)
-		// .toList();
-		// if (!CollectionUtils.isEmpty(completionSpecifications)) {
-		// serverBuilder.completions(completionSpecifications);
-		// capabilitiesBuilder.completions();
-		// logger.info("Registered completions: " + completionSpecifications.size());
-		// }
+		List<SyncCompletionSpecification> completionSpecifications = completions.stream()
+			.flatMap(List::stream)
+			.toList();
+		if (!CollectionUtils.isEmpty(completionSpecifications)) {
+			serverBuilder.completions(completionSpecifications);
+			capabilitiesBuilder.completions();
+			logger.info("Registered completions: " + completionSpecifications.size());
+		}
 
 		rootsChangeConsumers.ifAvailable(consumer -> {
 			serverBuilder.rootsChangeHandler((exchange, roots) -> consumer.accept(exchange, roots));
@@ -283,7 +282,7 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<AsyncToolSpecification>> tools,
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
-			// ObjectProvider<List<AsyncCompletionSpecification>> completions,
+			ObjectProvider<List<AsyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpAsyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumer,
 			List<ToolCallbackProvider> toolCallbackProvider) {
 
@@ -327,15 +326,14 @@ public class McpServerAutoConfiguration {
 					+ serverProperties.isPromptChangeNotification());
 		}
 
-		// List<AsyncCompletionSpecification> completionSpecifications =
-		// completions.stream()
-		// .flatMap(List::stream)
-		// .toList();
-		// if (!CollectionUtils.isEmpty(completionSpecifications)) {
-		// serverBuilder.completions(completionSpecifications);
-		// capabilitiesBuilder.completions();
-		// logger.info("Registered completions: " + completionSpecifications.size());
-		// }
+		List<AsyncCompletionSpecification> completionSpecifications = completions.stream()
+			.flatMap(List::stream)
+			.toList();
+		if (!CollectionUtils.isEmpty(completionSpecifications)) {
+			serverBuilder.completions(completionSpecifications);
+			capabilitiesBuilder.completions();
+			logger.info("Registered completions: " + completionSpecifications.size());
+		}
 
 		rootsChangeConsumer.ifAvailable(consumer -> {
 			BiFunction<McpAsyncServerExchange, List<McpSchema.Root>, Mono<Void>> asyncConsumer = (exchange, roots) -> {

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
 		<okhttp3.version>4.12.0</okhttp3.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.9.0</mcp.sdk.version>
+		<mcp.sdk.version>0.10.0-SNAPSHOT</mcp.sdk.version>
 
 		<!-- plugin versions -->
 		<antlr.version>4.13.1</antlr.version>


### PR DESCRIPTION
- Re-enables completionspec features in MCP server by uncommenting previously commented code
- Updates MCP SDK version to 0.10.0-SNAPSHOT to support these features