### PR TITLE
feat: Support custom table and column names for JdbcChatMemoryRepository

### DIFF
--- a/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepository.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/main/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepository.java
@@ -59,22 +59,25 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 	private final JdbcTemplate jdbcTemplate;
 
 	public final static String DEFAULT_TABLE_NAME = "ai_chat_memory";
+
 	public final static String DEFAULT_CONVERSION_ID_FIELD_NAME = "conversation_id";
+
 	public final static String DEFAULT_CONTENT_FIELD_NAME = "content";
+
 	public final static String DEFAULT_TYPE_FIELD_NAME = "type";
+
 	public final static String DEFAULT_TIMESTAMP_FIELD_NAME = "\"timestamp\"";
 
 	public final static String DEFAULT_GET_IDS_QUERY = "SELECT DISTINCT %s FROM %s";
+
 	public final static String DEFAULT_ADD_QUERY = "INSERT INTO %s (%s, %s, %s, %s) VALUES (?, ?, ?, ?)";
+
 	public final static String DEFAULT_GET_QUERY = "SELECT %s, %s FROM %s WHERE %s = ? ORDER BY %s";
+
 	public final static String DEFAULT_CLEAR_QUERY = "DELETE FROM %s WHERE %s = ?";
 
-	private JdbcChatMemoryRepository(JdbcTemplate jdbcTemplate,
-									 String tableName,
-									 String conversionIdFiledName,
-									 String contentFiledName,
-									 String typeFiledName,
-									 String timestampFiledName) {
+	private JdbcChatMemoryRepository(JdbcTemplate jdbcTemplate, String tableName, String conversionIdFiledName,
+			String contentFiledName, String typeFiledName, String timestampFiledName) {
 		Assert.notNull(jdbcTemplate, "jdbcTemplate cannot be null");
 		Assert.notNull(tableName, "tableName cannot be null");
 		Assert.notNull(conversionIdFiledName, "conversionIdFiledName cannot be null");
@@ -83,10 +86,10 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		Assert.notNull(timestampFiledName, "timestampFiledName cannot be null");
 		this.jdbcTemplate = jdbcTemplate;
 		this.queryGetIds = DEFAULT_GET_IDS_QUERY.formatted(conversionIdFiledName, tableName);
-		this.queryAdd = DEFAULT_ADD_QUERY.formatted(
-				tableName, conversionIdFiledName, contentFiledName, typeFiledName, timestampFiledName);
-		this.queryGet = DEFAULT_GET_QUERY.formatted(contentFiledName, typeFiledName,
-				tableName, conversionIdFiledName, timestampFiledName);
+		this.queryAdd = DEFAULT_ADD_QUERY.formatted(tableName, conversionIdFiledName, contentFiledName, typeFiledName,
+				timestampFiledName);
+		this.queryGet = DEFAULT_GET_QUERY.formatted(contentFiledName, typeFiledName, tableName, conversionIdFiledName,
+				timestampFiledName);
 		this.queryClear = DEFAULT_CLEAR_QUERY.formatted(tableName, conversionIdFiledName);
 	}
 
@@ -176,9 +179,13 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		private JdbcTemplate jdbcTemplate;
 
 		private String tableName = DEFAULT_TABLE_NAME;
+
 		private String conversionIdFiledName = DEFAULT_CONVERSION_ID_FIELD_NAME;
+
 		private String contentFiledName = DEFAULT_CONTENT_FIELD_NAME;
+
 		private String typeFiledName = DEFAULT_TYPE_FIELD_NAME;
+
 		private String timestampFiledName = DEFAULT_TIMESTAMP_FIELD_NAME;
 
 		private Builder() {

--- a/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepositoryPostgresqlIT.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepositoryPostgresqlIT.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.ai.chat.memory.jdbc.JdbcChatMemoryRepository.*;
 
 /**
  * Integration tests for {@link JdbcChatMemoryRepository}.
@@ -160,7 +161,14 @@ class JdbcChatMemoryRepositoryPostgresqlIT {
 
 		@Bean
 		ChatMemoryRepository chatMemoryRepository(JdbcTemplate jdbcTemplate) {
-			return JdbcChatMemoryRepository.builder().jdbcTemplate(jdbcTemplate).build();
+			return JdbcChatMemoryRepository.builder()
+					.jdbcTemplate(jdbcTemplate)
+					.tableName(DEFAULT_TABLE_NAME)
+					.conversionIdFiledName(DEFAULT_CONVERSION_ID_FIELD_NAME)
+					.contentFiledName(DEFAULT_CONTENT_FIELD_NAME)
+					.typeFiledName(DEFAULT_TYPE_FIELD_NAME)
+					.timestampFiledName(DEFAULT_TIMESTAMP_FIELD_NAME)
+					.build();
 		}
 
 	}

--- a/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepositoryPostgresqlIT.java
+++ b/memory/spring-ai-model-chat-memory-jdbc/src/test/java/org/springframework/ai/chat/memory/jdbc/JdbcChatMemoryRepositoryPostgresqlIT.java
@@ -162,13 +162,13 @@ class JdbcChatMemoryRepositoryPostgresqlIT {
 		@Bean
 		ChatMemoryRepository chatMemoryRepository(JdbcTemplate jdbcTemplate) {
 			return JdbcChatMemoryRepository.builder()
-					.jdbcTemplate(jdbcTemplate)
-					.tableName(DEFAULT_TABLE_NAME)
-					.conversionIdFiledName(DEFAULT_CONVERSION_ID_FIELD_NAME)
-					.contentFiledName(DEFAULT_CONTENT_FIELD_NAME)
-					.typeFiledName(DEFAULT_TYPE_FIELD_NAME)
-					.timestampFiledName(DEFAULT_TIMESTAMP_FIELD_NAME)
-					.build();
+				.jdbcTemplate(jdbcTemplate)
+				.tableName(DEFAULT_TABLE_NAME)
+				.conversionIdFiledName(DEFAULT_CONVERSION_ID_FIELD_NAME)
+				.contentFiledName(DEFAULT_CONTENT_FIELD_NAME)
+				.typeFiledName(DEFAULT_TYPE_FIELD_NAME)
+				.timestampFiledName(DEFAULT_TIMESTAMP_FIELD_NAME)
+				.build();
 		}
 
 	}


### PR DESCRIPTION
The JdbcChatMemoryRepository currently only supports predefined table and column names when in use, which limits its usability for users. We need the ability to customize these names. This PR addresses that by supporting custom configuration of these properties during build time.