### PR TITLE
Update dependencies for milvus stores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
 		<pgvector.version>0.1.6</pgvector.version>
 		<sap.hanadb.version>2.20.11</sap.hanadb.version>
 		<coherence.version>24.09</coherence.version>
-		<milvus.version>2.5.7</milvus.version>
+		<milvus.version>2.5.8</milvus.version>
 		<gemfire.testcontainers.version>2.3.0</gemfire.testcontainers.version>
 
 		<pinecone.version>4.0.1</pinecone.version>


### PR DESCRIPTION
Milvus from 2.5.7 to 2.5.8

Solved the following error:
java.lang.NoSuchMethodError: 'boolean com.google.protobuf.GeneratedMessageV3.isStringEmpty(java.lang.Object)' 
at io.milvus.grpc.ClientInfo.getSerializedSize(ClientInfo.java:402) ~[milvus-sdk-java-2.5.7.jar:na] 
at com.google.protobuf.CodedOutputStream.computeMessageSizeNoTag(CodedOutputStream.java:916) ~[protobuf-java-3.6.1.jar:na] 
at com.google.protobuf.CodedOutputStream.computeMessageSize(CodedOutputStream.java:668) ~[protobuf-java-3.6.1.jar:na] 
at io.milvus.grpc.ConnectRequest.getSerializedSize(ConnectRequest.java:129) ~[milvus-sdk-java-2.5.7.jar:na] 
at io.grpc.protobuf.lite.ProtoInputStream.available(ProtoInputStream.java:108) ~[grpc-protobuf-lite-1.59.1.jar:1.59.1] 
at io.grpc.internal.MessageFramer.getKnownLength(MessageFramer.java:208) ~[grpc-core-1.59.1.jar:1.59.1]