### PR TITLE
Align JdbcChatMemoryProperties with other modules in Spring Boot

### DIFF
--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/main/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryDataSourceScriptDatabaseInitializer.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/main/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryDataSourceScriptDatabaseInitializer.java
@@ -22,35 +22,36 @@ import javax.sql.DataSource;
 
 import org.springframework.boot.jdbc.init.DataSourceScriptDatabaseInitializer;
 import org.springframework.boot.jdbc.init.PlatformPlaceholderDatabaseDriverResolver;
-import org.springframework.boot.sql.init.DatabaseInitializationMode;
 import org.springframework.boot.sql.init.DatabaseInitializationSettings;
+import org.springframework.util.StringUtils;
 
 /**
  * Performs database initialization for the JDBC Chat Memory Repository.
  *
+ * @author Jonathan Leijendekker
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 class JdbcChatMemoryDataSourceScriptDatabaseInitializer extends DataSourceScriptDatabaseInitializer {
 
-	private static final String SCHEMA_LOCATION = "classpath:org/springframework/ai/chat/memory/jdbc/schema-@@platform@@.sql";
-
-	JdbcChatMemoryDataSourceScriptDatabaseInitializer(DataSource dataSource) {
-		super(dataSource, getSettings(dataSource));
+	JdbcChatMemoryDataSourceScriptDatabaseInitializer(DataSource dataSource, JdbcChatMemoryProperties properties) {
+		super(dataSource, getSettings(dataSource, properties));
 	}
 
-	static DatabaseInitializationSettings getSettings(DataSource dataSource) {
+	static DatabaseInitializationSettings getSettings(DataSource dataSource, JdbcChatMemoryProperties properties) {
 		var settings = new DatabaseInitializationSettings();
-		settings.setSchemaLocations(resolveSchemaLocations(dataSource));
-		settings.setMode(DatabaseInitializationMode.ALWAYS);
+		settings.setSchemaLocations(resolveSchemaLocations(dataSource, properties));
+		settings.setMode(properties.getInitializeSchema());
 		settings.setContinueOnError(true);
-
 		return settings;
 	}
 
-	static List<String> resolveSchemaLocations(DataSource dataSource) {
+	static List<String> resolveSchemaLocations(DataSource dataSource, JdbcChatMemoryProperties properties) {
 		var platformResolver = new PlatformPlaceholderDatabaseDriverResolver();
-
-		return platformResolver.resolveAll(dataSource, SCHEMA_LOCATION);
+		if (StringUtils.hasText(properties.getPlatform())) {
+			return platformResolver.resolveAll(properties.getPlatform(), properties.getSchema());
+		}
+		return platformResolver.resolveAll(dataSource, properties.getSchema());
 	}
 
 }

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/main/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryProperties.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/main/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryProperties.java
@@ -17,10 +17,12 @@
 package org.springframework.ai.model.chat.memory.jdbc.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
 
 /**
  * @author Jonathan Leijendekker
  * @author Thomas Vitale
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 @ConfigurationProperties(JdbcChatMemoryProperties.CONFIG_PREFIX)
@@ -28,16 +30,45 @@ public class JdbcChatMemoryProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.jdbc";
 
-	/**
-	 * Whether to initialize the schema on startup.
-	 */
-	private boolean initializeSchema = true;
+	private static final String DEFAULT_SCHEMA_LOCATION = "classpath:org/springframework/ai/chat/memory/jdbc/schema-@@platform@@.sql";
 
-	public boolean isInitializeSchema() {
+	/**
+	 * Path to the SQL file to use to initialize the database schema.
+	 */
+	private String schema = DEFAULT_SCHEMA_LOCATION;
+
+	/**
+	 * Platform to use in initialization scripts if the @@platform@@ placeholder is used.
+	 * Auto-detected by default.
+	 */
+	private String platform;
+
+	/**
+	 * Database schema initialization mode.
+	 */
+	private DatabaseInitializationMode initializeSchema = DatabaseInitializationMode.EMBEDDED;
+
+	public String getPlatform() {
+		return platform;
+	}
+
+	public void setPlatform(String platform) {
+		this.platform = platform;
+	}
+
+	public String getSchema() {
+		return schema;
+	}
+
+	public void setSchema(String schema) {
+		this.schema = schema;
+	}
+
+	public DatabaseInitializationMode getInitializeSchema() {
 		return this.initializeSchema;
 	}
 
-	public void setInitializeSchema(boolean initializeSchema) {
+	public void setInitializeSchema(DatabaseInitializationMode initializeSchema) {
 		this.initializeSchema = initializeSchema;
 	}
 

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/test/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryDataSourceScriptDatabaseInitializerPostgresqlTests.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/test/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryDataSourceScriptDatabaseInitializerPostgresqlTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Jonathan Leijendekker
+ * @author Yanming Zhou
  */
 @Testcontainers
 class JdbcChatMemoryDataSourceScriptDatabaseInitializerPostgresqlTests {
@@ -57,7 +58,8 @@ class JdbcChatMemoryDataSourceScriptDatabaseInitializerPostgresqlTests {
 	void getSettings_shouldHaveSchemaLocations() {
 		this.contextRunner.run(context -> {
 			var dataSource = context.getBean(DataSource.class);
-			var settings = JdbcChatMemoryDataSourceScriptDatabaseInitializer.getSettings(dataSource);
+			var properties = context.getBean(JdbcChatMemoryProperties.class);
+			var settings = JdbcChatMemoryDataSourceScriptDatabaseInitializer.getSettings(dataSource, properties);
 
 			assertThat(settings.getSchemaLocations())
 				.containsOnly("classpath:org/springframework/ai/chat/memory/jdbc/schema-postgresql.sql");

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/test/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryPropertiesTests.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-jdbc/src/test/java/org/springframework/ai/model/chat/memory/jdbc/autoconfigure/JdbcChatMemoryPropertiesTests.java
@@ -17,11 +17,13 @@
 package org.springframework.ai.model.chat.memory.jdbc.autoconfigure;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Jonathan Leijendekker
+ * @author Yanming Zhou
  */
 class JdbcChatMemoryPropertiesTests {
 
@@ -29,15 +31,15 @@ class JdbcChatMemoryPropertiesTests {
 	void defaultValues() {
 		var props = new JdbcChatMemoryProperties();
 
-		assertThat(props.isInitializeSchema()).isTrue();
+		assertThat(props.getInitializeSchema()).isEqualTo(DatabaseInitializationMode.EMBEDDED);
 	}
 
 	@Test
 	void customValues() {
 		var props = new JdbcChatMemoryProperties();
-		props.setInitializeSchema(false);
+		props.setInitializeSchema(DatabaseInitializationMode.ALWAYS);
 
-		assertThat(props.isInitializeSchema()).isFalse();
+		assertThat(props.getInitializeSchema()).isEqualTo(DatabaseInitializationMode.ALWAYS);
 	}
 
 }


### PR DESCRIPTION
Such as `BatchProperties.Jdbc` and `IntegrationProperties.Jdbc`

1. Change type of `initialize-schema` from `boolean` to `DatabaseInitializationMode`
2. Allow to customize schema location
