### PR TITLE
Fix incorrect artifactId

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -28,7 +28,7 @@ Full MCP Server features support with `STDIO` server transport.
 ----
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-starter-mcp-server</artifactId>
+    <artifactId>spring-ai-mcp-server-spring-boot-starter</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
IntelliJ couldn't find `spring-ai-starter-mcp-server` artifactId even, when I added Spring repositories
```
  <repositories>
      <repository>
          <id>spring-milestones</id>
          <name>Spring Milestones</name>
          <url>https://repo.spring.io/milestone</url>
          <snapshots>
              <enabled>false</enabled>
          </snapshots>
      </repository>

      <repository>
          <id>spring-snapshots</id>
          <name>Spring Snapshots</name>
          <url>https://repo.spring.io/snapshot</url>
          <releases>
              <enabled>false</enabled>
          </releases>
      </repository>
  </repositories>
```

I guess the artifactId has been changed overtime to `spring-ai-mcp-server-spring-boot-starter` and it's available in MVN Repository: https://mvnrepository.com/artifact/org.springframework.ai/spring-ai-mcp-server-spring-boot-starter/1.0.0-M6