### PR TITLE
Improve StTemplateRenderer

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -180,6 +180,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	 * Whether to store the output of this chat completion request for use in our model <a href="https://platform.openai.com/docs/guides/distillation">distillation</a> or <a href="https://platform.openai.com/docs/guides/evals">evals</a> products.
 	 */
 	private @JsonProperty("store") Boolean store;
+
 	/**
 	 * Developer-defined tags and values used for filtering completions in the <a href="https://platform.openai.com/chat-completions">dashboard</a>.
 	 */

--- a/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/package-info.java
+++ b/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.template.st;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererEdgeTests.java
+++ b/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererEdgeTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.template.st;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.template.ValidationMode;
+
+/**
+ * Additional edge and robustness tests for {@link StTemplateRenderer}.
+ */
+class StTemplateRendererEdgeTests {
+
+	// --- Built-in Function Handling Tests START ---
+
+	/**
+	 * Built-in functions (first, last) are rendered correctly with variables.
+	 */
+	@Test
+	void shouldHandleMultipleBuiltInFunctionsAndVariables() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("list", java.util.Arrays.asList("a", "b", "c"));
+		variables.put("name", "Mark");
+		String template = "{name}: {first(list)}, {last(list)}";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("Mark: a, c");
+	}
+
+	/**
+	 * Nested and chained built-in functions are handled when validation is enabled.
+	 */
+	/**
+	 * Confirms that ST4 supports valid nested function expressions.
+	 */
+	@Test
+	void shouldSupportValidNestedFunctionExpressionInST4() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("words", java.util.Arrays.asList("hello", "WORLD"));
+		String template = "{first(words)} {last(words)} {length(words)}";
+		StTemplateRenderer defaultRenderer = StTemplateRenderer.builder().build();
+		String defaultResult = defaultRenderer.apply(template, variables);
+		assertThat(defaultResult).isEqualTo("hello WORLD 2");
+	}
+
+	/**
+	 * Nested and chained built-in functions are handled when validation is enabled.
+	 */
+	@Test
+	void shouldHandleNestedBuiltInFunctions() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("words", java.util.Arrays.asList("hello", "WORLD"));
+		String template = "{first(words)} {last(words)} {length(words)}";
+		StTemplateRenderer renderer = StTemplateRenderer.builder().validateStFunctions().build();
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("hello WORLD 2");
+	}
+
+	/**
+	 * Built-in functions as properties are rendered correctly if supported.
+	 */
+	@Test
+	@Disabled("It is very hard to validate the template expression when using property style access of built-in functions ")
+	void shouldSupportBuiltInFunctionsAsProperties() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("words", java.util.Arrays.asList("hello", "WORLD"));
+		String template = "{words.first} {words.last} {words.length}";
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("hello WORLD 2");
+	}
+
+	/**
+	 * Built-in functions are not reported as missing variables in THROW mode.
+	 */
+	@Test
+	void shouldNotReportBuiltInFunctionsAsMissingVariablesInThrowMode() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().validationMode(ValidationMode.THROW).build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("memory", "abc");
+		String template = "{if(strlen(memory))}ok{endif}";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("ok");
+	}
+
+	/**
+	 * Built-in functions are not reported as missing variables in WARN mode.
+	 */
+	@Test
+	void shouldNotReportBuiltInFunctionsAsMissingVariablesInWarnMode() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().validationMode(ValidationMode.WARN).build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("memory", "abc");
+		String template = "{if(strlen(memory))}ok{endif}";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("ok");
+	}
+
+	/**
+	 * Variables with names similar to built-in functions are treated as normal variables.
+	 */
+	@Test
+	void shouldHandleVariableNamesSimilarToBuiltInFunctions() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("lengthy", "foo");
+		variables.put("firstName", "bar");
+		String template = "{lengthy} {firstName}";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("foo bar");
+	}
+
+	// --- Built-in Function Handling Tests END ---
+
+	@Test
+	void shouldRenderEscapedDelimiters() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("x", "y");
+		String template = "{x} \\{foo\\}";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("y {foo}");
+	}
+
+	@Test
+	void shouldRenderStaticTextTemplate() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		String template = "Just static text.";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("Just static text.");
+	}
+
+	// Duplicate removed: shouldHandleVariableNamesSimilarToBuiltInFunctions
+	// (now grouped at the top of the class)
+
+	@Test
+	void shouldHandleLargeNumberOfVariables() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		StringBuilder template = new StringBuilder();
+		for (int i = 0; i < 100; i++) {
+			String key = "var" + i;
+			variables.put(key, i);
+			template.append("{" + key + "} ");
+		}
+		String result = renderer.apply(template.toString().trim(), variables);
+		StringBuilder expected = new StringBuilder();
+		for (int i = 0; i < 100; i++) {
+			expected.append(i).append(" ");
+		}
+		assertThat(result).isEqualTo(expected.toString().trim());
+	}
+
+	@Test
+	void shouldRenderUnicodeAndSpecialCharacters() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("emoji", "😀");
+		variables.put("accented", "Café");
+		String template = "{emoji} {accented}";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("😀 Café");
+	}
+
+	@Test
+	void shouldRenderNullVariableValuesAsBlank() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("foo", null);
+		String template = "Value: {foo}";
+		String result = renderer.apply(template, variables);
+		assertThat(result).isEqualTo("Value: ");
+	}
+
+}

--- a/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
+++ b/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
@@ -282,11 +282,11 @@ class StTemplateRendererTests {
 
 	/**
 	 * Test whether StringTemplate can correctly render a template containing built-in
-	 * functions when {@code supportStFunctions()} is enabled. It should render properly.
+	 * functions. It should render properly.
 	 */
 	@Test
-	void shouldRenderTemplateWithSupportStFunctions() {
-		StTemplateRenderer renderer = StTemplateRenderer.builder().supportStFunctions().build();
+	void shouldRenderTemplateWithBuiltInFunctions() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
 		Map<String, Object> variables = new HashMap<>();
 		variables.put("memory", "you are a helpful assistant");
 		String template = "{if(strlen(memory))}Hello!{endif}";


### PR DESCRIPTION
Rename supportStFunctions to validateStFunctions and improve variable extraction

- Renamed all occurrences of supportStFunctions to validateStFunctions for clarity.
- Updated default field, constructor, and builder method to use new naming.
- Improved getInputVariables logic to better distinguish variables, function calls, and property access.
- Ensured built-in functions accessed as properties are only skipped when validateStFunctions is true.
- Enhanced builder usage to reflect new flag and naming.
- More tests added
