### PR TITLE
Enable MCP tool callback by default

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfiguration.java
@@ -77,7 +77,7 @@ public class McpToolCallbackAutoConfiguration {
 		}
 
 		@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX + ".toolcallback", name = "enabled",
-				havingValue = "true", matchIfMissing = false)
+				havingValue = "true", matchIfMissing = true)
 		static class ToolCallbackProviderEnabled {
 
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpClientCommonProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpClientCommonProperties.java
@@ -18,9 +18,6 @@ package org.springframework.ai.mcp.client.autoconfigure.properties;
 
 import java.time.Duration;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -110,7 +107,7 @@ public class McpClientCommonProperties {
 	 * <p>
 	 * This configuration is used to enable or disable tool callbacks in the MCP client.
 	 */
-	private Toolcallback toolcallback = new Toolcallback(false);
+	private Toolcallback toolcallback = new Toolcallback();
 
 	/**
 	 * Represents a callback configuration for tools.
@@ -121,14 +118,22 @@ public class McpClientCommonProperties {
 	 * @param enabled A boolean flag indicating whether the tool callback is enabled. If
 	 * true, the tool callback is active; otherwise, it is disabled.
 	 */
-	@JsonInclude(JsonInclude.Include.NON_ABSENT)
-	public record Toolcallback(
+	public static class Toolcallback {
 
-			/**
-			 * A boolean flag indicating whether the tool callback is enabled. If true,
-			 * the tool callback is active; otherwise, it is disabled.
-			 */
-			@JsonProperty("enabled") boolean enabled) {
+		/**
+		 * A boolean flag indicating whether the tool callback is enabled. If true, the
+		 * tool callback is active; otherwise, it is disabled.
+		 */
+		private boolean enabled = true;
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
 	}
 
 	public boolean isEnabled() {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationConditionTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationConditionTests.java
@@ -63,18 +63,14 @@ public class McpToolCallbackAutoConfigurationConditionTests {
 	}
 
 	@Test
-	void doesNotMatchWhenToolCallbackPropertyIsMissing() {
-		// McpClientEnabled is true by default if missing, but ToolCallbackEnabled is
-		// false by default if missing
+	void doesMatchWhenToolCallbackPropertyIsMissing() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.client.enabled=true")
-			.run(context -> assertThat(context).doesNotHaveBean("testBean"));
+			.run(context -> assertThat(context).hasBean("testBean"));
 	}
 
 	@Test
-	void doesNotMatchWhenBothPropertiesAreMissing() {
-		// McpClientEnabled is true by default if missing, but ToolCallbackEnabled is
-		// false by default if missing
-		this.contextRunner.run(context -> assertThat(context).doesNotHaveBean("testBean"));
+	void doesMatchWhenBothPropertiesAreMissing() {
+		this.contextRunner.run(context -> assertThat(context).hasBean("testBean"));
 	}
 
 	@Configuration

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/test/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfigurationTests.java
@@ -29,17 +29,17 @@ public class McpToolCallbackAutoConfigurationTests {
 		.withConfiguration(AutoConfigurations.of(McpToolCallbackAutoConfiguration.class));
 
 	@Test
-	void disabledByDefault() {
+	void enableddByDefault() {
 
 		this.applicationContext.run(context -> {
-			assertThat(context).doesNotHaveBean("mcpToolCallbacks");
+			assertThat(context).hasBean("mcpToolCallbacks");
 			assertThat(context).doesNotHaveBean("mcpAsyncToolCallbacks");
 		});
 
 		this.applicationContext
 			.withPropertyValues("spring.ai.mcp.client.enabled=true", "spring.ai.mcp.client.type=SYNC")
 			.run(context -> {
-				assertThat(context).doesNotHaveBean("mcpToolCallbacks");
+				assertThat(context).hasBean("mcpToolCallbacks");
 				assertThat(context).doesNotHaveBean("mcpAsyncToolCallbacks");
 			});
 
@@ -47,7 +47,7 @@ public class McpToolCallbackAutoConfigurationTests {
 			.withPropertyValues("spring.ai.mcp.client.enabled=true", "spring.ai.mcp.client.type=ASYNC")
 			.run(context -> {
 				assertThat(context).doesNotHaveBean("mcpToolCallbacks");
-				assertThat(context).doesNotHaveBean("mcpAsyncToolCallbacks");
+				assertThat(context).hasBean("mcpAsyncToolCallbacks");
 			});
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -87,7 +87,7 @@ The common properties are prefixed with `spring.ai.mcp.client`:
 
 |`toolcallback.enabled`
 |Enable/disable the MCP tool callback integration with Spring AI's tool execution framework
-|`false`
+|`true`
 |===
 
 === Stdio Transport Properties


### PR DESCRIPTION
- Change the default value of `toolcallback.enabled` property to `true` in both configuration and documentation.
- Update `McpClientCommonProperties.Toolcallback` to default `enabled` to `true` and refactor from record to class.
- Adjust `@ConditionalOnProperty` in `McpToolCallbackAutoConfiguration` to `matchIfMissing = true` for tool callback.
- Update tests to reflect new default behavior: tool callback is now enabled by default when the property is missing.
- Update documentation to indicate the new default value for `toolcallback.enabled` is `true`.
