### PR TITLE
Add JsonIgnoreProperties to Model Response objects

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -699,6 +700,7 @@ public class AnthropicApi {
 	 * response.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ContentBlock(
 	// @formatter:off
 		@JsonProperty("type") Type type,
@@ -958,6 +960,7 @@ public class AnthropicApi {
 	 * @param usage Input and output token usage.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionResponse(
 	// @formatter:off
 		@JsonProperty("id") String id,
@@ -980,6 +983,7 @@ public class AnthropicApi {
 	 * @param outputTokens The number of output tokens which were used. completion).
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Usage(
 	// @formatter:off
 		@JsonProperty("input_tokens") Integer inputTokens,
@@ -1078,6 +1082,7 @@ public class AnthropicApi {
 	 * @param contentBlock The content block body.
 	*/
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ContentBlockStartEvent(
 			// @formatter:off
 		@JsonProperty("type") EventType type,
@@ -1100,6 +1105,7 @@ public class AnthropicApi {
 		  * @param input The tool use input.
 		*/
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ContentBlockToolUse(
 			@JsonProperty("type") String type,
 			@JsonProperty("id") String id,
@@ -1113,6 +1119,7 @@ public class AnthropicApi {
 		  * @param text The text content.
 		*/
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ContentBlockText(
 			@JsonProperty("type") String type,
 			@JsonProperty("text") String text) implements ContentBlockBody {
@@ -1130,6 +1137,7 @@ public class AnthropicApi {
 	 * @param delta The content block delta body.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ContentBlockDeltaEvent(
 	// @formatter:off
 		@JsonProperty("type") EventType type,
@@ -1153,6 +1161,7 @@ public class AnthropicApi {
 		 * @param text The text content.
 		*/
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ContentBlockDeltaText(
 			@JsonProperty("type") String type,
 			@JsonProperty("text") String text) implements ContentBlockDeltaBody {
@@ -1164,6 +1173,7 @@ public class AnthropicApi {
 		  * @param partialJson The partial JSON content.
 		  */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ContentBlockDeltaJson(
 			@JsonProperty("type") String type,
 			@JsonProperty("partial_json") String partialJson) implements ContentBlockDeltaBody {
@@ -1174,6 +1184,8 @@ public class AnthropicApi {
 		 * @param type The content block type.
 		 * @param thinking The thinking content.
 		 */
+		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ContentBlockDeltaThinking(
 			@JsonProperty("type") String type,
 			@JsonProperty("thinking") String thinking) implements ContentBlockDeltaBody {
@@ -1184,6 +1196,8 @@ public class AnthropicApi {
 		 * @param type The content block type.
 		 * @param signature The signature content.
 		 */
+		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ContentBlockDeltaSignature(
 			@JsonProperty("type") String type,
 			@JsonProperty("signature") String signature) implements ContentBlockDeltaBody {
@@ -1200,6 +1214,7 @@ public class AnthropicApi {
 	 * @param index The index of the content block.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ContentBlockStopEvent(
 	// @formatter:off
 		@JsonProperty("type") EventType type,
@@ -1214,6 +1229,7 @@ public class AnthropicApi {
 	 * @param message The message body.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record MessageStartEvent(// @formatter:off
 		@JsonProperty("type") EventType type,
 		@JsonProperty("message") ChatCompletionResponse message) implements StreamEvent {
@@ -1228,6 +1244,7 @@ public class AnthropicApi {
 	 * @param usage The message delta usage.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record MessageDeltaEvent(
 	// @formatter:off
 		@JsonProperty("type") EventType type,
@@ -1239,6 +1256,7 @@ public class AnthropicApi {
 		  * @param stopSequence The stop sequence.
 		  */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record MessageDelta(
 			@JsonProperty("stop_reason") String stopReason,
 			@JsonProperty("stop_sequence") String stopSequence) {
@@ -1249,6 +1267,7 @@ public class AnthropicApi {
 		 * @param outputTokens The output tokens.
 		*/
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record MessageDeltaUsage(
 			@JsonProperty("output_tokens") Integer outputTokens) {
 		}
@@ -1261,6 +1280,7 @@ public class AnthropicApi {
 	 * @param type The event type.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record MessageStopEvent(
 	//@formatter:off
 		@JsonProperty("type") EventType type) implements StreamEvent {
@@ -1277,6 +1297,7 @@ public class AnthropicApi {
 	 * @param error The error body.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ErrorEvent(
 	// @formatter:off
 		@JsonProperty("type") EventType type,
@@ -1288,6 +1309,7 @@ public class AnthropicApi {
 		 * @param message The error message.
 		*/
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Error(
 			@JsonProperty("type") String type,
 			@JsonProperty("message") String message) {
@@ -1304,6 +1326,7 @@ public class AnthropicApi {
 	 * @param type The event type.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record PingEvent(
 	// @formatter:off
 		@JsonProperty("type") EventType type) implements StreamEvent {

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
@@ -22,7 +22,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -331,6 +331,7 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 	 * @param invocationLatency The time in milliseconds between the request being sent and the response being received.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record AmazonBedrockInvocationMetrics(
 			@JsonProperty("inputTokenCount") Long inputTokenCount,
 			@JsonProperty("firstByteLatency") Long firstByteLatency,

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/api/CohereEmbeddingBedrockApi.java
@@ -19,6 +19,7 @@ package org.springframework.ai.bedrock.cohere.api;
 import java.time.Duration;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -233,6 +234,7 @@ public class CohereEmbeddingBedrockApi
 	 * doesn't return invocationMetrics for the cohere embedding model.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record CohereEmbeddingResponse(@JsonProperty("id") String id,
 			@JsonProperty("embeddings") List<float[]> embeddings, @JsonProperty("texts") List<String> texts,
 			@JsonProperty("response_type") String responseType,

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/api/TitanEmbeddingBedrockApi.java
@@ -19,6 +19,7 @@ package org.springframework.ai.bedrock.titan.api;
 import java.time.Duration;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -174,6 +175,7 @@ public class TitanEmbeddingBedrockApi extends
 	 * @param message No idea what this is.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record TitanEmbeddingResponse(
 			@JsonProperty("embedding") float[] embedding,
 			@JsonProperty("inputTextTokenCount") Integer inputTextTokenCount,

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -654,6 +655,7 @@ public class MiniMaxApi {
 	 * {@link Role#ASSISTANT} role and null otherwise.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionMessage(
 			@JsonProperty("content") Object rawContent,
 			@JsonProperty("role") Role role,
@@ -719,6 +721,7 @@ public class MiniMaxApi {
 		 * images by adding multiple image_url content parts.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record MediaContent(
 			@JsonProperty("type") String type,
 			@JsonProperty("text") String text,
@@ -748,6 +751,7 @@ public class MiniMaxApi {
 			 * @param detail Specifies the detail level of the image.
 			 */
 			@JsonInclude(Include.NON_NULL)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record ImageUrl(
 				@JsonProperty("url") String url,
 				@JsonProperty("detail") String detail) {
@@ -766,6 +770,7 @@ public class MiniMaxApi {
 		 * @param function The function definition.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ToolCall(
 				@JsonProperty("id") String id,
 				@JsonProperty("type") String type,
@@ -779,6 +784,7 @@ public class MiniMaxApi {
 		 * @param arguments The arguments that the model expects you to pass to the function.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChatCompletionFunction(
 				@JsonProperty("name") String name,
 				@JsonProperty("arguments") String arguments) {
@@ -800,6 +806,7 @@ public class MiniMaxApi {
 	 * @param usage Usage statistics for the completion request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletion(
 			@JsonProperty("id") String id,
 			@JsonProperty("choices") List<Choice> choices,
@@ -821,6 +828,7 @@ public class MiniMaxApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Choice(
 				@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
 				@JsonProperty("index") Integer index,
@@ -829,6 +837,8 @@ public class MiniMaxApi {
 				@JsonProperty("logprobs") LogProbs logprobs) {
 		}
 
+		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record BaseResponse(
 				@JsonProperty("status_code") Long statusCode,
 				@JsonProperty("status_msg") String message
@@ -841,6 +851,7 @@ public class MiniMaxApi {
 	 * @param content A list of message content tokens with log probability information.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record LogProbs(
 			@JsonProperty("content") List<Content> content) {
 
@@ -858,6 +869,7 @@ public class MiniMaxApi {
 		 * requested top_logprobs returned.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Content(
 				@JsonProperty("token") String token,
 				@JsonProperty("logprob") Float logprob,
@@ -875,6 +887,7 @@ public class MiniMaxApi {
 			 * text representation. Can be null if there is no bytes representation for the token.
 			 */
 			@JsonInclude(Include.NON_NULL)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record TopLogProbs(
 					@JsonProperty("token") String token,
 					@JsonProperty("logprob") Float logprob,
@@ -891,6 +904,7 @@ public class MiniMaxApi {
 	 * @param totalTokens Total number of tokens used in the request (prompt + completion).
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Usage(
 			@JsonProperty("completion_tokens") Integer completionTokens,
 			@JsonProperty("prompt_tokens") Integer promptTokens,
@@ -912,6 +926,7 @@ public class MiniMaxApi {
 	 * @param object The object type, which is always 'chat.completion.chunk'.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionChunk(
 			@JsonProperty("id") String id,
 			@JsonProperty("choices") List<ChunkChoice> choices,
@@ -929,6 +944,7 @@ public class MiniMaxApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChunkChoice(
 				@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
 				@JsonProperty("index") Integer index,
@@ -1021,6 +1037,7 @@ public class MiniMaxApi {
 	 * @param totalTokens Usage tokens the request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record EmbeddingList(
 			@JsonProperty("vectors") List<float[]> vectors,
 			@JsonProperty("model") String model,

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -488,6 +489,7 @@ public class MistralAiApi {
 	 * applicable for completion requests.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Usage(
 	// @formatter:off
 		@JsonProperty("prompt_tokens") Integer promptTokens,
@@ -505,6 +507,7 @@ public class MistralAiApi {
 	 * @param object The object type, which is always 'embedding'.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Embedding(
 	// @formatter:off
 		@JsonProperty("index") Integer index,
@@ -598,6 +601,7 @@ public class MistralAiApi {
 	 * @param usage Usage statistics for the completion request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record EmbeddingList<T>(
 	// @formatter:off
 			@JsonProperty("object") String object,
@@ -770,6 +774,7 @@ public class MistralAiApi {
 	 * the {@link Role#TOOL} role and null otherwise.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionMessage(
 	// @formatter:off
 		@JsonProperty("content") Object rawContent,
@@ -846,6 +851,7 @@ public class MistralAiApi {
 		 * @param index The index of the tool call in the list of tool calls.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ToolCall(@JsonProperty("id") String id, @JsonProperty("type") String type,
 				@JsonProperty("function") ChatCompletionFunction function, @JsonProperty("index") Integer index) {
 
@@ -859,6 +865,7 @@ public class MistralAiApi {
 		 * function.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChatCompletionFunction(@JsonProperty("name") String name,
 				@JsonProperty("arguments") String arguments) {
 
@@ -873,6 +880,7 @@ public class MistralAiApi {
 		 * @param imageUrl The image content of the message.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record MediaContent(
 		// @formatter:off
 		   		@JsonProperty("type") String type,
@@ -936,6 +944,7 @@ public class MistralAiApi {
 	 * @param usage Usage statistics for the completion request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletion(
 	// @formatter:off
 		@JsonProperty("id") String id,
@@ -955,6 +964,7 @@ public class MistralAiApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Choice(
 		// @formatter:off
 			@JsonProperty("index") Integer index,
@@ -973,6 +983,7 @@ public class MistralAiApi {
 	 * @param content A list of message content tokens with log probability information.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record LogProbs(@JsonProperty("content") List<Content> content) {
 
 		/**
@@ -990,6 +1001,7 @@ public class MistralAiApi {
 		 * requested top_logprobs returned.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Content(@JsonProperty("token") String token, @JsonProperty("logprob") Float logprob,
 				@JsonProperty("bytes") List<Integer> probBytes,
 				@JsonProperty("top_logprobs") List<TopLogProbs> topLogprobs) {
@@ -1006,6 +1018,7 @@ public class MistralAiApi {
 			 * is no bytes representation for the token.
 			 */
 			@JsonInclude(Include.NON_NULL)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record TopLogProbs(@JsonProperty("token") String token, @JsonProperty("logprob") Float logprob,
 					@JsonProperty("bytes") List<Integer> probBytes) {
 
@@ -1029,6 +1042,7 @@ public class MistralAiApi {
 	 * @param usage usage metrics for the chat completion.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionChunk(
 	// @formatter:off
 		@JsonProperty("id") String id,
@@ -1048,12 +1062,13 @@ public class MistralAiApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChunkChoice(
 		// @formatter:off
 			@JsonProperty("index") Integer index,
 			@JsonProperty("delta") ChatCompletionMessage delta,
 			@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
-		@JsonProperty("logprobs") LogProbs logprobs) {
+			@JsonProperty("logprobs") LogProbs logprobs) {
 			 // @formatter:on
 		}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -253,6 +254,7 @@ public class OllamaApi {
 	 * @param toolCalls The relevant tool call.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Message(
 			@JsonProperty("role") Role role,
 			@JsonProperty("content") String content,
@@ -523,6 +525,7 @@ public class OllamaApi {
 	 * Types</a>
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatResponse(
 			@JsonProperty("model") String model,
 			@JsonProperty("created_at") Instant createdAt,
@@ -599,6 +602,7 @@ public class OllamaApi {
 	 * @param promptEvalCount The number of tokens in the prompt.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record EmbeddingsResponse(
 			@JsonProperty("model") String model,
 			@JsonProperty("embeddings") List<float[]> embeddings,
@@ -609,6 +613,7 @@ public class OllamaApi {
 	}
 
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Model(
 			@JsonProperty("name") String name,
 			@JsonProperty("model") String model,
@@ -618,6 +623,7 @@ public class OllamaApi {
 			@JsonProperty("details") Details details
 	) {
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Details(
 				@JsonProperty("parent_model") String parentModel,
 				@JsonProperty("format") String format,
@@ -629,6 +635,7 @@ public class OllamaApi {
 	}
 
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ListModelResponse(
 			@JsonProperty("models") List<Model> models
 	) { }
@@ -646,6 +653,7 @@ public class OllamaApi {
 	}
 
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ShowModelResponse(
 			@JsonProperty("license") String license,
 			@JsonProperty("modelfile") String modelfile,
@@ -692,6 +700,7 @@ public class OllamaApi {
 	}
 
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ProgressResponse(
 			@JsonProperty("status") String status,
 			@JsonProperty("digest") String digest,

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -1167,6 +1167,7 @@ public class OpenAiApi {
 	 * Support audio input modality)
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionMessage(// @formatter:off
 			@JsonProperty("content") Object rawContent,
 			@JsonProperty("role") Role role,
@@ -1241,6 +1242,7 @@ public class OpenAiApi {
 		 * @param inputAudio Audio content part.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record MediaContent(// @formatter:off
 			@JsonProperty("type") String type,
 			@JsonProperty("text") String text,
@@ -1320,6 +1322,7 @@ public class OpenAiApi {
 		 * @param function The function definition.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ToolCall(// @formatter:off
 				@JsonProperty("index") Integer index,
 				@JsonProperty("id") String id,
@@ -1340,6 +1343,7 @@ public class OpenAiApi {
 		 * function.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChatCompletionFunction(// @formatter:off
 				@JsonProperty("name") String name,
 				@JsonProperty("arguments") String arguments) { // @formatter:on
@@ -1355,6 +1359,7 @@ public class OpenAiApi {
 		 * @param transcript Transcript of the audio output from the model.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record AudioOutput(// @formatter:off
 				@JsonProperty("id") String id,
 				@JsonProperty("data") String data,
@@ -1383,6 +1388,7 @@ public class OpenAiApi {
 	 * @param usage Usage statistics for the completion request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletion(// @formatter:off
 			@JsonProperty("id") String id,
 			@JsonProperty("choices") List<Choice> choices,
@@ -1403,6 +1409,7 @@ public class OpenAiApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Choice(// @formatter:off
 				@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
 				@JsonProperty("index") Integer index,
@@ -1419,6 +1426,7 @@ public class OpenAiApi {
 	 * @param refusal A list of message refusal tokens with log probability information.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record LogProbs(@JsonProperty("content") List<Content> content,
 			@JsonProperty("refusal") List<Content> refusal) {
 
@@ -1437,6 +1445,7 @@ public class OpenAiApi {
 		 * requested top_logprobs returned.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Content(// @formatter:off
 				@JsonProperty("token") String token,
 				@JsonProperty("logprob") Float logprob,
@@ -1455,6 +1464,7 @@ public class OpenAiApi {
 			 * is no bytes representation for the token.
 			 */
 			@JsonInclude(Include.NON_NULL)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record TopLogProbs(// @formatter:off
 					@JsonProperty("token") String token,
 					@JsonProperty("logprob") Float logprob,
@@ -1508,6 +1518,7 @@ public class OpenAiApi {
 		 * @param cachedTokens Cached tokens present in the prompt.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record PromptTokensDetails(// @formatter:off
 			@JsonProperty("audio_tokens") Integer audioTokens,
 			@JsonProperty("cached_tokens") Integer cachedTokens) { // @formatter:on
@@ -1553,6 +1564,7 @@ public class OpenAiApi {
 	 * only if the StreamOptions.includeUsage is set to true.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionChunk(// @formatter:off
 			@JsonProperty("id") String id,
 			@JsonProperty("choices") List<ChunkChoice> choices,
@@ -1572,6 +1584,7 @@ public class OpenAiApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChunkChoice(// @formatter:off
 				@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
 				@JsonProperty("index") Integer index,
@@ -1591,6 +1604,7 @@ public class OpenAiApi {
 	 * @param object The object type, which is always 'embedding'.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Embedding(// @formatter:off
 			@JsonProperty("index") Integer index,
 			@JsonProperty("embedding") float[] embedding,
@@ -1665,6 +1679,7 @@ public class OpenAiApi {
 	 * @param usage Usage statistics for the completion request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record EmbeddingList<T>(// @formatter:off
 			@JsonProperty("object") String object,
 			@JsonProperty("data") List<T> data,

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
@@ -19,6 +19,7 @@ package org.springframework.ai.openai.api;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -685,6 +686,7 @@ public class OpenAiAudioApi {
 	 * details.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record StructuredResponse(
 	// @formatter:off
 		@JsonProperty("language") String language,
@@ -702,6 +704,7 @@ public class OpenAiAudioApi {
 		 * @param end The end time of the word in seconds.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Word(
 		// @formatter:off
 			@JsonProperty("word") String word,
@@ -728,6 +731,7 @@ public class OpenAiAudioApi {
 		 * higher than 1.0 and the avg_logprob is below -1, consider this segment silent.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Segment(
 		// @formatter:off
 			@JsonProperty("id") Integer id,

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiImageApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiImageApi.java
@@ -18,6 +18,7 @@ package org.springframework.ai.openai.api;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -133,6 +134,7 @@ public class OpenAiImageApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record OpenAiImageResponse(
 		@JsonProperty("created") Long created,
 		@JsonProperty("data") List<Data> data) {
@@ -140,6 +142,7 @@ public class OpenAiImageApi {
 	// @formatter:onn
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Data(@JsonProperty("url") String url, @JsonProperty("b64_json") String b64Json,
 			@JsonProperty("revised_prompt") String revisedPrompt) {
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiModerationApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiModerationApi.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.openai.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -100,6 +101,7 @@ public class OpenAiModerationApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record OpenAiModerationResponse(
 			@JsonProperty("id") String id,
 			@JsonProperty("model") String model,
@@ -108,6 +110,7 @@ public class OpenAiModerationApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record OpenAiModerationResult(
 			@JsonProperty("flagged") boolean flagged,
 			@JsonProperty("categories") Categories categories,
@@ -116,6 +119,7 @@ public class OpenAiModerationApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Categories(
 			@JsonProperty("sexual") boolean sexual,
 			@JsonProperty("hate") boolean hate,
@@ -131,6 +135,8 @@ public class OpenAiModerationApi {
 
 	}
 
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record CategoryScores(
 			@JsonProperty("sexual") double sexual,
 			@JsonProperty("hate") double hate,
@@ -148,6 +154,7 @@ public class OpenAiModerationApi {
 	// @formatter:onn
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Data(@JsonProperty("url") String url, @JsonProperty("b64_json") String b64Json,
 			@JsonProperty("revised_prompt") String revisedPrompt) {
 

--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiApi.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiApi.java
@@ -19,6 +19,7 @@ package org.springframework.ai.stabilityai.api;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -197,9 +198,12 @@ public class StabilityAiApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record GenerateImageResponse(@JsonProperty("result") String result,
 			@JsonProperty("artifacts") List<Artifacts> artifacts) {
 
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Artifacts(@JsonProperty("seed") long seed, @JsonProperty("base64") String base64,
 				@JsonProperty("finishReason") String finishReason) {
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -624,6 +625,7 @@ public class ZhiPuAiApi {
 	 * {@link Role#ASSISTANT} role and null otherwise.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionMessage(
 			@JsonProperty("content") Object rawContent,
 			@JsonProperty("role") Role role,
@@ -691,6 +693,7 @@ public class ZhiPuAiApi {
 		 * supported when using the glm-4v model.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record MediaContent(
 			@JsonProperty("type") String type,
 			@JsonProperty("text") String text,
@@ -720,6 +723,7 @@ public class ZhiPuAiApi {
 			 * @param detail Specifies the detail level of the image.
 			 */
 			@JsonInclude(Include.NON_NULL)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record ImageUrl(
 				@JsonProperty("url") String url,
 				@JsonProperty("detail") String detail) {
@@ -738,6 +742,7 @@ public class ZhiPuAiApi {
 		 * @param function The function definition.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ToolCall(
 				@JsonProperty("id") String id,
 				@JsonProperty("type") String type,
@@ -751,6 +756,7 @@ public class ZhiPuAiApi {
 		 * @param arguments The arguments that the model expects you to pass to the function.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChatCompletionFunction(
 				@JsonProperty("name") String name,
 				@JsonProperty("arguments") String arguments) {
@@ -771,6 +777,7 @@ public class ZhiPuAiApi {
 	 * @param usage Usage statistics for the completion request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletion(
 			@JsonProperty("id") String id,
 			@JsonProperty("choices") List<Choice> choices,
@@ -789,6 +796,7 @@ public class ZhiPuAiApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Choice(
 				@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
 				@JsonProperty("index") Integer index,
@@ -804,6 +812,7 @@ public class ZhiPuAiApi {
 	 * @param content A list of message content tokens with log probability information.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record LogProbs(
 			@JsonProperty("content") List<Content> content) {
 
@@ -821,6 +830,7 @@ public class ZhiPuAiApi {
 		 * requested top_logprobs returned.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record Content(
 				@JsonProperty("token") String token,
 				@JsonProperty("logprob") Float logprob,
@@ -838,6 +848,7 @@ public class ZhiPuAiApi {
 			 * text representation. Can be null if there is no bytes representation for the token.
 			 */
 			@JsonInclude(Include.NON_NULL)
+			@JsonIgnoreProperties(ignoreUnknown = true)
 			public record TopLogProbs(
 					@JsonProperty("token") String token,
 					@JsonProperty("logprob") Float logprob,
@@ -854,6 +865,7 @@ public class ZhiPuAiApi {
 	 * @param totalTokens Total number of tokens used in the request (prompt + completion).
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Usage(
 			@JsonProperty("completion_tokens") Integer completionTokens,
 			@JsonProperty("prompt_tokens") Integer promptTokens,
@@ -875,6 +887,7 @@ public class ZhiPuAiApi {
 	 * @param object The object type, which is always 'chat.completion.chunk'.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ChatCompletionChunk(
 			@JsonProperty("id") String id,
 			@JsonProperty("choices") List<ChunkChoice> choices,
@@ -892,6 +905,7 @@ public class ZhiPuAiApi {
 		 * @param logprobs Log probability information for the choice.
 		 */
 		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
 		public record ChunkChoice(
 				@JsonProperty("finish_reason") ChatCompletionFinishReason finishReason,
 				@JsonProperty("index") Integer index,
@@ -908,6 +922,7 @@ public class ZhiPuAiApi {
 	 * @param object The object type, which is always 'embedding'.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Embedding(
 			@JsonProperty("index") Integer index,
 			@JsonProperty("embedding") float[] embedding,
@@ -995,6 +1010,7 @@ public class ZhiPuAiApi {
 	 * @param usage Usage statistics for the completion request.
 	 */
 	@JsonInclude(Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record EmbeddingList<T>(
 			@JsonProperty("object") String object,
 			@JsonProperty("data") List<T> data,

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiImageApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiImageApi.java
@@ -18,6 +18,7 @@ package org.springframework.ai.zhipuai.api;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -118,6 +119,7 @@ public class ZhiPuAiImageApi {
 	}
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record ZhiPuAiImageResponse(
 		@JsonProperty("created") Long created,
 		@JsonProperty("data") List<Data> data) {
@@ -125,6 +127,7 @@ public class ZhiPuAiImageApi {
 	// @formatter:onn
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Data(@JsonProperty("url") String url) {
 
 	}


### PR DESCRIPTION
 - For all the model response API objects, add `@JsonIgnoreProperties(ignoreUnknown = true)` which provides flexibility to ignore any unknown properties which come as part of the response

Resolves #3026

