### PR TITLE
fix(jsonparser): support scientific notation parsing for int/long

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.util.json;
 
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -128,13 +129,15 @@ public final class JsonParser {
 			return Byte.parseByte(value.toString());
 		}
 		else if (javaType == Integer.class) {
-			return Integer.parseInt(value.toString());
+			BigDecimal bigDecimal = new BigDecimal(value.toString());
+			return bigDecimal.intValueExact();
 		}
 		else if (javaType == Short.class) {
 			return Short.parseShort(value.toString());
 		}
 		else if (javaType == Long.class) {
-			return Long.parseLong(value.toString());
+			BigDecimal bigDecimal = new BigDecimal(value.toString());
+			return bigDecimal.longValueExact();
 		}
 		else if (javaType == Double.class) {
 			return Double.parseDouble(value.toString());

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
@@ -241,6 +241,20 @@ class JsonParserTests {
 		assertThat(value).isEqualTo(new TestRecord("John", 30));
 	}
 
+	@Test
+	void fromScientificNotationToInteger() {
+		var value = JsonParser.toTypedObject("1.5E7", Integer.class);
+		assertThat(value).isInstanceOf(Integer.class);
+		assertThat(value).isEqualTo(15_000_000);
+	}
+
+	@Test
+	void fromScientificNotationToLong() {
+		var value = JsonParser.toTypedObject("1.5E12", Long.class);
+		assertThat(value).isInstanceOf(Long.class);
+		assertThat(value).isEqualTo(1_500_000_000_000L);
+	}
+
 	record TestRecord(String name, Integer age) {
 	}
 


### PR DESCRIPTION
Fixes: #2995

Replaces the use of `parseInt` / `parseLong` in `JsonParser.toTypedObject()` 
with `BigDecimal.intValueExact()` / `longValueExact()` to support scientific notation 
(e.g., "1.5E7") safely and accurately.

- Added tests for scientific notation in `JsonParserTests`

