### PR TITLE
Update neo4j.adoc - change `spring.ai.vectorstore.neo4j.dimensions` to `spring.ai.vectorstore.neo4j.embedding-dimension` 

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc
@@ -100,7 +100,7 @@ spring:
         initialize-schema: true
         database-name: neo4j
         index-name: custom-index
-        dimensions: 1536
+        embedding-dimension: 1536
         distance-type: cosine
 ----
 
@@ -124,7 +124,7 @@ Properties starting with `spring.ai.vectorstore.neo4j.*` are used to configure t
 |`spring.ai.vectorstore.neo4j.initialize-schema`| Whether to initialize the required schema | `false`
 |`spring.ai.vectorstore.neo4j.database-name` | The name of the Neo4j database to use | `neo4j`
 |`spring.ai.vectorstore.neo4j.index-name` | The name of the index to store the vectors | `spring-ai-document-index`
-|`spring.ai.vectorstore.neo4j.dimensions` | The number of dimensions in the vector | `1536`
+|`spring.ai.vectorstore.neo4j.embedding-dimension` | The number of dimensions in the vector | `1536`
 |`spring.ai.vectorstore.neo4j.distance-type` | The distance function to use | `cosine`
 |`spring.ai.vectorstore.neo4j.label` | The label used for document nodes | `Document`
 |`spring.ai.vectorstore.neo4j.embedding-property` | The property name used to store embeddings | `embedding`
@@ -179,7 +179,7 @@ public VectorStore vectorStore(Driver driver, EmbeddingModel embeddingModel) {
     return Neo4jVectorStore.builder(driver, embeddingModel)
         .databaseName("neo4j")                // Optional: defaults to "neo4j"
         .distanceType(Neo4jDistanceType.COSINE) // Optional: defaults to COSINE
-        .dimensions(1536)                      // Optional: defaults to 1536
+        .embeddingDimension(1536)                      // Optional: defaults to 1536
         .label("Document")                     // Optional: defaults to "Document"
         .embeddingProperty("embedding")        // Optional: defaults to "embedding"
         .indexName("custom-index")             // Optional: defaults to "spring-ai-document-index"


### PR DESCRIPTION
Update the documentation of spring property from `spring.ai.vectorstore.neo4j.dimensions` to `spring.ai.vectorstore.neo4j.embedding-dimension`  to reflect what the code reads.  Without this change, changes to the property `dimensions` are not propagated to runtime code, resulting in discrepancies if an embedding model that has  a different number of dimensions is used

See backign configuration property in the builder at https://github.com/spring-projects/spring-ai/blob/main/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java#L453

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
