### PR TITLE
Support pre-parsed Filter.Expression in getFilterExpression

### DIFF
--- a/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/QuestionAnswerAdvisor.java
+++ b/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/QuestionAnswerAdvisor.java
@@ -155,11 +155,15 @@ public class QuestionAnswerAdvisor implements BaseAdvisor {
 
 	@Nullable
 	protected Filter.Expression doGetFilterExpression(Map<String, Object> context) {
+		var filterExpression = context.get(FILTER_EXPRESSION);
+		if (filterExpression instanceof Filter.Expression) {
+			return (Filter.Expression) filterExpression;
+		}
 		if (!context.containsKey(FILTER_EXPRESSION)
-				|| !StringUtils.hasText(context.get(FILTER_EXPRESSION).toString())) {
+				|| !StringUtils.hasText(filterExpression.toString())) {
 			return this.searchRequest.getFilterExpression();
 		}
-		return new FilterExpressionTextParser().parse(context.get(FILTER_EXPRESSION).toString());
+		return new FilterExpressionTextParser().parse(filterExpression.toString());
 	}
 
 	@Override

--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/retrieval/search/VectorStoreDocumentRetriever.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/retrieval/search/VectorStoreDocumentRetriever.java
@@ -91,6 +91,9 @@ public final class VectorStoreDocumentRetriever implements DocumentRetriever {
 
 	private Filter.Expression computeRequestFilterExpression(Query query) {
 		var contextFilterExpression = query.context().get(FILTER_EXPRESSION);
+		if (contextFilterExpression instanceof Filter.Expression) {
+			return (Filter.Expression) contextFilterExpression;
+		}
 		if (contextFilterExpression != null && StringUtils.hasText(contextFilterExpression.toString())) {
 			return new FilterExpressionTextParser().parse(contextFilterExpression.toString());
 		}

--- a/spring-ai-rag/src/test/java/org/springframework/ai/rag/retrieval/search/VectorStoreDocumentRetrieverTests.java
+++ b/spring-ai-rag/src/test/java/org/springframework/ai/rag/retrieval/search/VectorStoreDocumentRetrieverTests.java
@@ -234,6 +234,31 @@ class VectorStoreDocumentRetrieverTests {
 			.isEqualTo(new FilterExpressionBuilder().eq("location", "Rivendell").build());
 	}
 
+	@Test
+	void retrieveWithQueryObjectAndRequestFilterExpressionBuilder() {
+		FilterExpressionBuilder b = new FilterExpressionBuilder();
+		var mockVectorStore = mock(VectorStore.class);
+		var documentRetriever = VectorStoreDocumentRetriever.builder().vectorStore(mockVectorStore).build();
+
+		var query = Query.builder()
+			.text("test query")
+			.context(Map.of(VectorStoreDocumentRetriever.FILTER_EXPRESSION, b.eq("location", "Rivendell").build()))
+			.build();
+		documentRetriever.retrieve(query);
+
+		// Verify the mock interaction
+		var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(mockVectorStore).similaritySearch(searchRequestCaptor.capture());
+
+		// Verify the search request
+		var searchRequest = searchRequestCaptor.getValue();
+		assertThat(searchRequest.getQuery()).isEqualTo("test query");
+		assertThat(searchRequest.getSimilarityThreshold()).isEqualTo(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+		assertThat(searchRequest.getTopK()).isEqualTo(SearchRequest.DEFAULT_TOP_K);
+		assertThat(searchRequest.getFilterExpression())
+			.isEqualTo(new FilterExpressionBuilder().eq("location", "Rivendell").build());
+	}
+
 	static final class TenantContextHolder {
 
 		private static final ThreadLocal<String> tenantIdentifier = new ThreadLocal<>();


### PR DESCRIPTION
QuestionAnswerAdvisor.doGetFilterExpression
VectorStoreDocumentRetriever.computeRequestFilterExpression

- Add type check to return Filter.Expression directly if already parsed.
- Prevent unnecessary parsing when expression is already in correct form.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
