### PR TITLE
chore: Add IgnoredInToolInputSchema annotation to ignore the parameter when generating the tool's input schema.

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ToolContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ToolContext.java
@@ -16,11 +16,12 @@
 
 package org.springframework.ai.chat.model;
 
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.tool.annotation.IgnoredInToolInputSchema;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.ai.chat.messages.Message;
 
 /**
  * Represents the context for tool execution in a function calling scenario.
@@ -43,6 +44,7 @@ import org.springframework.ai.chat.messages.Message;
  * @author Christian Tzolov
  * @since 1.0.0
  */
+@IgnoredInToolInputSchema
 public final class ToolContext {
 
 	/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/IgnoredInToolInputSchema.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/IgnoredInToolInputSchema.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a type should be ignored when generate the tool input schema.
+ *
+ * @author He-Pin
+ * @since 1.0.0
+ */
+@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface IgnoredInToolInputSchema {
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -16,13 +16,6 @@
 
 package org.springframework.ai.util.json.schema;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -38,14 +31,20 @@ import com.github.victools.jsonschema.module.jackson.JacksonModule;
 import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.annotation.IgnoredInToolInputSchema;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.util.json.JsonParser;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Utilities to generate JSON Schemas from Java types and method signatures. It's designed
@@ -129,9 +128,10 @@ public final class JsonSchemaGenerator {
 			String parameterName = method.getParameters()[i].getName();
 			Type parameterType = method.getGenericParameterTypes()[i];
 			if (parameterType instanceof Class<?> parameterClass
-					&& ClassUtils.isAssignable(parameterClass, ToolContext.class)) {
-				// A ToolContext method parameter is not included in the JSON Schema
-				// generation.
+					&& AnnotationUtils.findAnnotation(parameterClass, IgnoredInToolInputSchema.class) != null) {
+				// A ToolContext or any other method parameter which annotated with
+				// `IgnoredInToolInputSchema`
+				// is not included in the JSON Schema generation.
 				// It's a special type used by Spring AI to pass contextual data to tools
 				// outside the model interaction flow.
 				continue;


### PR DESCRIPTION
Motivation: 

Ignore the parameter when generating the input schema.

instead of https://github.com/spring-projects/spring-ai/pull/3062