### PR TITLE
Removed deprecated method in ChatMemory

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -35,6 +35,7 @@ import org.springframework.ai.chat.model.MessageAggregator;
  * Memory is retrieved added as a collection of messages to the prompt
  *
  * @author Christian Tzolov
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemory> {
@@ -79,10 +80,8 @@ public class MessageChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemo
 	private ChatClientRequest before(ChatClientRequest chatClientRequest) {
 		String conversationId = this.doGetConversationId(chatClientRequest.context());
 
-		int chatMemoryRetrieveSize = this.doGetChatMemoryRetrieveSize(chatClientRequest.context());
-
 		// 1. Retrieve the chat memory for the current conversation.
-		List<Message> memoryMessages = this.getChatMemoryStore().get(conversationId, chatMemoryRetrieveSize);
+		List<Message> memoryMessages = this.getChatMemoryStore().get(conversationId);
 
 		// 2. Advise the request messages list.
 		List<Message> processedMessages = new ArrayList<>(memoryMessages);

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisor.java
@@ -42,6 +42,7 @@ import org.springframework.ai.chat.model.MessageAggregator;
  * @author Christian Tzolov
  * @author Miloš Havránek
  * @author Thomas Vitale
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 public class PromptChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemory> {
@@ -112,10 +113,9 @@ public class PromptChatMemoryAdvisor extends AbstractChatMemoryAdvisor<ChatMemor
 
 	private ChatClientRequest before(ChatClientRequest chatClientRequest) {
 		String conversationId = this.doGetConversationId(chatClientRequest.context());
-		int chatMemoryRetrieveSize = this.doGetChatMemoryRetrieveSize(chatClientRequest.context());
 
 		// 1. Retrieve the chat memory for the current conversation.
-		List<Message> memoryMessages = this.getChatMemoryStore().get(conversationId, chatMemoryRetrieveSize);
+		List<Message> memoryMessages = this.getChatMemoryStore().get(conversationId);
 
 		// 2. Processed memory messages as a string.
 		String memory = memoryMessages.stream()

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemory.java
@@ -26,6 +26,7 @@ import java.util.List;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 public interface ChatMemory {
@@ -49,16 +50,7 @@ public interface ChatMemory {
 	/**
 	 * Get the messages in the chat memory for the specified conversation.
 	 */
-	default List<Message> get(String conversationId) {
-		Assert.hasText(conversationId, "conversationId cannot be null or empty");
-		return get(conversationId, Integer.MAX_VALUE);
-	}
-
-	/**
-	 * @deprecated in favor of using {@link MessageWindowChatMemory}.
-	 */
-	@Deprecated
-	List<Message> get(String conversationId, int lastN);
+	List<Message> get(String conversationId);
 
 	/**
 	 * Clear the chat memory for the specified conversation.

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  *
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 public final class MessageWindowChatMemory implements ChatMemory {
@@ -69,12 +70,6 @@ public final class MessageWindowChatMemory implements ChatMemory {
 	public List<Message> get(String conversationId) {
 		Assert.hasText(conversationId, "conversationId cannot be null or empty");
 		return this.chatMemoryRepository.findByConversationId(conversationId);
-	}
-
-	@Override
-	@Deprecated // in favor of get(conversationId)
-	public List<Message> get(String conversationId, int lastN) {
-		return get(conversationId);
 	}
 
 	@Override


### PR DESCRIPTION
- Removed the get(String conversationId, int lastN) method from ChatMemory.
- Replaced all usages with get(String conversationId) which returns the full message list.

Closes #3075 