### PR TITLE
Add EnabledIfEnvironmentVariable annotation to MariaDBStoreCustomNamesIT

### DIFF
--- a/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBStoreCustomNamesIT.java
+++ b/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBStoreCustomNamesIT.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Diego Dupin
  */
 @Testcontainers
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 public class MariaDBStoreCustomNamesIT {
 
 	private static String schemaName = "testdb";


### PR DESCRIPTION
`MariaDBStoreCustomNamesIT.java` requires the `OPENAI_API_KEY` system environment variable.

https://github.com/spring-projects/spring-ai/blob/5a40ac074489a2e6d69f175b7fa523c476f12435/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBStoreCustomNamesIT.java#L256-L258

However, it lacks the `@EnabledIfEnvironmentVariable` annotation, causing the test to fail.

I have added the annotation to resolve this issue.