### PR TITLE
HttpHost regression issues in OpenSearchVectorStoreAutoConfiguration

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreAutoConfiguration.java
@@ -105,8 +105,14 @@ public class OpenSearchVectorStoreAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean
-		OpenSearchClient openSearchClient(OpenSearchVectorStoreProperties properties, Optional<SslBundles> sslBundles) {
-			HttpHost[] httpHosts = properties.getUris().stream().map(this::createHttpHost).toArray(HttpHost[]::new);
+		OpenSearchClient openSearchClient(OpenSearchVectorStoreProperties properties,
+				OpenSearchConnectionDetails connectionDetails, Optional<SslBundles> sslBundles) {
+
+			HttpHost[] httpHosts = connectionDetails.getUris()
+				.stream()
+				.map(s -> createHttpHost(s))
+				.toArray(HttpHost[]::new);
+
 			Optional<BasicCredentialsProvider> basicCredentialsProvider = Optional.ofNullable(properties.getUsername())
 				.map(username -> createBasicCredentialsProvider(httpHosts, username, properties.getPassword()));
 


### PR DESCRIPTION
Changes introduced for https://github.com/spring-projects/spring-ai/issues/2954 introduced a regression in the way OpenSearch works with test containers.

Restore the retrieval of HttpHost from OpenSearchConnectionDetails insted of getting them directly from properties.

