### PR TITLE
fix: add @JsonProperty for response_format to ensure correct JSON map

### DIFF
--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiImageOptions.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiImageOptions.java
@@ -121,6 +121,7 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * The format in which the generated images are returned. It is sent as part of the
 	 * accept header. Must be "application/json" or "image/png"
 	 */
+	@JsonProperty("response_format")
 	private String responseFormat;
 
 	/**


### PR DESCRIPTION
## Summary

This pull request adds the missing `@JsonProperty("response_format")` annotation to the `responseFormat` field in `StabilityAiImageOptions`.

## Background

Most fields in `StabilityAiImageOptions` are annotated with `@JsonProperty` to ensure correct snake_case mapping for JSON serialization. However, the `responseFormat` field was missing this annotation, which could cause compatibility issues with Stability AI's API if it expects the `response_format` key in the payload.

## Changes

- Added `@JsonProperty("response_format")` to the `responseFormat` field.
- Ensured consistent naming conventions aligned with other fields and Stability AI's expected schema.

## Motivation

This change ensures correct JSON serialization and full compatibility with Stability AI’s API specifications, improving request correctness and code robustness.

## Additional Notes

Let me know if you’d prefer additional test coverage or broader cleanup for consistency across other fields.

