### PR TITLE
Fix outdated configuration key `include-completion` and `include-query-response`

### DIFF
--- a/auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation/src/main/java/org/springframework/ai/model/chat/observation/autoconfigure/ChatObservationProperties.java
+++ b/auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation/src/main/java/org/springframework/ai/model/chat/observation/autoconfigure/ChatObservationProperties.java
@@ -31,9 +31,9 @@ public class ChatObservationProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.chat.observations";
 
 	/**
-	 * Whether to include the completion content in the observations.
+	 * Whether to log the completion content in the observations.
 	 */
-	private boolean includeCompletion = false;
+	private boolean logCompletion = false;
 
 	/**
 	 * Whether to log the prompt content in the observations.
@@ -45,12 +45,12 @@ public class ChatObservationProperties {
 	 */
 	private boolean includeErrorLogging = false;
 
-	public boolean isIncludeCompletion() {
-		return this.includeCompletion;
+	public boolean isLogCompletion() {
+		return this.logCompletion;
 	}
 
-	public void setIncludeCompletion(boolean includeCompletion) {
-		this.includeCompletion = includeCompletion;
+	public void setLogCompletion(boolean logCompletion) {
+		this.logCompletion = logCompletion;
 	}
 
 	public boolean isLogPrompt() {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreObservationProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreObservationProperties.java
@@ -30,16 +30,16 @@ public class VectorStoreObservationProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.observations";
 
 	/**
-	 * Whether to include the search response content in the observations.
+	 * Whether to log the search response content in the observations.
 	 */
-	private boolean includeQueryResponse = false;
+	private boolean logQueryResponse = false;
 
-	public boolean isIncludeQueryResponse() {
-		return this.includeQueryResponse;
+	public boolean isLogQueryResponse() {
+		return this.logQueryResponse;
 	}
 
-	public void setIncludeQueryResponse(boolean includeQueryResponse) {
-		this.includeQueryResponse = includeQueryResponse;
+	public void setLogQueryResponse(boolean logQueryResponse) {
+		this.logQueryResponse = logQueryResponse;
 	}
 
 }


### PR DESCRIPTION
Follow-up of commit ca843e85887aa1da6300c77550c379c103500897,`includeCompletion` is renamed to `logCompletion`.
