### PR TITLE
Added transaction support for saveAll in JdbcChatMemoryRepository

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
@@ -60,7 +60,8 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		Assert.notNull(jdbcTemplate.getDataSource(), "dataSource can not be null");
 		this.jdbcTemplate = jdbcTemplate;
 		this.dialect = dialect;
-		this.transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(jdbcTemplate.getDataSource()));
+		this.transactionTemplate = new TransactionTemplate(
+				new DataSourceTransactionManager(jdbcTemplate.getDataSource()));
 	}
 
 	@Override

--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
@@ -60,7 +60,7 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		Assert.notNull(jdbcTemplate.getDataSource(), "dataSource can not be null");
 		this.jdbcTemplate = jdbcTemplate;
 		this.dialect = dialect;
-		transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(jdbcTemplate.getDataSource()));
+		this.transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(jdbcTemplate.getDataSource()));
 	}
 
 	@Override
@@ -88,15 +88,9 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		Assert.noNullElements(messages, "messages cannot contain null elements");
 
 		transactionTemplate.execute(status -> {
-			try {
-				deleteByConversationId(conversationId);
-				jdbcTemplate.batchUpdate(dialect.getInsertMessageSql(),
-						new AddBatchPreparedStatement(conversationId, messages));
-			}
-			catch (RuntimeException e) {
-				status.setRollbackOnly();
-				throw e;
-			}
+			deleteByConversationId(conversationId);
+			jdbcTemplate.batchUpdate(dialect.getInsertMessageSql(),
+					new AddBatchPreparedStatement(conversationId, messages));
 			return null;
 		});
 	}

--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
@@ -50,13 +50,17 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 
 	private final JdbcTemplate jdbcTemplate;
 
+	private final TransactionTemplate transactionTemplate;
+
 	private final JdbcChatMemoryRepositoryDialect dialect;
 
 	private JdbcChatMemoryRepository(JdbcTemplate jdbcTemplate, JdbcChatMemoryRepositoryDialect dialect) {
 		Assert.notNull(jdbcTemplate, "jdbcTemplate cannot be null");
 		Assert.notNull(dialect, "dialect cannot be null");
+		Assert.notNull(jdbcTemplate.getDataSource(), "dataSource can not be null");
 		this.jdbcTemplate = jdbcTemplate;
 		this.dialect = dialect;
+		transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(jdbcTemplate.getDataSource()));
 	}
 
 	@Override
@@ -82,10 +86,6 @@ public class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		Assert.hasText(conversationId, "conversationId cannot be null or empty");
 		Assert.notNull(messages, "messages cannot be null");
 		Assert.noNullElements(messages, "messages cannot contain null elements");
-
-		Assert.notNull(jdbcTemplate.getDataSource(), "dataSource can not be null");
-		TransactionTemplate transactionTemplate = new TransactionTemplate(
-				new DataSourceTransactionManager(jdbcTemplate.getDataSource()));
 
 		transactionTemplate.execute(status -> {
 			try {


### PR DESCRIPTION
In the saveAll method of JdbcChatMemoryRepository, all historical messages of the current conversation are first deleted, and then the latest list of messages is saved. This operation should be transactional. This PR adds transaction support for it.