### PR TITLE
Fix: Initialize TokenTextSplitter Builder fields with default values

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -154,15 +154,15 @@ public class TokenTextSplitter extends TextSplitter {
 
 	public static final class Builder {
 
-		private int chunkSize;
+		private int chunkSize = DEFAULT_CHUNK_SIZE;
 
-		private int minChunkSizeChars;
+		private int minChunkSizeChars = MIN_CHUNK_SIZE_CHARS;
 
-		private int minChunkLengthToEmbed;
+		private int minChunkLengthToEmbed = MIN_CHUNK_LENGTH_TO_EMBED;
 
-		private int maxNumChunks;
+		private int maxNumChunks = MAX_NUM_CHUNKS;
 
-		private boolean keepSeparator;
+		private boolean keepSeparator = KEEP_SEPARATOR;
 
 		private Builder() {
 		}


### PR DESCRIPTION
<!-- Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission -->

### Description

- Fix the TokenTextSplitter's Builder pattern by properly initializing fields with default values.

### Related Issue

- Fixes #3166 
