### PR TITLE
Fix capabilities configuration not taking effect when the queue is empty in MCP server.

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/pom.xml
@@ -68,6 +68,11 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
@@ -198,26 +198,26 @@ public class McpServerAutoConfiguration {
 
 		if (!CollectionUtils.isEmpty(toolSpecifications)) {
 			serverBuilder.tools(toolSpecifications);
-			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
 			logger.info("Registered tools: " + toolSpecifications.size() + ", notification: "
 					+ serverProperties.isToolChangeNotification());
 		}
+		capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
 
 		List<SyncResourceSpecification> resourceSpecifications = resources.stream().flatMap(List::stream).toList();
 		if (!CollectionUtils.isEmpty(resourceSpecifications)) {
 			serverBuilder.resources(resourceSpecifications);
-			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
 			logger.info("Registered resources: " + resourceSpecifications.size() + ", notification: "
 					+ serverProperties.isResourceChangeNotification());
 		}
+		capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
 
 		List<SyncPromptSpecification> promptSpecifications = prompts.stream().flatMap(List::stream).toList();
 		if (!CollectionUtils.isEmpty(promptSpecifications)) {
 			serverBuilder.prompts(promptSpecifications);
-			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
 			logger.info("Registered prompts: " + promptSpecifications.size() + ", notification: "
 					+ serverProperties.isPromptChangeNotification());
 		}
+		capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
 
 		List<SyncCompletionSpecification> completionSpecifications = completions.stream()
 			.flatMap(List::stream)
@@ -305,26 +305,26 @@ public class McpServerAutoConfiguration {
 
 		if (!CollectionUtils.isEmpty(toolSpecifications)) {
 			serverBuilder.tools(toolSpecifications);
-			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
 			logger.info("Registered tools: " + toolSpecifications.size() + ", notification: "
 					+ serverProperties.isToolChangeNotification());
 		}
+		capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
 
 		List<AsyncResourceSpecification> resourceSpecifications = resources.stream().flatMap(List::stream).toList();
 		if (!CollectionUtils.isEmpty(resourceSpecifications)) {
 			serverBuilder.resources(resourceSpecifications);
-			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
 			logger.info("Registered resources: " + resourceSpecifications.size() + ", notification: "
 					+ serverProperties.isResourceChangeNotification());
 		}
+		capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
 
 		List<AsyncPromptSpecification> promptSpecifications = prompts.stream().flatMap(List::stream).toList();
 		if (!CollectionUtils.isEmpty(promptSpecifications)) {
 			serverBuilder.prompts(promptSpecifications);
-			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
 			logger.info("Registered prompts: " + promptSpecifications.size() + ", notification: "
 					+ serverProperties.isPromptChangeNotification());
 		}
+		capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
 
 		List<AsyncCompletionSpecification> completionSpecifications = completions.stream()
 			.flatMap(List::stream)


### PR DESCRIPTION
For example, when tool-change-notification defaults to true but tools queue is empty during startup, adding tools later throws 'Caused by: io.modelcontextprotocol.spec.McpError: Server must be configured with tool capabilities', which is inconsistent with expectations.  Added unit tests to verify the fix.