### PR TITLE
refactor: remove redundant Builder.samples() method in StabilityAiImageOptions

### DIFF
--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiImageOptions.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiImageOptions.java
@@ -485,11 +485,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 			return this;
 		}
 
-		public Builder samples(Integer samples) {
-			this.options.setN(samples);
-			return this;
-		}
-
 		public Builder stylePreset(String stylePreset) {
 			this.options.setStylePreset(stylePreset);
 			return this;


### PR DESCRIPTION
### Summary

This PR removes the `samples(Integer samples)` method from the `StabilityAiImageOptions.Builder` class, as it duplicates the existing `N(Integer n)` method.

### Motivation

- Both `samples()` and `N()` internally call `setN()`, which sets the same field (`samples` JSON property).
- Having both methods introduces unnecessary redundancy and may cause confusion for users.
- `N()` is already consistent with the `ImageOptions.getN()` interface method and commonly used throughout the codebase.

### Additional Notes

If needed, developers can still set the `samples` value using the `N()` method:

```java
StabilityAiImageOptions options = StabilityAiImageOptions.builder()
    .N(3)
    .build();
```