### PR TITLE
refactor: simplify stylePreset merge logic in StabilityAiModel

### DIFF
--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
@@ -130,14 +130,13 @@ public class StabilityAiImageModel implements ImageModel {
 					defaultOptions.getResponseFormat()))
 			.width(ModelOptionsUtils.mergeOption(runtimeOptions.getWidth(), defaultOptions.getWidth()))
 			.height(ModelOptionsUtils.mergeOption(runtimeOptions.getHeight(), defaultOptions.getHeight()))
-			.stylePreset(ModelOptionsUtils.mergeOption(runtimeOptions.getStyle(), defaultOptions.getStyle()))
 			// Always set the stability-specific defaults
 			.cfgScale(defaultOptions.getCfgScale())
 			.clipGuidancePreset(defaultOptions.getClipGuidancePreset())
 			.sampler(defaultOptions.getSampler())
 			.seed(defaultOptions.getSeed())
 			.steps(defaultOptions.getSteps())
-			.stylePreset(defaultOptions.getStylePreset());
+			.stylePreset(ModelOptionsUtils.mergeOption(runtimeOptions.getStyle(), defaultOptions.getStylePreset()));
 		if (runtimeOptions instanceof StabilityAiImageOptions) {
 			StabilityAiImageOptions stabilityOptions = (StabilityAiImageOptions) runtimeOptions;
 			// Handle Stability AI specific image options


### PR DESCRIPTION
### Summary

This PR refactors the `stylePreset` configuration logic in `StabilityAiImageOptions.Builder` to remove redundant assignments and ensure consistent merging behavior.

### Motivation

- Previously, `stylePreset()` could be called multiple times with potentially conflicting values.
- The new implementation consolidates this into a single line using:
  
  ```java
  .stylePreset(ModelOptionsUtils.mergeOption(
      runtimeOptions.getStyle(),
      defaultOptions.getStylePreset()))
  ```
  
This change ensures that if a runtime option is provided, it takes precedence; otherwise, the default is used—matching the behavior of other portable image options such as model, width, and responseFormat.

> #### Why use getStyle() and not getStylePreset() in runtime options?
- ImageOptions defines a getStyle() method, which is implemented in StabilityAiImageOptions as:
```java
@Override
@JsonIgnore
public String getStyle() {
    return getStylePreset();
}
```
- The @JsonIgnore annotation ensures that this method is excluded from JSON serialization, so the style field does not accidentally appear in the outgoing payload.
- The actual JSON property used by the Stability API is style_preset, which is explicitly annotated:
```java
@JsonProperty("style_preset")
private String stylePreset;
```
- This implementation keeps the merging logic interface-compliant via getStyle(), while ensuring that only style_preset is serialized in API requests.


### Impact
- Improves clarity and predictability of the stylePreset merging process.
- Prevents unintended overrides or inconsistencies due to multiple stylePreset() calls.
- Ensures the correct field is serialized (style_preset) and avoids any accidental inclusion of an incorrect style field.
