### PR TITLE
Do not trigger GHA workflows on forks

### DIFF
--- a/.github/workflows/continuous-inspection.yml
+++ b/.github/workflows/continuous-inspection.yml
@@ -9,6 +9,7 @@ jobs:
   code-quality-analysis:
     name: code quality analysis report
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'spring-projects' }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Build branch
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'spring-projects' }}
     services:
       ollama:
         image: ollama/ollama:latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'spring-projects'
+    if: ${{ github.repository_owner == 'spring-projects' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Build branch
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'spring-projects' }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
GHA workflows are automatically executed on forks where they fail. This change prevents this (only for those workflows that are automatically triggered, e.g.: on push or schedule).