### PR TITLE
Fix VectorStoreDocumentRetriever to handle Filter.Expression objects

### DIFF
--- a/spring-ai-rag/src/test/java/org/springframework/ai/rag/retrieval/search/VectorStoreDocumentRetrieverTests.java
+++ b/spring-ai-rag/src/test/java/org/springframework/ai/rag/retrieval/search/VectorStoreDocumentRetrieverTests.java
@@ -234,6 +234,32 @@ class VectorStoreDocumentRetrieverTests {
 			.isEqualTo(new FilterExpressionBuilder().eq("location", "Rivendell").build());
 	}
 
+	@Test
+	void retrieveWithQueryObjectAndFilterExpressionObject() {
+		var mockVectorStore = mock(VectorStore.class);
+		var documentRetriever = VectorStoreDocumentRetriever.builder().vectorStore(mockVectorStore).build();
+
+		// Create a Filter.Expression object directly
+		var filterExpression = new Filter.Expression(EQ, new Filter.Key("location"), new Filter.Value("Rivendell"));
+
+		var query = Query.builder()
+			.text("test query")
+			.context(Map.of(VectorStoreDocumentRetriever.FILTER_EXPRESSION, filterExpression))
+			.build();
+		documentRetriever.retrieve(query);
+
+		// Verify the mock interaction
+		var searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(mockVectorStore).similaritySearch(searchRequestCaptor.capture());
+
+		// Verify the search request
+		var searchRequest = searchRequestCaptor.getValue();
+		assertThat(searchRequest.getQuery()).isEqualTo("test query");
+		assertThat(searchRequest.getSimilarityThreshold()).isEqualTo(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+		assertThat(searchRequest.getTopK()).isEqualTo(SearchRequest.DEFAULT_TOP_K);
+		assertThat(searchRequest.getFilterExpression()).isEqualTo(filterExpression);
+	}
+
 	static final class TenantContextHolder {
 
 		private static final ThreadLocal<String> tenantIdentifier = new ThreadLocal<>();


### PR DESCRIPTION
- Updated computeRequestFilterExpression to check if the context value is already a Filter.Expression object before attempting to parse it as a string
- Added docs for FILTER_EXPRESSION key that it accepts both String and Filter.Expression
- Added test

Fixes #3179

