### PR TITLE
GH-3160: Handle element types correctly in CassandraFilterExpressionC…

### DIFF
--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraFilterExpressionConverter.java
@@ -23,7 +23,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.MapType;
+import com.datastax.oss.driver.api.core.type.SetType;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 
@@ -118,10 +122,19 @@ class CassandraFilterExpressionConverter extends AbstractFilterExpressionConvert
 	}
 
 	private void doValue(ColumnMetadata column, Object v, StringBuilder context) {
+
+		DataType dataType = column.getType();
+
+		// Check if we're handling an element inside a collection for an IN clause
+		if ((dataType instanceof ListType) && !(v instanceof Collection)) {
+			// Extract the element type from the collection type
+			dataType = ((ListType) dataType).getElementType();
+		}
+
 		if (DataTypes.SMALLINT.equals(column.getType())) {
 			v = ((Number) v).shortValue();
 		}
-		context.append(CodecRegistry.DEFAULT.codecFor(column.getType()).format(v));
+		context.append(CodecRegistry.DEFAULT.codecFor(dataType).format(v));
 	}
 
 	private Optional<ColumnMetadata> getColumn(String name) {


### PR DESCRIPTION
…onverter.doValue

Fixes: 3160

https://github.com/spring-projects/spring-ai/issues/3160

When using a filter expression with IN operator on a collection field in CassandraVectorStore.similaritySearch, a ClassCastException was thrown because the code attempted to format individual collection elements using the collection's codec instead of the element type's codec.

This fix modifies doValue to detect when we are formatting elements inside a collection type and use the appropriate element type codec. While Cassandra does not support using the IN operator directly on collection columns, this fix ensures we generate syntactically correct CQL rather than throwing a Java exception.

The change specifically addresses ListType collections by using the element type codec for individual elements within the list.

