### PR TITLE
Revise JdbcChatMemoryRepository tests

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryMysqlIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryMysqlIT.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.chat.memory.repository.jdbc;
 
-import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
@@ -27,15 +26,11 @@ import org.springframework.test.context.jdbc.Sql;
  * @author Jonathan Leijendekker
  * @author Thomas Vitale
  * @author Mark Pollack
+ * @author Yanming Zhou
  */
-@SpringBootTest(classes = JdbcChatMemoryRepositoryMysqlIT.TestConfiguration.class)
+@SpringBootTest
 @TestPropertySource(properties = { "spring.datasource.url=jdbc:tc:mariadb:10.3.39:///" })
 @Sql(scripts = "classpath:org/springframework/ai/chat/memory/repository/jdbc/schema-mariadb.sql")
 class JdbcChatMemoryRepositoryMysqlIT extends AbstractJdbcChatMemoryRepositoryIT {
-
-	@SpringBootConfiguration
-	static class TestConfiguration extends BaseTestConfiguration {
-
-	}
 
 }

--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryPostgresqlIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryPostgresqlIT.java
@@ -16,26 +16,9 @@
 
 package org.springframework.ai.chat.memory.repository.jdbc;
 
-import java.util.List;
-import java.util.UUID;
-import javax.sql.DataSource;
-
-import org.junit.jupiter.api.Test;
-
-import org.springframework.ai.chat.memory.ChatMemoryRepository;
-import org.springframework.ai.chat.messages.AssistantMessage;
-import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.messages.SystemMessage;
-import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for {@link JdbcChatMemoryRepository} with PostgreSQL.
@@ -43,57 +26,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Jonathan Leijendekker
  * @author Thomas Vitale
  * @author Mark Pollack
+ * @author Yanming Zhou
  */
-@SpringBootTest(classes = JdbcChatMemoryRepositoryPostgresqlIT.TestConfiguration.class)
+@SpringBootTest
 @TestPropertySource(properties = "spring.datasource.url=jdbc:tc:postgresql:17:///")
 @Sql(scripts = "classpath:org/springframework/ai/chat/memory/repository/jdbc/schema-postgresql.sql")
 class JdbcChatMemoryRepositoryPostgresqlIT extends AbstractJdbcChatMemoryRepositoryIT {
-
-	@Test
-	void repositoryWithExplicitTransactionManager() {
-		// Get the repository with explicit transaction manager
-		ChatMemoryRepository repositoryWithTxManager = TestConfiguration
-			.chatMemoryRepositoryWithTransactionManager(jdbcTemplate, jdbcTemplate.getDataSource());
-
-		var conversationId = UUID.randomUUID().toString();
-		var messages = List.<Message>of(new AssistantMessage("Message with transaction manager - " + conversationId),
-				new UserMessage("User message with transaction manager - " + conversationId));
-
-		// Save messages using the repository with explicit transaction manager
-		repositoryWithTxManager.saveAll(conversationId, messages);
-
-		// Verify messages were saved correctly
-		var savedMessages = repositoryWithTxManager.findByConversationId(conversationId);
-		assertThat(savedMessages).hasSize(2);
-		assertThat(savedMessages).isEqualTo(messages);
-
-		// Verify transaction works by updating and checking atomicity
-		var newMessages = List.<Message>of(new SystemMessage("New system message - " + conversationId));
-		repositoryWithTxManager.saveAll(conversationId, newMessages);
-
-		// The old messages should be deleted and only the new one should exist
-		var updatedMessages = repositoryWithTxManager.findByConversationId(conversationId);
-		assertThat(updatedMessages).hasSize(1);
-		assertThat(updatedMessages).isEqualTo(newMessages);
-	}
-
-	@SpringBootConfiguration
-	static class TestConfiguration extends BaseTestConfiguration {
-
-		@Bean
-		ChatMemoryRepository chatMemoryRepositoryWithTxManager(JdbcTemplate jdbcTemplate, DataSource dataSource) {
-			return chatMemoryRepositoryWithTransactionManager(jdbcTemplate, dataSource);
-		}
-
-		static ChatMemoryRepository chatMemoryRepositoryWithTransactionManager(JdbcTemplate jdbcTemplate,
-				DataSource dataSource) {
-			return JdbcChatMemoryRepository.builder()
-				.jdbcTemplate(jdbcTemplate)
-				.dialect(JdbcChatMemoryRepositoryDialect.from(dataSource))
-				.transactionManager(new DataSourceTransactionManager(dataSource))
-				.build();
-		}
-
-	}
 
 }


### PR DESCRIPTION
1. Fix failed `JdbcChatMemoryRepositoryPostgresqlIT` tests due to connection leakage:
```
org.springframework.jdbc.CannotGetJdbcConnectionException: Failed to obtain JDBC Connection

	at org.springframework.jdbc.datasource.DataSourceUtils.getConnection(DataSourceUtils.java:84)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:653)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:723)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:754)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:767)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:820)
	at org.springframework.jdbc.core.JdbcTemplate.queryForList(JdbcTemplate.java:954)
	at org.springframework.ai.chat.memory.repository.jdbc.AbstractJdbcChatMemoryRepositoryIT.saveMessagesMultipleMessages(AbstractJdbcChatMemoryRepositoryIT.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30001ms (total=10, active=10, idle=0, waiting=0)
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:686)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:179)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:144)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:127)
	at org.springframework.jdbc.datasource.DataSourceUtils.fetchConnection(DataSourceUtils.java:160)
	at org.springframework.jdbc.datasource.DataSourceUtils.doGetConnection(DataSourceUtils.java:118)
	at org.springframework.jdbc.datasource.DataSourceUtils.getConnection(DataSourceUtils.java:81)
	... 10 more
```

2. Remove unnecessary tests, `correctChatMemoryRepositoryInstance()` do nothing, `repositoryWithExplicitTransactionManager()` actually doesn't test explicit transaction manager

