### PR TITLE
feat(mcp): Add granular control over MCP server capabilities

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
@@ -149,11 +149,11 @@ public class McpServerAutoConfiguration {
 
 		// De-duplicate tools by their name, keeping the first occurrence of each tool
 		// name
-		return tools.stream()
-			.collect(Collectors.toMap(tool -> tool.getToolDefinition().name(), // Key:
-																				// tool
-																				// name
-					tool -> tool, // Value: the tool itself
+		return tools.stream() // Key: tool name
+			.collect(Collectors.toMap(tool -> tool.getToolDefinition().name(), tool -> tool, // Value:
+																								// the
+																								// tool
+																								// itself
 					(existing, replacement) -> existing)) // On duplicate key, keep the
 															// existing tool
 			.values()
@@ -185,47 +185,66 @@ public class McpServerAutoConfiguration {
 		// Create the server with both tool and resource capabilities
 		SyncSpecification serverBuilder = McpServer.sync(transportProvider).serverInfo(serverInfo);
 
-		List<SyncToolSpecification> toolSpecifications = new ArrayList<>(tools.stream().flatMap(List::stream).toList());
-
-		List<ToolCallback> providerToolCallbacks = toolCallbackProvider.stream()
-			.map(pr -> List.of(pr.getToolCallbacks()))
-			.flatMap(List::stream)
-			.filter(fc -> fc instanceof ToolCallback)
-			.map(fc -> (ToolCallback) fc)
-			.toList();
-
-		toolSpecifications.addAll(this.toSyncToolSpecifications(providerToolCallbacks, serverProperties));
-
-		if (!CollectionUtils.isEmpty(toolSpecifications)) {
-			serverBuilder.tools(toolSpecifications);
+		// Tools
+		if (serverProperties.getCapabilities().isTool()) {
+			logger.info("Enable tools capabilities, notification: " + serverProperties.isToolChangeNotification());
 			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
-			logger.info("Registered tools: " + toolSpecifications.size() + ", notification: "
-					+ serverProperties.isToolChangeNotification());
+
+			List<SyncToolSpecification> toolSpecifications = new ArrayList<>(
+					tools.stream().flatMap(List::stream).toList());
+
+			List<ToolCallback> providerToolCallbacks = toolCallbackProvider.stream()
+				.map(pr -> List.of(pr.getToolCallbacks()))
+				.flatMap(List::stream)
+				.filter(fc -> fc instanceof ToolCallback)
+				.map(fc -> (ToolCallback) fc)
+				.toList();
+
+			toolSpecifications.addAll(this.toSyncToolSpecifications(providerToolCallbacks, serverProperties));
+
+			if (!CollectionUtils.isEmpty(toolSpecifications)) {
+				serverBuilder.tools(toolSpecifications);
+				logger.info("Registered tools: " + toolSpecifications.size());
+			}
 		}
 
-		List<SyncResourceSpecification> resourceSpecifications = resources.stream().flatMap(List::stream).toList();
-		if (!CollectionUtils.isEmpty(resourceSpecifications)) {
-			serverBuilder.resources(resourceSpecifications);
+		// Resources
+		if (serverProperties.getCapabilities().isResource()) {
+			logger.info(
+					"Enable resources capabilities, notification: " + serverProperties.isResourceChangeNotification());
 			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
-			logger.info("Registered resources: " + resourceSpecifications.size() + ", notification: "
-					+ serverProperties.isResourceChangeNotification());
+
+			List<SyncResourceSpecification> resourceSpecifications = resources.stream().flatMap(List::stream).toList();
+			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
+				serverBuilder.resources(resourceSpecifications);
+				logger.info("Registered resources: " + resourceSpecifications.size());
+			}
 		}
 
-		List<SyncPromptSpecification> promptSpecifications = prompts.stream().flatMap(List::stream).toList();
-		if (!CollectionUtils.isEmpty(promptSpecifications)) {
-			serverBuilder.prompts(promptSpecifications);
+		// Prompts
+		if (serverProperties.getCapabilities().isPrompt()) {
+			logger.info("Enable prompts capabilities, notification: " + serverProperties.isPromptChangeNotification());
 			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
-			logger.info("Registered prompts: " + promptSpecifications.size() + ", notification: "
-					+ serverProperties.isPromptChangeNotification());
+
+			List<SyncPromptSpecification> promptSpecifications = prompts.stream().flatMap(List::stream).toList();
+			if (!CollectionUtils.isEmpty(promptSpecifications)) {
+				serverBuilder.prompts(promptSpecifications);
+				logger.info("Registered prompts: " + promptSpecifications.size());
+			}
 		}
 
-		List<SyncCompletionSpecification> completionSpecifications = completions.stream()
-			.flatMap(List::stream)
-			.toList();
-		if (!CollectionUtils.isEmpty(completionSpecifications)) {
-			serverBuilder.completions(completionSpecifications);
+		// Completions
+		if (serverProperties.getCapabilities().isCompletion()) {
+			logger.info("Enable completions capabilities");
 			capabilitiesBuilder.completions();
-			logger.info("Registered completions: " + completionSpecifications.size());
+
+			List<SyncCompletionSpecification> completionSpecifications = completions.stream()
+				.flatMap(List::stream)
+				.toList();
+			if (!CollectionUtils.isEmpty(completionSpecifications)) {
+				serverBuilder.completions(completionSpecifications);
+				logger.info("Registered completions: " + completionSpecifications.size());
+			}
 		}
 
 		rootsChangeConsumers.ifAvailable(consumer -> {
@@ -257,11 +276,11 @@ public class McpServerAutoConfiguration {
 			McpServerProperties serverProperties) {
 		// De-duplicate tools by their name, keeping the first occurrence of each tool
 		// name
-		return tools.stream()
-			.collect(Collectors.toMap(tool -> tool.getToolDefinition().name(), // Key:
-																				// tool
-																				// name
-					tool -> tool, // Value: the tool itself
+		return tools.stream() // Key: tool name
+			.collect(Collectors.toMap(tool -> tool.getToolDefinition().name(), tool -> tool, // Value:
+																								// the
+																								// tool
+																								// itself
 					(existing, replacement) -> existing)) // On duplicate key, keep the
 															// existing tool
 			.values()
@@ -303,35 +322,51 @@ public class McpServerAutoConfiguration {
 
 		toolSpecifications.addAll(this.toAsyncToolSpecification(providerToolCallbacks, serverProperties));
 
+		// Tools
+		if (serverProperties.getCapabilities().isTool()) {
+			logger.info("Enable tools capabilities, notification: " + serverProperties.isToolChangeNotification());
+			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
+		}
+
 		if (!CollectionUtils.isEmpty(toolSpecifications)) {
 			serverBuilder.tools(toolSpecifications);
-			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
-			logger.info("Registered tools: " + toolSpecifications.size() + ", notification: "
-					+ serverProperties.isToolChangeNotification());
+			logger.info("Registered tools: " + toolSpecifications.size());
+		}
+
+		// Resources
+		if (serverProperties.getCapabilities().isResource()) {
+			logger.info(
+					"Enable resources capabilities, notification: " + serverProperties.isResourceChangeNotification());
+			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
 		}
 
 		List<AsyncResourceSpecification> resourceSpecifications = resources.stream().flatMap(List::stream).toList();
 		if (!CollectionUtils.isEmpty(resourceSpecifications)) {
 			serverBuilder.resources(resourceSpecifications);
-			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
-			logger.info("Registered resources: " + resourceSpecifications.size() + ", notification: "
-					+ serverProperties.isResourceChangeNotification());
+			logger.info("Registered resources: " + resourceSpecifications.size());
 		}
 
+		// Prompts
+		if (serverProperties.getCapabilities().isPrompt()) {
+			logger.info("Enable prompts capabilities, notification: " + serverProperties.isPromptChangeNotification());
+			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
+		}
 		List<AsyncPromptSpecification> promptSpecifications = prompts.stream().flatMap(List::stream).toList();
 		if (!CollectionUtils.isEmpty(promptSpecifications)) {
 			serverBuilder.prompts(promptSpecifications);
-			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
-			logger.info("Registered prompts: " + promptSpecifications.size() + ", notification: "
-					+ serverProperties.isPromptChangeNotification());
+			logger.info("Registered prompts: " + promptSpecifications.size());
 		}
 
+		// Completions
+		if (serverProperties.getCapabilities().isCompletion()) {
+			logger.info("Enable completions capabilities");
+			capabilitiesBuilder.completions();
+		}
 		List<AsyncCompletionSpecification> completionSpecifications = completions.stream()
 			.flatMap(List::stream)
 			.toList();
 		if (!CollectionUtils.isEmpty(completionSpecifications)) {
 			serverBuilder.completions(completionSpecifications);
-			capabilitiesBuilder.completions();
 			logger.info("Registered completions: " + completionSpecifications.size());
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
@@ -132,6 +132,56 @@ public class McpServerProperties {
 	 */
 	private ServerType type = ServerType.SYNC;
 
+	private Capabilities capabilities = new Capabilities();
+
+	public static class Capabilities {
+
+		private boolean resource = true;
+
+		private boolean tool = true;
+
+		private boolean prompt = true;
+
+		private boolean completion = true;
+
+		public boolean isResource() {
+			return resource;
+		}
+
+		public void setResource(boolean resource) {
+			this.resource = resource;
+		}
+
+		public boolean isTool() {
+			return tool;
+		}
+
+		public void setTool(boolean tool) {
+			this.tool = tool;
+		}
+
+		public boolean isPrompt() {
+			return prompt;
+		}
+
+		public void setPrompt(boolean prompt) {
+			this.prompt = prompt;
+		}
+
+		public boolean isCompletion() {
+			return completion;
+		}
+
+		public void setCompletion(boolean completion) {
+			this.completion = completion;
+		}
+
+	}
+
+	public Capabilities getCapabilities() {
+		return capabilities;
+	}
+
 	/**
 	 * Server types supported by the MCP server.
 	 */

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
@@ -134,52 +134,8 @@ public class McpServerProperties {
 
 	private Capabilities capabilities = new Capabilities();
 
-	public static class Capabilities {
-
-		private boolean resource = true;
-
-		private boolean tool = true;
-
-		private boolean prompt = true;
-
-		private boolean completion = true;
-
-		public boolean isResource() {
-			return resource;
-		}
-
-		public void setResource(boolean resource) {
-			this.resource = resource;
-		}
-
-		public boolean isTool() {
-			return tool;
-		}
-
-		public void setTool(boolean tool) {
-			this.tool = tool;
-		}
-
-		public boolean isPrompt() {
-			return prompt;
-		}
-
-		public void setPrompt(boolean prompt) {
-			this.prompt = prompt;
-		}
-
-		public boolean isCompletion() {
-			return completion;
-		}
-
-		public void setCompletion(boolean completion) {
-			this.completion = completion;
-		}
-
-	}
-
 	public Capabilities getCapabilities() {
-		return capabilities;
+		return this.capabilities;
 	}
 
 	/**
@@ -308,6 +264,50 @@ public class McpServerProperties {
 
 	public Map<String, String> getToolResponseMimeType() {
 		return this.toolResponseMimeType;
+	}
+
+	public static class Capabilities {
+
+		private boolean resource = true;
+
+		private boolean tool = true;
+
+		private boolean prompt = true;
+
+		private boolean completion = true;
+
+		public boolean isResource() {
+			return this.resource;
+		}
+
+		public void setResource(boolean resource) {
+			this.resource = resource;
+		}
+
+		public boolean isTool() {
+			return this.tool;
+		}
+
+		public void setTool(boolean tool) {
+			this.tool = tool;
+		}
+
+		public boolean isPrompt() {
+			return this.prompt;
+		}
+
+		public void setPrompt(boolean prompt) {
+			this.prompt = prompt;
+		}
+
+		public boolean isCompletion() {
+			return this.completion;
+		}
+
+		public void setCompletion(boolean completion) {
+			this.completion = completion;
+		}
+
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfigurationIT.java
@@ -241,42 +241,6 @@ public class McpServerAutoConfigurationIT {
 			});
 	}
 
-	@Configuration
-	static class TestResourceConfiguration {
-
-		@Bean
-		List<SyncResourceSpecification> testResources() {
-			return List.of();
-		}
-
-	}
-
-	@Configuration
-	static class TestPromptConfiguration {
-
-		@Bean
-		List<SyncPromptSpecification> testPrompts() {
-			return List.of();
-		}
-
-	}
-
-	@Configuration
-	static class CustomCapabilitiesConfiguration {
-
-		@Bean
-		McpSchema.ServerCapabilities.Builder customCapabilitiesBuilder() {
-			return new CustomCapabilitiesBuilder();
-		}
-
-	}
-
-	static class CustomCapabilitiesBuilder extends McpSchema.ServerCapabilities.Builder {
-
-		// Custom implementation for testing
-
-	}
-
 	@Test
 	void capabilitiesConfiguration() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.server.capabilities.tool=false",
@@ -329,9 +293,44 @@ public class McpServerAutoConfigurationIT {
 
 	@Test
 	void toolCallbackProviderConfiguration() {
-		this.contextRunner.withUserConfiguration(TestToolCallbackProviderConfiguration.class).run(context -> {
-			assertThat(context).hasSingleBean(ToolCallbackProvider.class);
-		});
+		this.contextRunner.withUserConfiguration(TestToolCallbackProviderConfiguration.class)
+			.run(context -> assertThat(context).hasSingleBean(ToolCallbackProvider.class));
+	}
+
+	@Configuration
+	static class TestResourceConfiguration {
+
+		@Bean
+		List<SyncResourceSpecification> testResources() {
+			return List.of();
+		}
+
+	}
+
+	@Configuration
+	static class TestPromptConfiguration {
+
+		@Bean
+		List<SyncPromptSpecification> testPrompts() {
+			return List.of();
+		}
+
+	}
+
+	@Configuration
+	static class CustomCapabilitiesConfiguration {
+
+		@Bean
+		McpSchema.ServerCapabilities.Builder customCapabilitiesBuilder() {
+			return new CustomCapabilitiesBuilder();
+		}
+
+	}
+
+	static class CustomCapabilitiesBuilder extends McpSchema.ServerCapabilities.Builder {
+
+		// Custom implementation for testing
+
 	}
 
 	@Configuration
@@ -379,11 +378,8 @@ public class McpServerAutoConfigurationIT {
 		List<SyncCompletionSpecification> testCompletions() {
 
 			BiFunction<McpSyncServerExchange, McpSchema.CompleteRequest, McpSchema.CompleteResult> completionHandler = (
-					exchange, request) -> {
-				// Test implementation
-				return new McpSchema.CompleteResult(
-						new McpSchema.CompleteResult.CompleteCompletion(List.of(), 0, false));
-			};
+					exchange, request) -> new McpSchema.CompleteResult(
+							new McpSchema.CompleteResult.CompleteCompletion(List.of(), 0, false));
 
 			return List.of(new McpServerFeatures.SyncCompletionSpecification(
 					new McpSchema.PromptReference("ref/prompt", "code_review"), completionHandler));
@@ -397,11 +393,9 @@ public class McpServerAutoConfigurationIT {
 		@Bean
 		List<AsyncCompletionSpecification> testAsyncCompletions() {
 			BiFunction<McpAsyncServerExchange, McpSchema.CompleteRequest, Mono<McpSchema.CompleteResult>> completionHandler = (
-					exchange, request) -> {
-				// Test implementation
-				return Mono.just(new McpSchema.CompleteResult(
-						new McpSchema.CompleteResult.CompleteCompletion(List.of(), 0, false)));
-			};
+					exchange, request) -> Mono.just(new McpSchema.CompleteResult(
+							new McpSchema.CompleteResult.CompleteCompletion(List.of(), 0, false)));
+
 			return List.of(new McpServerFeatures.AsyncCompletionSpecification(
 					new McpSchema.PromptReference("ref/prompt", "code_review"), completionHandler));
 		}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -91,7 +91,12 @@ All properties are prefixed with `spring.ai.mcp.server`:
 |`stdio` |Enable/disable stdio transport |`false`
 |`name` |Server name for identification |`mcp-server`
 |`version` |Server version |`1.0.0`
+|`instructions` |Optional instructions to provide guidance to the client on how to interact with this server |`null`
 |`type` |Server type (SYNC/ASYNC) |`SYNC`
+|`capabilities.resource` |Enable/disable resource capabilities |`true`
+|`capabilities.tool` |Enable/disable tool capabilities |`true`
+|`capabilities.prompt` |Enable/disable prompt capabilities |`true`
+|`capabilities.completion` |Enable/disable completion capabilities |`true`
 |`resource-change-notification` |Enable resource change notifications |`true`
 |`prompt-change-notification` |Enable prompt change notifications |`true`
 |`tool-change-notification` |Enable tool change notifications |`true`
@@ -111,6 +116,17 @@ When activated, it automatically handles the configuration of synchronous tool s
 * **Asynchronous Server** - The asynchronous server implementation uses `McpAsyncServer` and is optimized for non-blocking operations. 
 To enable this server type, configure your application with `spring.ai.mcp.server.type=ASYNC`. 
 This server type automatically sets up asynchronous tool specifications with built-in Project Reactor support.
+
+== Server Capabilities
+
+The MCP Server supports four main capability types that can be individually enabled or disabled:
+
+* **Tools** - Enable/disable tool capabilities with `spring.ai.mcp.server.capabilities.tool=true|false`
+* **Resources** - Enable/disable resource capabilities with `spring.ai.mcp.server.capabilities.resource=true|false`
+* **Prompts** - Enable/disable prompt capabilities with `spring.ai.mcp.server.capabilities.prompt=true|false`
+* **Completions** - Enable/disable completion capabilities with `spring.ai.mcp.server.capabilities.completion=true|false`
+
+All capabilities are enabled by default. Disabling a capability will prevent the server from registering and exposing the corresponding features to clients.
 
 == Transport Options
 
@@ -141,6 +157,17 @@ public ToolCallbackProvider myTools(...) {
 }
 ----
 
+or directly as individual tool callbacks:
+
+[source,java]
+----
+@Bean
+public ToolCallback myTool(...) {
+    // Create and return a single tool callback
+    return new ToolCallback(...);
+}
+----
+
 or using the low-level API:
 
 [source,java]
@@ -151,6 +178,13 @@ public List<McpServerFeatures.SyncToolSpecification> myTools(...) {
     return tools;
 }
 ----
+
+The auto-configuration will automatically detect and register all tool callbacks from:
+* Individual `ToolCallback` beans
+* Lists of `ToolCallback` beans
+* `ToolCallbackProvider` beans
+
+Tools are de-duplicated by name, with the first occurrence of each tool name being used.
 
 === link:https://spec.modelcontextprotocol.io/specification/2024-11-05/server/resources/[Resource Management]
 
@@ -210,6 +244,33 @@ public List<McpServerFeatures.SyncPromptSpecification> myPrompts() {
 }
 ----
 
+=== link:https://spec.modelcontextprotocol.io/specification/2024-11-05/server/completions/[Completion Management]
+
+Provides a standardized way for servers to expose completion capabilities to clients.
+
+* Support for both sync and async completion specifications
+* Automatic registration through Spring beans:
+
+[source,java]
+----
+@Bean
+public List<McpServerFeatures.SyncCompletionSpecification> myCompletions() {
+    var completion = new McpServerFeatures.SyncCompletionSpecification(
+        "code-completion", 
+        "Provides code completion suggestions",
+        (exchange, request) -> {
+            // Implementation that returns completion suggestions
+            return new McpSchema.CompletionResult(List.of(
+                new McpSchema.Completion("suggestion1", "First suggestion"),
+                new McpSchema.Completion("suggestion2", "Second suggestion")
+            ));
+        }
+    );
+    
+    return List.of(completion);
+}
+----
+
 === link:https://spec.modelcontextprotocol.io/specification/2024-11-05/client/roots/#root-list-changes[Root Change Consumers]
 
 When roots change, clients that support `listChanged` send a Root Change notification.
@@ -254,7 +315,13 @@ spring:
         name: webmvc-mcp-server
         version: 1.0.0
         type: SYNC
+        instructions: "This server provides weather information tools and resources"
         sse-message-endpoint: /mcp/messages
+        capabilities:
+          tool: true
+          resource: true
+          prompt: true
+          completion: true
 ----
 
 === WebFlux Server Configuration
@@ -268,7 +335,13 @@ spring:
         name: webflux-mcp-server
         version: 1.0.0
         type: ASYNC  # Recommended for reactive applications
+        instructions: "This reactive server provides weather information tools and resources"
         sse-message-endpoint: /mcp/messages
+        capabilities:
+          tool: true
+          resource: true
+          prompt: true
+          completion: true
 ----
 
 === Creating a Spring Boot Application with MCP Server


### PR DESCRIPTION
- Add capability configuration to enable/disable tools, resources, prompts, and completions individually
- Refactor server configuration to conditionally register capabilities based on configuration
- Add support for server instructions configuration
- Update documentation with new capability options and completion management
- Add tests for new capabilities and configurations

Resolves #3207

