### PR TITLE
Change log level from DEBUG to INFO for ObservationHandlers

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/ChatClientPromptContentObservationHandler.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/ChatClientPromptContentObservationHandler.java
@@ -40,7 +40,7 @@ public class ChatClientPromptContentObservationHandler implements ObservationHan
 
 	@Override
 	public void onStop(ChatClientObservationContext context) {
-		logger.debug("Chat Client Prompt Content:\n{}", ObservabilityHelper.concatenateEntries(processPrompt(context)));
+		logger.info("Chat Client Prompt Content:\n{}", ObservabilityHelper.concatenateEntries(processPrompt(context)));
 	}
 
 	private Map<String, Object> processPrompt(ChatClientObservationContext context) {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/ChatClientPromptContentObservationHandlerTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/ChatClientPromptContentObservationHandlerTests.java
@@ -63,7 +63,7 @@ class ChatClientPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Client Prompt Content:
+				INFO  o.s.a.c.c.o.ChatClientPromptContentObservationHandler -- Chat Client Prompt Content:
 				[]
 				""");
 	}
@@ -75,7 +75,7 @@ class ChatClientPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Client Prompt Content:
+				INFO  o.s.a.c.c.o.ChatClientPromptContentObservationHandler -- Chat Client Prompt Content:
 				["user":"supercalifragilisticexpialidocious"]
 				""");
 	}
@@ -90,7 +90,7 @@ class ChatClientPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Client Prompt Content:
+				INFO  o.s.a.c.c.o.ChatClientPromptContentObservationHandler -- Chat Client Prompt Content:
 				["system":"you're a chimney sweep", "user":"supercalifragilisticexpialidocious"]
 				""");
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelCompletionObservationHandler.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelCompletionObservationHandler.java
@@ -40,7 +40,7 @@ public class ChatModelCompletionObservationHandler implements ObservationHandler
 
 	@Override
 	public void onStop(ChatModelObservationContext context) {
-		logger.debug("Chat Model Completion:\n{}", ObservabilityHelper.concatenateStrings(completion(context)));
+		logger.info("Chat Model Completion:\n{}", ObservabilityHelper.concatenateStrings(completion(context)));
 	}
 
 	private List<String> completion(ChatModelObservationContext context) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelPromptContentObservationHandler.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelPromptContentObservationHandler.java
@@ -40,7 +40,7 @@ public class ChatModelPromptContentObservationHandler implements ObservationHand
 
 	@Override
 	public void onStop(ChatModelObservationContext context) {
-		logger.debug("Chat Model Prompt Content:\n{}", ObservabilityHelper.concatenateStrings(prompt(context)));
+		logger.info("Chat Model Prompt Content:\n{}", ObservabilityHelper.concatenateStrings(prompt(context)));
 	}
 
 	private List<String> prompt(ChatModelObservationContext context) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/image/observation/ImageModelPromptContentObservationHandler.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/image/observation/ImageModelPromptContentObservationHandler.java
@@ -44,7 +44,7 @@ public class ImageModelPromptContentObservationHandler implements ObservationHan
 				.getInstructions()
 				.forEach(message -> promptMessagesJoiner.add("\"" + message.getText() + "\""));
 
-			logger.debug("Image Model Prompt Content:\n{}", promptMessagesJoiner);
+			logger.info("Image Model Prompt Content:\n{}", promptMessagesJoiner);
 		}
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelCompletionObservationHandlerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelCompletionObservationHandlerTests.java
@@ -66,7 +66,7 @@ class ChatModelCompletionObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Model Completion:
+				INFO  o.s.a.c.o.ChatModelCompletionObservationHandler -- Chat Model Completion:
 				[]
 				""");
 	}
@@ -80,7 +80,7 @@ class ChatModelCompletionObservationHandlerTests {
 		context.setResponse(new ChatResponse(List.of(new Generation(new AssistantMessage("")))));
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Model Completion:
+				INFO  o.s.a.c.o.ChatModelCompletionObservationHandler -- Chat Model Completion:
 				[]
 				""");
 	}
@@ -95,7 +95,7 @@ class ChatModelCompletionObservationHandlerTests {
 				new Generation(new AssistantMessage("seriously, say please")))));
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Model Completion:
+				INFO  o.s.a.c.o.ChatModelCompletionObservationHandler -- Chat Model Completion:
 				["say please", "seriously, say please"]
 				""");
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelPromptContentObservationHandlerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelPromptContentObservationHandlerTests.java
@@ -65,7 +65,7 @@ class ChatModelPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Model Prompt Content:
+				INFO  o.s.a.c.o.ChatModelPromptContentObservationHandler -- Chat Model Prompt Content:
 				[]
 				""");
 	}
@@ -78,7 +78,7 @@ class ChatModelPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Model Prompt Content:
+				INFO  o.s.a.c.o.ChatModelPromptContentObservationHandler -- Chat Model Prompt Content:
 				["supercalifragilisticexpialidocious"]
 				""");
 	}
@@ -94,7 +94,7 @@ class ChatModelPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Chat Model Prompt Content:
+				INFO  o.s.a.c.o.ChatModelPromptContentObservationHandler -- Chat Model Prompt Content:
 				["you're a chimney sweep", "supercalifragilisticexpialidocious"]
 				""");
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/image/observation/ImageModelPromptContentObservationHandlerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/image/observation/ImageModelPromptContentObservationHandlerTests.java
@@ -64,7 +64,7 @@ class ImageModelPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Image Model Prompt Content:
+				INFO  o.s.a.i.o.ImageModelPromptContentObservationHandler -- Image Model Prompt Content:
 				[""]
 				""");
 	}
@@ -78,7 +78,7 @@ class ImageModelPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Image Model Prompt Content:
+				INFO  o.s.a.i.o.ImageModelPromptContentObservationHandler -- Image Model Prompt Content:
 				["supercalifragilisticexpialidocious"]
 				""");
 	}
@@ -94,7 +94,7 @@ class ImageModelPromptContentObservationHandlerTests {
 			.build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Image Model Prompt Content:
+				INFO  o.s.a.i.o.ImageModelPromptContentObservationHandler -- Image Model Prompt Content:
 				["you're a chimney sweep", "supercalifragilisticexpialidocious"]
 				""");
 	}

--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/observation/VectorStoreQueryResponseObservationHandler.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/observation/VectorStoreQueryResponseObservationHandler.java
@@ -40,7 +40,7 @@ public class VectorStoreQueryResponseObservationHandler implements ObservationHa
 
 	@Override
 	public void onStop(VectorStoreObservationContext context) {
-		logger.debug("Vector Store Query Response:\n{}", ObservabilityHelper.concatenateStrings(documents(context)));
+		logger.info("Vector Store Query Response:\n{}", ObservabilityHelper.concatenateStrings(documents(context)));
 	}
 
 	private List<String> documents(VectorStoreObservationContext context) {

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/observation/VectorStoreQueryResponseObservationHandlerTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/observation/VectorStoreQueryResponseObservationHandlerTests.java
@@ -57,7 +57,7 @@ class VectorStoreQueryResponseObservationHandlerTests {
 		var context = VectorStoreObservationContext.builder("db", VectorStoreObservationContext.Operation.ADD).build();
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Vector Store Query Response:
+				INFO  o.s.a.v.o.VectorStoreQueryResponseObservationHandler -- Vector Store Query Response:
 				[]
 				""");
 	}
@@ -68,7 +68,7 @@ class VectorStoreQueryResponseObservationHandlerTests {
 		context.setQueryResponse(List.of(new Document("doc1"), new Document("doc2")));
 		this.observationHandler.onStop(context);
 		assertThat(output).contains("""
-				Vector Store Query Response:
+				INFO  o.s.a.v.o.VectorStoreQueryResponseObservationHandler -- Vector Store Query Response:
 				["doc1", "doc2"]
 				""");
 	}


### PR DESCRIPTION
The features are disabled by default and users need to explicitly enable them. Probably it makes more sense to log on INFO level so that users don't need to change the log level if they use the default behavior of Spring Boot.

See gh-3003
See gh-3127