### PR TITLE
GH-886: feat(opensearch): Add path prefix configuration support

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,10 @@ public class OpenSearchVectorStoreAutoConfiguration {
 				httpClientBuilder.setDefaultRequestConfig(createRequestConfig(properties));
 				return httpClientBuilder;
 			});
+			String pathPrefix = properties.getPathPrefix();
+			if (StringUtils.hasText(pathPrefix)) {
+				transportBuilder.setPathPrefix(pathPrefix);
+			}
 
 			return new OpenSearchClient(transportBuilder.build());
 		}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreProperties.java
@@ -55,6 +55,13 @@ public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties
 	 */
 	private Duration readTimeout;
 
+	/**
+	 * Path prefix for OpenSearch API endpoints. Used when OpenSearch is behind a reverse
+	 * proxy with a non-root path. For example, if your OpenSearch instance is accessible
+	 * at https://example.com/opensearch/, set this to "/opensearch".
+	 */
+	private String pathPrefix;
+
 	private Aws aws = new Aws();
 
 	public List<String> getUris() {
@@ -119,6 +126,14 @@ public class OpenSearchVectorStoreProperties extends CommonVectorStoreProperties
 
 	public void setReadTimeout(Duration readTimeout) {
 		this.readTimeout = readTimeout;
+	}
+
+	public String getPathPrefix() {
+		return pathPrefix;
+	}
+
+	public void setPathPrefix(String pathPrefix) {
+		this.pathPrefix = pathPrefix;
 	}
 
 	public Aws getAws() {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc
@@ -105,6 +105,7 @@ spring:
         similarity-function: cosinesimil
         read-timeout: <time to wait for response>
         connect-timeout: <time to wait until connection established>
+        path-prefix: <custom path prefix>
         ssl-bundle: <name of SSL bundle>
         aws:  # Only for Amazon OpenSearch Service
           host: <aws opensearch host>
@@ -128,6 +129,7 @@ Properties starting with `spring.ai.vectorstore.opensearch.*` are used to config
 |`spring.ai.vectorstore.opensearch.similarity-function`| The similarity function to use | `cosinesimil`
 |`spring.ai.vectorstore.opensearch.read-timeout`| Time to wait for response from the opposite endpoint. 0 - infinity. | -
 |`spring.ai.vectorstore.opensearch.connect-timeout`| Time to wait until connection established. 0 - infinity. | -
+|`spring.ai.vectorstore.opensearch.path-prefix`| Path prefix for OpenSearch API endpoints. Useful when OpenSearch is behind a reverse proxy with a non-root path. | -
 |`spring.ai.vectorstore.opensearch.ssl-bundle`| Name of the SSL Bundle to use in case of SSL connection | -
 |`spring.ai.vectorstore.opensearch.aws.host`| Hostname of the OpenSearch instance | -
 |`spring.ai.vectorstore.opensearch.aws.service-name`| AWS service name | -
@@ -147,6 +149,11 @@ You can control whether the AWS-specific OpenSearch auto-configuration is enable
 This fallback logic ensures that users have explicit control over the type of OpenSearch integration, preventing accidental activation of AWS-specific logic when not desired.
 ====
 
+[NOTE]
+====
+The `path-prefix` property allows you to specify a custom path prefix when OpenSearch is running behind a reverse proxy that uses a non-root path.
+For example, if your OpenSearch instance is accessible at `https://example.com/opensearch/` instead of `https://example.com/`, you would set `path-prefix: /opensearch`.
+====
 
 The following similarity functions are available:
 


### PR DESCRIPTION
Fixes: #886

Add ability to configure path prefix for OpenSearch API endpoints via properties. This allows connecting to OpenSearch instances running behind a reverse proxy with a non-root path, similar to Spring Elasticsearch's path-prefix property.

- Add pathPrefix property to OpenSearchVectorStoreProperties
- Apply pathPrefix to OpenSearchClient when configured
- Add documentation and unit tests
