### PR TITLE
feat(mcp): Add request timeout configuration for MCP server

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
@@ -256,6 +256,8 @@ public class McpServerAutoConfiguration {
 
 		serverBuilder.instructions(serverProperties.getInstructions());
 
+		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
+
 		return serverBuilder.build();
 	}
 
@@ -311,26 +313,26 @@ public class McpServerAutoConfiguration {
 		// Create the server with both tool and resource capabilities
 		AsyncSpecification serverBuilder = McpServer.async(transportProvider).serverInfo(serverInfo);
 
-		List<AsyncToolSpecification> toolSpecifications = new ArrayList<>(
-				tools.stream().flatMap(List::stream).toList());
-		List<ToolCallback> providerToolCallbacks = toolCallbackProvider.stream()
-			.map(pr -> List.of(pr.getToolCallbacks()))
-			.flatMap(List::stream)
-			.filter(fc -> fc instanceof ToolCallback)
-			.map(fc -> (ToolCallback) fc)
-			.toList();
-
-		toolSpecifications.addAll(this.toAsyncToolSpecification(providerToolCallbacks, serverProperties));
-
 		// Tools
 		if (serverProperties.getCapabilities().isTool()) {
+			List<AsyncToolSpecification> toolSpecifications = new ArrayList<>(
+					tools.stream().flatMap(List::stream).toList());
+			List<ToolCallback> providerToolCallbacks = toolCallbackProvider.stream()
+				.map(pr -> List.of(pr.getToolCallbacks()))
+				.flatMap(List::stream)
+				.filter(fc -> fc instanceof ToolCallback)
+				.map(fc -> (ToolCallback) fc)
+				.toList();
+
+			toolSpecifications.addAll(this.toAsyncToolSpecification(providerToolCallbacks, serverProperties));
+
 			logger.info("Enable tools capabilities, notification: " + serverProperties.isToolChangeNotification());
 			capabilitiesBuilder.tools(serverProperties.isToolChangeNotification());
-		}
 
-		if (!CollectionUtils.isEmpty(toolSpecifications)) {
-			serverBuilder.tools(toolSpecifications);
-			logger.info("Registered tools: " + toolSpecifications.size());
+			if (!CollectionUtils.isEmpty(toolSpecifications)) {
+				serverBuilder.tools(toolSpecifications);
+				logger.info("Registered tools: " + toolSpecifications.size());
+			}
 		}
 
 		// Resources
@@ -338,36 +340,38 @@ public class McpServerAutoConfiguration {
 			logger.info(
 					"Enable resources capabilities, notification: " + serverProperties.isResourceChangeNotification());
 			capabilitiesBuilder.resources(false, serverProperties.isResourceChangeNotification());
-		}
 
-		List<AsyncResourceSpecification> resourceSpecifications = resources.stream().flatMap(List::stream).toList();
-		if (!CollectionUtils.isEmpty(resourceSpecifications)) {
-			serverBuilder.resources(resourceSpecifications);
-			logger.info("Registered resources: " + resourceSpecifications.size());
+			List<AsyncResourceSpecification> resourceSpecifications = resources.stream().flatMap(List::stream).toList();
+			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
+				serverBuilder.resources(resourceSpecifications);
+				logger.info("Registered resources: " + resourceSpecifications.size());
+			}
 		}
 
 		// Prompts
 		if (serverProperties.getCapabilities().isPrompt()) {
 			logger.info("Enable prompts capabilities, notification: " + serverProperties.isPromptChangeNotification());
 			capabilitiesBuilder.prompts(serverProperties.isPromptChangeNotification());
-		}
-		List<AsyncPromptSpecification> promptSpecifications = prompts.stream().flatMap(List::stream).toList();
-		if (!CollectionUtils.isEmpty(promptSpecifications)) {
-			serverBuilder.prompts(promptSpecifications);
-			logger.info("Registered prompts: " + promptSpecifications.size());
+			List<AsyncPromptSpecification> promptSpecifications = prompts.stream().flatMap(List::stream).toList();
+
+			if (!CollectionUtils.isEmpty(promptSpecifications)) {
+				serverBuilder.prompts(promptSpecifications);
+				logger.info("Registered prompts: " + promptSpecifications.size());
+			}
 		}
 
 		// Completions
 		if (serverProperties.getCapabilities().isCompletion()) {
 			logger.info("Enable completions capabilities");
 			capabilitiesBuilder.completions();
-		}
-		List<AsyncCompletionSpecification> completionSpecifications = completions.stream()
-			.flatMap(List::stream)
-			.toList();
-		if (!CollectionUtils.isEmpty(completionSpecifications)) {
-			serverBuilder.completions(completionSpecifications);
-			logger.info("Registered completions: " + completionSpecifications.size());
+			List<AsyncCompletionSpecification> completionSpecifications = completions.stream()
+				.flatMap(List::stream)
+				.toList();
+
+			if (!CollectionUtils.isEmpty(completionSpecifications)) {
+				serverBuilder.completions(completionSpecifications);
+				logger.info("Registered completions: " + completionSpecifications.size());
+			}
 		}
 
 		rootsChangeConsumer.ifAvailable(consumer -> {
@@ -382,6 +386,8 @@ public class McpServerAutoConfiguration {
 		serverBuilder.capabilities(capabilitiesBuilder.build());
 
 		serverBuilder.instructions(serverProperties.getInstructions());
+
+		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
 
 		return serverBuilder.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mcp.server.autoconfigure;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -133,6 +134,22 @@ public class McpServerProperties {
 	private ServerType type = ServerType.SYNC;
 
 	private Capabilities capabilities = new Capabilities();
+
+	/**
+	 * Sets the duration to wait for server responses before timing out requests. This
+	 * timeout applies to all requests made through the client, including tool calls,
+	 * resource access, and prompt operations.
+	 */
+	private Duration requestTimeout = Duration.ofSeconds(20);
+
+	public Duration getRequestTimeout() {
+		return this.requestTimeout;
+	}
+
+	public void setRequestTimeout(Duration requestTimeout) {
+		Assert.notNull(requestTimeout, "Request timeout must not be null");
+		this.requestTimeout = requestTimeout;
+	}
 
 	public Capabilities getCapabilities() {
 		return this.capabilities;

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -104,6 +104,7 @@ All properties are prefixed with `spring.ai.mcp.server`:
 |`sse-message-endpoint` | Custom SSE Message endpoint path for web transport to be used by the client to send messages|`/mcp/message`
 |`sse-endpoint` |Custom SSE endpoint path for web transport |`/sse`
 |`base-url` | Optional URL prefix. For example `base-url=/api/v1` means that the client should access the sse endpont at `/api/v1` + `sse-endpoint` and the message endpoint is `/api/v1` + `sse-message-endpoint` | -
+|`request-timeout` | Duration to wait for server responses before timing out requests. Applies to all requests made through the client, including tool calls, resource access, and prompt operations. | `20` seconds
 |===
 
 == Sync/Async Server Types


### PR DESCRIPTION
Add support for configuring request timeout in MCP server with a default of 20 seconds. This timeout applies to all requests made through the client, including tool calls, resource access, and prompt operations.

- Add requestTimeout property to McpServerProperties with default of 20s
- Configure server builder with the timeout value
- Add tests for default and custom timeout configurations
- Update documentation with the new property

Resolves #3205