### PR TITLE
docs: replace CLA section with DCO (#3094)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,12 @@
 Thank you for taking time to contribute this pull request!
 You might have already read the [contributor guide][1], but as a reminder, please make sure to:
 
-* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
+* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
 * Rebase your changes on the latest `main` branch and squash your commits
 * Add/Update unit tests as needed
 * Run a build and make sure all tests pass prior to submission
+
+For more details, please check the [contributor guide][1].
+Thank you upfront!
+
+[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc


### PR DESCRIPTION
### What
Update `.github/PULL_REQUEST_TEMPLATE.md`  
to replace the obsolete **CLA** bullet with a **DCO** bullet.

### Why
Spring AI now uses the Developer Certificate of Origin (DCO).  
The old CLA link was broken and misleading.

### How
* Replaced the “Sign the CLA” bullet with:  
  `Add a Signed-off-by line to each commit (\`git commit -s\`) per the DCO`
* Kept the remaining bullets (rebase, tests, build) unchanged
* Added the same DCO link used in the official blog post

No functional code changes, docs only.

Fixes #3094
