### PR TITLE
Add builder support to AssistantMessage and ToolResponseMessage

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -784,7 +784,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		given(chatModel.call(promptCaptor.capture()))
-			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage(null)))));
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage((String) null)))));
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
@@ -814,7 +814,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		given(chatModel.call(promptCaptor.capture()))
-			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage(null)))));
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage((String) null)))));
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
@@ -874,7 +874,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		given(chatModel.call(promptCaptor.capture()))
-			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage(null)))));
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage((String) null)))));
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
@@ -926,7 +926,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		given(chatModel.call(promptCaptor.capture()))
-			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage(null)))));
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage((String) null)))));
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
@@ -978,7 +978,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		given(chatModel.call(promptCaptor.capture()))
-			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage(null)))));
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage((String) null)))));
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
@@ -1076,7 +1076,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		given(chatModel.call(promptCaptor.capture()))
-			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage(null)))));
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage((String) null)))));
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
@@ -1282,7 +1282,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
 		given(chatModel.stream(promptCaptor.capture()))
-			.willReturn(Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage(null))))));
+			.willReturn(Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage((String) null))))));
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
 		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
@@ -16,14 +16,20 @@
 
 package org.springframework.ai.chat.messages;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.ai.content.Media;
 import org.springframework.ai.content.MediaContent;
+import org.springframework.core.io.Resource;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Lets the generative know the content was generated as a response to the user. This role
@@ -31,6 +37,7 @@ import org.springframework.util.CollectionUtils;
  * including assistant messages in the series, you provide context to the generative about
  * prior exchanges in the conversation.
  *
+ * @author Jemin Huh
  * @author Mark Pollack
  * @author Christian Tzolov
  * @since 1.0.0
@@ -42,20 +49,16 @@ public class AssistantMessage extends AbstractMessage implements MediaContent {
 	protected final List<Media> media;
 
 	public AssistantMessage(String content) {
-		this(content, Map.of());
+		this(content, Map.of(), List.of(), List.of());
 	}
 
-	public AssistantMessage(String content, Map<String, Object> properties) {
-		this(content, properties, List.of());
+	public AssistantMessage(Resource resource) {
+		this(MessageUtils.readResource(resource));
 	}
 
-	public AssistantMessage(String content, Map<String, Object> properties, List<ToolCall> toolCalls) {
-		this(content, properties, toolCalls, List.of());
-	}
-
-	public AssistantMessage(String content, Map<String, Object> properties, List<ToolCall> toolCalls,
+	private AssistantMessage(String content, Map<String, Object> metadata, List<ToolCall> toolCalls,
 			List<Media> media) {
-		super(MessageType.ASSISTANT, content, properties);
+		super(MessageType.ASSISTANT, content, metadata);
 		Assert.notNull(toolCalls, "Tool calls must not be null");
 		Assert.notNull(media, "Media must not be null");
 		this.toolCalls = toolCalls;
@@ -101,6 +104,90 @@ public class AssistantMessage extends AbstractMessage implements MediaContent {
 	}
 
 	public record ToolCall(String id, String type, String name, String arguments) {
+
+	}
+
+	public AssistantMessage copy() {
+		return new Builder().text(getText())
+			.metadata(Map.copyOf(getMetadata()))
+			.toolCalls(List.copyOf(getToolCalls()))
+			.media(List.copyOf(getMedia()))
+			.build();
+	}
+
+	public AssistantMessage.Builder mutate() {
+		return new Builder().text(getText())
+			.metadata(Map.copyOf(getMetadata()))
+			.toolCalls(List.copyOf(getToolCalls()))
+			.media(List.copyOf(getMedia()));
+	}
+
+	public static AssistantMessage.Builder builder() {
+		return new AssistantMessage.Builder();
+	}
+
+	public static class Builder {
+
+		@Nullable
+		private String textContent;
+
+		@Nullable
+		private Resource resource;
+
+		private Map<String, Object> metadata = new HashMap<>();
+
+		private List<ToolCall> toolCalls = new ArrayList<>();
+
+		private List<Media> media = new ArrayList<>();
+
+		public AssistantMessage.Builder text(String textContent) {
+			this.textContent = textContent;
+			return this;
+		}
+
+		public AssistantMessage.Builder text(Resource resource) {
+			this.resource = resource;
+			return this;
+		}
+
+		public AssistantMessage.Builder metadata(Map<String, Object> metadata) {
+			this.metadata = metadata;
+			return this;
+		}
+
+		public AssistantMessage.Builder toolCalls(List<ToolCall> toolCalls) {
+			this.toolCalls = toolCalls;
+			return this;
+		}
+
+		public AssistantMessage.Builder toolCalls(@Nullable ToolCall... toolCalls) {
+			if (media != null) {
+				this.toolCalls = Arrays.asList(toolCalls);
+			}
+			return this;
+		}
+
+		public AssistantMessage.Builder media(List<Media> media) {
+			this.media = media;
+			return this;
+		}
+
+		public AssistantMessage.Builder media(@Nullable Media... media) {
+			if (media != null) {
+				this.media = Arrays.asList(media);
+			}
+			return this;
+		}
+
+		public AssistantMessage build() {
+			if (StringUtils.hasText(this.textContent) && this.resource != null) {
+				throw new IllegalArgumentException("textContent and resource cannot be set at the same time");
+			}
+			else if (this.resource != null) {
+				this.textContent = MessageUtils.readResource(this.resource);
+			}
+			return new AssistantMessage(this.textContent, this.metadata, this.toolCalls, this.media);
+		}
 
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/ToolResponseMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/ToolResponseMessage.java
@@ -16,6 +16,10 @@
 
 package org.springframework.ai.chat.messages;
 
+import org.springframework.lang.Nullable;
+
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -24,6 +28,7 @@ import java.util.Objects;
  * The ToolResponseMessage class represents a message with a function content in a chat
  * application.
  *
+ * @author Jemin Huh
  * @author Christian Tzolov
  * @since 1.0.0
  */
@@ -35,7 +40,7 @@ public class ToolResponseMessage extends AbstractMessage {
 		this(responses, Map.of());
 	}
 
-	public ToolResponseMessage(List<ToolResponse> responses, Map<String, Object> metadata) {
+	private ToolResponseMessage(List<ToolResponse> responses, Map<String, Object> metadata) {
 		super(MessageType.TOOL, "", metadata);
 		this.responses = responses;
 	}
@@ -70,6 +75,47 @@ public class ToolResponseMessage extends AbstractMessage {
 	}
 
 	public record ToolResponse(String id, String name, String responseData) {
+
+	}
+
+	public ToolResponseMessage copy() {
+		return new ToolResponseMessage(getResponses(), Map.copyOf(this.metadata));
+	}
+
+	public ToolResponseMessage.Builder mutate() {
+		return new Builder().responses(getResponses()).metadata(Map.copyOf(this.metadata));
+	}
+
+	public static ToolResponseMessage.Builder builder() {
+		return new ToolResponseMessage.Builder();
+	}
+
+	public static class Builder {
+
+		private List<ToolResponse> responses;
+
+		private Map<String, Object> metadata = new HashMap<>();
+
+		public ToolResponseMessage.Builder responses(List<ToolResponse> responses) {
+			this.responses = responses;
+			return this;
+		}
+
+		public ToolResponseMessage.Builder media(@Nullable ToolResponse... responses) {
+			if (responses != null) {
+				this.responses = Arrays.asList(responses);
+			}
+			return this;
+		}
+
+		public ToolResponseMessage.Builder metadata(Map<String, Object> metadata) {
+			this.metadata = metadata;
+			return this;
+		}
+
+		public ToolResponseMessage build() {
+			return new ToolResponseMessage(this.responses, this.metadata);
+		}
 
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  * Helper that for streaming chat responses, aggregate the chat response messages into a
  * single AssistantMessage. Job is performed in parallel to the chat response processing.
  *
+ * @author Jemin Huh
  * @author Christian Tzolov
  * @author Alexandros Pappas
  * @author Thomas Vitale
@@ -133,9 +134,10 @@ public class MessageAggregator {
 				.promptMetadata(metadataPromptMetadataRef.get())
 				.build();
 
-			onAggregationComplete.accept(new ChatResponse(List.of(new Generation(
-					new AssistantMessage(messageTextContentRef.get().toString(), messageMetadataMapRef.get()),
-					generationMetadataRef.get())), chatResponseMetadata));
+			onAggregationComplete.accept(new ChatResponse(List.of(new Generation(AssistantMessage.builder()
+				.text(messageTextContentRef.get().toString())
+				.metadata(messageMetadataMapRef.get())
+				.build(), generationMetadataRef.get())), chatResponseMetadata));
 
 			messageTextContentRef.set(new StringBuilder());
 			messageMetadataMapRef.set(new HashMap<>());

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  * The Prompt class represents a prompt used in AI model requests. A prompt consists of
  * one or more messages and additional chat options.
  *
+ * @author Jemin Huh
  * @author Mark Pollack
  * @author luocongqiu
  * @author Thomas Vitale
@@ -177,8 +178,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 				messagesCopy.add(systemMessage.copy());
 			}
 			else if (message instanceof AssistantMessage assistantMessage) {
-				messagesCopy.add(new AssistantMessage(assistantMessage.getText(), assistantMessage.getMetadata(),
-						assistantMessage.getToolCalls()));
+				messagesCopy.add(assistantMessage.copy());
 			}
 			else if (message instanceof ToolResponseMessage toolResponseMessage) {
 				messagesCopy.add(new ToolResponseMessage(new ArrayList<>(toolResponseMessage.getResponses()),

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -181,8 +181,10 @@ public class Prompt implements ModelRequest<List<Message>> {
 				messagesCopy.add(assistantMessage.copy());
 			}
 			else if (message instanceof ToolResponseMessage toolResponseMessage) {
-				messagesCopy.add(new ToolResponseMessage(new ArrayList<>(toolResponseMessage.getResponses()),
-						new HashMap<>(toolResponseMessage.getMetadata())));
+				messagesCopy.add(ToolResponseMessage.builder()
+					.responses(toolResponseMessage.getResponses())
+					.metadata(new HashMap<>(toolResponseMessage.getMetadata()))
+					.build());
 			}
 			else {
 				throw new IllegalArgumentException("Unsupported message type: " + message.getClass().getName());

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -233,7 +233,8 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 					toolCallResult != null ? toolCallResult : ""));
 		}
 
-		return new InternalToolExecutionResult(new ToolResponseMessage(toolResponses, Map.of()), returnDirect);
+		return new InternalToolExecutionResult(ToolResponseMessage.builder().responses(toolResponses).build(),
+				returnDirect);
 	}
 
 	private List<Message> buildConversationHistoryAfterToolExecution(List<Message> previousMessages,

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -50,6 +50,7 @@ import org.springframework.util.CollectionUtils;
 /**
  * Default implementation of {@link ToolCallingManager}.
  *
+ * @author Jemin Huh
  * @author Thomas Vitale
  * @since 1.0.0
  */
@@ -154,8 +155,7 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 			toolContextMap = new HashMap<>(toolCallingChatOptions.getToolContext());
 
 			List<Message> messageHistory = new ArrayList<>(prompt.copy().getInstructions());
-			messageHistory.add(new AssistantMessage(assistantMessage.getText(), assistantMessage.getMetadata(),
-					assistantMessage.getToolCalls()));
+			messageHistory.add(assistantMessage.copy());
 
 			toolContextMap.put(ToolContext.TOOL_CALL_HISTORY,
 					buildConversationHistoryBeforeToolExecution(prompt, assistantMessage));
@@ -167,8 +167,7 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 	private static List<Message> buildConversationHistoryBeforeToolExecution(Prompt prompt,
 			AssistantMessage assistantMessage) {
 		List<Message> messageHistory = new ArrayList<>(prompt.copy().getInstructions());
-		messageHistory.add(new AssistantMessage(assistantMessage.getText(), assistantMessage.getMetadata(),
-				assistantMessage.getToolCalls()));
+		messageHistory.add(assistantMessage.copy());
 		return messageHistory;
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/model/ChatResponseTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/model/ChatResponseTests.java
@@ -38,8 +38,10 @@ class ChatResponseTests {
 	@Test
 	void whenToolCallsArePresentThenReturnTrue() {
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))
+				.build())))
 			.build();
 		assertThat(chatResponse.hasToolCalls()).isTrue();
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerIT.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerIT.java
@@ -73,8 +73,10 @@ class DefaultToolCallingManagerIT {
 			.build();
 
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("Answer", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("Answer")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))
+				.build())))
 			.build();
 
 		ToolExecutionResult toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, chatResponse);

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTests.java
@@ -158,8 +158,10 @@ class DefaultToolCallingManagerTests {
 
 		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))
+				.build())))
 			.build();
 
 		ToolResponseMessage expectedToolResponse = new ToolResponseMessage(
@@ -180,8 +182,10 @@ class DefaultToolCallingManagerTests {
 
 		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))
+				.build())))
 			.build();
 
 		ToolResponseMessage expectedToolResponse = new ToolResponseMessage(
@@ -205,9 +209,11 @@ class DefaultToolCallingManagerTests {
 
 		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"),
-							new AssistantMessage.ToolCall("toolB", "function", "toolB", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"),
+						new AssistantMessage.ToolCall("toolB", "function", "toolB", "{}"))
+				.build())))
 			.build();
 
 		ToolResponseMessage expectedToolResponse = new ToolResponseMessage(
@@ -229,8 +235,10 @@ class DefaultToolCallingManagerTests {
 					.toolNames("toolA")
 					.build());
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"))
+				.build())))
 			.build();
 
 		ToolResponseMessage expectedToolResponse = new ToolResponseMessage(
@@ -253,9 +261,11 @@ class DefaultToolCallingManagerTests {
 
 		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"),
-							new AssistantMessage.ToolCall("toolB", "function", "toolB", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"),
+						new AssistantMessage.ToolCall("toolB", "function", "toolB", "{}"))
+				.build())))
 			.build();
 
 		ToolResponseMessage expectedToolResponse = new ToolResponseMessage(
@@ -280,9 +290,11 @@ class DefaultToolCallingManagerTests {
 
 		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"),
-							new AssistantMessage.ToolCall("toolB", "function", "toolB", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolA", "function", "toolA", "{}"),
+						new AssistantMessage.ToolCall("toolB", "function", "toolB", "{}"))
+				.build())))
 			.build();
 
 		ToolResponseMessage expectedToolResponse = new ToolResponseMessage(
@@ -305,8 +317,10 @@ class DefaultToolCallingManagerTests {
 
 		Prompt prompt = new Prompt(new UserMessage("Hello"), ToolCallingChatOptions.builder().build());
 		ChatResponse chatResponse = ChatResponse.builder()
-			.generations(List.of(new Generation(new AssistantMessage("", Map.of(),
-					List.of(new AssistantMessage.ToolCall("toolC", "function", "toolC", "{}"))))))
+			.generations(List.of(new Generation(AssistantMessage.builder()
+				.text("")
+				.toolCalls(new AssistantMessage.ToolCall("toolC", "function", "toolC", "{}"))
+				.build())))
 			.build();
 
 		ToolResponseMessage expectedToolResponse = new ToolResponseMessage(

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolExecutionEligibilityPredicateTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolExecutionEligibilityPredicateTests.java
@@ -44,7 +44,11 @@ class DefaultToolExecutionEligibilityPredicateTests {
 
 		// Create a ChatResponse with tool calls
 		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id1", "function", "testTool", "{}");
-		AssistantMessage assistantMessage = new AssistantMessage("test", Map.of(), List.of(toolCall));
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.text("test")
+			.metadata(Map.of())
+			.toolCalls(List.of(toolCall))
+			.build();
 		ChatResponse chatResponse = new ChatResponse(List.of(new Generation(assistantMessage)));
 
 		// Test the predicate
@@ -73,7 +77,11 @@ class DefaultToolExecutionEligibilityPredicateTests {
 
 		// Create a ChatResponse with tool calls
 		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id1", "function", "testTool", "{}");
-		AssistantMessage assistantMessage = new AssistantMessage("test", Map.of(), List.of(toolCall));
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.text("test")
+			.metadata(Map.of())
+			.toolCalls(List.of(toolCall))
+			.build();
 		ChatResponse chatResponse = new ChatResponse(List.of(new Generation(assistantMessage)));
 
 		// Test the predicate
@@ -102,7 +110,11 @@ class DefaultToolExecutionEligibilityPredicateTests {
 
 		// Create a ChatResponse with tool calls
 		AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("id1", "function", "testTool", "{}");
-		AssistantMessage assistantMessage = new AssistantMessage("test", Map.of(), List.of(toolCall));
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.text("test")
+			.metadata(Map.of())
+			.toolCalls(List.of(toolCall))
+			.build();
 		ChatResponse chatResponse = new ChatResponse(List.of(new Generation(assistantMessage)));
 
 		// Test the predicate - should use default value (true) for internal tool


### PR DESCRIPTION
Unlike UserMessage and SystemMessage, AssistantMessage and ToolResponseMessage did not support the builder pattern. This PR applies the builder pattern to these classes for consistent and flexible object creation.
Additionally, the properties field in AssistantMessage has been renamed to metadata for consistency with other message types.

- Added builder pattern to AssistantMessage and ToolResponseMessage.
- Renamed the properties field to metadata in AssistantMessage for improved semantic clarity and consistency.
