### PR TITLE
MCP ToolCallbackProvider autoconfig should use concrete class

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfiguration.java
@@ -52,14 +52,14 @@ public class McpToolCallbackAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
-	public ToolCallbackProvider mcpToolCallbacks(ObjectProvider<List<McpSyncClient>> syncMcpClients) {
+	public SyncMcpToolCallbackProvider mcpToolCallbacks(ObjectProvider<List<McpSyncClient>> syncMcpClients) {
 		List<McpSyncClient> mcpClients = syncMcpClients.stream().flatMap(List::stream).toList();
 		return new SyncMcpToolCallbackProvider(mcpClients);
 	}
 
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public ToolCallbackProvider mcpAsyncToolCallbacks(ObjectProvider<List<McpAsyncClient>> mcpClientsProvider) {
+	public AsyncMcpToolCallbackProvider mcpAsyncToolCallbacks(ObjectProvider<List<McpAsyncClient>> mcpClientsProvider) {
 		List<McpAsyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
 		return new AsyncMcpToolCallbackProvider(mcpClients);
 	}


### PR DESCRIPTION
Currently, the MCP Tool autoconfiguration defines the `SyncMcpToolCallbackProvider` and `AsyncMcpToolCallbackProvider` beans returning the `ToolCallbackProvider` interface. That generates autowiring warnings in IDEs when trying to inject the specific class.

<img width="739" alt="Screenshot 2025-05-18 at 19 25 37" src="https://github.com/user-attachments/assets/82e0d7d2-2f3c-47a1-9601-7c1591402038" />

The Spring Boot project recommends being specific:

> When declaring a @Bean method, provide as much type information as possible in the method’s return type. For example, if your bean’s concrete class implements an interface the bean method’s return type should be the concrete class and not the interface. Providing as much type information as possible in @Bean methods is particularly important when using bean conditions as their evaluation can only rely upon to type information that is available in the method signature.

See https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.condition-annotations.bean-conditions

This PR ensures concrete classes are used. That's also in line with what included in the [documentation](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html#_usage_example):

<img width="961" alt="Screenshot 2025-05-18 at 19 35 47" src="https://github.com/user-attachments/assets/6c1f655e-3d25-4a76-973c-cd5291d87ccd" />
