### PR TITLE
Fix: Add document's title

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/effective-agents.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/effective-agents.adoc
@@ -1,3 +1,6 @@
+[[effective-agents]]
+= Building Effective Agents
+
 In a recent research publication, https://www.anthropic.com/research/building-effective-agents[Building Effective Agents], Anthropic shared valuable insights about building effective Large Language Model (LLM) agents. What makes this research particularly interesting is its emphasis on simplicity and composability over complex frameworks. Let's explore how these principles translate into practical implementations using https://docs.spring.io/spring-ai/reference/index.html[Spring AI].
 
 image::https://raw.githubusercontent.com/spring-io/spring-io-static/refs/heads/main/blog/tzolov/spring-ai-agentic-systems.jpg[Agent Systems, width=350]


### PR DESCRIPTION
Hi!
I think that [the post](https://docs.spring.io/spring-ai/reference/api/effective-agents.html)'s title `Untitled` should be `Building Effective Agents`.
I found this while reading [a blog post](https://spring.io/blog/2025/05/20/spring-ai-1-0-GA-released) (released 1.0.0 GA 👏👏👏)


---
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
