### PR TITLE
Fixed a bug in the augmentSystemMessage method of the Prompt.

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -198,21 +198,21 @@ public class Prompt implements ModelRequest<List<Message>> {
 	 * @return a new {@link Prompt} instance with the augmented system message.
 	 */
 	public Prompt augmentSystemMessage(Function<SystemMessage, SystemMessage> systemMessageAugmenter) {
-
 		var messagesCopy = new ArrayList<>(this.messages);
-		for (int i = 0; i <= this.messages.size() - 1; i++) {
+		boolean found = false;
+		for (int i = 0; i < messagesCopy.size(); i++) {
 			Message message = messagesCopy.get(i);
 			if (message instanceof SystemMessage systemMessage) {
 				messagesCopy.set(i, systemMessageAugmenter.apply(systemMessage));
+				found = true;
 				break;
 			}
-			if (i == 0) {
-				// If no system message is found, create a new one with the provided text
-				// and add it as the first item in the list.
-				messagesCopy.add(0, systemMessageAugmenter.apply(new SystemMessage("")));
-			}
 		}
-
+		if (!found) {
+			// If no system message is found, create a new one with the provided text
+			// and add it as the first item in the list.
+			messagesCopy.add(0, systemMessageAugmenter.apply(new SystemMessage("")));
+		}
 		return new Prompt(messagesCopy, null == this.chatOptions ? null : this.chatOptions.copy());
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTests.java
@@ -239,4 +239,21 @@ class PromptTests {
 		assertThat(prompt.getSystemMessage().getText()).isEqualTo("");
 	}
 
+	@Test
+	void augmentSystemMessageWhenNotFirst() {
+		Message[] messages = { new SystemMessage("Hello"), new SystemMessage("How are you?") };
+		Prompt prompt = Prompt.builder().messages(messages).build();
+
+		assertThat(prompt.getSystemMessage()).isNotNull();
+		assertThat(prompt.getSystemMessage().getText()).isEqualTo("Hello");
+
+		Prompt copy = prompt.augmentSystemMessage(message -> message.mutate().text("What about you?").build());
+
+		assertThat(copy.getSystemMessage()).isNotNull();
+		assertThat(copy.getInstructions().size()).isEqualTo(messages.length);
+		assertThat(copy.getSystemMessage().getText()).isEqualTo("What about you?");
+		assertThat(prompt.getSystemMessage()).isNotNull();
+		assertThat(prompt.getSystemMessage().getText()).isEqualTo("Hello");
+	}
+
 }


### PR DESCRIPTION
As mentioned in issue: https://github.com/spring-projects/spring-ai/issues/3266, when executing the `augmentSystemMessage` method of the Prompt, an extra system message would be incorrectly added if the system message was not the first one in the message list. This PR fixes that issue.