### PR TITLE
Update mcp-server-boot-starter-docs.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -28,7 +28,7 @@ Full MCP Server features support with `STDIO` server transport.
 ----
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-mcp-server-spring-boot-starter</artifactId>
+    <artifactId>spring-ai-starter-mcp-server</artifactId>
 </dependency>
 ----
 


### PR DESCRIPTION
Older STDIO transports can't be pulled, this should be a milestone version and should use `spring-ai-starter-mcp-server`.