### PR TITLE
Fix datasource connection leak when using the JdbcChatMemoryRepository

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.memory.repository.jdbc;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 
 /**
  * Abstraction for database-specific SQL for chat memory repository.
@@ -53,8 +54,8 @@ public interface JdbcChatMemoryRepositoryDialect {
 	 */
 	static JdbcChatMemoryRepositoryDialect from(DataSource dataSource) {
 		// Simple detection (could be improved)
-		try {
-			String url = dataSource.getConnection().getMetaData().getURL().toLowerCase();
+		try (Connection connection = dataSource.getConnection()) {
+			String url = connection.getMetaData().getURL().toLowerCase();
 			if (url.contains("postgresql")) {
 				return new PostgresChatMemoryRepositoryDialect();
 			}
@@ -71,8 +72,7 @@ public interface JdbcChatMemoryRepositoryDialect {
 				return new HsqldbChatMemoryRepositoryDialect();
 			}
 			// Add more as needed
-		}
-		catch (Exception ignored) {
+		} catch (Exception ignored) {
 		}
 		return new PostgresChatMemoryRepositoryDialect(); // default
 	}


### PR DESCRIPTION
Fixes #3281 

- Updated `from` method in `JdbcChatMemoryRepositoryDialect` to use try with resources to safely access and close the datasource connection