### PR TITLE
Fix tools docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -625,7 +625,7 @@ The tool will only be available for the specific chat request it's added to.
 ----
 ChatClient.create(chatModel)
     .prompt("What's the weather like in Copenhagen?")
-    .tools("currentWeather")
+    .toolNames("currentWeather")
     .call()
     .content();
 ----
@@ -654,7 +654,7 @@ When using the dynamic specification approach, you can pass the tool name to the
 ChatModel chatModel = ...
 ChatOptions chatOptions = ToolCallingChatOptions.builder()
     .toolNames("currentWeather")
-    .build():
+    .build();
 Prompt prompt = new Prompt("What's the weather like in Copenhagen?", chatOptions);
 chatModel.call(prompt);
 ----


### PR DESCRIPTION
I updated project from 1.0.0-M7 to 1.0.0 and noticed I should be using `toolNames` instead of `tools`. See [commit](https://github.com/eddumelendez/spring-ai-dmr/commit/7830892df4bf179991d7ad4dc03115893e723ad9) 