### PR TITLE
Fix MCP protocol, related commands cannot be executed under Windows, such as npx

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
@@ -134,7 +134,6 @@ public class McpStdioClientProperties {
 				winArgs.addAll(this.args);
 				return ServerParameters.builder("cmd.exe").args(winArgs).env(this.env()).build();
 			}
-			
 			return ServerParameters.builder(this.command()).args(this.args()).env(this.env()).build();
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
@@ -134,6 +134,7 @@ public class McpStdioClientProperties {
 				winArgs.addAll(this.args);
 				return ServerParameters.builder("cmd.exe").args(winArgs).env(this.env()).build();
 			}
+			
 			return ServerParameters.builder(this.command()).args(this.args()).env(this.env()).build();
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
@@ -16,9 +16,7 @@
 
 package org.springframework.ai.mcp.client.autoconfigure.properties;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -44,6 +42,10 @@ import org.springframework.core.io.Resource;
 public class McpStdioClientProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.mcp.client.stdio";
+
+	private static final List<String> WIN_COMMAND = List.of("npx");
+
+	private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
 
 	/**
 	 * Resource containing the MCP servers configuration.
@@ -128,6 +130,11 @@ public class McpStdioClientProperties {
 			@JsonProperty("env") Map<String, String> env) {
 
 		public ServerParameters toServerParameters() {
+			if (OS_NAME.contains("win") && WIN_COMMAND.contains(command)) {
+				List<String> winArgs = new LinkedList<>(Arrays.asList("/c", this.command()));
+				winArgs.addAll(this.args);
+				return ServerParameters.builder("cmd.exe").args(winArgs).env(this.env()).build();
+			}
 			return ServerParameters.builder(this.command()).args(this.args()).env(this.env()).build();
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client/src/main/java/org/springframework/ai/mcp/client/autoconfigure/properties/McpStdioClientProperties.java
@@ -16,17 +16,16 @@
 
 package org.springframework.ai.mcp.client.autoconfigure.properties;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.ServerParameters;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Configuration properties for the Model Context Protocol (MCP) stdio client.


### PR DESCRIPTION
I cannot run bat related commands such as npx properly under Windows. I hope to be able to start it more friendly, otherwise it may be troublesome or catastrophic for cross platform development, which has caused me to be unable to configure it properly. Therefore, I hope to get a fix. Thank you.