### PR TITLE
Fix awesome-spring-ai link to official repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please refer to the [Getting Started Guide](https://docs.spring.io/spring-ai/ref
 * [Documentation](https://docs.spring.io/spring-ai/reference/)
 * [Issues](https://github.com/spring-projects/spring-ai/issues)
 <!-- * [Discussions](https://github.com/spring-projects/spring-ai/discussions) - Go here if you have a question, suggestion, or feedback! -->
-* [Awesome Spring AI](https://github.com/danvega/awesome-spring-ai) - A curated list of awesome resources, tools, tutorials, and projects for building generative AI applications using Spring AI
+* [Awesome Spring AI](https://github.com/spring-ai-community/awesome-spring-ai) - A curated list of awesome resources, tools, tutorials, and projects for building generative AI applications using Spring AI
 * [Spring AI Examples](https://github.com/spring-projects/spring-ai-examples) contains example projects that explain specific features in more detail.
 
 ## Breaking changes

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -153,4 +153,4 @@ Each of the following sections in the documentation shows which dependencies you
 
 == Spring AI samples
 
-Please refer to https://github.com/danvega/awesome-spring-ai[this page] for more resources and samples related to Spring AI.
+Please refer to https://github.com/spring-ai-community/awesome-spring-ai[this page] for more resources and samples related to Spring AI.


### PR DESCRIPTION
This pull request updates the link to the awesome-spring-ai project.

The previous link (https://github.com/danvega/awesome-spring-ai) has been replaced with the official repository:
https://github.com/spring-ai-community/awesome-spring-ai