### PR TITLE
feat(chroma): improve handling and testing of complex metadata values

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/pom.xml
@@ -103,5 +103,12 @@
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-advisors-vector-store</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -219,7 +219,7 @@ public class OpenAiChatModel implements ChatModel {
 							"index", choice.index(),
 							"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "",
 							"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
-							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of());
+							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(Map.of()));
 					return buildGeneration(choice, metadata, request);
 				}).toList();
 				// @formatter:on

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaApi.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaApi.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.ai.chroma.vectorstore.ChromaApi.QueryRequest.Include;
 import org.springframework.ai.chroma.vectorstore.common.ChromaApiConstants;
+import org.springframework.ai.util.json.JsonParser;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
@@ -253,7 +254,7 @@ public class ChromaApi {
 		this.restClient.post()
 			.uri("/api/v2/tenants/{tenant_name}/databases/{database_name}/collections/{collection_name}/upsert",
 					tenantName, databaseName, collectionId)
-			.headers(this::httpHeaders)
+			// .headers(this::httpHeaders)
 			.body(embedding)
 			.retrieve()
 			.toBodilessEntity();
@@ -443,7 +444,27 @@ public class ChromaApi {
 			@JsonProperty("metadatas") List<Map<String, Object>> metadata,
 			@JsonProperty("documents") List<String> documents) { // @formatter:on
 
-		// Convenance for adding a single embedding.
+		public AddEmbeddingsRequest {
+			// Process metadata to ensure all values are Integer, Boolean, or String.
+			// Other types are converted to JSON string using JsonParser.toJson().
+			List<Map<String, Object>> processedMetadatas = new ArrayList<>();
+			for (Map<String, Object> meta : metadata) {
+				Map<String, Object> processed = new HashMap<>();
+				for (Map.Entry<String, Object> entry : meta.entrySet()) {
+					Object value = entry.getValue();
+					if (value instanceof Number || value instanceof Boolean || value instanceof String) {
+						processed.put(entry.getKey(), value);
+					}
+					else {
+						processed.put(entry.getKey(), JsonParser.toJson(value));
+					}
+				}
+				processedMetadatas.add(processed);
+			}
+			metadata = processedMetadatas;
+		}
+
+		// Convenience for adding a single embedding.
 		public AddEmbeddingsRequest(String id, float[] embedding, Map<String, Object> metadata, String document) {
 			this(List.of(id), List.of(embedding), List.of(metadata), List.of(document));
 		}

--- a/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/chroma/vectorstore/ChromaApiIT.java
+++ b/vector-stores/spring-ai-chroma-store/src/test/java/org/springframework/ai/chroma/vectorstore/ChromaApiIT.java
@@ -275,6 +275,21 @@ public class ChromaApiIT {
 					"Collection non-existent doesn't exist and won't be created as the initializeSchema is set to false.");
 	}
 
+	@Test
+	public void testAddEmbeddingsRequestMetadataConversion() {
+		Map<String, Object> metadata = Map.of("intVal", 42, "boolVal", true, "strVal", "hello", "doubleVal", 3.14,
+				"listVal", List.of(1, 2, 3), "mapVal", Map.of("a", 1, "b", 2));
+		AddEmbeddingsRequest req = new AddEmbeddingsRequest("id", new float[] { 1f, 2f, 3f }, metadata, "doc");
+		Map<String, Object> processed = req.metadata().get(0);
+
+		assertThat(processed.get("intVal")).isInstanceOf(Integer.class);
+		assertThat(processed.get("boolVal")).isInstanceOf(Boolean.class);
+		assertThat(processed.get("strVal")).isInstanceOf(String.class);
+		assertThat(processed.get("doubleVal")).isInstanceOf(Number.class).isEqualTo(3.14);
+		assertThat(processed.get("listVal")).isInstanceOf(String.class).isEqualTo("[1,2,3]");
+		assertThat(processed.get("mapVal")).isInstanceOf(String.class);
+	}
+
 	@SpringBootConfiguration
 	public static class Config {
 


### PR DESCRIPTION
- Convert non-primitive metadata values to JSON strings in ChromaApi.AddEmbeddingsRequest for compatibility
- Add tests to verify metadata conversion and complex metadata handling in Chroma vector store integration
- Ensure OpenAiChatModel always returns annotations as a list of maps in metadata
- Add test dependency on spring-ai-advisors-vector-store for advisor-related tests

BACK-PORT to 1.0.1 as well!