### PR TITLE
docs: update custom API key example using OpenAiChatModel.builder()

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -631,9 +631,12 @@ OpenAiApi openAiApi = OpenAiApi.builder()
     .apiKey(customApiKey)
     .build();
 
-// Create a chat client with the custom OpenAiApi instance
-OpenAiChatClient chatClient = new OpenAiChatClient(openAiApi);
-
+// Create a chat model with the custom OpenAiApi instance
+OpenAiChatmodel chatModel = OpenAiChatModel.builder()
+    .openAiApi(openAiApi)
+    .build();
+// Build the ChatClient using the custom chat model
+ChatClient openAiChatClient = ChatClient.builder(chatModel).build();
 ----
 
 This is useful when you need to:


### PR DESCRIPTION
Fix outdated OpenAiChatClient usage in openai-api.adoc