### PR TITLE
support setting a similarity threshold in VectorStoreChatMemoryAdvisor

### DIFF
--- a/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
+++ b/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
@@ -64,6 +64,8 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 
 	private static final int DEFAULT_TOP_K = 20;
 
+	private static final double DEFAULT_SIMILARITY_THRESHOLD = 0;
+
 	private static final PromptTemplate DEFAULT_SYSTEM_PROMPT_TEMPLATE = new PromptTemplate("""
 			{instructions}
 
@@ -79,6 +81,8 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 
 	private final int defaultTopK;
 
+	private final double defaultSimilarityThreshold;
+
 	private final String defaultConversationId;
 
 	private final int order;
@@ -88,14 +92,17 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 	private final VectorStore vectorStore;
 
 	private VectorStoreChatMemoryAdvisor(PromptTemplate systemPromptTemplate, int defaultTopK,
-			String defaultConversationId, int order, Scheduler scheduler, VectorStore vectorStore) {
+			double defaultSimilarityThreshold, String defaultConversationId, int order, Scheduler scheduler,
+			VectorStore vectorStore) {
 		Assert.notNull(systemPromptTemplate, "systemPromptTemplate cannot be null");
 		Assert.isTrue(defaultTopK > 0, "topK must be greater than 0");
+		Assert.isTrue(defaultSimilarityThreshold >= 0, "similarityThreshold must be equal to or greater than 0");
 		Assert.hasText(defaultConversationId, "defaultConversationId cannot be null or empty");
 		Assert.notNull(scheduler, "scheduler cannot be null");
 		Assert.notNull(vectorStore, "vectorStore cannot be null");
 		this.systemPromptTemplate = systemPromptTemplate;
 		this.defaultTopK = defaultTopK;
+		this.defaultSimilarityThreshold = defaultSimilarityThreshold;
 		this.defaultConversationId = defaultConversationId;
 		this.order = order;
 		this.scheduler = scheduler;
@@ -221,6 +228,8 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 
 		private Integer defaultTopK = DEFAULT_TOP_K;
 
+		private Double defaultSimilarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
+
 		private String conversationId = ChatMemory.DEFAULT_CONVERSATION_ID;
 
 		private Scheduler scheduler = BaseAdvisor.DEFAULT_SCHEDULER;
@@ -258,6 +267,17 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 		}
 
 		/**
+		 * Set the similarity threshold for retrieving relevant documents.
+		 * @param defaultSimilarityThreshold the required similarity for documents to
+		 * retrieve
+		 * @return this builder
+		 */
+		public Builder defaultSimilarityThreshold(Double defaultSimilarityThreshold) {
+			this.defaultSimilarityThreshold = defaultSimilarityThreshold;
+			return this;
+		}
+
+		/**
 		 * Set the conversation id.
 		 * @param conversationId the conversation id
 		 * @return the builder
@@ -287,8 +307,8 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 		 * @return the advisor
 		 */
 		public VectorStoreChatMemoryAdvisor build() {
-			return new VectorStoreChatMemoryAdvisor(this.systemPromptTemplate, this.defaultTopK, this.conversationId,
-					this.order, this.scheduler, this.vectorStore);
+			return new VectorStoreChatMemoryAdvisor(this.systemPromptTemplate, this.defaultTopK,
+					this.defaultSimilarityThreshold, this.conversationId, this.order, this.scheduler, this.vectorStore);
 		}
 
 	}

--- a/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
+++ b/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisor.java
@@ -56,6 +56,8 @@ import org.springframework.util.Assert;
  */
 public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor {
 
+	public static final String SIMILARITY_THRESHOLD = "chat_memory_vector_store_similarity_threshold";
+
 	public static final String TOP_K = "chat_memory_vector_store_top_k";
 
 	private static final String DOCUMENT_METADATA_CONVERSATION_ID = "conversationId";
@@ -128,10 +130,12 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 		String conversationId = getConversationId(request.context(), this.defaultConversationId);
 		String query = request.prompt().getUserMessage() != null ? request.prompt().getUserMessage().getText() : "";
 		int topK = getChatMemoryTopK(request.context());
+		double similarityThreshold = getChatMemorySimilarityThreshold(request.context());
 		String filter = DOCUMENT_METADATA_CONVERSATION_ID + "=='" + conversationId + "'";
 		var searchRequest = org.springframework.ai.vectorstore.SearchRequest.builder()
 			.query(query)
 			.topK(topK)
+			.similarityThreshold(similarityThreshold)
 			.filterExpression(filter)
 			.build();
 		java.util.List<org.springframework.ai.document.Document> documents = this.vectorStore
@@ -161,6 +165,11 @@ public final class VectorStoreChatMemoryAdvisor implements BaseChatMemoryAdvisor
 
 	private int getChatMemoryTopK(Map<String, Object> context) {
 		return context.containsKey(TOP_K) ? Integer.parseInt(context.get(TOP_K).toString()) : this.defaultTopK;
+	}
+
+	private double getChatMemorySimilarityThreshold(Map<String, Object> context) {
+		return context.containsKey(SIMILARITY_THRESHOLD)
+				? Double.parseDouble(context.get(SIMILARITY_THRESHOLD).toString()) : this.defaultSimilarityThreshold;
 	}
 
 	@Override

--- a/advisors/spring-ai-advisors-vector-store/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisorTests.java
+++ b/advisors/spring-ai-advisors-vector-store/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisorTests.java
@@ -91,4 +91,14 @@ class VectorStoreChatMemoryAdvisorTests {
 			.hasMessageContaining("topK must be greater than 0");
 	}
 
+	@Test
+	void whenDefaultSimilarityThresholdIsLessThanZeroThenThrow() {
+		VectorStore vectorStore = Mockito.mock(VectorStore.class);
+
+		assertThatThrownBy(
+				() -> VectorStoreChatMemoryAdvisor.builder(vectorStore).defaultSimilarityThreshold(-0.1).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("similarityThreshold must be equal to or greater than 0");
+	}
+
 }


### PR DESCRIPTION
The `VectorStoreChatMemoryAdvisor` did not support setting a similarity threshold, so it was fetching everything it found including messages that were not relevant to the user's message in the case where the user has asked about a different topic.

I experimented with setting a threshold higher than 0 and liked the results so I thought I'd submit a PR. The default is still 0 so as not to change the original behavior.