### PR TITLE
support for similarity threshold in VectorStoreChatMemoryAdvisor

### DIFF
--- a/advisors/spring-ai-advisors-vector-store/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisorTests.java
+++ b/advisors/spring-ai-advisors-vector-store/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/VectorStoreChatMemoryAdvisorTests.java
@@ -91,4 +91,14 @@ class VectorStoreChatMemoryAdvisorTests {
 			.hasMessageContaining("topK must be greater than 0");
 	}
 
+	@Test
+	void whenDefaultSimilarityThresholdIsLessThanZeroThenThrow() {
+		VectorStore vectorStore = Mockito.mock(VectorStore.class);
+
+		assertThatThrownBy(
+				() -> VectorStoreChatMemoryAdvisor.builder(vectorStore).defaultSimilarityThreshold(-0.1).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("similarityThreshold must be equal to or greater than 0");
+	}
+
 }


### PR DESCRIPTION
This advisor did not have support for setting the similarity threshold, so it defaulted to returning every document regardless of similarity. In a conversation where the user has changed to a different topic the result was returning a bunch of documents with no relevance to the user's latest input.

I experimented with setting a value greater than 0 and liked the results because it would begin to include results more relevant to the conversation. I thought it would be nice to contribute the change back.

I left the default at 0 so as not to change the earlier behavior.