### PR TITLE
Resolve OpenAI ApiKey for every request

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -128,10 +128,6 @@ public class OpenAiApi {
 
 		// @formatter:off
 		Consumer<HttpHeaders> finalHeaders = h -> {
-			if (!(apiKey instanceof NoopApiKey)) {
-				h.setBearerAuth(apiKey.getValue());
-			}
-
 			h.setContentType(MediaType.APPLICATION_JSON);
 			h.addAll(headers);
 		};
@@ -139,11 +135,21 @@ public class OpenAiApi {
 			.baseUrl(baseUrl)
 			.defaultHeaders(finalHeaders)
 			.defaultStatusHandler(responseErrorHandler)
+			.defaultRequest(requestHeadersSpec -> {
+				if (!(apiKey instanceof NoopApiKey)) {
+					requestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.getValue());
+				}
+			})
 			.build();
 
 		this.webClient = webClientBuilder.clone()
 			.baseUrl(baseUrl)
 			.defaultHeaders(finalHeaders)
+			.defaultRequest(requestHeadersSpec -> {
+				if (!(apiKey instanceof NoopApiKey)) {
+					requestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.getValue());
+				}
+			})
 			.build(); // @formatter:on
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiAudioApi.java
@@ -71,20 +71,30 @@ public class OpenAiAudioApi {
 			ResponseErrorHandler responseErrorHandler) {
 
 		Consumer<HttpHeaders> authHeaders = h -> {
-			if (!(apiKey instanceof NoopApiKey)) {
-				h.setBearerAuth(apiKey.getValue());
-			}
 			h.addAll(headers);
-			// h.setContentType(MediaType.APPLICATION_JSON);
 		};
 
+		// @formatter:off
 		this.restClient = restClientBuilder.clone()
 			.baseUrl(baseUrl)
 			.defaultHeaders(authHeaders)
 			.defaultStatusHandler(responseErrorHandler)
+			.defaultRequest(requestHeadersSpec -> {
+				if (!(apiKey instanceof NoopApiKey)) {
+					requestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.getValue());
+				}
+			})
 			.build();
 
-		this.webClient = webClientBuilder.clone().baseUrl(baseUrl).defaultHeaders(authHeaders).build();
+		this.webClient = webClientBuilder.clone()
+			.baseUrl(baseUrl)
+			.defaultHeaders(authHeaders)
+			.defaultRequest(requestHeadersSpec -> {
+				if (!(apiKey instanceof NoopApiKey)) {
+					requestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.getValue());
+				}
+			})
+			.build(); // @formatter:on
 	}
 
 	public static Builder builder() {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiImageApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiImageApi.java
@@ -27,6 +27,7 @@ import org.springframework.ai.model.NoopApiKey;
 import org.springframework.ai.model.SimpleApiKey;
 import org.springframework.ai.openai.api.common.OpenAiApiConstants;
 import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
@@ -62,15 +63,18 @@ public class OpenAiImageApi {
 			RestClient.Builder restClientBuilder, ResponseErrorHandler responseErrorHandler) {
 
 		// @formatter:off
-		this.restClient = restClientBuilder.baseUrl(baseUrl)
+		this.restClient = restClientBuilder.clone()
+			.baseUrl(baseUrl)
 			.defaultHeaders(h -> {
-				if (!(apiKey instanceof NoopApiKey)) {
-					h.setBearerAuth(apiKey.getValue());
-				}
 				h.setContentType(MediaType.APPLICATION_JSON);
 				h.addAll(headers);
 			})
 			.defaultStatusHandler(responseErrorHandler)
+			.defaultRequest(requestHeadersSpec -> {
+				if (!(apiKey instanceof NoopApiKey)) {
+					requestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.getValue());
+				}
+			})
 			.build();
 		// @formatter:on
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiModerationApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiModerationApi.java
@@ -27,6 +27,7 @@ import org.springframework.ai.model.NoopApiKey;
 import org.springframework.ai.model.SimpleApiKey;
 import org.springframework.ai.openai.api.common.OpenAiApiConstants;
 import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
@@ -64,13 +65,20 @@ public class OpenAiModerationApi {
 
 		this.objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-		this.restClient = restClientBuilder.baseUrl(baseUrl).defaultHeaders(h -> {
-			if (!(apiKey instanceof NoopApiKey)) {
-				h.setBearerAuth(apiKey.getValue());
-			}
-			h.setContentType(MediaType.APPLICATION_JSON);
-			h.addAll(headers);
-		}).defaultStatusHandler(responseErrorHandler).build();
+		// @formatter:off
+		this.restClient = restClientBuilder.clone()
+			.baseUrl(baseUrl)
+			.defaultHeaders(h -> {
+				h.setContentType(MediaType.APPLICATION_JSON);
+				h.addAll(headers);
+			})
+			.defaultStatusHandler(responseErrorHandler)
+			.defaultRequest(requestHeadersSpec -> {
+				if (!(apiKey instanceof NoopApiKey)) {
+					requestHeadersSpec.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.getValue());
+				}
+			})
+			.build(); // @formatter:on
 	}
 
 	public ResponseEntity<OpenAiModerationResponse> createModeration(OpenAiModerationRequest openAiModerationRequest) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/api/OpenAiAudioApiBuilderTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/audio/api/OpenAiAudioApiBuilderTests.java
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.openai.api;
+package org.springframework.ai.openai.audio.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -22,17 +26,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.ai.model.ApiKey;
 import org.springframework.ai.model.SimpleApiKey;
+import org.springframework.ai.openai.api.OpenAiAudioApi;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -43,23 +43,22 @@ import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
-public class OpenAiApiBuilderTests {
+/**
+ * @author Filip Hrisafov
+ */
+class OpenAiAudioApiBuilderTests {
 
 	private static final ApiKey TEST_API_KEY = new SimpleApiKey("test-api-key");
 
 	private static final String TEST_BASE_URL = "https://test.openai.com";
 
-	private static final String TEST_COMPLETIONS_PATH = "/test/completions";
-
-	private static final String TEST_EMBEDDINGS_PATH = "/test/embeddings";
-
 	@Test
 	void testMinimalBuilder() {
-		OpenAiApi api = OpenAiApi.builder().apiKey(TEST_API_KEY).build();
+		OpenAiAudioApi api = OpenAiAudioApi.builder().apiKey(TEST_API_KEY).build();
 
 		assertThat(api).isNotNull();
 	}
@@ -72,12 +71,10 @@ public class OpenAiApiBuilderTests {
 		WebClient.Builder webClientBuilder = WebClient.builder();
 		ResponseErrorHandler errorHandler = mock(ResponseErrorHandler.class);
 
-		OpenAiApi api = OpenAiApi.builder()
-			.apiKey(TEST_API_KEY)
+		OpenAiAudioApi api = OpenAiAudioApi.builder()
 			.baseUrl(TEST_BASE_URL)
+			.apiKey(TEST_API_KEY)
 			.headers(headers)
-			.completionsPath(TEST_COMPLETIONS_PATH)
-			.embeddingsPath(TEST_EMBEDDINGS_PATH)
 			.restClientBuilder(restClientBuilder)
 			.webClientBuilder(webClientBuilder)
 			.responseErrorHandler(errorHandler)
@@ -87,74 +84,46 @@ public class OpenAiApiBuilderTests {
 	}
 
 	@Test
-	void testDefaultValues() {
-		OpenAiApi api = OpenAiApi.builder().apiKey(TEST_API_KEY).build();
-
-		assertThat(api).isNotNull();
-		// We can't directly test the default values as they're private fields,
-		// but we know the builder succeeded with defaults
-	}
-
-	@Test
 	void testMissingApiKey() {
-		assertThatThrownBy(() -> OpenAiApi.builder().build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> OpenAiAudioApi.builder().build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("apiKey must be set");
 	}
 
 	@Test
 	void testInvalidBaseUrl() {
-		assertThatThrownBy(() -> OpenAiApi.builder().baseUrl("").build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> OpenAiAudioApi.builder().baseUrl("").build())
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("baseUrl cannot be null or empty");
 
-		assertThatThrownBy(() -> OpenAiApi.builder().baseUrl(null).build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> OpenAiAudioApi.builder().baseUrl(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("baseUrl cannot be null or empty");
 	}
 
 	@Test
 	void testInvalidHeaders() {
-		assertThatThrownBy(() -> OpenAiApi.builder().headers(null).build()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> OpenAiAudioApi.builder().headers(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("headers cannot be null");
 	}
 
 	@Test
-	void testInvalidCompletionsPath() {
-		assertThatThrownBy(() -> OpenAiApi.builder().completionsPath("").build())
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("completionsPath cannot be null or empty");
-
-		assertThatThrownBy(() -> OpenAiApi.builder().completionsPath(null).build())
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("completionsPath cannot be null or empty");
-	}
-
-	@Test
-	void testInvalidEmbeddingsPath() {
-		assertThatThrownBy(() -> OpenAiApi.builder().embeddingsPath("").build())
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("embeddingsPath cannot be null or empty");
-
-		assertThatThrownBy(() -> OpenAiApi.builder().embeddingsPath(null).build())
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("embeddingsPath cannot be null or empty");
-	}
-
-	@Test
 	void testInvalidRestClientBuilder() {
-		assertThatThrownBy(() -> OpenAiApi.builder().restClientBuilder(null).build())
+		assertThatThrownBy(() -> OpenAiAudioApi.builder().restClientBuilder(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("restClientBuilder cannot be null");
 	}
 
 	@Test
 	void testInvalidWebClientBuilder() {
-		assertThatThrownBy(() -> OpenAiApi.builder().webClientBuilder(null).build())
+		assertThatThrownBy(() -> OpenAiAudioApi.builder().webClientBuilder(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("webClientBuilder cannot be null");
 	}
 
 	@Test
 	void testInvalidResponseErrorHandler() {
-		assertThatThrownBy(() -> OpenAiApi.builder().responseErrorHandler(null).build())
+		assertThatThrownBy(() -> OpenAiAudioApi.builder().responseErrorHandler(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("responseErrorHandler cannot be null");
 	}
@@ -178,49 +147,27 @@ public class OpenAiApiBuilderTests {
 		@Test
 		void dynamicApiKeyRestClient() throws InterruptedException {
 			Queue<ApiKey> apiKeys = new LinkedList<>(List.of(new SimpleApiKey("key1"), new SimpleApiKey("key2")));
-			OpenAiApi api = OpenAiApi.builder()
+			OpenAiAudioApi api = OpenAiAudioApi.builder()
 				.apiKey(() -> Objects.requireNonNull(apiKeys.poll()).getValue())
 				.baseUrl(mockWebServer.url("/").toString())
 				.build();
 
 			MockResponse mockResponse = new MockResponse().setResponseCode(200)
-				.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-				.setBody("""
-						{
-							"id": "chatcmpl-12345",
-							"object": "chat.completion",
-							"created": 1677858242,
-							"model": "gpt-3.5-turbo",
-							"choices": [
-								{
-						    		"index": 0,
-									"message": {
-									"role": "assistant",
-									"content": "Hello world"
-									},
-									"finish_reason": "stop"
-								}
-							],
-							"usage": {
-								"prompt_tokens": 10,
-								"completion_tokens": 5,
-								"total_tokens": 15
-							}
-						}
-						""");
+				.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
+				.setBody("Audio bytes as string");
 			mockWebServer.enqueue(mockResponse);
 			mockWebServer.enqueue(mockResponse);
 
-			OpenAiApi.ChatCompletionMessage chatCompletionMessage = new OpenAiApi.ChatCompletionMessage("Hello world",
-					OpenAiApi.ChatCompletionMessage.Role.USER);
-			OpenAiApi.ChatCompletionRequest request = new OpenAiApi.ChatCompletionRequest(
-					List.of(chatCompletionMessage), "gpt-3.5-turbo", 0.8, false);
-			ResponseEntity<OpenAiApi.ChatCompletion> response = api.chatCompletionEntity(request);
+			OpenAiAudioApi.SpeechRequest request = OpenAiAudioApi.SpeechRequest.builder()
+				.model(OpenAiAudioApi.TtsModel.TTS_1.value)
+				.input("Test input")
+				.build();
+			ResponseEntity<byte[]> response = api.createSpeech(request);
 			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 			RecordedRequest recordedRequest = mockWebServer.takeRequest();
 			assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer key1");
 
-			response = api.chatCompletionEntity(request);
+			response = api.createSpeech(request);
 			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
 			recordedRequest = mockWebServer.takeRequest();
@@ -230,49 +177,27 @@ public class OpenAiApiBuilderTests {
 		@Test
 		void dynamicApiKeyWebClient() throws InterruptedException {
 			Queue<ApiKey> apiKeys = new LinkedList<>(List.of(new SimpleApiKey("key1"), new SimpleApiKey("key2")));
-			OpenAiApi api = OpenAiApi.builder()
+			OpenAiAudioApi api = OpenAiAudioApi.builder()
 				.apiKey(() -> Objects.requireNonNull(apiKeys.poll()).getValue())
 				.baseUrl(mockWebServer.url("/").toString())
 				.build();
 
 			MockResponse mockResponse = new MockResponse().setResponseCode(200)
-				.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-				.setBody("""
-						{
-							"id": "chatcmpl-12345",
-							"object": "chat.completion",
-							"created": 1677858242,
-							"model": "gpt-3.5-turbo",
-							"choices": [
-								{
-						    		"index": 0,
-									"message": {
-									"role": "assistant",
-									"content": "Hello world"
-									},
-									"finish_reason": "stop"
-								}
-							],
-							"usage": {
-								"prompt_tokens": 10,
-								"completion_tokens": 5,
-								"total_tokens": 15
-							}
-						}
-						""".replace("\n", ""));
+				.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
+				.setBody("Audio bytes as string");
 			mockWebServer.enqueue(mockResponse);
 			mockWebServer.enqueue(mockResponse);
 
-			OpenAiApi.ChatCompletionMessage chatCompletionMessage = new OpenAiApi.ChatCompletionMessage("Hello world",
-					OpenAiApi.ChatCompletionMessage.Role.USER);
-			OpenAiApi.ChatCompletionRequest request = new OpenAiApi.ChatCompletionRequest(
-					List.of(chatCompletionMessage), "gpt-3.5-turbo", 0.8, true);
-			List<OpenAiApi.ChatCompletionChunk> response = api.chatCompletionStream(request).collectList().block();
+			OpenAiAudioApi.SpeechRequest request = OpenAiAudioApi.SpeechRequest.builder()
+				.model(OpenAiAudioApi.TtsModel.TTS_1.value)
+				.input("Test input")
+				.build();
+			List<ResponseEntity<byte[]>> response = api.stream(request).collectList().block();
 			assertThat(response).hasSize(1);
 			RecordedRequest recordedRequest = mockWebServer.takeRequest();
 			assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer key1");
 
-			response = api.chatCompletionStream(request).collectList().block();
+			response = api.stream(request).collectList().block();
 			assertThat(response).hasSize(1);
 
 			recordedRequest = mockWebServer.takeRequest();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/api/OpenAiImageApiBuilderTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/api/OpenAiImageApiBuilderTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.image.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.model.ApiKey;
+import org.springframework.ai.model.SimpleApiKey;
+import org.springframework.ai.openai.api.OpenAiImageApi;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * @author Filip Hrisafov
+ */
+class OpenAiImageApiBuilderTests {
+
+	private static final ApiKey TEST_API_KEY = new SimpleApiKey("test-api-key");
+
+	private static final String TEST_BASE_URL = "https://test.openai.com";
+
+	@Test
+	void testMinimalBuilder() {
+		OpenAiImageApi api = OpenAiImageApi.builder().apiKey(TEST_API_KEY).build();
+
+		assertThat(api).isNotNull();
+	}
+
+	@Test
+	void testFullBuilder() {
+		MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+		headers.add("Custom-Header", "test-value");
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		ResponseErrorHandler errorHandler = mock(ResponseErrorHandler.class);
+
+		OpenAiImageApi api = OpenAiImageApi.builder()
+			.baseUrl(TEST_BASE_URL)
+			.apiKey(TEST_API_KEY)
+			.headers(headers)
+			.restClientBuilder(restClientBuilder)
+			.responseErrorHandler(errorHandler)
+			.build();
+
+		assertThat(api).isNotNull();
+	}
+
+	@Test
+	void testMissingApiKey() {
+		assertThatThrownBy(() -> OpenAiImageApi.builder().build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("apiKey must be set");
+	}
+
+	@Test
+	void testInvalidBaseUrl() {
+		assertThatThrownBy(() -> OpenAiImageApi.builder().baseUrl("").build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("baseUrl cannot be null or empty");
+
+		assertThatThrownBy(() -> OpenAiImageApi.builder().baseUrl(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("baseUrl cannot be null or empty");
+	}
+
+	@Test
+	void testInvalidHeaders() {
+		assertThatThrownBy(() -> OpenAiImageApi.builder().headers(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("headers cannot be null");
+	}
+
+	@Test
+	void testInvalidRestClientBuilder() {
+		assertThatThrownBy(() -> OpenAiImageApi.builder().restClientBuilder(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("restClientBuilder cannot be null");
+	}
+
+	@Test
+	void testInvalidResponseErrorHandler() {
+		assertThatThrownBy(() -> OpenAiImageApi.builder().responseErrorHandler(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("responseErrorHandler cannot be null");
+	}
+
+	@Nested
+	class MockRequests {
+
+		MockWebServer mockWebServer;
+
+		@BeforeEach
+		void setUp() throws IOException {
+			mockWebServer = new MockWebServer();
+			mockWebServer.start();
+		}
+
+		@AfterEach
+		void tearDown() throws IOException {
+			mockWebServer.shutdown();
+		}
+
+		@Test
+		void dynamicApiKeyRestClient() throws InterruptedException {
+			Queue<ApiKey> apiKeys = new LinkedList<>(List.of(new SimpleApiKey("key1"), new SimpleApiKey("key2")));
+			OpenAiImageApi api = OpenAiImageApi.builder()
+				.apiKey(() -> Objects.requireNonNull(apiKeys.poll()).getValue())
+				.baseUrl(mockWebServer.url("/").toString())
+				.build();
+
+			MockResponse mockResponse = new MockResponse().setResponseCode(200)
+				.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+				.setBody("""
+						{
+							"created": 1589478378,
+							"data": [
+								{
+									"url": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Mini_Golden_Doodle.jpg"
+								}
+							]
+						}
+						""");
+			mockWebServer.enqueue(mockResponse);
+			mockWebServer.enqueue(mockResponse);
+
+			OpenAiImageApi.OpenAiImageRequest request = new OpenAiImageApi.OpenAiImageRequest("Test",
+					OpenAiImageApi.ImageModel.DALL_E_3.getValue());
+			ResponseEntity<OpenAiImageApi.OpenAiImageResponse> response = api.createImage(request);
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			RecordedRequest recordedRequest = mockWebServer.takeRequest();
+			assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer key1");
+
+			response = api.createImage(request);
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+			recordedRequest = mockWebServer.takeRequest();
+			assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer key2");
+		}
+
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/api/OpenAiModerationApiBuilderTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/api/OpenAiModerationApiBuilderTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.moderation.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.model.ApiKey;
+import org.springframework.ai.model.SimpleApiKey;
+import org.springframework.ai.openai.api.OpenAiModerationApi;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * @author Filip Hrisafov
+ */
+class OpenAiModerationApiBuilderTests {
+
+	private static final ApiKey TEST_API_KEY = new SimpleApiKey("test-api-key");
+
+	private static final String TEST_BASE_URL = "https://test.openai.com";
+
+	@Test
+	void testMinimalBuilder() {
+		OpenAiModerationApi api = OpenAiModerationApi.builder().apiKey(TEST_API_KEY).build();
+
+		assertThat(api).isNotNull();
+	}
+
+	@Test
+	void testFullBuilder() {
+		MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+		headers.add("Custom-Header", "test-value");
+		RestClient.Builder restClientBuilder = RestClient.builder();
+		ResponseErrorHandler errorHandler = mock(ResponseErrorHandler.class);
+
+		OpenAiModerationApi api = OpenAiModerationApi.builder()
+			.baseUrl(TEST_BASE_URL)
+			.apiKey(TEST_API_KEY)
+			.headers(headers)
+			.restClientBuilder(restClientBuilder)
+			.responseErrorHandler(errorHandler)
+			.build();
+
+		assertThat(api).isNotNull();
+	}
+
+	@Test
+	void testMissingApiKey() {
+		assertThatThrownBy(() -> OpenAiModerationApi.builder().build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("apiKey must be set");
+	}
+
+	@Test
+	void testInvalidBaseUrl() {
+		assertThatThrownBy(() -> OpenAiModerationApi.builder().baseUrl("").build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("baseUrl cannot be null or empty");
+
+		assertThatThrownBy(() -> OpenAiModerationApi.builder().baseUrl(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("baseUrl cannot be null or empty");
+	}
+
+	@Test
+	void testInvalidHeaders() {
+		assertThatThrownBy(() -> OpenAiModerationApi.builder().headers(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("headers cannot be null");
+	}
+
+	@Test
+	void testInvalidRestClientBuilder() {
+		assertThatThrownBy(() -> OpenAiModerationApi.builder().restClientBuilder(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("restClientBuilder cannot be null");
+	}
+
+	@Test
+	void testInvalidResponseErrorHandler() {
+		assertThatThrownBy(() -> OpenAiModerationApi.builder().responseErrorHandler(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("responseErrorHandler cannot be null");
+	}
+
+	@Nested
+	class MockRequests {
+
+		MockWebServer mockWebServer;
+
+		@BeforeEach
+		void setUp() throws IOException {
+			mockWebServer = new MockWebServer();
+			mockWebServer.start();
+		}
+
+		@AfterEach
+		void tearDown() throws IOException {
+			mockWebServer.shutdown();
+		}
+
+		@Test
+		void dynamicApiKeyRestClient() throws InterruptedException {
+			Queue<ApiKey> apiKeys = new LinkedList<>(List.of(new SimpleApiKey("key1"), new SimpleApiKey("key2")));
+			OpenAiModerationApi api = OpenAiModerationApi.builder()
+				.apiKey(() -> Objects.requireNonNull(apiKeys.poll()).getValue())
+				.baseUrl(mockWebServer.url("/").toString())
+				.build();
+
+			MockResponse mockResponse = new MockResponse().setResponseCode(200)
+				.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+				.setBody("""
+						{
+							"created": 1589478378,
+							"data": [
+								{
+									"url": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Mini_Golden_Doodle.jpg"
+								}
+							]
+						}
+						""");
+			mockWebServer.enqueue(mockResponse);
+			mockWebServer.enqueue(mockResponse);
+
+			OpenAiModerationApi.OpenAiModerationRequest request = new OpenAiModerationApi.OpenAiModerationRequest(
+					"Test");
+			ResponseEntity<OpenAiModerationApi.OpenAiModerationResponse> response = api.createModeration(request);
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			RecordedRequest recordedRequest = mockWebServer.takeRequest();
+			assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer key1");
+
+			response = api.createModeration(request);
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+			recordedRequest = mockWebServer.takeRequest();
+			assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer key2");
+		}
+
+	}
+
+}


### PR DESCRIPTION
I am working on adding some dynamic support for using the `OpenAiApi` from Spring AI. Reading the `ApiKey` javadoc, it looks like a great fit for us, since we want to support dynamic resolving of it.

However, I realized that it's value is not resolved on every request, but only once in the constructor when the headers are set.

While adding this to the `OpenAiApi` I realized that the rest of the Open AI API classes were also not resolving it so I added it there as well. 

I did apply the spring format, but I am not sure that the imports are correct. Please let me know if I need to adjust something