### PR TITLE
fix(qdrant): support Long type in payload by converting to String

### DIFF
--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantValueFactory.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantValueFactory.java
@@ -75,6 +75,9 @@ final class QdrantValueFactory {
 				return ValueFactory.value((String) value);
 			case "Integer":
 				return ValueFactory.value((Integer) value);
+			case "Long":
+				// use String representation
+				return ValueFactory.value(String.valueOf(value));
 			case "Double":
 				return ValueFactory.value((Double) value);
 			case "Float":


### PR DESCRIPTION
Qdrant does not support java.lang.Long as a native payload type. Previously, passing a Long value caused the following exception:

  java.lang.IllegalArgumentException: Unsupported Qdrant value type: class java.lang.Long
    at org.springframework.ai.vectorstore.qdrant.QdrantValueFactory.value(QdrantValueFactory.java:85)
    at org.springframework.ai.vectorstore.qdrant.QdrantValueFactory.lambda$toValueMap$1(QdrantValueFactory.java:46)
    ...

To resolve this, Long values are now converted to their String representation in QdrantValueFactory. This preserves precision and avoids serialization issues.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
