### PR TITLE
Fixed an issue where tool calls could not function properly when using the new version of Ollama.

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -84,6 +84,7 @@ import org.springframework.util.StringUtils;
  * @author Jihoon Kim
  * @author Alexandros Pappas
  * @author Ilayaperumal Gopinathan
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public class OllamaChatModel implements ChatModel {
@@ -170,18 +171,21 @@ public class OllamaChatModel implements ChatModel {
 		Duration totalDuration = response.getTotalDuration();
 
 		if (previousChatResponse != null && previousChatResponse.getMetadata() != null) {
-			if (previousChatResponse.getMetadata().get(METADATA_EVAL_DURATION) != null) {
-				evalDuration = evalDuration.plus(previousChatResponse.getMetadata().get(METADATA_EVAL_DURATION));
+			Object metadataEvalDuration = previousChatResponse.getMetadata().get(METADATA_EVAL_DURATION);
+			if (metadataEvalDuration != null && evalDuration != null) {
+				evalDuration = evalDuration.plus((Duration) metadataEvalDuration);
 			}
-			if (previousChatResponse.getMetadata().get(METADATA_PROMPT_EVAL_DURATION) != null) {
-				promptEvalDuration = promptEvalDuration
-					.plus(previousChatResponse.getMetadata().get(METADATA_PROMPT_EVAL_DURATION));
+			Object metadataPromptEvalDuration = previousChatResponse.getMetadata().get(METADATA_PROMPT_EVAL_DURATION);
+			if (metadataPromptEvalDuration != null && promptEvalDuration != null) {
+				promptEvalDuration = promptEvalDuration.plus((Duration) metadataPromptEvalDuration);
 			}
-			if (previousChatResponse.getMetadata().get(METADATA_LOAD_DURATION) != null) {
-				loadDuration = loadDuration.plus(previousChatResponse.getMetadata().get(METADATA_LOAD_DURATION));
+			Object metadataLoadDuration = previousChatResponse.getMetadata().get(METADATA_LOAD_DURATION);
+			if (metadataLoadDuration != null && loadDuration != null) {
+				loadDuration = loadDuration.plus((Duration) metadataLoadDuration);
 			}
-			if (previousChatResponse.getMetadata().get(METADATA_TOTAL_DURATION) != null) {
-				totalDuration = totalDuration.plus(previousChatResponse.getMetadata().get(METADATA_TOTAL_DURATION));
+			Object metadataTotalDuration = previousChatResponse.getMetadata().get(METADATA_TOTAL_DURATION);
+			if (metadataTotalDuration != null && totalDuration != null) {
+				totalDuration = totalDuration.plus((Duration) metadataTotalDuration);
 			}
 			if (previousChatResponse.getMetadata().getUsage() != null) {
 				promptTokens += previousChatResponse.getMetadata().getUsage().getPromptTokens();

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
@@ -37,8 +37,7 @@ import org.springframework.ai.ollama.api.OllamaOptions;
 import org.springframework.ai.ollama.management.ModelManagementOptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Jihoon Kim
@@ -144,6 +143,30 @@ class OllamaChatModelTests {
 		assertEquals(Duration.ofNanos(promptEvalDuration).plus(Duration.ofSeconds(2)),
 				metadata.get("prompt-eval-duration"));
 		assertEquals(promptEvalCount + 66, (Integer) metadata.get("prompt-eval-count"));
+	}
+
+	@Test
+	void buildChatResponseMetadataAggregationWithNonEmptyMetadataButEmptyEval() {
+
+		OllamaApi.ChatResponse response = new OllamaApi.ChatResponse("model", Instant.now(), null, null, null, null,
+				null, null, null, null, null);
+
+		ChatResponse previousChatResponse = ChatResponse.builder()
+			.generations(List.of())
+			.metadata(ChatResponseMetadata.builder()
+				.usage(new DefaultUsage(66, 99))
+				.keyValue("eval-duration", Duration.ofSeconds(2))
+				.keyValue("prompt-eval-duration", Duration.ofSeconds(2))
+				.build())
+			.build();
+
+		ChatResponseMetadata metadata = OllamaChatModel.from(response, previousChatResponse);
+
+		assertNull(metadata.get("eval-duration"));
+		assertNull(metadata.get("prompt-eval-duration"));
+		assertEquals(Integer.valueOf(99), metadata.get("eval-count"));
+		assertEquals(Integer.valueOf(66), metadata.get("prompt-eval-count"));
+
 	}
 
 }


### PR DESCRIPTION
As stated in the issue: https://github.com/spring-projects/spring-ai/issues/3369, when using the new version of Ollama and a tool call is made, a `NullPointerException` occurs involving `"evalDuration"`. 

This is because, according to the official Ollama API documentation: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion, fields like `eval_duration` are only populated when the model response is completed. However, during a tool call, the `from` method of `org.springframework.ai.ollama.OllamaChatModel` fails to handle null values properly, leading to this issue.

I'm not entirely sure whether it's due to any changes Ollama may have made to the response interface. However, by adding more robust null checks, we can make this functionality work correctly.