### PR TITLE
ToolCallingChatOptions support internalToolExecutionMaxAttempts, to limit the maximum number of tool calls and prevent infinite recursive calls to LLM in special cases

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Alexandros Pappas
  * @author Ilayaperumal Gopinathan
+ * @author lambochen
  * @since 1.0.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -78,6 +79,9 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	 */
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
+
+	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -224,6 +228,16 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return this.internalToolExecutionMaxIterations;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
 	}
 
 	@Override

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -81,7 +81,7 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -231,13 +231,13 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return this.internalToolExecutionMaxIterations;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	@Override

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -81,7 +81,7 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  * @author Alexandros Pappas
  * @author Andres da Silva Santos
+ * @author lambochen
  */
 @JsonInclude(Include.NON_NULL)
 public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
@@ -200,6 +201,9 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
 
+	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
+
 	/**
 	 * Whether to include token usage information in streaming chat completion responses.
 	 * Only applies to streaming responses.
@@ -255,6 +259,16 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return this.internalToolExecutionMaxIterations;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
 	}
 
 	public static Builder builder() {
@@ -504,6 +518,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.toolNames, that.toolNames)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
+				&& Objects.equals(this.internalToolExecutionMaxIterations, that.internalToolExecutionMaxIterations)
 				&& Objects.equals(this.logprobs, that.logprobs) && Objects.equals(this.topLogProbs, that.topLogProbs)
 				&& Objects.equals(this.enhancements, that.enhancements)
 				&& Objects.equals(this.streamOptions, that.streamOptions)
@@ -518,10 +533,10 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.logitBias, this.user, this.n, this.stop, this.deploymentName, this.responseFormat,
-				this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled, this.seed, this.logprobs,
-				this.topLogProbs, this.enhancements, this.streamOptions, this.reasoningEffort, this.enableStreamUsage,
-				this.toolContext, this.maxTokens, this.frequencyPenalty, this.presencePenalty, this.temperature,
-				this.topP);
+				this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
+				this.internalToolExecutionMaxIterations, this.seed, this.logprobs, this.topLogProbs, this.enhancements,
+				this.streamOptions, this.reasoningEffort, this.enableStreamUsage, this.toolContext, this.maxTokens,
+				this.frequencyPenalty, this.presencePenalty, this.temperature, this.topP);
 	}
 
 	public static class Builder {
@@ -661,6 +676,11 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder InternalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
+			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
 			return this;
 		}
 

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -202,7 +202,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	/**
 	 * Whether to include token usage information in streaming chat completion responses.
@@ -679,7 +679,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		public Builder InternalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
+		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
 			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxIterations);
 			return this;
 		}

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -202,7 +202,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	/**
 	 * Whether to include token usage information in streaming chat completion responses.
@@ -262,13 +262,13 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return this.internalToolExecutionMaxIterations;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	public static Builder builder() {
@@ -518,7 +518,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.toolNames, that.toolNames)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
-				&& Objects.equals(this.internalToolExecutionMaxIterations, that.internalToolExecutionMaxIterations)
+				&& Objects.equals(this.internalToolExecutionMaxAttempts, that.internalToolExecutionMaxAttempts)
 				&& Objects.equals(this.logprobs, that.logprobs) && Objects.equals(this.topLogProbs, that.topLogProbs)
 				&& Objects.equals(this.enhancements, that.enhancements)
 				&& Objects.equals(this.streamOptions, that.streamOptions)
@@ -534,7 +534,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	public int hashCode() {
 		return Objects.hash(this.logitBias, this.user, this.n, this.stop, this.deploymentName, this.responseFormat,
 				this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
-				this.internalToolExecutionMaxIterations, this.seed, this.logprobs, this.topLogProbs, this.enhancements,
+				this.internalToolExecutionMaxAttempts, this.seed, this.logprobs, this.topLogProbs, this.enhancements,
 				this.streamOptions, this.reasoningEffort, this.enableStreamUsage, this.toolContext, this.maxTokens,
 				this.frequencyPenalty, this.presencePenalty, this.temperature, this.topP);
 	}
@@ -680,7 +680,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 		}
 
 		public Builder InternalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
-			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxIterations);
 			return this;
 		}
 

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
@@ -124,7 +124,7 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	/**
 	 * Tool Function Callbacks to register with the ChatModel.
@@ -301,7 +301,7 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 
 	@Override
 	@JsonIgnore
-	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+	public void setInternalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
 		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
     }
 
@@ -506,7 +506,7 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		public Builder internalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		public Builder internalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
 			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
@@ -123,6 +123,9 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
 
+	@JsonIgnore
+	private Integer internalToolExecutionMaxAttempts;
+
 	/**
 	 * Tool Function Callbacks to register with the ChatModel.
 	 * For Prompt Options the toolCallbacks are automatically enabled for the duration of the prompt execution.
@@ -292,14 +295,14 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 
 	@Override
 	@JsonIgnore
-	public Integer getInternalToolExecutionMaxIterations() {
-    	return 0;
+	public Integer getInternalToolExecutionMaxAttempts() {
+    	return this.internalToolExecutionMaxAttempts;
     }
 
 	@Override
 	@JsonIgnore
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
     }
 
 	public Boolean getLogprobs() {
@@ -370,7 +373,9 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolCallbacks, other.toolCallbacks)
 				&& Objects.equals(this.toolNames, other.toolNames)
 				&& Objects.equals(this.toolContext, other.toolContext)
-				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled);
+				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
+				&& Objects.equals(this.internalToolExecutionMaxAttempts, other.internalToolExecutionMaxAttempts)
+				;
 	}
 
 	public static DeepSeekChatOptions fromOptions(DeepSeekChatOptions fromOptions) {
@@ -391,6 +396,7 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 						fromOptions.getToolCallbacks() != null ? new ArrayList<>(fromOptions.getToolCallbacks()) : null)
 				.toolNames(fromOptions.getToolNames() != null ? new HashSet<>(fromOptions.getToolNames()) : null)
 				.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
+				.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
 				.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
 				.build();
 	}
@@ -497,6 +503,11 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder internalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}
 

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * chat completion</a>
  *
  * @author Geng Rong
+ * @author lambochen
  */
 @JsonInclude(Include.NON_NULL)
 public class DeepSeekChatOptions implements ToolCallingChatOptions {
@@ -288,6 +289,18 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
 	}
+
+	@Override
+	@JsonIgnore
+	public Integer getInternalToolExecutionMaxIterations() {
+    	return 0;
+    }
+
+	@Override
+	@JsonIgnore
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+
+    }
 
 	public Boolean getLogprobs() {
 		return this.logprobs;

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Geng Rong
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author lambochen
  * @since 1.0.0 M1
  */
 @JsonInclude(Include.NON_NULL)
@@ -152,6 +153,12 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	 */
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
+
+	/**
+	 * The maximum number of iterations for tool execution.
+	 */
+	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
 
 	// @formatter:on
 
@@ -347,6 +354,16 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return 0;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+
 	}
 
 	@Override

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -154,11 +154,8 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
 
-	/**
-	 * The maximum number of iterations for tool execution.
-	 */
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	// @formatter:on
 
@@ -183,6 +180,7 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 			.toolCallbacks(fromOptions.getToolCallbacks())
 			.toolNames(fromOptions.getToolNames())
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
+				.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
 			.toolContext(fromOptions.getToolContext())
 			.build();
 	}
@@ -357,13 +355,13 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return 0;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	@Override
@@ -397,6 +395,8 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		result = prime * result + ((this.toolNames == null) ? 0 : this.toolNames.hashCode());
 		result = prime * result
 				+ ((this.internalToolExecutionEnabled == null) ? 0 : this.internalToolExecutionEnabled.hashCode());
+		result = prime * result
+				+ ((this.internalToolExecutionMaxAttempts == null) ? 0 : this.internalToolExecutionMaxAttempts.hashCode());
 		result = prime * result + ((this.toolContext == null) ? 0 : this.toolContext.hashCode());
 		return result;
 	}
@@ -523,6 +523,15 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 			}
 		}
 		else if (!this.internalToolExecutionEnabled.equals(other.internalToolExecutionEnabled)) {
+			return false;
+		}
+
+		if (this.internalToolExecutionMaxAttempts == null) {
+			if (other.internalToolExecutionMaxAttempts != null) {
+				return false;
+			}
+		}
+		else if (!this.internalToolExecutionMaxAttempts.equals(other.internalToolExecutionMaxAttempts)) {
 			return false;
 		}
 
@@ -663,6 +672,11 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder internalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -180,7 +180,7 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 			.toolCallbacks(fromOptions.getToolCallbacks())
 			.toolNames(fromOptions.getToolNames())
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
-				.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
+			.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
 			.toolContext(fromOptions.getToolContext())
 			.build();
 	}
@@ -395,8 +395,8 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		result = prime * result + ((this.toolNames == null) ? 0 : this.toolNames.hashCode());
 		result = prime * result
 				+ ((this.internalToolExecutionEnabled == null) ? 0 : this.internalToolExecutionEnabled.hashCode());
-		result = prime * result
-				+ ((this.internalToolExecutionMaxAttempts == null) ? 0 : this.internalToolExecutionMaxAttempts.hashCode());
+		result = prime * result + ((this.internalToolExecutionMaxAttempts == null) ? 0
+				: this.internalToolExecutionMaxAttempts.hashCode());
 		result = prime * result + ((this.toolContext == null) ? 0 : this.toolContext.hashCode());
 		return result;
 	}

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -155,7 +155,7 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	// @formatter:on
 
@@ -395,7 +395,8 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		result = prime * result + ((this.toolNames == null) ? 0 : this.toolNames.hashCode());
 		result = prime * result
 				+ ((this.internalToolExecutionEnabled == null) ? 0 : this.internalToolExecutionEnabled.hashCode());
-		result = prime * result + ((this.internalToolExecutionMaxAttempts == null) ? 0
+		result = prime * result + ((this.internalToolExecutionMaxAttempts == null)
+				? ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS
 				: this.internalToolExecutionMaxAttempts.hashCode());
 		result = prime * result + ((this.toolContext == null) ? 0 : this.toolContext.hashCode());
 		return result;

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Alexandros Pappas
+ * @author lambochen
  * @since 0.8.1
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -157,6 +158,9 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
+
+	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
 
 	public static Builder builder() {
@@ -180,6 +184,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 			.toolCallbacks(fromOptions.getToolCallbacks())
 			.toolNames(fromOptions.getToolNames())
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
+			.internalToolExecutionMaxIterations(fromOptions.getInternalToolExecutionMaxIterations())
 			.toolContext(fromOptions.getToolContext())
 			.build();
 	}
@@ -348,6 +353,16 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return this.internalToolExecutionMaxIterations;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	}
+
+	@Override
 	@JsonIgnore
 	public Integer getTopK() {
 		return null;
@@ -374,7 +389,8 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	public int hashCode() {
 		return Objects.hash(this.model, this.temperature, this.topP, this.maxTokens, this.safePrompt, this.randomSeed,
 				this.responseFormat, this.stop, this.frequencyPenalty, this.presencePenalty, this.n, this.tools,
-				this.toolChoice, this.toolCallbacks, this.tools, this.internalToolExecutionEnabled, this.toolContext);
+				this.toolChoice, this.toolCallbacks, this.tools, this.internalToolExecutionEnabled,
+				this.internalToolExecutionMaxIterations, this.toolContext);
 	}
 
 	@Override
@@ -400,6 +416,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolCallbacks, other.toolCallbacks)
 				&& Objects.equals(this.toolNames, other.toolNames)
 				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
+				&& Objects.equals(this.internalToolExecutionMaxIterations, other.internalToolExecutionMaxIterations)
 				&& Objects.equals(this.toolContext, other.toolContext);
 	}
 
@@ -502,6 +519,11 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
+			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
 			return this;
 		}
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
@@ -158,7 +158,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -184,7 +184,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 			.toolCallbacks(fromOptions.getToolCallbacks())
 			.toolNames(fromOptions.getToolNames())
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
-			.internalToolExecutionMaxIterations(fromOptions.getInternalToolExecutionMaxIterations())
+			.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
 			.toolContext(fromOptions.getToolContext())
 			.build();
 	}
@@ -353,13 +353,13 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return this.internalToolExecutionMaxIterations;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	@Override
@@ -390,7 +390,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 		return Objects.hash(this.model, this.temperature, this.topP, this.maxTokens, this.safePrompt, this.randomSeed,
 				this.responseFormat, this.stop, this.frequencyPenalty, this.presencePenalty, this.n, this.tools,
 				this.toolChoice, this.toolCallbacks, this.tools, this.internalToolExecutionEnabled,
-				this.internalToolExecutionMaxIterations, this.toolContext);
+				this.internalToolExecutionMaxAttempts, this.toolContext);
 	}
 
 	@Override
@@ -416,7 +416,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolCallbacks, other.toolCallbacks)
 				&& Objects.equals(this.toolNames, other.toolNames)
 				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
-				&& Objects.equals(this.internalToolExecutionMaxIterations, other.internalToolExecutionMaxIterations)
+				&& Objects.equals(this.internalToolExecutionMaxAttempts, other.internalToolExecutionMaxAttempts)
 				&& Objects.equals(this.toolContext, other.toolContext);
 	}
 
@@ -522,8 +522,8 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
-			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
+		public Builder internalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
@@ -158,7 +158,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -358,7 +358,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+	public void setInternalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
 		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -321,8 +321,9 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
+
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	/**
 	 * Tool Function Callbacks to register with the ChatModel.
@@ -400,7 +401,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				.stop(fromOptions.getStop())
 				.toolNames(fromOptions.getToolNames())
 				.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
-				.internalToolExecutionMaxIterations(fromOptions.getInternalToolExecutionMaxIterations())
+				.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
 				.toolCallbacks(fromOptions.getToolCallbacks())
 				.toolContext(fromOptions.getToolContext()).build();
 	}
@@ -751,13 +752,13 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 	}
 
 	@Override
-    public Integer getInternalToolExecutionMaxIterations() {
-        return this.internalToolExecutionMaxIterations;
+    public Integer getInternalToolExecutionMaxAttempts() {
+        return this.internalToolExecutionMaxAttempts;
     }
 
 	@Override
-    public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+    public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
     }
 
 	@Override
@@ -823,7 +824,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				&& Objects.equals(this.penalizeNewline, that.penalizeNewline) && Objects.equals(this.stop, that.stop)
 				&& Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
-				&& Objects.equals(this.internalToolExecutionMaxIterations, that.internalToolExecutionMaxIterations)
+				&& Objects.equals(this.internalToolExecutionMaxAttempts, that.internalToolExecutionMaxAttempts)
 				&& Objects.equals(this.toolNames, that.toolNames) && Objects.equals(this.toolContext, that.toolContext);
 	}
 
@@ -835,7 +836,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				this.topP, this.minP, this.tfsZ, this.typicalP, this.repeatLastN, this.temperature, this.repeatPenalty,
 				this.presencePenalty, this.frequencyPenalty, this.mirostat, this.mirostatTau, this.mirostatEta,
 				this.penalizeNewline, this.stop, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
-				this.internalToolExecutionMaxIterations, this.toolContext);
+				this.internalToolExecutionMaxAttempts, this.toolContext);
 	}
 
 	public static class Builder {
@@ -1044,8 +1045,8 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 			return this;
 		}
 
-		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
-			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
+		public Builder internalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -323,7 +323,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	/**
 	 * Tool Function Callbacks to register with the ChatModel.
@@ -757,7 +757,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
     }
 
 	@Override
-    public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+    public void setInternalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
 		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
     }
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author lambochen
  * @since 0.8.0
  * @see <a href=
  * "https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values">Ollama
@@ -320,6 +321,8 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
+	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
 
 	/**
 	 * Tool Function Callbacks to register with the ChatModel.
@@ -397,6 +400,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				.stop(fromOptions.getStop())
 				.toolNames(fromOptions.getToolNames())
 				.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
+				.internalToolExecutionMaxIterations(fromOptions.getInternalToolExecutionMaxIterations())
 				.toolCallbacks(fromOptions.getToolCallbacks())
 				.toolContext(fromOptions.getToolContext()).build();
 	}
@@ -747,6 +751,16 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 	}
 
 	@Override
+    public Integer getInternalToolExecutionMaxIterations() {
+        return this.internalToolExecutionMaxIterations;
+    }
+
+	@Override
+    public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+    }
+
+	@Override
 	@JsonIgnore
 	public Integer getDimensions() {
 		return null;
@@ -809,6 +823,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				&& Objects.equals(this.penalizeNewline, that.penalizeNewline) && Objects.equals(this.stop, that.stop)
 				&& Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
+				&& Objects.equals(this.internalToolExecutionMaxIterations, that.internalToolExecutionMaxIterations)
 				&& Objects.equals(this.toolNames, that.toolNames) && Objects.equals(this.toolContext, that.toolContext);
 	}
 
@@ -820,7 +835,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				this.topP, this.minP, this.tfsZ, this.typicalP, this.repeatLastN, this.temperature, this.repeatPenalty,
 				this.presencePenalty, this.frequencyPenalty, this.mirostat, this.mirostatTau, this.mirostatEta,
 				this.penalizeNewline, this.stop, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
-				this.toolContext);
+				this.internalToolExecutionMaxIterations, this.toolContext);
 	}
 
 	public static class Builder {
@@ -1026,6 +1041,11 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
+			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -220,7 +220,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	/**
 	 * Optional HTTP headers to be added to the chat completion request.
@@ -515,7 +515,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+	public void setInternalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
 		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  * @author Mariusz Bernacki
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author lambochen
  * @since 0.8.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -218,6 +219,9 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
 
+	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
+
 	/**
 	 * Optional HTTP headers to be added to the chat completion request.
 	 */
@@ -262,6 +266,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 			.toolNames(fromOptions.getToolNames() != null ? new HashSet<>(fromOptions.getToolNames()) : null)
 			.httpHeaders(fromOptions.getHttpHeaders() != null ? new HashMap<>(fromOptions.getHttpHeaders()) : null)
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
+			.internalToolExecutionMaxIterations(fromOptions.getInternalToolExecutionMaxIterations())
 			.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
 			.store(fromOptions.getStore())
 			.metadata(fromOptions.getMetadata())
@@ -504,6 +509,16 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
 	}
 
+	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return this.internalToolExecutionMaxIterations;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	}
+
 	public Map<String, String> getHttpHeaders() {
 		return this.httpHeaders;
 	}
@@ -573,8 +588,9 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 				this.maxTokens, this.maxCompletionTokens, this.n, this.presencePenalty, this.responseFormat,
 				this.streamOptions, this.seed, this.stop, this.temperature, this.topP, this.tools, this.toolChoice,
 				this.user, this.parallelToolCalls, this.toolCallbacks, this.toolNames, this.httpHeaders,
-				this.internalToolExecutionEnabled, this.toolContext, this.outputModalities, this.outputAudio,
-				this.store, this.metadata, this.reasoningEffort, this.webSearchOptions);
+				this.internalToolExecutionEnabled, this.internalToolExecutionMaxIterations, this.toolContext,
+				this.outputModalities, this.outputAudio, this.store, this.metadata, this.reasoningEffort,
+				this.webSearchOptions);
 	}
 
 	@Override
@@ -603,6 +619,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.httpHeaders, other.httpHeaders)
 				&& Objects.equals(this.toolContext, other.toolContext)
 				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
+				&& Objects.equals(this.internalToolExecutionMaxIterations, other.internalToolExecutionMaxIterations)
 				&& Objects.equals(this.outputModalities, other.outputModalities)
 				&& Objects.equals(this.outputAudio, other.outputAudio) && Objects.equals(this.store, other.store)
 				&& Objects.equals(this.metadata, other.metadata)
@@ -762,6 +779,11 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
+			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -220,7 +220,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	/**
 	 * Optional HTTP headers to be added to the chat completion request.
@@ -266,7 +266,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 			.toolNames(fromOptions.getToolNames() != null ? new HashSet<>(fromOptions.getToolNames()) : null)
 			.httpHeaders(fromOptions.getHttpHeaders() != null ? new HashMap<>(fromOptions.getHttpHeaders()) : null)
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
-			.internalToolExecutionMaxIterations(fromOptions.getInternalToolExecutionMaxIterations())
+			.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
 			.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
 			.store(fromOptions.getStore())
 			.metadata(fromOptions.getMetadata())
@@ -510,13 +510,13 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return this.internalToolExecutionMaxIterations;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	public Map<String, String> getHttpHeaders() {
@@ -588,7 +588,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 				this.maxTokens, this.maxCompletionTokens, this.n, this.presencePenalty, this.responseFormat,
 				this.streamOptions, this.seed, this.stop, this.temperature, this.topP, this.tools, this.toolChoice,
 				this.user, this.parallelToolCalls, this.toolCallbacks, this.toolNames, this.httpHeaders,
-				this.internalToolExecutionEnabled, this.internalToolExecutionMaxIterations, this.toolContext,
+				this.internalToolExecutionEnabled, this.internalToolExecutionMaxAttempts, this.toolContext,
 				this.outputModalities, this.outputAudio, this.store, this.metadata, this.reasoningEffort,
 				this.webSearchOptions);
 	}
@@ -619,7 +619,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.httpHeaders, other.httpHeaders)
 				&& Objects.equals(this.toolContext, other.toolContext)
 				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
-				&& Objects.equals(this.internalToolExecutionMaxIterations, other.internalToolExecutionMaxIterations)
+				&& Objects.equals(this.internalToolExecutionMaxAttempts, other.internalToolExecutionMaxAttempts)
 				&& Objects.equals(this.outputModalities, other.outputModalities)
 				&& Objects.equals(this.outputAudio, other.outputAudio) && Objects.equals(this.store, other.store)
 				&& Objects.equals(this.metadata, other.metadata)
@@ -782,8 +782,8 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
-			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
+		public Builder internalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -128,7 +128,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -291,7 +291,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+	public void setInternalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
 		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Grogdunn
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
+ * @author lambochen
  * @since 1.0.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -125,6 +126,9 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 	 */
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
+
+	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -282,6 +286,16 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return this.internalToolExecutionMaxIterations;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	}
+
+	@Override
 	public Double getFrequencyPenalty() {
 		return this.frequencyPenalty;
 	}
@@ -346,6 +360,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolNames, that.toolNames)
 				&& Objects.equals(this.safetySettings, that.safetySettings)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
+				&& Objects.equals(this.internalToolExecutionMaxIterations, that.internalToolExecutionMaxIterations)
 				&& Objects.equals(this.toolContext, that.toolContext);
 	}
 
@@ -354,7 +369,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 		return Objects.hash(this.stopSequences, this.temperature, this.topP, this.topK, this.candidateCount,
 				this.frequencyPenalty, this.presencePenalty, this.maxOutputTokens, this.model, this.responseMimeType,
 				this.toolCallbacks, this.toolNames, this.googleSearchRetrieval, this.safetySettings,
-				this.internalToolExecutionEnabled, this.toolContext);
+				this.internalToolExecutionEnabled, this.internalToolExecutionMaxIterations, this.toolContext);
 	}
 
 	@Override
@@ -475,6 +490,11 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(boolean internalToolExecutionEnabled) {
 			this.options.internalToolExecutionEnabled = internalToolExecutionEnabled;
+			return this;
+		}
+
+		public Builder internalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+			this.options.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
 			return this;
 		}
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -128,7 +128,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -286,13 +286,13 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return this.internalToolExecutionMaxIterations;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	@Override
@@ -360,7 +360,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolNames, that.toolNames)
 				&& Objects.equals(this.safetySettings, that.safetySettings)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
-				&& Objects.equals(this.internalToolExecutionMaxIterations, that.internalToolExecutionMaxIterations)
+				&& Objects.equals(this.internalToolExecutionMaxAttempts, that.internalToolExecutionMaxAttempts)
 				&& Objects.equals(this.toolContext, that.toolContext);
 	}
 
@@ -369,7 +369,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 		return Objects.hash(this.stopSequences, this.temperature, this.topP, this.topK, this.candidateCount,
 				this.frequencyPenalty, this.presencePenalty, this.maxOutputTokens, this.model, this.responseMimeType,
 				this.toolCallbacks, this.toolNames, this.googleSearchRetrieval, this.safetySettings,
-				this.internalToolExecutionEnabled, this.internalToolExecutionMaxIterations, this.toolContext);
+				this.internalToolExecutionEnabled, this.internalToolExecutionMaxAttempts, this.toolContext);
 	}
 
 	@Override
@@ -493,8 +493,8 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		public Builder internalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-			this.options.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+		public Builder internalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+			this.options.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 			return this;
 		}
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -127,7 +127,7 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxIterations;
+	private Integer internalToolExecutionMaxAttempts;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -312,13 +312,13 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return this.internalToolExecutionMaxIterations;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	@Override
@@ -345,8 +345,8 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 		result = prime * result + ((this.user == null) ? 0 : this.user.hashCode());
 		result = prime * result
 				+ ((this.internalToolExecutionEnabled == null) ? 0 : this.internalToolExecutionEnabled.hashCode());
-		result = prime * result + ((this.internalToolExecutionMaxIterations == null) ? 0
-				: this.internalToolExecutionMaxIterations.hashCode());
+		result = prime * result + ((this.internalToolExecutionMaxAttempts == null) ? 0
+				: this.internalToolExecutionMaxAttempts.hashCode());
 		result = prime * result + ((this.toolCallbacks == null) ? 0 : this.toolCallbacks.hashCode());
 		result = prime * result + ((this.toolNames == null) ? 0 : this.toolNames.hashCode());
 		result = prime * result + ((this.toolContext == null) ? 0 : this.toolContext.hashCode());
@@ -453,12 +453,12 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 		else if (!this.internalToolExecutionEnabled.equals(other.internalToolExecutionEnabled)) {
 			return false;
 		}
-		if (this.internalToolExecutionMaxIterations == null) {
-			if (other.internalToolExecutionMaxIterations != null) {
+		if (this.internalToolExecutionMaxAttempts == null) {
+			if (other.internalToolExecutionMaxAttempts != null) {
 				return false;
 			}
 		}
-		else if (!this.internalToolExecutionMaxIterations.equals(other.internalToolExecutionMaxIterations)) {
+		else if (!this.internalToolExecutionMaxAttempts.equals(other.internalToolExecutionMaxAttempts)) {
 			return false;
 		}
 		if (this.toolContext == null) {
@@ -492,10 +492,10 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 			builder.internalToolExecutionEnabled(toolCallingChatOptions.getInternalToolExecutionEnabled() != null
 					? (toolCallingChatOptions).getInternalToolExecutionEnabled()
 					: this.getInternalToolExecutionEnabled());
-			builder.internalToolExecutionMaxIterations(
-					toolCallingChatOptions.getInternalToolExecutionMaxIterations() != null
-							? toolCallingChatOptions.getInternalToolExecutionMaxIterations()
-							: this.getInternalToolExecutionMaxIterations());
+			builder.internalToolExecutionMaxAttempts(
+					toolCallingChatOptions.getInternalToolExecutionMaxAttempts() != null
+							? toolCallingChatOptions.getInternalToolExecutionMaxAttempts()
+							: this.getInternalToolExecutionMaxAttempts());
 
 			Set<String> toolNames = new HashSet<>();
 			if (this.toolNames != null) {
@@ -526,7 +526,7 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 		}
 		else {
 			builder.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
-			builder.internalToolExecutionMaxIterations(this.internalToolExecutionMaxIterations);
+			builder.internalToolExecutionMaxAttempts(this.internalToolExecutionMaxAttempts);
 			builder.toolNames(this.toolNames != null ? new HashSet<>(this.toolNames) : null);
 			builder.toolCallbacks(this.toolCallbacks != null ? new ArrayList<>(this.toolCallbacks) : null);
 			builder.toolContext(this.toolContext != null ? new HashMap<>(this.toolContext) : null);
@@ -632,8 +632,8 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
-			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
+		public Builder internalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -492,10 +492,10 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 			builder.internalToolExecutionEnabled(toolCallingChatOptions.getInternalToolExecutionEnabled() != null
 					? (toolCallingChatOptions).getInternalToolExecutionEnabled()
 					: this.getInternalToolExecutionEnabled());
-			builder.internalToolExecutionMaxAttempts(
-					toolCallingChatOptions.getInternalToolExecutionMaxAttempts() != null
-							? toolCallingChatOptions.getInternalToolExecutionMaxAttempts()
-							: this.getInternalToolExecutionMaxAttempts());
+			builder
+				.internalToolExecutionMaxAttempts(toolCallingChatOptions.getInternalToolExecutionMaxAttempts() != null
+						? toolCallingChatOptions.getInternalToolExecutionMaxAttempts()
+						: this.getInternalToolExecutionMaxAttempts());
 
 			Set<String> toolNames = new HashSet<>();
 			if (this.toolNames != null) {

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Geng Rong
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author lambochen
  * @since 1.0.0 M1
  */
 @JsonInclude(Include.NON_NULL)
@@ -124,6 +125,9 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	 */
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
+
+	@JsonIgnore
+	private Integer internalToolExecutionMaxIterations;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -308,6 +312,16 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return this.internalToolExecutionMaxIterations;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+		this.internalToolExecutionMaxIterations = internalToolExecutionMaxIterations;
+	}
+
+	@Override
 	public Map<String, Object> getToolContext() {
 		return this.toolContext;
 	}
@@ -331,6 +345,8 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 		result = prime * result + ((this.user == null) ? 0 : this.user.hashCode());
 		result = prime * result
 				+ ((this.internalToolExecutionEnabled == null) ? 0 : this.internalToolExecutionEnabled.hashCode());
+		result = prime * result + ((this.internalToolExecutionMaxIterations == null) ? 0
+				: this.internalToolExecutionMaxIterations.hashCode());
 		result = prime * result + ((this.toolCallbacks == null) ? 0 : this.toolCallbacks.hashCode());
 		result = prime * result + ((this.toolNames == null) ? 0 : this.toolNames.hashCode());
 		result = prime * result + ((this.toolContext == null) ? 0 : this.toolContext.hashCode());
@@ -437,6 +453,14 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 		else if (!this.internalToolExecutionEnabled.equals(other.internalToolExecutionEnabled)) {
 			return false;
 		}
+		if (this.internalToolExecutionMaxIterations == null) {
+			if (other.internalToolExecutionMaxIterations != null) {
+				return false;
+			}
+		}
+		else if (!this.internalToolExecutionMaxIterations.equals(other.internalToolExecutionMaxIterations)) {
+			return false;
+		}
 		if (this.toolContext == null) {
 			if (other.toolContext != null) {
 				return false;
@@ -468,6 +492,10 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 			builder.internalToolExecutionEnabled(toolCallingChatOptions.getInternalToolExecutionEnabled() != null
 					? (toolCallingChatOptions).getInternalToolExecutionEnabled()
 					: this.getInternalToolExecutionEnabled());
+			builder.internalToolExecutionMaxIterations(
+					toolCallingChatOptions.getInternalToolExecutionMaxIterations() != null
+							? toolCallingChatOptions.getInternalToolExecutionMaxIterations()
+							: this.getInternalToolExecutionMaxIterations());
 
 			Set<String> toolNames = new HashSet<>();
 			if (this.toolNames != null) {
@@ -498,6 +526,7 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 		}
 		else {
 			builder.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
+			builder.internalToolExecutionMaxIterations(this.internalToolExecutionMaxIterations);
 			builder.toolNames(this.toolNames != null ? new HashSet<>(this.toolNames) : null);
 			builder.toolCallbacks(this.toolCallbacks != null ? new ArrayList<>(this.toolCallbacks) : null);
 			builder.toolContext(this.toolContext != null ? new HashMap<>(this.toolContext) : null);
@@ -600,6 +629,11 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder internalToolExecutionMaxIterations(@Nullable Integer internalToolExecutionMaxIterations) {
+			this.options.setInternalToolExecutionMaxIterations(internalToolExecutionMaxIterations);
 			return this;
 		}
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -127,7 +127,7 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@JsonIgnore
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
@@ -152,6 +152,7 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 			.toolCallbacks(fromOptions.getToolCallbacks())
 			.toolNames(fromOptions.getToolNames())
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
+				.internalToolExecutionMaxAttempts(fromOptions.getInternalToolExecutionMaxAttempts())
 			.toolContext(fromOptions.getToolContext())
 			.build();
 	}
@@ -317,7 +318,7 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+	public void setInternalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts) {
 		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * Default implementation of {@link ToolCallingChatOptions}.
  *
  * @author Thomas Vitale
+ * @author lambochen
  * @since 1.0.0
  */
 public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
@@ -116,6 +117,16 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 	@Override
 	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	@Override
+	public Integer getInternalToolExecutionMaxIterations() {
+		return 0;
+	}
+
+	@Override
+	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
+
 	}
 
 	@Override

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
@@ -48,7 +48,7 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@Nullable
-	private Integer internalToolExecutionMaxAttempts;
+	private Integer internalToolExecutionMaxAttempts = ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS;
 
 	@Nullable
 	private String model;

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
@@ -293,7 +293,8 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 		}
 
 		@Override
-		public ToolCallingChatOptions.Builder internalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		public ToolCallingChatOptions.Builder internalToolExecutionMaxAttempts(
+				Integer internalToolExecutionMaxAttempts) {
 			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
@@ -48,6 +48,9 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 	private Boolean internalToolExecutionEnabled;
 
 	@Nullable
+	private Integer internalToolExecutionMaxAttempts;
+
+	@Nullable
 	private String model;
 
 	@Nullable
@@ -120,13 +123,13 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
-	public Integer getInternalToolExecutionMaxIterations() {
-		return 0;
+	public Integer getInternalToolExecutionMaxAttempts() {
+		return this.internalToolExecutionMaxAttempts;
 	}
 
 	@Override
-	public void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations) {
-
+	public void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+		this.internalToolExecutionMaxAttempts = internalToolExecutionMaxAttempts;
 	}
 
 	@Override
@@ -217,6 +220,7 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 		options.setToolNames(getToolNames());
 		options.setToolContext(getToolContext());
 		options.setInternalToolExecutionEnabled(getInternalToolExecutionEnabled());
+		options.setInternalToolExecutionMaxAttempts(getInternalToolExecutionMaxAttempts());
 		options.setModel(getModel());
 		options.setFrequencyPenalty(getFrequencyPenalty());
 		options.setMaxTokens(getMaxTokens());
@@ -285,6 +289,12 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 		public ToolCallingChatOptions.Builder internalToolExecutionEnabled(
 				@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		@Override
+		public ToolCallingChatOptions.Builder internalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts) {
+			this.options.setInternalToolExecutionMaxAttempts(internalToolExecutionMaxAttempts);
 			return this;
 		}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
@@ -96,7 +96,7 @@ public interface ToolCallingChatOptions extends ChatOptions {
 	 * Set the maximum number of attempts for tool execution.
 	 * @param internalToolExecutionMaxAttempts the maximum number of attempts.
 	 */
-	void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts);
+	void setInternalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts);
 
 	/**
 	 * Get the configured tool context.

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
@@ -48,6 +48,7 @@ public interface ToolCallingChatOptions extends ChatOptions {
 	 * No limit for tool execution attempts.
 	 */
 	int TOOL_EXECUTION_NO_LIMIT = Integer.MAX_VALUE;
+
 	int DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS = TOOL_EXECUTION_NO_LIMIT;
 
 	/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
@@ -37,6 +37,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author lambochen
  * @since 1.0.0
  */
 public interface ToolCallingChatOptions extends ChatOptions {
@@ -75,6 +76,20 @@ public interface ToolCallingChatOptions extends ChatOptions {
 	 * by the model or if the tools should be executed directly by the caller.
 	 */
 	void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled);
+
+	/**
+	 * Get the maximum number of iterations for tool execution. 0 or null means no limit.
+	 * @return the maximum number of iterations.
+	 * @see #getInternalToolExecutionEnabled()
+	 */
+	@Nullable
+	Integer getInternalToolExecutionMaxIterations();
+
+	/**
+	 * Set the maximum number of iterations for tool execution. 0 or null means no limit.
+	 * @param internalToolExecutionMaxIterations the maximum number of iterations.
+	 */
+	void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations);
 
 	/**
 	 * Get the configured tool context.

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolCallingChatOptions.java
@@ -45,6 +45,12 @@ public interface ToolCallingChatOptions extends ChatOptions {
 	boolean DEFAULT_TOOL_EXECUTION_ENABLED = true;
 
 	/**
+	 * No limit for tool execution attempts.
+	 */
+	int TOOL_EXECUTION_NO_LIMIT = Integer.MAX_VALUE;
+	int DEFAULT_TOOL_EXECUTION_MAX_ATTEMPTS = TOOL_EXECUTION_NO_LIMIT;
+
+	/**
 	 * ToolCallbacks to be registered with the ChatModel.
 	 */
 	List<ToolCallback> getToolCallbacks();
@@ -78,18 +84,18 @@ public interface ToolCallingChatOptions extends ChatOptions {
 	void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled);
 
 	/**
-	 * Get the maximum number of iterations for tool execution. 0 or null means no limit.
-	 * @return the maximum number of iterations.
+	 * Get the maximum number of attempts for tool execution.
+	 * @return the maximum number of attempts.
 	 * @see #getInternalToolExecutionEnabled()
 	 */
 	@Nullable
-	Integer getInternalToolExecutionMaxIterations();
+	Integer getInternalToolExecutionMaxAttempts();
 
 	/**
-	 * Set the maximum number of iterations for tool execution. 0 or null means no limit.
-	 * @param internalToolExecutionMaxIterations the maximum number of iterations.
+	 * Set the maximum number of attempts for tool execution.
+	 * @param internalToolExecutionMaxAttempts the maximum number of attempts.
 	 */
-	void setInternalToolExecutionMaxIterations(Integer internalToolExecutionMaxIterations);
+	void setInternalToolExecutionMaxAttempts(Integer internalToolExecutionMaxAttempts);
 
 	/**
 	 * Get the configured tool context.
@@ -192,6 +198,13 @@ public interface ToolCallingChatOptions extends ChatOptions {
 		 * by the model or if the tools should be executed directly by the caller.
 		 */
 		Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled);
+
+		/**
+		 * the maximum number of attempts for tool execution.
+		 * @param internalToolExecutionMaxAttempts the maximum number of attempts.
+		 * @return the {@link ToolCallingChatOptions} Builder.
+		 */
+		Builder internalToolExecutionMaxAttempts(@Nullable Integer internalToolExecutionMaxAttempts);
 
 		/**
 		 * Add a {@link Map} of context values into tool context.

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityChecker.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityChecker.java
@@ -45,7 +45,8 @@ public interface ToolExecutionEligibilityChecker extends Function<ChatResponse, 
 	}
 
 	/**
-	 * Determines if tool execution should be performed based on the prompt options and chat response and attempts.
+	 * Determines if tool execution should be performed based on the prompt options and
+	 * chat response and attempts.
 	 * @param promptOptions The options from the prompt
 	 * @param chatResponse The response from the chat model
 	 * @param attempts The number of attempts to execute the tool
@@ -104,7 +105,8 @@ public interface ToolExecutionEligibilityChecker extends Function<ChatResponse, 
 		if (chatOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
 			return toolCallingChatOptions.getInternalToolExecutionMaxAttempts() == null
 					|| attempts <= toolCallingChatOptions.getInternalToolExecutionMaxAttempts();
-		} else {
+		}
+		else {
 			internalToolExecutionEnabled = true;
 		}
 		return internalToolExecutionEnabled;

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityChecker.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityChecker.java
@@ -74,4 +74,26 @@ public interface ToolExecutionEligibilityChecker extends Function<ChatResponse, 
 		return internalToolExecutionEnabled;
 	}
 
+	/**
+	 * Determines if tool execution should be performed by the Spring AI or by the client.
+	 * @param chatOptions The options from the chat
+	 * @param attempts The number of attempts to execute the tool
+	 * @return true if tool execution should be performed by Spring AI, false if it should
+	 * be performed by the client
+	 */
+	default boolean isInternalToolExecutionEnabled(ChatOptions chatOptions, int attempts) {
+		boolean internalToolExecutionEnabled = isInternalToolExecutionEnabled(chatOptions);
+		if (!internalToolExecutionEnabled) {
+			return false;
+		}
+
+		if (chatOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			return toolCallingChatOptions.getInternalToolExecutionMaxAttempts() == null
+					|| attempts <= toolCallingChatOptions.getInternalToolExecutionMaxAttempts();
+		} else {
+			internalToolExecutionEnabled = true;
+		}
+		return internalToolExecutionEnabled;
+	}
+
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityChecker.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityChecker.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
  * responses.
  *
  * @author Christian Tzolov
+ * @author lambochen
  */
 public interface ToolExecutionEligibilityChecker extends Function<ChatResponse, Boolean> {
 
@@ -41,6 +42,19 @@ public interface ToolExecutionEligibilityChecker extends Function<ChatResponse, 
 		Assert.notNull(promptOptions, "promptOptions cannot be null");
 		Assert.notNull(chatResponse, "chatResponse cannot be null");
 		return this.isInternalToolExecutionEnabled(promptOptions) && this.isToolCallResponse(chatResponse);
+	}
+
+	/**
+	 * Determines if tool execution should be performed based on the prompt options and chat response and attempts.
+	 * @param promptOptions The options from the prompt
+	 * @param chatResponse The response from the chat model
+	 * @param attempts The number of attempts to execute the tool
+	 * @return true if tool execution should be performed, false otherwise
+	 */
+	default boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse, int attempts) {
+		Assert.notNull(promptOptions, "promptOptions cannot be null");
+		Assert.notNull(chatResponse, "chatResponse cannot be null");
+		return this.isInternalToolExecutionEnabled(promptOptions, attempts) && this.isToolCallResponse(chatResponse);
 	}
 
 	/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityPredicate.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolExecutionEligibilityPredicate.java
@@ -43,4 +43,20 @@ public interface ToolExecutionEligibilityPredicate extends BiPredicate<ChatOptio
 		return test(promptOptions, chatResponse);
 	}
 
+	default boolean isToolExecutionRequired(ChatOptions promptOptions, ChatResponse chatResponse, int attempts) {
+		boolean isToolExecutionRequired = isToolExecutionRequired(promptOptions, chatResponse);
+		if (!isToolExecutionRequired) {
+			return true;
+		}
+
+		if (promptOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			return toolCallingChatOptions.getInternalToolExecutionMaxAttempts() == null
+					|| attempts <= toolCallingChatOptions.getInternalToolExecutionMaxAttempts();
+		}
+		else {
+			isToolExecutionRequired = true;
+		}
+		return isToolExecutionRequired;
+	}
+
 }


### PR DESCRIPTION
This PR primarily addresses the issue of infinite recursive calls to LLM under certain special conditions, with internalToolExecutionEnabled=true in place, ref issue: https://github.com/spring-projects/spring-ai/issues/3333.

By introducing support for internalToolExecutionMaxAttempts in ToolCallingChatOptions and performing call count checks in each ChatModel, interrupt the process when the maximum call count is reached.

[x] Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
[x] Rebase your changes on the latest `main` branch and squash your commits
[ ] Add/Update unit tests as needed
[ ] Run a build and make sure all tests pass prior to submission

