### PR TITLE
Upgrade Spring Boot to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
 		<kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
 
 		<!-- production dependencies -->
-		<spring-boot.version>3.4.5</spring-boot.version>
+		<spring-boot.version>3.5.0</spring-boot.version>
 		<ST4.version>4.3.4</ST4.version>
 		<azure-open-ai-client.version>1.0.0-beta.16</azure-open-ai-client.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
@@ -296,6 +296,7 @@
 		<azure-identity.version>1.15.4</azure-identity.version>
 		<azure-search.version>11.7.6</azure-search.version>
 		<azure-cosmos.version>5.22.0</azure-cosmos.version>
+		<elasticsearch-java.version>8.18.1</elasticsearch-java.version>
 		<weaviate-client.version>5.2.0</weaviate-client.version>
 		<qdrant.version>1.13.0</qdrant.version>
 		<typesense.version>1.3.0</typesense.version>

--- a/vector-stores/spring-ai-elasticsearch-store/pom.xml
+++ b/vector-stores/spring-ai-elasticsearch-store/pom.xml
@@ -53,6 +53,7 @@
 		<dependency>
 			<groupId>co.elastic.clients</groupId>
 			<artifactId>elasticsearch-java</artifactId>
+			<version>${elasticsearch-java.version}</version>
 		</dependency>
 
 		<!-- TESTING -->

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.mapping.DenseVectorSimilarity;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
@@ -331,7 +332,8 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 			this.elasticsearchClient.indices()
 				.create(cr -> cr.index(this.options.getIndexName())
 					.mappings(map -> map.properties(this.options.getEmbeddingFieldName(),
-							p -> p.denseVector(dv -> dv.similarity(this.options.getSimilarity().toString())
+							p -> p.denseVector(dv -> dv
+								.similarity(DenseVectorSimilarity.valueOf(this.options.getSimilarity().toString()))
 								.dims(this.options.getDimensions())))));
 		}
 		catch (IOException e) {


### PR DESCRIPTION
 - Update Spring Boot version to 3.5.0
 - Enforce elasticsearch-java client to use the explicit version 8.18.1 - This is because of the incompatibility between Spring Boot 3.4.x and 3.5.0 in using the elastic search java client versions 8.15.1 vs 8.18.1
