### PR TITLE
Added support for the "think" for Ollama

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -460,7 +460,8 @@ public class OllamaChatModel implements ChatModel {
 		OllamaApi.ChatRequest.Builder requestBuilder = OllamaApi.ChatRequest.builder(requestOptions.getModel())
 			.stream(stream)
 			.messages(ollamaMessages)
-			.options(requestOptions);
+			.options(requestOptions)
+			.think(requestOptions.getThink());
 
 		if (requestOptions.getFormat() != null) {
 			requestBuilder.format(requestOptions.getFormat());

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -51,6 +51,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Jonghoon Park
+ * @author Sun Yuhan
  * @since 0.8.0
  */
 // @formatter:off
@@ -251,6 +252,7 @@ public final class OllamaApi {
 	 *
 	 * @param role The role of the message of type {@link Role}.
 	 * @param content The content of the message.
+	 * @param thinking The thinking of the model.
 	 * @param images The list of base64-encoded images to send with the message.
 	 * 				 Requires multimodal models such as llava or bakllava.
 	 * @param toolCalls The relevant tool call.
@@ -260,6 +262,7 @@ public final class OllamaApi {
 	public record Message(
 			@JsonProperty("role") Role role,
 			@JsonProperty("content") String content,
+			@JsonProperty("thinking") String thinking,
 			@JsonProperty("images") List<String> images,
 			@JsonProperty("tool_calls") List<ToolCall> toolCalls) {
 
@@ -321,6 +324,7 @@ public final class OllamaApi {
 
 			private final Role role;
 			private String content;
+			private String thinking;
 			private List<String> images;
 			private List<ToolCall> toolCalls;
 
@@ -330,6 +334,11 @@ public final class OllamaApi {
 
 			public Builder content(String content) {
 				this.content = content;
+				return this;
+			}
+
+			public Builder thinking(String thinking) {
+				this.thinking = thinking;
 				return this;
 			}
 
@@ -344,7 +353,7 @@ public final class OllamaApi {
 			}
 
 			public Message build() {
-				return new Message(this.role, this.content, this.images, this.toolCalls);
+				return new Message(this.role, this.content, this.thinking, this.images, this.toolCalls);
 			}
 		}
 	}
@@ -359,6 +368,7 @@ public final class OllamaApi {
 	 * @param keepAlive Controls how long the model will stay loaded into memory following this request (default: 5m).
 	 * @param tools List of tools the model has access to.
 	 * @param options Model-specific options. For example, "temperature" can be set through this field, if the model supports it.
+	 * @param think The model should think before responding, if the model supports it.
 	 * You can use the {@link OllamaOptions} builder to create the options then {@link OllamaOptions#toMap()} to convert the options into a map.
 	 *
 	 * @see <a href=
@@ -375,7 +385,8 @@ public final class OllamaApi {
 			@JsonProperty("format") Object format,
 			@JsonProperty("keep_alive") String keepAlive,
 			@JsonProperty("tools") List<Tool> tools,
-			@JsonProperty("options") Map<String, Object> options
+			@JsonProperty("options") Map<String, Object> options,
+			@JsonProperty("think") Boolean think
 	) {
 
 		public static Builder builder(String model) {
@@ -448,6 +459,7 @@ public final class OllamaApi {
 			private String keepAlive;
 			private List<Tool> tools = List.of();
 			private Map<String, Object> options = Map.of();
+			private boolean think;
 
 			public Builder(String model) {
 				Assert.notNull(model, "The model can not be null.");
@@ -492,8 +504,13 @@ public final class OllamaApi {
 				return this;
 			}
 
+			public Builder think(boolean think) {
+				this.think = think;
+				return this;
+			}
+
 			public ChatRequest build() {
-				return new ChatRequest(this.model, this.messages, this.stream, this.format, this.keepAlive, this.tools, this.options);
+				return new ChatRequest(this.model, this.messages, this.stream, this.format, this.keepAlive, this.tools, this.options, this.think);
 			}
 		}
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApiHelper.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApiHelper.java
@@ -25,6 +25,7 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * @author Christian Tzolov
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public final class OllamaApiHelper {
@@ -81,12 +82,18 @@ public final class OllamaApiHelper {
 	private static OllamaApi.Message merge(OllamaApi.Message previous, OllamaApi.Message current) {
 
 		String content = mergeContent(previous, current);
+		String thinking = mergeThinking(previous, current);
 		OllamaApi.Message.Role role = (current.role() != null ? current.role() : previous.role());
 		role = (role != null ? role : OllamaApi.Message.Role.ASSISTANT);
 		List<String> images = mergeImages(previous, current);
 		List<OllamaApi.Message.ToolCall> toolCalls = mergeToolCall(previous, current);
 
-		return OllamaApi.Message.builder(role).content(content).images(images).toolCalls(toolCalls).build();
+		return OllamaApi.Message.builder(role)
+			.content(content)
+			.thinking(thinking)
+			.images(images)
+			.toolCalls(toolCalls)
+			.build();
 	}
 
 	private static Instant merge(Instant previous, Instant current) {
@@ -132,6 +139,17 @@ public final class OllamaApiHelper {
 		}
 
 		return previous.content() + current.content();
+	}
+
+	private static String mergeThinking(OllamaApi.Message previous, OllamaApi.Message current) {
+		if (previous == null || previous.thinking() == null) {
+			return (current != null ? current.thinking() : null);
+		}
+		if (current == null || current.thinking() == null) {
+			return (previous != null ? previous.thinking() : null);
+		}
+
+		return previous.thinking() + current.thinking();
 	}
 
 	private static List<OllamaApi.Message.ToolCall> mergeToolCall(OllamaApi.Message previous,

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaModel.java
@@ -23,6 +23,7 @@ import org.springframework.ai.model.ChatModelDescription;
  *
  * @author Siarhei Blashuk
  * @author Thomas Vitale
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public enum OllamaModel implements ChatModelDescription {
@@ -31,6 +32,16 @@ public enum OllamaModel implements ChatModelDescription {
 	 * Qwen 2.5
 	 */
 	QWEN_2_5_7B("qwen2.5"),
+
+	/**
+	 * Qwen3
+	 */
+	QWEN_3_8B("qwen3"),
+
+	/**
+	 * Qwen3 4b
+	 */
+	QWEN_3_4B("qwen3:4b"),
 
 	/**
 	 * QwQ is the reasoning model of the Qwen series.

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Sun Yuhan
  * @since 0.8.0
  * @see <a href=
  * "https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values">Ollama
@@ -318,6 +319,14 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 	@JsonProperty("truncate")
 	private Boolean truncate;
 
+	/**
+	 * The model should think before responding, if supported.
+	 * If this value is not specified, it defaults to null, and Ollama will return
+	 * the thought process within the `content` field of the response, wrapped in `&lt;thinking&gt;` tags.
+	 */
+	@JsonProperty("think")
+	private Boolean think;
+
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
 
@@ -365,6 +374,7 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				.format(fromOptions.getFormat())
 				.keepAlive(fromOptions.getKeepAlive())
 				.truncate(fromOptions.getTruncate())
+				.think(fromOptions.getThink())
 				.useNUMA(fromOptions.getUseNUMA())
 				.numCtx(fromOptions.getNumCtx())
 				.numBatch(fromOptions.getNumBatch())
@@ -704,6 +714,14 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 		this.truncate = truncate;
 	}
 
+	public Boolean getThink() {
+		return this.think;
+	}
+
+	public void setThink(Boolean think) {
+		this.think = think;
+	}
+
 	@Override
 	@JsonIgnore
 	public List<ToolCallback> getToolCallbacks() {
@@ -804,7 +822,8 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 				&& Objects.equals(this.repeatPenalty, that.repeatPenalty)
 				&& Objects.equals(this.presencePenalty, that.presencePenalty)
 				&& Objects.equals(this.frequencyPenalty, that.frequencyPenalty)
-				&& Objects.equals(this.mirostat, that.mirostat) && Objects.equals(this.mirostatTau, that.mirostatTau)
+				&& Objects.equals(this.think, that.think) && Objects.equals(this.mirostat, that.mirostat)
+				&& Objects.equals(this.mirostatTau, that.mirostatTau)
 				&& Objects.equals(this.mirostatEta, that.mirostatEta)
 				&& Objects.equals(this.penalizeNewline, that.penalizeNewline) && Objects.equals(this.stop, that.stop)
 				&& Objects.equals(this.toolCallbacks, that.toolCallbacks)
@@ -814,13 +833,13 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.model, this.format, this.keepAlive, this.truncate, this.useNUMA, this.numCtx,
-				this.numBatch, this.numGPU, this.mainGPU, this.lowVRAM, this.f16KV, this.logitsAll, this.vocabOnly,
-				this.useMMap, this.useMLock, this.numThread, this.numKeep, this.seed, this.numPredict, this.topK,
-				this.topP, this.minP, this.tfsZ, this.typicalP, this.repeatLastN, this.temperature, this.repeatPenalty,
-				this.presencePenalty, this.frequencyPenalty, this.mirostat, this.mirostatTau, this.mirostatEta,
-				this.penalizeNewline, this.stop, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
-				this.toolContext);
+		return Objects.hash(this.model, this.format, this.keepAlive, this.truncate, this.think, this.useNUMA,
+				this.numCtx, this.numBatch, this.numGPU, this.mainGPU, this.lowVRAM, this.f16KV, this.logitsAll,
+				this.vocabOnly, this.useMMap, this.useMLock, this.numThread, this.numKeep, this.seed, this.numPredict,
+				this.topK, this.topP, this.minP, this.tfsZ, this.typicalP, this.repeatLastN, this.temperature,
+				this.repeatPenalty, this.presencePenalty, this.frequencyPenalty, this.mirostat, this.mirostatTau,
+				this.mirostatEta, this.penalizeNewline, this.stop, this.toolCallbacks, this.toolNames,
+				this.internalToolExecutionEnabled, this.toolContext);
 	}
 
 	public static class Builder {
@@ -849,6 +868,11 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 
 		public Builder truncate(Boolean truncate) {
 			this.options.truncate = truncate;
+			return this;
+		}
+
+		public Builder think(Boolean think) {
+			this.options.think = think;
 			return this;
 		}
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaImage.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class OllamaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.5.2");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.9.0");
 
 	private OllamaImage() {
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiIT.java
@@ -33,6 +33,7 @@ import org.springframework.ai.ollama.api.OllamaApi.Message;
 import org.springframework.ai.ollama.api.OllamaApi.Message.Role;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Christian Tzolov
@@ -112,6 +113,34 @@ public class OllamaApiIT extends BaseOllamaIT {
 		assertThat(response.promptEvalCount()).isEqualTo(5);
 		assertThat(response.loadDuration()).isGreaterThan(1);
 		assertThat(response.totalDuration()).isGreaterThan(1);
+	}
+
+	@Test
+	public void chatWithThinking() {
+		var request = ChatRequest.builder(MODEL)
+			.stream(true)
+			.think(true)
+			.messages(List.of(Message.builder(Role.USER)
+				.content("What is the capital of Bulgaria and what is the size? " + "What it the national anthem?")
+				.build()))
+			.options(OllamaOptions.builder().temperature(0.9).build().toMap())
+			.build();
+
+		Flux<ChatResponse> response = getOllamaApi().streamingChat(request);
+
+		List<ChatResponse> responses = response.collectList().block();
+		System.out.println(responses);
+
+		assertThat(responses).isNotNull();
+		assertThat(responses.stream()
+			.filter(r -> r.message() != null)
+			.map(r -> r.message().thinking())
+			.collect(Collectors.joining(System.lineSeparator()))).contains("Sofia");
+
+		ChatResponse lastResponse = responses.get(responses.size() - 1);
+		assertThat(lastResponse.message().content()).isEmpty();
+		assertNull(lastResponse.message().thinking());
+		assertThat(lastResponse.done()).isTrue();
 	}
 
 }


### PR DESCRIPTION
As mentioned in issue: https://github.com/spring-projects/spring-ai/issues/3383 , Ollama added support for "think" in its latest 0.9.0 version: 
https://github.com/ollama/ollama/releases
https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion. 

This PR implements support for that attribute and includes the following key changes: 
1. Added the `think` field to Ollama's `ChatRequest`
2. Added the `thinking` field to Ollama's `Message`
3. Added the `think` property to `OllamaOptions`, allowing users to specify whether to enable or disable thinking

