### PR TITLE
Fix CustomerTools example to use existing methods

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -939,7 +939,7 @@ class CustomerTools {
 
     @Tool(description = "Retrieve customer information")
     Customer getCustomerInfo(Long id, ToolContext toolContext) {
-        return customerRepository.findById(id, toolContext.get("tenantId"));
+        return customerRepository.findById(id, toolContext.getContext().get("tenantId"));
     }
 
 }


### PR DESCRIPTION
The `ToolContext` does not have a `get(String)` method. This PR is fixing the documentation to show the methods that can be used.

However, I think that it would be better if `ToolContext` had a `get(String)` method that would look like:

```java
public Object get(String key) {
    return this.context.get(key);
}
```

It could also be made generic:

```java
public <T> T get(String key) {
    return (T) this.context.get(key);
}
```

If you prefer to add the method, I can go ahead and create a PR for that instead