### PR TITLE
Avoid looping through all the page tree if there is no destination page

### DIFF
--- a/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
+++ b/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
@@ -140,7 +140,7 @@ public class ParagraphManager {
 			return -1;
 		}
 		PDPage currentPage = current.findDestinationPage(this.document);
-		if(currentPage != null){
+		if (currentPage != null) {
 			PDPageTree pages = this.document.getDocumentCatalog().getPages();
 			for (int i = 0; i < pages.getCount(); i++) {
 				var page = pages.get(i);

--- a/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
+++ b/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/config/ParagraphManager.java
@@ -140,11 +140,13 @@ public class ParagraphManager {
 			return -1;
 		}
 		PDPage currentPage = current.findDestinationPage(this.document);
-		PDPageTree pages = this.document.getDocumentCatalog().getPages();
-		for (int i = 0; i < pages.getCount(); i++) {
-			var page = pages.get(i);
-			if (page.equals(currentPage)) {
-				return i + 1;
+		if(currentPage != null){
+			PDPageTree pages = this.document.getDocumentCatalog().getPages();
+			for (int i = 0; i < pages.getCount(); i++) {
+				var page = pages.get(i);
+				if (page.equals(currentPage)) {
+					return i + 1;
+				}
 			}
 		}
 		return -1;


### PR DESCRIPTION
Added a simple null check to avoid looping through all the page tree if currentPage is null and there is nothing to be found