### PR TITLE
Create new ToolChatOptions if input request has tool configuration without options

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -22,10 +22,14 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import io.micrometer.observation.Observation;
@@ -570,7 +574,7 @@ public class DefaultChatClient implements ChatClient {
 
 		private final List<Media> media = new ArrayList<>();
 
-		private final List<String> toolNames = new ArrayList<>();
+		private final Set<String> toolNames = new LinkedHashSet<>();
 
 		private final List<ToolCallback> toolCallbacks = new ArrayList<>();
 
@@ -606,9 +610,9 @@ public class DefaultChatClient implements ChatClient {
 
 		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
 				Map<String, Object> userParams, @Nullable String systemText, Map<String, Object> systemParams,
-				List<ToolCallback> toolCallbacks, List<Message> messages, List<String> toolNames, List<Media> media,
-				@Nullable ChatOptions chatOptions, List<Advisor> advisors, Map<String, Object> advisorParams,
-				ObservationRegistry observationRegistry,
+				List<ToolCallback> toolCallbacks, List<Message> messages, Collection<String> toolNames,
+				List<Media> media, @Nullable ChatOptions chatOptions, List<Advisor> advisors,
+				Map<String, Object> advisorParams, ObservationRegistry observationRegistry,
 				@Nullable ChatClientObservationConvention observationConvention, Map<String, Object> toolContext,
 				@Nullable TemplateRenderer templateRenderer) {
 
@@ -685,7 +689,7 @@ public class DefaultChatClient implements ChatClient {
 			return this.media;
 		}
 
-		public List<String> getToolNames() {
+		public Set<String> getToolNames() {
 			return this.toolNames;
 		}
 
@@ -699,6 +703,10 @@ public class DefaultChatClient implements ChatClient {
 
 		public TemplateRenderer getTemplateRenderer() {
 			return this.templateRenderer;
+		}
+
+		public boolean hasToolConfiguration() {
+			return !this.toolNames.isEmpty() || !this.toolCallbacks.isEmpty() || !this.toolContext.isEmpty();
 		}
 
 		/**
@@ -778,7 +786,7 @@ public class DefaultChatClient implements ChatClient {
 		public ChatClientRequestSpec toolNames(String... toolNames) {
 			Assert.notNull(toolNames, "toolNames cannot be null");
 			Assert.noNullElements(toolNames, "toolNames cannot contain null elements");
-			this.toolNames.addAll(List.of(toolNames));
+			Collections.addAll(this.toolNames, toolNames);
 			return this;
 		}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
@@ -94,22 +94,40 @@ final class DefaultChatClientUtils {
 		 */
 
 		ChatOptions processedChatOptions = inputRequest.getChatOptions();
-		if (processedChatOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
-			if (!inputRequest.getToolNames().isEmpty()) {
-				Set<String> toolNames = ToolCallingChatOptions
-					.mergeToolNames(new HashSet<>(inputRequest.getToolNames()), toolCallingChatOptions.getToolNames());
-				toolCallingChatOptions.setToolNames(toolNames);
+		if (inputRequest.hasToolConfiguration()) {
+			if (processedChatOptions == null) {
+				ToolCallingChatOptions.Builder builder = ToolCallingChatOptions.builder();
+				if (!inputRequest.getToolNames().isEmpty()) {
+					builder.toolNames(inputRequest.getToolNames());
+				}
+				if (!inputRequest.getToolCallbacks().isEmpty()) {
+					List<ToolCallback> toolCallbacks = inputRequest.getToolCallbacks();
+					ToolCallingChatOptions.validateToolCallbacks(toolCallbacks);
+					builder.toolCallbacks(inputRequest.getToolCallbacks());
+				}
+				if (!CollectionUtils.isEmpty(inputRequest.getToolContext())) {
+					builder.toolContext(inputRequest.getToolContext());
+				}
+
+				processedChatOptions = builder.build();
 			}
-			if (!inputRequest.getToolCallbacks().isEmpty()) {
-				List<ToolCallback> toolCallbacks = ToolCallingChatOptions
-					.mergeToolCallbacks(inputRequest.getToolCallbacks(), toolCallingChatOptions.getToolCallbacks());
-				ToolCallingChatOptions.validateToolCallbacks(toolCallbacks);
-				toolCallingChatOptions.setToolCallbacks(toolCallbacks);
-			}
-			if (!CollectionUtils.isEmpty(inputRequest.getToolContext())) {
-				Map<String, Object> toolContext = ToolCallingChatOptions.mergeToolContext(inputRequest.getToolContext(),
-						toolCallingChatOptions.getToolContext());
-				toolCallingChatOptions.setToolContext(toolContext);
+			else if (processedChatOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
+				if (!inputRequest.getToolNames().isEmpty()) {
+					Set<String> toolNames = ToolCallingChatOptions.mergeToolNames(
+							new HashSet<>(inputRequest.getToolNames()), toolCallingChatOptions.getToolNames());
+					toolCallingChatOptions.setToolNames(toolNames);
+				}
+				if (!inputRequest.getToolCallbacks().isEmpty()) {
+					List<ToolCallback> toolCallbacks = ToolCallingChatOptions
+						.mergeToolCallbacks(inputRequest.getToolCallbacks(), toolCallingChatOptions.getToolCallbacks());
+					ToolCallingChatOptions.validateToolCallbacks(toolCallbacks);
+					toolCallingChatOptions.setToolCallbacks(toolCallbacks);
+				}
+				if (!CollectionUtils.isEmpty(inputRequest.getToolContext())) {
+					Map<String, Object> toolContext = ToolCallingChatOptions
+						.mergeToolContext(inputRequest.getToolContext(), toolCallingChatOptions.getToolContext());
+					toolCallingChatOptions.setToolContext(toolContext);
+				}
 			}
 		}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
@@ -323,6 +323,60 @@ class DefaultChatClientUtilsTests {
 	}
 
 	@Test
+	void whenToolNamesWithoutChatOptionsAreProvidedThenToolCallingChatOptionsAreSet() {
+		List<String> toolNames = List.of("tool1", "tool2");
+		ChatModel chatModel = mock(ChatModel.class);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.toolNames(toolNames.toArray(new String[0]));
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result).isNotNull();
+		assertThat(result.prompt().getOptions()).isInstanceOf(ToolCallingChatOptions.class);
+		ToolCallingChatOptions resultOptions = (ToolCallingChatOptions) result.prompt().getOptions();
+		assertThat(resultOptions).isNotNull();
+		assertThat(resultOptions.getToolNames()).containsExactlyInAnyOrderElementsOf(toolNames);
+	}
+
+	@Test
+	void whenToolCallbacksWithoutChatOptionsAreProvidedThenToolCallingChatOptionsAreSet() {
+		ToolCallback toolCallback = new TestToolCallback("tool1");
+		ChatModel chatModel = mock(ChatModel.class);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.toolCallbacks(toolCallback);
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result).isNotNull();
+		assertThat(result.prompt().getOptions()).isInstanceOf(ToolCallingChatOptions.class);
+		ToolCallingChatOptions resultOptions = (ToolCallingChatOptions) result.prompt().getOptions();
+		assertThat(resultOptions).isNotNull();
+		assertThat(resultOptions.getToolCallbacks()).contains(toolCallback);
+	}
+
+	@Test
+	void whenToolContextWithoutChatOptionsIsProvidedThenToolCallingChatOptionsAreSet() {
+		Map<String, Object> toolContext = Map.of("key", "value");
+		ChatModel chatModel = mock(ChatModel.class);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.toolContext(toolContext);
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result).isNotNull();
+		assertThat(result.prompt().getOptions()).isInstanceOf(ToolCallingChatOptions.class);
+		ToolCallingChatOptions resultOptions = (ToolCallingChatOptions) result.prompt().getOptions();
+		assertThat(resultOptions).isNotNull();
+		assertThat(resultOptions.getToolContext()).containsAllEntriesOf(toolContext);
+	}
+
+	@Test
 	void whenAdvisorParamsAreProvidedThenTheyAreAddedToContext() {
 		Map<String, Object> advisorParams = Map.of("key1", "value1", "key2", "value2");
 		ChatModel chatModel = mock(ChatModel.class);


### PR DESCRIPTION
This fixes a problem where the tool information is not provided to the underlying client if the prompt does not have any chat options set.

e.g.

```java
chatClient.prompt().toolNames("myTool").call()
```

The example above will not provide the tool name to the underlying chat model through the request.