### PR TITLE
docs: add description of embedding-field-name property in elasticsearch.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -157,6 +157,7 @@ Properties starting with `spring.ai.vectorstore.elasticsearch.*` are used to con
 |`spring.ai.vectorstore.elasticsearch.index-name` | The name of the index to store the vectors | `spring-ai-document-index`
 |`spring.ai.vectorstore.elasticsearch.dimensions` | The number of dimensions in the vector | `1536`
 |`spring.ai.vectorstore.elasticsearch.similarity` | The similarity function to use | `cosine`
+|`spring.ai.vectorstore.elasticsearch.embedding-field-name` | The name of the vector field to search against | `embedding`
 |===
 
 The following similarity functions are available:


### PR DESCRIPTION
add description of embedding-field-name property in elasticsearch.adoc

`embedding-field-name` property was implemented in https://github.com/spring-projects/spring-ai/pull/2175
However, the documentation had no explanation. So it was added in this PR.

---

please close https://github.com/spring-projects/spring-ai/issues/2082.