### PR TITLE
GH-3415: Add Spring Framework 7.x compatibility to RetryUtils#Respons…

### DIFF
--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@
 package org.springframework.ai.retry;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.lang.NonNull;
 import org.springframework.retry.RetryCallback;
@@ -37,6 +39,7 @@ import org.springframework.web.client.ResponseErrorHandler;
  * provides a default RetryTemplate and a default ResponseErrorHandler.
  *
  * @author Christian Tzolov
+ * @author Soby Chacko
  * @since 0.8.1
  */
 public abstract class RetryUtils {
@@ -49,6 +52,11 @@ public abstract class RetryUtils {
 		}
 
 		@Override
+		public void handleError(URI url, HttpMethod method, @NonNull ClientHttpResponse response) throws IOException {
+			handleError(response);
+		}
+
+		@SuppressWarnings("removal")
 		public void handleError(@NonNull ClientHttpResponse response) throws IOException {
 			if (response.getStatusCode().isError()) {
 				String error = StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8);


### PR DESCRIPTION
…eErrorHandler

Fixes: #3415

- Remove @Override annotation from handleError(ClientHttpResponse) method to support compilation against both Spring 6.2.x and 7.x
- Add delegation from new handleError(URI, HttpMethod, ClientHttpResponse) method to maintain backward compatibility
- Preserve existing error handling logic

This change allows Spring AI to work seamlessly across Spring Framework versions 6.x and 7.x without requiring reflection or version detection at runtime.
