### PR TITLE
fix: correct ToolDefinition.builder() usage in docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -316,7 +316,7 @@ The `ToolMetadata.Builder` allows you to build a `ToolMetadata` instance and def
 ----
 Method method = ReflectionUtils.findMethod(DateTimeTools.class, "getCurrentDateTime");
 ToolCallback toolCallback = MethodToolCallback.builder()
-    .toolDefinition(ToolDefinition.builder(method)
+    .toolDefinition(ToolDefinitions.builder(method)
             .description("Get the current date and time in the user's timezone")
             .build())
     .toolMethod(method)
@@ -349,7 +349,7 @@ class DateTimeTools {
 ----
 Method method = ReflectionUtils.findMethod(DateTimeTools.class, "getCurrentDateTime");
 ToolCallback toolCallback = MethodToolCallback.builder()
-    .toolDefinition(ToolDefinition.builder(method)
+    .toolDefinition(ToolDefinitions.builder(method)
             .description("Get the current date and time in the user's timezone")
             .build())
     .toolMethod(method)
@@ -801,7 +801,7 @@ If you'd rather provide some or all of the attributes explicitly, you can use th
 [source,java]
 ----
 Method method = ReflectionUtils.findMethod(DateTimeTools.class, "getCurrentDateTime");
-ToolDefinition toolDefinition = ToolDefinition.builder(method)
+ToolDefinition toolDefinition = ToolDefinitions.builder(method)
     .name("currentDateTime")
     .description("Get the current date and time in the user's timezone")
     .inputSchema(JsonSchemaGenerator.generateForMethodInput(method))


### PR DESCRIPTION
### 📄 Documentation Bug

**Problem:**  
In the current documentation or code samples, `ToolDefinition.builder(method)` is used to build a ToolDefinition from a `Method`. However, `ToolDefinition` does not have such a static builder method that accepts a `Method` — this causes confusion and runtime errors.

**Correct Usage:**  
It should be `ToolDefinitions.builder(method)` (note the plural form), as defined in the Spring AI tooling API.

**Suggested Fix:**  
Update all references of `ToolDefinition.builder(method)` to `ToolDefinitions.builder(method)` in documentation or samples.

**Version:** Spring AI 1.0.0
Thanks for your awesome work!
I may be wrong here, and if this was intentional, feel free to close the PR.
Just wanted to help improve the docs and avoid confusion for others.  Thanks again!
