### PR TITLE
Fixed the missing properties in the AutoConfiguration of ChromaVectorStore

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/src/main/java/org/springframework/ai/vectorstore/chroma/autoconfigure/ChromaVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/src/main/java/org/springframework/ai/vectorstore/chroma/autoconfigure/ChromaVectorStoreAutoConfiguration.java
@@ -95,6 +95,8 @@ public class ChromaVectorStoreAutoConfiguration {
 			BatchingStrategy chromaBatchingStrategy) {
 		return ChromaVectorStore.builder(chromaApi, embeddingModel)
 			.collectionName(storeProperties.getCollectionName())
+			.databaseName(storeProperties.getDatabaseName())
+			.tenantName(storeProperties.getTenantName())
 			.initializeSchema(storeProperties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))


### PR DESCRIPTION
Fixes #3427 
Added the missing databaseName and tenantName properties in the AutoConfiguration of ChromaVectorStore.