### PR TITLE
fix: Incorrect outputModalities judgment in stream mode

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -271,12 +271,12 @@ public class OpenAiChatModel implements ChatModel {
 		return Flux.deferContextual(contextView -> {
 			ChatCompletionRequest request = createRequest(prompt, true);
 
-			if (request.outputModalities() != null) {
-				if (request.outputModalities().stream().anyMatch(m -> m.equals("audio"))) {
-					logger.warn("Audio output is not supported for streaming requests. Removing audio output.");
-					throw new IllegalArgumentException("Audio output is not supported for streaming requests.");
-				}
+			if (request.outputModalities() != null
+					&& request.outputModalities().contains(OpenAiApi.OutputModality.AUDIO)) {
+				logger.warn("Audio output is not supported for streaming requests. Removing audio output.");
+				throw new IllegalArgumentException("Audio output is not supported for streaming requests.");
 			}
+
 			if (request.audioParameters() != null) {
 				logger.warn("Audio parameters are not supported for streaming requests. Removing audio parameters.");
 				throw new IllegalArgumentException("Audio parameters are not supported for streaming requests.");

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java
@@ -551,8 +551,7 @@ public class OpenAiChatModelIT extends AbstractIT {
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
 	@ValueSource(strings = { "gpt-4o-audio-preview" })
-	void streamingMultiModalityOutputAudio(String modelName) throws IOException {
-		// var audioResource = new ClassPathResource("speech1.mp3");
+	void streamingMultiModalityOutputAudio(String modelName) {
 		var userMessage = new UserMessage("Tell me joke about Spring Framework");
 
 		assertThatThrownBy(() -> this.chatModel
@@ -560,6 +559,16 @@ public class OpenAiChatModelIT extends AbstractIT {
 					OpenAiChatOptions.builder()
 						.model(modelName)
 						.outputModalities(List.of("text", "audio"))
+						.outputAudio(new AudioParameters(Voice.ALLOY, AudioResponseFormat.WAV))
+						.build()))
+			.collectList()
+			.block()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Audio output is not supported for streaming requests.");
+
+		assertThatThrownBy(() -> this.chatModel
+			.stream(new Prompt(List.of(userMessage),
+					OpenAiChatOptions.builder()
+						.model(modelName)
 						.outputAudio(new AudioParameters(Voice.ALLOY, AudioResponseFormat.WAV))
 						.build()))
 			.collectList()


### PR DESCRIPTION
The field `outputModalities` is of type `List<OutputModality>`. Comparing it with "audio" always returns `false`.