### PR TITLE
Ollama: Support custom Ollama API paths

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaApiAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaApiAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Eddú Meléndez
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author lambochen
  * @since 0.8.0
  */
 @AutoConfiguration
@@ -53,6 +54,13 @@ public class OllamaApiAutoConfiguration {
 			ObjectProvider<WebClient.Builder> webClientBuilderProvider) {
 		return OllamaApi.builder()
 			.baseUrl(connectionDetails.getBaseUrl())
+			.chatPath(connectionDetails.getChatPath())
+			.embedPath(connectionDetails.getEmbedPath())
+			.listModelsPath(connectionDetails.getListModelsPath())
+			.showModelPath(connectionDetails.getShowModelPath())
+			.copyModelPath(connectionDetails.getCopyModelPath())
+			.deleteModelPath(connectionDetails.getDeleteModelPath())
+			.pullModelPath(connectionDetails.getPullModelPath())
 			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
 			.webClientBuilder(webClientBuilderProvider.getIfAvailable(WebClient::builder))
 			.build();
@@ -69,6 +77,41 @@ public class OllamaApiAutoConfiguration {
 		@Override
 		public String getBaseUrl() {
 			return this.properties.getBaseUrl();
+		}
+
+		@Override
+		public String getChatPath() {
+			return this.properties.getChatPath();
+		}
+
+		@Override
+		public String getEmbedPath() {
+			return this.properties.getEmbedPath();
+		}
+
+		@Override
+		public String getListModelsPath() {
+			return this.properties.getListModelsPath();
+		}
+
+		@Override
+		public String getShowModelPath() {
+			return this.properties.getShowModelPath();
+		}
+
+		@Override
+		public String getCopyModelPath() {
+			return this.properties.getCopyModelPath();
+		}
+
+		@Override
+		public String getDeleteModelPath() {
+			return this.properties.getDeleteModelPath();
+		}
+
+		@Override
+		public String getPullModelPath() {
+			return this.properties.getPullModelPath();
 		}
 
 	}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionDetails.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionDetails.java
@@ -22,9 +22,24 @@ import org.springframework.boot.autoconfigure.service.connection.ConnectionDetai
  * Connection details for an Ollama service.
  *
  * @author Eddú Meléndez
+ * @author lambochen
  */
 public interface OllamaConnectionDetails extends ConnectionDetails {
 
 	String getBaseUrl();
+
+	String getChatPath();
+
+	String getEmbedPath();
+
+	String getListModelsPath();
+
+	String getShowModelPath();
+
+	String getCopyModelPath();
+
+	String getDeleteModelPath();
+
+	String getPullModelPath();
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionProperties.java
@@ -16,12 +16,14 @@
 
 package org.springframework.ai.model.ollama.autoconfigure;
 
+import org.springframework.ai.ollama.api.common.OllamaApiConstants;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Ollama connection autoconfiguration properties.
  *
  * @author Christian Tzolov
+ * @author lambochen
  * @since 0.8.0
  */
 @ConfigurationProperties(OllamaConnectionProperties.CONFIG_PREFIX)
@@ -32,7 +34,42 @@ public class OllamaConnectionProperties {
 	/**
 	 * Base URL where Ollama API server is running.
 	 */
-	private String baseUrl = "http://localhost:11434";
+	private String baseUrl = OllamaApiConstants.DEFAULT_BASE_URL;
+
+	/**
+	 * The path of the chat endpoint.
+	 */
+	private String chatPath = OllamaApiConstants.DEFAULT_CHAT_PATH;
+
+	/**
+	 * The path of the embed endpoint.
+	 */
+	private String embedPath = OllamaApiConstants.DEFAULT_EMBED_PATH;
+
+	/**
+	 * The path of the list models endpoint.
+	 */
+	private String listModelsPath = OllamaApiConstants.DEFAULT_LIST_MODELS_PATH;
+
+	/**
+	 * The path of the show model endpoint.
+	 */
+	private String showModelPath = OllamaApiConstants.DEFAULT_SHOW_MODEL_PATH;
+
+	/**
+	 * The path of the copy model endpoint.
+	 */
+	private String copyModelPath = OllamaApiConstants.DEFAULT_COPY_MODEL_PATH;
+
+	/**
+	 * The path of the delete model endpoint.
+	 */
+	private String deleteModelPath = OllamaApiConstants.DEFAULT_DELETE_MODEL_PATH;
+
+	/**
+	 * The path of the pull model endpoint.
+	 */
+	private String pullModelPath = OllamaApiConstants.DEFAULT_PULL_MODEL_PATH;
 
 	public String getBaseUrl() {
 		return this.baseUrl;
@@ -40,6 +77,62 @@ public class OllamaConnectionProperties {
 
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
+	}
+
+	public String getChatPath() {
+		return chatPath;
+	}
+
+	public void setChatPath(String chatPath) {
+		this.chatPath = chatPath;
+	}
+
+	public String getEmbedPath() {
+		return embedPath;
+	}
+
+	public void setEmbedPath(String embedPath) {
+		this.embedPath = embedPath;
+	}
+
+	public String getListModelsPath() {
+		return listModelsPath;
+	}
+
+	public void setListModelsPath(String listModelsPath) {
+		this.listModelsPath = listModelsPath;
+	}
+
+	public String getShowModelPath() {
+		return showModelPath;
+	}
+
+	public void setShowModelPath(String showModelPath) {
+		this.showModelPath = showModelPath;
+	}
+
+	public String getCopyModelPath() {
+		return copyModelPath;
+	}
+
+	public void setCopyModelPath(String copyModelPath) {
+		this.copyModelPath = copyModelPath;
+	}
+
+	public String getDeleteModelPath() {
+		return deleteModelPath;
+	}
+
+	public void setDeleteModelPath(String deleteModelPath) {
+		this.deleteModelPath = deleteModelPath;
+	}
+
+	public String getPullModelPath() {
+		return pullModelPath;
+	}
+
+	public void setPullModelPath(String pullModelPath) {
+		this.pullModelPath = pullModelPath;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaApiBuilderTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaApiBuilderTests.java
@@ -1,0 +1,68 @@
+package org.springframework.ai.model.ollama.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.ollama.api.OllamaApi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+/**
+ * @author lambochen
+ */
+public class OllamaApiBuilderTests {
+
+	@Test
+	void fullBuilder() {
+		OllamaApi ollamaApi = OllamaApi.builder()
+			.baseUrl("http://localhost:11434")
+			.chatPath("/api/chat")
+			.embedPath("/api/embeddings")
+			.listModelsPath("/api/tags")
+			.showModelPath("/api/show")
+			.copyModelPath("/api/copy")
+			.deleteModelPath("/api/delete")
+			.pullModelPath("/api/pull")
+			.build();
+
+		assertThat(ollamaApi).isNotNull();
+	}
+
+	@Test
+	void defaultBuilder() {
+		OllamaApi ollamaApi = OllamaApi.builder().build();
+		assertThat(ollamaApi).isNotNull();
+	}
+
+	@Test
+	void invalidPath() {
+		assertThatThrownBy(() -> OllamaApi.builder().chatPath("").build()).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().embedPath("").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().listModelsPath("").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().showModelPath("").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().copyModelPath("").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().deleteModelPath("").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().pullModelPath("").build())
+			.isInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> OllamaApi.builder().chatPath(null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().embedPath(null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().listModelsPath(null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().showModelPath(null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().copyModelPath(null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().deleteModelPath(null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> OllamaApi.builder().pullModelPath(null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -68,14 +68,47 @@ public final class OllamaApi {
 
 	private final WebClient webClient;
 
+	private final String chatPath;
+
+	private final String embedPath;
+
+	private final String listModelsPath;
+
+	private final String showModelPath;
+
+	private final String copyModelPath;
+
+	private final String deleteModelPath;
+
+	private final String pullModelPath;
+
 	/**
 	 * Create a new OllamaApi instance
 	 * @param baseUrl The base url of the Ollama server.
+	 * @param chatPath The path of the chat endpoint.
+	 * @param copyModelPath The path of the copy model endpoint.
+	 * @param deleteModelPath The path of the delete model endpoint.
+	 * @param embedPath The path of the embed endpoint.
+	 * @param listModelsPath The path of the list models endpoint.
+	 * @param pullModelPath The path of the pull model endpoint.
+	 * @param showModelPath The path of the show model endpoint.
 	 * @param restClientBuilder The {@link RestClient.Builder} to use.
      * @param webClientBuilder The {@link WebClient.Builder} to use.
 	 * @param responseErrorHandler Response error handler.
 	 */
-	private OllamaApi(String baseUrl, RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder, ResponseErrorHandler responseErrorHandler) {
+	private OllamaApi(String baseUrl,
+					  String chatPath, String copyModelPath, String deleteModelPath, String embedPath,
+					  String listModelsPath, String pullModelPath, String showModelPath,
+					  RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder,
+					  ResponseErrorHandler responseErrorHandler) {
+
+		this.chatPath = chatPath;
+		this.copyModelPath = copyModelPath;
+		this.deleteModelPath = deleteModelPath;
+		this.embedPath = embedPath;
+		this.listModelsPath = listModelsPath;
+		this.pullModelPath = pullModelPath;
+		this.showModelPath = showModelPath;
 
 		Consumer<HttpHeaders> defaultHeaders = headers -> {
 			headers.setContentType(MediaType.APPLICATION_JSON);
@@ -109,7 +142,7 @@ public final class OllamaApi {
 		Assert.isTrue(!chatRequest.stream(), "Stream mode must be disabled.");
 
 		return this.restClient.post()
-			.uri("/api/chat")
+			.uri(this.chatPath)
 			.body(chatRequest)
 			.retrieve()
 			.body(ChatResponse.class);
@@ -127,7 +160,7 @@ public final class OllamaApi {
 		AtomicBoolean isInsideTool = new AtomicBoolean(false);
 
 		return this.webClient.post()
-			.uri("/api/chat")
+			.uri(this.chatPath)
 			.body(Mono.just(chatRequest), ChatRequest.class)
 			.retrieve()
 			.bodyToFlux(ChatResponse.class)
@@ -175,7 +208,7 @@ public final class OllamaApi {
 		Assert.notNull(embeddingsRequest, REQUEST_BODY_NULL_ERROR);
 
 		return this.restClient.post()
-			.uri("/api/embed")
+			.uri(this.embedPath)
 			.body(embeddingsRequest)
 			.retrieve()
 			.body(EmbeddingsResponse.class);
@@ -186,7 +219,7 @@ public final class OllamaApi {
 	 */
 	public ListModelResponse listModels() {
 		return this.restClient.get()
-				.uri("/api/tags")
+				.uri(this.listModelsPath)
 				.retrieve()
 				.body(ListModelResponse.class);
 	}
@@ -197,7 +230,7 @@ public final class OllamaApi {
 	public ShowModelResponse showModel(ShowModelRequest showModelRequest) {
 		Assert.notNull(showModelRequest, "showModelRequest must not be null");
 		return this.restClient.post()
-				.uri("/api/show")
+				.uri(this.showModelPath)
 				.body(showModelRequest)
 				.retrieve()
 				.body(ShowModelResponse.class);
@@ -209,7 +242,7 @@ public final class OllamaApi {
 	public ResponseEntity<Void> copyModel(CopyModelRequest copyModelRequest) {
 		Assert.notNull(copyModelRequest, "copyModelRequest must not be null");
 		return this.restClient.post()
-				.uri("/api/copy")
+				.uri(this.copyModelPath)
 				.body(copyModelRequest)
 				.retrieve()
 				.toBodilessEntity();
@@ -221,7 +254,7 @@ public final class OllamaApi {
 	public ResponseEntity<Void> deleteModel(DeleteModelRequest deleteModelRequest) {
 		Assert.notNull(deleteModelRequest, "deleteModelRequest must not be null");
 		return this.restClient.method(HttpMethod.DELETE)
-				.uri("/api/delete")
+				.uri(this.deleteModelPath)
 				.body(deleteModelRequest)
 				.retrieve()
 				.toBodilessEntity();
@@ -240,7 +273,7 @@ public final class OllamaApi {
 		Assert.isTrue(pullModelRequest.stream(), "Request must set the stream property to true.");
 
 		return this.webClient.post()
-				.uri("/api/pull")
+				.uri(this.pullModelPath)
 				.bodyValue(pullModelRequest)
 				.retrieve()
 				.bodyToFlux(ProgressResponse.class);
@@ -714,6 +747,20 @@ public final class OllamaApi {
 
 		private String baseUrl = OllamaApiConstants.DEFAULT_BASE_URL;
 
+		private String chatPath = OllamaApiConstants.DEFAULT_CHAT_PATH;
+
+		private String embedPath = OllamaApiConstants.DEFAULT_EMBED_PATH;
+
+		private String listModelsPath = OllamaApiConstants.DEFAULT_LIST_MODELS_PATH;
+
+		private String showModelPath = OllamaApiConstants.DEFAULT_SHOW_MODEL_PATH;
+
+		private String copyModelPath = OllamaApiConstants.DEFAULT_COPY_MODEL_PATH;
+
+		private String deleteModelPath = OllamaApiConstants.DEFAULT_DELETE_MODEL_PATH;
+
+		private String pullModelPath = OllamaApiConstants.DEFAULT_PULL_MODEL_PATH;
+
 		private RestClient.Builder restClientBuilder = RestClient.builder();
 
 		private WebClient.Builder webClientBuilder = WebClient.builder();
@@ -723,6 +770,48 @@ public final class OllamaApi {
 		public Builder baseUrl(String baseUrl) {
 			Assert.hasText(baseUrl, "baseUrl cannot be null or empty");
 			this.baseUrl = baseUrl;
+			return this;
+		}
+
+		public Builder chatPath(String chatPath) {
+			Assert.hasText(chatPath, "chatPath cannot be null or empty");
+			this.chatPath = chatPath;
+			return this;
+		}
+
+		public Builder embedPath(String embedPath) {
+			Assert.hasText(embedPath, "embedPath cannot be null or empty");
+			this.embedPath = embedPath;
+			return this;
+		}
+
+		public Builder listModelsPath(String listModelsPath) {
+			Assert.hasText(listModelsPath, "listModelsPath cannot be null or empty");
+			this.listModelsPath = listModelsPath;
+			return this;
+		}
+
+		public Builder showModelPath(String showModelPath) {
+			Assert.hasText(showModelPath, "showModelPath cannot be null or empty");
+			this.showModelPath = showModelPath;
+			return this;
+		}
+
+		public Builder copyModelPath(String copyModelPath) {
+			Assert.hasText(copyModelPath, "copyModelPath cannot be null or empty");
+			this.copyModelPath = copyModelPath;
+			return this;
+		}
+
+		public Builder deleteModelPath(String deleteModelPath) {
+			Assert.hasText(deleteModelPath, "deleteModelPath cannot be null or empty");
+			this.deleteModelPath = deleteModelPath;
+			return this;
+		}
+
+		public Builder pullModelPath(String pullModelPath) {
+			Assert.hasText(pullModelPath, "pullModelPath cannot be null or empty");
+			this.pullModelPath = pullModelPath;
 			return this;
 		}
 
@@ -745,7 +834,10 @@ public final class OllamaApi {
 		}
 
 		public OllamaApi build() {
-			return new OllamaApi(this.baseUrl, this.restClientBuilder, this.webClientBuilder, this.responseErrorHandler);
+			return new OllamaApi(this.baseUrl,
+					this.chatPath, this.copyModelPath, this.deleteModelPath, this.embedPath, this.listModelsPath,
+					this.pullModelPath, this.showModelPath,
+					this.restClientBuilder, this.webClientBuilder, this.responseErrorHandler);
 		}
 
 	}

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/common/OllamaApiConstants.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/common/OllamaApiConstants.java
@@ -22,12 +22,27 @@ import org.springframework.ai.observation.conventions.AiProvider;
  * Common value constants for Ollama api.
  *
  * @author Jonghoon Park
+ * @author lambochen
  */
 public final class OllamaApiConstants {
 
 	public static final String DEFAULT_BASE_URL = "http://localhost:11434";
 
 	public static final String PROVIDER_NAME = AiProvider.OLLAMA.value();
+
+	public static final String DEFAULT_CHAT_PATH = "/api/chat";
+
+	public static final String DEFAULT_EMBED_PATH = "/api/embed";
+
+	public static final String DEFAULT_LIST_MODELS_PATH = "/api/tags";
+
+	public static final String DEFAULT_SHOW_MODEL_PATH = "/api/show";
+
+	public static final String DEFAULT_COPY_MODEL_PATH = "/api/copy";
+
+	public static final String DEFAULT_DELETE_MODEL_PATH = "/api/delete";
+
+	public static final String DEFAULT_PULL_MODEL_PATH = "/api/pull";
 
 	private OllamaApiConstants() {
 

--- a/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/ollama/OllamaDockerComposeConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-docker-compose/src/main/java/org/springframework/ai/docker/compose/service/connection/ollama/OllamaDockerComposeConnectionDetailsFactory.java
@@ -17,12 +17,14 @@
 package org.springframework.ai.docker.compose.service.connection.ollama;
 
 import org.springframework.ai.model.ollama.autoconfigure.OllamaConnectionDetails;
+import org.springframework.ai.ollama.api.common.OllamaApiConstants;
 import org.springframework.boot.docker.compose.core.RunningService;
 import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionDetailsFactory;
 import org.springframework.boot.docker.compose.service.connection.DockerComposeConnectionSource;
 
 /**
  * @author Eddú Meléndez
+ * @author lambochen
  */
 class OllamaDockerComposeConnectionDetailsFactory
 		extends DockerComposeConnectionDetailsFactory<OllamaConnectionDetails> {
@@ -46,6 +48,41 @@ class OllamaDockerComposeConnectionDetailsFactory
 
 		private final String baseUrl;
 
+		/**
+		 * The path of the chat endpoint.
+		 */
+		private String chatPath = OllamaApiConstants.DEFAULT_CHAT_PATH;
+
+		/**
+		 * The path of the embed endpoint.
+		 */
+		private String embedPath = OllamaApiConstants.DEFAULT_EMBED_PATH;
+
+		/**
+		 * The path of the list models endpoint.
+		 */
+		private String listModelsPath = OllamaApiConstants.DEFAULT_LIST_MODELS_PATH;
+
+		/**
+		 * The path of the show model endpoint.
+		 */
+		private String showModelPath = OllamaApiConstants.DEFAULT_SHOW_MODEL_PATH;
+
+		/**
+		 * The path of the copy model endpoint.
+		 */
+		private String copyModelPath = OllamaApiConstants.DEFAULT_COPY_MODEL_PATH;
+
+		/**
+		 * The path of the delete model endpoint.
+		 */
+		private String deleteModelPath = OllamaApiConstants.DEFAULT_DELETE_MODEL_PATH;
+
+		/**
+		 * The path of the pull model endpoint.
+		 */
+		private String pullModelPath = OllamaApiConstants.DEFAULT_PULL_MODEL_PATH;
+
 		OllamaDockerComposeConnectionDetails(RunningService service) {
 			super(service);
 			this.baseUrl = "http://" + service.host() + ":" + service.ports().get(OLLAMA_PORT);
@@ -54,6 +91,41 @@ class OllamaDockerComposeConnectionDetailsFactory
 		@Override
 		public String getBaseUrl() {
 			return this.baseUrl;
+		}
+
+		@Override
+		public String getChatPath() {
+			return this.chatPath;
+		}
+
+		@Override
+		public String getEmbedPath() {
+			return this.embedPath;
+		}
+
+		@Override
+		public String getListModelsPath() {
+			return this.listModelsPath;
+		}
+
+		@Override
+		public String getShowModelPath() {
+			return this.showModelPath;
+		}
+
+		@Override
+		public String getCopyModelPath() {
+			return this.copyModelPath;
+		}
+
+		@Override
+		public String getDeleteModelPath() {
+			return this.deleteModelPath;
+		}
+
+		@Override
+		public String getPullModelPath() {
+			return this.pullModelPath;
 		}
 
 	}

--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaContainerConnectionDetailsFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.testcontainers.service.connection.ollama;
 
+import org.springframework.ai.ollama.api.common.OllamaApiConstants;
 import org.testcontainers.ollama.OllamaContainer;
 
 import org.springframework.ai.model.ollama.autoconfigure.OllamaConnectionDetails;
@@ -24,6 +25,7 @@ import org.springframework.boot.testcontainers.service.connection.ContainerConne
 
 /**
  * @author Eddú Meléndez
+ * @author lambochen
  */
 class OllamaContainerConnectionDetailsFactory
 		extends ContainerConnectionDetailsFactory<OllamaContainer, OllamaConnectionDetails> {
@@ -46,6 +48,41 @@ class OllamaContainerConnectionDetailsFactory
 		@Override
 		public String getBaseUrl() {
 			return getContainer().getEndpoint();
+		}
+
+		@Override
+		public String getChatPath() {
+			return OllamaApiConstants.DEFAULT_CHAT_PATH;
+		}
+
+		@Override
+		public String getEmbedPath() {
+			return OllamaApiConstants.DEFAULT_EMBED_PATH;
+		}
+
+		@Override
+		public String getListModelsPath() {
+			return OllamaApiConstants.DEFAULT_LIST_MODELS_PATH;
+		}
+
+		@Override
+		public String getShowModelPath() {
+			return OllamaApiConstants.DEFAULT_SHOW_MODEL_PATH;
+		}
+
+		@Override
+		public String getCopyModelPath() {
+			return OllamaApiConstants.DEFAULT_COPY_MODEL_PATH;
+		}
+
+		@Override
+		public String getDeleteModelPath() {
+			return OllamaApiConstants.DEFAULT_DELETE_MODEL_PATH;
+		}
+
+		@Override
+		public String getPullModelPath() {
+			return OllamaApiConstants.DEFAULT_PULL_MODEL_PATH;
 		}
 
 	}


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Sign the [contributor license agreement](https://cla.pivotal.io/sign/spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
---

Hi, This PR is a feature enhancement change that supports custom Ollama API paths.

Background: When implementing Spring AI in my project, I made some adjustments to the Ollama API, and the API provided externally is a custom path. Therefore, I expect the Spring AI Ollama Model to support custom paths.

Current behavior: The Ollama API path is fixed in the hard-coded code, for example:
```java
public ListModelResponse listModels() {
	return this.restClient.get()
			.uri("/api/tags")
			.retrieve()
			.body(ListModelResponse.class);
}
```


