### PR TITLE
Fixed the logic error in the validateToolContextSupport method of MethodToolCallback

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallback.java
@@ -118,8 +118,8 @@ public final class MethodToolCallback implements ToolCallback {
 	private void validateToolContextSupport(@Nullable ToolContext toolContext) {
 		var isNonEmptyToolContextProvided = toolContext != null && !CollectionUtils.isEmpty(toolContext.getContext());
 		var isToolContextAcceptedByMethod = Stream.of(this.toolMethod.getParameterTypes())
-			.anyMatch(type -> ClassUtils.isAssignable(type, ToolContext.class));
-		if (isToolContextAcceptedByMethod && !isNonEmptyToolContextProvided) {
+			.anyMatch(type -> ClassUtils.isAssignable(ToolContext.class, type));
+		if (isNonEmptyToolContextProvided && !isToolContextAcceptedByMethod) {
 			throw new IllegalArgumentException("ToolContext is required by the method as an argument");
 		}
 	}


### PR DESCRIPTION
Fixes #3466 

As mentioned in the PR, there were some issues with the implementation of the `validateToolContextSupport` method in `MethodToolCallback`, which led to validation failures. This PR makes the following adjustments:  

1. Adjusted the parameter order when calling `ClassUtils.isAssignable` to ensure correct semantics.  
2. Modified the condition for throwing exceptions to align with the method's intended functionality.