### PR TITLE
Fixed GH-3355: Fixed the judgment error in the isFunctionalType method of MethodToolCallbackProvider

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/method/MethodToolCallbackProvider.java
@@ -103,9 +103,9 @@ public final class MethodToolCallbackProvider implements ToolCallbackProvider {
 	}
 
 	private boolean isFunctionalType(Method toolMethod) {
-		var isFunction = ClassUtils.isAssignable(toolMethod.getReturnType(), Function.class)
-				|| ClassUtils.isAssignable(toolMethod.getReturnType(), Supplier.class)
-				|| ClassUtils.isAssignable(toolMethod.getReturnType(), Consumer.class);
+		var isFunction = ClassUtils.isAssignable(Function.class, toolMethod.getReturnType())
+				|| ClassUtils.isAssignable(Supplier.class, toolMethod.getReturnType())
+				|| ClassUtils.isAssignable(Consumer.class, toolMethod.getReturnType());
 
 		if (isFunction) {
 			logger.warn("Method {} is annotated with @Tool but returns a functional type. "

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackProviderTests.java
@@ -78,6 +78,15 @@ class MethodToolCallbackProviderTests {
 			.hasMessageContaining("Multiple tools with the same name (validTool) found in sources");
 	}
 
+	@Test
+	void whenToolObjectHasObjectTypeMethodThenSuccess() {
+		MethodToolCallbackProvider provider = MethodToolCallbackProvider.builder()
+			.toolObjects(new ObjectTypeToolMethodsObject())
+			.build();
+		assertThat(provider.getToolCallbacks()).hasSize(1);
+		assertThat(provider.getToolCallbacks()[0].getToolDefinition().name()).isEqualTo("objectTool");
+	}
+
 	static class ValidToolObject {
 
 		@Tool
@@ -133,6 +142,15 @@ class MethodToolCallbackProviderTests {
 		@Tool
 		public String validTool() {
 			return "Duplicate tool result";
+		}
+
+	}
+
+	static class ObjectTypeToolMethodsObject {
+
+		@Tool
+		public Object objectTool() {
+			return "Object tool result";
 		}
 
 	}


### PR DESCRIPTION
Fixes #3355 
As mentioned in the issue, there was an incorrect judgment of the method return type in the `isFunctionalType` method of `MethodToolCallbackProvider`. This PR fixes that problem and adds corresponding unit tests.