### PR TITLE
Refactor QdrantObjectFactory to allow null metadata values

### DIFF
--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactory.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.vectorstore.qdrant;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -30,6 +31,7 @@ import org.springframework.util.Assert;
  * Utility methods for building Java objects from io.qdrant.client.grpc.JsonWithInt.Value.
  *
  * @author Anush Shetty
+ * @author Heonwoo Kim
  * @since 0.8.1
  */
 final class QdrantObjectFactory {
@@ -41,7 +43,11 @@ final class QdrantObjectFactory {
 
 	public static Map<String, Object> toObjectMap(Map<String, Value> payload) {
 		Assert.notNull(payload, "Payload map must not be null");
-		return payload.entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> object(e.getValue())));
+		Map<String, Object> map = new HashMap<>();
+		for (Map.Entry<String, Value> entry : payload.entrySet()) {
+			map.put(entry.getKey(), object(entry.getValue()));
+		}
+		return map;
 	}
 
 	private static Object object(ListValue listValue) {

--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactoryTest.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      <https://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.qdrant;
+
+import java.util.Map;
+
+import io.qdrant.client.grpc.JsonWithInt.NullValue;
+import io.qdrant.client.grpc.JsonWithInt.Value;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link QdrantObjectFactory}.
+ *
+ * @author Heonwoo Kim
+ */
+class QdrantObjectFactoryTest {
+
+	@Test
+	void toObjectMapShouldHandleNullValues() {
+
+		Map<String, Value> payloadWithNull = Map.of(
+				"name", Value.newBuilder().setStringValue("Spring AI").build(),
+				"version", Value.newBuilder().setDoubleValue(1.0).build(),
+				"is_ga", Value.newBuilder().setBoolValue(true).build(),
+				"description", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build()
+		);
+
+		Map<String, Object> result = QdrantObjectFactory.toObjectMap(payloadWithNull);
+
+
+		assertThat(result).isNotNull();
+
+		assertThat(result).hasSize(4);
+
+		assertThat(result.get("name")).isEqualTo("Spring AI");
+		assertThat(result.get("version")).isEqualTo(1.0);
+		assertThat(result.get("is_ga")).isEqualTo(true);
+
+		assertThat(result).containsKey("description");
+		assertThat(result.get("description")).isNull();
+	}
+
+}

--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactoryTests.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactoryTests.java
@@ -34,15 +34,12 @@ class QdrantObjectFactoryTests {
 
 	@Test
 	void toObjectMapShouldHandleNullValues() {
-		Map<String, Value> payloadWithNull = Map.of(
-				"name", Value.newBuilder().setStringValue("Spring AI").build(),
-				"version", Value.newBuilder().setDoubleValue(1.0).build(),
-				"is_ga", Value.newBuilder().setBoolValue(true).build(),
-				"description", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build()
-		);
+		Map<String, Value> payloadWithNull = Map.of("name", Value.newBuilder().setStringValue("Spring AI").build(),
+				"version", Value.newBuilder().setDoubleValue(1.0).build(), "is_ga",
+				Value.newBuilder().setBoolValue(true).build(), "description",
+				Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build());
 
 		Map<String, Object> result = QdrantObjectFactory.toObjectMap(payloadWithNull);
-
 
 		assertThat(result).isNotNull();
 		assertThat(result).hasSize(4);

--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactoryTests.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      <https://www.apache.org/licenses/LICENSE-2.0>
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,11 +29,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Heonwoo Kim
  */
-class QdrantObjectFactoryTest {
+
+class QdrantObjectFactoryTests {
 
 	@Test
 	void toObjectMapShouldHandleNullValues() {
-
 		Map<String, Value> payloadWithNull = Map.of(
 				"name", Value.newBuilder().setStringValue("Spring AI").build(),
 				"version", Value.newBuilder().setDoubleValue(1.0).build(),
@@ -45,13 +45,10 @@ class QdrantObjectFactoryTest {
 
 
 		assertThat(result).isNotNull();
-
 		assertThat(result).hasSize(4);
-
 		assertThat(result.get("name")).isEqualTo("Spring AI");
 		assertThat(result.get("version")).isEqualTo(1.0);
 		assertThat(result.get("is_ga")).isEqualTo(true);
-
 		assertThat(result).containsKey("description");
 		assertThat(result.get("description")).isNull();
 	}


### PR DESCRIPTION
related issue : #3420 
When retrieving documents from a Qdrant vector store, a NullPointerException was being thrown if the metadata payload for any document contained a field with a null value.

I fix the issue by replacing the stream-based Collectors.toMap() implementation with a more robust and explicit for-each loop.

I have confirmed the fix by performing tests in my local environment. 