### PR TITLE
Add contributor guide link and update CLA to DCO

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for taking time to contribute this pull request!
-You might have already read the [contributor guide][https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc], but as a reminder, please make sure to:
+You might have already read the [contributor guide](https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc), but as a reminder, please make sure to:
 
 * Ensure commits include Signed-off-by trailer [Hello DCO, Goodbye CLA: Simplifying Contributions to Spring](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring)
 * Rebase your changes on the latest `main` branch and squash your commits


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide](https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc), but as a reminder, please make sure to:

* Ensure commits include Signed-off-by trailer [Hello DCO, Goodbye CLA: Simplifying Contributions to Spring](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission
