### PR TITLE
Remove `Object...` varargs overloads in `FilterExpressionBuilderTests`

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionBuilder.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import org.springframework.ai.vectorstore.filter.Filter.Value;
  * syntax.
  *
  * @author Christian Tzolov
+ * @author Andrey Litvitski
  */
 public class FilterExpressionBuilder {
 
@@ -89,16 +90,8 @@ public class FilterExpressionBuilder {
 		return new Op(new Filter.Expression(ExpressionType.OR, left.expression, right.expression));
 	}
 
-	public Op in(String key, Object... values) {
-		return this.in(key, List.of(values));
-	}
-
 	public Op in(String key, List<Object> values) {
 		return new Op(new Filter.Expression(ExpressionType.IN, new Key(key), new Value(values)));
-	}
-
-	public Op nin(String key, Object... values) {
-		return this.nin(key, List.of(values));
 	}
 
 	public Op nin(String key, List<Object> values) {

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionBuilderTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.OR
 
 /**
  * @author Christian Tzolov
+ * @author Andrey Litvitski
  */
 public class FilterExpressionBuilderTests {
 
@@ -60,7 +61,7 @@ public class FilterExpressionBuilderTests {
 	@Test
 	public void testIn() {
 		// genre in ["comedy", "documentary", "drama"]
-		var exp = this.b.in("genre", "comedy", "documentary", "drama").build();
+		var exp = this.b.in("genre", List.of("comedy", "documentary", "drama")).build();
 		assertThat(exp)
 			.isEqualTo(new Expression(IN, new Key("genre"), new Value(List.of("comedy", "documentary", "drama"))));
 	}
@@ -83,7 +84,7 @@ public class FilterExpressionBuilderTests {
 		// (year >= 2020 OR country == "BG") AND city NIN ["Sofia", "Plovdiv"]
 		var exp = this.b
 			.and(this.b.group(this.b.or(this.b.gte("year", 2020), this.b.eq("country", "BG"))),
-					this.b.nin("city", "Sofia", "Plovdiv"))
+					this.b.nin("city", List.of("Sofia", "Plovdiv")))
 			.build();
 
 		assertThat(exp).isEqualTo(new Expression(AND,
@@ -97,7 +98,7 @@ public class FilterExpressionBuilderTests {
 		// isOpen == true AND year >= 2020 AND country IN ["BG", "NL", "US"]
 		var exp = this.b
 			.and(this.b.and(this.b.eq("isOpen", true), this.b.gte("year", 2020)),
-					this.b.in("country", "BG", "NL", "US"))
+					this.b.in("country", List.of("BG", "NL", "US")))
 			.build();
 
 		assertThat(exp).isEqualTo(new Expression(AND,
@@ -110,7 +111,7 @@ public class FilterExpressionBuilderTests {
 	public void tesNot() {
 		// isOpen == true AND year >= 2020 AND country IN ["BG", "NL", "US"]
 		var exp = this.b.not(this.b.and(this.b.and(this.b.eq("isOpen", true), this.b.gte("year", 2020)),
-				this.b.in("country", "BG", "NL", "US")))
+				this.b.in("country", List.of("BG", "NL", "US"))))
 			.build();
 
 		assertThat(exp).isEqualTo(new Expression(NOT,
@@ -119,6 +120,13 @@ public class FilterExpressionBuilderTests {
 								new Expression(GTE, new Key("year"), new Value(2020))),
 						new Expression(IN, new Key("country"), new Value(List.of("BG", "NL", "US")))),
 				null));
+	}
+
+	@Test
+	public void testInWithStringList() {
+		Expression exp = b.in("country", List.of("BG", "NL", "US")).build();
+
+		assertThat(exp).isEqualTo(new Expression(IN, new Key("country"), new Value(List.of("BG", "NL", "US"))));
 	}
 
 }


### PR DESCRIPTION
When we swipe `List` where in the generic we don't have `Object`, we hit `Object...` which is wrong, and we make a double list. That is, one element is added in this case, which is fundamentally wrong.

There are two ways to fix this. Either remove overloading with `Object...` (as I did), or make `FilterExpressionBuilderTests` generic and make `List<T>` values in the argument of acceptance. However, both changes **are breaking**.

If the second option is better for you to fix the problem I am ready to discuss it as I like both options I have given.

_The test I gave will not work without changes in the class itself._

Fix: #3482