### PR TITLE
docs: update OpenAI page Vision section

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -228,17 +228,19 @@ The OpenAI link:https://platform.openai.com/docs/api-reference/chat/create#chat-
 Spring AI’s link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/Message.java[Message] interface facilitates multimodal AI models by introducing the link:https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/model/Media.java[Media] type.
 This type encompasses data and details regarding media attachments in messages, utilizing Spring’s `org.springframework.util.MimeType` and a `org.springframework.core.io.Resource` for the raw media data.
 
-Below is a code example excerpted from link:https://github.com/spring-projects/spring-ai/blob/c9a3e66f90187ce7eae7eb78c462ec622685de6c/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java#L293[OpenAiChatModelIT.java], illustrating the fusion of user text with an image using the `gpt-4o` model.
+Below is a code example excerpted from link:https://github.com/spring-projects/spring-ai/blob/v1.0.0/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelIT.java#L469[OpenAiChatModelIT.java], illustrating the fusion of user text with an image using the `gpt-4o` model.
 
 [source,java]
 ----
-var imageResource = new ClassPathResource("/multimodal.test.png");
+var imageData = new ClassPathResource("/test.png");
 
-var userMessage = new UserMessage("Explain what do you see on this picture?",
-        new Media(MimeTypeUtils.IMAGE_PNG, this.imageResource));
+var userMessage = UserMessage.builder()
+    .text("Explain what do you see on this picture?")
+    .media(List.of(new Media(MimeTypeUtils.IMAGE_PNG, imageData)))
+    .build();
 
-ChatResponse response = chatModel.call(new Prompt(this.userMessage,
-        OpenAiChatOptions.builder().model(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));
+var response = this.chatModel
+    .call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().model(modelName).build()));
 ----
 
 TIP: GPT_4_VISION_PREVIEW will continue to be available only to existing users of this model starting June 17, 2024. If you are not an existing user, please use the GPT_4_O or GPT_4_TURBO models. More details https://platform.openai.com/docs/deprecations/2024-06-06-gpt-4-32k-and-vision-preview-models[here]
@@ -247,12 +249,16 @@ or the image URL equivalent using the `gpt-4o` model:
 
 [source,java]
 ----
-var userMessage = new UserMessage("Explain what do you see on this picture?",
-        new Media(MimeTypeUtils.IMAGE_PNG,
-                URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png")));
+var userMessage = UserMessage.builder()
+    .text("Explain what do you see on this picture?")
+    .media(List.of(Media.builder()
+        .mimeType(MimeTypeUtils.IMAGE_PNG)
+        .data(URI.create("https://docs.spring.io/spring-ai/reference/_images/multimodal.test.png"))
+        .build()))
+    .build();
 
-ChatResponse response = chatModel.call(new Prompt(this.userMessage,
-        OpenAiChatOptions.builder().model(OpenAiApi.ChatModel.GPT_4_O.getValue()).build()));
+ChatResponse response = this.chatModel
+    .call(new Prompt(List.of(userMessage), OpenAiChatOptions.builder().model(modelName).build()));
 ----
 
 TIP: You can pass multiple images as well.


### PR DESCRIPTION
**📄 Documentation Bug**

**Problem:**
#3486 
In the 1.0.0 version of the documentation, the Vision example shown is actually from version 1.1.0-SNAPSHOT. Shouldn't the example below be included instead if it's truly the 1.0.0 documentation?

**Suggested Fix:**
Update OpenAI page Vision section

**Version:** Spring AI 1.0.0