### PR TITLE
Fixed GH-3492: Fixed the SQL error in the `isTableExists` method of `MariaDBSchemaValidator`

### DIFF
--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
@@ -46,7 +46,7 @@ public class MariaDBSchemaValidator {
 	private boolean isTableExists(String schemaName, String tableName) {
 		// schema and table are expected to be escaped
 		String sql = String.format(
-				"SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s",
+				"SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'",
 				(schemaName == null) ? "SCHEMA()" : schemaName, tableName);
 		try {
 			// Query for a single integer value, if it exists, table exists


### PR DESCRIPTION
Fixes #3492 As stated in issue, the SQL in the `isTableExists` method was not adding single quotes on either side of the placeholder, this PR fixes that issue