### PR TITLE
build: Use swagger-annotations-jakarta instead of swagger-annotations

### DIFF
--- a/models/spring-ai-huggingface/pom.xml
+++ b/models/spring-ai-huggingface/pom.xml
@@ -47,11 +47,11 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
+		<!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations-jakarta -->
 		<dependency>
 			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-annotations</artifactId>
-			<version>2.2.15</version>
+			<artifactId>swagger-annotations-jakarta</artifactId>
+			<version>${swagger-annotations.version}</version>
 		</dependency>
 
 		<dependency>

--- a/spring-ai-client-chat/pom.xml
+++ b/spring-ai-client-chat/pom.xml
@@ -51,7 +51,7 @@
 
 		<dependency>
 			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-annotations</artifactId>
+			<artifactId>swagger-annotations-jakarta</artifactId>
 			<version>${swagger-annotations.version}</version>
 		</dependency>
 

--- a/spring-ai-model/pom.xml
+++ b/spring-ai-model/pom.xml
@@ -112,7 +112,7 @@
 
 		<dependency>
 			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-annotations</artifactId>
+			<artifactId>swagger-annotations-jakarta</artifactId>
 			<version>${swagger-annotations.version}</version>
 		</dependency>
 


### PR DESCRIPTION
Functionality is the same, but modern applications won't use javax variant of Swagger JARs, so the dependency on swagger-annotations caused duplicate classes on the classpath.

spring-ai is built against Spring Boot 3.4, which is jakarta-only.

See:
* https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Getting-started
* modern applications will avoid https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-core/2.2.25 and use https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-core-jakarta/2.2.25 instead
