### PR TITLE
refactor(spring-ai-model): improve parameter name in ChatGenerationMetadata

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/ChatGenerationMetadata.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/metadata/ChatGenerationMetadata.java
@@ -67,7 +67,7 @@ public interface ChatGenerationMetadata extends ResultMetadata {
 		/**
 		 * Set the reason this choice completed for the generation.
 		 */
-		Builder finishReason(String id);
+		Builder finishReason(String finishReason);
 
 		/**
 		 * Add metadata to the Generation result.


### PR DESCRIPTION
- Changed the parameter name in the finishReason method from 'id' to 'finishReason' for better clarity and accuracy
