### PR TITLE
Improved the documentation in the MCP Server Boot Starter regarding Starter selection

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -80,7 +80,12 @@ The starter activates the `McpWebFluxServerAutoConfiguration` and `McpServerAuto
 * Optional `STDIO` transport (enabled by setting `spring.ai.mcp.server.stdio=true`)
 * Included `spring-boot-starter-webflux` and `mcp-spring-webflux` dependencies
 
-== Configuration Properties
+[NOTE]
+====
+Due to Spring Boot's default behavior, when both `org.springframework.web.servlet.DispatcherServlet` and `org.springframework.web.reactive.DispatcherHandler` are present on the classpath, Spring Boot will prioritize `DispatcherServlet`. As a result, if your project uses `spring-boot-starter-web`, it is recommended to use `spring-ai-starter-mcp-server-webmvc` instead of `spring-ai-starter-mcp-server-webflux`.
+====
+
+Configuration Properties
 
 All properties are prefixed with `spring.ai.mcp.server`:
 


### PR DESCRIPTION
Spring AI provides three starters for MCP servers: `spring-ai-starter-mcp-server`, `spring-ai-starter-mcp-server-webmvc`, and `spring-ai-starter-mcp-server-webflux`, among which `spring-ai-starter-mcp-server-webflux` is designed for reactive projects. 

However, due to Spring Boot's default behavior, if both `org.springframework.web.servlet.DispatcherServlet` and `org.springframework.web.reactive.DispatcherHandler` are present in the classpath, Spring Boot will prioritize the former:

https://github.com/spring-projects/spring-boot/blob/0daf3f5897a9bad169ad7ebad6d79e4260a24822/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/WebApplicationType.java#L60-L71

This means that if users mistakenly use `spring-ai-starter-mcp-server-webflux` in a project built with `spring-boot-starter-web`, MCP endpoints such as `/sse` will become non-functional.

Of course, this is not an issue with Spring AI itself. However, considering that it has already caused considerable confusion :

* https://github.com/spring-projects/spring-ai/issues/3499
* https://github.com/spring-projects/spring-ai/issues/2732

 I believe adding appropriate documentation would help users better understand what they are doing and avoid such pitfalls.