### PR TITLE
feat: Add new Mistral AI chat models

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -280,12 +280,16 @@ public class MistralAiApi {
 
 		// @formatter:off
 		// Premier Models
+		MAGISTRAL_MEDIUM("magistral-medium-latest"),
+		MISTRAL_MEDIUM("mistral-medium-latest"),
 		CODESTRAL("codestral-latest"),
 		LARGE("mistral-large-latest"),
 		PIXTRAL_LARGE("pixtral-large-latest"),
 		MINISTRAL_3B_LATEST("ministral-3b-latest"),
 		MINISTRAL_8B_LATEST("ministral-8b-latest"),
 		// Free Models
+		MAGISTRAL_SMALL("magistral-small-latest"),
+		DEVSTRAL_SMALL("devstral-small-latest"),
 		SMALL("mistral-small-latest"),
 		PIXTRAL("pixtral-12b-2409"),
 		// Free Models - Research


### PR DESCRIPTION
Adds MAGISTRAL_MEDIUM, MISTRAL_MEDIUM, MAGISTRAL_SMALL, and DEVSTRAL_SMALL to the available chat models.
