### PR TITLE
Update zhipuai-chat.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/zhipuai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/zhipuai-chat.adoc
@@ -210,7 +210,7 @@ public class ChatController {
         return Map.of("generation", this.chatModel.call(message));
     }
 
-    @GetMapping("/ai/generateStream")
+    @GetMapping(value = "/ai/generateStream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public Flux<ChatResponse> generateStream(@RequestParam(value = "message", defaultValue = "Tell me a joke") String message) {
         var prompt = new Prompt(new UserMessage(message));
         return this.chatModel.stream(prompt);


### PR DESCRIPTION
we will not get a stream return unless to add the element "produces = MediaType.TEXT_EVENT_STREAM_VALUE"  ( Content-Type = "text/event-stream" ) in the "@GetMapping" annotation. I have run the code and make this pr