### PR TITLE
fix: failed to generate `spring.ai.tools.observations` config metadata

### DIFF
--- a/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingProperties.java
+++ b/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingProperties.java
@@ -31,6 +31,10 @@ public class ToolCallingProperties {
 
 	private final Observations observations = new Observations();
 
+	public Observations getObservations() {
+		return this.observations;
+	}
+
 	/**
 	 * If true, tool calling errors are thrown as exceptions for the caller to handle. If
 	 * false, errors are converted to messages and sent back to the AI model, allowing it


### PR DESCRIPTION
Fix: #3550  
Add getter method for `ToolCallingProperties#observations` to make spring config metadata json fully generated.
