### PR TITLE
fix: handle root exceptions in McpToolCallback

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
@@ -16,11 +16,12 @@
 
 package org.springframework.ai.mcp;
 
-import java.util.Map;
-
 import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.Map;
+import reactor.core.publisher.Mono;
 
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.ModelOptionsUtils;
@@ -112,19 +113,16 @@ public class AsyncMcpToolCallback implements ToolCallback {
 		Map<String, Object> arguments = ModelOptionsUtils.jsonToMap(functionInput);
 		// Note that we use the original tool name here, not the adapted one from
 		// getToolDefinition
-		try {
-			return this.asyncMcpClient.callTool(new CallToolRequest(this.tool.name(), arguments)).map(response -> {
-				if (response.isError() != null && response.isError()) {
-					throw new ToolExecutionException(this.getToolDefinition(),
-							new IllegalStateException("Error calling tool: " + response.content()));
-				}
-				return ModelOptionsUtils.toJsonString(response.content());
-			}).block();
-		}
-		catch (Exception ex) {
-			throw new ToolExecutionException(this.getToolDefinition(), ex.getCause());
-		}
-
+		return this.asyncMcpClient.callTool(new CallToolRequest(this.tool.name(), arguments)).onErrorMap(exception -> {
+			// If the tool throws an error during execution
+			throw new ToolExecutionException(this.getToolDefinition(), exception);
+		}).map(response -> {
+			if (response.isError() != null && response.isError()) {
+				throw new ToolExecutionException(this.getToolDefinition(),
+						new IllegalStateException("Error calling tool: " + response.content()));
+			}
+			return ModelOptionsUtils.toJsonString(response.content());
+		}).block();
 	}
 
 	@Override

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -1,0 +1,54 @@
+package org.springframework.ai.mcp;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import org.springframework.ai.tool.execution.ToolExecutionException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AsyncMcpToolCallbackTest {
+
+	@Mock
+	private McpAsyncClient mcpClient;
+
+	@Mock
+	private McpSchema.Tool tool;
+
+	@Test
+	void callShouldThrowOnError() {
+		when(this.tool.name()).thenReturn("testTool");
+		var clientInfo = new McpSchema.Implementation("testClient", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		var callToolResult = McpSchema.CallToolResult.builder().addTextContent("Some error data").isError(true).build();
+		when(this.mcpClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(Mono.just(callToolResult));
+
+		var callback = new AsyncMcpToolCallback(this.mcpClient, this.tool);
+		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
+			.cause()
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Error calling tool: [TextContent[audience=null, priority=null, text=Some error data]]");
+	}
+
+	@Test
+	void callShouldWrapReactiveErrors() {
+		when(this.tool.name()).thenReturn("testTool");
+		var clientInfo = new McpSchema.Implementation("testClient", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		when(this.mcpClient.callTool(any(McpSchema.CallToolRequest.class)))
+			.thenReturn(Mono.error(new Exception("Testing tool error")));
+
+		var callback = new AsyncMcpToolCallback(this.mcpClient, this.tool);
+		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
+			.rootCause()
+			.hasMessage("Testing tool error");
+	}
+
+}


### PR DESCRIPTION
Sync and Async McpToolCallback can now handle exceptions where cause == null instead of throwing a NPE.

This is the case when we do OAuth2 flows with Spring Security in MCP tools, because Spring Security relies on exceptions as signals to trigger "fetch an access_token" behavior.