### PR TITLE
Make the `content` field configurable in Weaviate vector store properties

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
@@ -28,12 +28,14 @@ import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.vectorstore.SpringAIVectorStoreTypes;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
 import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStore;
+import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStoreOptions;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -42,6 +44,7 @@ import org.springframework.context.annotation.Bean;
  * @author Christian Tzolov
  * @author Eddú Meléndez
  * @author Soby Chacko
+ * @author Jonghoon Park
  */
 @AutoConfiguration
 @ConditionalOnClass({ EmbeddingModel.class, WeaviateVectorStore.class })
@@ -82,9 +85,8 @@ public class WeaviateVectorStoreAutoConfiguration {
 			WeaviateVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
-
 		return WeaviateVectorStore.builder(weaviateClient, embeddingModel)
-			.objectClass(properties.getObjectClass())
+			.options(mappingPropertiesToOptions(properties))
 			.filterMetadataFields(properties.getFilterField()
 				.entrySet()
 				.stream()
@@ -95,6 +97,16 @@ public class WeaviateVectorStoreAutoConfiguration {
 			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))
 			.batchingStrategy(batchingStrategy)
 			.build();
+	}
+
+	WeaviateVectorStoreOptions mappingPropertiesToOptions(WeaviateVectorStoreProperties properties) {
+		WeaviateVectorStoreOptions weaviateVectorStoreOptions = new WeaviateVectorStoreOptions();
+
+		PropertyMapper mapper = PropertyMapper.get();
+		mapper.from(properties::getContentFieldName).whenHasText().to(weaviateVectorStoreOptions::setContentFieldName);
+		mapper.from(properties::getObjectClass).whenHasText().to(weaviateVectorStoreOptions::setObjectClass);
+
+		return weaviateVectorStoreOptions;
 	}
 
 	static class PropertiesWeaviateConnectionDetails implements WeaviateConnectionDetails {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for Weaviate Vector Store.
  *
  * @author Christian Tzolov
+ * @author Jonghoon Park
  */
 @ConfigurationProperties(WeaviateVectorStoreProperties.CONFIG_PREFIX)
 public class WeaviateVectorStoreProperties {
@@ -40,6 +41,8 @@ public class WeaviateVectorStoreProperties {
 	private String apiKey = "";
 
 	private String objectClass = "SpringAiWeaviate";
+
+	private String contentFieldName = "content";
 
 	private ConsistentLevel consistencyLevel = WeaviateVectorStore.ConsistentLevel.ONE;
 
@@ -76,6 +79,20 @@ public class WeaviateVectorStoreProperties {
 
 	public String getObjectClass() {
 		return this.objectClass;
+	}
+
+	/**
+	 * @since 1.1.0
+	 */
+	public String getContentFieldName() {
+		return contentFieldName;
+	}
+
+	/**
+	 * @since 1.1.0
+	 */
+	public void setContentFieldName(String contentFieldName) {
+		this.contentFieldName = contentFieldName;
 	}
 
 	public void setObjectClass(String indexName) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
 import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStore;
 import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStore.MetadataField;
+import org.springframework.ai.vectorstore.weaviate.WeaviateVectorStoreOptions;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -48,6 +49,7 @@ import static org.springframework.ai.test.vectorstore.ObservationTestUtil.assert
  * @author Eddú Meléndez
  * @author Soby Chacko
  * @author Thomas Vitale
+ * @author Jonghoon Park
  */
 @Testcontainers
 public class WeaviateVectorStoreAutoConfigurationIT {
@@ -172,6 +174,22 @@ public class WeaviateVectorStoreAutoConfigurationIT {
 			assertThat(context.getBeansOfType(VectorStore.class)).isNotEmpty();
 			assertThat(context.getBean(VectorStore.class)).isInstanceOf(WeaviateVectorStore.class);
 		});
+	}
+
+	@Test
+	public void testMappingPropertiesToOptions() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.vectorstore.weaviate.object-class=CustomObjectClass",
+					"spring.ai.vectorstore.weaviate.content-field-name=customContentFieldName")
+			.run(context -> {
+				WeaviateVectorStoreAutoConfiguration autoConfiguration = context
+					.getBean(WeaviateVectorStoreAutoConfiguration.class);
+				WeaviateVectorStoreProperties properties = context.getBean(WeaviateVectorStoreProperties.class);
+				WeaviateVectorStoreOptions options = autoConfiguration.mappingPropertiesToOptions(properties);
+
+				assertThat(options.getObjectClass()).isEqualTo("CustomObjectClass");
+				assertThat(options.getContentFieldName()).isEqualTo("customContentFieldName");
+			});
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
@@ -156,7 +156,7 @@ public WeaviateClient weaviateClient() {
 @Bean
 public VectorStore vectorStore(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
     return WeaviateVectorStore.builder(weaviateClient, embeddingModel)
-        .objectClass("CustomClass")                    // Optional: defaults to "SpringAiWeaviate"
+        .options(options)                              // Optional: use custom options
         .consistencyLevel(ConsistentLevel.QUORUM)      // Optional: defaults to ConsistentLevel.ONE
         .filterMetadataFields(List.of(                 // Optional: fields that can be used in filters
             MetadataField.text("country"),
@@ -261,10 +261,13 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.weaviate.host`|The host of the Weaviate server|localhost:8080
 |`spring.ai.vectorstore.weaviate.scheme`|Connection schema|http
 |`spring.ai.vectorstore.weaviate.api-key`|The API key for authentication|
-|`spring.ai.vectorstore.weaviate.object-class`|The class name for storing documents|SpringAiWeaviate
+|`spring.ai.vectorstore.weaviate.object-class`|The class name for storing documents. should|SpringAiWeaviate
+|`spring.ai.vectorstore.weaviate.content-field-name`|The field name for content|content
 |`spring.ai.vectorstore.weaviate.consistency-level`|Desired tradeoff between consistency and speed|ConsistentLevel.ONE
 |`spring.ai.vectorstore.weaviate.filter-field`|Configures metadata fields that can be used in filters. Format: spring.ai.vectorstore.weaviate.filter-field.<field-name>=<field-type>|
 |===
+
+TIP: Object class names should start with an uppercase letter, and field names should start with a lowercase letter. see link:https://weaviate.io/developers/weaviate/concepts/data#data-object-concepts[data-object-concepts]
 
 == Accessing the Native Client
 

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptions.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.weaviate;
+
+import org.springframework.util.Assert;
+
+/**
+ * Provided Weaviate vector option configuration.
+ *
+ * @author Jonghoon Park
+ * @since 1.1.0.
+ */
+public class WeaviateVectorStoreOptions {
+
+	private String objectClass = "SpringAiWeaviate";
+
+	private String contentFieldName = "content";
+
+	public String getObjectClass() {
+		return objectClass;
+	}
+
+	public void setObjectClass(String objectClass) {
+		Assert.hasText(objectClass, "objectClass cannot be null or empty");
+		this.objectClass = objectClass;
+	}
+
+	public String getContentFieldName() {
+		return contentFieldName;
+	}
+
+	public void setContentFieldName(String contentFieldName) {
+		Assert.hasText(contentFieldName, "contentFieldName cannot be null or empty");
+		this.contentFieldName = contentFieldName;
+	}
+
+}

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for {@link WeaviateVectorStore.Builder}.
  *
  * @author Mark Pollack
+ * @author Jonghoon Park
  */
 @ExtendWith(MockitoExtension.class)
 class WeaviateVectorStoreBuilderTests {
@@ -56,8 +57,12 @@ class WeaviateVectorStoreBuilderTests {
 	void shouldBuildWithCustomConfiguration() {
 		WeaviateClient weaviateClient = new WeaviateClient(new Config("http", "localhost:8080"));
 
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+		options.setObjectClass("CustomObjectClass");
+		options.setContentFieldName("customContentFieldName");
+
 		WeaviateVectorStore vectorStore = WeaviateVectorStore.builder(weaviateClient, this.embeddingModel)
-			.objectClass("CustomClass")
+			.options(options)
 			.consistencyLevel(ConsistentLevel.QUORUM)
 			.filterMetadataFields(List.of(MetadataField.text("country"), MetadataField.number("year")))
 			.build();
@@ -82,13 +87,12 @@ class WeaviateVectorStoreBuilderTests {
 	}
 
 	@Test
-	void shouldFailWithInvalidObjectClass() {
+	void shouldFailWithNullOptions() {
 		WeaviateClient weaviateClient = new WeaviateClient(new Config("http", "localhost:8080"));
 
-		assertThatThrownBy(
-				() -> WeaviateVectorStore.builder(weaviateClient, this.embeddingModel).objectClass("").build())
+		assertThatThrownBy(() -> WeaviateVectorStore.builder(weaviateClient, this.embeddingModel).options(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("objectClass must not be empty");
+			.hasMessage("options must not be empty");
 	}
 
 	@Test

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreIT.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreIT.java
@@ -47,6 +47,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.DefaultResourceLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Christian Tzolov
@@ -83,7 +86,16 @@ public class WeaviateVectorStoreIT extends BaseVectorStoreTests {
 	}
 
 	private void resetCollection(VectorStore vectorStore) {
+		initCollection(vectorStore);
 		vectorStore.delete(this.documents.stream().map(Document::getId).toList());
+	}
+
+	// This method is used to resolve errors that occur when it is executed independently
+	// without BaseVectorStoreTests.
+	private void initCollection(VectorStore vectorStore) {
+		List<Document> dummyDocuments = List.of(new Document("", Map.of("country", "", "year", 0)));
+		vectorStore.add(dummyDocuments);
+		vectorStore.delete(List.of(dummyDocuments.get(0).getId()));
 	}
 
 	@Override
@@ -136,6 +148,8 @@ public class WeaviateVectorStoreIT extends BaseVectorStoreTests {
 					Map.of("country", "NL"));
 			var bgDocument2 = new Document("The World is Big and Salvation Lurks Around the Corner",
 					Map.of("country", "BG", "year", 2023));
+
+			resetCollection(vectorStore);
 
 			vectorStore.add(List.of(bgDocument, nlDocument, bgDocument2));
 
@@ -274,15 +288,83 @@ public class WeaviateVectorStoreIT extends BaseVectorStoreTests {
 		});
 	}
 
+	@Test
+	public void addAndSearchWithCustomObjectClass() {
+
+		this.contextRunner.run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+			resetCollection(vectorStore);
+		});
+
+		this.contextRunner.run(context -> {
+			WeaviateClient weaviateClient = context.getBean(WeaviateClient.class);
+			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+
+			WeaviateVectorStoreOptions optionsWithCustomObjectClass = new WeaviateVectorStoreOptions();
+			optionsWithCustomObjectClass.setObjectClass("CustomObjectClass");
+
+			VectorStore customVectorStore = WeaviateVectorStore.builder(weaviateClient, embeddingModel)
+				.options(optionsWithCustomObjectClass)
+				.build();
+
+			resetCollection(customVectorStore);
+			customVectorStore.add(this.documents);
+
+			List<Document> results = customVectorStore
+				.similaritySearch(SearchRequest.builder().query("Spring").topK(1).build());
+			assertFalse(results.isEmpty());
+		});
+
+		this.contextRunner.run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+			List<Document> results = vectorStore
+				.similaritySearch(SearchRequest.builder().query("Spring").topK(1).build());
+			assertTrue(results.isEmpty());
+		});
+	}
+
+	@Test
+	public void addAndSearchWithCustomContentFieldName() {
+
+		WeaviateVectorStoreOptions optionsWithCustomContentFieldName = new WeaviateVectorStoreOptions();
+		optionsWithCustomContentFieldName.setContentFieldName("customContentFieldName");
+
+		this.contextRunner.run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+			resetCollection(vectorStore);
+		});
+
+		this.contextRunner.run(context -> {
+			WeaviateClient weaviateClient = context.getBean(WeaviateClient.class);
+			EmbeddingModel embeddingModel = context.getBean(EmbeddingModel.class);
+
+			VectorStore customVectorStore = WeaviateVectorStore.builder(weaviateClient, embeddingModel)
+				.options(optionsWithCustomContentFieldName)
+				.build();
+
+			customVectorStore.add(this.documents);
+
+			List<Document> results = customVectorStore
+				.similaritySearch(SearchRequest.builder().query("Spring").topK(1).build());
+			assertFalse(results.isEmpty());
+		});
+
+		this.contextRunner.run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			assertThatThrownBy(
+					() -> vectorStore.similaritySearch(SearchRequest.builder().query("Spring").topK(1).build()))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("exactly one of text or media must be specified");
+		});
+	}
+
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
 	public static class TestApplication {
 
 		@Bean
-		public VectorStore vectorStore(EmbeddingModel embeddingModel) {
-			WeaviateClient weaviateClient = new WeaviateClient(
-					new Config("http", weaviateContainer.getHttpHostAddress()));
-
+		public VectorStore vectorStore(WeaviateClient weaviateClient, EmbeddingModel embeddingModel) {
 			return WeaviateVectorStore.builder(weaviateClient, embeddingModel)
 				.filterMetadataFields(List.of(WeaviateVectorStore.MetadataField.text("country"),
 						WeaviateVectorStore.MetadataField.number("year")))
@@ -293,6 +375,11 @@ public class WeaviateVectorStoreIT extends BaseVectorStoreTests {
 		@Bean
 		public EmbeddingModel embeddingModel() {
 			return new TransformersEmbeddingModel();
+		}
+
+		@Bean
+		public WeaviateClient weaviateClient() {
+			return new WeaviateClient(new Config("http", weaviateContainer.getHttpHostAddress()));
 		}
 
 	}

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptionsTests.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptionsTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.weaviate;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link WeaviateVectorStoreOptions}.
+ *
+ * @author Jonghoon Park
+ */
+class WeaviateVectorStoreOptionsTests {
+
+	@Test
+	void shouldPassWithValidInputs() {
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+		options.setObjectClass("CustomObjectClass");
+		options.setContentFieldName("customContentFieldName");
+	}
+
+	@Test
+	void shouldFailWithNullObjectClass() {
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+
+		assertThatThrownBy(() -> options.setObjectClass(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("objectClass cannot be null or empty");
+	}
+
+	@Test
+	void shouldFailWithEmptyObjectClass() {
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+
+		assertThatThrownBy(() -> options.setObjectClass("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("objectClass cannot be null or empty");
+	}
+
+	@Test
+	void shouldFailWithNullContentFieldName() {
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+
+		assertThatThrownBy(() -> options.setContentFieldName(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("contentFieldName cannot be null or empty");
+	}
+
+	@Test
+	void shouldFailWithEmptyContentFieldName() {
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+
+		assertThatThrownBy(() -> options.setContentFieldName("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("contentFieldName cannot be null or empty");
+	}
+
+}


### PR DESCRIPTION
related issue: https://github.com/spring-projects/spring-ai/issues/3535

Currently, the content field in the Weaviate vector store cannot be modified.
This PR has been improved to make it configurable, and relevant tests have been added.

## changes
- Added a new property: `spring.ai.vectorstore.weaviate.content-field-name`