### PR TITLE
fixed #3559 Modify the DefaultToolCallResultConverter.convert method …

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverter.java
@@ -27,6 +27,7 @@ import javax.imageio.ImageIO;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
 
 import org.springframework.ai.util.json.JsonParser;
 import org.springframework.lang.Nullable;
@@ -47,6 +48,11 @@ public final class DefaultToolCallResultConverter implements ToolCallResultConve
 			logger.debug("The tool has no return type. Converting to conventional response.");
 			return JsonParser.toJson("Done");
 		}
+		// handle results of Mono type
+		if (result instanceof Mono<?>) {
+			result = ((Mono<?>) result).block();
+		}
+
 		if (result instanceof RenderedImage) {
 			final var buf = new ByteArrayOutputStream(1024 * 4);
 			try {


### PR DESCRIPTION
…and add the Mono processing code

Especially for MCP asynchronous servers, this bug is fatal, request merge.