### PR TITLE
Fix exception in `OpenAiAudioTranscriptionResponseMetadata.toString`

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/audio/OpenAiAudioTranscriptionResponseMetadata.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/metadata/audio/OpenAiAudioTranscriptionResponseMetadata.java
@@ -38,7 +38,7 @@ public class OpenAiAudioTranscriptionResponseMetadata extends AudioTranscription
 
 	};
 
-	protected static final String AI_METADATA_STRING = "{ @type: %1$s, rateLimit: %4$s }";
+	protected static final String AI_METADATA_STRING = "{ @type: %1$s, rateLimit: %2$s }";
 
 	@Nullable
 	private RateLimit rateLimit;


### PR DESCRIPTION
The current situation is that calling the `toString` method of `OpenAiAudioTranscriptionResponseMetadata` will throw this exception.

<img width="927" alt="image" src="https://github.com/user-attachments/assets/2f6b6aca-aa13-4b1b-968c-a0263b03589a" />