### PR TITLE
Fixed GH-3577, Fixed the error in the `PgVectorFilterExpressionConverter` when parsing expressions.

### DIFF
--- a/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-pgvector-store/src/test/java/org/springframework/ai/vectorstore/pgvector/PgVectorFilterExpressionConverterTests.java
@@ -119,4 +119,16 @@ public class PgVectorFilterExpressionConverterTests {
 		assertThat(vectorExpr).isEqualTo("$.\"country 1 2 3\" == \"BG\"");
 	}
 
+	@Test
+	public void testAndAndOrNesting() {
+		Expression eq1 = new Expression(EQ, new Key("id"), new Value("1"));
+		Expression eq2 = new Expression(EQ, new Key("id"), new Value("2"));
+		Expression eqTom = new Expression(EQ, new Key("name"), new Value("tom"));
+		Expression or = new Expression(OR, eq1, eq2);
+		Expression and = new Expression(AND, or, eqTom);
+
+		String vectorExpr = this.converter.convertExpression(and);
+		assertThat(vectorExpr).isEqualTo("(($.id == \"1\" || $.id == \"2\") && $.name == \"tom\")");
+	}
+
 }


### PR DESCRIPTION
As mentioned in the issue, the `PgVectorFilterExpressionConverter` had an operator precedence problem when processing nested `And` and `Or` expressions due to missing parentheses. 

This PR fixes that issue by making the following two adjustments:  

1. Modified the `PgVectorFilterExpressionConverter` to add parentheses when handling `And` and `Or` operators.  
2. Added corresponding unit tests.

Fixed #3577 