### PR TITLE
Fix Test Failure in ChromaVectorStoreAutoConfigurationIT

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/src/test/java/org/springframework/ai/vectorstore/chroma/autoconfigure/ChromaVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/src/test/java/org/springframework/ai/vectorstore/chroma/autoconfigure/ChromaVectorStoreAutoConfigurationIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import static org.springframework.ai.test.vectorstore.ObservationTestUtil.assert
  * @author Eddú Meléndez
  * @author Soby Chacko
  * @author Thomas Vitale
+ * @author Jonghoon Park
  */
 @Testcontainers
 public class ChromaVectorStoreAutoConfigurationIT {
@@ -182,7 +183,7 @@ public class ChromaVectorStoreAutoConfigurationIT {
 				.hasCauseInstanceOf(BeanCreationException.class)
 				.hasRootCauseExactlyInstanceOf(RuntimeException.class)
 				.hasRootCauseMessage(
-						"Collection TestCollection doesn't exist and won't be created as the initializeSchema is set to false."));
+						"Collection TestCollection with the tenant: SpringAiTenant and the database: SpringAiDatabase doesn't exist and won't be created as the initializeSchema is set to false."));
 	}
 
 	@Test


### PR DESCRIPTION
[A recent merged commit](https://github.com/dev-jonghoonpark/spring-ai-forked/commit/0d8eebdf4e10fb3b4b4aa8556b7f410ed07d2a24#diff-a3807dba2d7686519953f21c1cccf1f49572e8fcd2f3d66810d93b5198e7f668) updated the exception message, causing the ChromaVectorStoreAutoConfigurationIT test to fail during the `CI/CD build` process.
This PR resolves the issue.

related action logs
- https://github.com/spring-projects/spring-ai/actions/runs/15720273878/job/44299605016
- https://github.com/spring-projects/spring-ai/actions/runs/15719638256/job/44297754454
- https://github.com/spring-projects/spring-ai/actions/runs/15719286848/job/44296683957
- https://github.com/spring-projects/spring-ai/actions/runs/15719202946/job/44296425830
- ...
