### PR TITLE
chore: Fix order of getter and setter methods in `WeaviateVectorStoreProperties`

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
@@ -81,6 +81,10 @@ public class WeaviateVectorStoreProperties {
 		return this.objectClass;
 	}
 
+	public void setObjectClass(String indexName) {
+		this.objectClass = indexName;
+	}
+
 	/**
 	 * @since 1.1.0
 	 */
@@ -93,10 +97,6 @@ public class WeaviateVectorStoreProperties {
 	 */
 	public void setContentFieldName(String contentFieldName) {
 		this.contentFieldName = contentFieldName;
-	}
-
-	public void setObjectClass(String indexName) {
-		this.objectClass = indexName;
 	}
 
 	public ConsistentLevel getConsistencyLevel() {


### PR DESCRIPTION
Fix order of getter and setter methods in `WeaviateVectorStoreProperties`

related pr: https://github.com/spring-projects/spring-ai/pull/3555

I apologize for the mistake.
I mistakenly placed the getContentFieldName and setContentFieldName methods between the getter and setter for objectClass. I've corrected the order to align with the conventional grouping of getter and setter methods for the same property.

## current 

```java
	public String getObjectClass() {
		return this.objectClass;
	}

	/**
	 * @since 1.1.0
	 */
	public String getContentFieldName() {
		return contentFieldName;
	}

	/**
	 * @since 1.1.0
	 */
	public void setContentFieldName(String contentFieldName) {
		this.contentFieldName = contentFieldName;
	}

	public void setObjectClass(String indexName) {
		this.objectClass = indexName;
	}
```

## changed

```java
	public String getObjectClass() {
		return this.objectClass;
	}
	
	public void setObjectClass(String indexName) {
		this.objectClass = indexName;
	}

	/**
	 * @since 1.1.0
	 */
	public String getContentFieldName() {
		return contentFieldName;
	}

	/**
	 * @since 1.1.0
	 */
	public void setContentFieldName(String contentFieldName) {
		this.contentFieldName = contentFieldName;
	}
```