### PR TITLE
Make the `meta field prefix` configurable in Weaviate vector store properties

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
@@ -105,6 +105,7 @@ public class WeaviateVectorStoreAutoConfiguration {
 		PropertyMapper mapper = PropertyMapper.get();
 		mapper.from(properties::getContentFieldName).whenHasText().to(weaviateVectorStoreOptions::setContentFieldName);
 		mapper.from(properties::getObjectClass).whenHasText().to(weaviateVectorStoreOptions::setObjectClass);
+		mapper.from(properties::getMetaFieldPrefix).whenHasText().to(weaviateVectorStoreOptions::setMetaFieldPrefix);
 
 		return weaviateVectorStoreOptions;
 	}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreProperties.java
@@ -44,6 +44,8 @@ public class WeaviateVectorStoreProperties {
 
 	private String contentFieldName = "content";
 
+	private String metaFieldPrefix = "meta_";
+
 	private ConsistentLevel consistencyLevel = WeaviateVectorStore.ConsistentLevel.ONE;
 
 	/**
@@ -97,6 +99,20 @@ public class WeaviateVectorStoreProperties {
 	 */
 	public void setContentFieldName(String contentFieldName) {
 		this.contentFieldName = contentFieldName;
+	}
+
+	/**
+	 * @since 1.1.0
+	 */
+	public String getMetaFieldPrefix() {
+		return metaFieldPrefix;
+	}
+
+	/**
+	 * @since 1.1.0
+	 */
+	public void setMetaFieldPrefix(String metaFieldPrefix) {
+		this.metaFieldPrefix = metaFieldPrefix;
 	}
 
 	public ConsistentLevel getConsistencyLevel() {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfigurationIT.java
@@ -180,7 +180,8 @@ public class WeaviateVectorStoreAutoConfigurationIT {
 	public void testMappingPropertiesToOptions() {
 		this.contextRunner
 			.withPropertyValues("spring.ai.vectorstore.weaviate.object-class=CustomObjectClass",
-					"spring.ai.vectorstore.weaviate.content-field-name=customContentFieldName")
+					"spring.ai.vectorstore.weaviate.content-field-name=customContentFieldName",
+					"spring.ai.vectorstore.weaviate.meta-field-prefix=custom_")
 			.run(context -> {
 				WeaviateVectorStoreAutoConfiguration autoConfiguration = context
 					.getBean(WeaviateVectorStoreAutoConfiguration.class);
@@ -189,6 +190,7 @@ public class WeaviateVectorStoreAutoConfigurationIT {
 
 				assertThat(options.getObjectClass()).isEqualTo("CustomObjectClass");
 				assertThat(options.getContentFieldName()).isEqualTo("customContentFieldName");
+				assertThat(options.getMetaFieldPrefix()).isEqualTo("custom_");
 			});
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc
@@ -264,6 +264,7 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.weaviate.api-key`|The API key for authentication|
 |`spring.ai.vectorstore.weaviate.object-class`|The class name for storing documents. |SpringAiWeaviate
 |`spring.ai.vectorstore.weaviate.content-field-name`|The field name for content|content
+|`spring.ai.vectorstore.weaviate.meta-field-prefix`|The field prefix for metadata|meta_
 |`spring.ai.vectorstore.weaviate.consistency-level`|Desired tradeoff between consistency and speed|ConsistentLevel.ONE
 |`spring.ai.vectorstore.weaviate.filter-field`|Configures metadata fields that can be used in filters. Format: spring.ai.vectorstore.weaviate.filter-field.<field-name>=<field-type>|
 |===

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateFilterExpressionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,19 +35,42 @@ import org.springframework.util.Assert;
  * (https://weaviate.io/developers/weaviate/api/graphql/filters)
  *
  * @author Christian Tzolov
+ * @author Jonghoon Park
  */
 public class WeaviateFilterExpressionConverter extends AbstractFilterExpressionConverter {
 
 	// https://weaviate.io/developers/weaviate/api/graphql/filters#special-cases
 	private static final List<String> SYSTEM_IDENTIFIERS = List.of("id", "_creationTimeUnix", "_lastUpdateTimeUnix");
 
+	private static final String DEFAULT_META_FIELD_PREFIX = "meta_";
+
 	private boolean mapIntegerToNumberValue = true;
 
 	private List<String> allowedIdentifierNames;
 
+	private final String metaFieldPrefix;
+
+	/**
+	 * Constructs a new instance of the {@code WeaviateFilterExpressionConverter} class.
+	 * This constructor uses the default meta field prefix
+	 * ({@link #DEFAULT_META_FIELD_PREFIX}).
+	 * @param allowedIdentifierNames A {@code List} of allowed identifier names.
+	 */
 	public WeaviateFilterExpressionConverter(List<String> allowedIdentifierNames) {
+		this(allowedIdentifierNames, DEFAULT_META_FIELD_PREFIX);
+	}
+
+	/**
+	 * Constructs a new instance of the {@code WeaviateFilterExpressionConverter} class.
+	 * @param allowedIdentifierNames A {@code List} of allowed identifier names.
+	 * @param metaFieldPrefix the prefix for meta fields
+	 * @since 1.1.0
+	 */
+	public WeaviateFilterExpressionConverter(List<String> allowedIdentifierNames, String metaFieldPrefix) {
 		Assert.notNull(allowedIdentifierNames, "List can be empty but not null.");
+		Assert.notNull(metaFieldPrefix, "metaFieldPrefix can be empty but not null.");
 		this.allowedIdentifierNames = allowedIdentifierNames;
+		this.metaFieldPrefix = metaFieldPrefix;
 	}
 
 	public void setAllowedIdentifierNames(List<String> allowedIdentifierNames) {
@@ -112,7 +135,7 @@ public class WeaviateFilterExpressionConverter extends AbstractFilterExpressionC
 		}
 
 		if (this.allowedIdentifierNames.contains(identifier)) {
-			return "meta_" + identifier;
+			return this.metaFieldPrefix + identifier;
 		}
 
 		throw new IllegalArgumentException("Not allowed filter identifier name: " + identifier

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
@@ -96,8 +96,6 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 
 	private static final Logger logger = LoggerFactory.getLogger(WeaviateVectorStore.class);
 
-	private static final String METADATA_FIELD_PREFIX = "meta_";
-
 	private static final String METADATA_FIELD_NAME = "metadata";
 
 	private static final String ADDITIONAL_FIELD_NAME = "_additional";
@@ -162,7 +160,8 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		this.consistencyLevel = builder.consistencyLevel;
 		this.filterMetadataFields = builder.filterMetadataFields;
 		this.filterExpressionConverter = new WeaviateFilterExpressionConverter(
-				this.filterMetadataFields.stream().map(MetadataField::name).toList());
+				this.filterMetadataFields.stream().map(MetadataField::name).toList(),
+				this.options.getMetaFieldPrefix());
 		this.weaviateSimilaritySearchFields = buildWeaviateSimilaritySearchFields();
 	}
 
@@ -182,7 +181,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		searchWeaviateFieldList.add(Field.builder().name(this.options.getContentFieldName()).build());
 		searchWeaviateFieldList.add(Field.builder().name(METADATA_FIELD_NAME).build());
 		searchWeaviateFieldList.addAll(this.filterMetadataFields.stream()
-			.map(mf -> Field.builder().name(METADATA_FIELD_PREFIX + mf.name()).build())
+			.map(mf -> Field.builder().name(this.options.getMetaFieldPrefix() + mf.name()).build())
 			.toList());
 		searchWeaviateFieldList.add(Field.builder()
 			.name(ADDITIONAL_FIELD_NAME)
@@ -260,7 +259,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 		// expressions on them.
 		for (MetadataField mf : this.filterMetadataFields) {
 			if (document.getMetadata().containsKey(mf.name())) {
-				fields.put(METADATA_FIELD_PREFIX + mf.name(), document.getMetadata().get(mf.name()));
+				fields.put(this.options.getMetaFieldPrefix() + mf.name(), document.getMetadata().get(mf.name()));
 			}
 		}
 

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptions.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptions.java
@@ -22,13 +22,15 @@ import org.springframework.util.Assert;
  * Provided Weaviate vector option configuration.
  *
  * @author Jonghoon Park
- * @since 1.1.0.
+ * @since 1.1.0
  */
 public class WeaviateVectorStoreOptions {
 
 	private String objectClass = "SpringAiWeaviate";
 
 	private String contentFieldName = "content";
+
+	private String metaFieldPrefix = "meta_";
 
 	public String getObjectClass() {
 		return objectClass;
@@ -46,6 +48,15 @@ public class WeaviateVectorStoreOptions {
 	public void setContentFieldName(String contentFieldName) {
 		Assert.hasText(contentFieldName, "contentFieldName cannot be null or empty");
 		this.contentFieldName = contentFieldName;
+	}
+
+	public String getMetaFieldPrefix() {
+		return metaFieldPrefix;
+	}
+
+	public void setMetaFieldPrefix(String metaFieldPrefix) {
+		Assert.notNull(metaFieldPrefix, "metaFieldPrefix can be empty but not null");
+		this.metaFieldPrefix = metaFieldPrefix;
 	}
 
 }

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreBuilderTests.java
@@ -60,6 +60,7 @@ class WeaviateVectorStoreBuilderTests {
 		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
 		options.setObjectClass("CustomObjectClass");
 		options.setContentFieldName("customContentFieldName");
+		options.setMetaFieldPrefix("custom_");
 
 		WeaviateVectorStore vectorStore = WeaviateVectorStore.builder(weaviateClient, this.embeddingModel)
 			.options(options)

--- a/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptionsTests.java
+++ b/vector-stores/spring-ai-weaviate-store/src/test/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStoreOptionsTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.vectorstore.weaviate;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -64,6 +65,21 @@ class WeaviateVectorStoreOptionsTests {
 
 		assertThatThrownBy(() -> options.setContentFieldName("")).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("contentFieldName cannot be null or empty");
+	}
+
+	@Test
+	void shouldFailWithNullMetaFieldPrefix() {
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+
+		assertThatThrownBy(() -> options.setMetaFieldPrefix(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metaFieldPrefix can be empty but not null");
+	}
+
+	@Test
+	void shouldPassWithEmptyMetaFieldPrefix() {
+		WeaviateVectorStoreOptions options = new WeaviateVectorStoreOptions();
+		options.setMetaFieldPrefix("");
+		assertThat(options.getMetaFieldPrefix()).isEqualTo("");
 	}
 
 }


### PR DESCRIPTION
related issue: https://github.com/spring-projects/spring-ai/issues/3535

Currently, the `meta field prefix` in the Weaviate vector store cannot be modified.
This PR has been improved to make it configurable, and relevant tests have been added.

## changes
- Added a new property: `spring.ai.vectorstore.weaviate.meta-field-prefix`
  - Note: Whitespace is also allowed in this property.
