### PR TITLE
Fixed GH-3604, Add `STErrorListener` to `StTemplateRenderer`.

### DIFF
--- a/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderErrorListener.java
+++ b/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderErrorListener.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.template.st;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.stringtemplate.v4.STErrorListener;
+import org.stringtemplate.v4.misc.ErrorType;
+import org.stringtemplate.v4.misc.STMessage;
+
+/**
+ * An ErrorListener for the {@link StTemplateRenderer} rendering exceptions.
+ * <p>
+ * By default, StringTemplate uses
+ * {@link org.stringtemplate.v4.misc.ErrorManager#DEFAULT_ERROR_LISTENER} as the exception
+ * handler, which outputs exceptions via System.err.println. This can lead to a loss of
+ * detailed exception logs from the user's perspective. The current ErrorListener retains
+ * the behavior of the default handler but additionally outputs the exceptions through
+ * logging mechanisms.
+ * </p>
+ *
+ * @author Sun Yuhan
+ */
+public class StTemplateRenderErrorListener implements STErrorListener {
+
+	private final Logger logger = LoggerFactory.getLogger(StTemplateRenderErrorListener.class);
+
+	@Override
+	public void compileTimeError(STMessage msg) {
+		logger.error(msg.toString());
+	}
+
+	@Override
+	public void runTimeError(STMessage msg) {
+		if (msg.error != ErrorType.NO_SUCH_PROPERTY) { // ignore these
+			logger.error(msg.toString());
+		}
+	}
+
+	@Override
+	public void IOError(STMessage msg) {
+		logger.error(msg.toString());
+	}
+
+	@Override
+	public void internalError(STMessage msg) {
+		logger.error(msg.toString());
+	}
+
+}

--- a/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
+++ b/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
@@ -25,6 +25,7 @@ import org.antlr.runtime.TokenStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.STGroup;
 import org.stringtemplate.v4.compiler.Compiler;
 import org.stringtemplate.v4.compiler.STLexer;
 
@@ -49,6 +50,7 @@ import org.springframework.util.Assert;
  * is shared between threads.
  *
  * @author Thomas Vitale
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public class StTemplateRenderer implements TemplateRenderer {
@@ -112,7 +114,9 @@ public class StTemplateRenderer implements TemplateRenderer {
 
 	private ST createST(String template) {
 		try {
-			return new ST(template, this.startDelimiterToken, this.endDelimiterToken);
+			STGroup group = new STGroup(this.startDelimiterToken, this.endDelimiterToken);
+			group.setListener(new StTemplateRenderErrorListener());
+			return new ST(group, template);
 		}
 		catch (Exception ex) {
 			throw new IllegalArgumentException("The template string is not valid.", ex);


### PR DESCRIPTION
As mentioned in the issue, `StTemplateRenderer` uses `StringTemplate` as the template rendering engine. 

By default, `StringTemplate` use `org.stringtemplate.v4.misc.ErrorManager#DEFAULT_ERROR_LISTENER` as the error listener for rendering exceptions, which outputs errors using `System.err.println`. 

```
public static STErrorListener DEFAULT_ERROR_LISTENER = new STErrorListener() {
        public void compileTimeError(STMessage msg) {
            System.err.println(msg);
        }

        public void runTimeError(STMessage msg) {
            if (msg.error != ErrorType.NO_SUCH_PROPERTY) {
                System.err.println(msg);
            }

        }

        public void IOError(STMessage msg) {
            System.err.println(msg);
        }

        public void internalError(STMessage msg) {
            System.err.println(msg);
        }

        public void error(String s) {
            this.error(s, (Throwable)null);
        }

        public void error(String s, Throwable e) {
            System.err.println(s);
            if (e != null) {
                e.printStackTrace(System.err);
            }

        }
}
```

This can lead to users losing important information about rendering errors. 

This PR introduces a custom `STErrorListener` that logs the exceptions to the application's logging system instead.