### PR TITLE
add a verification when using tools

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
@@ -110,7 +110,7 @@ public class OpenAiStreamFunctionCallingHelper {
 				toolCalls.addAll(previous.toolCalls().subList(0, previous.toolCalls().size() - 1));
 			}
 		}
-		if (current.toolCalls() != null) {
+		if (current.toolCalls() != null && current.toolCalls().size() > 0) {
 			if (current.toolCalls().size() > 1) {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}


### PR DESCRIPTION
When deploying qwen3 using vllm version 0.9.1, the ‘current. toolCalls()’ will result in an empty array. If only verifying whether it is null, an exception will be thrown

