### PR TITLE
fix(elevenlabs): correct autoconfiguration class name and add ElevenLabs speech doc link

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.springframework.ai.model.elevenlabs.autoconfigure.elevenlabsChatAutoConfiguration
+org.springframework.ai.model.elevenlabs.autoconfigure.ElevenLabsAutoConfiguration

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -65,6 +65,7 @@
 ***** xref:api/audio/transcriptions/openai-transcriptions.adoc[OpenAI]
 **** xref:api/audio/speech.adoc[]
 ***** xref:api/audio/speech/openai-speech.adoc[OpenAI]
+***** xref:api/audio/speech/elevenlabs-speech.adoc[ElevenLabs]
 
 *** xref:api/moderation[Moderation Models]
 **** xref:api/moderation/openai-moderation.adoc[OpenAI]


### PR DESCRIPTION
This commit updates the ElevenLabs autoconfiguration import to use the correct class name and adds a navigation link for ElevenLabs speech documentation.