### PR TITLE
chore: Remove unnecessary environment variable validation in `QdrantVectorStoreIT`

### DIFF
--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
@@ -58,11 +58,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eddú Meléndez
  * @author Thomas Vitale
  * @author Soby Chacko
+ * @author Jonghoon Park
  * @since 0.8.1
  */
 @Testcontainers
-@EnabledIfEnvironmentVariables({ @EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+"),
-		@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+") })
+@EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
 public class QdrantVectorStoreIT extends BaseVectorStoreTests {
 
 	private static final String COLLECTION_NAME = "test_collection";
@@ -73,8 +73,7 @@ public class QdrantVectorStoreIT extends BaseVectorStoreTests {
 	static QdrantContainer qdrantContainer = new QdrantContainer(QdrantImage.DEFAULT_IMAGE);
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withUserConfiguration(TestApplication.class)
-		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"));
+		.withUserConfiguration(TestApplication.class);
 
 	List<Document> documents = List.of(
 			new Document("Spring AI rocks!! Spring AI rocks!! Spring AI rocks!! Spring AI rocks!! Spring AI rocks!!",


### PR DESCRIPTION
With the changes made in https://github.com/spring-projects/spring-ai/pull/1262,
`QdrantVectorStoreIT` no longer uses `OpenAI` in its tests.
However, when creating the ApplicationContextRunner, it still requires the `OPENAI_API_KEY`.

Following that, in https://github.com/spring-projects/spring-ai/pull/1612,
a validation for the `OPENAI_API_KEY` environment variable was added to `QdrantVectorStoreIT`.

This PR removes those parts accordingly.