### PR TITLE
fix(bedrock): Handle streaming tool calling with no input arguments

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -421,8 +421,7 @@ public final class ConverseApiUtils {
 		}
 
 		public boolean isEmpty() {
-			return (this.index == null || this.id == null || this.name == null
-					|| !StringUtils.hasText(this.partialJson));
+			return (this.index == null || this.id == null || this.name == null || this.partialJson == null);
 		}
 
 		ToolUseAggregationEvent withIndex(Integer index) {
@@ -451,7 +450,9 @@ public final class ConverseApiUtils {
 		}
 
 		void squashIntoContentBlock() {
-			this.toolUseEntries.add(new ToolUseEntry(this.index, this.id, this.name, this.partialJson, this.usage));
+			// Workaround to handle streaming tool calling with no input arguments.
+			String json = StringUtils.hasText(this.partialJson) ? this.partialJson : "{}";
+			this.toolUseEntries.add(new ToolUseEntry(this.index, this.id, this.name, json, this.usage));
 			this.index = null;
 			this.id = null;
 			this.name = null;

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
@@ -212,28 +212,6 @@ public class BedrockNovaChatClientIT {
 		assertThat(content).contains("20 degrees");
 	}
 
-	@Test
-	void streamingToolCallingWithArgumentlessToolSonnet() {
-
-		ChatClient chatClient = ChatClient.builder(this.chatModel).build();
-
-		Flux<ChatResponse> responses = chatClient.prompt()
-			.tools(new DummyWeatherForecastTools())
-			.options(ToolCallingChatOptions.builder().model("us.anthropic.claude-3-7-sonnet-20250219-v1:0").build())
-			.user("Get current weather in Amsterdam")
-			.stream()
-			.chatResponse();
-
-		String content = responses.collectList()
-			.block()
-			.stream()
-			.filter(cr -> cr.getResult() != null)
-			.map(cr -> cr.getResult().getOutput().getText())
-			.collect(Collectors.joining());
-
-		assertThat(content).contains("20 degrees");
-	}
-
 	// https://github.com/spring-projects/spring-ai/issues/1878
 	@Test
 	void supplierBasedToolCalling() {

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
@@ -23,6 +23,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -186,13 +188,38 @@ public class BedrockNovaChatClientIT {
 		assertThat(response).contains("20 degrees");
 	}
 
+	// https://github.com/spring-projects/spring-ai/issues/1878
+	@ParameterizedTest
+	@ValueSource(strings = { "amazon.nova-pro-v1:0", "us.anthropic.claude-3-7-sonnet-20250219-v1:0" })
+	void toolAnnotationWeatherForecastStreaming(String modelName) {
+
+		ChatClient chatClient = ChatClient.builder(this.chatModel).build();
+
+		Flux<ChatResponse> responses = chatClient.prompt()
+			.options(ToolCallingChatOptions.builder().model(modelName).build())
+			.tools(new DummyWeatherForecastTools())
+			.user("Get current weather in Amsterdam")
+			.stream()
+			.chatResponse();
+
+		String content = responses.collectList()
+			.block()
+			.stream()
+			.filter(cr -> cr.getResult() != null)
+			.map(cr -> cr.getResult().getOutput().getText())
+			.collect(Collectors.joining());
+
+		assertThat(content).contains("20 degrees");
+	}
+
 	@Test
-	void toolAnnotationWeatherForecastStreaming() {
+	void streamingToolCallingWithArgumentlessToolSonnet() {
 
 		ChatClient chatClient = ChatClient.builder(this.chatModel).build();
 
 		Flux<ChatResponse> responses = chatClient.prompt()
 			.tools(new DummyWeatherForecastTools())
+			.options(ToolCallingChatOptions.builder().model("us.anthropic.claude-3-7-sonnet-20250219-v1:0").build())
 			.user("Get current weather in Amsterdam")
 			.stream()
 			.chatResponse();
@@ -257,6 +284,7 @@ public class BedrockNovaChatClientIT {
 		public BedrockProxyChatModel bedrockConverseChatModel() {
 
 			String modelId = "amazon.nova-pro-v1:0";
+			// String modelId = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
 
 			return BedrockProxyChatModel.builder()
 				.credentialsProvider(EnvironmentVariableCredentialsProvider.create())

--- a/pom.xml
+++ b/pom.xml
@@ -264,8 +264,8 @@
 		<kotlin.version>1.9.25</kotlin.version>
 
 		<!-- NOTE: keep bedrockruntime and awssdk versions aligned -->
-		<bedrockruntime.version>2.31.26</bedrockruntime.version>
-		<awssdk.version>2.29.29</awssdk.version>
+		<bedrockruntime.version>2.31.65</bedrockruntime.version>
+		<awssdk.version>2.31.65</awssdk.version>
 
 		<djl.version>0.32.0</djl.version>
 		<onnxruntime.version>1.19.2</onnxruntime.version>


### PR DESCRIPTION
- Fix isEmpty() check in ConverseApiUtils to properly handle null partialJson
- Add workaround for streaming tool calls with empty arguments by defaulting to {}
- Add parameterized tests for multiple Bedrock models (Nova Pro and Claude Sonnet)
- Update AWS SDK and Bedrock runtime versions to 2.31.65

Fixes #1878
