### PR TITLE
Remove hardcoded topK in BedrockConverseProxyChatProperties

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
@@ -33,11 +33,7 @@ public class BedrockConverseProxyChatProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.bedrock.converse.chat";
 
 	@NestedConfigurationProperty
-	private ToolCallingChatOptions options = ToolCallingChatOptions.builder()
-		.temperature(0.7)
-		.maxTokens(300)
-		.topK(10)
-		.build();
+	private ToolCallingChatOptions options = ToolCallingChatOptions.builder().temperature(0.7).maxTokens(300).build();
 
 	public ToolCallingChatOptions getOptions() {
 		return this.options;


### PR DESCRIPTION
Bedrock does not support topK and setting it via BedrockConverseProxyChatProperties does not have any effect.

