### PR TITLE
docs: correct `SimpleLoggerAdvisor` documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -593,8 +593,9 @@ You can customize what data from `AdvisedRequest` and `ChatResponse` is logged b
 [source,java]
 ----
 SimpleLoggerAdvisor(
-    Function<AdvisedRequest, String> requestToString,
-    Function<ChatResponse, String> responseToString
+    Function<ChatClientRequest, String> requestToString,
+    Function<ChatResponse, String> responseToString,
+    int order
 )
 ----
 
@@ -603,8 +604,9 @@ Example usage:
 [source,java]
 ----
 SimpleLoggerAdvisor customLogger = new SimpleLoggerAdvisor(
-    request -> "Custom request: " + request.userText,
-    response -> "Custom response: " + response.getResult()
+    request -> "Custom request: " + request.prompt().getUserMessage(),
+    response -> "Custom response: " + response.getResult(),
+    0
 );
 ----
 


### PR DESCRIPTION
## Issue

In https://docs.spring.io/spring-ai/reference/api/chatclient.html,
The `SimpleLoggerAdvisor` class documentation incorrectly shows a constructor signature:

```java
SimpleLoggerAdvisor(
    Function<AdvisedRequest, String> requestToString,
    Function<ChatResponse, String> responseToString
)
```
However, the actual constructor includes an additional parameter, `int order`.

Additionally, the `AdvisedRequest` class does not include a variable named `userText`.

## Correction
Update the documentation to reflect the correct constructor:

```java
SimpleLoggerAdvisor(
    Function<AdvisedRequest, String> requestToString,
    Function<ChatResponse, String> responseToString,
    int order
)
```

And Update the example to replace the incorrect `userText` reference with `request.prompt().getUserMessage()`