### PR TITLE
fix: GH-3646 Added a license header for `FileDocumentWriterTest`

### DIFF
--- a/spring-ai-commons/src/test/java/org/springframework/ai/writer/FileDocumentWriterTest.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/writer/FileDocumentWriterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.writer;
 
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
Added a license header for `FileDocumentWriterTest`