### PR TITLE
fix: Correct naming inconsistencies in Mistral package

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -99,7 +99,7 @@ public class MistralAiChatModel implements ChatModel {
 	private final MistralAiChatOptions defaultOptions;
 
 	/**
-	 * Low-level access to the OpenAI API.
+	 * Low-level access to the Mistral API.
 	 */
 	private final MistralAiApi mistralAiApi;
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
@@ -102,10 +102,10 @@ public class MistralAiModerationModel implements ModerationModel {
 	}
 
 	private ModerationResponse convertResponse(ResponseEntity<MistralAiModerationResponse> moderationResponseEntity,
-			MistralAiModerationRequest openAiModerationRequest) {
+			MistralAiModerationRequest mistralAiModerationRequest) {
 		var moderationApiResponse = moderationResponseEntity.getBody();
 		if (moderationApiResponse == null) {
-			logger.warn("No moderation response returned for request: {}", openAiModerationRequest);
+			logger.warn("No moderation response returned for request: {}", mistralAiModerationRequest);
 			return new ModerationResponse(new Generation());
 		}
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelObservationIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelObservationIT.java
@@ -184,7 +184,7 @@ public class MistralAiChatModelObservationIT {
 		}
 
 		@Bean
-		public MistralAiChatModel openAiChatModel(MistralAiApi mistralAiApi,
+		public MistralAiChatModel mistralAiChatModel(MistralAiApi mistralAiApi,
 				TestObservationRegistry observationRegistry) {
 			return MistralAiChatModel.builder()
 				.mistralAiApi(mistralAiApi)

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiEmbeddingModelObservationIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiEmbeddingModelObservationIT.java
@@ -105,7 +105,7 @@ public class MistralAiEmbeddingModelObservationIT {
 		}
 
 		@Bean
-		public MistralAiEmbeddingModel openAiEmbeddingModel(MistralAiApi mistralAiApi,
+		public MistralAiEmbeddingModel mistralAiEmbeddingModel(MistralAiApi mistralAiApi,
 				TestObservationRegistry observationRegistry) {
 			return new MistralAiEmbeddingModel(mistralAiApi, MetadataMode.EMBED,
 					MistralAiEmbeddingOptions.builder().build(), RetryTemplate.defaultInstance(), observationRegistry);


### PR DESCRIPTION
Replaced incorrect references to 'OpenAI' with 'Mistral' in the Mistral package.
