### PR TITLE
Fix NPE for media-only Document in QdrantVectorStore (GH-3609)

### DIFF
--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -296,6 +296,13 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 	 */
 	private Map<String, Value> toPayload(Document document) {
 		try {
+			if(!document.isText()) {
+				throw new IllegalArgumentException("""
+						QdrantVectorStore supports only text-based Document for now –
+						received media-only Document; see issue #3609.
+						""");
+			}
+
 			var payload = QdrantValueFactory.toValueMap(document.getMetadata());
 			payload.put(CONTENT_FIELD_NAME, io.qdrant.client.ValueFactory.value(document.getText()));
 			return payload;


### PR DESCRIPTION
### Problem
Storing a Document that contains only media currently results in a NPE because
`ValueFactory.value(null)` is invoked.

### Solution
* Check `document.isText()`.  
* If false, throw an `IllegalArgumentException` with a clear message.

### Issue
Closes #3609 