### PR TITLE
chore: fix `SimpleApiKey` assert message

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/SimpleApiKey.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/SimpleApiKey.java
@@ -31,11 +31,11 @@ public record SimpleApiKey(String value) implements ApiKey {
 
 	/**
 	 * Create a new SimpleApiKey.
-	 * @param value the API key value, must not be null or empty
-	 * @throws IllegalArgumentException if value is null or empty
+	 * @param value the API key value, must not be null
+	 * @throws IllegalArgumentException if value is null
 	 */
 	public SimpleApiKey(String value) {
-		Assert.notNull(value, "API key value must not be null or empty");
+		Assert.notNull(value, "API key value must not be null");
 		this.value = value;
 	}
 


### PR DESCRIPTION
After https://github.com/spring-projects/spring-ai/pull/2084, https://github.com/spring-projects/spring-ai/commit/e92616b10e36f438bfc4def8c54945ba97f931f8

`SimpleApiKey` no longer checks for empty strings.
Therefore, the corresponding message has been removed.