### PR TITLE
Use OkHttpClient for AzureOpenAiAudioTranscriptionModelIT

### DIFF
--- a/models/spring-ai-azure-openai/pom.xml
+++ b/models/spring-ai-azure-openai/pom.xml
@@ -83,6 +83,13 @@
 			<artifactId>micrometer-observation-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-core-http-okhttp</artifactId>
+			<version>1.12.11</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModelIT.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2023-2024 the original author or authors.
  *
@@ -16,9 +17,13 @@
 
 package org.springframework.ai.azure.openai;
 
+import java.util.concurrent.TimeUnit;
+
 import com.azure.ai.openai.OpenAIClient;
 import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
+import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
@@ -91,8 +96,16 @@ class AzureOpenAiAudioTranscriptionModelIT {
 
 			// System.out.println("API Key: " + apiKey);
 			// System.out.println("Endpoint: " + endpoint);
+			int readTimeout = 120;
+			int writeTimeout = 120;
 
-			return new OpenAIClientBuilder().credential(new AzureKeyCredential(apiKey))
+			// OkHttp client with long timeouts
+			OkHttpClient okHttpClient = new OkHttpClient.Builder().readTimeout(readTimeout, TimeUnit.SECONDS)
+				.callTimeout(writeTimeout, TimeUnit.SECONDS)
+				.build();
+
+			return new OpenAIClientBuilder().httpClient(new OkHttpAsyncHttpClientBuilder(okHttpClient).build())
+				.credential(new AzureKeyCredential(apiKey))
 				.endpoint(endpoint)
 				// .serviceVersion(OpenAIServiceVersion.V2024_02_15_PREVIEW)
 				.buildClient();


### PR DESCRIPTION
 - To fix the race condition with the default HTTP client used by the Azure OpenAIClient, switch to use OkHttpClient. More discussion on this here: https://github.com/Azure/azure-sdk-for-java/issues/43583

 - Thanks to @Allamss for the suggestion here: https://github.com/Azure/azure-sdk-for-java/issues/43583#issuecomment-2785088500