### PR TITLE
fix: ZhiPuAiEmbedding supports custom dimensions

### DIFF
--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingOptions.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.zhipuai;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -63,9 +62,8 @@ public class ZhiPuAiEmbeddingOptions implements EmbeddingOptions {
 	}
 
 	@Override
-	@JsonIgnore
 	public Integer getDimensions() {
-		return null;
+		return this.dimensions;
 	}
 
 	public static class Builder {

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/embedding/EmbeddingIT.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/embedding/EmbeddingIT.java
@@ -21,9 +21,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.zhipuai.ZhiPuAiEmbeddingModel;
+import org.springframework.ai.zhipuai.ZhiPuAiEmbeddingOptions;
 import org.springframework.ai.zhipuai.ZhiPuAiTestConfiguration;
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -51,6 +54,31 @@ class EmbeddingIT {
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).hasSize(1024);
 
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);
+	}
+
+	@Test
+	void embeddingV3WithDefault() {
+		EmbeddingResponse embeddingResponse = this.embeddingModel.call(new EmbeddingRequest(List.of("Hello World"),
+				ZhiPuAiEmbeddingOptions.builder().model(ZhiPuAiApi.EmbeddingModel.Embedding_3.getValue()).build()));
+
+		assertThat(embeddingResponse.getResults()).hasSize(1);
+
+		assertThat(embeddingResponse.getResults().get(0)).isNotNull();
+		assertThat(embeddingResponse.getResults().get(0).getOutput()).hasSize(2048);
+	}
+
+	@Test
+	void embeddingV3WithCustomDimension() {
+		EmbeddingResponse embeddingResponse = this.embeddingModel.call(new EmbeddingRequest(List.of("Hello World"),
+				ZhiPuAiEmbeddingOptions.builder()
+					.model(ZhiPuAiApi.EmbeddingModel.Embedding_3.getValue())
+					.dimensions(512)
+					.build()));
+
+		assertThat(embeddingResponse.getResults()).hasSize(1);
+
+		assertThat(embeddingResponse.getResults().get(0)).isNotNull();
+		assertThat(embeddingResponse.getResults().get(0).getOutput()).hasSize(512);
 	}
 
 	@Test


### PR DESCRIPTION
I've run the integration tests locally, and everything checks out.

![image](https://github.com/user-attachments/assets/26195dba-447a-4769-b3ac-687597723666)
