### PR TITLE
fix: remove unused options from ZhiPu model

### DIFF
--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -568,16 +568,6 @@ public class ZhiPuAiChatModel implements ChatModel {
 		}
 	}
 
-	private ChatOptions buildRequestOptions(ZhiPuAiApi.ChatCompletionRequest request) {
-		return ChatOptions.builder()
-			.model(request.model())
-			.maxTokens(request.maxTokens())
-			.stopSequences(request.stop())
-			.temperature(request.temperature())
-			.topP(request.topP())
-			.build();
-	}
-
 	public void setObservationConvention(ChatModelObservationConvention observationConvention) {
 		this.observationConvention = observationConvention;
 	}

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -78,9 +78,6 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	 * provide a list of functions the model may generate JSON inputs for.
 	 */
 	private @JsonProperty("tools") List<ZhiPuAiApi.FunctionTool> tools;
-
-	private @JsonProperty("tools1")  List<ZhiPuAiApi.Foo> foos;
-
 	/**
 	 * Controls which (if any) function is called by the model. none means the model will not call a
 	 * function and instead generates a message. auto means the model can pick between generating a message or calling a

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -314,18 +314,6 @@ public class ZhiPuAiApi {
 		}
 	}
 
-	public class Foo {
-
-		String foo;
-
-		public Foo() {
-
-		}
-		public Foo(String foo) {
-			this.foo = foo;
-		}
-	}
-
 
 	/**
 	 * Represents a tool the model may call. Currently, only functions are supported as a tool.


### PR DESCRIPTION
I couldn’t find anything about the tools1 parameter in Zhipu’s official docs. Not sure what this field is for — seems unused.

Also noticed that `buildRequestOptions` method isn’t used anywhere. ( It's a private method )