### PR TITLE
Add link to javadoc on Content class

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/content/Content.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/content/Content.java
@@ -21,7 +21,7 @@ import java.util.Map;
 /**
  * Data structure that contains content and metadata. Common parent for the
  * {@link org.springframework.ai.document.Document} and the
- * org.springframework.ai.chat.messages.Message classes.
+ * {@link org.springframework.ai.chat.messages.Message} classes.
  *
  * @author Mark Pollack
  * @author Christian Tzolov


### PR DESCRIPTION
The javadoc on top of the class Content mention a reference to the Message class but there is non {@link } around it.