### PR TITLE
Validate documents for text/media check when adding to vector store

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/observation/AbstractObservationVectorStore.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/observation/AbstractObservationVectorStore.java
@@ -74,7 +74,7 @@ public abstract class AbstractObservationVectorStore implements VectorStore {
 	 */
 	@Override
 	public void add(List<Document> documents) {
-
+		validateNonTextDocuments(documents);
 		VectorStoreObservationContext observationContext = this
 			.createObservationContextBuilder(VectorStoreObservationContext.Operation.ADD.value())
 			.build();
@@ -83,6 +83,17 @@ public abstract class AbstractObservationVectorStore implements VectorStore {
 			.observation(this.customObservationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
 					this.observationRegistry)
 			.observe(() -> this.doAdd(documents));
+	}
+
+	private void validateNonTextDocuments(List<Document> documents) {
+		if (documents == null)
+			return;
+		for (Document document : documents) {
+			if (document != null && !document.isText()) {
+				throw new IllegalArgumentException(
+						"Only text documents are supported for now. One of the documents contains non-text content.");
+			}
+		}
 	}
 
 	@Override

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreTests.java
@@ -32,13 +32,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.springframework.ai.content.Media;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.util.MimeType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -257,6 +262,17 @@ class SimpleVectorStoreTests {
 		assertThatThrownBy(() -> SimpleVectorStore.EmbeddingMath.cosineSimilarity(vector, null))
 			.isInstanceOf(RuntimeException.class)
 			.hasMessage("Vectors must not be null");
+	}
+
+	@Test
+	void shouldFailNonTextDocuments() {
+		Media media = new Media(MimeType.valueOf("image/png"), new ByteArrayResource(new byte[] { 0x00 }));
+
+		Document imgDoc = Document.builder().media(media).metadata(Map.of("fileName", "pixel.png")).build();
+
+		Exception exception = assertThrows(IllegalArgumentException.class, () -> this.vectorStore.add(List.of(imgDoc)));
+		assertEquals("Only text documents are supported for now. One of the documents contains non-text content.",
+				exception.getMessage());
 	}
 
 }


### PR DESCRIPTION
 - Since the non-text documents aren't supported, we need a validation to throw exception if non text documents are encountered
 - Add tests
    - Add test to QdrantVectorStoreIT with the usecase provided by @devMtn30
    - Add simple vector store test for the validation 
   
 Fixes #3609