### PR TITLE
docs: correct property name from `is-auto-id` to `auto-id` in milvus.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/milvus.adoc
@@ -236,7 +236,7 @@ You can use the following properties in your Spring Boot configuration to custom
 |spring.ai.vectorstore.milvus.metric-type | The metric type to be used for the Milvus collection.  | COSINE
 |spring.ai.vectorstore.milvus.index-parameters | The index parameters to be used for the Milvus collection.  | {"nlist":1024}
 |spring.ai.vectorstore.milvus.id-field-name | The ID field name for the collection | doc_id
-|spring.ai.vectorstore.milvus.is-auto-id | Boolean flag to indicate if the auto-id is used for the ID field | false
+|spring.ai.vectorstore.milvus.auto-id | Boolean flag to indicate if the auto-id is used for the ID field | false
 |spring.ai.vectorstore.milvus.content-field-name | The content field name for the collection | content
 |spring.ai.vectorstore.milvus.metadata-field-name | The metadata field name for the collection | metadata
 |spring.ai.vectorstore.milvus.embedding-field-name | The embedding field name for the collection | embedding


### PR DESCRIPTION
correct property name from `is-auto-id` to `auto-id` in milvus.adoc

close https://github.com/spring-projects/spring-ai/issues/3702