### PR TITLE
improve schema initialization logic and update deprecated code for Milvus vectorstore

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -38,6 +38,7 @@ import io.milvus.param.MetricType;
 import io.milvus.param.R;
 import io.milvus.param.R.Status;
 import io.milvus.param.RpcStatus;
+import io.milvus.param.collection.CollectionSchemaParam;
 import io.milvus.param.collection.CreateCollectionParam;
 import io.milvus.param.collection.DropCollectionParam;
 import io.milvus.param.collection.FieldType;
@@ -443,6 +444,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		if (!isDatabaseCollectionExists()) {
 			createCollection(this.databaseName, this.collectionName, this.idFieldName, this.isAutoId,
 					this.contentFieldName, this.metadataFieldName, this.embeddingFieldName);
+			createIndex(this.databaseName, this.collectionName, this.embeddingFieldName, this.indexType,
+					this.metricType, this.indexParameters);
 		}
 
 		R<DescribeIndexResponse> indexDescriptionResponse = this.milvusClient
@@ -452,19 +455,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 				.build());
 
 		if (indexDescriptionResponse.getData() == null) {
-			R<RpcStatus> indexStatus = this.milvusClient.createIndex(CreateIndexParam.newBuilder()
-				.withDatabaseName(this.databaseName)
-				.withCollectionName(this.collectionName)
-				.withFieldName(this.embeddingFieldName)
-				.withIndexType(this.indexType)
-				.withMetricType(this.metricType)
-				.withExtraParam(this.indexParameters)
-				.withSyncMode(Boolean.FALSE)
-				.build());
-
-			if (indexStatus.getException() != null) {
-				throw new RuntimeException("Failed to create Index", indexStatus.getException());
-			}
+			createIndex(this.databaseName, this.collectionName, this.embeddingFieldName, this.indexType,
+					this.metricType, this.indexParameters);
 		}
 
 		R<RpcStatus> loadCollectionStatus = this.milvusClient.loadCollection(LoadCollectionParam.newBuilder()
@@ -507,10 +499,12 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			.withDescription("Spring AI Vector Store")
 			.withConsistencyLevel(ConsistencyLevelEnum.STRONG)
 			.withShardsNum(2)
-			.addFieldType(docIdFieldType)
-			.addFieldType(contentFieldType)
-			.addFieldType(metadataFieldType)
-			.addFieldType(embeddingFieldType)
+			.withSchema(CollectionSchemaParam.newBuilder()
+				.addFieldType(docIdFieldType)
+				.addFieldType(contentFieldType)
+				.addFieldType(metadataFieldType)
+				.addFieldType(embeddingFieldType)
+				.build())
 			.build();
 
 		R<RpcStatus> collectionStatus = this.milvusClient.createCollection(createCollectionReq);
@@ -518,6 +512,23 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			throw new RuntimeException("Failed to create collection", collectionStatus.getException());
 		}
 
+	}
+
+	void createIndex(String databaseName, String collectionName, String embeddingFieldName, IndexType indexType,
+			MetricType metricType, String indexParameters) {
+		R<RpcStatus> indexStatus = this.milvusClient.createIndex(CreateIndexParam.newBuilder()
+			.withDatabaseName(databaseName)
+			.withCollectionName(collectionName)
+			.withFieldName(embeddingFieldName)
+			.withIndexType(indexType)
+			.withMetricType(metricType)
+			.withExtraParam(indexParameters)
+			.withSyncMode(Boolean.FALSE)
+			.build());
+
+		if (indexStatus.getException() != null) {
+			throw new RuntimeException("Failed to create Index", indexStatus.getException());
+		}
 	}
 
 	int embeddingDimensions() {

--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreIT.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStoreIT.java
@@ -18,6 +18,7 @@ package org.springframework.ai.vectorstore.milvus;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,10 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import io.milvus.client.AbstractMilvusGrpcClient;
 import io.milvus.client.MilvusServiceClient;
 import io.milvus.param.ConnectParam;
 import io.milvus.param.IndexType;
@@ -34,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.milvus.MilvusContainer;
@@ -321,6 +327,37 @@ public class MilvusVectorStoreIT extends BaseVectorStoreTests {
 			assertThat(results.stream().map(doc -> doc.getMetadata().get("priority")).collect(Collectors.toList()))
 				.containsExactlyInAnyOrder(1.0, 1.0);
 		});
+	}
+
+	@Test
+	void initializeSchema() {
+		this.contextRunner.withPropertyValues("test.spring.ai.vectorstore.milvus.metricType=COSINE").run(context -> {
+			VectorStore vectorStore = context.getBean(VectorStore.class);
+
+			Logger logger = (Logger) LoggerFactory.getLogger(AbstractMilvusGrpcClient.class);
+			LogAppender logAppender = new LogAppender();
+			logger.addAppender(logAppender);
+			logAppender.start();
+
+			resetCollection(vectorStore);
+
+			assertThat(logAppender.capturedLogs).isEmpty();
+		});
+	}
+
+	static class LogAppender extends AppenderBase<ILoggingEvent> {
+
+		private final List<String> capturedLogs = new ArrayList<>();
+
+		@Override
+		protected void append(ILoggingEvent eventObject) {
+			capturedLogs.add(eventObject.getFormattedMessage());
+		}
+
+		public List<String> getCapturedLogs() {
+			return capturedLogs;
+		}
+
 	}
 
 	@Test


### PR DESCRIPTION
## changes

### improve schema initialization logic

In the current logic, since `createCollection` is executed without following it up with `createIndex`, the following error occurs during `describeIndex`:

```
20:36:07.664 [main] ERROR io.milvus.client.AbstractMilvusGrpcClient -- DescribeIndexRequest collectionName:test_vector_store_custom_fields, indexName: failed! Exception:{}
io.milvus.exception.ServerException: index not found[collection=test_vector_store_custom_fields]
	at io.milvus.client.AbstractMilvusGrpcClient.handleResponse(AbstractMilvusGrpcClient.java:399)
	at io.milvus.client.AbstractMilvusGrpcClient.describeIndex(AbstractMilvusGrpcClient.java:1423)
	at io.milvus.client.MilvusServiceClient.lambda$describeIndex$32(MilvusServiceClient.java:611)
	at io.milvus.client.MilvusServiceClient.retry(MilvusServiceClient.java:326)
	at io.milvus.client.MilvusServiceClient.describeIndex(MilvusServiceClient.java:611)
	at org.springframework.ai.vectorstore.milvus.MilvusVectorStore.createCollection(MilvusVectorStore.java:449)
```

However, it is natural for an index to not exist immediately after `createCollection`.
Thus, the logic was modified to attempt `createIndex` right after `createCollection`.

**This prevents unnecessary error logs from being recorded.**

current example log: https://github.com/spring-projects/spring-ai/actions/runs/15934060747/job/44949781008#step:7:10851

### update deprecated code 

`addFieldType` has been deprecated.
It is recommended to use `withSchema` instead for adding field types, so the implementation has been updated accordingly.