### PR TITLE
docs(mcp): add dynamic MCP client selection example

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-helpers.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-helpers.adoc
@@ -65,7 +65,24 @@ For multiple clients:
 List<McpSyncClient> clients = // obtain list of clients
 List<ToolCallback> callbacks = SyncMcpToolCallbackProvider.syncToolCallbacks(clients);
 ----
++
+For dynamic selection of a subset of clients 
++
+[source,java]
+----
+@Autowired
+private List<McpSyncClient> mcpSyncClients;
 
+public ToolCallbackProvider buildProvider(Set<String> allowedServerNames) {
+    // Filter by server.name().
+    List<McpSyncClient> selected = mcpSyncClients.stream()
+        .filter(c -> allowedServerNames.contains(c.getServerInfo().name()))
+        .toList();
+
+    return new SyncMcpToolCallbackProvider(selected);
+}
+
+----
 Async::
 +
 [source,java]


### PR DESCRIPTION
- demonstrate how to filter injected MCP clients by server name
  using getServerInfo().name()

This helps users dynamically choose which MCP services to expose
based on context (e.g. permissions, intent), instead of registering
all available tools unconditionally.