### PR TITLE
Fix NPE in AnthropicApi StreamHelper

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/StreamHelper.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionResponse;
 import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock;
 import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock.Type;
@@ -55,6 +58,8 @@ import org.springframework.util.StringUtils;
  * @since 1.0.0
  */
 public class StreamHelper {
+
+	private static final Logger logger = LoggerFactory.getLogger(StreamHelper.class);
 
 	public boolean isToolUseStart(StreamEvent event) {
 		if (event == null || event.type() == null || event.type() != EventType.CONTENT_BLOCK_START) {
@@ -216,7 +221,11 @@ public class StreamHelper {
 		}
 		else {
 			// Any other event types that should propagate upwards without content
+			if (contentBlockReference.get() == null) {
+				contentBlockReference.set(new ChatCompletionResponseBuilder());
+			}
 			contentBlockReference.get().withType(event.type().name()).withContent(List.of());
+			logger.warn("Unhandled event type: {}", event.type().name());
 		}
 
 		return contentBlockReference.get().build();

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/StreamHelperTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/StreamHelperTests.java
@@ -1,0 +1,27 @@
+package org.springframework.ai.anthropic.api;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.anthropic.api.StreamHelper.ChatCompletionResponseBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Ilayaperumal Gopinathan
+ */
+class StreamHelperTest {
+
+	@Test
+	void testErrorEventTypeWithEmptyContentBlock() {
+		AnthropicApi.ErrorEvent errorEvent = new AnthropicApi.ErrorEvent(AnthropicApi.EventType.ERROR,
+				new AnthropicApi.ErrorEvent.Error("error", "error message"));
+		AtomicReference<ChatCompletionResponseBuilder> contentBlockReference = new AtomicReference<>();
+		StreamHelper streamHelper = new StreamHelper();
+		AnthropicApi.ChatCompletionResponse response = streamHelper.eventToChatCompletionResponse(errorEvent,
+				contentBlockReference);
+		assertThat(response).isNotNull();
+	}
+
+}


### PR DESCRIPTION
 - When the error event occurs, the ChatCompletionResponseBuilder is empty and hence the contentBlockReference.get() throws NPE.
   - Add null check to unhandled event in addition to the logging the event type
   - Add test to verify the usecase

Resolves #3740