### PR TITLE
 Fix string return conversion in DefaultToolCallResultConverter

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverter.java
@@ -35,6 +35,7 @@ import org.springframework.lang.Nullable;
  * A default implementation of {@link ToolCallResultConverter}.
  *
  * @author Thomas Vitale
+ * @author Jemin Huh
  * @since 1.0.0
  */
 public final class DefaultToolCallResultConverter implements ToolCallResultConverter {
@@ -45,7 +46,11 @@ public final class DefaultToolCallResultConverter implements ToolCallResultConve
 	public String convert(@Nullable Object result, @Nullable Type returnType) {
 		if (returnType == Void.TYPE) {
 			logger.debug("The tool has no return type. Converting to conventional response.");
-			return JsonParser.toJson("Done");
+			return "Done";
+		}
+		if (returnType instanceof Class<?> cls && cls.equals(String.class)) {
+			logger.debug("Tool return type is String. Returning result as is.");
+			return String.valueOf(result);
 		}
 		if (result instanceof RenderedImage) {
 			final var buf = new ByteArrayOutputStream(1024 * 4);

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverterTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolCallResultConverterTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for {@link DefaultToolCallResultConverter}.
  *
  * @author Thomas Vitale
+ * @author Jemin Huh
  */
 class DefaultToolCallResultConverterTests {
 
@@ -52,13 +53,13 @@ class DefaultToolCallResultConverterTests {
 	@Test
 	void convertVoidReturnTypeShouldReturnDoneJson() {
 		String result = this.converter.convert(null, void.class);
-		assertThat(result).isEqualTo("\"Done\"");
+		assertThat(result).isEqualTo("Done");
 	}
 
 	@Test
 	void convertStringReturnTypeShouldReturnJson() {
 		String result = this.converter.convert("test", String.class);
-		assertThat(result).isEqualTo("\"test\"");
+		assertThat(result).isEqualTo("test");
 	}
 
 	@Test


### PR DESCRIPTION
Return String tool results directly (or "null" if null) when returnType is String.class, instead of serializing them to JSON. This removes unnecessary formatting while preserving existing behavior for other types.