### PR TITLE
fix: update default sse-message-endpoint from /mcp/message to /mcp/messages

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * All properties are prefixed with {@code spring.ai.mcp.server}.
  *
  * @author Christian Tzolov
+ * @author Jemin Huh
  * @since 1.0.0
  * @see McpServerAutoConfiguration
  */
@@ -120,7 +121,7 @@ public class McpServerProperties {
 	 * <p>
 	 * This property is only used when transport is set to WEBMVC or WEBFLUX.
 	 */
-	private String sseMessageEndpoint = "/mcp/message";
+	private String sseMessageEndpoint = "/mcp/messages";
 
 	/**
 	 * The type of server to use for MCP server communication.

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/test/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfigurationIT.java
@@ -75,7 +75,7 @@ public class McpServerAutoConfigurationIT {
 			assertThat(properties.getRequestTimeout().getSeconds()).isEqualTo(20);
 			assertThat(properties.getBaseUrl()).isEqualTo("");
 			assertThat(properties.getSseEndpoint()).isEqualTo("/sse");
-			assertThat(properties.getSseMessageEndpoint()).isEqualTo("/mcp/message");
+			assertThat(properties.getSseMessageEndpoint()).isEqualTo("/mcp/messages");
 
 			// Check capabilities
 			assertThat(properties.getCapabilities().isTool()).isTrue();
@@ -300,12 +300,12 @@ public class McpServerAutoConfigurationIT {
 		this.contextRunner
 			.withPropertyValues("spring.ai.mcp.server.base-url=http://localhost:8080",
 					"spring.ai.mcp.server.sse-endpoint=/events",
-					"spring.ai.mcp.server.sse-message-endpoint=/api/mcp/message")
+					"spring.ai.mcp.server.sse-message-endpoint=/api/mcp/messages")
 			.run(context -> {
 				McpServerProperties properties = context.getBean(McpServerProperties.class);
 				assertThat(properties.getBaseUrl()).isEqualTo("http://localhost:8080");
 				assertThat(properties.getSseEndpoint()).isEqualTo("/events");
-				assertThat(properties.getSseMessageEndpoint()).isEqualTo("/api/mcp/message");
+				assertThat(properties.getSseMessageEndpoint()).isEqualTo("/api/mcp/messages");
 
 				// Verify the server is configured with the endpoints
 				McpSyncServer server = context.getBean(McpSyncServer.class);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -106,7 +106,7 @@ All properties are prefixed with `spring.ai.mcp.server`:
 |`prompt-change-notification` |Enable prompt change notifications |`true`
 |`tool-change-notification` |Enable tool change notifications |`true`
 |`tool-response-mime-type` |(optional) response MIME type per tool name. For example `spring.ai.mcp.server.tool-response-mime-type.generateImage=image/png` will associate the `image/png` mime type with the `generateImage()` tool name |`-`
-|`sse-message-endpoint` | Custom SSE Message endpoint path for web transport to be used by the client to send messages|`/mcp/message`
+|`sse-message-endpoint` | Custom SSE Message endpoint path for web transport to be used by the client to send messages|`/mcp/messages`
 |`sse-endpoint` |Custom SSE endpoint path for web transport |`/sse`
 |`base-url` | Optional URL prefix. For example `base-url=/api/v1` means that the client should access the sse endpoint at `/api/v1` + `sse-endpoint` and the message endpoint is `/api/v1` + `sse-message-endpoint` | -
 |`request-timeout` | Duration to wait for server responses before timing out requests. Applies to all requests made through the client, including tool calls, resource access, and prompt operations. | `20` seconds

--- a/spring-ai-docs/src/main/asciidoc/mcp.md
+++ b/spring-ai-docs/src/main/asciidoc/mcp.md
@@ -28,7 +28,7 @@ The MCP server can be configured using the following properties under the `sprin
 | `tool-change-notification` | `true` | Enable/disable tool change notifications |
 | `prompt-change-notification` | `true` | Enable/disable prompt change notifications |
 | `transport` | `STDIO` | Transport type (`STDIO`, `WEBMVC`, or `WEBFLUX`) |
-| `sse-message-endpoint` | `"/mcp/message"` | Server-Sent Events (SSE) message endpoint for web transports |
+| `sse-message-endpoint` | `"/mcp/messages"` | Server-Sent Events (SSE) message endpoint for web transports |
 
 ## Server Types
 
@@ -84,7 +84,7 @@ spring:
     mcp:
       server:
         transport: WEBMVC
-        sse-message-endpoint: /mcp/message  # Optional, defaults to /mcp/message
+        sse-message-endpoint: /mcp/messages  # Optional, defaults to /mcp/messages
 ```
 
 Required dependencies:
@@ -109,7 +109,7 @@ spring:
     mcp:
       server:
         transport: WEBFLUX
-        sse-message-endpoint: /mcp/message  # Optional, defaults to /mcp/message
+        sse-message-endpoint: /mcp/messages  # Optional, defaults to /mcp/messages
 ```
 
 Required dependencies:


### PR DESCRIPTION
This pull request updates the default sse-message-endpoint in the Spring AI MCP server from /mcp/message to /mcp/messages, aligning it with the official MCP specification and the common practice used by MCP Framework (which defaults to /messages) to improve interoperability and avoid confusion. 