### PR TITLE
Upgrade io.modelcontextprotocol 0.10.0 -> 0.11.0-SNAPSHOT

### DIFF
--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -34,7 +34,7 @@ class AsyncMcpToolCallbackTest {
 		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
 			.cause()
 			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("Error calling tool: [TextContent[audience=null, priority=null, text=Some error data]]");
+			.hasMessage("Error calling tool: [TextContent[annotations=null, text=Some error data]]");
 	}
 
 	@Test

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -114,7 +114,7 @@ class SyncMcpToolCallbackTests {
 		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
 			.cause()
 			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("Error calling tool: [TextContent[audience=null, priority=null, text=Some error data]]");
+			.hasMessage("Error calling tool: [TextContent[annotations=null, text=Some error data]]");
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.10.0</mcp.sdk.version>
+		<mcp.sdk.version>0.11.0-SNAPSHOT</mcp.sdk.version>
 
 		<!-- plugin versions -->
 		<antlr.version>4.13.1</antlr.version>


### PR DESCRIPTION
For the next development version, we use MCP v0.11.0-SNAPSHOT.

Since this is a SNAPSHOT, it will be the Central Portal Snapshots repo, which you can add to your build file:

```xml
<repositories>
	<repository>
		<name>Central Portal Snapshots</name>
		<id>central-portal-snapshots</id>
		<url>https://central.sonatype.com/repository/maven-snapshots/</url>
		<releases>
			<enabled>false</enabled>
		</releases>
		<snapshots>
			<enabled>true</enabled>
		</snapshots>
	</repository>
	<!-- Spring snapshots & milestones repo ... -->
</repositories>
```