### PR TITLE
fix: Handling default implementation of ToolCallback#call(String,ToolContext)

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -217,7 +217,12 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 				.observe(() -> {
 					String toolResult;
 					try {
-						toolResult = toolCallback.call(toolInputArguments, toolContext);
+						if (toolContext != null) {
+							toolResult = toolCallback.call(toolInputArguments, toolContext);
+						}
+						else {
+							toolResult = toolCallback.call(toolInputArguments);
+						}
 					}
 					catch (ToolExecutionException ex) {
 						toolResult = this.toolExecutionExceptionProcessor.process(ex);

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/ToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/ToolCallback.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.tool;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.metadata.ToolMetadata;
@@ -28,6 +31,8 @@ import org.springframework.lang.Nullable;
  * @since 1.0.0
  */
 public interface ToolCallback {
+
+	Logger logger = LoggerFactory.getLogger(ToolCallback.class);
 
 	/**
 	 * Definition used by the AI model to determine when and how to call the tool.
@@ -53,7 +58,8 @@ public interface ToolCallback {
 	 */
 	default String call(String toolInput, @Nullable ToolContext toolContext) {
 		if (toolContext != null && !toolContext.getContext().isEmpty()) {
-			throw new UnsupportedOperationException("Tool context is not supported!");
+			logger.debug(
+					"Using default implementation of ToolCallback#call(String,ToolContext) and toolContext will be ignored.");
 		}
 		return call(toolInput);
 	}


### PR DESCRIPTION
 Context: Currently, the default implementation of ToolCallback#call(String,ToolContext) throws exception when an non-empty ToolContext is passed. This gives bad user experience when the application has multiple tool callbacks with one of them doesn't use toolcontext but the chat client passes non-empty toolcontext. For more information #https://github.com/spring-projects/spring-ai/issues/3389

  - This fix removes the explicit exception when the toolcontext is non empty for the default implementation of call(String, ToolContext)
    - Instead, log debug message that tool context will be ignored

  - Also, add explicit null check at the DefaultToolCallingManager when invoking ToolCallback's methods

Resolves #3389