### PR TITLE
fix: Fixed the issue where the returnDirect attribute was not effective on the MCP server side.

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -59,6 +59,7 @@ import org.springframework.util.MimeType;
  * </ul>
  *
  * @author Christian Tzolov
+ * @author Sun Yuhan
  */
 public final class McpToolUtils {
 
@@ -166,9 +167,12 @@ public final class McpToolUtils {
 	 */
 	public static McpServerFeatures.SyncToolSpecification toSyncToolSpecification(ToolCallback toolCallback,
 			MimeType mimeType) {
+		McpSchema.ToolAnnotations toolAnnotations = new McpSchema.ToolAnnotations(null, null, null, null, null,
+				toolCallback.getToolMetadata().returnDirect());
 
 		var tool = new McpSchema.Tool(toolCallback.getToolDefinition().name(),
-				toolCallback.getToolDefinition().description(), toolCallback.getToolDefinition().inputSchema());
+				toolCallback.getToolDefinition().description(), toolCallback.getToolDefinition().inputSchema(),
+				toolAnnotations);
 
 		return new McpServerFeatures.SyncToolSpecification(tool, (exchange, request) -> {
 			try {

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -9,6 +9,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
 import org.springframework.ai.tool.execution.ToolExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -21,6 +23,27 @@ class AsyncMcpToolCallbackTest {
 
 	@Mock
 	private McpSchema.Tool tool;
+
+	@Test
+	void getToolDefinitionShouldReturnCorrectDefinition() {
+
+		var clientInfo = new McpSchema.Implementation("testClient", "1.0.0");
+		var toolAnnotations = new McpSchema.ToolAnnotations(null, false, false, false, false, true);
+
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		when(this.tool.name()).thenReturn("testTool");
+		when(this.tool.description()).thenReturn("Test tool description");
+		when(this.tool.annotations()).thenReturn(toolAnnotations);
+
+		AsyncMcpToolCallback callback = new AsyncMcpToolCallback(this.mcpClient, this.tool);
+
+		var toolDefinition = callback.getToolDefinition();
+		var toolMetadata = callback.getToolMetadata();
+
+		assertThat(toolDefinition.name()).isEqualTo(clientInfo.name() + "_testTool");
+		assertThat(toolDefinition.description()).isEqualTo("Test tool description");
+		assertThat(toolMetadata.returnDirect()).isEqualTo(true);
+	}
 
 	@Test
 	void callShouldThrowOnError() {

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -31,7 +31,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.chat.model.ToolContext;
-import org.springframework.ai.content.Content;
 import org.springframework.ai.tool.execution.ToolExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,16 +52,21 @@ class SyncMcpToolCallbackTests {
 	void getToolDefinitionShouldReturnCorrectDefinition() {
 
 		var clientInfo = new Implementation("testClient", "1.0.0");
+		var toolAnnotations = new McpSchema.ToolAnnotations(null, false, false, false, false, true);
+
 		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
 		when(this.tool.name()).thenReturn("testTool");
 		when(this.tool.description()).thenReturn("Test tool description");
+		when(this.tool.annotations()).thenReturn(toolAnnotations);
 
 		SyncMcpToolCallback callback = new SyncMcpToolCallback(this.mcpClient, this.tool);
 
 		var toolDefinition = callback.getToolDefinition();
+		var toolMetadata = callback.getToolMetadata();
 
 		assertThat(toolDefinition.name()).isEqualTo(clientInfo.name() + "_testTool");
 		assertThat(toolDefinition.description()).isEqualTo("Test tool description");
+		assertThat(toolMetadata.returnDirect()).isEqualTo(true);
 	}
 
 	@Test


### PR DESCRIPTION

### Background

Before this PR, when using the `@Tool` annotation to define tools on the MCP server side and specifying the `returnDirect` attribute, the attribute would not be properly propagated. As a result, the client was unable to retrieve this information. For a detailed discussion and root cause analysis of this issue, please refer to: #3481 .

Thanks to the merge of PR #3781 , we now have the foundation to fix this problem.

---

### Changes in This PR

1. **Preserve the `returnDirect` Attribute**  
   Adjusted the logic in the `McpToolUtils` class that constructs tool declarations, ensuring that the `returnDirect` attribute from the `@Tool` annotation is correctly retained and passed through.

2. **Implemented `getToolMetadata` Method**  
   Added implementations of the `getToolMetadata` method in both `AsyncMcpToolCallback` and `SyncMcpToolCallback` classes. This enables clients to retrieve tool metadata, including the `returnDirect` flag.

3. **Added Unit Tests**  
   Included corresponding unit tests to verify the correctness and stability of the above changes.

Fixes: #3481 