### PR TITLE
McpSyncServer: set immediate execution when in a servlet context

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerAutoConfiguration.java
@@ -55,9 +55,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
+import org.springframework.web.context.support.StandardServletEnvironment;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for the Model Context Protocol (MCP)
@@ -177,7 +179,7 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
-			List<ToolCallbackProvider> toolCallbackProvider) {
+			List<ToolCallbackProvider> toolCallbackProvider, Environment environment) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
@@ -258,6 +260,9 @@ public class McpServerAutoConfiguration {
 		serverBuilder.instructions(serverProperties.getInstructions());
 
 		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
+		if (environment instanceof StandardServletEnvironment) {
+			serverBuilder.immediateExecution(true);
+		}
 
 		return serverBuilder.build();
 	}


### PR DESCRIPTION
When using an MCP sync server, in a servlet environment, use `SyncSpecification#immediateExecution(true)`, introduced in https://github.com/modelcontextprotocol/java-sdk/pull/371 .

This allows to propagate thread-locals to the `@Tool` method; granting access to e.g. Framework's `RequestContextHolder#getRequestAttributes()` or Security's `SecurityContextHolder#getContext()`.

This, in turn, allows users to use Spring Security's method-level security, e.g.:

```java
@PreAuthorize("hasScope('widget.read')")
@Tool(description = "...")
public Widget getWidget(...) {
    // ...
}

@PreAuthorize("hasScope('widget.admin')")
@Tool(description = "...")
public Widget addWidget(...) {
    // ...
}
```