### PR TITLE
GH-3690: Support customization of RedisVectorStore via builder customizer

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.vectorstore.redis.autoconfigure;
 
 import io.micrometer.observation.ObservationRegistry;
+import org.springframework.ai.vectorstore.redis.RedisVectorStoreBuilderCustomizer;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
@@ -46,6 +47,7 @@ import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
  * @author Eddú Meléndez
  * @author Soby Chacko
  * @author Jihoon Kim
+ * @author Dongha Koo
  */
 @AutoConfiguration(after = RedisAutoConfiguration.class)
 @ConditionalOnClass({ JedisPooled.class, JedisConnectionFactory.class, RedisVectorStore.class, EmbeddingModel.class })
@@ -63,20 +65,33 @@ public class RedisVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public RedisVectorStore vectorStore(EmbeddingModel embeddingModel, RedisVectorStoreProperties properties,
-			JedisConnectionFactory jedisConnectionFactory, ObjectProvider<ObservationRegistry> observationRegistry,
+	public RedisVectorStore.Builder redisVectorStoreBuilder(
+			EmbeddingModel embeddingModel,
+			RedisVectorStoreProperties properties,
+			JedisConnectionFactory jedisConnectionFactory,
+			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
-			BatchingStrategy batchingStrategy) {
-
+			BatchingStrategy batchingStrategy,
+			ObjectProvider<RedisVectorStoreBuilderCustomizer> customizers
+	) {
 		JedisPooled jedisPooled = this.jedisPooled(jedisConnectionFactory);
-		return RedisVectorStore.builder(jedisPooled, embeddingModel)
-			.initializeSchema(properties.isInitializeSchema())
-			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
-			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))
-			.batchingStrategy(batchingStrategy)
-			.indexName(properties.getIndexName())
-			.prefix(properties.getPrefix())
-			.build();
+
+		RedisVectorStore.Builder builder = RedisVectorStore.builder(jedisPooled, embeddingModel)
+				.initializeSchema(properties.isInitializeSchema())
+				.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+				.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))
+				.batchingStrategy(batchingStrategy)
+				.indexName(properties.getIndexName())
+				.prefix(properties.getPrefix());
+		customizers.orderedStream().forEach(c -> c.customize(builder));
+
+		return builder;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public RedisVectorStore vectorStore(RedisVectorStore.Builder builder) {
+		return builder.build();
 	}
 
 	private JedisPooled jedisPooled(JedisConnectionFactory jedisConnectionFactory) {

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreBuilderCustomizer.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStoreBuilderCustomizer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.redis;
+
+/**
+ * A customizer interface for RedisVectorStore builder.
+ *
+ * @author Dongha Koo
+ * @since 1.0.0
+ */
+public interface RedisVectorStoreBuilderCustomizer
+		extends VectorStoreBuilderCustomizer<RedisVectorStore.Builder> {
+}

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/VectorStoreBuilderCustomizer.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/VectorStoreBuilderCustomizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.redis;
+
+import org.springframework.ai.vectorstore.VectorStore;
+
+/**
+ * A customizer interface for customizing a VectorStore builder instance.
+ *
+ * @param <T> the type of VectorStore builder
+ * @author Dongha Koo
+ * @since 1.0.0
+ */
+public interface VectorStoreBuilderCustomizer<T extends VectorStore.Builder<T>> {
+	void customize(T builder);
+}


### PR DESCRIPTION
GH-3690: Add RedisVectorStore builder customization support

Closes #3690

This PR introduces an extension point to customize `RedisVectorStore.Builder` via `RedisVectorStoreBuilderCustomizer`.

---

## 📌 Background

When using `VectorStoreChatMemoryAdvisor` with RedisVectorStore and `initialize-schema=true`,  
metadata fields such as `conversationId` (used in `filterExpression`) are not registered in the Redis schema,  
leading to **retrieval failures** during similarity search.

This issue was raised by @lanpf in #3690, and we experimentally adopted the direction they proposed —  
allowing schema-related settings to be injected through a `Customizer`, without overriding auto-configuration.

---

## ✨ Changes

- Add a generic extension point:  
  `VectorStoreBuilderCustomizer<T extends VectorStore.Builder<T>>`
- Specialize it for Redis:  
  `RedisVectorStoreBuilderCustomizer extends VectorStoreBuilderCustomizer<RedisVectorStore.Builder>`
- Apply ordered customizers in `RedisVectorStoreAutoConfiguration`:

```java
customizers.orderedStream().forEach(c -> c.customize(builder));
```

This provides a **Spring-style Customizer Pattern**, enabling open extension without modifying the default auto-configuration.

---

## ✅ Example

Developers can now customize metadata fields non-invasively like this:

```java
@Bean
public RedisVectorStoreBuilderCustomizer metadataCustomizer() {
    return builder -> builder.metadataFields(List.of(RedisVectorStore.MetadataField.tag("conversationId")));
}
```

This allows schema initialization and metadata filter-based retrieval to work together as expected —  
without disabling `initialize-schema=true` or manually wiring a `RedisVectorStore`.

---

## 🧪 Test & Compliance

- ✔️ `./mvnw clean verify` all passed  
- ✔️ Checkstyle passed  
- ✔️ DCO signed: `Signed-off-by: Dongha Koo <koo.dongha@gmail.com>`  
- ✔️ Rebased on latest `main`, linear commit history preserved

We hope this solution addresses the needs expressed by @lanpf and others with similar issues.  
Looking forward to your review and feedback. Thank you!
