### PR TITLE
feat(zhipuai): Support glm-4.1v-thinking-flash model

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration
 import org.springframework.ai.zhipuai.ZhiPuAiImageModel;
 import org.springframework.ai.zhipuai.api.ZhiPuAiApi;
 import org.springframework.ai.zhipuai.api.ZhiPuAiImageApi;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -51,8 +52,8 @@ public class ZhiPuAiImageAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public ZhiPuAiImageModel zhiPuAiImageModel(ZhiPuAiConnectionProperties commonProperties,
-			ZhiPuAiImageProperties imageProperties, RestClient.Builder restClientBuilder, RetryTemplate retryTemplate,
-			ResponseErrorHandler responseErrorHandler) {
+			ZhiPuAiImageProperties imageProperties, ObjectProvider<RestClient.Builder> restClientBuilderProvider,
+			RetryTemplate retryTemplate, ResponseErrorHandler responseErrorHandler) {
 
 		String apiKey = StringUtils.hasText(imageProperties.getApiKey()) ? imageProperties.getApiKey()
 				: commonProperties.getApiKey();
@@ -63,7 +64,9 @@ public class ZhiPuAiImageAutoConfiguration {
 		Assert.hasText(apiKey, "ZhiPuAI API key must be set");
 		Assert.hasText(baseUrl, "ZhiPuAI base URL must be set");
 
-		var zhiPuAiImageApi = new ZhiPuAiImageApi(baseUrl, apiKey, restClientBuilder, responseErrorHandler);
+		// TODO add ZhiPuAiApi support for image
+		var zhiPuAiImageApi = new ZhiPuAiImageApi(baseUrl, apiKey,
+				restClientBuilderProvider.getIfAvailable(RestClient::builder), responseErrorHandler);
 
 		return new ZhiPuAiImageModel(zhiPuAiImageApi, imageProperties.getOptions(), retryTemplate);
 	}

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.zhipuai;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.content.Media;
+
+/**
+ * @author YunKui Lu
+ */
+public class ZhiPuAiAssistantMessage extends AssistantMessage {
+
+	/**
+	 * The CoT content of the message.
+	 */
+	private String reasoningContent;
+
+	public ZhiPuAiAssistantMessage(String content) {
+		super(content);
+	}
+
+	public ZhiPuAiAssistantMessage(String content, String reasoningContent, Map<String, Object> properties,
+			List<ToolCall> toolCalls, List<Media> media) {
+		super(content, properties, toolCalls, media);
+		this.reasoningContent = reasoningContent;
+	}
+
+	public String getReasoningContent() {
+		return reasoningContent;
+	}
+
+	public ZhiPuAiAssistantMessage setReasoningContent(String reasoningContent) {
+		this.reasoningContent = reasoningContent;
+		return this;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof ZhiPuAiAssistantMessage that)) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		return Objects.equals(reasoningContent, that.reasoningContent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), reasoningContent);
+	}
+
+	@Override
+	public String toString() {
+		return "ZhiPuAiAssistantMessage{" + "media=" + media + ", messageType=" + messageType + ", metadata=" + metadata
+				+ ", reasoningContent='" + reasoningContent + '\'' + ", textContent='" + textContent + '\'' + '}';
+	}
+
+}

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,7 +227,11 @@ public class ZhiPuAiChatModel implements ChatModel {
 							toolCall.function().name(), toolCall.function().arguments()))
 					.toList();
 
-		var assistantMessage = new AssistantMessage(choice.message().content(), metadata, toolCalls);
+		String textContent = choice.message().content();
+		String reasoningContent = choice.message().reasoningContent();
+
+		var assistantMessage = new ZhiPuAiAssistantMessage(textContent, reasoningContent, metadata, toolCalls,
+				List.of());
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
 		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);
@@ -510,7 +514,7 @@ public class ZhiPuAiChatModel implements ChatModel {
 					}).toList();
 				}
 				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
-						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls));
+						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;
@@ -521,7 +525,7 @@ public class ZhiPuAiChatModel implements ChatModel {
 				return toolMessage.getResponses()
 					.stream()
 					.map(tr -> new ChatCompletionMessage(tr.responseData(), ChatCompletionMessage.Role.TOOL, tr.name(),
-							tr.id(), null))
+							tr.id(), null, null))
 					.toList();
 			}
 			else {

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -379,7 +379,15 @@ public class ZhiPuAiApi {
 
 		GLM_4_Flash("glm-4-flash"),
 
-		GLM_3_Turbo("GLM-3-Turbo"); // @formatter:on
+		GLM_3_Turbo("GLM-3-Turbo"),
+
+		// --- Visual Reasoning Models ---
+
+		GLM_4_Thinking_FlashX("glm-4.1v-thinking-flashx"),
+
+		GLM_4_Thinking_Flash("glm-4.1v-thinking-flash"),
+
+		; // @formatter:on
 
 		public final String value;
 
@@ -774,7 +782,8 @@ public class ZhiPuAiApi {
 			@JsonProperty("role") Role role,
 			@JsonProperty("name") String name,
 			@JsonProperty("tool_call_id") String toolCallId,
-			@JsonProperty("tool_calls") List<ToolCall> toolCalls) { // @formatter:on
+			@JsonProperty("tool_calls") List<ToolCall> toolCalls,
+			@JsonProperty("reasoning_content") String reasoningContent) { // @formatter:on
 
 		/**
 		 * Create a chat completion message with the given content and role. All other
@@ -783,7 +792,7 @@ public class ZhiPuAiApi {
 		 * @param role The role of the author of this message.
 		 */
 		public ChatCompletionMessage(Object content, Role role) {
-			this(content, role, null, null, null);
+			this(content, role, null, null, null, null);
 		}
 
 		/**

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiStreamFunctionCallingHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,8 @@ public class ZhiPuAiStreamFunctionCallingHelper {
 	private ChatCompletionMessage merge(ChatCompletionMessage previous, ChatCompletionMessage current) {
 		String content = (current.content() != null ? current.content()
 				: (previous.content() != null) ? previous.content() : "");
+		String reasoningContent = (current.reasoningContent() != null ? current.reasoningContent()
+				: (previous.reasoningContent() != null ? previous.reasoningContent() : ""));
 		Role role = (current.role() != null ? current.role() : previous.role());
 		role = (role != null ? role : Role.ASSISTANT); // default to ASSISTANT (if null
 		String name = (current.name() != null ? current.name() : previous.name());
@@ -118,7 +120,7 @@ public class ZhiPuAiStreamFunctionCallingHelper {
 				toolCalls.add(lastPreviousTooCall);
 			}
 		}
-		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls);
+		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, reasoningContent);
 	}
 
 	private ToolCall merge(ToolCall previous, ToolCall current) {

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiApiToolFunctionCallIT.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiApiToolFunctionCallIT.java
@@ -124,7 +124,7 @@ public class ZhiPuAiApiToolFunctionCallIT {
 
 				// extend conversation with function response.
 				messages.add(new ChatCompletionMessage("" + weatherResponse.temp() + weatherRequest.unit(), Role.TOOL,
-						functionName, toolCall.id(), null));
+						functionName, toolCall.id(), null, null));
 			}
 		}
 


### PR DESCRIPTION
- Add `reasoning_content` fields to ChatCompletionMessage
- Added ZhiPuAiAssistantMessage as a subclass of AssistantMessage to support returning CoT content.
- Add integration tests
- fix "RestClient.Builder bean not found" exception for zhipu's image auto-config


`glm-4.1v-thinking-flash` is a new visual reasoning model, and it puts the COT content into a new field called `reasoning_content`.
This PR references the implementation from the `spring-ai-deepseek` module.

DeepSeek Module: https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekAssistantMessage.java

ZhiPuAi official document: https://www.bigmodel.cn/dev/api/visual-reasoning-model/GLM-4.1V-Thinking