### PR TITLE
Feature (template): Supports multi character template separators

### DIFF
--- a/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
+++ b/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
@@ -148,8 +148,8 @@ class StTemplateRendererTests {
 	@Test
 	void shouldRenderWithCustomDelimiters() {
 		StTemplateRenderer renderer = StTemplateRenderer.builder()
-			.startDelimiterToken('<')
-			.endDelimiterToken('>')
+			.startDelimiterToken("<")
+			.endDelimiterToken(">")
 			.build();
 		Map<String, Object> variables = new HashMap<>();
 		variables.put("name", "Spring AI");
@@ -160,10 +160,39 @@ class StTemplateRendererTests {
 	}
 
 	@Test
+	void shouldRenderWithDoubleAngleBracketDelimiters() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder()
+			.startDelimiterToken("<<")
+			.endDelimiterToken(">>")
+			.build();
+
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		String result = renderer.apply("Hello <<name>>!", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void shouldHandleDoubleCurlyBracesAsDelimiters() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder()
+			.startDelimiterToken("{{")
+			.endDelimiterToken("}}")
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		String result = renderer.apply("Hello {{name}}!", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
 	void shouldHandleSpecialCharactersAsDelimiters() {
 		StTemplateRenderer renderer = StTemplateRenderer.builder()
-			.startDelimiterToken('$')
-			.endDelimiterToken('$')
+			.startDelimiterToken("$")
+			.endDelimiterToken("$")
 			.build();
 		Map<String, Object> variables = new HashMap<>();
 		variables.put("name", "Spring AI");


### PR DESCRIPTION
- Allow the use of multiple characters as start and end separators for templates
- Implemented the function of converting custom separators into ST built-in format
- Updated test cases to support new multi character delimiter functionality
- Relevant unit tests have been provided
- This PR resolves Issue # 3800