### PR TITLE
GH-2947: Add @ToolParam annotation support for parameter name binding

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/ToolParam.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/annotation/ToolParam.java
@@ -23,9 +23,25 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a tool argument.
+ * Marks a tool argument for method-based tools.
+ * <p>
+ * This annotation can be used to specify metadata for a tool parameter, including whether
+ * it is required, a description, or a custom name to bind to.
+ * <p>
+ * When the parameter name cannot be inferred (e.g. compiled without `-parameters`), the
+ * {@code value} field can be used to manually specify the name that should match the key
+ * in the tool input map.
+ *
+ * <p>
+ * <b>Example:</b> <pre class="code">
+ * public String greet(
+ *     {@code @ToolParam(value = "user_name")} String name) {
+ *   return "Hello, " + name;
+ * }
+ * </pre>
  *
  * @author Thomas Vitale
+ * @author Dongha Koo
  * @since 1.0.0
  */
 @Target({ ElementType.PARAMETER, ElementType.FIELD, ElementType.ANNOTATION_TYPE })
@@ -42,5 +58,10 @@ public @interface ToolParam {
 	 * The description of the tool argument.
 	 */
 	String description() default "";
+
+	/**
+	 * The name of the parameter to bind to.
+	 */
+	String value() default "";
 
 }


### PR DESCRIPTION

✨ Summary
This PR introduces support for the @ToolParam annotation, enabling flexible and explicit JSON-to-method parameter binding when invoking tools via MethodToolCallback.

✨ Changes
Introduced @ToolParam(String value) annotation
Enhanced MethodToolCallback to resolve method parameters by:
First using @ToolParam.value if present
Falling back to the actual parameter name otherwise
Allows flexible and explicit JSON-to-parameter binding for method-based tools

💡 Example
Developers can now define tool methods like this:

```java
public String greet(@ToolParam("user_name") String name) {
    return "Hello, " + name;
}
```

Given the input:
`{ "user_name": "Alice" }`
The method will be invoked with name set to 'Alice'
This enhances flexibility when defining tools and avoids tight coupling between Java parameter names and input JSON structure.



🧪 Tests & Verification
✅ Unit tests added for:
Binding using @ToolParam("alias")
Binding with empty @ToolParam (falls back to parameter name)
Missing input values (should pass null)
Multiple annotated parameters
Compatibility with generic types and ToolContext

✅ ./mvnw clean verify passed (including Checkstyle)
✅ Apache license headers
✅ DCO signed
✅ Rebased on latest main, linear commit history maintained

📘 Documentation
JavaDoc provided for the new @ToolParam annotation
Inline comments in MethodToolCallback clarify binding logic

🔗 Closes #2947
📬 Let me know if any adjustments or refinements are needed!