### PR TITLE
Use maven wrapper and batch-mode in GitHub Actions

### DIFF
--- a/.github/workflows/continuous-inspection.yml
+++ b/.github/workflows/continuous-inspection.yml
@@ -22,12 +22,12 @@ jobs:
           cache: 'maven'
 
       - name: Analyse test coverage with Jacoco
-        run: mvn -P test-coverage verify
+        run: ./mvnw --batch-mode -P test-coverage verify
 
       - name: Analyse code quality with Sonar
         if: github.repository == 'spring-projects/spring-ai'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
-        run: mvn sonar:sonar -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_TOKEN
+        run: ./mvnw --batch-mode sonar:sonar -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.login=$SONAR_TOKEN
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,15 +53,15 @@ jobs:
           OLLAMA_AUTOCONF_TESTS_ENABLED: "true"
           OLLAMA_WITH_REUSE: true
         run: |
-          mvn -s settings.xml -Pci-fast-integration-tests -Pjavadoc -Dfailsafe.rerunFailingTestsCount=3 \
+          ./mvnw -s settings.xml -Pci-fast-integration-tests -Pjavadoc -Dfailsafe.rerunFailingTestsCount=3 \
           --batch-mode --update-snapshots deploy
 
       - name: Generate Java docs
-        run: mvn javadoc:aggregate
+        run: ./mvnw --batch-mode javadoc:aggregate
 
       - name: Generate assembly
         working-directory: spring-ai-docs
-        run: mvn assembly:single
+        run: ./mvnw --batch-mode assembly:single
 
       - name: Capture project version
         run: echo PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version --quiet -DforceStdout) >> $GITHUB_ENV

--- a/.github/workflows/documentation-upload.yml
+++ b/.github/workflows/documentation-upload.yml
@@ -26,14 +26,14 @@ jobs:
           cache: 'maven'
 
       - name: Generate Java docs
-        run: mvn clean install -DskipTests -Pjavadoc
+        run: ./mvnw --batch-mode clean install -DskipTests -Pjavadoc
 
       - name: Aggregate Java docs
-        run: mvn javadoc:aggregate
+        run: ./mvnw --batch-mode javadoc:aggregate
 
       - name: Generate assembly
         working-directory: spring-ai-docs
-        run: mvn assembly:single
+        run: ./mvnw --batch-mode assembly:single
 
       - name: Setup SSH key
         env:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,4 +23,4 @@ jobs:
 
       - name: Run tests
         run: |
-          ./mvnw test
+          ./mvnw --batch-mode test


### PR DESCRIPTION
I noticed that some of the GitHub actions are using `mvn` and not `./mvnw` the Maven Wrapper part of the project. Additionally I noticed that some commands are not using `--batch-mode`. This leads to builds which have:

```
Downloaded from central-portal-snapshots: https://central.sonatype.com/repository/maven-snapshots/io/modelcontextprotocol/sdk/mcp-bom/0.11.0-SNAPSHOT/mcp-bom-0.11.0-20250716.113131-38.pom (2.1 kB at 8.4 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
Progress (1): 4.1/169 kB
Progress (1): 8.2/169 kB
Progress (1): 12/169 kB 
Progress (1): 16/169 kB
Progress (1): 20/169 kB
````

The default "CI/CD build" already contains `--batch-mode`. However, some other ones such as the "Documentation Upload" or more importantly the "PR Check" did not, which make them way to noisy when you want to see what is happening. I would even argue that for "PR Check" the `--no-transfer-progress` could be used, in which case the 

```
[INFO] Downloading from maven-central: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-bom/1.9.25/kotlin-bom-1.9.25.pom
[INFO] Downloaded from maven-central: https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-bom/1.9.25/kotlin-bom-1.9.25.pom (9.1 kB at 326 kB/s)
```

would not be present. Entirely up to you if you prefer to go with the `--no-transfer-progress`
