### PR TITLE
GH-3842: Optimize the Bedrock documentation to keep it synchronized with the code

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -108,7 +108,7 @@ The prefix `spring.ai.bedrock.converse.chat` is the property prefix that configu
 
 == Runtime Options [[chat-options]]
 
-Use the portable `ChatOptions` or `ToolCallingChatOptions` portable builders to create model configurations, such as temperature, maxToken, topP, etc.
+Use the portable `ChatOptions` or `BedrockChatOptions` portable builders to create model configurations, such as temperature, maxToken, topP, etc.
 
 On start-up, the default options can be configured with the `BedrockConverseProxyChatModel(api, options)` constructor or the `spring.ai.bedrock.converse.chat.options.*` properties.
 
@@ -116,7 +116,7 @@ At run-time you can override the default options by adding new, request specific
 
 [source,java]
 ----
-var options = ToolCallingChatOptions.builder()
+var options = BedrockChatOptions.builder()
         .model("anthropic.claude-3-5-sonnet-20240620-v1:0")
         .temperature(0.6)
         .maxTokens(300)


### PR DESCRIPTION
As mentioned in the issue, this PR completes the `Runtime Options` section in the Bedrock documentation to keep it synchronized with the latest code.

Fixes: #3842 