### PR TITLE
fix: change log level for tool execution errors

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessor.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessor.java
@@ -18,6 +18,7 @@ package org.springframework.ai.tool.execution;
 
 import java.util.Collections;
 import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,7 @@ public class DefaultToolExecutionExceptionProcessor implements ToolExecutionExce
 		if (this.alwaysThrow) {
 			throw exception;
 		}
-		logger.debug("Exception thrown by tool: {}. Message: {}", exception.getToolDefinition().name(),
+		logger.error("Exception thrown by tool: {}. Message: {}", exception.getToolDefinition().name(),
 				exception.getMessage());
 		return exception.getMessage();
 	}


### PR DESCRIPTION
- Changed log level for tool execution errors from DEBUG to ERROR.

When an exception is thrown during tool execution, an ERROR-level log should be printed to help users troubleshoot the issue.
Or, should we set `DEFAULT_ALWAYS_THROW` to `true`?