### PR TITLE
Improve method param name in ChatClient.Builder.defaultAdvisors()

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -261,7 +261,7 @@ public interface ChatClient {
 	 */
 	interface Builder {
 
-		Builder defaultAdvisors(Advisor... advisor);
+		Builder defaultAdvisors(Advisor... advisors);
 
 		Builder defaultAdvisors(Consumer<AdvisorSpec> advisorSpecConsumer);
 


### PR DESCRIPTION
Improve method param name in `ChatClient.Builder.defaultAdvisors(Advisor...)` from `advisor` to `advisors`.
Method parameter naming rules should be consistent.

```java
	interface AdvisorSpec {

		AdvisorSpec advisors(Advisor... advisors);

	}
```

```java
	interface ChatClientRequestSpec {

		ChatClientRequestSpec advisors(Advisor... advisors);

	}
```

<img width="2870" height="468" alt="image" src="https://github.com/user-attachments/assets/14cbaf18-3d5e-43d9-b991-4fa1cefcbf1f" />
