### PR TITLE
GH-3873 Add an `api-version` option for Azure OpenAI

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiAudioTranscriptionOptions.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.azure.ai.openai.models.AudioTranscriptionFormat;
 import com.azure.ai.openai.models.AudioTranscriptionTimestampGranularity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -66,6 +67,12 @@ public class AzureOpenAiAudioTranscriptionOptions implements AudioTranscriptionO
 	private @JsonProperty("temperature") Float temperature = 0F;
 
 	private @JsonProperty("timestamp_granularities") List<GranularityType> granularityType;
+
+	/**
+	 * The explicit Azure AI Foundry Models API version to use for this request. latest if
+	 * not otherwise specified.
+	 */
+	@JsonIgnore private String apiVersion;
 
 	public static Builder builder() {
 		return new Builder();
@@ -128,6 +135,14 @@ public class AzureOpenAiAudioTranscriptionOptions implements AudioTranscriptionO
 		this.granularityType = granularityType;
 	}
 
+	public String getApiVersion() {
+		return apiVersion;
+	}
+
+	public void setApiVersion(String apiVersion) {
+		this.apiVersion = apiVersion;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -136,6 +151,7 @@ public class AzureOpenAiAudioTranscriptionOptions implements AudioTranscriptionO
 		result = prime * result + ((this.prompt == null) ? 0 : this.prompt.hashCode());
 		result = prime * result + ((this.language == null) ? 0 : this.language.hashCode());
 		result = prime * result + ((this.responseFormat == null) ? 0 : this.responseFormat.hashCode());
+		result = prime * result + ((this.apiVersion == null) ? 0 : this.apiVersion.hashCode());
 		return result;
 	}
 
@@ -175,6 +191,16 @@ public class AzureOpenAiAudioTranscriptionOptions implements AudioTranscriptionO
 		else if (!this.language.equals(other.language)) {
 			return false;
 		}
+
+		if (this.apiVersion == null) {
+			if (other.apiVersion != null) {
+				return false;
+			}
+		}
+		else if (!this.apiVersion.equals(other.apiVersion)) {
+			return false;
+		}
+
 		if (this.responseFormat == null) {
 			return other.responseFormat == null;
 		}
@@ -299,6 +325,11 @@ public class AzureOpenAiAudioTranscriptionOptions implements AudioTranscriptionO
 
 		public Builder granularityType(List<GranularityType> granularityType) {
 			this.options.granularityType = granularityType;
+			return this;
+		}
+
+		public Builder apiVersion(String apiVersion) {
+			this.options.apiVersion = apiVersion;
 			return this;
 		}
 

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -216,6 +216,13 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	@JsonProperty("reasoning_effort")
 	private String reasoningEffort;
 
+	/**
+	 * The explicit Azure AI Foundry Models API version to use for this request. latest if
+	 * not otherwise specified.
+	 */
+	@JsonIgnore
+	private String apiVersion;
+
 	@Override
 	@JsonIgnore
 	public List<ToolCallback> getToolCallbacks() {
@@ -288,6 +295,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 			.toolCallbacks(
 					fromOptions.getToolCallbacks() != null ? new ArrayList<>(fromOptions.getToolCallbacks()) : null)
 			.toolNames(fromOptions.getToolNames() != null ? new HashSet<>(fromOptions.getToolNames()) : null)
+			.apiVersion(fromOptions.getApiVersion())
 			.build();
 	}
 
@@ -482,6 +490,14 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 		this.streamOptions = streamOptions;
 	}
 
+	public String getApiVersion() {
+		return apiVersion;
+	}
+
+	public void setApiVersion(String apiVersion) {
+		this.apiVersion = apiVersion;
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public AzureOpenAiChatOptions copy() {
@@ -512,7 +528,8 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolContext, that.toolContext) && Objects.equals(this.maxTokens, that.maxTokens)
 				&& Objects.equals(this.frequencyPenalty, that.frequencyPenalty)
 				&& Objects.equals(this.presencePenalty, that.presencePenalty)
-				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP);
+				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP)
+				&& Objects.equals(this.apiVersion, that.apiVersion);
 	}
 
 	@Override
@@ -521,7 +538,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 				this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled, this.seed, this.logprobs,
 				this.topLogProbs, this.enhancements, this.streamOptions, this.reasoningEffort, this.enableStreamUsage,
 				this.toolContext, this.maxTokens, this.frequencyPenalty, this.presencePenalty, this.temperature,
-				this.topP);
+				this.topP, this.apiVersion);
 	}
 
 	public static class Builder {
@@ -661,6 +678,11 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder apiVersion(String apiVersion) {
+			this.options.setApiVersion(apiVersion);
 			return this;
 		}
 

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingOptions.java
@@ -57,6 +57,12 @@ public class AzureOpenAiEmbeddingOptions implements EmbeddingOptions {
 	 */
 	private Integer dimensions;
 
+	/**
+	 * The explicit Azure AI Foundry Models API version to use for this request. latest if
+	 * not otherwise specified.
+	 */
+	private String apiVersion;
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -105,6 +111,14 @@ public class AzureOpenAiEmbeddingOptions implements EmbeddingOptions {
 		this.dimensions = dimensions;
 	}
 
+	public String getApiVersion() {
+		return apiVersion;
+	}
+
+	public void setApiVersion(String apiVersion) {
+		this.apiVersion = apiVersion;
+	}
+
 	public com.azure.ai.openai.models.EmbeddingsOptions toAzureOptions(List<String> instructions) {
 
 		var azureOptions = new com.azure.ai.openai.models.EmbeddingsOptions(instructions);
@@ -144,6 +158,9 @@ public class AzureOpenAiEmbeddingOptions implements EmbeddingOptions {
 				if (castFrom.getDimensions() != null) {
 					this.options.setDimensions(castFrom.getDimensions());
 				}
+				if (castFrom.getApiVersion() != null) {
+					this.options.setApiVersion(castFrom.getApiVersion());
+				}
 			}
 			return this;
 		}
@@ -174,6 +191,11 @@ public class AzureOpenAiEmbeddingOptions implements EmbeddingOptions {
 
 		public Builder dimensions(Integer dimensions) {
 			this.options.dimensions = dimensions;
+			return this;
+		}
+
+		public Builder apiVersion(String apiVersion) {
+			this.options.apiVersion = apiVersion;
 			return this;
 		}
 

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureChatCompletionsOptionsTests.java
@@ -70,6 +70,7 @@ public class AzureChatCompletionsOptionsTests {
 			.topLogprobs(5)
 			.enhancements(mockAzureChatEnhancementConfiguration)
 			.responseFormat(AzureOpenAiResponseFormat.builder().type(Type.TEXT).build())
+			.apiVersion("preview")
 			.build();
 
 		var client = AzureOpenAiChatModel.builder()
@@ -79,6 +80,7 @@ public class AzureChatCompletionsOptionsTests {
 
 		var requestOptions = client.toAzureChatCompletionsOptions(new Prompt("Test message content"));
 
+		assertThat(client.getDefaultOptions().getApiVersion()).isEqualTo("preview");
 		assertThat(requestOptions.getMessages()).hasSize(1);
 
 		assertThat(requestOptions.getModel()).isEqualTo("DEFAULT_MODEL");


### PR DESCRIPTION
As mentioned in the issue, almost all interfaces of `azure-openai` support the `api-version` option. This is not a parameter within the request body, but rather passed as a query parameter in the URL (refer to the official documentation: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference-preview-latest#create-chat-completion). Currently, Spring AI does not support this option. This PR adds that support.

What this PR does:

1. Adds an `apiVersion` configuration option to `AzureOpenAiChatOptions`, `AzureOpenAiAudioTranscriptionOptions`, and `AzureOpenAiEmbeddingOptions`. The parameter is then passed through to the corresponding models and ultimately provided to the Azure SDK. The transmission is achieved via the SDK's `RequestOptions`, which supports appending query parameters to the request URL.

2. I initially intended to add this option to `AzureOpenAiImageOptions` as well. However, the Azure SDK does not expose any method accepting `RequestOptions` as public for image-related operations(`com.azure.ai.openai.OpenAIClient#getImageGenerationsWithResponse(java.lang.String, com.azure.core.util.BinaryData, com.azure.core.http.rest.RequestOptions)`). I believe this is a bug, as it is inconsistent with the behavior of other interfaces. I have submitted a PR to Azure to attempt to fix it: 
https://github.com/Azure/azure-sdk-for-java/pull/46102
Once that PR is accepted, I will follow up with another PR to Spring AI to add the `apiVersion` option to `AzureOpenAiImageOptions`.

Fixes: #3873 