### PR TITLE
fix: Make sure that `XXXResponseSpec` instances can only be used once

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -58,6 +58,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -687,6 +688,19 @@ class DefaultChatClientTests {
 	}
 
 	@Test
+	void whenUseCallResponseSpecTwiceThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt("question");
+		DefaultChatClient.DefaultCallResponseSpec spec = (DefaultChatClient.DefaultCallResponseSpec) chatClientRequestSpec
+			.call();
+
+		assertThatNoException().isThrownBy(() -> spec.content());
+		assertThatThrownBy(() -> spec.content()).isInstanceOf(IllegalStateException.class)
+			.hasMessage("The CallResponseSpec instance can only be used once.");
+	}
+
+	@Test
 	void whenSimplePromptThenChatClientResponse() {
 		ChatModel chatModel = mock(ChatModel.class);
 		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
@@ -1197,6 +1211,19 @@ class DefaultChatClientTests {
 				mock(BaseAdvisorChain.class), mock(ObservationRegistry.class), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationConvention cannot be null");
+	}
+
+	@Test
+	void whenUseStreamResponseSpecTwiceThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		DefaultChatClient.DefaultChatClientRequestSpec chatClientRequestSpec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt("question");
+		DefaultChatClient.DefaultStreamResponseSpec spec = (DefaultChatClient.DefaultStreamResponseSpec) chatClientRequestSpec
+			.stream();
+
+		assertThatNoException().isThrownBy(() -> spec.content());
+		assertThatThrownBy(() -> spec.content()).isInstanceOf(IllegalStateException.class)
+			.hasMessage("The StreamResponseSpec instance can only be used once.");
 	}
 
 	@Test


### PR DESCRIPTION
- Add an `AtomicBoolean` to DefaultCallResponseSpec and DefaultStreamResponseSpec to track whether the instance has been used
- Check if the instance has already been used before calling `advisorChain.nextCall`, and throw an `IllegalStateException` if it has
- Add unit tests to confirm that case

Based on issue #3880, we could add checks to detect if methods in `DefaultCallResponseSpec` and `DefaultStreamResponseSpec` are called more than once, and throw a clear exception to help with debugging.

