### PR TITLE
Make OpenAiApi available as a bean for injection

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
@@ -24,6 +24,7 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.ai.openai.OpenAiModerationModel;
+import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
@@ -42,6 +43,7 @@ public class OpenAiModelConfigurationTests {
 	@Test
 	void chatModelActivation() {
 		this.contextRunner.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class)).run(context -> {
+			assertThat(context.getBeansOfType(OpenAiApi.class)).isNotEmpty();
 			assertThat(context.getBeansOfType(OpenAiChatModel.class)).isNotEmpty();
 			assertThat(context.getBeansOfType(OpenAiEmbeddingModel.class)).isEmpty();
 			assertThat(context.getBeansOfType(OpenAiImageModel.class)).isEmpty();
@@ -301,6 +303,16 @@ public class OpenAiModelConfigurationTests {
 				assertThat(context.getBeansOfType(OpenAiAudioTranscriptionModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(OpenAiModerationModel.class)).isNotEmpty();
 			});
+	}
+
+	@Test
+	void openAiApiBean() {
+		// Test that OpenAiApi bean is registered and can be injected
+		this.contextRunner.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class)).run(context -> {
+			assertThat(context.getBeansOfType(OpenAiApi.class)).hasSize(1);
+			OpenAiApi openAiApi = context.getBean(OpenAiApi.class);
+			assertThat(openAiApi).isNotNull();
+		});
 	}
 
 }


### PR DESCRIPTION
## Summary
- Extract OpenAiApi creation to a separate @Bean method
- Update OpenAiChatModel to inject the OpenAiApi bean instead of creating it internally
- Add test to verify OpenAiApi bean registration

## Details
This PR addresses #3878 where OpenAiApi was not available for injection despite documentation suggesting it could be used to configure multiple OpenAI-compatible ChatClients.

### Changes
1. **OpenAiChatAutoConfiguration.java**:
   - Moved `openAiApi` from private method to public `@Bean` method
   - Updated `openAiChatModel` to inject the OpenAiApi bean

2. **OpenAiModelConfigurationTests.java**:
   - Added import for OpenAiApi
   - Added verification that OpenAiApi bean is registered in `chatModelActivation` test
   - Added new test `openAiApiBean` to specifically test OpenAiApi bean injection

### Testing
All existing tests pass, plus new test confirms OpenAiApi can be injected as a bean.

Fixes #3878

Signed-off-by: Hyunjoon Park <academey@gmail.com>