### PR TITLE
Adds support for retrieving the model name directly from DefaultChatClient

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import io.micrometer.observation.ObservationRegistry;
@@ -88,6 +89,14 @@ public interface ChatClient {
 	ChatClientRequestSpec prompt(String content);
 
 	ChatClientRequestSpec prompt(Prompt prompt);
+
+	/**
+	 * Returns the underlying {@link ChatModel} used by this client. This allows access to
+	 * model metadata such as the model name, temperature, etc.
+	 * @return the ChatModel
+	 * @since 1.0.1
+	 */
+	ChatModel getChatModel();
 
 	/**
 	 * Return a {@link ChatClient.Builder} to create a new {@link ChatClient} whose

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -80,15 +80,19 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultChatClient implements ChatClient {
 
+	private final ChatModel chatModel;
+
 	private static final ChatClientObservationConvention DEFAULT_CHAT_CLIENT_OBSERVATION_CONVENTION = new DefaultChatClientObservationConvention();
 
 	private static final TemplateRenderer DEFAULT_TEMPLATE_RENDERER = StTemplateRenderer.builder().build();
 
 	private final DefaultChatClientRequestSpec defaultChatClientRequest;
 
-	public DefaultChatClient(DefaultChatClientRequestSpec defaultChatClientRequest) {
+	public DefaultChatClient(DefaultChatClientRequestSpec defaultChatClientRequest, @Nullable ChatModel chatModel) {
 		Assert.notNull(defaultChatClientRequest, "defaultChatClientRequest cannot be null");
+		Assert.notNull(chatModel, "chatModel cannot be null");
 		this.defaultChatClientRequest = defaultChatClientRequest;
+		this.chatModel = chatModel;
 	}
 
 	@Override
@@ -119,6 +123,16 @@ public class DefaultChatClient implements ChatClient {
 		}
 
 		return spec;
+	}
+
+	/**
+	 * Returns the underlying {@link ChatModel} used by this client. This allows access to
+	 * model metadata such as the model name, temperature, etc.
+	 * @return the ChatModel
+	 */
+	@Override
+	public ChatModel getChatModel() {
+		return this.chatModel;
 	}
 
 	/**

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -54,6 +54,8 @@ import org.springframework.util.Assert;
  */
 public class DefaultChatClientBuilder implements Builder {
 
+	private final ChatModel chatModel;
+
 	protected final DefaultChatClientRequestSpec defaultRequest;
 
 	DefaultChatClientBuilder(ChatModel chatModel) {
@@ -67,10 +69,11 @@ public class DefaultChatClientBuilder implements Builder {
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), null, Map.of(), List.of(),
 				List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
 				customObservationConvention, Map.of(), null);
+		this.chatModel = chatModel;
 	}
 
 	public ChatClient build() {
-		return new DefaultChatClient(this.defaultRequest);
+		return new DefaultChatClient(this.defaultRequest, chatModel);
 	}
 
 	public Builder clone() {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -74,7 +74,7 @@ class DefaultChatClientTests {
 
 	@Test
 	void whenChatClientRequestIsNullThenThrow() {
-		assertThatThrownBy(() -> new DefaultChatClient(null)).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> new DefaultChatClient(null, null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("defaultChatClientRequest cannot be null");
 	}
 
@@ -1956,6 +1956,23 @@ class DefaultChatClientTests {
 		assertThat(defaultSpec.getUserText()).isEqualTo("my question about {topic}");
 		assertThat(defaultSpec.getUserParams()).containsEntry("topic", "AI");
 		assertThat(defaultSpec.getMedia()).hasSize(1);
+	}
+
+	@Test
+	void whenGetChatModelThenReturnModelName() {
+		// Arrange
+		ChatModel mockChatModel = mock(ChatModel.class);
+		ChatOptions mockOptions = mock(ChatOptions.class);
+
+		when(mockChatModel.getDefaultOptions()).thenReturn(mockOptions);
+		when(mockOptions.getModel()).thenReturn("gpt-4o-mini");
+
+		// Act
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel).build();
+
+		// Assert
+		assertThat(chatClient.getChatModel()).isNotNull();
+		assertThat(chatClient.getChatModel().getDefaultOptions().getModel()).isEqualTo("gpt-4o-mini");
 	}
 
 	record Person(String name) {


### PR DESCRIPTION
✨ PR: Expose Model Name from ChatClient
﻿
📝 Summary
﻿
This PR adds support for retrieving the model name directly from `DefaultChatClient`.

🚀 Motivation
﻿
In multi-model environments, we often need to log or observe which underlying model is being used (e.g., `gpt-4o`, `llama3`, etc.).  
Currently, this requires injecting both `ChatClient` and `ChatModel`, or rebuilding the client manually.  
This change simplifies the process and improves observability.
﻿
🔧 Changes
﻿
- 🧠 Stored the `ChatModel` inside `DefaultChatClient` for later access  
- 🏗️ Modified `DefaultChatClientBuilder` to pass the `ChatModel` when building  
- ✅ Added unit test to validate the new functionality  

This PR resolves issue #3790 