### PR TITLE
GH-3896 Similarity searches with the MariaDBVectorStore do not provide a score

### DIFF
--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBVectorStore.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBVectorStore.java
@@ -485,9 +485,13 @@ public class MariaDBVectorStore extends AbstractObservationVectorStore implement
 			Map<String, Object> metadata = toMap(rs.getString(3));
 			float distance = rs.getFloat(4);
 
-			metadata.put("distance", distance);
-
-			return new Document(id, content, metadata);
+			// @formatter:off
+			return Document.builder()
+					.id(id)
+					.text(content)
+					.metadata(metadata)
+					.score(1.0 - distance)
+					.build(); // @formatter:on
 		}
 
 		private Map<String, Object> toMap(String source) {


### PR DESCRIPTION
Fixes GH-3896 (https://github.com/spring-projects/spring-ai/issues/3896)

The MariaDBVectorStore no longer puts the distance in the metadata when doing a similarity search. Instead, the score is calculated from the distance and set via the builder.

<!--Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc-->