### PR TITLE
Add `KotlinModule` support for schema generation in `BeanOutputConverter`

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -37,7 +37,9 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.model.KotlinModule;
 import org.springframework.ai.util.JacksonUtils;
+import org.springframework.core.KotlinDetector;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.lang.NonNull;
 
@@ -136,6 +138,11 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 				com.github.victools.jsonschema.generator.OptionPreset.PLAIN_JSON)
 			.with(jacksonModule)
 			.with(Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT);
+
+		if (KotlinDetector.isKotlinReflectPresent()) {
+			configBuilder.with(new KotlinModule());
+		}
+
 		SchemaGeneratorConfig config = configBuilder.build();
 		SchemaGenerator generator = new SchemaGenerator(config);
 		JsonNode jsonNode = generator.generateSchema(this.type);

--- a/spring-ai-model/src/test/kotlin/org/springframework/ai/converter/BeanOutputConverterTests.kt
+++ b/spring-ai-model/src/test/kotlin/org/springframework/ai/converter/BeanOutputConverterTests.kt
@@ -1,0 +1,58 @@
+package org.springframework.ai.converter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class KotlinBeanOutputConverterTests {
+
+	private data class Foo(val bar: String, val baz: String?)
+	private data class FooWithDefault(val bar: String, val baz: Int = 10)
+
+	private val objectMapper = ObjectMapper()
+
+	@Test
+	fun `test Kotlin data class schema generation using getJsonSchema`() {
+		val converter = BeanOutputConverter(Foo::class.java)
+
+		val schemaJson = converter.jsonSchema
+
+		val schemaNode = objectMapper.readTree(schemaJson)
+
+		val required = schemaNode["required"]
+		assertThat(required).isNotNull
+		assertThat(required.toString()).contains("bar")
+		assertThat(required.toString()).doesNotContain("baz")
+
+		val properties = schemaNode["properties"]
+		assertThat(properties["bar"]["type"].asText()).isEqualTo("string")
+
+		val bazTypeNode = properties["baz"]["type"]
+		if (bazTypeNode.isArray) {
+			assertThat(bazTypeNode.toString()).contains("string")
+			assertThat(bazTypeNode.toString()).contains("null")
+		} else {
+			assertThat(bazTypeNode.asText()).isEqualTo("string")
+		}
+	}
+
+	@Test
+	fun `test Kotlin data class with default values`() {
+		val converter = BeanOutputConverter(FooWithDefault::class.java)
+
+		val schemaJson = converter.jsonSchema
+
+		val schemaNode = objectMapper.readTree(schemaJson)
+
+		val required = schemaNode["required"]
+		assertThat(required).isNotNull
+		assertThat(required.toString()).contains("bar")
+		assertThat(required.toString()).doesNotContain("baz")
+
+		val properties = schemaNode["properties"]
+		assertThat(properties["bar"]["type"].asText()).isEqualTo("string")
+
+		val bazTypeNode = properties["baz"]["type"]
+		assertThat(bazTypeNode.asText()).isEqualTo("integer")
+	}
+}


### PR DESCRIPTION
It is stated in the **Integrating with BeanOutputConverter Utilities** section of the OpenAI ChatModel [documentation](https://docs.spring.io/spring-ai/reference/api/chat/openai-chat.html#_integrating_with_beanoutputconverter_utilities) that

> Kotlin reflection is used to infer which property are required or not based on the nullability of types and default values of parameters, so for most use case `@get:JsonProperty(required = true)` is not needed.

However, this is not true for `BeanOutputConverter`, because `KotlinModule` that infers the required Kotlin properties is used only in the `ModelOptionsUtils` class.

This PR fixes the issue by adding Kotlin class support to the `BeanOutputConverter`.