### PR TITLE
Introduce McpToolDefinition to preserve original tool and client name

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
@@ -26,6 +26,7 @@ import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.McpToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.ToolExecutionException;
 
@@ -83,15 +84,21 @@ public class AsyncMcpToolCallback implements ToolCallback {
 	 * <li>The tool's name from the MCP definition</li>
 	 * <li>The tool's description from the MCP definition</li>
 	 * <li>The input schema converted to JSON format</li>
+	 * <li>The tool's name before being prefixed with MCP client info</li>
+	 * <li>The client name from the MCP client info</li>
 	 * </ul>
 	 * @return the Spring AI tool definition
 	 */
 	@Override
 	public ToolDefinition getToolDefinition() {
-		return DefaultToolDefinition.builder()
-			.name(McpToolUtils.prefixedToolName(this.asyncMcpClient.getClientInfo().name(), this.tool.name()))
+		String clientName = this.asyncMcpClient.getClientInfo().name();
+		String toolName = this.tool.name();
+		return McpToolDefinition.builder()
+			.name(McpToolUtils.prefixedToolName(clientName, toolName))
 			.description(this.tool.description())
 			.inputSchema(ModelOptionsUtils.toJsonString(this.tool.inputSchema()))
+			.toolName(toolName)
+			.clientName(clientName)
 			.build();
 	}
 

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
@@ -28,6 +28,7 @@ import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.McpToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.ToolExecutionException;
 
@@ -88,15 +89,21 @@ public class SyncMcpToolCallback implements ToolCallback {
 	 * <li>The tool's name from the MCP definition</li>
 	 * <li>The tool's description from the MCP definition</li>
 	 * <li>The input schema converted to JSON format</li>
+	 * <li>The tool's name before being prefixed with MCP client info</li>
+	 * <li>The client name from the MCP client info</li>
 	 * </ul>
 	 * @return the Spring AI tool definition
 	 */
 	@Override
 	public ToolDefinition getToolDefinition() {
-		return DefaultToolDefinition.builder()
-			.name(McpToolUtils.prefixedToolName(this.mcpClient.getClientInfo().name(), this.tool.name()))
+		String clientName = this.mcpClient.getClientInfo().name();
+		String toolName = this.tool.name();
+		return McpToolDefinition.builder()
+			.name(McpToolUtils.prefixedToolName(clientName, toolName))
 			.description(this.tool.description())
 			.inputSchema(ModelOptionsUtils.toJsonString(this.tool.inputSchema()))
+			.toolName(toolName)
+			.clientName(clientName)
 			.build();
 	}
 

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -8,7 +8,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.tool.definition.McpToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.ToolExecutionException;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -51,4 +54,34 @@ class AsyncMcpToolCallbackTest {
 			.hasMessage("Testing tool error");
 	}
 
+	@Test
+	void getToolDefinitionShouldReturnMcpToolDefinitionInstance() {
+		var clientInfo = new McpSchema.Implementation("spring_ai_mcp_client", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		when(this.tool.name()).thenReturn("sum");
+		when(this.tool.description()).thenReturn("Adds two numbers");
+
+		AsyncMcpToolCallback callback = new AsyncMcpToolCallback(this.mcpClient, this.tool);
+
+		ToolDefinition toolDefinition = callback.getToolDefinition();
+
+		assertThat(toolDefinition).isInstanceOf(McpToolDefinition.class);
+	}
+
+	@Test
+	void getToolDefinitionShouldPreserveOriginalToolNameAndClientName() {
+		var clientInfo = new McpSchema.Implementation("spring_ai_mcp_client", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		when(this.tool.name()).thenReturn("sum");
+		when(this.tool.description()).thenReturn("Adds two numbers");
+
+		AsyncMcpToolCallback callback = new AsyncMcpToolCallback(this.mcpClient, this.tool);
+
+		ToolDefinition toolDefinition = callback.getToolDefinition();
+		McpToolDefinition mcpDefinition = (McpToolDefinition) toolDefinition;
+
+		assertThat(mcpDefinition.toolName()).isEqualTo("sum");
+		assertThat(mcpDefinition.clientName()).isEqualTo("spring_ai_mcp_client");
+		assertThat(mcpDefinition.name()).isEqualTo("spring_ai_mcp_client_sum");
+	}
 }

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -31,7 +31,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.chat.model.ToolContext;
-import org.springframework.ai.content.Content;
+import org.springframework.ai.tool.definition.McpToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.ToolExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -129,6 +130,37 @@ class SyncMcpToolCallbackTests {
 		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
 			.rootCause()
 			.hasMessage("Testing tool error");
+	}
+
+	@Test
+	void getToolDefinitionShouldReturnMcpToolDefinitionInstance() {
+		var clientInfo = new Implementation("spring_ai_mcp_client", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		when(this.tool.name()).thenReturn("sum");
+		when(this.tool.description()).thenReturn("Adds two numbers");
+
+		SyncMcpToolCallback callback = new SyncMcpToolCallback(this.mcpClient, this.tool);
+
+		ToolDefinition toolDefinition = callback.getToolDefinition();
+
+		assertThat(toolDefinition).isInstanceOf(McpToolDefinition.class);
+	}
+
+	@Test
+	void getToolDefinitionShouldPreserveOriginalToolNameAndClientName() {
+		var clientInfo = new Implementation("spring_ai_mcp_client", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		when(this.tool.name()).thenReturn("sum");
+		when(this.tool.description()).thenReturn("Adds two numbers");
+
+		SyncMcpToolCallback callback = new SyncMcpToolCallback(this.mcpClient, this.tool);
+
+		ToolDefinition toolDefinition = callback.getToolDefinition();
+		McpToolDefinition mcpDefinition = (McpToolDefinition) toolDefinition;
+
+		assertThat(mcpDefinition.toolName()).isEqualTo("sum");
+		assertThat(mcpDefinition.clientName()).isEqualTo("spring_ai_mcp_client");
+		assertThat(mcpDefinition.name()).isEqualTo("spring_ai_mcp_client_sum");
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/definition/McpToolDefinition.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/definition/McpToolDefinition.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.definition;
+
+import org.springframework.ai.util.ParsingUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Extended implementation of {@link ToolDefinition} that preserves the original MCP tool
+ * name and client name in addition to the prefixed name.
+ *
+ * @author Danny Sortino
+ */
+public record McpToolDefinition(String name, String description, String inputSchema, String toolName,
+		String clientName) implements ToolDefinition {
+
+	public McpToolDefinition {
+		Assert.hasText(name, "name cannot be null or empty");
+		Assert.hasText(description, "description cannot be null or empty");
+		Assert.hasText(inputSchema, "inputSchema cannot be null or empty");
+		Assert.hasText(toolName, "toolName cannot be null or empty");
+		Assert.hasText(clientName, "clientName cannot be null or empty");
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		private String name;
+
+		private String description;
+
+		private String inputSchema;
+
+		private String toolName;
+
+		private String clientName;
+
+		private Builder() {
+		}
+
+		public Builder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public Builder description(String description) {
+			this.description = description;
+			return this;
+		}
+
+		public Builder inputSchema(String inputSchema) {
+			this.inputSchema = inputSchema;
+			return this;
+		}
+
+		public Builder toolName(String toolName) {
+			this.toolName = toolName;
+			return this;
+		}
+
+		public Builder clientName(String clientName) {
+			this.clientName = clientName;
+			return this;
+		}
+
+		public McpToolDefinition build() {
+			if (!StringUtils.hasText(this.description)) {
+				Assert.hasText(this.toolName, "toolName cannot be null or empty");
+				this.description = ParsingUtils.reConcatenateCamelCase(this.toolName, " ");
+			}
+			return new McpToolDefinition(this.name, this.description, this.inputSchema, this.toolName, this.clientName);
+		}
+
+	}
+
+}


### PR DESCRIPTION
This pull request introduces a new `McpToolDefinition` class to extend the existing `ToolDefinition` functionality, allowing the preservation of the original tool name and client name alongside the prefixed name. It also updates the `AsyncMcpToolCallback` and `SyncMcpToolCallback` classes to use this new definition and adds corresponding unit tests to validate the changes.

### Enhancements to Tool Definition:

* Added a new `McpToolDefinition` class in `spring-ai-model/src/main/java/org/springframework/ai/tool/definition/McpToolDefinition.java`. This class extends `ToolDefinition` to include additional fields for the original tool name (`toolName`) and client name (`clientName`). It also provides a builder for creating instances.

### Updates to Callback Classes:

* Updated `AsyncMcpToolCallback` to use `McpToolDefinition` instead of `DefaultToolDefinition` in the `getToolDefinition` method. This change includes capturing and passing the original tool name and client name. [[1]](diffhunk://#diff-5416896f76088e6794ea2ecec76221270c709bae29491ea8b215978b339dec24R29) [[2]](diffhunk://#diff-5416896f76088e6794ea2ecec76221270c709bae29491ea8b215978b339dec24R87-R101)
* Updated `SyncMcpToolCallback` similarly to use `McpToolDefinition` in its `getToolDefinition` method. [[1]](diffhunk://#diff-9db1f11ac44da8ac3fc7747a999f930d20fd70f52e78e0b4c05b18cea16e1ba5R31) [[2]](diffhunk://#diff-9db1f11ac44da8ac3fc7747a999f930d20fd70f52e78e0b4c05b18cea16e1ba5R92-R106)

### Unit Test Additions:

* Added tests in `AsyncMcpToolCallbackTest` to verify that:
  - The `getToolDefinition` method returns an instance of `McpToolDefinition`.
  - The original tool name and client name are preserved in the returned `McpToolDefinition`.
* Added similar tests in `SyncMcpToolCallbackTests` to validate the behavior of `getToolDefinition` for synchronous callbacks.

These changes improve the flexibility and traceability of tool definitions by retaining additional metadata, which can be useful for debugging or integration scenarios.

Closes #3897 