### PR TITLE
chore: made embedding options builder methods consistent

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingOptions.java
@@ -66,7 +66,12 @@ public class BedrockTitanEmbeddingOptions implements EmbeddingOptions {
 
 		private BedrockTitanEmbeddingOptions options = new BedrockTitanEmbeddingOptions();
 
+		@Deprecated
 		public Builder withInputType(InputType inputType) {
+			return this.inputType(inputType);
+		}
+
+		public Builder inputType(InputType inputType) {
 			Assert.notNull(inputType, "input type can not be null.");
 
 			this.options.setInputType(inputType);

--- a/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModelIT.java
+++ b/models/spring-ai-bedrock/src/test/java/org/springframework/ai/bedrock/titan/BedrockTitanEmbeddingModelIT.java
@@ -55,7 +55,7 @@ class BedrockTitanEmbeddingModelIT {
 	void singleEmbedding() {
 		assertThat(this.embeddingModel).isNotNull();
 		EmbeddingResponse embeddingResponse = this.embeddingModel.call(new EmbeddingRequest(List.of("Hello World"),
-				BedrockTitanEmbeddingOptions.builder().withInputType(InputType.TEXT).build()));
+				BedrockTitanEmbeddingOptions.builder().inputType(InputType.TEXT).build()));
 		assertThat(embeddingResponse.getResults()).hasSize(1);
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);
@@ -69,7 +69,7 @@ class BedrockTitanEmbeddingModelIT {
 
 		EmbeddingResponse embeddingResponse = this.embeddingModel
 			.call(new EmbeddingRequest(List.of(Base64.getEncoder().encodeToString(image)),
-					BedrockTitanEmbeddingOptions.builder().withInputType(InputType.IMAGE).build()));
+					BedrockTitanEmbeddingOptions.builder().inputType(InputType.IMAGE).build()));
 		assertThat(embeddingResponse.getResults()).hasSize(1);
 		assertThat(embeddingResponse.getResults().get(0).getOutput()).isNotEmpty();
 		assertThat(this.embeddingModel.dimensions()).isEqualTo(1024);

--- a/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/TransformersEmbeddingModelObservationTests.java
+++ b/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/TransformersEmbeddingModelObservationTests.java
@@ -55,8 +55,7 @@ public class TransformersEmbeddingModelObservationTests {
 
 	@Test
 	void observationForEmbeddingOperation() {
-
-		var options = EmbeddingOptionsBuilder.builder().withModel("bert-base-uncased").build();
+		var options = EmbeddingOptionsBuilder.builder().model("bert-base-uncased").build();
 
 		EmbeddingRequest embeddingRequest = new EmbeddingRequest(List.of("Here comes the sun"), options);
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/embedding/EmbeddingOptionsBuilder.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/embedding/EmbeddingOptionsBuilder.java
@@ -33,14 +33,24 @@ public final class EmbeddingOptionsBuilder {
 		return new EmbeddingOptionsBuilder();
 	}
 
-	public EmbeddingOptionsBuilder withModel(String model) {
+	public EmbeddingOptionsBuilder model(String model) {
 		this.embeddingOptions.setModel(model);
 		return this;
 	}
 
-	public EmbeddingOptionsBuilder withDimensions(Integer dimensions) {
+	@Deprecated
+	public EmbeddingOptionsBuilder withModel(String model) {
+		return model(model);
+	}
+
+	public EmbeddingOptionsBuilder dimensions(Integer dimensions) {
 		this.embeddingOptions.setDimensions(dimensions);
 		return this;
+	}
+
+	@Deprecated
+	public EmbeddingOptionsBuilder withDimensions(Integer dimensions) {
+		return dimensions(dimensions);
 	}
 
 	public EmbeddingOptions build() {

--- a/spring-ai-model/src/test/java/org/springframework/ai/embedding/observation/DefaultEmbeddingModelObservationConventionTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/embedding/observation/DefaultEmbeddingModelObservationConventionTests.java
@@ -53,7 +53,7 @@ class DefaultEmbeddingModelObservationConventionTests {
 	@Test
 	void contextualNameWhenModelIsDefined() {
 		EmbeddingModelObservationContext observationContext = EmbeddingModelObservationContext.builder()
-			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().withModel("mistral").build()))
+			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().model("mistral").build()))
 			.provider("superprovider")
 			.build();
 		assertThat(this.observationConvention.getContextualName(observationContext)).isEqualTo("embedding mistral");
@@ -71,8 +71,7 @@ class DefaultEmbeddingModelObservationConventionTests {
 	@Test
 	void supportsOnlyEmbeddingModelObservationContext() {
 		EmbeddingModelObservationContext observationContext = EmbeddingModelObservationContext.builder()
-			.embeddingRequest(
-					generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().withModel("supermodel").build()))
+			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().model("supermodel").build()))
 			.provider("superprovider")
 			.build();
 		assertThat(this.observationConvention.supportsContext(observationContext)).isTrue();
@@ -82,7 +81,7 @@ class DefaultEmbeddingModelObservationConventionTests {
 	@Test
 	void shouldHaveLowCardinalityKeyValuesWhenDefined() {
 		EmbeddingModelObservationContext observationContext = EmbeddingModelObservationContext.builder()
-			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().withModel("mistral").build()))
+			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().model("mistral").build()))
 			.provider("superprovider")
 			.build();
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(observationContext)).contains(
@@ -95,7 +94,7 @@ class DefaultEmbeddingModelObservationConventionTests {
 	void shouldHaveLowCardinalityKeyValuesWhenDefinedAndResponse() {
 		EmbeddingModelObservationContext observationContext = EmbeddingModelObservationContext.builder()
 			.embeddingRequest(generateEmbeddingRequest(
-					EmbeddingOptionsBuilder.builder().withModel("mistral").withDimensions(1492).build()))
+					EmbeddingOptionsBuilder.builder().model("mistral").dimensions(1492).build()))
 			.provider("superprovider")
 			.build();
 		observationContext.setResponse(new EmbeddingResponse(List.of(),

--- a/spring-ai-model/src/test/java/org/springframework/ai/embedding/observation/EmbeddingModelMeterObservationHandlerTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/embedding/observation/EmbeddingModelMeterObservationHandlerTests.java
@@ -93,7 +93,7 @@ class EmbeddingModelMeterObservationHandlerTests {
 
 	private EmbeddingModelObservationContext generateObservationContext() {
 		return EmbeddingModelObservationContext.builder()
-			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().withModel("mistral").build()))
+			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().model("mistral").build()))
 			.provider("superprovider")
 			.build();
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/embedding/observation/EmbeddingModelObservationContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/embedding/observation/EmbeddingModelObservationContextTests.java
@@ -36,8 +36,7 @@ class EmbeddingModelObservationContextTests {
 	@Test
 	void whenMandatoryRequestOptionsThenReturn() {
 		var observationContext = EmbeddingModelObservationContext.builder()
-			.embeddingRequest(
-					generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().withModel("supermodel").build()))
+			.embeddingRequest(generateEmbeddingRequest(EmbeddingOptionsBuilder.builder().model("supermodel").build()))
 			.provider("superprovider")
 			.build();
 


### PR DESCRIPTION
* Deprecated methods that start with set and with.
* Added replacements