### PR TITLE
Allow MCP toolcallback to use ToolContext

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
@@ -45,6 +45,8 @@ public class McpToolCallbackAutoConfiguration {
 	 * <p>
 	 * These callbacks enable integration with Spring AI's tool execution framework,
 	 * allowing MCP tools to be used as part of AI interactions.
+	 * @param syncClientsToolFilter list of {@link McpSyncClientBiPredicate}s for the sync
+	 * client to filter the discovered tools
 	 * @param syncMcpClients provider of MCP sync clients
 	 * @return list of tool callbacks for MCP integration
 	 */

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
@@ -81,8 +81,8 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider {
 	/**
 	 * Creates a new {@code AsyncMcpToolCallbackProvider} instance with a list of MCP
 	 * clients.
-	 * @param mcpClients the list of MCP clients to use for discovering tools
 	 * @param toolFilter a filter to apply to each discovered tool
+	 * @param mcpClients the list of MCP clients to use for discovering tools
 	 */
 	public AsyncMcpToolCallbackProvider(BiPredicate<McpAsyncClient, Tool> toolFilter, List<McpAsyncClient> mcpClients) {
 		Assert.notNull(mcpClients, "MCP clients must not be null");
@@ -106,8 +106,8 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider {
 	/**
 	 * Creates a new {@code AsyncMcpToolCallbackProvider} instance with one or more MCP
 	 * clients.
-	 * @param mcpClients the MCP clients to use for discovering tools
 	 * @param toolFilter a filter to apply to each discovered tool
+	 * @param mcpClients the MCP clients to use for discovering tools
 	 */
 	public AsyncMcpToolCallbackProvider(BiPredicate<McpAsyncClient, Tool> toolFilter, McpAsyncClient... mcpClients) {
 		this(toolFilter, List.of(mcpClients));

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -1,5 +1,7 @@
 package org.springframework.ai.mcp;
 
+import java.util.Map;
+
 import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
@@ -8,9 +10,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.execution.ToolExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,6 +57,26 @@ class AsyncMcpToolCallbackTest {
 		assertThatThrownBy(() -> callback.call("{\"param\":\"value\"}")).isInstanceOf(ToolExecutionException.class)
 			.rootCause()
 			.hasMessage("Testing tool error");
+	}
+
+	@Test
+	void shouldApplyToolContext() {
+
+		when(this.tool.name()).thenReturn("testTool");
+		McpSchema.CallToolResult callResult = mock(McpSchema.CallToolResult.class);
+		when(this.mcpClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(Mono.just(callResult));
+
+		AsyncMcpToolCallback callback = new AsyncMcpToolCallback(this.mcpClient, this.tool);
+
+		String response = callback.call("{\"param\":\"value\"}", new ToolContext(Map.of("foo", "bar")));
+
+		assertThat(response).isNotNull();
+
+		verify(this.mcpClient).callTool(argThat(callToolRequest -> callToolRequest.name().equals("testTool")));
+		verify(this.mcpClient)
+			.callTool(argThat(callToolRequest -> callToolRequest.arguments().equals(Map.of("param", "value"))));
+		verify(this.mcpClient)
+			.callTool(argThat(callToolRequest -> callToolRequest.meta().equals(Map.of("foo", "bar"))));
 	}
 
 }

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -37,7 +37,9 @@ import org.springframework.ai.tool.execution.ToolExecutionException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,9 +86,7 @@ class SyncMcpToolCallbackTests {
 	}
 
 	@Test
-	void callShouldIgnoreToolContext() {
-		// when(mcpClient.getClientInfo()).thenReturn(new Implementation("testClient",
-		// "1.0.0"));
+	void shouldApplyToolContext() {
 
 		when(this.tool.name()).thenReturn("testTool");
 		CallToolResult callResult = mock(CallToolResult.class);
@@ -97,6 +97,12 @@ class SyncMcpToolCallbackTests {
 		String response = callback.call("{\"param\":\"value\"}", new ToolContext(Map.of("foo", "bar")));
 
 		assertThat(response).isNotNull();
+
+		verify(this.mcpClient).callTool(argThat(callToolRequest -> callToolRequest.name().equals("testTool")));
+		verify(this.mcpClient)
+			.callTool(argThat(callToolRequest -> callToolRequest.arguments().equals(Map.of("param", "value"))));
+		verify(this.mcpClient)
+			.callTool(argThat(callToolRequest -> callToolRequest.meta().equals(Map.of("foo", "bar"))));
 	}
 
 	@Test


### PR DESCRIPTION
 - Update Sync/Async toolCallbacks to pass the toolcontext via MCP CallToolRequest's meta argument
 - Add tests to verify the MCP CallToolRequest's meta argument is updated with ToolContext

Fixes #3505