### PR TITLE
fix: add strict option to ChatCompletionsJsonSchemaResponseFormat (#3…

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -959,6 +959,7 @@ public class AzureOpenAiChatModel implements ChatModel {
 			var responseFormatJsonSchema = new ChatCompletionsJsonSchemaResponseFormatJsonSchema(jsonSchema.getName());
 			String jsonString = ModelOptionsUtils.toJsonString(jsonSchema.getSchema());
 			responseFormatJsonSchema.setSchema(BinaryData.fromString(jsonString));
+			responseFormatJsonSchema.setStrict(jsonSchema.getStrict());
 			return new ChatCompletionsJsonSchemaResponseFormat(responseFormatJsonSchema);
 		}
 		return new ChatCompletionsTextResponseFormat();


### PR DESCRIPTION
Fixes the missing mapping of the strict property when using json schema mode for Azure Open AI.