### PR TITLE
Bump postgresql JDBC driver from 42.7.5 to 42.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
 		<qdrant.version>1.13.0</qdrant.version>
 		<typesense.version>1.3.0</typesense.version>
 		<opensearch-client.version>2.23.0</opensearch-client.version>
-		<postgresql.version>42.7.5</postgresql.version>
+		<postgresql.version>42.7.7</postgresql.version>
 		<mariadb.version>3.5.3</mariadb.version>
 		<mysql.version>9.2.0</mysql.version>
 		<commonmark.version>0.22.0</commonmark.version>


### PR DESCRIPTION
Bump postgresql JDBC driver from 42.7.5 to 42.7.7 which resolves CVE-2025-49146