### PR TITLE
test: Add additional test coverage for `OpenSearchAiSearchFilterExpressionConverter`

### DIFF
--- a/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchAiSearchFilterExpressionConverterTest.java
+++ b/vector-stores/spring-ai-opensearch-store/src/test/java/org/springframework/ai/vectorstore/opensearch/OpenSearchAiSearchFilterExpressionConverterTest.java
@@ -123,4 +123,108 @@ class OpenSearchAiSearchFilterExpressionConverterTest {
 		assertThat(vectorExpr).isEqualTo("metadata.country 1 2 3:BG");
 	}
 
+	@Test
+	public void testEmptyList() {
+		// category IN []
+		String vectorExpr = this.converter
+			.convertExpression(new Filter.Expression(IN, new Filter.Key("category"), new Filter.Value(List.of())));
+		assertThat(vectorExpr).isEqualTo("(metadata.category:)");
+	}
+
+	@Test
+	public void testSingleItemList() {
+		// status IN ["active"]
+		String vectorExpr = this.converter.convertExpression(
+				new Filter.Expression(IN, new Filter.Key("status"), new Filter.Value(List.of("active"))));
+		assertThat(vectorExpr).isEqualTo("(metadata.status:active)");
+	}
+
+	@Test
+	public void testNullValue() {
+		// description == null
+		String vectorExpr = this.converter
+			.convertExpression(new Filter.Expression(EQ, new Filter.Key("description"), new Filter.Value(null)));
+		assertThat(vectorExpr).isEqualTo("metadata.description:null");
+	}
+
+	@Test
+	public void testNestedJsonPath() {
+		// entity.profile.name == "EntityA"
+		String vectorExpr = this.converter.convertExpression(
+				new Filter.Expression(EQ, new Filter.Key("entity.profile.name"), new Filter.Value("EntityA")));
+		assertThat(vectorExpr).isEqualTo("metadata.entity.profile.name:EntityA");
+	}
+
+	@Test
+	public void testNumericStringValue() {
+		// id == "1"
+		String vectorExpr = this.converter
+			.convertExpression(new Filter.Expression(EQ, new Filter.Key("id"), new Filter.Value("1")));
+		assertThat(vectorExpr).isEqualTo("metadata.id:1");
+	}
+
+	@Test
+	public void testZeroValue() {
+		// count == 0
+		String vectorExpr = this.converter
+			.convertExpression(new Filter.Expression(EQ, new Filter.Key("count"), new Filter.Value(0)));
+		assertThat(vectorExpr).isEqualTo("metadata.count:0");
+	}
+
+	@Test
+	public void testComplexNestedGroups() {
+		// ((fieldA >= 100 AND fieldB == "X1") OR (fieldA >= 50 AND fieldB == "Y2")) AND
+		// fieldC != "inactive"
+		String vectorExpr = this.converter.convertExpression(new Filter.Expression(AND,
+				new Filter.Group(new Filter.Expression(OR,
+						new Filter.Group(new Filter.Expression(AND,
+								new Filter.Expression(GTE, new Filter.Key("fieldA"), new Filter.Value(100)),
+								new Filter.Expression(EQ, new Filter.Key("fieldB"), new Filter.Value("X1")))),
+						new Filter.Group(new Filter.Expression(AND,
+								new Filter.Expression(GTE, new Filter.Key("fieldA"), new Filter.Value(50)),
+								new Filter.Expression(EQ, new Filter.Key("fieldB"), new Filter.Value("Y2")))))),
+				new Filter.Expression(NE, new Filter.Key("fieldC"), new Filter.Value("inactive"))));
+
+		assertThat(vectorExpr).isEqualTo(
+				"((metadata.fieldA:>=100 AND metadata.fieldB:X1) OR (metadata.fieldA:>=50 AND metadata.fieldB:Y2)) AND metadata.fieldC: NOT inactive");
+	}
+
+	@Test
+	public void testMixedDataTypes() {
+		// active == true AND score >= 1.5 AND tags IN ["featured", "premium"] AND version
+		// == 1
+		String vectorExpr = this.converter.convertExpression(new Filter.Expression(AND, new Filter.Expression(AND,
+				new Filter.Expression(AND, new Filter.Expression(EQ, new Filter.Key("active"), new Filter.Value(true)),
+						new Filter.Expression(GTE, new Filter.Key("score"), new Filter.Value(1.5))),
+				new Filter.Expression(IN, new Filter.Key("tags"), new Filter.Value(List.of("featured", "premium")))),
+				new Filter.Expression(EQ, new Filter.Key("version"), new Filter.Value(1))));
+
+		assertThat(vectorExpr).isEqualTo(
+				"metadata.active:true AND metadata.score:>=1.5 AND (metadata.tags:featured OR premium) AND metadata.version:1");
+	}
+
+	@Test
+	public void testNinWithMixedTypes() {
+		// status NIN ["A", "B", "C"]
+		String vectorExpr = this.converter.convertExpression(
+				new Filter.Expression(NIN, new Filter.Key("status"), new Filter.Value(List.of("A", "B", "C"))));
+		assertThat(vectorExpr).isEqualTo("NOT (metadata.status:A OR B OR C)");
+	}
+
+	@Test
+	public void testEmptyStringValue() {
+		// description != ""
+		String vectorExpr = this.converter
+			.convertExpression(new Filter.Expression(NE, new Filter.Key("description"), new Filter.Value("")));
+		assertThat(vectorExpr).isEqualTo("metadata.description: NOT ");
+	}
+
+	@Test
+	public void testArrayIndexAccess() {
+		// tags[0] == "important"
+		String vectorExpr = this.converter
+			.convertExpression(new Filter.Expression(EQ, new Filter.Key("tags[0]"), new Filter.Value("important")));
+		assertThat(vectorExpr).isEqualTo("metadata.tags[0]:important");
+	}
+
 }


### PR DESCRIPTION
Added additional test cases for OpenSearch filter expression converter:

- testEmptyList() - Handles IN operations with empty lists gracefully
- testSingleItemList() - Validates IN operations with single-item lists
- testNullValue() - Tests equality checks against null values
- testNestedJsonPath() - Supports nested field paths like entity.profile.name
- testNumericStringValue() - Properly handles numeric values as strings
- testZeroValue() - Edge case testing for zero values
- testComplexNestedGroups() - Complex boolean logic with multiple AND/OR groupings
- testMixedDataTypes() - Real-world scenarios mixing booleans, numbers, and strings
- testNinWithMixedTypes() - NOT IN operations with various data types
- testEmptyStringValue() - Not-equal comparisons with empty strings
- testArrayIndexAccess() - Direct array element access like tags[0]