### PR TITLE
Don't log AWS SDK stack trace, updates documentation

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -807,7 +807,7 @@ public class BedrockProxyChatModel implements ChatModel {
 				this.region = DefaultAwsRegionProviderChain.builder().build().getRegion();
 			}
 			catch (SdkClientException e) {
-				logger.warn("Failed to load region from DefaultAwsRegionProviderChain, using US_EAST_1", e);
+				logger.warn("Failed to load region from DefaultAwsRegionProviderChain, using {}}", this.region);
 			}
 		}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -73,7 +73,7 @@ The prefix `spring.ai.bedrock.aws` is the property prefix to configure the conne
 |====
 | Property | Description | Default
 
-| spring.ai.bedrock.aws.region     | AWS region to use.  | us-east-1
+| spring.ai.bedrock.aws.region     | AWS region to use.  | AWS SDK value or us-east-1
 | spring.ai.bedrock.aws.timeout    | AWS timeout to use. | 5m
 | spring.ai.bedrock.aws.access-key | AWS access key.  | -
 | spring.ai.bedrock.aws.secret-key | AWS secret key.  | -
@@ -89,6 +89,8 @@ To enable, spring.ai.model.chat=bedrock-converse (It is enabled by default)
 To disable, spring.ai.model.chat=none (or any value which doesn't match bedrock-converse)
 
 This change is done to allow configuration of multiple models.
+
+The AWS SDK checks several places for the region, if none of these are set then "us-east-1" is used.
 ====
 
 The prefix `spring.ai.bedrock.converse.chat` is the property prefix that configures the chat model implementation for the Converse API.


### PR DESCRIPTION
This PR will change the `BedrockProxyChatModel` such that it no longer logs a stack trace if the Amazon SDK for Java fails to find a region. Instead a warning is logged letting the developer know which region is being used.

This also updates the documentation to let people know that first we use the SDK's choice of region and fall back to the Spring AI property only if that is not set.

Resolves #3951