### PR TITLE
Keep the same pass check behavior for Evaluator

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
@@ -134,7 +134,7 @@ public class FactCheckingEvaluator implements Evaluator {
 			.call()
 			.content();
 
-		boolean passing = evaluationResponse.equalsIgnoreCase("yes");
+		boolean passing = "yes".equalsIgnoreCase(evaluationResponse);
 		return new EvaluationResponse(passing, "", Collections.emptyMap());
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
@@ -79,7 +79,7 @@ public class RelevancyEvaluator implements Evaluator {
 
 		boolean passing = false;
 		float score = 0;
-		if (evaluationResponse != null && evaluationResponse.toLowerCase().contains("yes")) {
+		if ("yes".equalsIgnoreCase(evaluationResponse)) {
 			passing = true;
 			score = 1;
 		}


### PR DESCRIPTION
Keep the same pass check behavior for `FactCheckingEvaluator` and `RelevancyEvaluator`, and avoid NPE.

Some test cases:
- When `evaluationResponse` is `null`, return false.
- When `evaluationResponse` is `yes`, return true.
- When `evaluationResponse` is `Yes`, return true.
- When `evaluationResponse` is `yES`, return true.
- When `evaluationResponse` is `no and yes`, return false.
- When `evaluationResponse` is `yes. `, return false.

