### PR TITLE
feat: Add `metadata` support to `PromptUserSpec` and `PromptSystemSpec` in ChatClient

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -114,6 +114,10 @@ public interface ChatClient {
 
 		PromptUserSpec media(MimeType mimeType, Resource resource);
 
+		PromptUserSpec metadata(Map<String, Object> metadata);
+
+		PromptUserSpec metadata(String k, Object v);
+
 	}
 
 	/**
@@ -130,6 +134,10 @@ public interface ChatClient {
 		PromptSystemSpec params(Map<String, Object> p);
 
 		PromptSystemSpec param(String k, Object v);
+
+		PromptSystemSpec metadata(Map<String, Object> metadata);
+
+		PromptSystemSpec metadata(String k, Object v);
 
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -134,6 +134,8 @@ public class DefaultChatClient implements ChatClient {
 
 		private final Map<String, Object> params = new HashMap<>();
 
+		private final Map<String, Object> metadata = new HashMap<>();
+
 		private final List<Media> media = new ArrayList<>();
 
 		@Nullable
@@ -212,6 +214,23 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
+		public PromptUserSpec metadata(Map<String, Object> metadata) {
+			Assert.notNull(metadata, "metadata cannot be null");
+			Assert.noNullElements(metadata.keySet(), "metadata keys cannot contain null elements");
+			Assert.noNullElements(metadata.values(), "metadata values cannot contain null elements");
+			this.metadata.putAll(metadata);
+			return this;
+		}
+
+		@Override
+		public PromptUserSpec metadata(String key, Object value) {
+			Assert.hasText(key, "metadata key cannot be null or empty");
+			Assert.notNull(value, "metadata value cannot be null");
+			this.metadata.put(key, value);
+			return this;
+		}
+
 		@Nullable
 		protected String text() {
 			return this.text;
@@ -225,11 +244,17 @@ public class DefaultChatClient implements ChatClient {
 			return this.media;
 		}
 
+		protected Map<String, Object> metadata() {
+			return this.metadata;
+		}
+
 	}
 
 	public static class DefaultPromptSystemSpec implements PromptSystemSpec {
 
 		private final Map<String, Object> params = new HashMap<>();
+
+		private final Map<String, Object> metadata = new HashMap<>();
 
 		@Nullable
 		private String text;
@@ -278,6 +303,23 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
+		public PromptSystemSpec metadata(Map<String, Object> metadata) {
+			Assert.notNull(metadata, "metadata cannot be null");
+			Assert.noNullElements(metadata.keySet(), "metadata keys cannot contain null elements");
+			Assert.noNullElements(metadata.values(), "metadata values cannot contain null elements");
+			this.metadata.putAll(metadata);
+			return this;
+		}
+
+		@Override
+		public PromptSystemSpec metadata(String key, Object value) {
+			Assert.hasText(key, "metadata key cannot be null or empty");
+			Assert.notNull(value, "metadata value cannot be null");
+			this.metadata.put(key, value);
+			return this;
+		}
+
 		@Nullable
 		protected String text() {
 			return this.text;
@@ -285,6 +327,10 @@ public class DefaultChatClient implements ChatClient {
 
 		protected Map<String, Object> params() {
 			return this.params;
+		}
+
+		protected Map<String, Object> metadata() {
+			return this.metadata;
 		}
 
 	}
@@ -579,7 +625,11 @@ public class DefaultChatClient implements ChatClient {
 
 		private final Map<String, Object> userParams = new HashMap<>();
 
+		private final Map<String, Object> userMetadata = new HashMap<>();
+
 		private final Map<String, Object> systemParams = new HashMap<>();
+
+		private final Map<String, Object> systemMetadata = new HashMap<>();
 
 		private final List<Advisor> advisors = new ArrayList<>();
 
@@ -600,22 +650,25 @@ public class DefaultChatClient implements ChatClient {
 
 		/* copy constructor */
 		DefaultChatClientRequestSpec(DefaultChatClientRequestSpec ccr) {
-			this(ccr.chatModel, ccr.userText, ccr.userParams, ccr.systemText, ccr.systemParams, ccr.toolCallbacks,
-					ccr.messages, ccr.toolNames, ccr.media, ccr.chatOptions, ccr.advisors, ccr.advisorParams,
-					ccr.observationRegistry, ccr.observationConvention, ccr.toolContext, ccr.templateRenderer);
+			this(ccr.chatModel, ccr.userText, ccr.userParams, ccr.userMetadata, ccr.systemText, ccr.systemParams,
+					ccr.systemMetadata, ccr.toolCallbacks, ccr.messages, ccr.toolNames, ccr.media, ccr.chatOptions,
+					ccr.advisors, ccr.advisorParams, ccr.observationRegistry, ccr.observationConvention,
+					ccr.toolContext, ccr.templateRenderer);
 		}
 
 		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
-				Map<String, Object> userParams, @Nullable String systemText, Map<String, Object> systemParams,
-				List<ToolCallback> toolCallbacks, List<Message> messages, List<String> toolNames, List<Media> media,
-				@Nullable ChatOptions chatOptions, List<Advisor> advisors, Map<String, Object> advisorParams,
-				ObservationRegistry observationRegistry,
+				Map<String, Object> userParams, Map<String, Object> userMetadata, @Nullable String systemText,
+				Map<String, Object> systemParams, Map<String, Object> systemMetadata, List<ToolCallback> toolCallbacks,
+				List<Message> messages, List<String> toolNames, List<Media> media, @Nullable ChatOptions chatOptions,
+				List<Advisor> advisors, Map<String, Object> advisorParams, ObservationRegistry observationRegistry,
 				@Nullable ChatClientObservationConvention observationConvention, Map<String, Object> toolContext,
 				@Nullable TemplateRenderer templateRenderer) {
 
 			Assert.notNull(chatModel, "chatModel cannot be null");
 			Assert.notNull(userParams, "userParams cannot be null");
+			Assert.notNull(userMetadata, "userMetadata cannot be null");
 			Assert.notNull(systemParams, "systemParams cannot be null");
+			Assert.notNull(systemMetadata, "systemMetadata cannot be null");
 			Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
 			Assert.notNull(messages, "messages cannot be null");
 			Assert.notNull(toolNames, "toolNames cannot be null");
@@ -631,8 +684,11 @@ public class DefaultChatClient implements ChatClient {
 
 			this.userText = userText;
 			this.userParams.putAll(userParams);
+			this.userMetadata.putAll(userMetadata);
+
 			this.systemText = systemText;
 			this.systemParams.putAll(systemParams);
+			this.systemMetadata.putAll(systemMetadata);
 
 			this.toolNames.addAll(toolNames);
 			this.toolCallbacks.addAll(toolCallbacks);
@@ -656,6 +712,10 @@ public class DefaultChatClient implements ChatClient {
 			return this.userParams;
 		}
 
+		public Map<String, Object> getUserMetadata() {
+			return this.userMetadata;
+		}
+
 		@Nullable
 		public String getSystemText() {
 			return this.systemText;
@@ -663,6 +723,10 @@ public class DefaultChatClient implements ChatClient {
 
 		public Map<String, Object> getSystemParams() {
 			return this.systemParams;
+		}
+
+		public Map<String, Object> getSystemMetadata() {
+			return this.systemMetadata;
 		}
 
 		@Nullable
@@ -720,12 +784,15 @@ public class DefaultChatClient implements ChatClient {
 			}
 
 			if (StringUtils.hasText(this.userText)) {
-				builder.defaultUser(
-						u -> u.text(this.userText).params(this.userParams).media(this.media.toArray(new Media[0])));
+				builder.defaultUser(u -> u.text(this.userText)
+					.params(this.userParams)
+					.media(this.media.toArray(new Media[0]))
+					.metadata(this.userMetadata));
 			}
 
 			if (StringUtils.hasText(this.systemText)) {
-				builder.defaultSystem(s -> s.text(this.systemText).params(this.systemParams));
+				builder.defaultSystem(
+						s -> s.text(this.systemText).params(this.systemParams).metadata(this.systemMetadata));
 			}
 
 			if (this.chatOptions != null) {
@@ -737,6 +804,7 @@ public class DefaultChatClient implements ChatClient {
 			return builder;
 		}
 
+		@Override
 		public ChatClientRequestSpec advisors(Consumer<ChatClient.AdvisorSpec> consumer) {
 			Assert.notNull(consumer, "consumer cannot be null");
 			var advisorSpec = new DefaultAdvisorSpec();
@@ -746,6 +814,7 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec advisors(Advisor... advisors) {
 			Assert.notNull(advisors, "advisors cannot be null");
 			Assert.noNullElements(advisors, "advisors cannot contain null elements");
@@ -753,6 +822,7 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec advisors(List<Advisor> advisors) {
 			Assert.notNull(advisors, "advisors cannot be null");
 			Assert.noNullElements(advisors, "advisors cannot contain null elements");
@@ -760,6 +830,7 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec messages(Message... messages) {
 			Assert.notNull(messages, "messages cannot be null");
 			Assert.noNullElements(messages, "messages cannot contain null elements");
@@ -767,6 +838,7 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec messages(List<Message> messages) {
 			Assert.notNull(messages, "messages cannot be null");
 			Assert.noNullElements(messages, "messages cannot contain null elements");
@@ -822,6 +894,7 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec toolContext(Map<String, Object> toolContext) {
 			Assert.notNull(toolContext, "toolContext cannot be null");
 			Assert.noNullElements(toolContext.keySet(), "toolContext keys cannot contain null elements");
@@ -830,12 +903,14 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec system(String text) {
 			Assert.hasText(text, "text cannot be null or empty");
 			this.systemText = text;
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec system(Resource text, Charset charset) {
 			Assert.notNull(text, "text cannot be null");
 			Assert.notNull(charset, "charset cannot be null");
@@ -849,11 +924,13 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec system(Resource text) {
 			Assert.notNull(text, "text cannot be null");
 			return this.system(text, Charset.defaultCharset());
 		}
 
+		@Override
 		public ChatClientRequestSpec system(Consumer<PromptSystemSpec> consumer) {
 			Assert.notNull(consumer, "consumer cannot be null");
 
@@ -861,16 +938,18 @@ public class DefaultChatClient implements ChatClient {
 			consumer.accept(systemSpec);
 			this.systemText = StringUtils.hasText(systemSpec.text()) ? systemSpec.text() : this.systemText;
 			this.systemParams.putAll(systemSpec.params());
-
+			this.systemMetadata.putAll(systemSpec.metadata());
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec user(String text) {
 			Assert.hasText(text, "text cannot be null or empty");
 			this.userText = text;
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec user(Resource text, Charset charset) {
 			Assert.notNull(text, "text cannot be null");
 			Assert.notNull(charset, "charset cannot be null");
@@ -884,11 +963,13 @@ public class DefaultChatClient implements ChatClient {
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec user(Resource text) {
 			Assert.notNull(text, "text cannot be null");
 			return this.user(text, Charset.defaultCharset());
 		}
 
+		@Override
 		public ChatClientRequestSpec user(Consumer<PromptUserSpec> consumer) {
 			Assert.notNull(consumer, "consumer cannot be null");
 
@@ -897,21 +978,25 @@ public class DefaultChatClient implements ChatClient {
 			this.userText = StringUtils.hasText(us.text()) ? us.text() : this.userText;
 			this.userParams.putAll(us.params());
 			this.media.addAll(us.media());
+			this.userMetadata.putAll(us.metadata());
 			return this;
 		}
 
+		@Override
 		public ChatClientRequestSpec templateRenderer(TemplateRenderer templateRenderer) {
 			Assert.notNull(templateRenderer, "templateRenderer cannot be null");
 			this.templateRenderer = templateRenderer;
 			return this;
 		}
 
+		@Override
 		public CallResponseSpec call() {
 			BaseAdvisorChain advisorChain = buildAdvisorChain();
 			return new DefaultCallResponseSpec(DefaultChatClientUtils.toChatClientRequest(this), advisorChain,
 					this.observationRegistry, this.observationConvention);
 		}
 
+		@Override
 		public StreamResponseSpec stream() {
 			BaseAdvisorChain advisorChain = buildAdvisorChain();
 			return new DefaultStreamResponseSpec(DefaultChatClientUtils.toChatClientRequest(this), advisorChain,

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -64,8 +64,8 @@ public class DefaultChatClientBuilder implements Builder {
 			@Nullable ChatClientObservationConvention customObservationConvention) {
 		Assert.notNull(chatModel, "the " + ChatModel.class.getName() + " must be non-null");
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
-		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), null, Map.of(), List.of(),
-				List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
+		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), Map.of(), null, Map.of(),
+				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
 				customObservationConvention, Map.of(), null);
 	}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
@@ -67,7 +67,10 @@ final class DefaultChatClientUtils {
 					.build()
 					.render();
 			}
-			processedMessages.add(new SystemMessage(processedSystemText));
+			processedMessages.add(SystemMessage.builder()
+				.text(processedSystemText)
+				.metadata(inputRequest.getSystemMetadata())
+				.build());
 		}
 
 		// Messages => In the middle of the list
@@ -86,7 +89,11 @@ final class DefaultChatClientUtils {
 					.build()
 					.render();
 			}
-			processedMessages.add(UserMessage.builder().text(processedUserText).media(inputRequest.getMedia()).build());
+			processedMessages.add(UserMessage.builder()
+				.text(processedUserText)
+				.media(inputRequest.getMedia())
+				.metadata(inputRequest.getUserMetadata())
+				.build());
 		}
 
 		/*

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -143,7 +143,10 @@ class DefaultChatClientTests {
 		defaultChatClientBuilder.addMessages(List.of(userMessage1, userMessage2));
 		ChatClient originalChatClient = defaultChatClientBuilder.defaultAdvisors(advisor)
 			.defaultOptions(chatOptions)
-			.defaultUser(u -> u.text("original user {userParams}").param("userParams", "user value2").media(media))
+			.defaultUser(u -> u.text("original user {userParams}")
+				.param("userParams", "user value2")
+				.media(media)
+				.metadata("userMetadata", "user data3"))
 			.defaultSystem(s -> s.text("original system {sysParams}").param("sysParams", "system value1"))
 			.defaultTemplateRenderer(templateRenderer)
 			.defaultToolNames("toolName1", "toolName2")
@@ -162,6 +165,7 @@ class DefaultChatClientTests {
 		assertThat(mutateSpec.getChatOptions()).isEqualTo(copyChatOptions);
 		assertThat(mutateSpec.getUserText()).isEqualTo("original user {userParams}");
 		assertThat(mutateSpec.getUserParams()).containsEntry("userParams", "user value2");
+		assertThat(mutateSpec.getUserMetadata()).containsEntry("userMetadata", "user data3");
 		assertThat(mutateSpec.getMedia()).hasSize(1).containsOnly(media);
 		assertThat(mutateSpec.getSystemText()).isEqualTo("original system {sysParams}");
 		assertThat(mutateSpec.getSystemParams()).containsEntry("sysParams", "system value1");
@@ -196,6 +200,7 @@ class DefaultChatClientTests {
 		assertThat(spec).isNotNull();
 		assertThat(spec.media()).isNotNull();
 		assertThat(spec.params()).isNotNull();
+		assertThat(spec.metadata()).isNotNull();
 		assertThat(spec.text()).isNull();
 	}
 
@@ -395,6 +400,66 @@ class DefaultChatClientTests {
 		assertThat(spec.params()).containsEntry("key", "value");
 	}
 
+	@Test
+	void whenUserMetadataKeyIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		assertThatThrownBy(() -> spec.metadata(null, "value")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata key cannot be null or empty");
+	}
+
+	@Test
+	void whenUserMetadataKeyIsEmptyThenThrow() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		assertThatThrownBy(() -> spec.metadata("", "value")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata key cannot be null or empty");
+	}
+
+	@Test
+	void whenUserMetadataValueIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		assertThatThrownBy(() -> spec.metadata("key", null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata value cannot be null");
+	}
+
+	@Test
+	void whenUserMetadataKeyValueThenReturn() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		spec = (DefaultChatClient.DefaultPromptUserSpec) spec.metadata("key", "value");
+		assertThat(spec.metadata()).containsEntry("key", "value");
+	}
+
+	@Test
+	void whenUserMetadataIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		assertThatThrownBy(() -> spec.metadata(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata cannot be null");
+	}
+
+	@Test
+	void whenUserMetadataMapKeyIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put(null, "value");
+		assertThatThrownBy(() -> spec.metadata(metadata)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata keys cannot contain null elements");
+	}
+
+	@Test
+	void whenUserMetadataMapValueIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("key", null);
+		assertThatThrownBy(() -> spec.metadata(metadata)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata values cannot contain null elements");
+	}
+
+	@Test
+	void whenUserMetadataThenReturn() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		spec = (DefaultChatClient.DefaultPromptUserSpec) spec.metadata(Map.of("key", "value"));
+		assertThat(spec.metadata()).containsEntry("key", "value");
+	}
+
 	// DefaultPromptSystemSpec
 
 	@Test
@@ -402,6 +467,7 @@ class DefaultChatClientTests {
 		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
 		assertThat(spec).isNotNull();
 		assertThat(spec.params()).isNotNull();
+		assertThat(spec.metadata()).isNotNull();
 		assertThat(spec.text()).isNull();
 	}
 
@@ -522,6 +588,66 @@ class DefaultChatClientTests {
 		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
 		spec = (DefaultChatClient.DefaultPromptSystemSpec) spec.params(Map.of("key", "value"));
 		assertThat(spec.params()).containsEntry("key", "value");
+	}
+
+	@Test
+	void whenSystemMetadataKeyIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		assertThatThrownBy(() -> spec.metadata(null, "value")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata key cannot be null or empty");
+	}
+
+	@Test
+	void whenSystemMetadataKeyIsEmptyThenThrow() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		assertThatThrownBy(() -> spec.metadata("", "value")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata key cannot be null or empty");
+	}
+
+	@Test
+	void whenSystemMetadataValueIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		assertThatThrownBy(() -> spec.metadata("key", null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata value cannot be null");
+	}
+
+	@Test
+	void whenSystemMetadataKeyValueThenReturn() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		spec = (DefaultChatClient.DefaultPromptSystemSpec) spec.metadata("key", "value");
+		assertThat(spec.metadata()).containsEntry("key", "value");
+	}
+
+	@Test
+	void whenSystemMetadataIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		assertThatThrownBy(() -> spec.metadata(null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata cannot be null");
+	}
+
+	@Test
+	void whenSystemMetadataMapKeyIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put(null, "value");
+		assertThatThrownBy(() -> spec.metadata(metadata)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata keys cannot contain null elements");
+	}
+
+	@Test
+	void whenSystemMetadataMapValueIsNullThenThrow() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put("key", null);
+		assertThatThrownBy(() -> spec.metadata(metadata)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("metadata values cannot contain null elements");
+	}
+
+	@Test
+	void whenSystemMetadataThenReturn() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		spec = (DefaultChatClient.DefaultPromptSystemSpec) spec.metadata(Map.of("key", "value"));
+		assertThat(spec.metadata()).containsEntry("key", "value");
 	}
 
 	// DefaultAdvisorSpec
@@ -1347,15 +1473,15 @@ class DefaultChatClientTests {
 	void buildChatClientRequestSpec() {
 		ChatModel chatModel = mock(ChatModel.class);
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
-				chatModel, null, Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(),
-				Map.of(), ObservationRegistry.NOOP, null, Map.of(), null);
+				chatModel, null, Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(),
+				List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null);
 		assertThat(spec).isNotNull();
 	}
 
 	@Test
 	void whenChatModelIsNullThenThrow() {
-		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), null,
-				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
+		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), Map.of(),
+				null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
 				ObservationRegistry.NOOP, null, Map.of(), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
@@ -1364,8 +1490,8 @@ class DefaultChatClientTests {
 	@Test
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mock(ChatModel.class), null,
-				Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), null,
-				null, Map.of(), null))
+				Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), null,
+				List.of(), Map.of(), null, null, Map.of(), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");
 	}
@@ -1817,30 +1943,37 @@ class DefaultChatClientTests {
 	void whenSystemConsumerThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		spec = spec.system(system -> system.text("my instruction about {topic}").param("topic", "AI"));
+		spec = spec.system(system -> system.text("my instruction about {topic}")
+			.param("topic", "AI")
+			.metadata("msgId", "uuid-xxx"));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getSystemText()).isEqualTo("my instruction about {topic}");
 		assertThat(defaultSpec.getSystemParams()).containsEntry("topic", "AI");
+		assertThat(defaultSpec.getSystemMetadata()).containsEntry("msgId", "uuid-xxx");
 	}
 
 	@Test
 	void whenSystemConsumerWithExistingSystemTextThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().system("my instruction");
-		spec = spec.system(system -> system.text("my instruction about {topic}").param("topic", "AI"));
+		spec = spec.system(system -> system.text("my instruction about {topic}")
+			.param("topic", "AI")
+			.metadata("msgId", "uuid-xxx"));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getSystemText()).isEqualTo("my instruction about {topic}");
 		assertThat(defaultSpec.getSystemParams()).containsEntry("topic", "AI");
+		assertThat(defaultSpec.getSystemMetadata()).containsEntry("msgId", "uuid-xxx");
 	}
 
 	@Test
 	void whenSystemConsumerWithoutSystemTextThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().system("my instruction about {topic}");
-		spec = spec.system(system -> system.param("topic", "AI"));
+		spec = spec.system(system -> system.param("topic", "AI").metadata("msgId", "uuid-xxx"));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getSystemText()).isEqualTo("my instruction about {topic}");
 		assertThat(defaultSpec.getSystemParams()).containsEntry("topic", "AI");
+		assertThat(defaultSpec.getSystemMetadata()).containsEntry("msgId", "uuid-xxx");
 	}
 
 	@Test
@@ -1926,11 +2059,13 @@ class DefaultChatClientTests {
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
 		spec = spec.user(user -> user.text("my question about {topic}")
 			.param("topic", "AI")
+			.metadata("msgId", "uuid-xxx")
 			.media(MimeTypeUtils.IMAGE_PNG, new ClassPathResource("tabby-cat.png")));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getUserText()).isEqualTo("my question about {topic}");
 		assertThat(defaultSpec.getUserParams()).containsEntry("topic", "AI");
 		assertThat(defaultSpec.getMedia()).hasSize(1);
+		assertThat(defaultSpec.getUserMetadata()).containsEntry("msgId", "uuid-xxx");
 	}
 
 	@Test
@@ -1939,11 +2074,13 @@ class DefaultChatClientTests {
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("my question");
 		spec = spec.user(user -> user.text("my question about {topic}")
 			.param("topic", "AI")
+			.metadata("msgId", "uuid-xxx")
 			.media(MimeTypeUtils.IMAGE_PNG, new ClassPathResource("tabby-cat.png")));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getUserText()).isEqualTo("my question about {topic}");
 		assertThat(defaultSpec.getUserParams()).containsEntry("topic", "AI");
 		assertThat(defaultSpec.getMedia()).hasSize(1);
+		assertThat(defaultSpec.getUserMetadata()).containsEntry("msgId", "uuid-xxx");
 	}
 
 	@Test
@@ -1951,11 +2088,13 @@ class DefaultChatClientTests {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("my question about {topic}");
 		spec = spec.user(user -> user.param("topic", "AI")
+			.metadata("msgId", "uuid-xxx")
 			.media(MimeTypeUtils.IMAGE_PNG, new ClassPathResource("tabby-cat.png")));
 		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
 		assertThat(defaultSpec.getUserText()).isEqualTo("my question about {topic}");
 		assertThat(defaultSpec.getUserParams()).containsEntry("topic", "AI");
 		assertThat(defaultSpec.getMedia()).hasSize(1);
+		assertThat(defaultSpec.getUserMetadata()).containsEntry("msgId", "uuid-xxx");
 	}
 
 	record Person(String name) {


### PR DESCRIPTION
- Add `metadata` methods to `PromptUserSpec` and `PromptSystemSpec` interfaces
- Update `DefaultChatClientRequestSpec` to handle user and system `metadata`
- Modify `DefaultChatClientUtils` to include `metadata` in `SystemMessage` and `UserMessage` builders
- Add comprehensive test coverage for `metadata` functionality

--- 
This PR allows users to set the `metadata` field for `UserMessage` and `SystemMessage` through `Consumer<PromptUserSpec>` and `Consumer<PromptSystemSpec>`.
 
Users can set information like message ID through `metadata`, and then get them in `ChatMemoryRepository`.  
Example as follows:

```java
  private static final ChatMemoryRepository myChatMemoryRepository = new ChatMemoryRepository() {
      @Override
      public void saveAll(String conversationId, List<Message> messages) {
          log.info("messages={}", messages);
          log.info("id={}", messages.getLast().getMetadata().get("id"));
      }
  };
  
  @GetMapping("/ai/tool")
  public String tool() {
      String userMessageId = UUID.randomUUID().toString();
  
      ChatResponse result = chatClient.prompt()
              .system(s -> s.text("You are a helpful assistant.")
                           // Allow setting metadata for SystemMessage.
                           .metadata("version", "v1.0"))
              .tools(this)
              .user(u -> u.text("What is the weather in New York?")
                          // Allow setting metadata for UserMessage.
                          .metadata("id", userMessageId))
              .advisors(MessageChatMemoryAdvisor.builder(
                      MessageWindowChatMemory.builder()
                              .chatMemoryRepository(myChatMemoryRepository)
                              .maxMessages(10).build()
              ).build())
              .call()
              .chatResponse();
  
      return result.getResult().getOutput().getText();
  }
```