### PR TITLE
Autoconfigure MCP Client with and async HTTP request customizer

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -23,7 +23,9 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
@@ -36,6 +38,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.log.LogAccessor;
 
 /**
  * Auto-configuration for Server-Sent Events (SSE) HTTP client transport in the Model
@@ -68,6 +71,8 @@ import org.springframework.context.annotation.Bean;
 		matchIfMissing = true)
 public class SseHttpClientTransportAutoConfiguration {
 
+	private static final LogAccessor logger = new LogAccessor(SseHttpClientTransportAutoConfiguration.class);
+
 	/**
 	 * Creates a list of HTTP client-based SSE transports for MCP communication.
 	 *
@@ -77,15 +82,22 @@ public class SseHttpClientTransportAutoConfiguration {
 	 * <li>A new HttpClient instance
 	 * <li>Server URL from properties
 	 * <li>ObjectMapper for JSON processing
+	 * <li>A sync or async HTTP request customizer. Sync takes precedence.
 	 * </ul>
 	 * @param sseProperties the SSE client properties containing server configurations
 	 * @param objectMapperProvider the provider for ObjectMapper or a new instance if not
+	 * available
+	 * @param syncHttpRequestCustomizer provider for {@link SyncHttpRequestCustomizer} if
+	 * available
+	 * @param asyncHttpRequestCustomizer provider fo {@link AsyncHttpRequestCustomizer} if
 	 * available
 	 * @return list of named MCP transports
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> sseHttpClientTransports(McpSseClientProperties sseProperties,
-			ObjectProvider<ObjectMapper> objectMapperProvider) {
+			ObjectProvider<ObjectMapper> objectMapperProvider,
+			ObjectProvider<SyncHttpRequestCustomizer> syncHttpRequestCustomizer,
+			ObjectProvider<AsyncHttpRequestCustomizer> asyncHttpRequestCustomizer) {
 
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
@@ -96,11 +108,21 @@ public class SseHttpClientTransportAutoConfiguration {
 			String baseUrl = serverParameters.getValue().url();
 			String sseEndpoint = serverParameters.getValue().sseEndpoint() != null
 					? serverParameters.getValue().sseEndpoint() : "/sse";
-			var transport = HttpClientSseClientTransport.builder(baseUrl)
+			HttpClientSseClientTransport.Builder transportBuilder = HttpClientSseClientTransport.builder(baseUrl)
 				.sseEndpoint(sseEndpoint)
 				.clientBuilder(HttpClient.newBuilder())
-				.objectMapper(objectMapper)
-				.build();
+				.objectMapper(objectMapper);
+
+			asyncHttpRequestCustomizer.ifUnique(transportBuilder::asyncHttpRequestCustomizer);
+			syncHttpRequestCustomizer.ifUnique(transportBuilder::httpRequestCustomizer);
+			if (asyncHttpRequestCustomizer.getIfUnique() != null && syncHttpRequestCustomizer.getIfUnique() != null) {
+				logger.warn("Found beans of type %s and %s. Using %s.".formatted(
+						AsyncHttpRequestCustomizer.class.getSimpleName(),
+						SyncHttpRequestCustomizer.class.getSimpleName(),
+						SyncHttpRequestCustomizer.class.getSimpleName()));
+			}
+
+			HttpClientSseClientTransport transport = transportBuilder.build();
 			sseTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
@@ -31,12 +31,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.log.LogAccessor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema;
 
 /**
@@ -59,6 +61,7 @@ import io.modelcontextprotocol.spec.McpSchema;
  * connections
  * <li>Configures ObjectMapper for JSON serialization/deserialization
  * <li>Supports multiple named server connections with different URLs
+ * <li>Adds a sync or async HTTP request customizer. Sync takes precedence.
  * </ul>
  *
  * @see HttpClientStreamableHttpTransport
@@ -70,6 +73,8 @@ import io.modelcontextprotocol.spec.McpSchema;
 @ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 		matchIfMissing = true)
 public class StreamableHttpHttpClientTransportAutoConfiguration {
+
+	private static final LogAccessor logger = new LogAccessor(StreamableHttpHttpClientTransportAutoConfiguration.class);
 
 	/**
 	 * Creates a list of HTTP client-based Streamable HTTP transports for MCP
@@ -86,11 +91,17 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 	 * configurations
 	 * @param objectMapperProvider the provider for ObjectMapper or a new instance if not
 	 * available
+	 * @param syncHttpRequestCustomizer provider for {@link SyncHttpRequestCustomizer} if
+	 * available
+	 * @param asyncHttpRequestCustomizer provider fo {@link AsyncHttpRequestCustomizer} if
+	 * available
 	 * @return list of named MCP transports
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> streamableHttpHttpClientTransports(
-			McpStreamableHttpClientProperties streamableProperties, ObjectProvider<ObjectMapper> objectMapperProvider) {
+			McpStreamableHttpClientProperties streamableProperties, ObjectProvider<ObjectMapper> objectMapperProvider,
+			ObjectProvider<SyncHttpRequestCustomizer> syncHttpRequestCustomizer,
+			ObjectProvider<AsyncHttpRequestCustomizer> asyncHttpRequestCustomizer) {
 
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
@@ -103,11 +114,22 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 			String streamableHttpEndpoint = serverParameters.getValue().endpoint() != null
 					? serverParameters.getValue().endpoint() : "/mcp";
 
-			HttpClientStreamableHttpTransport transport = HttpClientStreamableHttpTransport.builder(baseUrl)
+			HttpClientStreamableHttpTransport.Builder transportBuilder = HttpClientStreamableHttpTransport
+				.builder(baseUrl)
 				.endpoint(streamableHttpEndpoint)
 				.clientBuilder(HttpClient.newBuilder())
-				.objectMapper(objectMapper)
-				.build();
+				.objectMapper(objectMapper);
+
+			asyncHttpRequestCustomizer.ifUnique(transportBuilder::asyncHttpRequestCustomizer);
+			syncHttpRequestCustomizer.ifUnique(transportBuilder::httpRequestCustomizer);
+			if (asyncHttpRequestCustomizer.getIfUnique() != null && syncHttpRequestCustomizer.getIfUnique() != null) {
+				logger.warn("Found beans of type %s and %s. Using %s.".formatted(
+						AsyncHttpRequestCustomizer.class.getSimpleName(),
+						SyncHttpRequestCustomizer.class.getSimpleName(),
+						SyncHttpRequestCustomizer.class.getSimpleName()));
+			}
+
+			HttpClientStreamableHttpTransport transport = transportBuilder.build();
 
 			streamableHttpTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationIT.java
@@ -1,10 +1,16 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  */
 
 package org.springframework.ai.mcp.client.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -17,12 +23,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
 import org.springframework.ai.mcp.client.httpclient.autoconfigure.SseHttpClientTransportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
+import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
+import reactor.core.publisher.Mono;
 
 @Timeout(15)
 public class SseHttpClientTransportAutoConfigurationIT {
@@ -79,8 +92,69 @@ public class SseHttpClientTransportAutoConfigurationIT {
 			assertThat(toolsResult.tools()).hasSize(8);
 
 			logger.info("tools = {}", toolsResult);
-
 		});
+	}
+
+	@Test
+	void usesSyncRequestCustomizer() {
+		this.contextRunner
+			.withConfiguration(UserConfigurations.of(SyncRequestCustomizerConfiguration.class,
+					AsyncRequestCustomizerConfiguration.class))
+			.run(context -> {
+				List<McpSyncClient> mcpClients = (List<McpSyncClient>) context.getBean("mcpSyncClients");
+
+				assertThat(mcpClients).isNotNull();
+				assertThat(mcpClients).hasSize(1);
+
+				McpSyncClient mcpClient = mcpClients.get(0);
+
+				mcpClient.ping();
+
+				verify(context.getBean(SyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
+						any());
+				verifyNoInteractions(context.getBean(AsyncHttpRequestCustomizer.class));
+			});
+	}
+
+	@Test
+	void usesAsyncRequestCustomizer() {
+		this.contextRunner.withConfiguration(UserConfigurations.of(AsyncRequestCustomizerConfiguration.class))
+			.run(context -> {
+				List<McpSyncClient> mcpClients = (List<McpSyncClient>) context.getBean("mcpSyncClients");
+
+				assertThat(mcpClients).isNotNull();
+				assertThat(mcpClients).hasSize(1);
+
+				McpSyncClient mcpClient = mcpClients.get(0);
+
+				mcpClient.ping();
+
+				verify(context.getBean(AsyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
+						any());
+			});
+	}
+
+	@Configuration
+	static class SyncRequestCustomizerConfiguration {
+
+		@Bean
+		SyncHttpRequestCustomizer syncHttpRequestCustomizer() {
+			return mock(SyncHttpRequestCustomizer.class);
+		}
+
+	}
+
+	@Configuration
+	static class AsyncRequestCustomizerConfiguration {
+
+		@Bean
+		AsyncHttpRequestCustomizer asyncHttpRequestCustomizer() {
+			AsyncHttpRequestCustomizer requestCustomizerMock = mock(AsyncHttpRequestCustomizer.class);
+			when(requestCustomizerMock.customize(any(), any(), any(), any()))
+				.thenAnswer(invocation -> Mono.just(invocation.getArguments()[0]));
+			return requestCustomizerMock;
+		}
+
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationIT.java
@@ -1,10 +1,16 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  */
 
 package org.springframework.ai.mcp.client.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -17,12 +23,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
 import org.springframework.ai.mcp.client.httpclient.autoconfigure.StreamableHttpHttpClientTransportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
+import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
+import reactor.core.publisher.Mono;
 
 @Timeout(15)
 public class StreamableHttpHttpClientTransportAutoConfigurationIT {
@@ -80,8 +93,69 @@ public class StreamableHttpHttpClientTransportAutoConfigurationIT {
 			assertThat(toolsResult.tools()).hasSize(8);
 
 			logger.info("tools = {}", toolsResult);
-
 		});
+	}
+
+	@Test
+	void usesSyncRequestCustomizer() {
+		this.contextRunner
+			.withConfiguration(UserConfigurations.of(SyncRequestCustomizerConfiguration.class,
+					AsyncRequestCustomizerConfiguration.class))
+			.run(context -> {
+				List<McpSyncClient> mcpClients = (List<McpSyncClient>) context.getBean("mcpSyncClients");
+
+				assertThat(mcpClients).isNotNull();
+				assertThat(mcpClients).hasSize(1);
+
+				McpSyncClient mcpClient = mcpClients.get(0);
+
+				mcpClient.ping();
+
+				verify(context.getBean(SyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
+						any());
+				verifyNoInteractions(context.getBean(AsyncHttpRequestCustomizer.class));
+			});
+	}
+
+	@Test
+	void usesAsyncRequestCustomizer() {
+		this.contextRunner.withConfiguration(UserConfigurations.of(AsyncRequestCustomizerConfiguration.class))
+			.run(context -> {
+				List<McpSyncClient> mcpClients = (List<McpSyncClient>) context.getBean("mcpSyncClients");
+
+				assertThat(mcpClients).isNotNull();
+				assertThat(mcpClients).hasSize(1);
+
+				McpSyncClient mcpClient = mcpClients.get(0);
+
+				mcpClient.ping();
+
+				verify(context.getBean(AsyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
+						any());
+			});
+	}
+
+	@Configuration
+	static class SyncRequestCustomizerConfiguration {
+
+		@Bean
+		SyncHttpRequestCustomizer syncHttpRequestCustomizer() {
+			return mock(SyncHttpRequestCustomizer.class);
+		}
+
+	}
+
+	@Configuration
+	static class AsyncRequestCustomizerConfiguration {
+
+		@Bean
+		AsyncHttpRequestCustomizer asyncHttpRequestCustomizer() {
+			AsyncHttpRequestCustomizer requestCustomizerMock = mock(AsyncHttpRequestCustomizer.class);
+			when(requestCustomizerMock.customize(any(), any(), any(), any()))
+				.thenAnswer(invocation -> Mono.just(invocation.getArguments()[0]));
+			return requestCustomizerMock;
+		}
+
 	}
 
 }


### PR DESCRIPTION
Make the work from https://github.com/modelcontextprotocol/java-sdk/pull/388 available in Spring Boot auto-configuration.

This will allow easier customizations of MCP client HTTP requests.