### PR TITLE
fix: When parameter "value" is json string, JsonParser should convert json string to Object directly.

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
@@ -168,8 +168,22 @@ public final class JsonParser {
 			return Enum.valueOf((Class<Enum>) javaType, value.toString());
 		}
 
-		String json = JsonParser.toJson(value);
-		return JsonParser.fromJson(json, javaType);
+		Object result = null;
+		if (value instanceof String jsonString) {
+			try {
+				result = JsonParser.fromJson(jsonString, javaType);
+			}
+			catch (Exception e) {
+				// ignore
+			}
+		}
+
+		if (result == null) {
+			String json = JsonParser.toJson(value);
+			result = JsonParser.fromJson(json, javaType);
+		}
+
+		return result;
 	}
 
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
@@ -16,10 +16,10 @@
 
 package org.springframework.ai.util.json;
 
-import java.lang.reflect.Type;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -242,6 +242,22 @@ class JsonParserTests {
 	}
 
 	@Test
+	void fromStringToObject() {
+		String jsonString = """
+				{
+				    "name": "foo",
+				    "age": 7
+				}
+				""";
+		var value = JsonParser.toTypedObject(jsonString, TestSimpleObject.class);
+		assertThat(value).isOfAnyClassIn(TestSimpleObject.class);
+
+		TestSimpleObject testSimpleObject = (TestSimpleObject) value;
+		assertThat(testSimpleObject.name).isEqualTo("foo");
+		assertThat(testSimpleObject.age).isEqualTo(7);
+	}
+
+	@Test
 	void fromScientificNotationToInteger() {
 		var value = JsonParser.toTypedObject("1.5E7", Integer.class);
 		assertThat(value).isInstanceOf(Integer.class);
@@ -263,6 +279,14 @@ class JsonParserTests {
 	}
 
 	record TestRecord(String name, Integer age) {
+	}
+
+	static class TestSimpleObject {
+
+		public String name;
+
+		public int age;
+
 	}
 
 	enum TestEnum {


### PR DESCRIPTION
when parameter "value" is json string:
```json
{
    "name": "foo"
}
```

current code will convert it to json string with escaped quotes:

```
{\\"name\\":\\"foo\\"}
```

following code will fail to parse it from escaped json string to object.