### PR TITLE
GH-4010 Fixed the documentation and comments for MCP Client and MCP Server.

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
@@ -42,15 +42,11 @@ public class McpClientCommonProperties {
 
 	/**
 	 * The name of the MCP client instance.
-	 * <p>
-	 * This name is reported to clients and used for compatibility checks.
 	 */
 	private String name = "spring-ai-mcp-client";
 
 	/**
 	 * The version of the MCP client instance.
-	 * <p>
-	 * This version is reported to clients and used for compatibility checks.
 	 */
 	private String version = "1.0.0";
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server/src/main/java/org/springframework/ai/mcp/server/autoconfigure/McpServerProperties.java
@@ -68,8 +68,6 @@ public class McpServerProperties {
 
 	/**
 	 * The version of the MCP server instance.
-	 * <p>
-	 * This version is reported to clients and used for compatibility checks.
 	 */
 	private String version = "1.0.0";
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -57,7 +57,7 @@ The common properties are prefixed with `spring.ai.mcp.client`:
 |`true`
 
 |`name`
-|Name of the MCP client instance (used for compatibility checks)
+|Name of the MCP client instance
 |`spring-ai-mcp-client`
 
 |`version`


### PR DESCRIPTION
As mentioned in the issue, fixed the documentation and comments for MCP Client and MCP Server.

Fixes #4010 