### PR TITLE
fix: handle errors when toolExecution fails for functionToolCallback

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/function/FunctionToolCallback.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/function/FunctionToolCallback.java
@@ -31,6 +31,7 @@ import org.springframework.ai.tool.definition.DefaultToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.DefaultToolCallResultConverter;
 import org.springframework.ai.tool.execution.ToolCallResultConverter;
+import org.springframework.ai.tool.execution.ToolExecutionException;
 import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.ai.tool.support.ToolUtils;
 import org.springframework.ai.util.json.JsonParser;
@@ -99,7 +100,15 @@ public class FunctionToolCallback<I, O> implements ToolCallback {
 		logger.debug("Starting execution of tool: {}", this.toolDefinition.name());
 
 		I request = JsonParser.fromJson(toolInput, this.toolInputType);
-		O response = this.toolFunction.apply(request, toolContext);
+		O response;
+
+		try {
+			response = this.toolFunction.apply(request, toolContext);
+		}
+		catch (Exception e) {
+			logger.error("Error executing tool: {}", this.toolDefinition.name(), e);
+			throw new ToolExecutionException(this.toolDefinition, e);
+		}
 
 		logger.debug("Successful execution of tool: {}", this.toolDefinition.name());
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/function/FunctionToolCallbackTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/function/FunctionToolCallbackTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.tool.function;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.tool.execution.ToolExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link FunctionToolCallback}.
+ *
+ * @author Marco Schäck
+ */
+class FunctionToolCallbackTests {
+
+	@Test
+	void whenToolFunctionExecutesSuccessfullyThenReturnExpectedValue() {
+		// Given
+		SquareRootTool squareRootTool = new SquareRootTool();
+		FunctionToolCallback<SquareRootTool.Input, SquareRootTool.Output> callback = FunctionToolCallback
+			.builder("squareRootTool", squareRootTool::calculate)
+			.inputType(SquareRootTool.Input.class)
+			.build();
+
+		// When
+		String result = callback.call("{\"number\":25}");
+
+		// Then
+		assertThat(result).isEqualTo("{\"result\":5.0}");
+	}
+
+	@Test
+	void whenToolFunctionThrowsExceptionThenWrapInToolExecutionException() {
+		// Given
+		SquareRootTool squareRootTool = new SquareRootTool();
+		FunctionToolCallback<SquareRootTool.Input, SquareRootTool.Output> callback = FunctionToolCallback
+			.builder("squareRootTool", squareRootTool::calculate)
+			.inputType(SquareRootTool.Input.class)
+			.build();
+
+		// When & Then
+		assertThatThrownBy(() -> callback.call("{\"number\":-9}")).isInstanceOf(ToolExecutionException.class)
+			.hasCause(new IllegalArgumentException("Cannot calculate square root of negative number: -9"))
+			.hasMessageContaining("Cannot calculate square root of negative number: -9");
+	}
+
+	static class SquareRootTool {
+
+		record Input(int number) {
+		}
+
+		record Output(double result) {
+		}
+
+		public Output calculate(Input input) {
+			if (input.number < 0) {
+				throw new IllegalArgumentException("Cannot calculate square root of negative number: " + input.number);
+			}
+			return new Output(Math.sqrt(input.number));
+		}
+
+	}
+
+}


### PR DESCRIPTION
## FunctionToolCallback does not wrap exceptions in ToolExecutionException

fixes issue [2857](https://github.com/spring-projects/spring-ai/issues/2857)

## Description

The `FunctionToolCallback` does not properly handle exceptions thrown by user-defined tool functions. Unlike other tool callback implementations (such as `SyncMcpToolCallback`), it does not wrap exceptions in `ToolExecutionException`, which prevents proper error handling by the framework's exception processing mechanisms.

## Current Behavior

When a tool function throws an exception, it propagates uncaught through the `FunctionToolCallback.call()` method:

```java
@Override
public String call(String toolInput, @Nullable ToolContext toolContext) {
    Assert.hasText(toolInput, "toolInput cannot be null or empty");
    logger.debug("Starting execution of tool: {}", this.toolDefinition.name());
    I request = JsonParser.fromJson(toolInput, this.toolInputType);
    O response = this.toolFunction.apply(request, toolContext); // Exception not caught
    logger.debug("Successful execution of tool: {}", this.toolDefinition.name());
    return this.toolCallResultConverter.convert(response, null);
}
```

## Expected Behavior

Exceptions should be caught and wrapped in `ToolExecutionException` to maintain consistency with other tool callback implementations and enable proper error processing.

## Proposed Solution

Wrap the tool function execution in a try-catch block, similar to the implementation in [SyncMcpToolCallback](https://github.com/spring-projects/spring-ai/blob/main/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java):

```java
try {
    response = this.toolFunction.apply(request, toolContext);
} catch (Exception e) {
    logger.error("Error executing tool: {}", this.toolDefinition.name(), e);
    throw new ToolExecutionException(this.toolDefinition, e);
}
```

## Alternatives / Contribution for other options

If this is not an appropriate way to solve this issue please let me know! :) I would be happy to also contribute more general solutions - like making the `ToolExecutionExceptionProcessor` more generic (so that it can handle all kind of exceptions - and not just ToolExecutionExceptions)

## Impact

This change would:
- Enable error processing by the framework's exception processor (`ToolExecutionExceptionProcessor`)
- Improve debugging and error reporting for FunctionToolCallback execution failures

## Example Use Case

```kotlin
@Bean
fun exampleTool(): FunctionToolCallback<Void, List<String>> {
    return FunctionToolCallback
        .builder("ExampleTool", exampleTool::performCall)
        .description("This is an example tool that returns a list of example strings.")
        .build()
}

class ExampleTool {
    fun performCall(): List<String> {
        val response = client.execute("query { exampleField }")
        if (response.hasErrors()) {
            throw RuntimeException("Error fetching example data: $response") // This should be wrapped
        } else {
            val data = response.getData("exampleField")
            return data as List<String>
        }
    }
}
```

Currently, the `RuntimeException` thrown in `performCall()` is not wrapped in a `ToolExecutionException`, making it difficult for error processors to handle tool-specific failures appropriately.
