### PR TITLE
test: Add edge case tests for `VertexAI` `Gemini` runtime hints registration

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/aot/VertexAiGeminiRuntimeHintsTests.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/aot/VertexAiGeminiRuntimeHintsTests.java
@@ -53,4 +53,72 @@ class VertexAiGeminiRuntimeHintsTests {
 		assertThat(registeredTypes.contains(TypeReference.of(VertexAiGeminiChatOptions.class))).isTrue();
 	}
 
+	@Test
+	void registerHintsWithNullClassLoader() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		VertexAiGeminiRuntimeHints vertexAiGeminiRuntimeHints = new VertexAiGeminiRuntimeHints();
+
+		// Should not throw exception with null ClassLoader
+		org.assertj.core.api.Assertions
+			.assertThatCode(() -> vertexAiGeminiRuntimeHints.registerHints(runtimeHints, null))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	void ensureReflectionHintsAreRegistered() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		VertexAiGeminiRuntimeHints vertexAiGeminiRuntimeHints = new VertexAiGeminiRuntimeHints();
+		vertexAiGeminiRuntimeHints.registerHints(runtimeHints, null);
+
+		// Ensure reflection hints are properly registered
+		assertThat(runtimeHints.reflection().typeHints().spliterator().estimateSize()).isGreaterThan(0);
+	}
+
+	@Test
+	void verifyMultipleRegistrationCallsAreIdempotent() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		VertexAiGeminiRuntimeHints vertexAiGeminiRuntimeHints = new VertexAiGeminiRuntimeHints();
+
+		// Register hints multiple times
+		vertexAiGeminiRuntimeHints.registerHints(runtimeHints, null);
+		long firstCount = runtimeHints.reflection().typeHints().spliterator().estimateSize();
+
+		vertexAiGeminiRuntimeHints.registerHints(runtimeHints, null);
+		long secondCount = runtimeHints.reflection().typeHints().spliterator().estimateSize();
+
+		// Should not register duplicate hints
+		assertThat(firstCount).isEqualTo(secondCount);
+	}
+
+	@Test
+	void verifyJsonAnnotatedClassesFromCorrectPackage() {
+		Set<TypeReference> jsonAnnotatedClasses = findJsonAnnotatedClassesInPackage(
+				"org.springframework.ai.vertexai.gemini");
+
+		// Ensure we found some JSON annotated classes in the expected package
+		assertThat(jsonAnnotatedClasses.spliterator().estimateSize()).isGreaterThan(0);
+
+		// Verify all found classes are from the expected package
+		for (TypeReference classRef : jsonAnnotatedClasses) {
+			assertThat(classRef.getName()).startsWith("org.springframework.ai.vertexai.gemini");
+		}
+	}
+
+	@Test
+	void verifyNoUnnecessaryHintsRegistered() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		VertexAiGeminiRuntimeHints vertexAiGeminiRuntimeHints = new VertexAiGeminiRuntimeHints();
+		vertexAiGeminiRuntimeHints.registerHints(runtimeHints, null);
+
+		Set<TypeReference> jsonAnnotatedClasses = findJsonAnnotatedClassesInPackage(
+				"org.springframework.ai.vertexai.gemini");
+
+		Set<TypeReference> registeredTypes = new HashSet<>();
+		runtimeHints.reflection().typeHints().forEach(typeHint -> registeredTypes.add(typeHint.getType()));
+
+		// Ensure we don't register significantly more types than needed
+		// Allow for some additional utility types but prevent hint bloat
+		assertThat(registeredTypes.size()).isLessThanOrEqualTo(jsonAnnotatedClasses.size() + 10);
+	}
+
 }


### PR DESCRIPTION
Adds new test cases to strengthen VertexAiGeminiRuntimeHintsTests:

- **Null ClassLoader handling** - Ensures hint registration works with null ClassLoader (common in AOT)
- **Basic reflection hints validation** - Verifies hints are actually registered 
- **Idempotent registration** - Prevents duplicate hint registration on multiple calls
- **Package validation** - Confirms JSON annotated classes are found from correct package
- **Hint count validation** - Prevents excessive hint bloat that impacts native image build time

These tests catch potential AOT/GraalVM native compilation issues that could cause runtime failures.