### PR TITLE
test: Add comprehensive edge case and validation tests for runtime hints registration

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/aot/hint/JdbcChatMemoryRepositoryRuntimeHintsTest.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/chat/memory/repository/jdbc/aot/hint/JdbcChatMemoryRepositoryRuntimeHintsTest.java
@@ -34,6 +34,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author Jonathan Leijendekker
@@ -70,6 +71,12 @@ class JdbcChatMemoryRepositoryRuntimeHintsTest {
 		this.jdbcChatMemoryRepositoryRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
 
 		assertThat(RuntimeHintsPredicates.reflection().onType(DataSource.class)).accepts(this.hints);
+	}
+
+	@Test
+	void registerHintsWithNullClassLoader() {
+		assertThatNoException()
+			.isThrownBy(() -> this.jdbcChatMemoryRepositoryRuntimeHints.registerHints(this.hints, null));
 	}
 
 	private static Stream<String> getSchemaFileNames() throws IOException {

--- a/spring-ai-model/src/test/java/org/springframework/ai/aot/AiRuntimeHintsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/aot/AiRuntimeHintsTests.java
@@ -27,10 +27,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.util.Assert;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class AiRuntimeHintsTests {
 
 	@Test
-	void discoverRelevantClasses() throws Exception {
+	void discoverRelevantClasses() {
 		var classes = AiRuntimeHints.findJsonAnnotatedClassesInPackage(TestApi.class);
 		var included = Set.of(TestApi.Bar.class, TestApi.Foo.class)
 			.stream()
@@ -38,6 +40,24 @@ class AiRuntimeHintsTests {
 			.collect(Collectors.toSet());
 		LogFactory.getLog(getClass()).info(classes);
 		Assert.state(classes.containsAll(included), "there should be all of the enumerated classes. ");
+	}
+
+	@Test
+	void verifyRecordWithJsonPropertyIncluded() {
+		var classes = AiRuntimeHints.findJsonAnnotatedClassesInPackage(TestApi.class);
+
+		// Foo record should be included due to @JsonProperty on parameter
+		var recordClass = TypeReference.of(TestApi.Foo.class.getName());
+		assertThat(classes).contains(recordClass);
+	}
+
+	@Test
+	void verifyEnumWithJsonIncludeAnnotation() {
+		var classes = AiRuntimeHints.findJsonAnnotatedClassesInPackage(TestApi.class);
+
+		// Bar enum should be included due to @JsonInclude
+		var enumClass = TypeReference.of(TestApi.Bar.class.getName());
+		assertThat(classes).contains(enumClass);
 	}
 
 	@JsonInclude

--- a/spring-ai-model/src/test/java/org/springframework/ai/aot/ToolRuntimeHintsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/aot/ToolRuntimeHintsTests.java
@@ -22,6 +22,7 @@ import org.springframework.ai.tool.execution.DefaultToolCallResultConverter;
 import org.springframework.aot.hint.RuntimeHints;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.springframework.aot.hint.predicate.RuntimeHintsPredicates.reflection;
 
 /**
@@ -35,6 +36,15 @@ class ToolRuntimeHintsTests {
 		ToolRuntimeHints toolRuntimeHints = new ToolRuntimeHints();
 		toolRuntimeHints.registerHints(runtimeHints, null);
 		assertThat(runtimeHints).matches(reflection().onType(DefaultToolCallResultConverter.class));
+	}
+
+	@Test
+	void registerHintsWithNullClassLoader() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		ToolRuntimeHints toolRuntimeHints = new ToolRuntimeHints();
+
+		// Should not throw exception with null ClassLoader
+		assertThatCode(() -> toolRuntimeHints.registerHints(runtimeHints, null)).doesNotThrowAnyException();
 	}
 
 }


### PR DESCRIPTION
Adds 4 targeted test cases to strengthen runtime hints functionality across multiple components:

**ToolRuntimeHintsTests:**
- **Null ClassLoader handling** - Ensures tool hints registration doesn't fail when ClassLoader parameter is null (common in AOT processing)

**AiRuntimeHintsTests:**
- **Record validation** - Confirms records with `@JsonProperty` parameters are properly discovered for hint registration
- **Enum validation** - Verifies enums with `@JsonInclude` annotations are correctly identified for reflection hints

**JdbcChatMemoryRepositoryRuntimeHintsTest:**
- **Null ClassLoader robustness** - Validates JDBC chat memory hints registration handles null ClassLoader gracefully

These tests prevent runtime failures in native images by ensuring proper discovery of JSON-annotated classes (records/enums), robust hint registration under various ClassLoader conditions, and reliable chat memory persistence in GraalVM environments.