### PR TITLE
test: Add comprehensive test coverage for `KeywordMetadataEnricher`, `ToolRuntimeHints`, and `Usage` classes

### DIFF
--- a/spring-ai-model/src/test/java/org/springframework/ai/aot/ToolRuntimeHintsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/aot/ToolRuntimeHintsTests.java
@@ -47,4 +47,36 @@ class ToolRuntimeHintsTests {
 		assertThatCode(() -> toolRuntimeHints.registerHints(runtimeHints, null)).doesNotThrowAnyException();
 	}
 
+	@Test
+	void registerHintsWithCustomClassLoader() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		ToolRuntimeHints toolRuntimeHints = new ToolRuntimeHints();
+		ClassLoader customClassLoader = Thread.currentThread().getContextClassLoader();
+
+		toolRuntimeHints.registerHints(runtimeHints, customClassLoader);
+
+		assertThat(runtimeHints).matches(reflection().onType(DefaultToolCallResultConverter.class));
+	}
+
+	@Test
+	void registerHintsMultipleTimes() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		ToolRuntimeHints toolRuntimeHints = new ToolRuntimeHints();
+
+		toolRuntimeHints.registerHints(runtimeHints, null);
+		toolRuntimeHints.registerHints(runtimeHints, null);
+
+		assertThat(runtimeHints).matches(reflection().onType(DefaultToolCallResultConverter.class));
+	}
+
+	@Test
+	void toolRuntimeHintsInstanceCreation() {
+		assertThatCode(() -> new ToolRuntimeHints()).doesNotThrowAnyException();
+
+		ToolRuntimeHints hints1 = new ToolRuntimeHints();
+		ToolRuntimeHints hints2 = new ToolRuntimeHints();
+
+		assertThat(hints1).isNotSameAs(hints2);
+	}
+
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/metadata/UsageTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/metadata/UsageTests.java
@@ -87,4 +87,28 @@ public class UsageTests {
 		verifyUsage(usage);
 	}
 
+	@Test
+	void totalTokensHandlesZeroPromptTokens() {
+		Usage usage = mockUsage(0, 1);
+
+		assertThat(usage.getTotalTokens()).isEqualTo(1);
+		verifyUsage(usage);
+	}
+
+	@Test
+	void totalTokensHandlesZeroCompletionTokens() {
+		Usage usage = mockUsage(1, 0);
+
+		assertThat(usage.getTotalTokens()).isEqualTo(1);
+		verifyUsage(usage);
+	}
+
+	@Test
+	void totalTokensHandlesBothZeroTokens() {
+		Usage usage = mockUsage(0, 0);
+
+		assertThat(usage.getTotalTokens()).isZero();
+		verifyUsage(usage);
+	}
+
 }


### PR DESCRIPTION
**Enhances test coverage with additional edge cases and scenarios:**

`KeywordMetadataEnricher:`

- Empty documents list handling
- Single document processing
- Existing metadata preservation
- Empty/whitespace response handling
- Keyword overwriting behavior
- Builder pattern with mixed configurations
- Special characters in content

`ToolRuntimeHints:`

- Custom ClassLoader support
- Multiple registration calls
- Instance creation validation

`Usage:`

- Zero token edge cases for prompt/completion tokens
- Total token calculation with various inputs

These tests improve reliability by covering previously untested paths and edge cases.