### PR TITLE
test: Add comprehensive test coverage for `ModelObservationContext` and `ModelUsageMetricsGenerator`

### DIFF
--- a/spring-ai-model/src/test/java/org/springframework/ai/model/observation/ModelObservationContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/observation/ModelObservationContextTests.java
@@ -100,4 +100,157 @@ class ModelObservationContextTests {
 			.hasMessageContaining("response cannot be null");
 	}
 
+	@Test
+	void whenEmptyOperationTypeThenThrow() {
+		assertThatThrownBy(() -> new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder().operationType("").provider(AiProvider.OLLAMA.value()).build()))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void whenEmptyProviderThenThrow() {
+		assertThatThrownBy(() -> new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder().operationType(AiOperationType.CHAT.value()).provider("").build()))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void whenDifferentProvidersThenReturn() {
+		var ollamaContext = new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+
+		var openaiContext = new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OPENAI.value())
+					.build());
+
+		var anthropicContext = new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.ANTHROPIC.value())
+					.build());
+
+		assertThat(ollamaContext).isNotNull();
+		assertThat(openaiContext).isNotNull();
+		assertThat(anthropicContext).isNotNull();
+	}
+
+	@Test
+	void whenComplexObjectTypesAreUsedThenReturn() {
+		var observationContext = new ModelObservationContext<Integer, Boolean>(12345,
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+		observationContext.setResponse(true);
+
+		assertThat(observationContext).isNotNull();
+	}
+
+	@Test
+	void whenGetRequestThenReturn() {
+		var testRequest = "test request content";
+		var observationContext = new ModelObservationContext<String, String>(testRequest,
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+
+		assertThat(observationContext.getRequest()).isEqualTo(testRequest);
+	}
+
+	@Test
+	void whenGetResponseBeforeSettingThenReturnNull() {
+		var observationContext = new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+
+		assertThat(observationContext.getResponse()).isNull();
+	}
+
+	@Test
+	void whenGetResponseAfterSettingThenReturn() {
+		var testResponse = "test response content";
+		var observationContext = new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+		observationContext.setResponse(testResponse);
+
+		assertThat(observationContext.getResponse()).isEqualTo(testResponse);
+	}
+
+	@Test
+	void whenGetOperationMetadataThenReturn() {
+		var metadata = AiOperationMetadata.builder()
+			.operationType(AiOperationType.EMBEDDING.value())
+			.provider(AiProvider.OPENAI.value())
+			.build();
+		var observationContext = new ModelObservationContext<String, String>("test request", metadata);
+
+		assertThat(observationContext.getOperationMetadata()).isEqualTo(metadata);
+	}
+
+	@Test
+	void whenSetResponseMultipleTimesThenLastValueWins() {
+		var observationContext = new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+
+		observationContext.setResponse("first response");
+		observationContext.setResponse("second response");
+		observationContext.setResponse("final response");
+
+		assertThat(observationContext.getResponse()).isEqualTo("final response");
+	}
+
+	@Test
+	void whenWhitespaceOnlyOperationTypeThenThrow() {
+		assertThatThrownBy(() -> new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder().operationType("   ").provider(AiProvider.OLLAMA.value()).build()))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("operationType cannot be null or empty");
+	}
+
+	@Test
+	void whenWhitespaceOnlyProviderThenThrow() {
+		assertThatThrownBy(() -> new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder().operationType(AiOperationType.CHAT.value()).provider("   ").build()))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("provider cannot be null or empty");
+	}
+
+	@Test
+	void whenEmptyStringRequestThenReturn() {
+		var observationContext = new ModelObservationContext<String, String>("",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+
+		assertThat(observationContext).isNotNull();
+		assertThat(observationContext.getRequest()).isEqualTo("");
+	}
+
+	@Test
+	void whenEmptyStringResponseThenReturn() {
+		var observationContext = new ModelObservationContext<String, String>("test request",
+				AiOperationMetadata.builder()
+					.operationType(AiOperationType.CHAT.value())
+					.provider(AiProvider.OLLAMA.value())
+					.build());
+		observationContext.setResponse("");
+
+		assertThat(observationContext.getResponse()).isEqualTo("");
+	}
+
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/observation/ModelUsageMetricsGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/observation/ModelUsageMetricsGeneratorTests.java
@@ -123,4 +123,38 @@ class ModelUsageMetricsGeneratorTests {
 
 	}
 
+	@Test
+	void whenZeroTokenUsageThenMetrics() {
+		var meterRegistry = new SimpleMeterRegistry();
+		var usage = new TestUsage(0, 0, 0);
+		ModelUsageMetricsGenerator.generate(usage, buildContext(), meterRegistry);
+
+		assertThat(meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value()).meters()).hasSize(3);
+		assertThat(meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), AiTokenType.INPUT.value())
+			.counter()
+			.count()).isEqualTo(0);
+		assertThat(meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), AiTokenType.OUTPUT.value())
+			.counter()
+			.count()).isEqualTo(0);
+		assertThat(meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), AiTokenType.TOTAL.value())
+			.counter()
+			.count()).isEqualTo(0);
+	}
+
+	@Test
+	void whenBothPromptAndGenerationNullThenOnlyTotalMetric() {
+		var meterRegistry = new SimpleMeterRegistry();
+		var usage = new TestUsage(null, null, 100);
+		ModelUsageMetricsGenerator.generate(usage, buildContext(), meterRegistry);
+
+		assertThat(meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value()).meters()).hasSize(1);
+		assertThat(meterRegistry.get(AiObservationMetricNames.TOKEN_USAGE.value())
+			.tag(AiObservationMetricAttributes.TOKEN_TYPE.value(), AiTokenType.TOTAL.value())
+			.counter()
+			.count()).isEqualTo(100);
+	}
+
 }


### PR DESCRIPTION
This PR adds comprehensive unit test coverage for ModelObservationContext and ModelUsageMetricsGenerator classes, focusing on validation, edge cases, and metrics generation scenarios.

**Changes Made**

`ModelObservationContext Tests:`

- Added validation tests for empty and whitespace-only operation types and providers
- Added tests for different AI provider types (Ollama, OpenAI, Anthropic)
- Added generic type testing with complex object types (Integer, Boolean)
- Added getter/setter behavior validation including multiple response updates
- Added edge cases for empty string requests and responses

`ModelUsageMetricsGenerator Tests:`

- Added test for zero token usage metrics generation
- Added test for null prompt/generation tokens with valid total tokens
- Added validation of metric registry behavior and counter values
- Added testing of different token type tags

**Test Coverage Improvements**

Validation: Empty/null/whitespace parameter handling
Edge Cases: Zero values, null combinations, empty strings
Provider Support: Multiple AI provider validation
Metrics Generation: Token usage tracking and registry validation
Type Safety: Generic type parameter testing