### PR TITLE
test: Add comprehensive test coverage for `Prompt` and `ChatOptions` builders

### DIFF
--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/ChatOptionsBuilderTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/ChatOptionsBuilderTests.java
@@ -173,4 +173,73 @@ public class ChatOptionsBuilderTests {
 			.isInstanceOf(UnsupportedOperationException.class);
 	}
 
+	@Test
+	void shouldHandleNullStopSequences() {
+		ChatOptions options = this.builder.model("test-model").stopSequences(null).build();
+
+		assertThat(options.getStopSequences()).isNull();
+	}
+
+	@Test
+	void shouldHandleEmptyStopSequences() {
+		ChatOptions options = this.builder.model("test-model").stopSequences(List.of()).build();
+
+		assertThat(options.getStopSequences()).isEmpty();
+	}
+
+	@Test
+	void shouldHandleFrequencyAndPresencePenalties() {
+		ChatOptions options = this.builder.model("test-model").frequencyPenalty(0.5).presencePenalty(0.3).build();
+
+		assertThat(options.getFrequencyPenalty()).isEqualTo(0.5);
+		assertThat(options.getPresencePenalty()).isEqualTo(0.3);
+	}
+
+	@Test
+	void shouldMaintainStopSequencesOrder() {
+		List<String> orderedSequences = List.of("first", "second", "third", "fourth");
+
+		ChatOptions options = this.builder.model("test-model").stopSequences(orderedSequences).build();
+
+		assertThat(options.getStopSequences()).containsExactly("first", "second", "third", "fourth");
+	}
+
+	@Test
+	void shouldCreateIndependentCopies() {
+		ChatOptions original = this.builder.model("test-model")
+			.stopSequences(new ArrayList<>(List.of("stop1")))
+			.build();
+
+		ChatOptions copy1 = original.copy();
+		ChatOptions copy2 = original.copy();
+
+		assertThat(copy1).isNotSameAs(copy2);
+		assertThat(copy1.getStopSequences()).isNotSameAs(copy2.getStopSequences());
+		assertThat(copy1).usingRecursiveComparison().isEqualTo(copy2);
+	}
+
+	@Test
+	void shouldHandleSpecialStringValues() {
+		ChatOptions options = this.builder.model("") // Empty string
+			.stopSequences(List.of("", "  ", "\n", "\t"))
+			.build();
+
+		assertThat(options.getModel()).isEmpty();
+		assertThat(options.getStopSequences()).containsExactly("", "  ", "\n", "\t");
+	}
+
+	@Test
+	void shouldPreserveCopyIntegrity() {
+		List<String> mutableList = new ArrayList<>(List.of("original"));
+		ChatOptions original = this.builder.model("test-model").stopSequences(mutableList).build();
+
+		// Modify the original list after building
+		mutableList.add("modified");
+
+		ChatOptions copy = original.copy();
+
+		assertThat(original.getStopSequences()).containsExactly("original");
+		assertThat(copy.getStopSequences()).containsExactly("original");
+	}
+
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTests.java
@@ -261,4 +261,48 @@ class PromptTests {
 		assertThat(prompt.getSystemMessage().getText()).isEqualTo("Hello");
 	}
 
+	@Test
+	void shouldPreserveMessageOrder() {
+		SystemMessage system = new SystemMessage("You are helpful");
+		UserMessage user1 = new UserMessage("First question");
+		UserMessage user2 = new UserMessage("Second question");
+
+		Prompt prompt = Prompt.builder().messages(system, user1, user2).build();
+
+		assertThat(prompt.getInstructions()).hasSize(3);
+		assertThat(prompt.getInstructions().get(0)).isEqualTo(system);
+		assertThat(prompt.getInstructions().get(1)).isEqualTo(user1);
+		assertThat(prompt.getInstructions().get(2)).isEqualTo(user2);
+	}
+
+	@Test
+	void shouldHandleEmptyMessageList() {
+		Prompt prompt = Prompt.builder().messages(List.of()).build();
+
+		assertThat(prompt.getInstructions()).isEmpty();
+		assertThat(prompt.getUserMessage().getText()).isEmpty();
+		assertThat(prompt.getSystemMessage().getText()).isEmpty();
+	}
+
+	@Test
+	void shouldCreatePromptWithOptions() {
+		ChatOptions options = ChatOptions.builder().model("test-model").temperature(0.5).build();
+		Prompt prompt = new Prompt("Test content", options);
+
+		assertThat(prompt.getOptions()).isEqualTo(options);
+		assertThat(prompt.getUserMessage().getText()).isEqualTo("Test content");
+	}
+
+	@Test
+	void shouldHandleMixedMessageTypes() {
+		SystemMessage system = new SystemMessage("System message");
+		UserMessage user = new UserMessage("User message");
+
+		Prompt prompt = Prompt.builder().messages(user, system).build();
+
+		assertThat(prompt.getInstructions()).hasSize(2);
+		assertThat(prompt.getUserMessage().getText()).isEqualTo("User message");
+		assertThat(prompt.getSystemMessage().getText()).isEqualTo("System message");
+	}
+
 }


### PR DESCRIPTION
## Summary
Enhanced test coverage for Prompt and ChatOptions classes with additional edge cases and validation scenarios.

## Changes
**PromptTests:**
- Message order preservation validation
- Empty message list handling
- Prompt creation with ChatOptions
- Mixed message type scenarios

**ChatOptionsBuilderTests:**
- Null/empty stop sequences handling
- Frequency and presence penalty validation
- Stop sequences order preservation
- Independent copy creation verification
- Special string values (empty, whitespace) handling
- Copy integrity when original data is modified

## Testing
All new tests pass and maintain existing functionality coverage.