### PR TITLE
test: Add comprehensive test coverage for `DefaultChatClient` and `DefaultChatClientBuilder`

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
@@ -102,4 +102,61 @@ class DefaultChatClientBuilderTests {
 			.hasMessage("templateRenderer cannot be null");
 	}
 
+	@Test
+	void whenCloneBuilderThenModifyingOriginalDoesNotAffectClone() {
+		var chatModel = mock(ChatModel.class);
+		var originalBuilder = new DefaultChatClientBuilder(chatModel);
+		originalBuilder.defaultSystem("original system");
+		originalBuilder.defaultUser("original user");
+
+		var clonedBuilder = (DefaultChatClientBuilder) originalBuilder.clone();
+
+		// Modify original
+		originalBuilder.defaultSystem("modified system");
+		originalBuilder.defaultUser("modified user");
+
+		var clonedRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ReflectionTestUtils.getField(clonedBuilder,
+				"defaultRequest");
+
+		assertThat(clonedRequest.getSystemText()).isEqualTo("original system");
+		assertThat(clonedRequest.getUserText()).isEqualTo("original user");
+	}
+
+	@Test
+	void whenBuildChatClientThenReturnsValidInstance() {
+		var chatModel = mock(ChatModel.class);
+		var builder = new DefaultChatClientBuilder(chatModel);
+
+		var chatClient = builder.build();
+
+		assertThat(chatClient).isNotNull();
+		assertThat(chatClient).isInstanceOf(DefaultChatClient.class);
+	}
+
+	@Test
+	void whenOverridingSystemPromptThenLatestValueIsUsed() {
+		var chatModel = mock(ChatModel.class);
+		var builder = new DefaultChatClientBuilder(chatModel);
+
+		builder.defaultSystem("first system prompt");
+		builder.defaultSystem("second system prompt");
+
+		var defaultRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ReflectionTestUtils.getField(builder,
+				"defaultRequest");
+		assertThat(defaultRequest.getSystemText()).isEqualTo("second system prompt");
+	}
+
+	@Test
+	void whenOverridingUserPromptThenLatestValueIsUsed() {
+		var chatModel = mock(ChatModel.class);
+		var builder = new DefaultChatClientBuilder(chatModel);
+
+		builder.defaultUser("first user prompt");
+		builder.defaultUser("second user prompt");
+
+		var defaultRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ReflectionTestUtils.getField(builder,
+				"defaultRequest");
+		assertThat(defaultRequest.getUserText()).isEqualTo("second user prompt");
+	}
+
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1684,28 +1684,6 @@ class DefaultChatClientTests {
 	}
 
 	@Test
-	@Disabled("This fails now as the FunctionToolCallback description is allowed to be empty")
-	void whenFunctionDescriptionIsNullThenThrow() {
-		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(FunctionToolCallback.builder("name", input -> "hello")
-			.description(null)
-			.inputType(String.class)
-			.build())).isInstanceOf(IllegalArgumentException.class).hasMessage("Description must not be empty");
-	}
-
-	@Test
-	@Disabled("This fails now as the FunctionToolCallback description is allowed to be empty")
-	void whenFunctionDescriptionIsEmptyThenThrow() {
-		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
-		assertThatThrownBy(() -> spec.toolCallbacks(
-				FunctionToolCallback.builder("name", input -> "hello").description("").inputType(String.class).build()))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("Description must not be empty");
-	}
-
-	@Test
 	void whenFunctionThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
@@ -2098,6 +2076,106 @@ class DefaultChatClientTests {
 	}
 
 	record Person(String name) {
+	}
+
+	@Test
+	void whenDefaultChatClientBuilderWithObservationRegistryThenReturn() {
+		var chatModel = mock(ChatModel.class);
+		var observationRegistry = mock(ObservationRegistry.class);
+		var observationConvention = mock(ChatClientObservationConvention.class);
+
+		var builder = new DefaultChatClientBuilder(chatModel, observationRegistry, observationConvention);
+
+		assertThat(builder).isNotNull();
+	}
+
+	@Test
+	void whenPromptWithSystemUserAndOptionsThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatOptions options = ChatOptions.builder().build();
+
+		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt()
+			.system("instructions")
+			.user("question")
+			.options(options);
+
+		assertThat(spec.getSystemText()).isEqualTo("instructions");
+		assertThat(spec.getUserText()).isEqualTo("question");
+		assertThat(spec.getChatOptions()).isEqualTo(options);
+	}
+
+	@Test
+	void whenToolNamesWithEmptyArrayThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().toolNames();
+
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolNames()).isEmpty();
+	}
+
+	@Test
+	void whenUserParamsWithEmptyMapThenReturn() {
+		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
+		spec = (DefaultChatClient.DefaultPromptUserSpec) spec.params(Map.of());
+		assertThat(spec.params()).isEmpty();
+	}
+
+	@Test
+	void whenSystemParamsWithEmptyMapThenReturn() {
+		DefaultChatClient.DefaultPromptSystemSpec spec = new DefaultChatClient.DefaultPromptSystemSpec();
+		spec = (DefaultChatClient.DefaultPromptSystemSpec) spec.params(Map.of());
+		assertThat(spec.params()).isEmpty();
+	}
+
+	@Test
+	void whenAdvisorSpecWithMultipleParamsThenAllStored() {
+		DefaultChatClient.DefaultAdvisorSpec spec = new DefaultChatClient.DefaultAdvisorSpec();
+		spec = (DefaultChatClient.DefaultAdvisorSpec) spec.param("param1", "value1")
+			.param("param2", "value2")
+			.param("param3", "value3");
+
+		assertThat(spec.getParams()).containsEntry("param1", "value1")
+			.containsEntry("param2", "value2")
+			.containsEntry("param3", "value3");
+	}
+
+	@Test
+	void whenMessagesWithEmptyListThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().messages(List.of());
+
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		// Messages should not be modified from original state
+		assertThat(defaultSpec.getMessages()).isNotNull();
+	}
+
+	@Test
+	void whenMutateBuilderThenReturnsSameType() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.Builder mutatedBuilder = chatClient.mutate();
+
+		assertThat(mutatedBuilder).isInstanceOf(DefaultChatClientBuilder.class);
+	}
+
+	@Test
+	void whenSystemConsumerWithNullParamValueThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+
+		assertThatThrownBy(() -> spec.system(system -> system.param("key", null)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("value cannot be null");
+	}
+
+	@Test
+	void whenUserConsumerWithNullParamValueThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+
+		assertThatThrownBy(() -> spec.user(user -> user.param("key", null)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("value cannot be null");
 	}
 
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1684,6 +1684,28 @@ class DefaultChatClientTests {
 	}
 
 	@Test
+	@Disabled("This fails now as the FunctionToolCallback description is allowed to be empty")
+	void whenFunctionDescriptionIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		assertThatThrownBy(() -> spec.toolCallbacks(FunctionToolCallback.builder("name", input -> "hello")
+			.description(null)
+			.inputType(String.class)
+			.build())).isInstanceOf(IllegalArgumentException.class).hasMessage("Description must not be empty");
+	}
+
+	@Test
+	@Disabled("This fails now as the FunctionToolCallback description is allowed to be empty")
+	void whenFunctionDescriptionIsEmptyThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();
+		assertThatThrownBy(() -> spec.toolCallbacks(
+				FunctionToolCallback.builder("name", input -> "hello").description("").inputType(String.class).build()))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Description must not be empty");
+	}
+
+	@Test
 	void whenFunctionThenReturn() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mock(ChatModel.class)).build();
 		ChatClient.ChatClientRequestSpec spec = chatClient.prompt();


### PR DESCRIPTION
`DefaultChatClientTests:`

- Add constructor validation test for DefaultChatClientBuilder with ObservationRegistry
- Test complex prompt building with system, user, and options combined
- Verify empty collection handling for tool names, parameters, and messages
- Add parameter validation tests for null values in system/user consumers
- Test advisor spec with multiple parameters and builder mutation behavior

`DefaultChatClientBuilderTests:`

- Add clone isolation tests ensuring modifications to original don't affect clone
- Test build method returns proper DefaultChatClient instance
- Verify override behavior for system and user prompts

These tests improve edge case coverage and validate proper isolation, parameter handling, and builder pattern implementation.