### PR TITLE
test: Enhance `Anthropic` test coverage with comprehensive validation and edge cases

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -318,4 +318,157 @@ class AnthropicChatOptionsTests {
 		assertThat(copied.getToolContext()).isNotSameAs(original.getToolContext());
 	}
 
+	@Test
+	void testBoundaryValues() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.maxTokens(Integer.MAX_VALUE)
+			.temperature(1.0)
+			.topP(1.0)
+			.topK(Integer.MAX_VALUE)
+			.build();
+
+		assertThat(options.getMaxTokens()).isEqualTo(Integer.MAX_VALUE);
+		assertThat(options.getTemperature()).isEqualTo(1.0);
+		assertThat(options.getTopP()).isEqualTo(1.0);
+		assertThat(options.getTopK()).isEqualTo(Integer.MAX_VALUE);
+	}
+
+	@Test
+	void testToolContextWithVariousValueTypes() {
+		Map<String, Object> mixedMap = Map.of("string", "value", "number", 42, "boolean", true, "null_value", "null",
+				"nested_list", List.of("a", "b", "c"), "nested_map", Map.of("inner", "value"));
+
+		AnthropicChatOptions options = AnthropicChatOptions.builder().toolContext(mixedMap).build();
+
+		assertThat(options.getToolContext()).containsAllEntriesOf(mixedMap);
+		assertThat(options.getToolContext().get("string")).isEqualTo("value");
+		assertThat(options.getToolContext().get("number")).isEqualTo(42);
+		assertThat(options.getToolContext().get("boolean")).isEqualTo(true);
+	}
+
+	@Test
+	void testCopyWithMutableCollections() {
+		List<String> mutableStops = new java.util.ArrayList<>(List.of("stop1", "stop2"));
+		Map<String, Object> mutableContext = new java.util.HashMap<>(Map.of("key", "value"));
+
+		AnthropicChatOptions original = AnthropicChatOptions.builder()
+			.stopSequences(mutableStops)
+			.toolContext(mutableContext)
+			.build();
+
+		AnthropicChatOptions copied = original.copy();
+
+		// Modify original collections
+		mutableStops.add("stop3");
+		mutableContext.put("new_key", "new_value");
+
+		// Copied instance should not be affected
+		assertThat(copied.getStopSequences()).hasSize(2);
+		assertThat(copied.getToolContext()).hasSize(1);
+		assertThat(copied.getStopSequences()).doesNotContain("stop3");
+		assertThat(copied.getToolContext()).doesNotContainKey("new_key");
+	}
+
+	@Test
+	void testEqualsWithNullFields() {
+		AnthropicChatOptions options1 = new AnthropicChatOptions();
+		AnthropicChatOptions options2 = new AnthropicChatOptions();
+
+		assertThat(options1).isEqualTo(options2);
+		assertThat(options1.hashCode()).isEqualTo(options2.hashCode());
+	}
+
+	@Test
+	void testEqualsWithMixedNullAndNonNullFields() {
+		AnthropicChatOptions options1 = AnthropicChatOptions.builder()
+			.model("test")
+			.maxTokens(null)
+			.temperature(0.5)
+			.build();
+
+		AnthropicChatOptions options2 = AnthropicChatOptions.builder()
+			.model("test")
+			.maxTokens(null)
+			.temperature(0.5)
+			.build();
+
+		AnthropicChatOptions options3 = AnthropicChatOptions.builder()
+			.model("test")
+			.maxTokens(100)
+			.temperature(0.5)
+			.build();
+
+		assertThat(options1).isEqualTo(options2);
+		assertThat(options1).isNotEqualTo(options3);
+	}
+
+	@Test
+	void testCopyDoesNotShareMetadataReference() {
+		Metadata originalMetadata = new Metadata("user_123");
+		AnthropicChatOptions original = AnthropicChatOptions.builder().metadata(originalMetadata).build();
+
+		AnthropicChatOptions copied = original.copy();
+
+		// Metadata should be the same value but potentially different reference
+		assertThat(copied.getMetadata()).isEqualTo(original.getMetadata());
+
+		// Verify changing original doesn't affect copy
+		original.setMetadata(new Metadata("different_user"));
+		assertThat(copied.getMetadata()).isEqualTo(originalMetadata);
+	}
+
+	@Test
+	void testEqualsWithSelf() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().model("test").build();
+
+		assertThat(options).isEqualTo(options);
+		assertThat(options.hashCode()).isEqualTo(options.hashCode());
+	}
+
+	@Test
+	void testEqualsWithNull() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().model("test").build();
+
+		assertThat(options).isNotEqualTo(null);
+	}
+
+	@Test
+	void testEqualsWithDifferentClass() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().model("test").build();
+
+		assertThat(options).isNotEqualTo("not an AnthropicChatOptions");
+		assertThat(options).isNotEqualTo(1);
+	}
+
+	@Test
+	void testBuilderPartialConfiguration() {
+		// Test builder with only some fields set
+		AnthropicChatOptions onlyModel = AnthropicChatOptions.builder().model("model-only").build();
+
+		AnthropicChatOptions onlyTokens = AnthropicChatOptions.builder().maxTokens(10).build();
+
+		AnthropicChatOptions onlyTemperature = AnthropicChatOptions.builder().temperature(0.8).build();
+
+		assertThat(onlyModel.getModel()).isEqualTo("model-only");
+		assertThat(onlyModel.getMaxTokens()).isNull();
+
+		assertThat(onlyTokens.getModel()).isNull();
+		assertThat(onlyTokens.getMaxTokens()).isEqualTo(10);
+
+		assertThat(onlyTemperature.getModel()).isNull();
+		assertThat(onlyTemperature.getTemperature()).isEqualTo(0.8);
+	}
+
+	@Test
+	void testSetterOverwriteBehavior() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().model("initial-model").maxTokens(100).build();
+
+		// Overwrite with setters
+		options.setModel("updated-model");
+		options.setMaxTokens(10);
+
+		assertThat(options.getModel()).isEqualTo("updated-model");
+		assertThat(options.getMaxTokens()).isEqualTo(10);
+	}
+
 }


### PR DESCRIPTION
**PR Description:**
**Comprehensive test coverage improvements for Anthropic module**
Strengthens test suites for both AnthropicRuntimeHints and AnthropicChatOptions with extensive validation scenarios:

`AnthropicRuntimeHints` improvements:

- Verifies nested API classes (ChatCompletionRequest, AnthropicMessage, ContentBlock) are properly registered
- Ensures hint isolation - only reflection hints registered, no proxy/serialization hints
- Validates package specificity and prevents cross-contamination from other AI modules
- Tests consistency across multiple instances and JSON annotated class detection

`AnthropicChatOptions `improvements:

- Tests boundary values (Integer.MAX_VALUE, edge floating-point values)
- Validates deep copy behavior with mutable collections to prevent reference sharing
- Comprehensive equals/hashCode testing including null fields and mixed states
- Tests metadata isolation and builder partial configuration scenarios
- Ensures robust handling of various data types in tool context maps

These additions improve reliability, prevent regressions, and ensure robust handling of edge cases in native compilation scenarios and object lifecycle management.