### PR TITLE
Fix CI workflow: Use ../mvnw for assembly generation in spring-ai-docs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Generate assembly
         working-directory: spring-ai-docs
-        run: ./mvnw --batch-mode assembly:single
+        run: ../mvnw --batch-mode assembly:single
 
       - name: Capture project version
         run: echo PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version --quiet -DforceStdout) >> $GITHUB_ENV


### PR DESCRIPTION
The CI was failing because the 'Generate assembly' step was trying to run ./mvnw from within the spring-ai-docs directory, but the Maven wrapper script only exists in the repository root.

Fixed by changing './mvnw' to '../mvnw' to reference the script from the parent directory while maintaining the correct working directory for the assembly generation.

