### PR TITLE
test: Add validation and edge case tests for ObservabilityHelper and AiOperationMetadata

### DIFF
--- a/spring-ai-commons/src/test/java/org/springframework/ai/observation/AiOperationMetadataTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/observation/AiOperationMetadataTests.java
@@ -63,4 +63,18 @@ class AiOperationMetadataTests {
 			.hasMessageContaining("provider cannot be null or empty");
 	}
 
+	@Test
+	void whenOperationTypeIsBlankThenThrow() {
+		assertThatThrownBy(() -> AiOperationMetadata.builder().operationType("   ").provider("doofenshmirtz").build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("operationType cannot be null or empty");
+	}
+
+	@Test
+	void whenProviderIsBlankThenThrow() {
+		assertThatThrownBy(() -> AiOperationMetadata.builder().operationType("chat").provider("   ").build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("provider cannot be null or empty");
+	}
+
 }

--- a/spring-ai-commons/src/test/java/org/springframework/ai/observation/ObservabilityHelperTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/observation/ObservabilityHelperTests.java
@@ -52,4 +52,20 @@ class ObservabilityHelperTests {
 		assertThat(ObservabilityHelper.concatenateStrings(List.of("a", "b"))).isEqualTo("[\"a\", \"b\"]");
 	}
 
+	@Test
+	void shouldHandleSingleEntryMap() {
+		assertThat(ObservabilityHelper.concatenateEntries(Map.of("key", "value"))).isEqualTo("[\"key\":\"value\"]");
+	}
+
+	@Test
+	void shouldHandleSingleEntryList() {
+		assertThat(ObservabilityHelper.concatenateStrings(List.of("single"))).isEqualTo("[\"single\"]");
+	}
+
+	@Test
+	void shouldHandleEmptyStringsInList() {
+		assertThat(ObservabilityHelper.concatenateStrings(List.of("", "non-empty", "")))
+			.isEqualTo("[\"\", \"non-empty\", \"\"]");
+	}
+
 }


### PR DESCRIPTION
Adds comprehensive test coverage for validation and edge cases:
`ObservabilityHelper `tests:

- Single entry handling for maps and lists
- Empty string handling in lists

`AiOperationMetadata `tests:

- Blank/whitespace validation for required fields (operationType and provider)
- Ensures proper IllegalArgumentException with correct error messages

These tests improve robustness by covering previously untested edge cases and validation scenarios.