### PR TITLE
Issue 4082  Fix ResourceAccessException retry for network connectivity errors

### DIFF
--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
@@ -32,6 +32,7 @@ import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StreamUtils;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.ResponseErrorHandler;
 
 /**
@@ -80,6 +81,7 @@ public abstract class RetryUtils {
 	public static final RetryTemplate DEFAULT_RETRY_TEMPLATE = RetryTemplate.builder()
 		.maxAttempts(10)
 		.retryOn(TransientAiException.class)
+		.retryOn(ResourceAccessException.class)
 		.exponentialBackoff(Duration.ofMillis(2000), 5, Duration.ofMillis(3 * 60000))
 		.withListener(new RetryListener() {
 
@@ -98,6 +100,7 @@ public abstract class RetryUtils {
 	public static final RetryTemplate SHORT_RETRY_TEMPLATE = RetryTemplate.builder()
 		.maxAttempts(10)
 		.retryOn(TransientAiException.class)
+		.retryOn(ResourceAccessException.class)
 		.fixedBackoff(Duration.ofMillis(100))
 		.withListener(new RetryListener() {
 


### PR DESCRIPTION
#4082  
Network connectivity errors like "HTTP/1.1 header parser received no bytes" were not being retried across all Spring AI model providers. These
  ResourceAccessException errors occurred during poor network conditions but failed immediately instead of utilizing the existing retry mechanism.        

  Solution

  Added ResourceAccessException.class to both DEFAULT_RETRY_TEMPLATE and SHORT_RETRY_TEMPLATE in RetryUtils.java. This enables automatic retry of
  network-level connectivity issues with the same exponential backoff strategy used for other transient errors.

  Impact

  - ✅ Fixes network connectivity issues for all 19+ AI model providers (OpenAI, DeepSeek, Anthropic, etc.)
  - ✅ Maintains existing retry behavior for TransientAiException
  - ✅ Uses established retry configuration (10 attempts, exponential backoff)
  - ✅ No breaking changes - purely additive retry behavior
  
Manually verified with MockWebServer that ResourceAccessException is now properly retried and succeeds after network errors are resolved.

Signed-off-by: Mattia Pasetto [matpat17@gmail.com](mailto:matpat17@gmail.com)

I am still pretty new to contributions, please double check and let me know of any errors.