### PR TITLE
test: Add additional filter condition tests for `SimpleVectorStore`

### DIFF
--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreWithFilterTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreWithFilterTests.java
@@ -281,4 +281,69 @@ class SimpleVectorStoreWithFilterTests {
 		assertThat(results.get(0).getId()).isEqualTo("1");
 	}
 
+	@Test
+	void shouldFilterByNumericRange() {
+		List<Document> docs = Arrays.asList(
+				Document.builder().id("1").text("entity").metadata(Map.of("value", 1)).build(),
+				Document.builder().id("2").text("entity").metadata(Map.of("value", 2)).build(),
+				Document.builder().id("3").text("entity").metadata(Map.of("value", 3)).build()
+		);
+
+		vectorStore.add(docs);
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("entity").filterExpression("value >= 1 && value <= 1").build());
+
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo("1");
+	}
+
+	@Test
+	void shouldReturnEmptyResultsWhenNoDocumentsMatchFilter() {
+		Document doc = Document.builder()
+				.id("1")
+				.text("test")
+				.metadata(Map.of("type", "document"))
+				.build();
+
+		vectorStore.add(List.of(doc));
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("test").filterExpression("type == 'image'").build());
+
+		assertThat(results).isEmpty();
+	}
+
+	@Test
+	void shouldFilterByBooleanValue() {
+		List<Document> docs = Arrays.asList(
+				Document.builder().id("1").text("instance").metadata(Map.of("enabled", true)).build(),
+				Document.builder().id("2").text("instance").metadata(Map.of("enabled", false)).build()
+		);
+
+		vectorStore.add(docs);
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("instance").filterExpression("enabled == true").build());
+
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo("1");
+	}
+
+	@Test
+	void shouldFilterByNotEqual() {
+		List<Document> docs = Arrays.asList(
+				Document.builder().id("1").text("item").metadata(Map.of("classification", "typeA")).build(),
+				Document.builder().id("2").text("item").metadata(Map.of("classification", "typeB")).build()
+		);
+
+		vectorStore.add(docs);
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("item").filterExpression("classification != 'typeB'").build());
+
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo("1");
+	}
+
 }

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreWithFilterTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/SimpleVectorStoreWithFilterTests.java
@@ -286,8 +286,7 @@ class SimpleVectorStoreWithFilterTests {
 		List<Document> docs = Arrays.asList(
 				Document.builder().id("1").text("entity").metadata(Map.of("value", 1)).build(),
 				Document.builder().id("2").text("entity").metadata(Map.of("value", 2)).build(),
-				Document.builder().id("3").text("entity").metadata(Map.of("value", 3)).build()
-		);
+				Document.builder().id("3").text("entity").metadata(Map.of("value", 3)).build());
 
 		vectorStore.add(docs);
 
@@ -300,16 +299,12 @@ class SimpleVectorStoreWithFilterTests {
 
 	@Test
 	void shouldReturnEmptyResultsWhenNoDocumentsMatchFilter() {
-		Document doc = Document.builder()
-				.id("1")
-				.text("test")
-				.metadata(Map.of("type", "document"))
-				.build();
+		Document doc = Document.builder().id("1").text("test").metadata(Map.of("type", "document")).build();
 
 		vectorStore.add(List.of(doc));
 
-		List<Document> results = vectorStore.similaritySearch(
-				SearchRequest.builder().query("test").filterExpression("type == 'image'").build());
+		List<Document> results = vectorStore
+			.similaritySearch(SearchRequest.builder().query("test").filterExpression("type == 'image'").build());
 
 		assertThat(results).isEmpty();
 	}
@@ -318,13 +313,12 @@ class SimpleVectorStoreWithFilterTests {
 	void shouldFilterByBooleanValue() {
 		List<Document> docs = Arrays.asList(
 				Document.builder().id("1").text("instance").metadata(Map.of("enabled", true)).build(),
-				Document.builder().id("2").text("instance").metadata(Map.of("enabled", false)).build()
-		);
+				Document.builder().id("2").text("instance").metadata(Map.of("enabled", false)).build());
 
 		vectorStore.add(docs);
 
-		List<Document> results = vectorStore.similaritySearch(
-				SearchRequest.builder().query("instance").filterExpression("enabled == true").build());
+		List<Document> results = vectorStore
+			.similaritySearch(SearchRequest.builder().query("instance").filterExpression("enabled == true").build());
 
 		assertThat(results).hasSize(1);
 		assertThat(results.get(0).getId()).isEqualTo("1");
@@ -334,8 +328,7 @@ class SimpleVectorStoreWithFilterTests {
 	void shouldFilterByNotEqual() {
 		List<Document> docs = Arrays.asList(
 				Document.builder().id("1").text("item").metadata(Map.of("classification", "typeA")).build(),
-				Document.builder().id("2").text("item").metadata(Map.of("classification", "typeB")).build()
-		);
+				Document.builder().id("2").text("item").metadata(Map.of("classification", "typeB")).build());
 
 		vectorStore.add(docs);
 


### PR DESCRIPTION
Adds tests for additional filter scenarios:

- Numeric range filtering with exact bounds
- Empty results when no documents match filter criteria
- Boolean value equality filtering
- String inequality operations

Improves test coverage for edge cases and common filter patterns.