### PR TITLE
Remove debug System.out.println from QuestionAnswerAdvisorTests

### DIFF
--- a/advisors/spring-ai-advisors-vector-store/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/QuestionAnswerAdvisorTests.java
+++ b/advisors/spring-ai-advisors-vector-store/src/test/java/org/springframework/ai/chat/client/advisor/vectorstore/QuestionAnswerAdvisorTests.java
@@ -151,8 +151,6 @@ public class QuestionAnswerAdvisorTests {
 
 		Message systemMessage = this.promptCaptor.getValue().getInstructions().get(0);
 
-		System.out.println(systemMessage.getText());
-
 		assertThat(systemMessage.getText()).isEqualToIgnoringWhitespace("""
 				Default system text.
 				""");


### PR DESCRIPTION
Removes unnecessary System.out.println(systemMessage.getText()) from test method.

The debug output is redundant since the same value is validated by the assertion on the next line. This improves code quality and follows Spring project conventions of using proper logging instead of console output.

File changed:
- QuestionAnswerAdvisorTests.java (line 154)

Testing: Test continues to pass with no functional impact.

Auto-cherry-pick to 1.0.x
Fixes #4102