### PR TITLE
chore: remove unnecessary null checks

### DIFF
--- a/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
+++ b/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
@@ -128,7 +128,7 @@ public class StTemplateRenderer implements TemplateRenderer {
 	 */
 	private Set<String> validate(ST st, Map<String, Object> templateVariables) {
 		Set<String> templateTokens = getInputVariables(st);
-		Set<String> modelKeys = templateVariables != null ? templateVariables.keySet() : new HashSet<>();
+		Set<String> modelKeys = templateVariables.keySet();
 		Set<String> missingVariables = new HashSet<>(templateTokens);
 		missingVariables.removeAll(modelKeys);
 


### PR DESCRIPTION
This PR removes unnecessary null checks from the StTemplateRenderer class to simplify the code and avoid redundant validation.

### Changes
- Removed redundant null checks on template variables map keys in the apply method.
- Simplified validation logic by eliminating defensive checks that are unlikely to occur.
