### PR TITLE
Fix NPE when metadata is null in MilvusVectorStore

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -379,8 +379,10 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 				JsonObject metadata = new JsonObject();
 				try {
 					metadata = (JsonObject) rowRecord.get(this.metadataFieldName);
-					// inject the distance into the metadata.
-					metadata.addProperty(DocumentMetadata.DISTANCE.value(), 1 - getResultSimilarity(rowRecord));
+					if (metadata != null) {
+						// inject the distance into the metadata.
+						metadata.addProperty(DocumentMetadata.DISTANCE.value(), 1 - getResultSimilarity(rowRecord));
+					}
 				}
 				catch (ParamException e) {
 					// skip the ParamException if metadata doesn't exist for the custom


### PR DESCRIPTION
### Title
Guard against NPE when metadata is null during distance injection

### Description
Adds a null check before injecting the distance property into metadata to prevent a NullPointerException if metadata is missing from the row record. The change is intentionally minimal and does not alter existing behavior beyond avoiding the crash.

### Motivation / Background
Some search results do not carry metadata (or the metadata value is null). Calling JsonObject.addProperty(...) on a null reference throws an NPE and breaks the mapping pipeline.

### Changes
Add a null guard around the distance injection step to ensure we do not call addProperty(...) on a null metadata.

### Behavior
No functional changes other than preventing the NPE when metadata is null.

### Related issues
Fixes #4115 