### PR TITLE
Fix OpenAI streaming finish_reason handling for empty string values

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -218,7 +218,7 @@ public class OpenAiChatModel implements ChatModel {
 							"id", chatCompletion.id() != null ? chatCompletion.id() : "",
 							"role", choice.message().role() != null ? choice.message().role().name() : "",
 							"index", choice.index() != null ? choice.index() : 0,
-							"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "",
+							"finishReason", getFinishReasonJson(choice.finishReason()),
 							"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
 							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(Map.of()));
 					return buildGeneration(choice, metadata, request);
@@ -317,7 +317,7 @@ public class OpenAiChatModel implements ChatModel {
 									"id", id,
 									"role", roleMap.getOrDefault(id, ""),
 									"index", choice.index() != null ? choice.index() : 0,
-									"finishReason", choice.finishReason() != null ? choice.finishReason().name() : "",
+									"finishReason", getFinishReasonJson(choice.finishReason()),
 									"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
 									"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of());
 							return buildGeneration(choice, metadata, request);
@@ -420,8 +420,8 @@ public class OpenAiChatModel implements ChatModel {
 							toolCall.function().name(), toolCall.function().arguments()))
 					.toList();
 
-		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
-		var generationMetadataBuilder = ChatGenerationMetadata.builder().finishReason(finishReason);
+		var generationMetadataBuilder = ChatGenerationMetadata.builder()
+			.finishReason(getFinishReasonJson(choice.finishReason()));
 
 		List<Media> media = new ArrayList<>();
 		String textContent = choice.message().content();
@@ -449,6 +449,14 @@ public class OpenAiChatModel implements ChatModel {
 
 		var assistantMessage = new AssistantMessage(textContent, metadata, toolCalls, media);
 		return new Generation(assistantMessage, generationMetadataBuilder.build());
+	}
+
+	private String getFinishReasonJson(OpenAiApi.ChatCompletionFinishReason finishReason) {
+		if (finishReason == null) {
+			return "";
+		}
+		// Return enum name for backward compatibility
+		return finishReason.name();
 	}
 
 	private ChatResponseMetadata from(OpenAiApi.ChatCompletion result, RateLimit rateLimit, Usage usage) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiStreamingFinishReasonTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiStreamingFinishReasonTests.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.chat;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionFinishReason;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.retry.support.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Tests for OpenAI streaming responses with various finish_reason scenarios, particularly
+ * focusing on edge cases like empty string finish_reason values.
+ *
+ * @author Mark Pollack
+ * @author Christian Tzolov
+ */
+@ExtendWith(MockitoExtension.class)
+public class OpenAiStreamingFinishReasonTests {
+
+	@Mock
+	private OpenAiApi openAiApi;
+
+	private OpenAiChatModel chatModel;
+
+	@Test
+	void testStreamingWithNullFinishReason() {
+		// Setup
+		setupChatModel();
+
+		var choice = new ChunkChoice(null, 0, new ChatCompletionMessage("Hello", Role.ASSISTANT), null);
+		ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null, null,
+				"chat.completion.chunk", null);
+
+		given(this.openAiApi.chatCompletionStream(isA(ChatCompletionRequest.class), any()))
+			.willReturn(Flux.just(chunk));
+
+		// Execute
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("test"));
+
+		// Verify
+		List<ChatResponse> responses = result.collectList().block();
+		assertThat(responses).hasSize(1);
+		ChatResponse response = responses.get(0);
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).isEqualTo("Hello");
+		assertThat(response.getResult().getMetadata().getFinishReason()).isEqualTo("");
+	}
+
+	@Test
+	void testStreamingWithValidFinishReason() {
+		// Setup
+		setupChatModel();
+
+		var choice = new ChunkChoice(ChatCompletionFinishReason.STOP, 0,
+				new ChatCompletionMessage("Complete response", Role.ASSISTANT), null);
+		ChatCompletionChunk chunk = new ChatCompletionChunk("id", List.of(choice), 666L, "model", null, null,
+				"chat.completion.chunk", null);
+
+		given(this.openAiApi.chatCompletionStream(isA(ChatCompletionRequest.class), any()))
+			.willReturn(Flux.just(chunk));
+
+		// Execute
+		Flux<ChatResponse> result = this.chatModel.stream(new Prompt("test"));
+
+		// Verify
+		List<ChatResponse> responses = result.collectList().block();
+		assertThat(responses).hasSize(1);
+		ChatResponse response = responses.get(0);
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).isEqualTo("Complete response");
+		assertThat(response.getResult().getMetadata().getFinishReason()).isEqualTo("STOP");
+	}
+
+	@Test
+	void testJsonDeserializationWithEmptyStringFinishReason() throws JsonProcessingException {
+		// Test the specific JSON from the issue report
+		String problematicJson = """
+				{
+					"id": "chatcmpl-msg_bdrk_012bpm3yfa9inEuftTWYQ46F",
+					"object": "chat.completion.chunk",
+					"created": 1726239401,
+					"model": "claude-3-5-sonnet-20240620",
+					"choices": [{
+						"index": 0,
+						"delta": {
+							"role": "assistant",
+							"content": ""
+						},
+						"finish_reason": ""
+					}]
+				}
+				""";
+
+		// This should either work correctly or throw a clear exception
+		ChatCompletionChunk chunk = ModelOptionsUtils.jsonToObject(problematicJson, ChatCompletionChunk.class);
+
+		// If deserialization succeeds, verify the structure
+		assertThat(chunk).isNotNull();
+		assertThat(chunk.choices()).hasSize(1);
+
+		var choice = chunk.choices().get(0);
+		assertThat(choice.index()).isEqualTo(0);
+		assertThat(choice.delta().content()).isEmpty();
+
+		// The key test: what happens with empty string finish_reason?
+		// This might be null if Jackson handles empty string -> enum conversion
+		// gracefully
+		assertThat(choice.finishReason()).isNull();
+	}
+
+	@Test
+	void testJsonDeserializationWithNullFinishReason() throws JsonProcessingException {
+		// Test with null finish_reason (should work fine)
+		String validJson = """
+				{
+					"id": "chatcmpl-test",
+					"object": "chat.completion.chunk",
+					"created": 1726239401,
+					"model": "gpt-4",
+					"choices": [{
+						"index": 0,
+						"delta": {
+							"role": "assistant",
+							"content": "Hello"
+						},
+						"finish_reason": null
+					}]
+				}
+				""";
+
+		ChatCompletionChunk chunk = ModelOptionsUtils.jsonToObject(validJson, ChatCompletionChunk.class);
+
+		assertThat(chunk).isNotNull();
+		assertThat(chunk.choices()).hasSize(1);
+
+		var choice = chunk.choices().get(0);
+		assertThat(choice.finishReason()).isNull();
+		assertThat(choice.delta().content()).isEqualTo("Hello");
+	}
+
+	@Test
+	void testStreamingWithEmptyStringFinishReasonUsingMockWebServer() {
+		// Setup
+		setupChatModel();
+
+		// Simulate the problematic response by creating a chunk that would result from
+		// deserializing JSON with empty string finish_reason
+		try {
+			// Try to create a chunk with what would happen if empty string was
+			// deserialized
+			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage("", Role.ASSISTANT), null);
+			ChatCompletionChunk chunk = new ChatCompletionChunk("chatcmpl-msg_bdrk_012bpm3yfa9inEuftTWYQ46F",
+					List.of(choice), 1726239401L, "claude-3-5-sonnet-20240620", null, null, "chat.completion.chunk",
+					null);
+
+			given(this.openAiApi.chatCompletionStream(isA(ChatCompletionRequest.class), any()))
+				.willReturn(Flux.just(chunk));
+
+			// Execute
+			Flux<ChatResponse> result = this.chatModel.stream(new Prompt("test"));
+
+			// Verify that the streaming works even with null finish_reason
+			List<ChatResponse> responses = result.collectList().block();
+			assertThat(responses).hasSize(1);
+			ChatResponse response = responses.get(0);
+			assertThat(response).isNotNull();
+			assertThat(response.getResult().getMetadata().getFinishReason()).isEqualTo("");
+
+		}
+		catch (Exception e) {
+			// If this fails, it indicates the issue exists in our processing
+			System.out.println("Streaming failed with empty finish_reason: " + e.getMessage());
+			throw e;
+		}
+	}
+
+	@Test
+	void testModelOptionsUtilsJsonToObjectWithEmptyFinishReason() {
+		// Test the specific method mentioned in the issue
+		String jsonWithEmptyFinishReason = """
+				{
+					"id": "chatcmpl-msg_bdrk_012bpm3yfa9inEuftTWYQ46F",
+					"object": "chat.completion.chunk",
+					"created": 1726239401,
+					"model": "claude-3-5-sonnet-20240620",
+					"choices": [{
+						"index": 0,
+						"delta": {
+							"role": "assistant",
+							"content": ""
+						},
+						"finish_reason": ""
+					}]
+				}
+				""";
+
+		ChatCompletionChunk chunk = ModelOptionsUtils.jsonToObject(jsonWithEmptyFinishReason,
+				ChatCompletionChunk.class);
+
+		assertThat(chunk).isNotNull();
+		assertThat(chunk.choices()).hasSize(1);
+
+		var choice = chunk.choices().get(0);
+		// The critical test: how does ModelOptionsUtils handle empty string -> enum?
+		assertThat(choice.finishReason()).isNull();
+	}
+
+	private void setupChatModel() {
+		RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		this.chatModel = new OpenAiChatModel(this.openAiApi, OpenAiChatOptions.builder().build(), toolCallingManager,
+				retryTemplate, observationRegistry);
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
@@ -35,6 +35,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -71,6 +73,13 @@ public abstract class ModelOptionsUtils {
 		.addModules(JacksonUtils.instantiateAvailableModules())
 		.build()
 		.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+
+	static {
+		// Configure coercion for empty strings to null for Enum types
+		// This fixes the issue where empty string finish_reason values cause
+		// deserialization failures
+		OBJECT_MAPPER.coercionConfigFor(Enum.class).setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+	}
 
 	private static final List<String> BEAN_MERGE_FIELD_EXCISIONS = List.of("class");
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/ModelOptionsUtilsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/ModelOptionsUtilsTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.model;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -176,6 +177,114 @@ public class ModelOptionsUtilsTests {
 		}
 		assertThat(ModelOptionsUtils.getJsonPropertyValues(TestRecord.class)).hasSize(2);
 		assertThat(ModelOptionsUtils.getJsonPropertyValues(TestRecord.class)).containsExactly("field1", "field2");
+	}
+
+	@Test
+	public void enumCoercion_emptyStringAsNull() throws JsonProcessingException {
+		// Test direct enum deserialization with empty string
+		ColorEnum colorEnum = ModelOptionsUtils.OBJECT_MAPPER.readValue("\"\"", ColorEnum.class);
+		assertThat(colorEnum).isNull();
+
+		// Test direct enum deserialization with valid value
+		colorEnum = ModelOptionsUtils.OBJECT_MAPPER.readValue("\"RED\"", ColorEnum.class);
+		assertThat(colorEnum).isEqualTo(ColorEnum.RED);
+
+		// Test direct enum deserialization with invalid value should throw exception
+		final String jsonInvalid = "\"Invalid\"";
+		assertThatThrownBy(() -> ModelOptionsUtils.OBJECT_MAPPER.readValue(jsonInvalid, ColorEnum.class))
+			.isInstanceOf(JsonProcessingException.class);
+	}
+
+	@Test
+	public void enumCoercion_objectMapperConfiguration() throws JsonProcessingException {
+		// Test that ModelOptionsUtils.OBJECT_MAPPER has the correct coercion
+		// configuration
+		// This validates that our static configuration block is working
+
+		// Empty string should coerce to null for enums
+		ColorEnum colorEnum = ModelOptionsUtils.OBJECT_MAPPER.readValue("\"\"", ColorEnum.class);
+		assertThat(colorEnum).isNull();
+
+		// Null should remain null
+		colorEnum = ModelOptionsUtils.OBJECT_MAPPER.readValue("null", ColorEnum.class);
+		assertThat(colorEnum).isNull();
+
+		// Valid enum values should deserialize correctly
+		colorEnum = ModelOptionsUtils.OBJECT_MAPPER.readValue("\"BLUE\"", ColorEnum.class);
+		assertThat(colorEnum).isEqualTo(ColorEnum.BLUE);
+	}
+
+	@Test
+	public void enumCoercion_apiResponseWithFinishReason() throws JsonProcessingException {
+		// Test case 1: Empty string finish_reason should deserialize to null
+		String jsonWithEmptyFinishReason = """
+				{
+					"id": "test-123",
+					"finish_reason": ""
+				}
+				""";
+
+		TestApiResponse response = ModelOptionsUtils.OBJECT_MAPPER.readValue(jsonWithEmptyFinishReason,
+				TestApiResponse.class);
+		assertThat(response.id()).isEqualTo("test-123");
+		assertThat(response.finishReason()).isNull();
+
+		// Test case 2: Valid finish_reason should deserialize correctly (using JSON
+		// property value)
+		String jsonWithValidFinishReason = """
+				{
+					"id": "test-456",
+					"finish_reason": "stop"
+				}
+				""";
+
+		response = ModelOptionsUtils.OBJECT_MAPPER.readValue(jsonWithValidFinishReason, TestApiResponse.class);
+		assertThat(response.id()).isEqualTo("test-456");
+		assertThat(response.finishReason()).isEqualTo(TestFinishReason.STOP);
+
+		// Test case 3: Null finish_reason should remain null
+		String jsonWithNullFinishReason = """
+				{
+					"id": "test-789",
+					"finish_reason": null
+				}
+				""";
+
+		response = ModelOptionsUtils.OBJECT_MAPPER.readValue(jsonWithNullFinishReason, TestApiResponse.class);
+		assertThat(response.id()).isEqualTo("test-789");
+		assertThat(response.finishReason()).isNull();
+
+		// Test case 4: Invalid finish_reason should throw exception
+		String jsonWithInvalidFinishReason = """
+				{
+					"id": "test-error",
+					"finish_reason": "INVALID_VALUE"
+				}
+				""";
+
+		assertThatThrownBy(
+				() -> ModelOptionsUtils.OBJECT_MAPPER.readValue(jsonWithInvalidFinishReason, TestApiResponse.class))
+			.isInstanceOf(JsonProcessingException.class)
+			.hasMessageContaining("INVALID_VALUE");
+	}
+
+	public enum ColorEnum {
+
+		RED, GREEN, BLUE
+
+	}
+
+	public enum TestFinishReason {
+
+		@JsonProperty("stop")
+		STOP, @JsonProperty("length")
+		LENGTH, @JsonProperty("content_filter")
+		CONTENT_FILTER
+
+	}
+
+	public record TestApiResponse(@JsonProperty("id") String id,
+			@JsonProperty("finish_reason") TestFinishReason finishReason) {
 	}
 
 	public static class Person {


### PR DESCRIPTION
This commit addresses issues with OpenAI streaming responses where finish_reason is an empty string ("") instead of null, which caused Jackson deserialization failures and inconsistent metadata formatting.

Changes:
- Configure Jackson coercion in ModelOptionsUtils to handle empty string to enum conversion (empty string -> null)
- Fix getFinishReasonJson() method in OpenAiChatModel to return uppercase enum names for backward compatibility
- Fix null pointer exceptions in streaming processing by ensuring getFinishReasonJson() returns empty string instead of null
- Maintain finish_reason metadata as uppercase enum names ("STOP", "LENGTH") to preserve backward compatibility
- Add comprehensive test suite covering all edge cases
- Update streaming tests to expect correct uppercase finish reason values

Key fixes:
1. Empty string finish_reason now deserializes correctly without errors
2. Finish reason metadata maintains backward compatibility (uppercase enum names)
3. No more NullPointerException in streaming Map.of() calls
4. Proper handling of null, empty string, and valid finish_reason values

Jackson coercion configuration in ModelOptionsUtils now converts empty strings to null for ALL enum deserialization across Spring AI. Analysis shows this change is safe and beneficial for other providers:
- Anthropic, Ollama use String fields (unaffected by enum coercion)
- ZhiPuAI, MiniMax, MistralAI, DeepSeek use enum fields but have no documented empty string issues
- Coercion improves robustness by gracefully handling malformed responses
- No breaking changes expected for existing provider implementations

Testing:
- Added OpenAiStreamingFinishReasonTests with 6 comprehensive test cases
- Fixed existing metadata tests to maintain backward compatibility
- All tests pass, covering JSON deserialization and streaming scenarios
- Validates both error handling and correct behavior
- Added tests for changes to ModelOptionsUtils using enum coersion

This ensures robust handling of OpenAI's empty string finish_reason edge case while maintaining backward compatibility and improving overall system resilience for malformed API responses.

Auto-cherry-pick to 1.0.x
Fixes #1358

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc