### PR TITLE
chore(google genai): return the actual model version used for chat

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -417,7 +417,8 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 				Usage currentUsage = (usage.isPresent()) ? new DefaultUsage(usage.get().promptTokenCount().orElse(0),
 						usage.get().candidatesTokenCount().orElse(0)) : new EmptyUsage();
 				Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
-				ChatResponse chatResponse = new ChatResponse(generations, toChatResponseMetadata(cumulativeUsage));
+				ChatResponse chatResponse = new ChatResponse(generations,
+						toChatResponseMetadata(cumulativeUsage, generateContentResponse.modelVersion().get()));
 
 				observationContext.setResponse(chatResponse);
 				return chatResponse;
@@ -531,7 +532,8 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 					var usage = response.usageMetadata();
 					Usage currentUsage = usage.isPresent() ? getDefaultUsage(usage.get()) : new EmptyUsage();
 					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
-					ChatResponse chatResponse = new ChatResponse(generations, toChatResponseMetadata(cumulativeUsage));
+					ChatResponse chatResponse = new ChatResponse(generations,
+							toChatResponseMetadata(cumulativeUsage, response.modelVersion().get()));
 					return Flux.just(chatResponse);
 				});
 
@@ -626,8 +628,8 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		}
 	}
 
-	private ChatResponseMetadata toChatResponseMetadata(Usage usage) {
-		return ChatResponseMetadata.builder().usage(usage).build();
+	private ChatResponseMetadata toChatResponseMetadata(Usage usage, String modelVersion) {
+		return ChatResponseMetadata.builder().usage(usage).model(modelVersion).build();
 	}
 
 	private DefaultUsage getDefaultUsage(com.google.genai.types.GenerateContentResponseUsageMetadata usageMetadata) {


### PR DESCRIPTION
This will return the actual modelVersion used on a chat response, e.g. request goes to gemini-2.0-pro, response returns gemini-2.0-pro-002.