### PR TITLE
test: Enhance test coverage for `SyncMcpToolCallback` edge cases

### DIFF
--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -130,4 +130,52 @@ class SyncMcpToolCallbackTests {
 			.hasMessage("Testing tool error");
 	}
 
+	@Test
+	void callShouldHandleEmptyResponse() {
+		when(this.tool.name()).thenReturn("testTool");
+		CallToolResult callResult = mock(CallToolResult.class);
+		when(callResult.isError()).thenReturn(false);
+		when(callResult.content()).thenReturn(List.of());
+		when(this.mcpClient.callTool(any(CallToolRequest.class))).thenReturn(callResult);
+
+		SyncMcpToolCallback callback = new SyncMcpToolCallback(this.mcpClient, this.tool);
+
+		String response = callback.call("{\"param\":\"value\"}");
+
+		assertThat(response).isEqualTo("[]");
+	}
+
+	@Test
+	void callShouldHandleMultipleContentItems() {
+		when(this.tool.name()).thenReturn("testTool");
+		CallToolResult callResult = mock(CallToolResult.class);
+		when(callResult.isError()).thenReturn(false);
+		when(callResult.content()).thenReturn(
+				List.of(new McpSchema.TextContent("First content"), new McpSchema.TextContent("Second content")));
+		when(this.mcpClient.callTool(any(CallToolRequest.class))).thenReturn(callResult);
+
+		SyncMcpToolCallback callback = new SyncMcpToolCallback(this.mcpClient, this.tool);
+
+		String response = callback.call("{\"param\":\"value\"}");
+
+		assertThat(response).isNotNull();
+		assertThat(response).isEqualTo("[{\"text\":\"First content\"},{\"text\":\"Second content\"}]");
+	}
+
+	@Test
+	void callShouldHandleNonTextContent() {
+		when(this.tool.name()).thenReturn("testTool");
+		CallToolResult callResult = mock(CallToolResult.class);
+		when(callResult.isError()).thenReturn(false);
+		when(callResult.content()).thenReturn(List.of(new McpSchema.ImageContent(null, "base64data", "image/png")));
+		when(this.mcpClient.callTool(any(CallToolRequest.class))).thenReturn(callResult);
+
+		SyncMcpToolCallback callback = new SyncMcpToolCallback(this.mcpClient, this.tool);
+
+		String response = callback.call("{\"param\":\"value\"}");
+
+		assertThat(response).isNotNull();
+		assertThat(response).isEqualTo("[{\"data\":\"base64data\",\"mimeType\":\"image/png\"}]");
+	}
+
 }


### PR DESCRIPTION
Add additional test coverage for edge cases in `SyncMcpToolCallback`.

## Changes
- **Empty Response Handling**: Test that empty content lists return `"[]"` JSON array
- **Multiple Content Items**: Verify multiple `TextContent` items are properly serialized as JSON objects with `text` fields
- **Non-Text Content Support**: Ensure `ImageContent` is correctly serialized with `data` and `mimeType` fields

## Coverage Improvements  
- **API Contract Documentation**: Tests document exact JSON serialization format
- **Regression Prevention**: Will catch changes to response format in future
- **Edge Case Coverage**: Handles scenarios where tools return various content types
