### PR TITLE
Fix reordering issue in AzureOpenAiChatModel (Fixes #4155)

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -351,7 +351,7 @@ public class AzureOpenAiChatModel implements ChatModel {
 							MergeUtils::mergeChatCompletions);
 					return List.of(reduce);
 				})
-				.flatMap(mono -> mono);
+				.flatMapSequential(mono -> mono);
 
 			final Flux<ChatResponse> chatResponseFlux = accessibleChatCompletionsFlux.map(chatCompletion -> {
 				if (previousChatResponse == null) {
@@ -377,7 +377,7 @@ public class AzureOpenAiChatModel implements ChatModel {
 				return chatResponse1;
 			});
 
-			return chatResponseFlux.flatMap(chatResponse -> {
+			return chatResponseFlux.flatMapSequential(chatResponse -> {
 				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), chatResponse)) {
 					// FIXME: bounded elastic needs to be used since tool calling
 					// is currently only synchronous


### PR DESCRIPTION
Reordering might occur due to `Flux::flatMap` not having ordering guarantees, `flatMapSequential` fixes this.
See #4155 

I did not update any tests because the reproduction relies on a race condition and it was pretty hard for me to reproduce it locally.

<details>
<summary>Default PR description</summary>

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc
<details>