### PR TITLE
test: Enhance test coverage for `MistralAiBindingsPropertiesProcessor`

### DIFF
--- a/spring-ai-spring-cloud-bindings/src/test/java/org/springframework/ai/bindings/MistralAiBindingsPropertiesProcessorTests.java
+++ b/spring-ai-spring-cloud-bindings/src/test/java/org/springframework/ai/bindings/MistralAiBindingsPropertiesProcessorTests.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.bindings.Bindings;
 import org.springframework.mock.env.MockEnvironment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for {@link MistralAiBindingsPropertiesProcessor}.
@@ -62,6 +63,60 @@ class MistralAiBindingsPropertiesProcessorTests {
 				"false");
 
 		new MistralAiBindingsPropertiesProcessor().process(this.environment, this.bindings, this.properties);
+		assertThat(this.properties).isEmpty();
+	}
+
+	@Test
+	void nullBindingsShouldThrowException() {
+		assertThatThrownBy(
+				() -> new MistralAiBindingsPropertiesProcessor().process(this.environment, null, this.properties))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	void nullEnvironmentShouldThrowException() {
+		assertThatThrownBy(
+				() -> new MistralAiBindingsPropertiesProcessor().process(null, this.bindings, this.properties))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	void nullPropertiesShouldThrowException() {
+		assertThatThrownBy(
+				() -> new MistralAiBindingsPropertiesProcessor().process(this.environment, this.bindings, null))
+			.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	void missingApiKeyShouldStillSetNullValue() {
+		Bindings bindingsWithoutApiKey = new Bindings(new Binding("test-name", Paths.get("test-path"), Map
+			.of(Binding.TYPE, MistralAiBindingsPropertiesProcessor.TYPE, "uri", "https://my.mistralai.example.net")));
+
+		new MistralAiBindingsPropertiesProcessor().process(this.environment, bindingsWithoutApiKey, this.properties);
+
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.base-url", "https://my.mistralai.example.net");
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.api-key", null);
+	}
+
+	@Test
+	void emptyApiKeyIsStillSet() {
+		Bindings bindingsWithEmptyApiKey = new Bindings(new Binding("test-name", Paths.get("test-path"),
+				Map.of(Binding.TYPE, MistralAiBindingsPropertiesProcessor.TYPE, "api-key", "", "uri",
+						"https://my.mistralai.example.net")));
+
+		new MistralAiBindingsPropertiesProcessor().process(this.environment, bindingsWithEmptyApiKey, this.properties);
+
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.api-key", "");
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.base-url", "https://my.mistralai.example.net");
+	}
+
+	@Test
+	void wrongBindingTypeShouldBeIgnored() {
+		Bindings wrongTypeBindings = new Bindings(new Binding("test-name", Paths.get("test-path"),
+				Map.of(Binding.TYPE, "different-type", "api-key", "demo", "uri", "https://my.mistralai.example.net")));
+
+		new MistralAiBindingsPropertiesProcessor().process(this.environment, wrongTypeBindings, this.properties);
+
 		assertThat(this.properties).isEmpty();
 	}
 


### PR DESCRIPTION
This PR improves test coverage for `MistralAiBindingsPropertiesProcessor` to ensure handling of edge cases and invalid inputs.

### Tests Added

**Null Parameter Validation:**
- `nullBindingsShouldThrowException()` - Verifies NPE when bindings parameter is null
- `nullEnvironmentShouldThrowException()` - Verifies NPE when environment parameter is null  
- `nullPropertiesShouldThrowException()` - Verifies NPE when properties parameter is null

**Edge Case Handling:**
- `missingApiKeyShouldStillSetNullValue()` - Confirms behavior when api-key is absent from binding
- `emptyApiKeyIsStillSet()` - Verifies empty string api-key values are preserved
- `wrongBindingTypeShouldBeIgnored()` - Ensures processor ignores non-MistralAI binding types

### Improvements

These tests cover critical failure scenarios that could occur in production environments:
- **Input validation** prevents unexpected NPEs during configuration processing
- **Missing configuration handling** tests real-world scenarios where bindings may be incomplete
- **Type filtering** ensures the processor doesn't interfere with other binding processors

The tests verify actual implementation behavior rather than imposing new validation requirements, ensuring compatibility with existing functionality while documenting expected edge case behavior.