### PR TITLE
Fix "no private access for invokespecial"

### DIFF
--- a/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/mongo/MongoDbAtlasLocalContainerConnectionDetailsFactory.java
+++ b/spring-ai-spring-boot-testcontainers/src/main/java/org/springframework/ai/testcontainers/service/connection/mongo/MongoDbAtlasLocalContainerConnectionDetailsFactory.java
@@ -83,8 +83,8 @@ class MongoDbAtlasLocalContainerConnectionDetailsFactory
 		public SslBundle getSslBundle() {
 			if (GET_SSL_BUNDLE_METHOD != null) { // Boot 3.5.x+
 				try {
-					return (SslBundle) MethodHandles.lookup()
-						.in(GET_SSL_BUNDLE_METHOD.getDeclaringClass())
+					MethodHandles.Lookup origin = MethodHandles.lookup().in(getClass());
+					return (SslBundle) MethodHandles.privateLookupIn(GET_SSL_BUNDLE_METHOD.getDeclaringClass(), origin)
 						.unreflectSpecial(GET_SSL_BUNDLE_METHOD, GET_SSL_BUNDLE_METHOD.getDeclaringClass())
 						.bindTo(this)
 						.invokeWithArguments();


### PR DESCRIPTION
```
Caused by: java.lang.IllegalAccessException: no private access for invokespecial: interface org.springframework.boot.autoconfigure.mongo.MongoConnectionDetails, from interface org.springframework.boot.autoconfigure.mongo.MongoConnectionDetails (unnamed module @fcd6521)
        at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:889)
        at java.base/java.lang.invoke.MethodHandles$Lookup.checkSpecialCaller(MethodHandles.java:3801)
        at java.base/java.lang.invoke.MethodHandles$Lookup.unreflectSpecial(MethodHandles.java:3315)
        at org.springframework.ai.testcontainers.service.connection.mongo.MongoDbAtlasLocalContainerConnectionDetailsFactory$MongoDbAtlasLocalContainerConnectionDetails.getSslBundle(MongoDbAtlasLocalContainerConnectionDetailsFactory.java:88)
```

Introduced by GH-4149
