### PR TITLE
GH-4170 | Fix message order in MessageChatMemoryAdvisor and add test

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisorTests.java
@@ -17,12 +17,17 @@
 package org.springframework.ai.chat.client.advisor;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.chat.prompt.Prompt;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -108,4 +113,49 @@ public class MessageChatMemoryAdvisorTests {
 		assertThat(advisor.getOrder()).isEqualTo(Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER);
 	}
 
+	@Test
+	void testMessageOrder() {
+		// Arrange: Set up the test conditions.
+		String conversationId = "test-conversation-123";
+
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+				.chatMemoryRepository(new InMemoryChatMemoryRepository())
+				.build();
+
+		// Set up the past conversation history in memory.
+		chatMemory.add(conversationId, new UserMessage("This is user message history"));
+		chatMemory.add(conversationId, new AssistantMessage("This is assistant message history"));
+
+		MessageChatMemoryAdvisor advisor = MessageChatMemoryAdvisor.builder(chatMemory)
+				.conversationId(conversationId)
+				.build();
+
+		// Create the new user request, which includes a System message.
+		ChatClientRequest testRequest = ChatClientRequest.builder()
+				.prompt(new Prompt(List.of(
+						new SystemMessage("This is system message"),
+						new UserMessage("This is user message"))))
+				.build();
+
+		// Act
+		ChatClientRequest advisedRequest = advisor.before(testRequest, null);
+
+		// Assert
+		assertThat(advisedRequest).isNotNull();
+		List<Message> messages = advisedRequest.prompt().getInstructions();
+
+		assertThat(messages).hasSize(4);
+
+		assertThat(messages.get(0).getMessageType()).isEqualTo(MessageType.SYSTEM);
+		assertThat(messages.get(0).getText()).isEqualTo("This is system message");
+
+		assertThat(messages.get(1).getMessageType()).isEqualTo(MessageType.USER);
+		assertThat(messages.get(1).getText()).isEqualTo("This is user message history");
+
+		assertThat(messages.get(2).getMessageType()).isEqualTo(MessageType.ASSISTANT);
+		assertThat(messages.get(2).getText()).isEqualTo("This is assistant message history");
+
+		assertThat(messages.get(3).getMessageType()).isEqualTo(MessageType.USER);
+		assertThat(messages.get(3).getText()).isEqualTo("This is user message");
+	}
 }


### PR DESCRIPTION
# Description:
This pull request resolves issue #4170, where a `SystemMessage` was not guaranteed to be the first message in the list sent to the AI model. Certain models require the system prompt to be the initial message and would fail if the order is incorrect.
This change introduces a sorting step to guarantee that System messages always appear first, while preserving the relative order of User and Assistant messages.

# Details of Change:
- Added a comparator to processedMessages.sort(...)
- Messages of type SYSTEM are assigned a lower sort key (0) than other message types (1).

# Impact:
- Behavior is unchanged for message order among User and Assistant.
- Multiple System messages will all be grouped at the beginning, in the order they were added.