### PR TITLE
Bump io.swagger.core.v3:swagger-annotations from 2.2.25 to 2.2.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
 		<com.google.genai.version>1.10.0</com.google.genai.version>
 		<ibm.sdk.version>9.20.0</ibm.sdk.version>
 		<jsonschema.version>4.37.0</jsonschema.version>
-		<swagger-annotations.version>2.2.25</swagger-annotations.version>
+		<swagger-annotations.version>2.2.30</swagger-annotations.version>
 		<mockk-jvm.version>1.13.13</mockk-jvm.version>
 		<spring-cloud-bindings.version>2.0.3</spring-cloud-bindings.version>
 


### PR DESCRIPTION
Update io.swagger.core.v3:swagger-annotations to 2.2.30

Fixes https://github.com/spring-projects/spring-ai/issues/4185 where a method used is only available in a newer version.