### PR TITLE
fix McpToolUtils.prefixedToolName formatted in order to support Chinese characters in toolName

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -79,9 +79,9 @@ public final class McpToolUtils {
 
 		String input = prefix + "_" + toolName;
 
-		// Replace any character that isn't alphanumeric, underscore, or hyphen with
-		// concatenation
-		String formatted = input.replaceAll("[^a-zA-Z0-9_-]", "");
+        // Replace any character that isn't alphanumeric, underscore, hyphen, or Chinese 
+		// characters with empty string
+        String formatted = input.replaceAll("[^a-zA-Z0-9_\u4e00-\u9fa5]", "");
 
 		formatted = formatted.replaceAll("-", "_");
 


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc