### PR TITLE
Update SyncMcpToolCallback.java

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
@@ -100,6 +100,10 @@ public class SyncMcpToolCallback implements ToolCallback {
 			.build();
 	}
 
+	public String getOriginalToolName() {
+    	return this.tool.name();
+	}
+
 	/**
 	 * Executes the tool with the provided input.
 	 * <p>

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
@@ -100,9 +100,13 @@ public class SyncMcpToolCallback implements ToolCallback {
 			.build();
 	}
 
-	public String getOriginalToolName() {
-    	return this.tool.name();
-	}
+    /**
+     * get tool name
+     * @return the tool's name
+     */
+    public String getOriginalToolName() {
+        return this.tool.name();
+    }
 
 	/**
 	 * Executes the tool with the provided input.


### PR DESCRIPTION
Add getOriginalToolName method for AsyncMcpToolCallback in order to get easy access to the 'original' toolname before the prefix was added
