### PR TITLE
feat: Add annotation-based configuration support for MCP clients and servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ CLAUDE.md
 qodana.yaml
 __pycache__/
 *.pyc
+
+/contributing

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/pom.xml
@@ -35,11 +35,12 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- <dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
-			<artifactId>mcp-spring-webflux</artifactId>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-mcp-annotations</artifactId>
+			<version>${project.parent.version}</version>
 			<optional>true</optional>
-		</dependency> -->
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
@@ -24,6 +24,22 @@ import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 
+import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.AsyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpAsyncAnnotationCustomizer;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpSyncAnnotationCustomizer;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpAsyncClientConfigurer;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpSyncClientConfigurer;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
@@ -208,6 +224,20 @@ public class McpClientAutoConfiguration {
 		return new McpSyncClientConfigurer(customizerProvider.orderedStream().toList());
 	}
 
+	@Bean
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
+			matchIfMissing = true)
+	public McpSyncClientCustomizer mcpAnnotationMcpSyncClientCustomizer(List<SyncLoggingSpecification> loggingSpecs,
+			List<SyncSamplingSpecification> samplingSpecs, List<SyncElicitationSpecification> elicitationSpecs,
+			List<SyncProgressSpecification> progressSpecs,
+			List<SyncToolListChangedSpecification> syncToolListChangedSpecifications,
+			List<SyncResourceListChangedSpecification> syncResourceListChangedSpecifications,
+			List<SyncPromptListChangedSpecification> syncPromptListChangedSpecifications) {
+		return new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs, elicitationSpecs, progressSpecs,
+				syncToolListChangedSpecifications, syncResourceListChangedSpecifications,
+				syncPromptListChangedSpecifications);
+	}
+
 	// Async client configuration
 
 	@Bean
@@ -257,6 +287,18 @@ public class McpClientAutoConfiguration {
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	McpAsyncClientConfigurer mcpAsyncClientConfigurer(ObjectProvider<McpAsyncClientCustomizer> customizerProvider) {
 		return new McpAsyncClientConfigurer(customizerProvider.orderedStream().toList());
+	}
+
+	@Bean
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
+	public McpAsyncClientCustomizer mcpAnnotationMcpAsyncClientCustomizer(List<AsyncLoggingSpecification> loggingSpecs,
+			List<AsyncSamplingSpecification> samplingSpecs, List<AsyncElicitationSpecification> elicitationSpecs,
+			List<AsyncProgressSpecification> progressSpecs,
+			List<AsyncToolListChangedSpecification> toolListChangedSpecs,
+			List<AsyncResourceListChangedSpecification> resourceListChangedSpecs,
+			List<AsyncPromptListChangedSpecification> promptListChangedSpecs) {
+		return new McpAsyncAnnotationCustomizer(samplingSpecs, loggingSpecs, elicitationSpecs, progressSpecs,
+				toolListChangedSpecs, resourceListChangedSpecs, promptListChangedSpecs);
 	}
 
 	/**

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
@@ -23,7 +23,6 @@ import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
-
 import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
@@ -38,6 +37,7 @@ import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
 import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
 import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
 import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+
 import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpAsyncAnnotationCustomizer;
 import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpSyncAnnotationCustomizer;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpAsyncClientConfigurer;
@@ -111,8 +111,6 @@ import org.springframework.util.CollectionUtils;
  * @see McpSyncClientCustomizer
  * @see McpAsyncClientCustomizer
  * @see StdioTransportAutoConfiguration
- * @see SseHttpClientTransportAutoConfiguration
- * @see SseWebFluxTransportAutoConfiguration
  */
 @AutoConfiguration(afterName = {
 		"org.springframework.ai.mcp.client.common.autoconfigure.StdioTransportAutoConfiguration",

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerAutoConfiguration.java
@@ -23,8 +23,9 @@ import org.springaicommunity.mcp.annotation.McpElicitation;
 import org.springaicommunity.mcp.annotation.McpLogging;
 import org.springaicommunity.mcp.annotation.McpProgress;
 import org.springaicommunity.mcp.annotation.McpSampling;
-import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
+
 import org.springframework.ai.mcp.annotation.spring.scan.AbstractAnnotatedMethodBeanPostProcessor;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -43,19 +44,6 @@ public class ClientAnnotationScannerAutoConfiguration {
 	private static final Set<Class<? extends Annotation>> CLIENT_MCP_ANNOTATIONS = Set.of(McpLogging.class,
 			McpSampling.class, McpElicitation.class, McpProgress.class);
 
-	public static class ClientMcpAnnotatedBeans extends AbstractMcpAnnotatedBeans {
-
-	}
-
-	public static class ClientAnnotatedMethodBeanPostProcessor extends AbstractAnnotatedMethodBeanPostProcessor {
-
-		public ClientAnnotatedMethodBeanPostProcessor(ClientMcpAnnotatedBeans clientMcpAnnotatedBeans,
-				Set<Class<? extends Annotation>> targetAnnotations) {
-			super(clientMcpAnnotatedBeans, targetAnnotations);
-		}
-
-	}
-
 	@Bean
 	@ConditionalOnMissingBean
 	public ClientMcpAnnotatedBeans clientAnnotatedBeans() {
@@ -67,6 +55,19 @@ public class ClientAnnotationScannerAutoConfiguration {
 	public ClientAnnotatedMethodBeanPostProcessor clientAnnotatedMethodBeanPostProcessor(
 			ClientMcpAnnotatedBeans clientMcpAnnotatedBeans, ClientAnnotationScannerProperties properties) {
 		return new ClientAnnotatedMethodBeanPostProcessor(clientMcpAnnotatedBeans, CLIENT_MCP_ANNOTATIONS);
+	}
+
+	public static class ClientMcpAnnotatedBeans extends AbstractMcpAnnotatedBeans {
+
+	}
+
+	public static class ClientAnnotatedMethodBeanPostProcessor extends AbstractAnnotatedMethodBeanPostProcessor {
+
+		public ClientAnnotatedMethodBeanPostProcessor(ClientMcpAnnotatedBeans clientMcpAnnotatedBeans,
+				Set<Class<? extends Annotation>> targetAnnotations) {
+			super(clientMcpAnnotatedBeans, targetAnnotations);
+		}
+
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerAutoConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure.annotations;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractAnnotatedMethodBeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author Christian Tzolov
+ */
+@AutoConfiguration
+@ConditionalOnProperty(prefix = ClientAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+@EnableConfigurationProperties(ClientAnnotationScannerProperties.class)
+public class ClientAnnotationScannerAutoConfiguration {
+
+	private static final Set<Class<? extends Annotation>> CLIENT_MCP_ANNOTATIONS = Set.of(McpLogging.class,
+			McpSampling.class, McpElicitation.class, McpProgress.class);
+
+	public static class ClientMcpAnnotatedBeans extends AbstractMcpAnnotatedBeans {
+
+	}
+
+	public static class ClientAnnotatedMethodBeanPostProcessor extends AbstractAnnotatedMethodBeanPostProcessor {
+
+		public ClientAnnotatedMethodBeanPostProcessor(ClientMcpAnnotatedBeans clientMcpAnnotatedBeans,
+				Set<Class<? extends Annotation>> targetAnnotations) {
+			super(clientMcpAnnotatedBeans, targetAnnotations);
+		}
+
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ClientMcpAnnotatedBeans clientAnnotatedBeans() {
+		return new ClientMcpAnnotatedBeans();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ClientAnnotatedMethodBeanPostProcessor clientAnnotatedMethodBeanPostProcessor(
+			ClientMcpAnnotatedBeans clientMcpAnnotatedBeans, ClientAnnotationScannerProperties properties) {
+		return new ClientAnnotatedMethodBeanPostProcessor(clientMcpAnnotatedBeans, CLIENT_MCP_ANNOTATIONS);
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerProperties.java
@@ -29,7 +29,7 @@ public class ClientAnnotationScannerProperties {
 	private boolean enabled = true;
 
 	public boolean isEnabled() {
-		return enabled;
+		return this.enabled;
 	}
 
 	public void setEnabled(boolean enabled) {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientAnnotationScannerProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure.annotations;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Christian Tzolov
+ */
+@ConfigurationProperties(prefix = ClientAnnotationScannerProperties.CONFIG_PREFIX)
+public class ClientAnnotationScannerProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.mcp.client.annotation-scanner";
+
+	private boolean enabled = true;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientSpecificationFactoryAutoConfiguration.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure.annotations;
+
+import java.util.List;
+
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientAnnotationScannerAutoConfiguration.ClientMcpAnnotatedBeans;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Christian Tzolov
+ */
+@AutoConfiguration(after = ClientAnnotationScannerAutoConfiguration.class)
+@ConditionalOnProperty(prefix = ClientAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+public class ClientSpecificationFactoryAutoConfiguration {
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
+			matchIfMissing = true)
+	static class SyncClientSpecificationConfiguration {
+
+		@Bean
+		List<SyncLoggingSpecification> loggingSpecs(ClientMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.loggingSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpLogging.class));
+		}
+
+		@Bean
+		List<SyncSamplingSpecification> samplingSpecs(ClientMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.samplingSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpSampling.class));
+		}
+
+		@Bean
+		List<SyncElicitationSpecification> elicitationSpecs(ClientMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.elicitationSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpElicitation.class));
+		}
+
+		@Bean
+		List<SyncProgressSpecification> progressSpecs(ClientMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.progressSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpProgress.class));
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
+	static class AsyncClientSpecificationConfiguration {
+
+		@Bean
+		List<AsyncLoggingSpecification> loggingSpecs(ClientMcpAnnotatedBeans beanRegistry) {
+			return AsyncMcpAnnotationProviders.loggingSpecifications(beanRegistry.getAllAnnotatedBeans());
+		}
+
+		@Bean
+		List<AsyncSamplingSpecification> samplingSpecs(ClientMcpAnnotatedBeans beanRegistry) {
+			return AsyncMcpAnnotationProviders.samplingSpecifications(beanRegistry.getAllAnnotatedBeans());
+		}
+
+		@Bean
+		List<AsyncElicitationSpecification> elicitationSpecs(ClientMcpAnnotatedBeans beanRegistry) {
+			return AsyncMcpAnnotationProviders.elicitationSpecifications(beanRegistry.getAllAnnotatedBeans());
+		}
+
+		@Bean
+		List<AsyncProgressSpecification> progressSpecs(ClientMcpAnnotatedBeans beanRegistry) {
+			return AsyncMcpAnnotationProviders.progressSpecifications(beanRegistry.getAllAnnotatedBeans());
+		}
+
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/ClientSpecificationFactoryAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
 import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
 import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
 import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+
 import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientAnnotationScannerAutoConfiguration.ClientMcpAnnotatedBeans;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpAsyncAnnotationCustomizer.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpAsyncAnnotationCustomizer.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure.annotations;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.AsyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
+import org.springframework.ai.mcp.customizer.McpAsyncClientCustomizer;
+import org.springframework.util.CollectionUtils;
+
+import io.modelcontextprotocol.client.McpClient.AsyncSpec;
+
+/**
+ * @author Christian Tzolov
+ */
+public class McpAsyncAnnotationCustomizer implements McpAsyncClientCustomizer {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpAsyncAnnotationCustomizer.class);
+
+	private final List<AsyncSamplingSpecification> asyncSamplingSpecifications;
+
+	private final List<AsyncLoggingSpecification> asyncLoggingSpecifications;
+
+	private final List<AsyncElicitationSpecification> asyncElicitationSpecifications;
+
+	private final List<AsyncProgressSpecification> asyncProgressSpecifications;
+
+	private final List<AsyncToolListChangedSpecification> asyncToolListChangedSpecifications;
+
+	private final List<AsyncResourceListChangedSpecification> asyncResourceListChangedSpecifications;
+
+	private final List<AsyncPromptListChangedSpecification> asyncPromptListChangedSpecifications;
+
+	// Tracking registered specifications per client
+	private final Map<String, Boolean> clientElicitationSpecs = new ConcurrentHashMap<>();
+
+	private final Map<String, Boolean> clientSamplingSpecs = new ConcurrentHashMap<>();
+
+	public McpAsyncAnnotationCustomizer(List<AsyncSamplingSpecification> asyncSamplingSpecifications,
+			List<AsyncLoggingSpecification> asyncLoggingSpecifications,
+			List<AsyncElicitationSpecification> asyncElicitationSpecifications,
+			List<AsyncProgressSpecification> asyncProgressSpecifications,
+			List<AsyncToolListChangedSpecification> asyncToolListChangedSpecifications,
+			List<AsyncResourceListChangedSpecification> asyncResourceListChangedSpecifications,
+			List<AsyncPromptListChangedSpecification> asyncPromptListChangedSpecifications) {
+
+		this.asyncSamplingSpecifications = asyncSamplingSpecifications;
+		this.asyncLoggingSpecifications = asyncLoggingSpecifications;
+		this.asyncElicitationSpecifications = asyncElicitationSpecifications;
+		this.asyncProgressSpecifications = asyncProgressSpecifications;
+		this.asyncToolListChangedSpecifications = asyncToolListChangedSpecifications;
+		this.asyncResourceListChangedSpecifications = asyncResourceListChangedSpecifications;
+		this.asyncPromptListChangedSpecifications = asyncPromptListChangedSpecifications;
+	}
+
+	@Override
+	public void customize(String name, AsyncSpec clientSpec) {
+
+		if (!CollectionUtils.isEmpty(asyncElicitationSpecifications)) {
+			this.asyncElicitationSpecifications.forEach(elicitationSpec -> {
+				if (elicitationSpec.clientId().equalsIgnoreCase(name)) {
+
+					// Check if client already has an elicitation spec
+					if (clientElicitationSpecs.containsKey(name)) {
+						throw new IllegalArgumentException("Client '" + name
+								+ "' already has an elicitationSpec registered. Only one elicitationSpec is allowed per client.");
+					}
+
+					clientElicitationSpecs.put(name, Boolean.TRUE);
+					clientSpec.elicitation(elicitationSpec.elicitationHandler());
+
+					logger.info("Registered elicitationSpec for client '{}'.", name);
+
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(asyncSamplingSpecifications)) {
+			this.asyncSamplingSpecifications.forEach(samplingSpec -> {
+				if (samplingSpec.clientId().equalsIgnoreCase(name)) {
+
+					// Check if client already has a sampling spec
+					if (clientSamplingSpecs.containsKey(name)) {
+						throw new IllegalArgumentException("Client '" + name
+								+ "' already has a samplingSpec registered. Only one samplingSpec is allowed per client.");
+					}
+					clientSamplingSpecs.put(name, Boolean.TRUE);
+
+					clientSpec.sampling(samplingSpec.samplingHandler());
+
+					logger.info("Registered samplingSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(asyncLoggingSpecifications)) {
+			this.asyncLoggingSpecifications.forEach(loggingSpec -> {
+				if (loggingSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.loggingConsumer(loggingSpec.loggingHandler());
+					logger.info("Registered loggingSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(asyncProgressSpecifications)) {
+			this.asyncProgressSpecifications.forEach(progressSpec -> {
+				if (progressSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.progressConsumer(progressSpec.progressHandler());
+					logger.info("Registered progressSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(asyncToolListChangedSpecifications)) {
+			this.asyncToolListChangedSpecifications.forEach(toolListChangedSpec -> {
+				if (toolListChangedSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.toolsChangeConsumer(toolListChangedSpec.toolListChangeHandler());
+					logger.info("Registered toolListChangedSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(asyncResourceListChangedSpecifications)) {
+			this.asyncResourceListChangedSpecifications.forEach(resourceListChangedSpec -> {
+				if (resourceListChangedSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.resourcesChangeConsumer(resourceListChangedSpec.resourceListChangeHandler());
+					logger.info("Registered resourceListChangedSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(asyncPromptListChangedSpecifications)) {
+			this.asyncPromptListChangedSpecifications.forEach(promptListChangedSpec -> {
+				if (promptListChangedSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.promptsChangeConsumer(promptListChangedSpec.promptListChangeHandler());
+					logger.info("Registered promptListChangedSpec for client '{}'.", name);
+				}
+			});
+		}
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpSyncAnnotationCustomizer.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpSyncAnnotationCustomizer.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure.annotations;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+import org.springframework.ai.mcp.customizer.McpSyncClientCustomizer;
+import org.springframework.util.CollectionUtils;
+
+import io.modelcontextprotocol.client.McpClient.SyncSpec;
+
+/**
+ * @author Christian Tzolov
+ */
+public class McpSyncAnnotationCustomizer implements McpSyncClientCustomizer {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpSyncAnnotationCustomizer.class);
+
+	private final List<SyncSamplingSpecification> syncSamplingSpecifications;
+
+	private final List<SyncLoggingSpecification> syncLoggingSpecifications;
+
+	private final List<SyncElicitationSpecification> syncElicitationSpecifications;
+
+	private final List<SyncProgressSpecification> syncProgressSpecifications;
+
+	private final List<SyncToolListChangedSpecification> syncToolListChangedSpecifications;
+
+	private final List<SyncResourceListChangedSpecification> syncResourceListChangedSpecifications;
+
+	private final List<SyncPromptListChangedSpecification> syncPromptListChangedSpecifications;
+
+	// Tracking registered specifications per client
+	private final Map<String, Boolean> clientElicitationSpecs = new ConcurrentHashMap<>();
+
+	private final Map<String, Boolean> clientSamplingSpecs = new ConcurrentHashMap<>();
+
+	public McpSyncAnnotationCustomizer(List<SyncSamplingSpecification> syncSamplingSpecifications,
+			List<SyncLoggingSpecification> syncLoggingSpecifications,
+			List<SyncElicitationSpecification> syncElicitationSpecifications,
+			List<SyncProgressSpecification> syncProgressSpecifications,
+			List<SyncToolListChangedSpecification> syncToolListChangedSpecifications,
+			List<SyncResourceListChangedSpecification> syncResourceListChangedSpecifications,
+			List<SyncPromptListChangedSpecification> syncPromptListChangedSpecifications) {
+
+		this.syncSamplingSpecifications = syncSamplingSpecifications;
+		this.syncLoggingSpecifications = syncLoggingSpecifications;
+		this.syncElicitationSpecifications = syncElicitationSpecifications;
+		this.syncProgressSpecifications = syncProgressSpecifications;
+		this.syncToolListChangedSpecifications = syncToolListChangedSpecifications;
+		this.syncResourceListChangedSpecifications = syncResourceListChangedSpecifications;
+		this.syncPromptListChangedSpecifications = syncPromptListChangedSpecifications;
+	}
+
+	@Override
+	public void customize(String name, SyncSpec clientSpec) {
+
+		if (!CollectionUtils.isEmpty(syncElicitationSpecifications)) {
+			this.syncElicitationSpecifications.forEach(elicitationSpec -> {
+				if (elicitationSpec.clientId().equalsIgnoreCase(name)) {
+
+					// Check if client already has an elicitation spec
+					if (clientElicitationSpecs.containsKey(name)) {
+						throw new IllegalArgumentException("Client '" + name
+								+ "' already has an elicitationSpec registered. Only one elicitationSpec is allowed per client.");
+					}
+
+					clientElicitationSpecs.put(name, Boolean.TRUE);
+					clientSpec.elicitation(elicitationSpec.elicitationHandler());
+
+					logger.info("Registered elicitationSpec for client '{}'.", name);
+
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(syncSamplingSpecifications)) {
+			this.syncSamplingSpecifications.forEach(samplingSpec -> {
+				if (samplingSpec.clientId().equalsIgnoreCase(name)) {
+
+					// Check if client already has a sampling spec
+					if (clientSamplingSpecs.containsKey(name)) {
+						throw new IllegalArgumentException("Client '" + name
+								+ "' already has a samplingSpec registered. Only one samplingSpec is allowed per client.");
+					}
+					clientSamplingSpecs.put(name, Boolean.TRUE);
+
+					clientSpec.sampling(samplingSpec.samplingHandler());
+
+					logger.info("Registered samplingSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(syncLoggingSpecifications)) {
+			this.syncLoggingSpecifications.forEach(loggingSpec -> {
+				if (loggingSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.loggingConsumer(loggingSpec.loggingHandler());
+					logger.info("Registered loggingSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(syncProgressSpecifications)) {
+			this.syncProgressSpecifications.forEach(progressSpec -> {
+				if (progressSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.progressConsumer(progressSpec.progressHandler());
+					logger.info("Registered progressSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(syncToolListChangedSpecifications)) {
+			this.syncToolListChangedSpecifications.forEach(toolListChangedSpec -> {
+				if (toolListChangedSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.toolsChangeConsumer(toolListChangedSpec.toolListChangeHandler());
+					logger.info("Registered toolListChangedSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(syncResourceListChangedSpecifications)) {
+			this.syncResourceListChangedSpecifications.forEach(resourceListChangedSpec -> {
+				if (resourceListChangedSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.resourcesChangeConsumer(resourceListChangedSpec.resourceListChangeHandler());
+					logger.info("Registered resourceListChangedSpec for client '{}'.", name);
+				}
+			});
+		}
+
+		if (!CollectionUtils.isEmpty(syncPromptListChangedSpecifications)) {
+			this.syncPromptListChangedSpecifications.forEach(promptListChangedSpec -> {
+				if (promptListChangedSpec.clientId().equalsIgnoreCase(name)) {
+					clientSpec.promptsChangeConsumer(promptListChangedSpec.promptListChangeHandler());
+					logger.info("Registered promptListChangedSpec for client '{}'.", name);
+				}
+			});
+		}
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
@@ -175,8 +175,6 @@ public class McpClientCommonProperties {
 	 * This record is used to encapsulate the configuration for enabling or disabling tool
 	 * callbacks in the MCP client.
 	 *
-	 * @param enabled A boolean flag indicating whether the tool callback is enabled. If
-	 * true, the tool callback is active; otherwise, it is disabled.
 	 */
 	public static class Toolcallback {
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,5 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.springframework.ai.mcp.client.httpclient.autoconfigure.SseHttpClientTransportAutoConfiguration
-org.springframework.ai.mcp.client.httpclient.autoconfigure.StreamableHttpHttpClientTransportAutoConfiguration
+
+org.springframework.ai.mcp.client.common.autoconfigure.StdioTransportAutoConfiguration
+org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration
+org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration
+org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientSpecificationFactoryAutoConfiguration
+org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientAnnotationScannerAutoConfiguration

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpSyncAnnotationCustomizerTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpSyncAnnotationCustomizerTests.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure.annotations;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+
+import io.modelcontextprotocol.client.McpClient.SyncSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpSyncAnnotationCustomizerTests {
+
+	@Mock
+	private SyncSpec syncSpec;
+
+	private List<SyncSamplingSpecification> samplingSpecs;
+
+	private List<SyncLoggingSpecification> loggingSpecs;
+
+	private List<SyncElicitationSpecification> elicitationSpecs;
+
+	private List<SyncProgressSpecification> progressSpecs;
+
+	private List<SyncToolListChangedSpecification> toolListChangedSpecs;
+
+	private List<SyncResourceListChangedSpecification> resourceListChangedSpecs;
+
+	private List<SyncPromptListChangedSpecification> promptListChangedSpecs;
+
+	@BeforeEach
+	void setUp() {
+		samplingSpecs = new ArrayList<>();
+		loggingSpecs = new ArrayList<>();
+		elicitationSpecs = new ArrayList<>();
+		progressSpecs = new ArrayList<>();
+		toolListChangedSpecs = new ArrayList<>();
+		resourceListChangedSpecs = new ArrayList<>();
+		promptListChangedSpecs = new ArrayList<>();
+	}
+
+	@Test
+	void constructorShouldInitializeAllFields() {
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		assertThat(customizer).isNotNull();
+	}
+
+	@Test
+	void constructorShouldAcceptNullLists() {
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(null, null, null, null, null, null,
+				null);
+
+		assertThat(customizer).isNotNull();
+	}
+
+	@Test
+	void customizeShouldNotRegisterAnythingWhenAllListsAreEmpty() {
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		customizer.customize("test-client", syncSpec);
+
+		verifyNoInteractions(syncSpec);
+	}
+
+	@Test
+	void customizeShouldNotRegisterElicitationSpecForNonMatchingClient() {
+		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
+		when(elicitationSpec.clientId()).thenReturn("other-client");
+		elicitationSpecs.add(elicitationSpec);
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		customizer.customize("test-client", syncSpec);
+
+		verifyNoInteractions(syncSpec);
+	}
+
+	@Test
+	void customizeShouldThrowExceptionWhenDuplicateElicitationSpecRegistered() {
+		SyncElicitationSpecification elicitationSpec1 = mock(SyncElicitationSpecification.class);
+		SyncElicitationSpecification elicitationSpec2 = mock(SyncElicitationSpecification.class);
+
+		when(elicitationSpec1.clientId()).thenReturn("test-client");
+		when(elicitationSpec1.elicitationHandler()).thenReturn(request -> null);
+		when(elicitationSpec2.clientId()).thenReturn("test-client");
+		// No need to stub elicitationSpec2.elicitationHandler() as exception is thrown
+		// before it's accessed
+
+		elicitationSpecs.addAll(Arrays.asList(elicitationSpec1, elicitationSpec2));
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		assertThatThrownBy(() -> customizer.customize("test-client", syncSpec))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Client 'test-client' already has an elicitationSpec registered");
+	}
+
+	@Test
+	void customizeShouldThrowExceptionWhenDuplicateSamplingSpecRegistered() {
+		SyncSamplingSpecification samplingSpec1 = mock(SyncSamplingSpecification.class);
+		SyncSamplingSpecification samplingSpec2 = mock(SyncSamplingSpecification.class);
+
+		when(samplingSpec1.clientId()).thenReturn("test-client");
+		when(samplingSpec1.samplingHandler()).thenReturn(request -> null);
+		when(samplingSpec2.clientId()).thenReturn("test-client");
+		// No need to stub samplingSpec2.samplingHandler() as exception is thrown before
+		// it's accessed
+
+		samplingSpecs.addAll(Arrays.asList(samplingSpec1, samplingSpec2));
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		assertThatThrownBy(() -> customizer.customize("test-client", syncSpec))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Client 'test-client' already has a samplingSpec registered");
+	}
+
+	@Test
+	void customizeShouldSkipSpecificationsWithNonMatchingClientIds() {
+		// Setup specs with different client IDs
+		SyncLoggingSpecification loggingSpec = mock(SyncLoggingSpecification.class);
+		SyncProgressSpecification progressSpec = mock(SyncProgressSpecification.class);
+		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
+
+		when(loggingSpec.clientId()).thenReturn("other-client");
+		when(progressSpec.clientId()).thenReturn("another-client");
+		when(elicitationSpec.clientId()).thenReturn("different-client");
+
+		loggingSpecs.add(loggingSpec);
+		progressSpecs.add(progressSpec);
+		elicitationSpecs.add(elicitationSpec);
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		customizer.customize("target-client", syncSpec);
+
+		// None of the specifications should be registered since client IDs don't match
+		verifyNoInteractions(syncSpec);
+	}
+
+	@Test
+	void customizeShouldAllowElicitationSpecForDifferentClients() {
+		SyncElicitationSpecification elicitationSpec1 = mock(SyncElicitationSpecification.class);
+		SyncElicitationSpecification elicitationSpec2 = mock(SyncElicitationSpecification.class);
+
+		when(elicitationSpec1.clientId()).thenReturn("client1");
+		when(elicitationSpec1.elicitationHandler()).thenReturn(request -> null);
+		when(elicitationSpec2.clientId()).thenReturn("client2");
+		when(elicitationSpec2.elicitationHandler()).thenReturn(request -> null);
+
+		elicitationSpecs.addAll(Arrays.asList(elicitationSpec1, elicitationSpec2));
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// Should not throw exception since they are for different clients
+		SyncSpec syncSpec1 = mock(SyncSpec.class);
+		customizer.customize("client1", syncSpec1);
+
+		SyncSpec syncSpec2 = mock(SyncSpec.class);
+		customizer.customize("client2", syncSpec2);
+
+		// No exception should be thrown, indicating successful registration for different
+		// clients
+	}
+
+	@Test
+	void customizeShouldAllowSamplingSpecForDifferentClients() {
+		SyncSamplingSpecification samplingSpec1 = mock(SyncSamplingSpecification.class);
+		SyncSamplingSpecification samplingSpec2 = mock(SyncSamplingSpecification.class);
+
+		when(samplingSpec1.clientId()).thenReturn("client1");
+		when(samplingSpec1.samplingHandler()).thenReturn(request -> null);
+		when(samplingSpec2.clientId()).thenReturn("client2");
+		when(samplingSpec2.samplingHandler()).thenReturn(request -> null);
+
+		samplingSpecs.addAll(Arrays.asList(samplingSpec1, samplingSpec2));
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// Should not throw exception since they are for different clients
+		SyncSpec syncSpec1 = mock(SyncSpec.class);
+		customizer.customize("client1", syncSpec1);
+
+		SyncSpec syncSpec2 = mock(SyncSpec.class);
+		customizer.customize("client2", syncSpec2);
+
+		// No exception should be thrown, indicating successful registration for different
+		// clients
+	}
+
+	@Test
+	void customizeShouldPreventMultipleElicitationCallsForSameClient() {
+		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
+		when(elicitationSpec.clientId()).thenReturn("test-client");
+		when(elicitationSpec.elicitationHandler()).thenReturn(request -> null);
+		elicitationSpecs.add(elicitationSpec);
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// First call should succeed
+		customizer.customize("test-client", syncSpec);
+
+		// Second call should throw exception
+		SyncSpec syncSpec2 = mock(SyncSpec.class);
+		assertThatThrownBy(() -> customizer.customize("test-client", syncSpec2))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Client 'test-client' already has an elicitationSpec registered");
+	}
+
+	@Test
+	void customizeShouldPreventMultipleSamplingCallsForSameClient() {
+		SyncSamplingSpecification samplingSpec = mock(SyncSamplingSpecification.class);
+		when(samplingSpec.clientId()).thenReturn("test-client");
+		when(samplingSpec.samplingHandler()).thenReturn(request -> null);
+		samplingSpecs.add(samplingSpec);
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// First call should succeed
+		customizer.customize("test-client", syncSpec);
+
+		// Second call should throw exception
+		SyncSpec syncSpec2 = mock(SyncSpec.class);
+		assertThatThrownBy(() -> customizer.customize("test-client", syncSpec2))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Client 'test-client' already has a samplingSpec registered");
+	}
+
+	@Test
+	void customizeShouldPerformCaseInsensitiveClientIdMatching() {
+		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
+		when(elicitationSpec.clientId()).thenReturn("TEST-CLIENT");
+		when(elicitationSpec.elicitationHandler()).thenReturn(request -> null);
+		elicitationSpecs.add(elicitationSpec);
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// Should register elicitation spec when client ID matches case-insensitively
+		customizer.customize("test-client", syncSpec);
+
+		// Verify that a subsequent call for the same client (case-insensitive) throws
+		// exception
+		SyncSpec syncSpec2 = mock(SyncSpec.class);
+		assertThatThrownBy(() -> customizer.customize("test-client", syncSpec2))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Client 'test-client' already has an elicitationSpec registered");
+	}
+
+	@Test
+	void customizeShouldHandleEmptyClientName() {
+		SyncLoggingSpecification loggingSpec = mock(SyncLoggingSpecification.class);
+		when(loggingSpec.clientId()).thenReturn("");
+		when(loggingSpec.loggingHandler()).thenReturn(message -> {
+		});
+		loggingSpecs.add(loggingSpec);
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// Should not throw exception when customizing for empty client name
+		customizer.customize("", syncSpec);
+	}
+
+	@Test
+	void customizeShouldAllowMultipleLoggingSpecsForSameClient() {
+		SyncLoggingSpecification loggingSpec1 = mock(SyncLoggingSpecification.class);
+		SyncLoggingSpecification loggingSpec2 = mock(SyncLoggingSpecification.class);
+
+		when(loggingSpec1.clientId()).thenReturn("test-client");
+		when(loggingSpec1.loggingHandler()).thenReturn(message -> {
+		});
+		when(loggingSpec2.clientId()).thenReturn("test-client");
+		when(loggingSpec2.loggingHandler()).thenReturn(message -> {
+		});
+
+		loggingSpecs.addAll(Arrays.asList(loggingSpec1, loggingSpec2));
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// Should not throw exception for multiple logging specs for same client
+		customizer.customize("test-client", syncSpec);
+	}
+
+	@Test
+	void customizeShouldAllowMultipleProgressSpecsForSameClient() {
+		SyncProgressSpecification progressSpec1 = mock(SyncProgressSpecification.class);
+		SyncProgressSpecification progressSpec2 = mock(SyncProgressSpecification.class);
+
+		when(progressSpec1.clientId()).thenReturn("test-client");
+		when(progressSpec1.progressHandler()).thenReturn(notification -> {
+		});
+		when(progressSpec2.clientId()).thenReturn("test-client");
+		when(progressSpec2.progressHandler()).thenReturn(notification -> {
+		});
+
+		progressSpecs.addAll(Arrays.asList(progressSpec1, progressSpec2));
+
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
+				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
+				promptListChangedSpecs);
+
+		// Should not throw exception for multiple progress specs for same client
+		customizer.customize("test-client", syncSpec);
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpSyncAnnotationCustomizerTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpSyncAnnotationCustomizerTests.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import io.modelcontextprotocol.client.McpClient.SyncSpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,8 +33,6 @@ import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification
 import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
 import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
 import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
-
-import io.modelcontextprotocol.client.McpClient.SyncSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,20 +62,20 @@ class McpSyncAnnotationCustomizerTests {
 
 	@BeforeEach
 	void setUp() {
-		samplingSpecs = new ArrayList<>();
-		loggingSpecs = new ArrayList<>();
-		elicitationSpecs = new ArrayList<>();
-		progressSpecs = new ArrayList<>();
-		toolListChangedSpecs = new ArrayList<>();
-		resourceListChangedSpecs = new ArrayList<>();
-		promptListChangedSpecs = new ArrayList<>();
+		this.samplingSpecs = new ArrayList<>();
+		this.loggingSpecs = new ArrayList<>();
+		this.elicitationSpecs = new ArrayList<>();
+		this.progressSpecs = new ArrayList<>();
+		this.toolListChangedSpecs = new ArrayList<>();
+		this.resourceListChangedSpecs = new ArrayList<>();
+		this.promptListChangedSpecs = new ArrayList<>();
 	}
 
 	@Test
 	void constructorShouldInitializeAllFields() {
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		assertThat(customizer).isNotNull();
 	}
@@ -91,28 +90,28 @@ class McpSyncAnnotationCustomizerTests {
 
 	@Test
 	void customizeShouldNotRegisterAnythingWhenAllListsAreEmpty() {
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
-		customizer.customize("test-client", syncSpec);
+		customizer.customize("test-client", this.syncSpec);
 
-		verifyNoInteractions(syncSpec);
+		verifyNoInteractions(this.syncSpec);
 	}
 
 	@Test
 	void customizeShouldNotRegisterElicitationSpecForNonMatchingClient() {
 		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
-		when(elicitationSpec.clientId()).thenReturn("other-client");
-		elicitationSpecs.add(elicitationSpec);
+		when(elicitationSpec.clients()).thenReturn(new String[] { "other-client" });
+		this.elicitationSpecs.add(elicitationSpec);
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
-		customizer.customize("test-client", syncSpec);
+		customizer.customize("test-client", this.syncSpec);
 
-		verifyNoInteractions(syncSpec);
+		verifyNoInteractions(this.syncSpec);
 	}
 
 	@Test
@@ -120,19 +119,19 @@ class McpSyncAnnotationCustomizerTests {
 		SyncElicitationSpecification elicitationSpec1 = mock(SyncElicitationSpecification.class);
 		SyncElicitationSpecification elicitationSpec2 = mock(SyncElicitationSpecification.class);
 
-		when(elicitationSpec1.clientId()).thenReturn("test-client");
+		when(elicitationSpec1.clients()).thenReturn(new String[] { "test-client" });
 		when(elicitationSpec1.elicitationHandler()).thenReturn(request -> null);
-		when(elicitationSpec2.clientId()).thenReturn("test-client");
+		when(elicitationSpec2.clients()).thenReturn(new String[] { "test-client" });
 		// No need to stub elicitationSpec2.elicitationHandler() as exception is thrown
 		// before it's accessed
 
-		elicitationSpecs.addAll(Arrays.asList(elicitationSpec1, elicitationSpec2));
+		this.elicitationSpecs.addAll(Arrays.asList(elicitationSpec1, elicitationSpec2));
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
-		assertThatThrownBy(() -> customizer.customize("test-client", syncSpec))
+		assertThatThrownBy(() -> customizer.customize("test-client", this.syncSpec))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Client 'test-client' already has an elicitationSpec registered");
 	}
@@ -142,19 +141,19 @@ class McpSyncAnnotationCustomizerTests {
 		SyncSamplingSpecification samplingSpec1 = mock(SyncSamplingSpecification.class);
 		SyncSamplingSpecification samplingSpec2 = mock(SyncSamplingSpecification.class);
 
-		when(samplingSpec1.clientId()).thenReturn("test-client");
+		when(samplingSpec1.clients()).thenReturn(new String[] { "test-client" });
 		when(samplingSpec1.samplingHandler()).thenReturn(request -> null);
-		when(samplingSpec2.clientId()).thenReturn("test-client");
+		when(samplingSpec2.clients()).thenReturn(new String[] { "test-client" });
 		// No need to stub samplingSpec2.samplingHandler() as exception is thrown before
 		// it's accessed
 
-		samplingSpecs.addAll(Arrays.asList(samplingSpec1, samplingSpec2));
+		this.samplingSpecs.addAll(Arrays.asList(samplingSpec1, samplingSpec2));
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
-		assertThatThrownBy(() -> customizer.customize("test-client", syncSpec))
+		assertThatThrownBy(() -> customizer.customize("test-client", this.syncSpec))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Client 'test-client' already has a samplingSpec registered");
 	}
@@ -166,22 +165,22 @@ class McpSyncAnnotationCustomizerTests {
 		SyncProgressSpecification progressSpec = mock(SyncProgressSpecification.class);
 		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
 
-		when(loggingSpec.clientId()).thenReturn("other-client");
-		when(progressSpec.clientId()).thenReturn("another-client");
-		when(elicitationSpec.clientId()).thenReturn("different-client");
+		when(loggingSpec.clients()).thenReturn(new String[] { "other-client" });
+		when(progressSpec.clients()).thenReturn(new String[] { "another-client" });
+		when(elicitationSpec.clients()).thenReturn(new String[] { "different-client" });
 
-		loggingSpecs.add(loggingSpec);
-		progressSpecs.add(progressSpec);
-		elicitationSpecs.add(elicitationSpec);
+		this.loggingSpecs.add(loggingSpec);
+		this.progressSpecs.add(progressSpec);
+		this.elicitationSpecs.add(elicitationSpec);
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
-		customizer.customize("target-client", syncSpec);
+		customizer.customize("target-client", this.syncSpec);
 
 		// None of the specifications should be registered since client IDs don't match
-		verifyNoInteractions(syncSpec);
+		verifyNoInteractions(this.syncSpec);
 	}
 
 	@Test
@@ -189,16 +188,16 @@ class McpSyncAnnotationCustomizerTests {
 		SyncElicitationSpecification elicitationSpec1 = mock(SyncElicitationSpecification.class);
 		SyncElicitationSpecification elicitationSpec2 = mock(SyncElicitationSpecification.class);
 
-		when(elicitationSpec1.clientId()).thenReturn("client1");
+		when(elicitationSpec1.clients()).thenReturn(new String[] { "client1" });
 		when(elicitationSpec1.elicitationHandler()).thenReturn(request -> null);
-		when(elicitationSpec2.clientId()).thenReturn("client2");
+		when(elicitationSpec2.clients()).thenReturn(new String[] { "client2" });
 		when(elicitationSpec2.elicitationHandler()).thenReturn(request -> null);
 
-		elicitationSpecs.addAll(Arrays.asList(elicitationSpec1, elicitationSpec2));
+		this.elicitationSpecs.addAll(Arrays.asList(elicitationSpec1, elicitationSpec2));
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// Should not throw exception since they are for different clients
 		SyncSpec syncSpec1 = mock(SyncSpec.class);
@@ -216,16 +215,16 @@ class McpSyncAnnotationCustomizerTests {
 		SyncSamplingSpecification samplingSpec1 = mock(SyncSamplingSpecification.class);
 		SyncSamplingSpecification samplingSpec2 = mock(SyncSamplingSpecification.class);
 
-		when(samplingSpec1.clientId()).thenReturn("client1");
+		when(samplingSpec1.clients()).thenReturn(new String[] { "client1" });
 		when(samplingSpec1.samplingHandler()).thenReturn(request -> null);
-		when(samplingSpec2.clientId()).thenReturn("client2");
+		when(samplingSpec2.clients()).thenReturn(new String[] { "client2" });
 		when(samplingSpec2.samplingHandler()).thenReturn(request -> null);
 
-		samplingSpecs.addAll(Arrays.asList(samplingSpec1, samplingSpec2));
+		this.samplingSpecs.addAll(Arrays.asList(samplingSpec1, samplingSpec2));
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// Should not throw exception since they are for different clients
 		SyncSpec syncSpec1 = mock(SyncSpec.class);
@@ -241,16 +240,16 @@ class McpSyncAnnotationCustomizerTests {
 	@Test
 	void customizeShouldPreventMultipleElicitationCallsForSameClient() {
 		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
-		when(elicitationSpec.clientId()).thenReturn("test-client");
+		when(elicitationSpec.clients()).thenReturn(new String[] { "test-client" });
 		when(elicitationSpec.elicitationHandler()).thenReturn(request -> null);
-		elicitationSpecs.add(elicitationSpec);
+		this.elicitationSpecs.add(elicitationSpec);
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// First call should succeed
-		customizer.customize("test-client", syncSpec);
+		customizer.customize("test-client", this.syncSpec);
 
 		// Second call should throw exception
 		SyncSpec syncSpec2 = mock(SyncSpec.class);
@@ -262,16 +261,16 @@ class McpSyncAnnotationCustomizerTests {
 	@Test
 	void customizeShouldPreventMultipleSamplingCallsForSameClient() {
 		SyncSamplingSpecification samplingSpec = mock(SyncSamplingSpecification.class);
-		when(samplingSpec.clientId()).thenReturn("test-client");
+		when(samplingSpec.clients()).thenReturn(new String[] { "test-client" });
 		when(samplingSpec.samplingHandler()).thenReturn(request -> null);
-		samplingSpecs.add(samplingSpec);
+		this.samplingSpecs.add(samplingSpec);
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// First call should succeed
-		customizer.customize("test-client", syncSpec);
+		customizer.customize("test-client", this.syncSpec);
 
 		// Second call should throw exception
 		SyncSpec syncSpec2 = mock(SyncSpec.class);
@@ -283,16 +282,16 @@ class McpSyncAnnotationCustomizerTests {
 	@Test
 	void customizeShouldPerformCaseInsensitiveClientIdMatching() {
 		SyncElicitationSpecification elicitationSpec = mock(SyncElicitationSpecification.class);
-		when(elicitationSpec.clientId()).thenReturn("TEST-CLIENT");
+		when(elicitationSpec.clients()).thenReturn(new String[] { "TEST-CLIENT" });
 		when(elicitationSpec.elicitationHandler()).thenReturn(request -> null);
-		elicitationSpecs.add(elicitationSpec);
+		this.elicitationSpecs.add(elicitationSpec);
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// Should register elicitation spec when client ID matches case-insensitively
-		customizer.customize("test-client", syncSpec);
+		customizer.customize("test-client", this.syncSpec);
 
 		// Verify that a subsequent call for the same client (case-insensitive) throws
 		// exception
@@ -305,17 +304,18 @@ class McpSyncAnnotationCustomizerTests {
 	@Test
 	void customizeShouldHandleEmptyClientName() {
 		SyncLoggingSpecification loggingSpec = mock(SyncLoggingSpecification.class);
-		when(loggingSpec.clientId()).thenReturn("");
+		when(loggingSpec.clients()).thenReturn(new String[] { "" });
 		when(loggingSpec.loggingHandler()).thenReturn(message -> {
 		});
-		loggingSpecs.add(loggingSpec);
+		this.loggingSpecs.add(loggingSpec);
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// Should not throw exception when customizing for empty client name
-		customizer.customize("", syncSpec);
+		customizer.customize("", this.syncSpec);
+
 	}
 
 	@Test
@@ -323,21 +323,22 @@ class McpSyncAnnotationCustomizerTests {
 		SyncLoggingSpecification loggingSpec1 = mock(SyncLoggingSpecification.class);
 		SyncLoggingSpecification loggingSpec2 = mock(SyncLoggingSpecification.class);
 
-		when(loggingSpec1.clientId()).thenReturn("test-client");
+		when(loggingSpec1.clients()).thenReturn(new String[] { "test-client" });
 		when(loggingSpec1.loggingHandler()).thenReturn(message -> {
 		});
-		when(loggingSpec2.clientId()).thenReturn("test-client");
+		when(loggingSpec2.clients()).thenReturn(new String[] { "test-client" });
 		when(loggingSpec2.loggingHandler()).thenReturn(message -> {
 		});
 
-		loggingSpecs.addAll(Arrays.asList(loggingSpec1, loggingSpec2));
+		this.loggingSpecs.addAll(Arrays.asList(loggingSpec1, loggingSpec2));
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// Should not throw exception for multiple logging specs for same client
-		customizer.customize("test-client", syncSpec);
+		customizer.customize("test-client", this.syncSpec);
+
 	}
 
 	@Test
@@ -345,21 +346,21 @@ class McpSyncAnnotationCustomizerTests {
 		SyncProgressSpecification progressSpec1 = mock(SyncProgressSpecification.class);
 		SyncProgressSpecification progressSpec2 = mock(SyncProgressSpecification.class);
 
-		when(progressSpec1.clientId()).thenReturn("test-client");
+		when(progressSpec1.clients()).thenReturn(new String[] { "test-client" });
 		when(progressSpec1.progressHandler()).thenReturn(notification -> {
 		});
-		when(progressSpec2.clientId()).thenReturn("test-client");
+		when(progressSpec2.clients()).thenReturn(new String[] { "test-client" });
 		when(progressSpec2.progressHandler()).thenReturn(notification -> {
 		});
 
-		progressSpecs.addAll(Arrays.asList(progressSpec1, progressSpec2));
+		this.progressSpecs.addAll(Arrays.asList(progressSpec1, progressSpec2));
 
-		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs,
-				elicitationSpecs, progressSpecs, toolListChangedSpecs, resourceListChangedSpecs,
-				promptListChangedSpecs);
+		McpSyncAnnotationCustomizer customizer = new McpSyncAnnotationCustomizer(this.samplingSpecs, this.loggingSpecs,
+				this.elicitationSpecs, this.progressSpecs, this.toolListChangedSpecs, this.resourceListChangedSpecs,
+				this.promptListChangedSpecs);
 
 		// Should not throw exception for multiple progress specs for same client
-		customizer.customize("test-client", syncSpec);
+		customizer.customize("test-client", this.syncSpec);
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.springframework.ai.mcp.client.common.autoconfigure.StdioTransportAutoConfiguration
-org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration
-org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration
 org.springframework.ai.mcp.client.webflux.autoconfigure.SseWebFluxTransportAutoConfiguration
 org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/pom.xml
@@ -36,6 +36,14 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-mcp-annotations</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
 			<optional>true</optional>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerAutoConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractAnnotatedMethodBeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author Christian Tzolov
+ */
+@AutoConfiguration
+@ConditionalOnProperty(prefix = ServerAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+@EnableConfigurationProperties(ServerAnnotationScannerProperties.class)
+public class ServerAnnotationScannerAutoConfiguration {
+
+	private static final Set<Class<? extends Annotation>> SERVER_MCP_ANNOTATIONS = Set.of(McpTool.class,
+			McpResource.class, McpPrompt.class, McpComplete.class);
+
+	public static class ServerMcpAnnotatedBeans extends AbstractMcpAnnotatedBeans {
+
+	}
+
+	public static class ServerAnnotatedMethodBeanPostProcessor extends AbstractAnnotatedMethodBeanPostProcessor {
+
+		public ServerAnnotatedMethodBeanPostProcessor(ServerMcpAnnotatedBeans serverMcpAnnotatedBeans,
+				Set<Class<? extends Annotation>> targetAnnotations) {
+			super(serverMcpAnnotatedBeans, targetAnnotations);
+		}
+
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ServerMcpAnnotatedBeans serverAnnotatedBeanRegistry() {
+		return new ServerMcpAnnotatedBeans();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ServerAnnotatedMethodBeanPostProcessor serverAnnotatedMethodBeanPostProcessor(
+			ServerMcpAnnotatedBeans serverMcpAnnotatedBeans, ServerAnnotationScannerProperties properties) {
+		return new ServerAnnotatedMethodBeanPostProcessor(serverMcpAnnotatedBeans, SERVER_MCP_ANNOTATIONS);
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerAutoConfiguration.java
@@ -23,8 +23,9 @@ import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
-import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
+
 import org.springframework.ai.mcp.annotation.spring.scan.AbstractAnnotatedMethodBeanPostProcessor;
+import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -43,19 +44,6 @@ public class ServerAnnotationScannerAutoConfiguration {
 	private static final Set<Class<? extends Annotation>> SERVER_MCP_ANNOTATIONS = Set.of(McpTool.class,
 			McpResource.class, McpPrompt.class, McpComplete.class);
 
-	public static class ServerMcpAnnotatedBeans extends AbstractMcpAnnotatedBeans {
-
-	}
-
-	public static class ServerAnnotatedMethodBeanPostProcessor extends AbstractAnnotatedMethodBeanPostProcessor {
-
-		public ServerAnnotatedMethodBeanPostProcessor(ServerMcpAnnotatedBeans serverMcpAnnotatedBeans,
-				Set<Class<? extends Annotation>> targetAnnotations) {
-			super(serverMcpAnnotatedBeans, targetAnnotations);
-		}
-
-	}
-
 	@Bean
 	@ConditionalOnMissingBean
 	public ServerMcpAnnotatedBeans serverAnnotatedBeanRegistry() {
@@ -67,6 +55,19 @@ public class ServerAnnotationScannerAutoConfiguration {
 	public ServerAnnotatedMethodBeanPostProcessor serverAnnotatedMethodBeanPostProcessor(
 			ServerMcpAnnotatedBeans serverMcpAnnotatedBeans, ServerAnnotationScannerProperties properties) {
 		return new ServerAnnotatedMethodBeanPostProcessor(serverMcpAnnotatedBeans, SERVER_MCP_ANNOTATIONS);
+	}
+
+	public static class ServerMcpAnnotatedBeans extends AbstractMcpAnnotatedBeans {
+
+	}
+
+	public static class ServerAnnotatedMethodBeanPostProcessor extends AbstractAnnotatedMethodBeanPostProcessor {
+
+		public ServerAnnotatedMethodBeanPostProcessor(ServerMcpAnnotatedBeans serverMcpAnnotatedBeans,
+				Set<Class<? extends Annotation>> targetAnnotations) {
+			super(serverMcpAnnotatedBeans, targetAnnotations);
+		}
+
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerProperties.java
@@ -29,7 +29,7 @@ public class ServerAnnotationScannerProperties {
 	private boolean enabled = true;
 
 	public boolean isEnabled() {
-		return enabled;
+		return this.enabled;
 	}
 
 	public void setEnabled(boolean enabled) {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerAnnotationScannerProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Christian Tzolov
+ */
+@ConfigurationProperties(prefix = ServerAnnotationScannerProperties.CONFIG_PREFIX)
+public class ServerAnnotationScannerProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.mcp.server.annotation-scanner";
+
+	private boolean enabled = true;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerSpecificationFactoryAutoConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
+
+import java.util.List;
+
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerAnnotationScannerAutoConfiguration.ServerMcpAnnotatedBeans;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+
+/**
+ * @author Christian Tzolov
+ */
+@AutoConfiguration(after = ServerAnnotationScannerAutoConfiguration.class)
+@ConditionalOnProperty(prefix = ServerAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+@Conditional(McpServerAutoConfiguration.NonStatlessServerCondition.class)
+public class ServerSpecificationFactoryAutoConfiguration {
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
+			matchIfMissing = true)
+	static class SyncServerSpecificationConfiguration {
+
+		@Bean
+		public List<McpServerFeatures.SyncResourceSpecification> resourceSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.resourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncPromptSpecification> promptSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.promptSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpPrompt.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncCompletionSpecification> completionSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.completeSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpComplete.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncToolSpecification> toolSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.toolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
+	static class AsyncServerSpecificationConfiguration {
+
+		@Bean
+		public List<McpServerFeatures.AsyncResourceSpecification> resourceSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.resourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.AsyncPromptSpecification> promptSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.promptSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpPrompt.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.AsyncCompletionSpecification> completionSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.completeSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpComplete.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.AsyncToolSpecification> toolSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.toolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+		}
+
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/ServerSpecificationFactoryAutoConfiguration.java
@@ -18,10 +18,12 @@ package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
 
 import java.util.List;
 
+import io.modelcontextprotocol.server.McpServerFeatures;
 import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
+
 import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
@@ -32,8 +34,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-
-import io.modelcontextprotocol.server.McpServerFeatures;
 
 /**
  * @author Christian Tzolov

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -18,10 +18,13 @@ package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
 
 import java.util.List;
 
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpPrompt;
 import org.springaicommunity.mcp.annotation.McpResource;
 import org.springaicommunity.mcp.annotation.McpTool;
+
 import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
@@ -34,9 +37,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-
-import io.modelcontextprotocol.server.McpServerFeatures;
-import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 
 /**
  * @author Christian Tzolov

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
+
+import java.util.List;
+
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
+import org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerAnnotationScannerAutoConfiguration.ServerMcpAnnotatedBeans;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+
+/**
+ * @author Christian Tzolov
+ */
+@AutoConfiguration(after = ServerAnnotationScannerAutoConfiguration.class)
+@ConditionalOnProperty(prefix = ServerAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+@Conditional({ McpServerStdioDisabledCondition.class,
+		McpServerStatelessAutoConfiguration.EnabledStatelessServerCondition.class,
+		StatelessToolCallbackConverterAutoConfiguration.ToolCallbackConverterCondition.class })
+public class StatelessServerSpecificationFactoryAutoConfiguration {
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
+			matchIfMissing = true)
+	static class SyncStatelessServerSpecificationConfiguration {
+
+		@Bean
+		public List<McpStatelessServerFeatures.SyncResourceSpecification> resourceSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.statelessResourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+		}
+
+		@Bean
+		public List<McpStatelessServerFeatures.SyncPromptSpecification> promptSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.statelessPromptSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpPrompt.class));
+		}
+
+		@Bean
+		public List<McpStatelessServerFeatures.SyncCompletionSpecification> completionSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.statelessCompleteSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpComplete.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncToolSpecification> toolSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders
+				.toolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
+	static class AsyncStatelessServerSpecificationConfiguration {
+
+		@Bean
+		public List<McpStatelessServerFeatures.AsyncResourceSpecification> resourceSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.statelessResourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+		}
+
+		@Bean
+		public List<McpStatelessServerFeatures.AsyncPromptSpecification> promptSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.statelessPromptSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpPrompt.class));
+		}
+
+		@Bean
+		public List<McpStatelessServerFeatures.AsyncCompletionSpecification> completionSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.statelessCompleteSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpComplete.class));
+		}
+
+		@Bean
+		public List<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders
+				.statelessToolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+		}
+
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -17,3 +17,5 @@ org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguratio
 org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration
 org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
 org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration
+org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerSpecificationFactoryAutoConfiguration
+org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerAnnotationScannerAutoConfiguration

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/pom.xml
@@ -42,6 +42,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-mcp-annotations</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
 			<optional>true</optional>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsIT.java
@@ -16,10 +16,6 @@
 
 package org.springframework.ai.mcp.server.autoconfigure;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -29,46 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpArg;
-import org.springaicommunity.mcp.annotation.McpComplete;
-import org.springaicommunity.mcp.annotation.McpElicitation;
-import org.springaicommunity.mcp.annotation.McpLogging;
-import org.springaicommunity.mcp.annotation.McpMeta;
-import org.springaicommunity.mcp.annotation.McpProgress;
-import org.springaicommunity.mcp.annotation.McpProgressToken;
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.McpSampling;
-import org.springaicommunity.mcp.annotation.McpTool;
-import org.springaicommunity.mcp.annotation.McpToolParam;
-import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
-import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
-import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientAnnotationScannerAutoConfiguration;
-import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientSpecificationFactoryAutoConfiguration;
-import org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerAnnotationScannerAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerSpecificationFactoryAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
-import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.ResolvableType;
-import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
-import org.springframework.test.util.TestSocketUtils;
-import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.RouterFunctions;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
@@ -93,9 +50,50 @@ import io.modelcontextprotocol.spec.McpSchema.PromptReference;
 import io.modelcontextprotocol.spec.McpSchema.Resource;
 import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.test.util.TestSocketUtils;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StreamableMcpAnnotationsIT {
 
@@ -142,7 +140,7 @@ public class StreamableMcpAnnotationsIT {
 
 				var httpServer = startHttpServer(serverContext, serverPort);
 
-				clientApplicationContext.withUserConfiguration(TestMcpClientConfiguration.class)
+				this.clientApplicationContext.withUserConfiguration(TestMcpClientConfiguration.class)
 					.withPropertyValues(// @formatter:off
 						"spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:" + serverPort,
 						// "spring.ai.mcp.client.sse.connections.server1.url=http://localhost:" + serverPort,
@@ -223,10 +221,11 @@ public class StreamableMcpAnnotationsIT {
 							.containsEntry("operation", "2 + 3")
 							.containsEntry("timestamp", "2024-01-01T10:00:00Z");
 
-						assertThatJson(calculatorToolResponse.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+						JsonAssertions.assertThatJson(calculatorToolResponse.structuredContent())
+							.when(Option.IGNORING_ARRAY_ORDER)
 							.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
 							.isObject()
-							.isEqualTo(json("""
+							.isEqualTo(JsonAssertions.json("""
 									{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
 
 						assertThat(calculatorToolResponse.meta()).containsEntry("meta1Response", "value1");
@@ -278,7 +277,34 @@ public class StreamableMcpAnnotationsIT {
 			});
 	}
 
+	// Helper methods to start and stop the HTTP server
+	private static DisposableServer startHttpServer(ApplicationContext serverContext, int port) {
+		WebFluxStreamableServerTransportProvider mcpStreamableServerTransport = serverContext
+			.getBean(WebFluxStreamableServerTransportProvider.class);
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(mcpStreamableServerTransport.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		return HttpServer.create().port(port).handle(adapter).bindNow();
+	}
+
+	private static void stopHttpServer(DisposableServer server) {
+		if (server != null) {
+			server.disposeNow();
+		}
+	}
+
+	// Helper method to get the MCP sync client
+	private static McpSyncClient getMcpSyncClient(ApplicationContext clientContext) {
+		ObjectProvider<List<McpSyncClient>> mcpClients = clientContext
+			.getBeanProvider(ResolvableType.forClassWithGenerics(List.class, McpSyncClient.class));
+		return mcpClients.getIfAvailable().get(0);
+	}
+
 	public static class TestMcpServerConfiguration {
+
+		@Bean
+		public McpServerHandlers serverSideSpecProviders() {
+			return new McpServerHandlers();
+		}
 
 		public static class McpServerHandlers {
 
@@ -391,14 +417,19 @@ public class StreamableMcpAnnotationsIT {
 
 		}
 
-		@Bean
-		public McpServerHandlers serverSideSpecProviders() {
-			return new McpServerHandlers();
-		}
-
 	}
 
 	public static class TestMcpClientConfiguration {
+
+		@Bean
+		public TestContext testContext() {
+			return new TestContext();
+		}
+
+		@Bean
+		public TestMcpClientHandlers mcpClientHandlers(TestContext testContext) {
+			return new TestMcpClientHandlers(testContext);
+		}
 
 		public static class TestContext {
 
@@ -420,22 +451,22 @@ public class StreamableMcpAnnotationsIT {
 				this.testContext = testContext;
 			}
 
-			@McpProgress(clientId = "server1")
+			@McpProgress(clients = "server1")
 			public void progressHandler(ProgressNotification progressNotification) {
 				logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
 						progressNotification.progressToken(), progressNotification.progress(),
 						progressNotification.total(), progressNotification.message());
-				testContext.progressNotifications.add(progressNotification);
-				testContext.progressLatch.countDown();
+				this.testContext.progressNotifications.add(progressNotification);
+				this.testContext.progressLatch.countDown();
 			}
 
-			@McpLogging(clientId = "server1")
+			@McpLogging(clients = "server1")
 			public void loggingHandler(LoggingMessageNotification loggingMessage) {
-				testContext.loggingNotificationRef.set(loggingMessage);
+				this.testContext.loggingNotificationRef.set(loggingMessage);
 				logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
 			}
 
-			@McpSampling(clientId = "server1")
+			@McpSampling(clients = "server1")
 			public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
 				logger.info("MCP SAMPLING: {}", llmRequest);
 
@@ -447,7 +478,7 @@ public class StreamableMcpAnnotationsIT {
 					.build();
 			}
 
-			@McpElicitation(clientId = "server1")
+			@McpElicitation(clients = "server1")
 			public ElicitResult elicitationHandler(McpSchema.ElicitRequest request) {
 				logger.info("MCP ELICITATION: {}", request);
 				return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("message", request.message()));
@@ -455,38 +486,6 @@ public class StreamableMcpAnnotationsIT {
 
 		}
 
-		@Bean
-		public TestContext testContext() {
-			return new TestContext();
-		}
-
-		@Bean
-		public TestMcpClientHandlers mcpClientHandlers(TestContext testContext) {
-			return new TestMcpClientHandlers(testContext);
-		}
-
-	}
-
-	// Helper methods to start and stop the HTTP server
-	private static DisposableServer startHttpServer(ApplicationContext serverContext, int port) {
-		WebFluxStreamableServerTransportProvider mcpStreamableServerTransport = serverContext
-			.getBean(WebFluxStreamableServerTransportProvider.class);
-		HttpHandler httpHandler = RouterFunctions.toHttpHandler(mcpStreamableServerTransport.getRouterFunction());
-		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		return HttpServer.create().port(port).handle(adapter).bindNow();
-	}
-
-	private static void stopHttpServer(DisposableServer server) {
-		if (server != null) {
-			server.disposeNow();
-		}
-	}
-
-	// Helper method to get the MCP sync client
-	private static McpSyncClient getMcpSyncClient(ApplicationContext clientContext) {
-		ObjectProvider<List<McpSyncClient>> mcpClients = clientContext
-			.getBeanProvider(ResolvableType.forClassWithGenerics(List.class, McpSyncClient.class));
-		return mcpClients.getIfAvailable().get(0);
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsIT.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.autoconfigure;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.ClientSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.ServerSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.test.util.TestSocketUtils;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.CompleteRequest;
+import io.modelcontextprotocol.spec.McpSchema.CompleteResult;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
+import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
+import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
+import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
+import io.modelcontextprotocol.spec.McpSchema.ModelHint;
+import io.modelcontextprotocol.spec.McpSchema.ModelPreferences;
+import io.modelcontextprotocol.spec.McpSchema.ProgressNotification;
+import io.modelcontextprotocol.spec.McpSchema.PromptMessage;
+import io.modelcontextprotocol.spec.McpSchema.PromptReference;
+import io.modelcontextprotocol.spec.McpSchema.Resource;
+import io.modelcontextprotocol.spec.McpSchema.Role;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import net.javacrumbs.jsonunit.core.Option;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+public class StreamableMcpAnnotationsIT {
+
+	private final ApplicationContextRunner serverContextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.mcp.server.protocol=STREAMABLE")
+		.withConfiguration(AutoConfigurations.of(McpServerAutoConfiguration.class,
+				ToolCallbackConverterAutoConfiguration.class, McpServerStreamableHttpWebFluxAutoConfiguration.class,
+				ServerAnnotationScannerAutoConfiguration.class, ServerSpecificationFactoryAutoConfiguration.class));
+
+	private final ApplicationContextRunner clientApplicationContext = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(McpToolCallbackAutoConfiguration.class,
+				McpClientAutoConfiguration.class, StreamableHttpWebFluxTransportAutoConfiguration.class,
+				ClientAnnotationScannerAutoConfiguration.class, ClientSpecificationFactoryAutoConfiguration.class));
+
+	@Test
+	void clientServerCapabilities() {
+
+		int serverPort = TestSocketUtils.findAvailableTcpPort();
+
+		this.serverContextRunner.withUserConfiguration(TestMcpServerConfiguration.class)
+			.withPropertyValues(// @formatter:off
+				"spring.ai.mcp.server.name=test-mcp-server",
+				// "spring.ai.mcp.server.type=ASYNC",
+				// "spring.ai.mcp.server.protocol=SSE",
+				"spring.ai.mcp.server.version=1.0.0",
+				"spring.ai.mcp.server.streamable-http.keep-alive-interval=1s",
+				// "spring.ai.mcp.server.requestTimeout=1m",
+				"spring.ai.mcp.server.streamable-http.mcp-endpoint=/mcp") // @formatter:on
+			.run(serverContext -> {
+				// Verify all required beans are present
+				assertThat(serverContext).hasSingleBean(WebFluxStreamableServerTransportProvider.class);
+				assertThat(serverContext).hasSingleBean(RouterFunction.class);
+				assertThat(serverContext).hasSingleBean(McpSyncServer.class);
+
+				// Verify server properties are configured correctly
+				McpServerProperties properties = serverContext.getBean(McpServerProperties.class);
+				assertThat(properties.getName()).isEqualTo("test-mcp-server");
+				assertThat(properties.getVersion()).isEqualTo("1.0.0");
+
+				McpServerStreamableHttpProperties streamableHttpProperties = serverContext
+					.getBean(McpServerStreamableHttpProperties.class);
+				assertThat(streamableHttpProperties.getMcpEndpoint()).isEqualTo("/mcp");
+				assertThat(streamableHttpProperties.getKeepAliveInterval()).isEqualTo(Duration.ofSeconds(1));
+
+				var httpServer = startHttpServer(serverContext, serverPort);
+
+				clientApplicationContext.withUserConfiguration(TestMcpClientConfiguration.class)
+					.withPropertyValues(// @formatter:off
+						"spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:" + serverPort,
+						// "spring.ai.mcp.client.sse.connections.server1.url=http://localhost:" + serverPort,
+						// "spring.ai.mcp.client.request-timeout=20m",
+						"spring.ai.mcp.client.initialized=false") // @formatter:on
+					.run(clientContext -> {
+						McpSyncClient mcpClient = getMcpSyncClient(clientContext);
+						assertThat(mcpClient).isNotNull();
+						var initResult = mcpClient.initialize();
+						assertThat(initResult).isNotNull();
+
+						// TOOLS / SAMPLING / ELICITATION
+
+						// tool list
+						assertThat(mcpClient.listTools().tools()).hasSize(2);
+
+						// Call a tool that sends progress notifications
+						CallToolRequest toolRequest = CallToolRequest.builder()
+							.name("tool1")
+							.arguments(Map.of())
+							.progressToken("test-progress-token")
+							.build();
+
+						CallToolResult response = mcpClient.callTool(toolRequest);
+
+						assertThat(response).isNotNull();
+						assertThat(response.isError()).isFalse();
+						String responseText = ((TextContent) response.content().get(0)).text();
+						assertThat(responseText).contains("CALL RESPONSE");
+						assertThat(responseText).contains("Response Test Sampling Message with model hint OpenAi");
+						assertThat(responseText).contains("ElicitResult");
+
+						// PROGRESS
+						TestMcpClientConfiguration.TestContext testContext = clientContext
+							.getBean(TestMcpClientConfiguration.TestContext.class);
+						assertThat(testContext.progressLatch.await(5, TimeUnit.SECONDS))
+							.as("Should receive progress notifications in reasonable time")
+							.isTrue();
+						assertThat(testContext.progressNotifications).hasSize(3);
+
+						Map<String, McpSchema.ProgressNotification> notificationMap = testContext.progressNotifications
+							.stream()
+							.collect(Collectors.toMap(n -> n.message(), n -> n));
+
+						// First notification should be 0.0/1.0 progress
+						assertThat(notificationMap.get("tool call start").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("tool call start").progress()).isEqualTo(0.0);
+						assertThat(notificationMap.get("tool call start").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("tool call start").message()).isEqualTo("tool call start");
+
+						// Second notification should be 1.0/1.0 progress
+						assertThat(notificationMap.get("elicitation completed").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("elicitation completed").progress()).isEqualTo(0.5);
+						assertThat(notificationMap.get("elicitation completed").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("elicitation completed").message())
+							.isEqualTo("elicitation completed");
+
+						// Third notification should be 0.5/1.0 progress
+						assertThat(notificationMap.get("sampling completed").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("sampling completed").progress()).isEqualTo(1.0);
+						assertThat(notificationMap.get("sampling completed").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("sampling completed").message()).isEqualTo("sampling completed");
+
+						// TOOL STRUCTURED OUTPUT
+						// Call tool with valid structured output
+						CallToolResult calculatorToolResponse = mcpClient.callTool(new McpSchema.CallToolRequest(
+								"calculator", Map.of("expression", "2 + 3"), Map.of("meta1", "value1")));
+
+						assertThat(calculatorToolResponse).isNotNull();
+						assertThat(calculatorToolResponse.isError()).isFalse();
+
+						assertThat(calculatorToolResponse.structuredContent()).isNotNull();
+
+						assertThat(calculatorToolResponse.structuredContent()).containsEntry("result", 5.0)
+							.containsEntry("operation", "2 + 3")
+							.containsEntry("timestamp", "2024-01-01T10:00:00Z");
+
+						assertThatJson(calculatorToolResponse.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+							.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+							.isObject()
+							.isEqualTo(json("""
+									{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
+
+						assertThat(calculatorToolResponse.meta()).containsEntry("meta1Response", "value1");
+
+						// RESOURCES
+						assertThat(mcpClient.listResources()).isNotNull();
+						assertThat(mcpClient.listResources().resources()).hasSize(1);
+						assertThat(mcpClient.listResources().resources().get(0))
+							.isEqualToComparingFieldByFieldRecursively(Resource.builder()
+								.uri("file://resource")
+								.name("Test Resource")
+								.mimeType("text/plain")
+								.description("Test resource description")
+								.build());
+
+						// PROMPT / COMPLETION
+
+						// list prompts
+						assertThat(mcpClient.listPrompts()).isNotNull();
+						assertThat(mcpClient.listPrompts().prompts()).hasSize(1);
+
+						// get prompt
+						GetPromptResult promptResult = mcpClient
+							.getPrompt(new GetPromptRequest("code-completion", Map.of("language", "java")));
+						assertThat(promptResult).isNotNull();
+
+						// completion
+						CompleteRequest completeRequest = new CompleteRequest(
+								new PromptReference("ref/prompt", "code-completion", "Code completion"),
+								new CompleteRequest.CompleteArgument("language", "py"));
+
+						CompleteResult completeResult = mcpClient.completeCompletion(completeRequest);
+
+						assertThat(completeResult).isNotNull();
+						assertThat(completeResult.completion().total()).isEqualTo(10);
+						assertThat(completeResult.completion().values()).containsExactly("python", "pytorch", "pyside");
+						assertThat(completeResult.meta()).isNull();
+
+						// logging message
+						var logMessage = testContext.loggingNotificationRef.get();
+						assertThat(logMessage).isNotNull();
+						assertThat(logMessage.level()).isEqualTo(LoggingLevel.INFO);
+						assertThat(logMessage.logger()).isEqualTo("test-logger");
+						assertThat(logMessage.data()).contains("User prompt");
+
+					});
+
+				stopHttpServer(httpServer);
+			});
+	}
+
+	public static class TestMcpServerConfiguration {
+
+		public static class McpServerHandlers {
+
+			@McpTool(description = "Test tool", name = "tool1")
+			public String toolWithSamplingAndElicitation(McpSyncServerExchange exchange, @McpToolParam String input,
+					@McpProgressToken String progressToken) {
+
+				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Started!").build());
+
+				exchange.progressNotification(new ProgressNotification(progressToken, 0.0, 1.0, "tool call start"));
+
+				exchange.ping(); // call client ping
+
+				// call elicitation
+				var elicitationRequest = McpSchema.ElicitRequest.builder()
+					.message("Test message")
+					.requestedSchema(
+							Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
+					.build();
+
+				ElicitResult elicitationResult = exchange.createElicitation(elicitationRequest);
+
+				exchange
+					.progressNotification(new ProgressNotification(progressToken, 0.50, 1.0, "elicitation completed"));
+
+				// call sampling
+				var createMessageRequest = McpSchema.CreateMessageRequest.builder()
+					.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+							new McpSchema.TextContent("Test Sampling Message"))))
+					.modelPreferences(ModelPreferences.builder()
+						.hints(List.of(ModelHint.of("OpenAi"), ModelHint.of("Ollama")))
+						.costPriority(1.0)
+						.speedPriority(1.0)
+						.intelligencePriority(1.0)
+						.build())
+					.build();
+
+				CreateMessageResult samplingResponse = exchange.createMessage(createMessageRequest);
+
+				exchange.progressNotification(new ProgressNotification(progressToken, 1.0, 1.0, "sampling completed"));
+
+				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Done!").build());
+
+				return "CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString();
+			}
+
+			@McpTool(name = "calculator", description = "Performs mathematical calculations")
+			public CallToolResult calculator(@McpToolParam String expression, McpMeta meta) {
+				double result = evaluateExpression(expression);
+				return CallToolResult.builder()
+					.structuredContent(
+							Map.of("result", result, "operation", expression, "timestamp", "2024-01-01T10:00:00Z"))
+					.meta(Map.of("meta1Response", meta.get("meta1")))
+					.build();
+			}
+
+			private static double evaluateExpression(String expression) {
+				// Simple expression evaluator for testing
+				return switch (expression) {
+					case "2 + 3" -> 5.0;
+					case "10 * 2" -> 20.0;
+					case "7 + 8" -> 15.0;
+					case "5 + 3" -> 8.0;
+					default -> 0.0;
+				};
+			}
+
+			@McpResource(name = "Test Resource", uri = "file://resource", mimeType = "text/plain",
+					description = "Test resource description")
+			public McpSchema.ReadResourceResult testResource(McpSchema.ReadResourceRequest request) {
+				try {
+					var systemInfo = Map.of("os", System.getProperty("os.name"), "os_version",
+							System.getProperty("os.version"), "java_version", System.getProperty("java.version"));
+					String jsonContent = new ObjectMapper().writeValueAsString(systemInfo);
+					return new McpSchema.ReadResourceResult(List
+						.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)));
+				}
+				catch (Exception e) {
+					throw new RuntimeException("Failed to generate system info", e);
+				}
+			}
+
+			@McpPrompt(name = "code-completion", description = "this is code review prompt")
+			public McpSchema.GetPromptResult codeCompletionPrompt(McpSyncServerExchange exchange,
+					@McpArg(name = "language", required = false) String languageArgument) {
+
+				if (languageArgument == null) {
+					languageArgument = "java";
+				}
+
+				exchange.loggingNotification(LoggingMessageNotification.builder()
+					.logger("test-logger")
+					.data("User prompt: Hello " + languageArgument + "! How can I assist you today?")
+					.build());
+
+				var userMessage = new PromptMessage(Role.USER,
+						new TextContent("Hello " + languageArgument + "! How can I assist you today?"));
+
+				return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+			}
+
+			@McpComplete(prompt = "code-completion") // the code-completion is a reference
+														// to the prompt code completion
+			public McpSchema.CompleteResult codeCompletion() {
+				var expectedValues = List.of("python", "pytorch", "pyside");
+				return new McpSchema.CompleteResult(new CompleteResult.CompleteCompletion(expectedValues, 10, // total
+						true // hasMore
+				));
+			}
+
+		}
+
+		@Bean
+		public McpServerHandlers serverSideSpecProviders() {
+			return new McpServerHandlers();
+		}
+
+	}
+
+	public static class TestMcpClientConfiguration {
+
+		public static class TestContext {
+
+			final AtomicReference<LoggingMessageNotification> loggingNotificationRef = new AtomicReference<>();
+
+			final CountDownLatch progressLatch = new CountDownLatch(3);
+
+			final List<McpSchema.ProgressNotification> progressNotifications = new CopyOnWriteArrayList<>();
+
+		}
+
+		public static class TestMcpClientHandlers {
+
+			private static final Logger logger = LoggerFactory.getLogger(TestMcpClientHandlers.class);
+
+			private TestContext testContext;
+
+			public TestMcpClientHandlers(TestContext testContext) {
+				this.testContext = testContext;
+			}
+
+			@McpProgress(clientId = "server1")
+			public void progressHandler(ProgressNotification progressNotification) {
+				logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
+						progressNotification.progressToken(), progressNotification.progress(),
+						progressNotification.total(), progressNotification.message());
+				testContext.progressNotifications.add(progressNotification);
+				testContext.progressLatch.countDown();
+			}
+
+			@McpLogging(clientId = "server1")
+			public void loggingHandler(LoggingMessageNotification loggingMessage) {
+				testContext.loggingNotificationRef.set(loggingMessage);
+				logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
+			}
+
+			@McpSampling(clientId = "server1")
+			public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
+				logger.info("MCP SAMPLING: {}", llmRequest);
+
+				String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
+				String modelHint = llmRequest.modelPreferences().hints().get(0).name();
+
+				return CreateMessageResult.builder()
+					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+					.build();
+			}
+
+			@McpElicitation(clientId = "server1")
+			public ElicitResult elicitationHandler(McpSchema.ElicitRequest request) {
+				logger.info("MCP ELICITATION: {}", request);
+				return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("message", request.message()));
+			}
+
+		}
+
+		@Bean
+		public TestContext testContext() {
+			return new TestContext();
+		}
+
+		@Bean
+		public TestMcpClientHandlers mcpClientHandlers(TestContext testContext) {
+			return new TestMcpClientHandlers(testContext);
+		}
+
+	}
+
+	// Helper methods to start and stop the HTTP server
+	private static DisposableServer startHttpServer(ApplicationContext serverContext, int port) {
+		WebFluxStreamableServerTransportProvider mcpStreamableServerTransport = serverContext
+			.getBean(WebFluxStreamableServerTransportProvider.class);
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(mcpStreamableServerTransport.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		return HttpServer.create().port(port).handle(adapter).bindNow();
+	}
+
+	private static void stopHttpServer(DisposableServer server) {
+		if (server != null) {
+			server.disposeNow();
+		}
+	}
+
+	// Helper method to get the MCP sync client
+	private static McpSyncClient getMcpSyncClient(ApplicationContext clientContext) {
+		ObjectProvider<List<McpSyncClient>> mcpClients = clientContext
+			.getBeanProvider(ResolvableType.forClassWithGenerics(List.class, McpSyncClient.class));
+		return mcpClients.getIfAvailable().get(0);
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsManualIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsManualIT.java
@@ -1,0 +1,531 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.autoconfigure;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
+import org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.test.util.TestSocketUtils;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.CompleteRequest;
+import io.modelcontextprotocol.spec.McpSchema.CompleteResult;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+import io.modelcontextprotocol.spec.McpSchema.ElicitResult;
+import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
+import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
+import io.modelcontextprotocol.spec.McpSchema.LoggingLevel;
+import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
+import io.modelcontextprotocol.spec.McpSchema.ModelHint;
+import io.modelcontextprotocol.spec.McpSchema.ModelPreferences;
+import io.modelcontextprotocol.spec.McpSchema.ProgressNotification;
+import io.modelcontextprotocol.spec.McpSchema.PromptMessage;
+import io.modelcontextprotocol.spec.McpSchema.PromptReference;
+import io.modelcontextprotocol.spec.McpSchema.Resource;
+import io.modelcontextprotocol.spec.McpSchema.Role;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import net.javacrumbs.jsonunit.core.Option;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+public class StreamableMcpAnnotationsManualIT {
+
+	private final ApplicationContextRunner serverContextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.mcp.server.protocol=STREAMABLE")
+		.withConfiguration(AutoConfigurations.of(McpServerAutoConfiguration.class,
+				ToolCallbackConverterAutoConfiguration.class, McpServerStreamableHttpWebFluxAutoConfiguration.class));
+
+	private final ApplicationContextRunner clientApplicationContext = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(McpToolCallbackAutoConfiguration.class,
+				McpClientAutoConfiguration.class, StreamableHttpWebFluxTransportAutoConfiguration.class));
+
+	@Test
+	void clientServerCapabilities() {
+
+		int serverPort = TestSocketUtils.findAvailableTcpPort();
+
+		this.serverContextRunner.withUserConfiguration(TestMcpServerConfiguration.class)
+			.withPropertyValues(// @formatter:off
+				"spring.ai.mcp.server.name=test-mcp-server",
+				"spring.ai.mcp.server.version=1.0.0",
+				"spring.ai.mcp.server.streamable-http.keep-alive-interval=1s",
+				// "spring.ai.mcp.server.requestTimeout=1m",
+				"spring.ai.mcp.server.streamable-http.mcp-endpoint=/mcp") // @formatter:on
+			.run(serverContext -> {
+				// Verify all required beans are present
+				assertThat(serverContext).hasSingleBean(WebFluxStreamableServerTransportProvider.class);
+				assertThat(serverContext).hasSingleBean(RouterFunction.class);
+				assertThat(serverContext).hasSingleBean(McpSyncServer.class);
+
+				// Verify server properties are configured correctly
+				McpServerProperties properties = serverContext.getBean(McpServerProperties.class);
+				assertThat(properties.getName()).isEqualTo("test-mcp-server");
+				assertThat(properties.getVersion()).isEqualTo("1.0.0");
+
+				McpServerStreamableHttpProperties streamableHttpProperties = serverContext
+					.getBean(McpServerStreamableHttpProperties.class);
+				assertThat(streamableHttpProperties.getMcpEndpoint()).isEqualTo("/mcp");
+				assertThat(streamableHttpProperties.getKeepAliveInterval()).isEqualTo(Duration.ofSeconds(1));
+
+				var httpServer = startHttpServer(serverContext, serverPort);
+
+				clientApplicationContext.withUserConfiguration(TestMcpClientConfiguration.class)
+					.withPropertyValues(// @formatter:off
+						"spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:" + serverPort,
+						// "spring.ai.mcp.client.request-timeout=20m",
+						"spring.ai.mcp.client.initialized=false") // @formatter:on
+					.run(clientContext -> {
+						McpSyncClient mcpClient = getMcpSyncClient(clientContext);
+						assertThat(mcpClient).isNotNull();
+						var initResult = mcpClient.initialize();
+						assertThat(initResult).isNotNull();
+
+						// TOOLS / SAMPLING / ELICITATION
+
+						// tool list
+						assertThat(mcpClient.listTools().tools()).hasSize(2);
+
+						// Call a tool that sends progress notifications
+						CallToolRequest toolRequest = CallToolRequest.builder()
+							.name("tool1")
+							.arguments(Map.of())
+							.progressToken("test-progress-token")
+							.build();
+
+						CallToolResult response = mcpClient.callTool(toolRequest);
+
+						assertThat(response).isNotNull();
+						assertThat(response.isError()).isFalse();
+						String responseText = ((TextContent) response.content().get(0)).text();
+						assertThat(responseText).contains("CALL RESPONSE");
+						assertThat(responseText).contains("Response Test Sampling Message with model hint OpenAi");
+						assertThat(responseText).contains("ElicitResult");
+
+						// PROGRESS
+						TestMcpClientConfiguration.TestContext testContext = clientContext
+							.getBean(TestMcpClientConfiguration.TestContext.class);
+						assertThat(testContext.progressLatch.await(5, TimeUnit.SECONDS))
+							.as("Should receive progress notifications in reasonable time")
+							.isTrue();
+						assertThat(testContext.progressNotifications).hasSize(3);
+
+						Map<String, McpSchema.ProgressNotification> notificationMap = testContext.progressNotifications
+							.stream()
+							.collect(Collectors.toMap(n -> n.message(), n -> n));
+
+						// First notification should be 0.0/1.0 progress
+						assertThat(notificationMap.get("tool call start").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("tool call start").progress()).isEqualTo(0.0);
+						assertThat(notificationMap.get("tool call start").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("tool call start").message()).isEqualTo("tool call start");
+
+						// Second notification should be 1.0/1.0 progress
+						assertThat(notificationMap.get("elicitation completed").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("elicitation completed").progress()).isEqualTo(0.5);
+						assertThat(notificationMap.get("elicitation completed").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("elicitation completed").message())
+							.isEqualTo("elicitation completed");
+
+						// Third notification should be 0.5/1.0 progress
+						assertThat(notificationMap.get("sampling completed").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("sampling completed").progress()).isEqualTo(1.0);
+						assertThat(notificationMap.get("sampling completed").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("sampling completed").message()).isEqualTo("sampling completed");
+
+						// TOOL STRUCTURED OUTPUT
+						// Call tool with valid structured output
+						CallToolResult calculatorToolResponse = mcpClient.callTool(new McpSchema.CallToolRequest(
+								"calculator", Map.of("expression", "2 + 3"), Map.of("meta1", "value1")));
+
+						assertThat(calculatorToolResponse).isNotNull();
+						assertThat(calculatorToolResponse.isError()).isFalse();
+
+						assertThat(calculatorToolResponse.structuredContent()).isNotNull();
+
+						assertThat(calculatorToolResponse.structuredContent()).containsEntry("result", 5.0)
+							.containsEntry("operation", "2 + 3")
+							.containsEntry("timestamp", "2024-01-01T10:00:00Z");
+
+						assertThatJson(calculatorToolResponse.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+							.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
+							.isObject()
+							.isEqualTo(json("""
+									{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
+
+						assertThat(calculatorToolResponse.meta()).containsEntry("meta1Response", "value1");
+
+						// RESOURCES
+						assertThat(mcpClient.listResources()).isNotNull();
+						assertThat(mcpClient.listResources().resources()).hasSize(1);
+						assertThat(mcpClient.listResources().resources().get(0))
+							.isEqualToComparingFieldByFieldRecursively(Resource.builder()
+								.uri("file://resource")
+								.name("Test Resource")
+								.mimeType("text/plain")
+								.description("Test resource description")
+								.build());
+
+						// PROMPT / COMPLETION
+
+						// list prompts
+						assertThat(mcpClient.listPrompts()).isNotNull();
+						assertThat(mcpClient.listPrompts().prompts()).hasSize(1);
+
+						// get prompt
+						GetPromptResult promptResult = mcpClient
+							.getPrompt(new GetPromptRequest("code-completion", Map.of("language", "java")));
+						assertThat(promptResult).isNotNull();
+
+						// completion
+						CompleteRequest completeRequest = new CompleteRequest(
+								new PromptReference("ref/prompt", "code-completion", "Code completion"),
+								new CompleteRequest.CompleteArgument("language", "py"));
+
+						CompleteResult completeResult = mcpClient.completeCompletion(completeRequest);
+
+						assertThat(completeResult).isNotNull();
+						assertThat(completeResult.completion().total()).isEqualTo(10);
+						assertThat(completeResult.completion().values()).containsExactly("python", "pytorch", "pyside");
+						assertThat(completeResult.meta()).isNull();
+
+						// logging message
+						var logMessage = testContext.loggingNotificationRef.get();
+						assertThat(logMessage).isNotNull();
+						assertThat(logMessage.level()).isEqualTo(LoggingLevel.INFO);
+						assertThat(logMessage.logger()).isEqualTo("test-logger");
+						assertThat(logMessage.data()).contains("User prompt");
+
+					});
+
+				stopHttpServer(httpServer);
+			});
+	}
+
+	public static class TestMcpServerConfiguration {
+
+		public static class McpServerHandlers {
+
+			@McpTool(description = "Test tool", name = "tool1")
+			public String toolWithSamplingAndElicitation(McpSyncServerExchange exchange, @McpToolParam String input,
+					@McpProgressToken String progressToken) {
+
+				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Started!").build());
+
+				exchange.progressNotification(new ProgressNotification(progressToken, 0.0, 1.0, "tool call start"));
+
+				exchange.ping(); // call client ping
+
+				// call elicitation
+				var elicitationRequest = McpSchema.ElicitRequest.builder()
+					.message("Test message")
+					.requestedSchema(
+							Map.of("type", "object", "properties", Map.of("message", Map.of("type", "string"))))
+					.build();
+
+				ElicitResult elicitationResult = exchange.createElicitation(elicitationRequest);
+
+				exchange
+					.progressNotification(new ProgressNotification(progressToken, 0.50, 1.0, "elicitation completed"));
+
+				// call sampling
+				var createMessageRequest = McpSchema.CreateMessageRequest.builder()
+					.messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+							new McpSchema.TextContent("Test Sampling Message"))))
+					.modelPreferences(ModelPreferences.builder()
+						.hints(List.of(ModelHint.of("OpenAi"), ModelHint.of("Ollama")))
+						.costPriority(1.0)
+						.speedPriority(1.0)
+						.intelligencePriority(1.0)
+						.build())
+					.build();
+
+				CreateMessageResult samplingResponse = exchange.createMessage(createMessageRequest);
+
+				exchange.progressNotification(new ProgressNotification(progressToken, 1.0, 1.0, "sampling completed"));
+
+				exchange.loggingNotification(LoggingMessageNotification.builder().data("Tool1 Done!").build());
+
+				return "CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString();
+			}
+
+			@McpTool(name = "calculator", description = "Performs mathematical calculations")
+			public CallToolResult calculator(@McpToolParam String expression, McpMeta meta) {
+				double result = evaluateExpression(expression);
+				return CallToolResult.builder()
+					.structuredContent(
+							Map.of("result", result, "operation", expression, "timestamp", "2024-01-01T10:00:00Z"))
+					.meta(Map.of("meta1Response", meta.get("meta1")))
+					.build();
+			}
+
+			private static double evaluateExpression(String expression) {
+				// Simple expression evaluator for testing
+				return switch (expression) {
+					case "2 + 3" -> 5.0;
+					case "10 * 2" -> 20.0;
+					case "7 + 8" -> 15.0;
+					case "5 + 3" -> 8.0;
+					default -> 0.0;
+				};
+			}
+
+			@McpResource(name = "Test Resource", uri = "file://resource", mimeType = "text/plain",
+					description = "Test resource description")
+			public McpSchema.ReadResourceResult testResource(McpSchema.ReadResourceRequest request) {
+				try {
+					var systemInfo = Map.of("os", System.getProperty("os.name"), "os_version",
+							System.getProperty("os.version"), "java_version", System.getProperty("java.version"));
+					String jsonContent = new ObjectMapper().writeValueAsString(systemInfo);
+					return new McpSchema.ReadResourceResult(List
+						.of(new McpSchema.TextResourceContents(request.uri(), "application/json", jsonContent)));
+				}
+				catch (Exception e) {
+					throw new RuntimeException("Failed to generate system info", e);
+				}
+			}
+
+			@McpPrompt(name = "code-completion", description = "this is code review prompt")
+			public McpSchema.GetPromptResult codeCompletionPrompt(McpSyncServerExchange exchange,
+					@McpArg(name = "language", required = false) String languageArgument) {
+
+				if (languageArgument == null) {
+					languageArgument = "java";
+				}
+
+				exchange.loggingNotification(LoggingMessageNotification.builder()
+					.logger("test-logger")
+					.data("User prompt: Hello " + languageArgument + "! How can I assist you today?")
+					.build());
+
+				var userMessage = new PromptMessage(Role.USER,
+						new TextContent("Hello " + languageArgument + "! How can I assist you today?"));
+
+				return new GetPromptResult("A personalized greeting message", List.of(userMessage));
+			}
+
+			@McpComplete(prompt = "code-completion") // the code-completion is a reference
+														// to the prompt code completion
+			public McpSchema.CompleteResult codeCompletion() {
+				var expectedValues = List.of("python", "pytorch", "pyside");
+				return new McpSchema.CompleteResult(new CompleteResult.CompleteCompletion(expectedValues, 10, // total
+						true // hasMore
+				));
+			}
+
+		}
+
+		@Bean
+		public McpServerHandlers serverSideSpecProviders() {
+			return new McpServerHandlers();
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncToolSpecification> myTools(McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.toolSpecifications(List.of(serverSideSpecProviders));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncResourceSpecification> myResources(
+				McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.resourceSpecifications(List.of(serverSideSpecProviders));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncPromptSpecification> myPrompts(McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.promptSpecifications(List.of(serverSideSpecProviders));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncCompletionSpecification> myCompletions(
+				McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.completeSpecifications(List.of(serverSideSpecProviders));
+		}
+
+	}
+
+	public static class TestMcpClientConfiguration {
+
+		public static class TestContext {
+
+			final AtomicReference<LoggingMessageNotification> loggingNotificationRef = new AtomicReference<>();
+
+			final CountDownLatch progressLatch = new CountDownLatch(3);
+
+			final List<McpSchema.ProgressNotification> progressNotifications = new CopyOnWriteArrayList<>();
+
+		}
+
+		public static class McpClientHandlers {
+
+			private static final Logger logger = LoggerFactory.getLogger(McpClientHandlers.class);
+
+			private TestContext testContext;
+
+			public McpClientHandlers(TestContext testContext) {
+				this.testContext = testContext;
+			}
+
+			@McpProgress(clientId = "server1")
+			public void progressHandler(ProgressNotification progressNotification) {
+				logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
+						progressNotification.progressToken(), progressNotification.progress(),
+						progressNotification.total(), progressNotification.message());
+				testContext.progressNotifications.add(progressNotification);
+				testContext.progressLatch.countDown();
+			}
+
+			@McpLogging(clientId = "server1")
+			public void loggingHandler(LoggingMessageNotification loggingMessage) {
+				testContext.loggingNotificationRef.set(loggingMessage);
+				logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
+			}
+
+			@McpSampling(clientId = "server1")
+			public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
+				logger.info("MCP SAMPLING: {}", llmRequest);
+
+				String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
+				String modelHint = llmRequest.modelPreferences().hints().get(0).name();
+
+				return CreateMessageResult.builder()
+					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+					.build();
+			}
+
+			@McpElicitation(clientId = "server1")
+			public ElicitResult elicitationHandler(McpSchema.ElicitRequest request) {
+				logger.info("MCP ELICITATION: {}", request);
+				return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("message", request.message()));
+			}
+
+		}
+
+		@Bean
+		public TestContext testContext() {
+			return new TestContext();
+		}
+
+		@Bean
+		public McpClientHandlers mcpClientHandlers(TestContext testContext) {
+			return new McpClientHandlers(testContext);
+		}
+
+		@Bean
+		List<SyncLoggingSpecification> loggingSpecs(McpClientHandlers clientMcpHandlers) {
+			return SyncMcpAnnotationProviders.loggingSpecifications(List.of(clientMcpHandlers));
+		}
+
+		@Bean
+		List<SyncSamplingSpecification> samplingSpecs(McpClientHandlers clientMcpHandlers) {
+			return SyncMcpAnnotationProviders.samplingSpecifications(List.of(clientMcpHandlers));
+		}
+
+		@Bean
+		List<SyncElicitationSpecification> elicitationSpecs(McpClientHandlers clientMcpHandlers) {
+			return SyncMcpAnnotationProviders.elicitationSpecifications(List.of(clientMcpHandlers));
+		}
+
+		@Bean
+		List<SyncProgressSpecification> progressSpecs(McpClientHandlers clientMcpHandlers) {
+			return SyncMcpAnnotationProviders.progressSpecifications(List.of(clientMcpHandlers));
+		}
+
+	}
+
+	// Helper methods to start and stop the HTTP server
+	private static DisposableServer startHttpServer(ApplicationContext serverContext, int port) {
+		WebFluxStreamableServerTransportProvider mcpStreamableServerTransport = serverContext
+			.getBean(WebFluxStreamableServerTransportProvider.class);
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(mcpStreamableServerTransport.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		return HttpServer.create().port(port).handle(adapter).bindNow();
+	}
+
+	private static void stopHttpServer(DisposableServer server) {
+		if (server != null) {
+			server.disposeNow();
+		}
+	}
+
+	// Helper method to get the MCP sync client
+	private static McpSyncClient getMcpSyncClient(ApplicationContext clientContext) {
+		ObjectProvider<List<McpSyncClient>> mcpClients = clientContext
+			.getBeanProvider(ResolvableType.forClassWithGenerics(List.class, McpSyncClient.class));
+		return mcpClients.getIfAvailable().get(0);
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsManualIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsManualIT.java
@@ -16,10 +16,6 @@
 
 package org.springframework.ai.mcp.server.autoconfigure;
 
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -29,47 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springaicommunity.mcp.annotation.McpArg;
-import org.springaicommunity.mcp.annotation.McpComplete;
-import org.springaicommunity.mcp.annotation.McpElicitation;
-import org.springaicommunity.mcp.annotation.McpLogging;
-import org.springaicommunity.mcp.annotation.McpMeta;
-import org.springaicommunity.mcp.annotation.McpProgress;
-import org.springaicommunity.mcp.annotation.McpProgressToken;
-import org.springaicommunity.mcp.annotation.McpPrompt;
-import org.springaicommunity.mcp.annotation.McpResource;
-import org.springaicommunity.mcp.annotation.McpSampling;
-import org.springaicommunity.mcp.annotation.McpTool;
-import org.springaicommunity.mcp.annotation.McpToolParam;
-import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
-import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
-import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
-import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
-import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
-import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
-import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
-import org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
-import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
-import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.ResolvableType;
-import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
-import org.springframework.test.util.TestSocketUtils;
-import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.RouterFunctions;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
@@ -95,9 +51,51 @@ import io.modelcontextprotocol.spec.McpSchema.PromptReference;
 import io.modelcontextprotocol.spec.McpSchema.Resource;
 import io.modelcontextprotocol.spec.McpSchema.Role;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpMeta;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
+import org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.test.util.TestSocketUtils;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StreamableMcpAnnotationsManualIT {
 
@@ -140,7 +138,7 @@ public class StreamableMcpAnnotationsManualIT {
 
 				var httpServer = startHttpServer(serverContext, serverPort);
 
-				clientApplicationContext.withUserConfiguration(TestMcpClientConfiguration.class)
+				this.clientApplicationContext.withUserConfiguration(TestMcpClientConfiguration.class)
 					.withPropertyValues(// @formatter:off
 						"spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:" + serverPort,
 						// "spring.ai.mcp.client.request-timeout=20m",
@@ -220,10 +218,11 @@ public class StreamableMcpAnnotationsManualIT {
 							.containsEntry("operation", "2 + 3")
 							.containsEntry("timestamp", "2024-01-01T10:00:00Z");
 
-						assertThatJson(calculatorToolResponse.structuredContent()).when(Option.IGNORING_ARRAY_ORDER)
+						JsonAssertions.assertThatJson(calculatorToolResponse.structuredContent())
+							.when(Option.IGNORING_ARRAY_ORDER)
 							.when(Option.IGNORING_EXTRA_ARRAY_ITEMS)
 							.isObject()
-							.isEqualTo(json("""
+							.isEqualTo(JsonAssertions.json("""
 									{"result":5.0,"operation":"2 + 3","timestamp":"2024-01-01T10:00:00Z"}"""));
 
 						assertThat(calculatorToolResponse.meta()).containsEntry("meta1Response", "value1");
@@ -275,7 +274,56 @@ public class StreamableMcpAnnotationsManualIT {
 			});
 	}
 
+	// Helper methods to start and stop the HTTP server
+	private static DisposableServer startHttpServer(ApplicationContext serverContext, int port) {
+		WebFluxStreamableServerTransportProvider mcpStreamableServerTransport = serverContext
+			.getBean(WebFluxStreamableServerTransportProvider.class);
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(mcpStreamableServerTransport.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		return HttpServer.create().port(port).handle(adapter).bindNow();
+	}
+
+	private static void stopHttpServer(DisposableServer server) {
+		if (server != null) {
+			server.disposeNow();
+		}
+	}
+
+	// Helper method to get the MCP sync client
+	private static McpSyncClient getMcpSyncClient(ApplicationContext clientContext) {
+		ObjectProvider<List<McpSyncClient>> mcpClients = clientContext
+			.getBeanProvider(ResolvableType.forClassWithGenerics(List.class, McpSyncClient.class));
+		return mcpClients.getIfAvailable().get(0);
+	}
+
 	public static class TestMcpServerConfiguration {
+
+		@Bean
+		public McpServerHandlers serverSideSpecProviders() {
+			return new McpServerHandlers();
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncToolSpecification> myTools(McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.toolSpecifications(List.of(serverSideSpecProviders));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncResourceSpecification> myResources(
+				McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.resourceSpecifications(List.of(serverSideSpecProviders));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncPromptSpecification> myPrompts(McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.promptSpecifications(List.of(serverSideSpecProviders));
+		}
+
+		@Bean
+		public List<McpServerFeatures.SyncCompletionSpecification> myCompletions(
+				McpServerHandlers serverSideSpecProviders) {
+			return SyncMcpAnnotationProviders.completeSpecifications(List.of(serverSideSpecProviders));
+		}
 
 		public static class McpServerHandlers {
 
@@ -388,91 +436,9 @@ public class StreamableMcpAnnotationsManualIT {
 
 		}
 
-		@Bean
-		public McpServerHandlers serverSideSpecProviders() {
-			return new McpServerHandlers();
-		}
-
-		@Bean
-		public List<McpServerFeatures.SyncToolSpecification> myTools(McpServerHandlers serverSideSpecProviders) {
-			return SyncMcpAnnotationProviders.toolSpecifications(List.of(serverSideSpecProviders));
-		}
-
-		@Bean
-		public List<McpServerFeatures.SyncResourceSpecification> myResources(
-				McpServerHandlers serverSideSpecProviders) {
-			return SyncMcpAnnotationProviders.resourceSpecifications(List.of(serverSideSpecProviders));
-		}
-
-		@Bean
-		public List<McpServerFeatures.SyncPromptSpecification> myPrompts(McpServerHandlers serverSideSpecProviders) {
-			return SyncMcpAnnotationProviders.promptSpecifications(List.of(serverSideSpecProviders));
-		}
-
-		@Bean
-		public List<McpServerFeatures.SyncCompletionSpecification> myCompletions(
-				McpServerHandlers serverSideSpecProviders) {
-			return SyncMcpAnnotationProviders.completeSpecifications(List.of(serverSideSpecProviders));
-		}
-
 	}
 
 	public static class TestMcpClientConfiguration {
-
-		public static class TestContext {
-
-			final AtomicReference<LoggingMessageNotification> loggingNotificationRef = new AtomicReference<>();
-
-			final CountDownLatch progressLatch = new CountDownLatch(3);
-
-			final List<McpSchema.ProgressNotification> progressNotifications = new CopyOnWriteArrayList<>();
-
-		}
-
-		public static class McpClientHandlers {
-
-			private static final Logger logger = LoggerFactory.getLogger(McpClientHandlers.class);
-
-			private TestContext testContext;
-
-			public McpClientHandlers(TestContext testContext) {
-				this.testContext = testContext;
-			}
-
-			@McpProgress(clientId = "server1")
-			public void progressHandler(ProgressNotification progressNotification) {
-				logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
-						progressNotification.progressToken(), progressNotification.progress(),
-						progressNotification.total(), progressNotification.message());
-				testContext.progressNotifications.add(progressNotification);
-				testContext.progressLatch.countDown();
-			}
-
-			@McpLogging(clientId = "server1")
-			public void loggingHandler(LoggingMessageNotification loggingMessage) {
-				testContext.loggingNotificationRef.set(loggingMessage);
-				logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
-			}
-
-			@McpSampling(clientId = "server1")
-			public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
-				logger.info("MCP SAMPLING: {}", llmRequest);
-
-				String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
-				String modelHint = llmRequest.modelPreferences().hints().get(0).name();
-
-				return CreateMessageResult.builder()
-					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
-					.build();
-			}
-
-			@McpElicitation(clientId = "server1")
-			public ElicitResult elicitationHandler(McpSchema.ElicitRequest request) {
-				logger.info("MCP ELICITATION: {}", request);
-				return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("message", request.message()));
-			}
-
-		}
 
 		@Bean
 		public TestContext testContext() {
@@ -504,28 +470,61 @@ public class StreamableMcpAnnotationsManualIT {
 			return SyncMcpAnnotationProviders.progressSpecifications(List.of(clientMcpHandlers));
 		}
 
-	}
+		public static class TestContext {
 
-	// Helper methods to start and stop the HTTP server
-	private static DisposableServer startHttpServer(ApplicationContext serverContext, int port) {
-		WebFluxStreamableServerTransportProvider mcpStreamableServerTransport = serverContext
-			.getBean(WebFluxStreamableServerTransportProvider.class);
-		HttpHandler httpHandler = RouterFunctions.toHttpHandler(mcpStreamableServerTransport.getRouterFunction());
-		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		return HttpServer.create().port(port).handle(adapter).bindNow();
-	}
+			final AtomicReference<LoggingMessageNotification> loggingNotificationRef = new AtomicReference<>();
 
-	private static void stopHttpServer(DisposableServer server) {
-		if (server != null) {
-			server.disposeNow();
+			final CountDownLatch progressLatch = new CountDownLatch(3);
+
+			final List<McpSchema.ProgressNotification> progressNotifications = new CopyOnWriteArrayList<>();
+
 		}
-	}
 
-	// Helper method to get the MCP sync client
-	private static McpSyncClient getMcpSyncClient(ApplicationContext clientContext) {
-		ObjectProvider<List<McpSyncClient>> mcpClients = clientContext
-			.getBeanProvider(ResolvableType.forClassWithGenerics(List.class, McpSyncClient.class));
-		return mcpClients.getIfAvailable().get(0);
+		public static class McpClientHandlers {
+
+			private static final Logger logger = LoggerFactory.getLogger(McpClientHandlers.class);
+
+			private TestContext testContext;
+
+			public McpClientHandlers(TestContext testContext) {
+				this.testContext = testContext;
+			}
+
+			@McpProgress(clients = "server1")
+			public void progressHandler(ProgressNotification progressNotification) {
+				logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
+						progressNotification.progressToken(), progressNotification.progress(),
+						progressNotification.total(), progressNotification.message());
+				this.testContext.progressNotifications.add(progressNotification);
+				this.testContext.progressLatch.countDown();
+			}
+
+			@McpLogging(clients = "server1")
+			public void loggingHandler(LoggingMessageNotification loggingMessage) {
+				this.testContext.loggingNotificationRef.set(loggingMessage);
+				logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
+			}
+
+			@McpSampling(clients = "server1")
+			public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
+				logger.info("MCP SAMPLING: {}", llmRequest);
+
+				String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
+				String modelHint = llmRequest.modelPreferences().hints().get(0).name();
+
+				return CreateMessageResult.builder()
+					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+					.build();
+			}
+
+			@McpElicitation(clients = "server1")
+			public ElicitResult elicitationHandler(McpSchema.ElicitRequest request) {
+				logger.info("MCP ELICITATION: {}", request);
+				return new ElicitResult(ElicitResult.Action.ACCEPT, Map.of("message", request.message()));
+			}
+
+		}
+
 	}
 
 }

--- a/contributing/eclipse-google-style.xml
+++ b/contributing/eclipse-google-style.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+    <profile kind="CodeFormatterProfile" name="GoogleStyle" version="13">
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1" />
+    </profile>
+</profiles>

--- a/mcp/mcp-annotations-spring/pom.xml
+++ b/mcp/mcp-annotations-spring/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>1.1.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-mcp-annotations</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI MCP Java SDK - Annotations</name>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springaicommunity</groupId>
+			<artifactId>mcp-annotations</artifactId>
+			<version>${mcp-annotations.version}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+	</dependencies>
+
+
+</project>

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AnnotationProviderUtil.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AnnotationProviderUtil.java
@@ -1,0 +1,55 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.mcp.annotation.spring;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * @author Christian Tzolov
+ */
+public class AnnotationProviderUtil {
+
+	/**
+	 * Returns the declared methods of the given bean, sorted by method name and parameter
+	 * types. This is useful for consistent method ordering in annotation processing.
+	 * @param bean The bean instance to inspect
+	 * @return An array of sorted methods
+	 */
+	public static Method[] beanMethods(Object bean) {
+
+		Method[] methods = ReflectionUtils
+			.getUniqueDeclaredMethods(AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) : bean.getClass());
+
+		methods = Stream.of(methods).filter(ReflectionUtils.USER_DECLARED_METHODS::matches).toArray(Method[]::new);
+
+		// Method[] methods = ReflectionUtils
+		// .getDeclaredMethods(AopUtils.isAopProxy(bean) ? AopUtils.getTargetClass(bean) :
+		// bean.getClass());
+
+		// Sort methods by name and parameter types for consistent ordering
+		Arrays.sort(methods, Comparator.comparing(Method::getName)
+			.thenComparing(method -> Arrays.toString(method.getParameterTypes())));
+
+		return methods;
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AnnotationProviderUtil.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AnnotationProviderUtil.java
@@ -1,18 +1,19 @@
 /*
-* Copyright 2025 - 2025 the original author or authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.mcp.annotation.spring;
 
 import java.lang.reflect.Method;
@@ -26,7 +27,10 @@ import org.springframework.util.ReflectionUtils;
 /**
  * @author Christian Tzolov
  */
-public class AnnotationProviderUtil {
+public final class AnnotationProviderUtil {
+
+	private AnnotationProviderUtil() {
+	}
 
 	/**
 	 * Returns the declared methods of the given bean, sorted by method name and parameter

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
@@ -1,23 +1,29 @@
 /*
-* Copyright 2025 - 2025 the original author or authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.mcp.annotation.spring;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.tool.AsyncToolListChangedSpecification;
@@ -41,221 +47,12 @@ import org.springaicommunity.mcp.provider.sampling.AsyncMcpSamplingProvider;
 import org.springaicommunity.mcp.provider.tool.AsyncMcpToolProvider;
 import org.springaicommunity.mcp.provider.tool.AsyncStatelessMcpToolProvider;
 
-import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
-import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
-import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
-import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
-import io.modelcontextprotocol.server.McpStatelessServerFeatures;
-
 /**
  * @author Christian Tzolov
  */
-public class AsyncMcpAnnotationProviders {
+public final class AsyncMcpAnnotationProviders {
 
-	// LOGGING (CLIENT)
-	private static class SpringAiAsyncMcpLoggingProvider extends AsyncMcpLoggingProvider {
-
-		public SpringAiAsyncMcpLoggingProvider(List<Object> loggingObjects) {
-			super(loggingObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// SAMPLING (CLIENT)
-	private static class SpringAiAsyncMcpSamplingProvider extends AsyncMcpSamplingProvider {
-
-		public SpringAiAsyncMcpSamplingProvider(List<Object> samplingObjects) {
-			super(samplingObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// ELICITATION (CLIENT)
-	private static class SpringAiAsyncMcpElicitationProvider extends AsyncMcpElicitationProvider {
-
-		public SpringAiAsyncMcpElicitationProvider(List<Object> elicitationObjects) {
-			super(elicitationObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// PROGRESS (CLIENT)
-	private static class SpringAiAsyncMcpProgressProvider extends AsyncMcpProgressProvider {
-
-		public SpringAiAsyncMcpProgressProvider(List<Object> progressObjects) {
-			super(progressObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// TOOL
-	private static class SpringAiAsyncMcpToolProvider extends AsyncMcpToolProvider {
-
-		public SpringAiAsyncMcpToolProvider(List<Object> toolObjects) {
-			super(toolObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	private static class SpringAiAsyncStatelessMcpToolProvider extends AsyncStatelessMcpToolProvider {
-
-		public SpringAiAsyncStatelessMcpToolProvider(List<Object> toolObjects) {
-			super(toolObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// COMPLETE
-	private static class SpringAiAsyncMcpCompleteProvider extends AsyncMcpCompleteProvider {
-
-		public SpringAiAsyncMcpCompleteProvider(List<Object> completeObjects) {
-			super(completeObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	};
-
-	private static class SpringAiAsyncStatelessMcpCompleteProvider extends AsyncStatelessMcpCompleteProvider {
-
-		public SpringAiAsyncStatelessMcpCompleteProvider(List<Object> completeObjects) {
-			super(completeObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	};
-
-	// PROMPT
-	private static class SpringAiAsyncPromptProvider extends AsyncMcpPromptProvider {
-
-		public SpringAiAsyncPromptProvider(List<Object> promptObjects) {
-			super(promptObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	private static class SpringAiAsyncStatelessPromptProvider extends AsyncStatelessMcpPromptProvider {
-
-		public SpringAiAsyncStatelessPromptProvider(List<Object> promptObjects) {
-			super(promptObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// RESOURCE
-	private static class SpringAiAsyncResourceProvider extends AsyncMcpResourceProvider {
-
-		public SpringAiAsyncResourceProvider(List<Object> resourceObjects) {
-			super(resourceObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	private static class SpringAiAsyncStatelessResourceProvider extends AsyncStatelessMcpResourceProvider {
-
-		public SpringAiAsyncStatelessResourceProvider(List<Object> resourceObjects) {
-			super(resourceObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// TOOL LIST CHANGED
-	private static class SpringAiAsyncMcpToolListChangedProvider extends AsyncMcpToolListChangedProvider {
-
-		public SpringAiAsyncMcpToolListChangedProvider(List<Object> toolListChangedObjects) {
-			super(toolListChangedObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// RESOURCE LIST CHANGED
-	private static class SpringAiAsyncMcpResourceListChangedProvider extends AsyncMcpResourceListChangedProvider {
-
-		public SpringAiAsyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
-			super(resourceListChangedObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// PROMPT LIST CHANGED
-	private static class SpringAiAsyncMcpPromptListChangedProvider extends AsyncMcpPromptListChangedProvider {
-
-		public SpringAiAsyncMcpPromptListChangedProvider(List<Object> promptListChangedObjects) {
-			super(promptListChangedObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
+	private AsyncMcpAnnotationProviders() {
 	}
 
 	//
@@ -340,6 +137,212 @@ public class AsyncMcpAnnotationProviders {
 			List<Object> promptListChangedObjects) {
 		return new SpringAiAsyncMcpPromptListChangedProvider(promptListChangedObjects)
 			.getPromptListChangedSpecifications();
+	}
+
+	// LOGGING (CLIENT)
+	private final static class SpringAiAsyncMcpLoggingProvider extends AsyncMcpLoggingProvider {
+
+		private SpringAiAsyncMcpLoggingProvider(List<Object> loggingObjects) {
+			super(loggingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// SAMPLING (CLIENT)
+	private final static class SpringAiAsyncMcpSamplingProvider extends AsyncMcpSamplingProvider {
+
+		private SpringAiAsyncMcpSamplingProvider(List<Object> samplingObjects) {
+			super(samplingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// ELICITATION (CLIENT)
+	private final static class SpringAiAsyncMcpElicitationProvider extends AsyncMcpElicitationProvider {
+
+		private SpringAiAsyncMcpElicitationProvider(List<Object> elicitationObjects) {
+			super(elicitationObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROGRESS (CLIENT)
+	private final static class SpringAiAsyncMcpProgressProvider extends AsyncMcpProgressProvider {
+
+		private SpringAiAsyncMcpProgressProvider(List<Object> progressObjects) {
+			super(progressObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// TOOL
+	private final static class SpringAiAsyncMcpToolProvider extends AsyncMcpToolProvider {
+
+		private SpringAiAsyncMcpToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private final static class SpringAiAsyncStatelessMcpToolProvider extends AsyncStatelessMcpToolProvider {
+
+		private SpringAiAsyncStatelessMcpToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// COMPLETE
+	private final static class SpringAiAsyncMcpCompleteProvider extends AsyncMcpCompleteProvider {
+
+		private SpringAiAsyncMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	private final static class SpringAiAsyncStatelessMcpCompleteProvider extends AsyncStatelessMcpCompleteProvider {
+
+		private SpringAiAsyncStatelessMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	// PROMPT
+	private final static class SpringAiAsyncPromptProvider extends AsyncMcpPromptProvider {
+
+		private SpringAiAsyncPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private final static class SpringAiAsyncStatelessPromptProvider extends AsyncStatelessMcpPromptProvider {
+
+		private SpringAiAsyncStatelessPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE
+	private final static class SpringAiAsyncResourceProvider extends AsyncMcpResourceProvider {
+
+		private SpringAiAsyncResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private final static class SpringAiAsyncStatelessResourceProvider extends AsyncStatelessMcpResourceProvider {
+
+		private SpringAiAsyncStatelessResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// TOOL LIST CHANGED
+	private final static class SpringAiAsyncMcpToolListChangedProvider extends AsyncMcpToolListChangedProvider {
+
+		private SpringAiAsyncMcpToolListChangedProvider(List<Object> toolListChangedObjects) {
+			super(toolListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE LIST CHANGED
+	private final static class SpringAiAsyncMcpResourceListChangedProvider extends AsyncMcpResourceListChangedProvider {
+
+		private SpringAiAsyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
+			super(resourceListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROMPT LIST CHANGED
+	private final static class SpringAiAsyncMcpPromptListChangedProvider extends AsyncMcpPromptListChangedProvider {
+
+		private SpringAiAsyncMcpPromptListChangedProvider(List<Object> promptListChangedObjects) {
+			super(promptListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
 	}
 
 }

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
@@ -1,0 +1,345 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.mcp.annotation.spring;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.AsyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
+import org.springaicommunity.mcp.provider.changed.prompt.AsyncMcpPromptListChangedProvider;
+import org.springaicommunity.mcp.provider.changed.resource.AsyncMcpResourceListChangedProvider;
+import org.springaicommunity.mcp.provider.changed.tool.AsyncMcpToolListChangedProvider;
+import org.springaicommunity.mcp.provider.complete.AsyncMcpCompleteProvider;
+import org.springaicommunity.mcp.provider.complete.AsyncStatelessMcpCompleteProvider;
+import org.springaicommunity.mcp.provider.elicitation.AsyncMcpElicitationProvider;
+import org.springaicommunity.mcp.provider.logging.AsyncMcpLoggingProvider;
+import org.springaicommunity.mcp.provider.progress.AsyncMcpProgressProvider;
+import org.springaicommunity.mcp.provider.prompt.AsyncMcpPromptProvider;
+import org.springaicommunity.mcp.provider.prompt.AsyncStatelessMcpPromptProvider;
+import org.springaicommunity.mcp.provider.resource.AsyncMcpResourceProvider;
+import org.springaicommunity.mcp.provider.resource.AsyncStatelessMcpResourceProvider;
+import org.springaicommunity.mcp.provider.sampling.AsyncMcpSamplingProvider;
+import org.springaicommunity.mcp.provider.tool.AsyncMcpToolProvider;
+import org.springaicommunity.mcp.provider.tool.AsyncStatelessMcpToolProvider;
+
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+
+/**
+ * @author Christian Tzolov
+ */
+public class AsyncMcpAnnotationProviders {
+
+	// LOGGING (CLIENT)
+	private static class SpringAiAsyncMcpLoggingProvider extends AsyncMcpLoggingProvider {
+
+		public SpringAiAsyncMcpLoggingProvider(List<Object> loggingObjects) {
+			super(loggingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// SAMPLING (CLIENT)
+	private static class SpringAiAsyncMcpSamplingProvider extends AsyncMcpSamplingProvider {
+
+		public SpringAiAsyncMcpSamplingProvider(List<Object> samplingObjects) {
+			super(samplingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// ELICITATION (CLIENT)
+	private static class SpringAiAsyncMcpElicitationProvider extends AsyncMcpElicitationProvider {
+
+		public SpringAiAsyncMcpElicitationProvider(List<Object> elicitationObjects) {
+			super(elicitationObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROGRESS (CLIENT)
+	private static class SpringAiAsyncMcpProgressProvider extends AsyncMcpProgressProvider {
+
+		public SpringAiAsyncMcpProgressProvider(List<Object> progressObjects) {
+			super(progressObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// TOOL
+	private static class SpringAiAsyncMcpToolProvider extends AsyncMcpToolProvider {
+
+		public SpringAiAsyncMcpToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private static class SpringAiAsyncStatelessMcpToolProvider extends AsyncStatelessMcpToolProvider {
+
+		public SpringAiAsyncStatelessMcpToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// COMPLETE
+	private static class SpringAiAsyncMcpCompleteProvider extends AsyncMcpCompleteProvider {
+
+		public SpringAiAsyncMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	private static class SpringAiAsyncStatelessMcpCompleteProvider extends AsyncStatelessMcpCompleteProvider {
+
+		public SpringAiAsyncStatelessMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	// PROMPT
+	private static class SpringAiAsyncPromptProvider extends AsyncMcpPromptProvider {
+
+		public SpringAiAsyncPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private static class SpringAiAsyncStatelessPromptProvider extends AsyncStatelessMcpPromptProvider {
+
+		public SpringAiAsyncStatelessPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE
+	private static class SpringAiAsyncResourceProvider extends AsyncMcpResourceProvider {
+
+		public SpringAiAsyncResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private static class SpringAiAsyncStatelessResourceProvider extends AsyncStatelessMcpResourceProvider {
+
+		public SpringAiAsyncStatelessResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// TOOL LIST CHANGED
+	private static class SpringAiAsyncMcpToolListChangedProvider extends AsyncMcpToolListChangedProvider {
+
+		public SpringAiAsyncMcpToolListChangedProvider(List<Object> toolListChangedObjects) {
+			super(toolListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE LIST CHANGED
+	private static class SpringAiAsyncMcpResourceListChangedProvider extends AsyncMcpResourceListChangedProvider {
+
+		public SpringAiAsyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
+			super(resourceListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROMPT LIST CHANGED
+	private static class SpringAiAsyncMcpPromptListChangedProvider extends AsyncMcpPromptListChangedProvider {
+
+		public SpringAiAsyncMcpPromptListChangedProvider(List<Object> promptListChangedObjects) {
+			super(promptListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	//
+	// UTILITIES
+	//
+
+	// LOGGING (CLIENT)
+	public static List<AsyncLoggingSpecification> loggingSpecifications(List<Object> loggingObjects) {
+		return new SpringAiAsyncMcpLoggingProvider(loggingObjects).getLoggingSpecifications();
+	}
+
+	// SAMPLING (CLIENT)
+	public static List<AsyncSamplingSpecification> samplingSpecifications(List<Object> samplingObjects) {
+		return new SpringAiAsyncMcpSamplingProvider(samplingObjects).getSamplingSpecifictions();
+	}
+
+	// ELICITATION (CLIENT)
+	public static List<AsyncElicitationSpecification> elicitationSpecifications(List<Object> elicitationObjects) {
+		return new SpringAiAsyncMcpElicitationProvider(elicitationObjects).getElicitationSpecifications();
+	}
+
+	// PROGRESS (CLIENT)
+	public static List<AsyncProgressSpecification> progressSpecifications(List<Object> progressObjects) {
+		return new SpringAiAsyncMcpProgressProvider(progressObjects).getProgressSpecifications();
+	}
+
+	// TOOL
+	public static List<AsyncToolSpecification> toolSpecifications(List<Object> toolObjects) {
+		return new SpringAiAsyncMcpToolProvider(toolObjects).getToolSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.AsyncToolSpecification> statelessToolSpecifications(
+			List<Object> toolObjects) {
+		return new SpringAiAsyncStatelessMcpToolProvider(toolObjects).getToolSpecifications();
+	}
+
+	// COMPLETE
+	public static List<AsyncCompletionSpecification> completeSpecifications(List<Object> completeObjects) {
+		return new SpringAiAsyncMcpCompleteProvider(completeObjects).getCompleteSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.AsyncCompletionSpecification> statelessCompleteSpecifications(
+			List<Object> completeObjects) {
+		return new SpringAiAsyncStatelessMcpCompleteProvider(completeObjects).getCompleteSpecifications();
+	}
+
+	// PROMPT
+	public static List<AsyncPromptSpecification> promptSpecifications(List<Object> promptObjects) {
+		return new SpringAiAsyncPromptProvider(promptObjects).getPromptSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.AsyncPromptSpecification> statelessPromptSpecifications(
+			List<Object> promptObjects) {
+		return new SpringAiAsyncStatelessPromptProvider(promptObjects).getPromptSpecifications();
+	}
+
+	// RESOURCE
+	public static List<AsyncResourceSpecification> resourceSpecifications(List<Object> resourceObjects) {
+		return new SpringAiAsyncResourceProvider(resourceObjects).getResourceSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.AsyncResourceSpecification> statelessResourceSpecifications(
+			List<Object> resourceObjects) {
+		return new SpringAiAsyncStatelessResourceProvider(resourceObjects).getResourceSpecifications();
+	}
+
+	// RESOURCE LIST CHANGED
+	public static List<AsyncResourceListChangedSpecification> resourceListChangedSpecifications(
+			List<Object> resourceListChangedObjects) {
+		return new SpringAiAsyncMcpResourceListChangedProvider(resourceListChangedObjects)
+			.getResourceListChangedSpecifications();
+	}
+
+	// TOOL LIST CHANGED
+	public static List<AsyncToolListChangedSpecification> toolListChangedSpecifications(
+			List<Object> toolListChangedObjects) {
+		return new SpringAiAsyncMcpToolListChangedProvider(toolListChangedObjects).getToolListChangedSpecifications();
+	}
+
+	// PROMPT LIST CHANGED
+	public static List<AsyncPromptListChangedSpecification> promptListChangedSpecifications(
+			List<Object> promptListChangedObjects) {
+		return new SpringAiAsyncMcpPromptListChangedProvider(promptListChangedObjects)
+			.getPromptListChangedSpecifications();
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
@@ -1,0 +1,345 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.mcp.annotation.spring;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+import org.springaicommunity.mcp.provider.changed.prompt.SyncMcpPromptListChangedProvider;
+import org.springaicommunity.mcp.provider.changed.resource.SyncMcpResourceListChangedProvider;
+import org.springaicommunity.mcp.provider.changed.tool.SyncMcpToolListChangedProvider;
+import org.springaicommunity.mcp.provider.complete.SyncMcpCompleteProvider;
+import org.springaicommunity.mcp.provider.complete.SyncStatelessMcpCompleteProvider;
+import org.springaicommunity.mcp.provider.elicitation.SyncMcpElicitationProvider;
+import org.springaicommunity.mcp.provider.logging.SyncMcpLogginProvider;
+import org.springaicommunity.mcp.provider.progress.SyncMcpProgressProvider;
+import org.springaicommunity.mcp.provider.prompt.SyncMcpPromptProvider;
+import org.springaicommunity.mcp.provider.prompt.SyncStatelessMcpPromptProvider;
+import org.springaicommunity.mcp.provider.resource.SyncMcpResourceProvider;
+import org.springaicommunity.mcp.provider.resource.SyncStatelessMcpResourceProvider;
+import org.springaicommunity.mcp.provider.sampling.SyncMcpSamplingProvider;
+import org.springaicommunity.mcp.provider.tool.SyncMcpToolProvider;
+import org.springaicommunity.mcp.provider.tool.SyncStatelessMcpToolProvider;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+
+/**
+ * @author Christian Tzolov
+ */
+public class SyncMcpAnnotationProviders {
+
+	// COMPLETE
+	private static class SpringAiSyncMcpCompleteProvider extends SyncMcpCompleteProvider {
+
+		public SpringAiSyncMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	private static class SpringAiSyncStatelessMcpCompleteProvider extends SyncStatelessMcpCompleteProvider {
+
+		public SpringAiSyncStatelessMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	// TOOL
+	private static class SpringAiSyncToolProvider extends SyncMcpToolProvider {
+
+		public SpringAiSyncToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private static class SpringAiSyncStatelessToolProvider extends SyncStatelessMcpToolProvider {
+
+		public SpringAiSyncStatelessToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROMPT
+	private static class SpringAiSyncMcpPromptProvider extends SyncMcpPromptProvider {
+
+		public SpringAiSyncMcpPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	private static class SpringAiSyncStatelessPromptProvider extends SyncStatelessMcpPromptProvider {
+
+		public SpringAiSyncStatelessPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE
+	private static class SpringAiSyncMcpResourceProvider extends SyncMcpResourceProvider {
+
+		public SpringAiSyncMcpResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private static class SpringAiSyncStatelessResourceProvider extends SyncStatelessMcpResourceProvider {
+
+		public SpringAiSyncStatelessResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// LOGGING (CLIENT)
+	private static class SpringAiSyncMcpLoggingProvider extends SyncMcpLogginProvider {
+
+		public SpringAiSyncMcpLoggingProvider(List<Object> loggingObjects) {
+			super(loggingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// SAMPLING (CLIENT)
+	private static class SpringAiSyncMcpSamplingProvider extends SyncMcpSamplingProvider {
+
+		public SpringAiSyncMcpSamplingProvider(List<Object> samplingObjects) {
+			super(samplingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// ELICITATION (CLIENT)
+	private static class SpringAiSyncMcpElicitationProvider extends SyncMcpElicitationProvider {
+
+		public SpringAiSyncMcpElicitationProvider(List<Object> elicitationObjects) {
+			super(elicitationObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROGRESS (CLIENT)
+	private static class SpringAiSyncMcpProgressProvider extends SyncMcpProgressProvider {
+
+		public SpringAiSyncMcpProgressProvider(List<Object> progressObjects) {
+			super(progressObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// TOOL LIST CHANGE
+	private static class SpringAiSyncMcpToolListChangedProvider extends SyncMcpToolListChangedProvider {
+
+		public SpringAiSyncMcpToolListChangedProvider(List<Object> toolListChangedObjects) {
+			super(toolListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE LIST CHANGE
+	private static class SpringAiSyncMcpResourceListChangedProvider extends SyncMcpResourceListChangedProvider {
+
+		public SpringAiSyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
+			super(resourceListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROMPT LIST CHANGE
+	private static class SpringAiSyncMcpPromptListChangedProvider extends SyncMcpPromptListChangedProvider {
+
+		public SpringAiSyncMcpPromptListChangedProvider(List<Object> promptListChangedObjects) {
+			super(promptListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	//
+	// UTILITIES
+	//
+
+	// TOOLS
+	public static List<SyncToolSpecification> toolSpecifications(List<Object> toolObjects) {
+		return new SpringAiSyncToolProvider(toolObjects).getToolSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.SyncToolSpecification> statelessToolSpecifications(
+			List<Object> toolObjects) {
+		return new SpringAiSyncStatelessToolProvider(toolObjects).getToolSpecifications();
+	}
+
+	// COMPLETE
+	public static List<SyncCompletionSpecification> completeSpecifications(List<Object> completeObjects) {
+		return new SpringAiSyncMcpCompleteProvider(completeObjects).getCompleteSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.SyncCompletionSpecification> statelessCompleteSpecifications(
+			List<Object> completeObjects) {
+		return new SpringAiSyncStatelessMcpCompleteProvider(completeObjects).getCompleteSpecifications();
+	}
+
+	// PROMPT
+	public static List<SyncPromptSpecification> promptSpecifications(List<Object> promptObjects) {
+		return new SpringAiSyncMcpPromptProvider(promptObjects).getPromptSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.SyncPromptSpecification> statelessPromptSpecifications(
+			List<Object> promptObjects) {
+		return new SpringAiSyncStatelessPromptProvider(promptObjects).getPromptSpecifications();
+	}
+
+	// RESOURCE
+	public static List<SyncResourceSpecification> resourceSpecifications(List<Object> resourceObjects) {
+		return new SpringAiSyncMcpResourceProvider(resourceObjects).getResourceSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.SyncResourceSpecification> statelessResourceSpecifications(
+			List<Object> resourceObjects) {
+		return new SpringAiSyncStatelessResourceProvider(resourceObjects).getResourceSpecifications();
+	}
+
+	// LOGGING (CLIENT)
+	public static List<SyncLoggingSpecification> loggingSpecifications(List<Object> loggingObjects) {
+		return new SpringAiSyncMcpLoggingProvider(loggingObjects).getLoggingSpecifications();
+	}
+
+	// SAMPLING (CLIENT)
+	public static List<SyncSamplingSpecification> samplingSpecifications(List<Object> samplingObjects) {
+		return new SpringAiSyncMcpSamplingProvider(samplingObjects).getSamplingSpecifications();
+	}
+
+	// ELICITATION (CLIENT)
+	public static List<SyncElicitationSpecification> elicitationSpecifications(List<Object> elicitationObjects) {
+		return new SpringAiSyncMcpElicitationProvider(elicitationObjects).getElicitationSpecifications();
+	}
+
+	// PROGRESS (CLIENT)
+	public static List<SyncProgressSpecification> progressSpecifications(List<Object> progressObjects) {
+		return new SpringAiSyncMcpProgressProvider(progressObjects).getProgressSpecifications();
+	}
+
+	// TOOL LIST CHANGED
+	public static List<SyncToolListChangedSpecification> toolListChangedSpecifications(
+			List<Object> toolListChangedObjects) {
+		return new SpringAiSyncMcpToolListChangedProvider(toolListChangedObjects).getToolListChangedSpecifications();
+	}
+
+	// RESOURCE LIST CHANGED
+	public static List<SyncResourceListChangedSpecification> resourceListChangedSpecifications(
+			List<Object> resourceListChangedObjects) {
+		return new SpringAiSyncMcpResourceListChangedProvider(resourceListChangedObjects)
+			.getResourceListChangedSpecifications();
+	}
+
+	// PROMPT LIST CHANGED
+	public static List<SyncPromptListChangedSpecification> promptListChangedSpecifications(
+			List<Object> promptListChangedObjects) {
+		return new SpringAiSyncMcpPromptListChangedProvider(promptListChangedObjects)
+			.getPromptListChangedSpecifications();
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
@@ -1,23 +1,29 @@
 /*
-* Copyright 2025 - 2025 the original author or authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.ai.mcp.annotation.spring;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
+import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
@@ -41,221 +47,12 @@ import org.springaicommunity.mcp.provider.sampling.SyncMcpSamplingProvider;
 import org.springaicommunity.mcp.provider.tool.SyncMcpToolProvider;
 import org.springaicommunity.mcp.provider.tool.SyncStatelessMcpToolProvider;
 
-import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
-import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
-import io.modelcontextprotocol.server.McpStatelessServerFeatures;
-
 /**
  * @author Christian Tzolov
  */
-public class SyncMcpAnnotationProviders {
+public final class SyncMcpAnnotationProviders {
 
-	// COMPLETE
-	private static class SpringAiSyncMcpCompleteProvider extends SyncMcpCompleteProvider {
-
-		public SpringAiSyncMcpCompleteProvider(List<Object> completeObjects) {
-			super(completeObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	};
-
-	private static class SpringAiSyncStatelessMcpCompleteProvider extends SyncStatelessMcpCompleteProvider {
-
-		public SpringAiSyncStatelessMcpCompleteProvider(List<Object> completeObjects) {
-			super(completeObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	};
-
-	// TOOL
-	private static class SpringAiSyncToolProvider extends SyncMcpToolProvider {
-
-		public SpringAiSyncToolProvider(List<Object> toolObjects) {
-			super(toolObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	private static class SpringAiSyncStatelessToolProvider extends SyncStatelessMcpToolProvider {
-
-		public SpringAiSyncStatelessToolProvider(List<Object> toolObjects) {
-			super(toolObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// PROMPT
-	private static class SpringAiSyncMcpPromptProvider extends SyncMcpPromptProvider {
-
-		public SpringAiSyncMcpPromptProvider(List<Object> promptObjects) {
-			super(promptObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	};
-
-	private static class SpringAiSyncStatelessPromptProvider extends SyncStatelessMcpPromptProvider {
-
-		public SpringAiSyncStatelessPromptProvider(List<Object> promptObjects) {
-			super(promptObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// RESOURCE
-	private static class SpringAiSyncMcpResourceProvider extends SyncMcpResourceProvider {
-
-		public SpringAiSyncMcpResourceProvider(List<Object> resourceObjects) {
-			super(resourceObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	private static class SpringAiSyncStatelessResourceProvider extends SyncStatelessMcpResourceProvider {
-
-		public SpringAiSyncStatelessResourceProvider(List<Object> resourceObjects) {
-			super(resourceObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// LOGGING (CLIENT)
-	private static class SpringAiSyncMcpLoggingProvider extends SyncMcpLogginProvider {
-
-		public SpringAiSyncMcpLoggingProvider(List<Object> loggingObjects) {
-			super(loggingObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// SAMPLING (CLIENT)
-	private static class SpringAiSyncMcpSamplingProvider extends SyncMcpSamplingProvider {
-
-		public SpringAiSyncMcpSamplingProvider(List<Object> samplingObjects) {
-			super(samplingObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// ELICITATION (CLIENT)
-	private static class SpringAiSyncMcpElicitationProvider extends SyncMcpElicitationProvider {
-
-		public SpringAiSyncMcpElicitationProvider(List<Object> elicitationObjects) {
-			super(elicitationObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// PROGRESS (CLIENT)
-	private static class SpringAiSyncMcpProgressProvider extends SyncMcpProgressProvider {
-
-		public SpringAiSyncMcpProgressProvider(List<Object> progressObjects) {
-			super(progressObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// TOOL LIST CHANGE
-	private static class SpringAiSyncMcpToolListChangedProvider extends SyncMcpToolListChangedProvider {
-
-		public SpringAiSyncMcpToolListChangedProvider(List<Object> toolListChangedObjects) {
-			super(toolListChangedObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// RESOURCE LIST CHANGE
-	private static class SpringAiSyncMcpResourceListChangedProvider extends SyncMcpResourceListChangedProvider {
-
-		public SpringAiSyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
-			super(resourceListChangedObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
-	}
-
-	// PROMPT LIST CHANGE
-	private static class SpringAiSyncMcpPromptListChangedProvider extends SyncMcpPromptListChangedProvider {
-
-		public SpringAiSyncMcpPromptListChangedProvider(List<Object> promptListChangedObjects) {
-			super(promptListChangedObjects);
-		}
-
-		@Override
-		protected Method[] doGetClassMethods(Object bean) {
-			return AnnotationProviderUtil.beanMethods(bean);
-		}
-
+	private SyncMcpAnnotationProviders() {
 	}
 
 	//
@@ -340,6 +137,212 @@ public class SyncMcpAnnotationProviders {
 			List<Object> promptListChangedObjects) {
 		return new SpringAiSyncMcpPromptListChangedProvider(promptListChangedObjects)
 			.getPromptListChangedSpecifications();
+	}
+
+	// COMPLETE
+	private final static class SpringAiSyncMcpCompleteProvider extends SyncMcpCompleteProvider {
+
+		private SpringAiSyncMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	private final static class SpringAiSyncStatelessMcpCompleteProvider extends SyncStatelessMcpCompleteProvider {
+
+		private SpringAiSyncStatelessMcpCompleteProvider(List<Object> completeObjects) {
+			super(completeObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	// TOOL
+	private final static class SpringAiSyncToolProvider extends SyncMcpToolProvider {
+
+		private SpringAiSyncToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private final static class SpringAiSyncStatelessToolProvider extends SyncStatelessMcpToolProvider {
+
+		private SpringAiSyncStatelessToolProvider(List<Object> toolObjects) {
+			super(toolObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROMPT
+	private final static class SpringAiSyncMcpPromptProvider extends SyncMcpPromptProvider {
+
+		private SpringAiSyncMcpPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	};
+
+	private final static class SpringAiSyncStatelessPromptProvider extends SyncStatelessMcpPromptProvider {
+
+		private SpringAiSyncStatelessPromptProvider(List<Object> promptObjects) {
+			super(promptObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE
+	private final static class SpringAiSyncMcpResourceProvider extends SyncMcpResourceProvider {
+
+		private SpringAiSyncMcpResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	private final static class SpringAiSyncStatelessResourceProvider extends SyncStatelessMcpResourceProvider {
+
+		private SpringAiSyncStatelessResourceProvider(List<Object> resourceObjects) {
+			super(resourceObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// LOGGING (CLIENT)
+	private final static class SpringAiSyncMcpLoggingProvider extends SyncMcpLogginProvider {
+
+		private SpringAiSyncMcpLoggingProvider(List<Object> loggingObjects) {
+			super(loggingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// SAMPLING (CLIENT)
+	private final static class SpringAiSyncMcpSamplingProvider extends SyncMcpSamplingProvider {
+
+		private SpringAiSyncMcpSamplingProvider(List<Object> samplingObjects) {
+			super(samplingObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// ELICITATION (CLIENT)
+	private final static class SpringAiSyncMcpElicitationProvider extends SyncMcpElicitationProvider {
+
+		private SpringAiSyncMcpElicitationProvider(List<Object> elicitationObjects) {
+			super(elicitationObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROGRESS (CLIENT)
+	private final static class SpringAiSyncMcpProgressProvider extends SyncMcpProgressProvider {
+
+		private SpringAiSyncMcpProgressProvider(List<Object> progressObjects) {
+			super(progressObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// TOOL LIST CHANGE
+	private final static class SpringAiSyncMcpToolListChangedProvider extends SyncMcpToolListChangedProvider {
+
+		private SpringAiSyncMcpToolListChangedProvider(List<Object> toolListChangedObjects) {
+			super(toolListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// RESOURCE LIST CHANGE
+	private final static class SpringAiSyncMcpResourceListChangedProvider extends SyncMcpResourceListChangedProvider {
+
+		private SpringAiSyncMcpResourceListChangedProvider(List<Object> resourceListChangedObjects) {
+			super(resourceListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
+	}
+
+	// PROMPT LIST CHANGE
+	private final static class SpringAiSyncMcpPromptListChangedProvider extends SyncMcpPromptListChangedProvider {
+
+		private SpringAiSyncMcpPromptListChangedProvider(List<Object> promptListChangedObjects) {
+			super(promptListChangedObjects);
+		}
+
+		@Override
+		protected Method[] doGetClassMethods(Object bean) {
+			return AnnotationProviderUtil.beanMethods(bean);
+		}
+
 	}
 
 }

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessor.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring.scan;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * @author Christian Tzolov
+ */
+public abstract class AbstractAnnotatedMethodBeanPostProcessor implements BeanPostProcessor {
+
+	private final AbstractMcpAnnotatedBeans registry;
+
+	// Define the annotations to scan for
+	private final Set<Class<? extends Annotation>> targetAnnotations;
+
+	public AbstractAnnotatedMethodBeanPostProcessor(AbstractMcpAnnotatedBeans registry,
+			Set<Class<? extends Annotation>> targetAnnotations) {
+		Assert.notNull(registry, "AnnotatedBeanRegistry must not be null");
+		Assert.notEmpty(targetAnnotations, "Target annotations must not be empty");
+
+		this.registry = registry;
+		this.targetAnnotations = targetAnnotations;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		Class<?> beanClass = AopUtils.getTargetClass(bean); // Handle proxied beans
+
+		Set<Class<? extends Annotation>> foundAnnotations = new HashSet<>();
+
+		// Scan all methods in the bean class
+		ReflectionUtils.doWithMethods(beanClass, method -> {
+			targetAnnotations.forEach(annotationType -> {
+				if (AnnotationUtils.findAnnotation(method, annotationType) != null) {
+					foundAnnotations.add(annotationType);
+				}
+			});
+		});
+
+		// Register the bean if it has any of our target annotations
+		if (!foundAnnotations.isEmpty()) {
+			registry.addMcpAnnotatedBean(bean, foundAnnotations);
+		}
+
+		return bean;
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessor.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessor.java
@@ -54,7 +54,7 @@ public abstract class AbstractAnnotatedMethodBeanPostProcessor implements BeanPo
 
 		// Scan all methods in the bean class
 		ReflectionUtils.doWithMethods(beanClass, method -> {
-			targetAnnotations.forEach(annotationType -> {
+			this.targetAnnotations.forEach(annotationType -> {
 				if (AnnotationUtils.findAnnotation(method, annotationType) != null) {
 					foundAnnotations.add(annotationType);
 				}
@@ -63,7 +63,7 @@ public abstract class AbstractAnnotatedMethodBeanPostProcessor implements BeanPo
 
 		// Register the bean if it has any of our target annotations
 		if (!foundAnnotations.isEmpty()) {
-			registry.addMcpAnnotatedBean(bean, foundAnnotations);
+			this.registry.addMcpAnnotatedBean(bean, foundAnnotations);
 		}
 
 		return bean;

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeans.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeans.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 /**
  * Container for Beans that have method with MCP annotations
- * 
+ *
  * @author Christian Tzolov
  */
 public abstract class AbstractMcpAnnotatedBeans {
@@ -36,22 +36,23 @@ public abstract class AbstractMcpAnnotatedBeans {
 	private final Map<Class<? extends Annotation>, List<Object>> beansByAnnotation = new HashMap<>();
 
 	public void addMcpAnnotatedBean(Object bean, Set<Class<? extends Annotation>> annotations) {
-		beansWithCustomAnnotations.add(bean);
+		this.beansWithCustomAnnotations.add(bean);
 
-		annotations.forEach(
-				annotationType -> beansByAnnotation.computeIfAbsent(annotationType, k -> new ArrayList<>()).add(bean));
+		annotations
+			.forEach(annotationType -> this.beansByAnnotation.computeIfAbsent(annotationType, k -> new ArrayList<>())
+				.add(bean));
 	}
 
 	public List<Object> getAllAnnotatedBeans() {
-		return new ArrayList<>(beansWithCustomAnnotations);
+		return new ArrayList<>(this.beansWithCustomAnnotations);
 	}
 
 	public List<Object> getBeansByAnnotation(Class<? extends Annotation> annotationType) {
-		return beansByAnnotation.getOrDefault(annotationType, Collections.emptyList());
+		return this.beansByAnnotation.getOrDefault(annotationType, Collections.emptyList());
 	}
 
 	public int getCount() {
-		return beansWithCustomAnnotations.size();
+		return this.beansWithCustomAnnotations.size();
 	}
 
 }

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeans.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeans.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring.scan;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Container for Beans that have method with MCP annotations
+ * 
+ * @author Christian Tzolov
+ */
+public abstract class AbstractMcpAnnotatedBeans {
+
+	private final List<Object> beansWithCustomAnnotations = new ArrayList<>();
+
+	private final Map<Class<? extends Annotation>, List<Object>> beansByAnnotation = new HashMap<>();
+
+	public void addMcpAnnotatedBean(Object bean, Set<Class<? extends Annotation>> annotations) {
+		beansWithCustomAnnotations.add(bean);
+
+		annotations.forEach(
+				annotationType -> beansByAnnotation.computeIfAbsent(annotationType, k -> new ArrayList<>()).add(bean));
+	}
+
+	public List<Object> getAllAnnotatedBeans() {
+		return new ArrayList<>(beansWithCustomAnnotations);
+	}
+
+	public List<Object> getBeansByAnnotation(Class<? extends Annotation> annotationType) {
+		return beansByAnnotation.getOrDefault(annotationType, Collections.emptyList());
+	}
+
+	public int getCount() {
+		return beansWithCustomAnnotations.size();
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
 		<module>spring-ai-integration-tests</module>
 
 		<module>mcp/common</module>
+		<module>mcp/mcp-annotations-spring</module>
 	</modules>
 
 	<organization>
@@ -330,6 +331,7 @@
 
 		<!-- MCP-->
 		<mcp.sdk.version>0.11.3</mcp.sdk.version>
+		<mcp-annotations.version>0.3.0-SNAPSHOT</mcp-annotations.version>
 
 		<!-- plugin versions -->
 		<antlr.version>4.13.1</antlr.version>

--- a/release-notes-full-run.log
+++ b/release-notes-full-run.log
@@ -1,1 +1,0 @@
-python3: can't open file '/home/mark/project-mgmt/spring-ai-project-mgmt/release/spring-ai-release/generate-release-notes.py': [Errno 2] No such file or directory

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -1062,6 +1062,12 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-mcp-annotations</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
 
 			<!-- Spring AI Spring Boot starter for Chat Memory (with the default in-memory Chat memory repository) -->
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -82,7 +82,12 @@
 **** xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc[STDIO and SSE MCP Servers]
 **** xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc[Streamable-HTTP MCP Servers]
 **** xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc[Stateless MCP Servers]
-*** xref:api/mcp/mcp-helpers.adoc[MCP Utilities]
+// *** xref:api/mcp/mcp-helpers.adoc[MCP Utilities]
+*** xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations]
+**** xref:api/mcp/mcp-annotations-client.adoc[Client Annotations]
+**** xref:api/mcp/mcp-annotations-server.adoc[Server Annotations]
+**** xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters]
+**** xref:api/mcp/mcp-annotations-examples.adoc[MCP Annotations Examples]
 
 ** xref:api/retrieval-augmented-generation.adoc[Retrieval Augmented Generation (RAG)]
 *** xref:api/etl-pipeline.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-client.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-client.adoc
@@ -4,7 +4,7 @@ The MCP Client Annotations provide a declarative way to implement MCP client han
 These annotations simplify the handling of server notifications and client-side operations.
 
 [IMPORTANT]
-**All MCP client annotations MUST include a `clientId` parameter** to associate the handler with a specific MCP client connection. The `clientId` must match the connection name configured in your application properties.
+**All MCP client annotations MUST include a `clients` parameter** to associate the handler with a specific MCP client connection. The `clients` must match the connection name configured in your application properties.
 
 == Client Annotations
 
@@ -19,7 +19,7 @@ The `@McpLogging` annotation handles logging message notifications from MCP serv
 @Component
 public class LoggingHandler {
 
-    @McpLogging(clientId = "my-mcp-server")
+    @McpLogging(clients = "my-mcp-server")
     public void handleLoggingMessage(LoggingMessageNotification notification) {
         System.out.println("Received log: " + notification.level() + 
                           " - " + notification.data());
@@ -31,7 +31,7 @@ public class LoggingHandler {
 
 [source,java]
 ----
-@McpLogging(clientId = "my-mcp-server")
+@McpLogging(clients = "my-mcp-server")
 public void handleLoggingWithParams(LoggingLevel level, String logger, String data) {
     System.out.println(String.format("[%s] %s: %s", level, logger, data));
 }
@@ -41,13 +41,13 @@ public void handleLoggingWithParams(LoggingLevel level, String logger, String da
 
 [source,java]
 ----
-@McpLogging(clientId = "server1")
+@McpLogging(clients = "server1")
 public void handleServer1Logs(LoggingMessageNotification notification) {
     // Handle logs from specific server
     logToFile("server1.log", notification);
 }
 
-@McpLogging(clientId = "server2")
+@McpLogging(clients = "server2")
 public void handleServer2Logs(LoggingMessageNotification notification) {
     // Handle logs from another server
     logToDatabase("server2", notification);
@@ -65,7 +65,7 @@ The `@McpSampling` annotation handles sampling requests from MCP servers for LLM
 @Component
 public class SamplingHandler {
 
-    @McpSampling(clientId = "llm-server")
+    @McpSampling(clients = "llm-server")
     public CreateMessageResult handleSamplingRequest(CreateMessageRequest request) {
         // Process the request and generate a response
         String response = generateLLMResponse(request);
@@ -86,7 +86,7 @@ public class SamplingHandler {
 @Component
 public class AsyncSamplingHandler {
 
-    @McpSampling(clientId = "llm-server")
+    @McpSampling(clients = "llm-server")
     public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
         return Mono.fromCallable(() -> {
             String response = generateLLMResponse(request);
@@ -105,7 +105,7 @@ public class AsyncSamplingHandler {
 
 [source,java]
 ----
-@McpSampling(clientId = "specialized-server")
+@McpSampling(clients = "specialized-server")
 public CreateMessageResult handleSpecializedSampling(CreateMessageRequest request) {
     // Use specialized model for this server
     String response = generateSpecializedResponse(request);
@@ -129,7 +129,7 @@ The `@McpElicitation` annotation handles elicitation requests to gather addition
 @Component
 public class ElicitationHandler {
 
-    @McpElicitation(clientId = "interactive-server")
+    @McpElicitation(clients = "interactive-server")
     public ElicitResult handleElicitationRequest(ElicitRequest request) {
         // Present the request to the user and gather input
         Map<String, Object> userData = presentFormToUser(request.requestedSchema());
@@ -147,7 +147,7 @@ public class ElicitationHandler {
 
 [source,java]
 ----
-@McpElicitation(clientId = "interactive-server")
+@McpElicitation(clients = "interactive-server")
 public ElicitResult handleInteractiveElicitation(ElicitRequest request) {
     Map<String, Object> schema = request.requestedSchema();
     Map<String, Object> userData = new HashMap<>();
@@ -177,7 +177,7 @@ public ElicitResult handleInteractiveElicitation(ElicitRequest request) {
 
 [source,java]
 ----
-@McpElicitation(clientId = "interactive-server")
+@McpElicitation(clients = "interactive-server")
 public Mono<ElicitResult> handleAsyncElicitation(ElicitRequest request) {
     return Mono.fromCallable(() -> {
         // Async user interaction
@@ -199,7 +199,7 @@ The `@McpProgress` annotation handles progress notifications for long-running op
 @Component
 public class ProgressHandler {
 
-    @McpProgress(clientId = "my-mcp-server")
+    @McpProgress(clients = "my-mcp-server")
     public void handleProgressNotification(ProgressNotification notification) {
         double percentage = notification.progress() * 100;
         System.out.println(String.format("Progress: %.2f%% - %s", 
@@ -212,7 +212,7 @@ public class ProgressHandler {
 
 [source,java]
 ----
-@McpProgress(clientId = "my-mcp-server")
+@McpProgress(clients = "my-mcp-server")
 public void handleProgressWithDetails(
         String progressToken, 
         double progress, 
@@ -236,7 +236,7 @@ public void handleProgressWithDetails(
 
 [source,java]
 ----
-@McpProgress(clientId = "long-running-server")
+@McpProgress(clients = "long-running-server")
 public void handleLongRunningProgress(ProgressNotification notification) {
     // Track progress for specific server
     progressTracker.update("long-running-server", notification);
@@ -259,7 +259,7 @@ The `@McpToolListChanged` annotation handles notifications when the server's too
 @Component
 public class ToolListChangedHandler {
 
-    @McpToolListChanged(clientId = "tool-server")
+    @McpToolListChanged(clients = "tool-server")
     public void handleToolListChanged(List<McpSchema.Tool> updatedTools) {
         System.out.println("Tool list updated: " + updatedTools.size() + " tools available");
         
@@ -278,7 +278,7 @@ public class ToolListChangedHandler {
 
 [source,java]
 ----
-@McpToolListChanged(clientId = "tool-server")
+@McpToolListChanged(clients = "tool-server")
 public Mono<Void> handleAsyncToolListChanged(List<McpSchema.Tool> updatedTools) {
     return Mono.fromRunnable(() -> {
         // Process tool list update asynchronously
@@ -294,7 +294,7 @@ public Mono<Void> handleAsyncToolListChanged(List<McpSchema.Tool> updatedTools) 
 
 [source,java]
 ----
-@McpToolListChanged(clientId = "dynamic-server")
+@McpToolListChanged(clients = "dynamic-server")
 public void handleDynamicServerToolUpdate(List<McpSchema.Tool> updatedTools) {
     // Handle tools from a specific server that frequently changes its tools
     dynamicToolManager.updateServerTools("dynamic-server", updatedTools);
@@ -315,7 +315,7 @@ The `@McpResourceListChanged` annotation handles notifications when the server's
 @Component
 public class ResourceListChangedHandler {
 
-    @McpResourceListChanged(clientId = "resource-server")
+    @McpResourceListChanged(clients = "resource-server")
     public void handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
         System.out.println("Resources updated: " + updatedResources.size());
         
@@ -332,7 +332,7 @@ public class ResourceListChangedHandler {
 
 [source,java]
 ----
-@McpResourceListChanged(clientId = "resource-server")
+@McpResourceListChanged(clients = "resource-server")
 public void analyzeResourceChanges(List<McpSchema.Resource> updatedResources) {
     // Analyze what changed
     Set<String> newUris = updatedResources.stream()
@@ -363,7 +363,7 @@ The `@McpPromptListChanged` annotation handles notifications when the server's p
 @Component
 public class PromptListChangedHandler {
 
-    @McpPromptListChanged(clientId = "prompt-server")
+    @McpPromptListChanged(clients = "prompt-server")
     public void handlePromptListChanged(List<McpSchema.Prompt> updatedPrompts) {
         System.out.println("Prompts updated: " + updatedPrompts.size());
         
@@ -382,7 +382,7 @@ public class PromptListChangedHandler {
 
 [source,java]
 ----
-@McpPromptListChanged(clientId = "prompt-server")
+@McpPromptListChanged(clients = "prompt-server")
 public Mono<Void> handleAsyncPromptUpdate(List<McpSchema.Prompt> updatedPrompts) {
     return Flux.fromIterable(updatedPrompts)
         .flatMap(prompt -> validatePrompt(prompt))
@@ -409,18 +409,18 @@ public class McpClientApplication {
 
 @Component
 public class MyClientHandlers {
-    
-    @McpLogging(clientId = "my-server")
+
+    @McpLogging(clients = "my-server")
     public void handleLogs(LoggingMessageNotification notification) {
         // Handle logs
     }
-    
-    @McpSampling(clientId = "my-server")
+
+    @McpSampling(clients = "my-server")
     public CreateMessageResult handleSampling(CreateMessageRequest request) {
         // Handle sampling
     }
-    
-    @McpProgress(clientId = "my-server")
+
+    @McpProgress(clients = "my-server")
     public void handleProgress(ProgressNotification notification) {
         // Handle progress
     }
@@ -448,23 +448,23 @@ spring:
         type: SYNC  # or ASYNC
         annotation-scanner:
           enabled: true
-        # Configure client connections - the connection names become clientId values
+        # Configure client connections - the connection names become clients values
         sse:
           connections:
-            my-server:  # This becomes the clientId
+            my-server:  # This becomes the clients
               url: http://localhost:8080
-            tool-server:  # Another clientId
+            tool-server:  # Another clients
               url: http://localhost:8081
         stdio:
           connections:
-            local-server:  # This becomes the clientId
+            local-server:  # This becomes the clients
               command: /path/to/mcp-server
               args:
                 - --mode=production
 ----
 
 [IMPORTANT]
-The `clientId` parameter in annotations must match the connection names defined in your configuration. In the example above, valid `clientId` values would be: `"my-server"`, `"tool-server"`, and `"local-server"`.
+The `clients` parameter in annotations must match the connection names defined in your configuration. In the example above, valid `clients` values would be: `"my-server"`, `"tool-server"`, and `"local-server"`.
 
 == Usage with MCP Client
 
@@ -475,11 +475,11 @@ The annotated handlers are automatically integrated with the MCP client:
 @Autowired
 private List<McpSyncClient> mcpClients;
 
-// The clients will automatically use your annotated handlers based on clientId
+// The clients will automatically use your annotated handlers based on clients
 // No manual registration needed - handlers are matched to clients by name
 ----
 
-For each MCP client connection, handlers with matching `clientId` will be automatically registered and invoked when the corresponding events occur.
+For each MCP client connection, handlers with matching `clients` will be automatically registered and invoked when the corresponding events occur.
 
 == Additional Resources
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-client.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-client.adoc
@@ -1,0 +1,489 @@
+= MCP Client Annotations
+
+The MCP Client Annotations provide a declarative way to implement MCP client handlers using Java annotations. 
+These annotations simplify the handling of server notifications and client-side operations.
+
+[IMPORTANT]
+**All MCP client annotations MUST include a `clientId` parameter** to associate the handler with a specific MCP client connection. The `clientId` must match the connection name configured in your application properties.
+
+== Client Annotations
+
+=== @McpLogging
+
+The `@McpLogging` annotation handles logging message notifications from MCP servers.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class LoggingHandler {
+
+    @McpLogging(clientId = "my-mcp-server")
+    public void handleLoggingMessage(LoggingMessageNotification notification) {
+        System.out.println("Received log: " + notification.level() + 
+                          " - " + notification.data());
+    }
+}
+----
+
+==== With Individual Parameters
+
+[source,java]
+----
+@McpLogging(clientId = "my-mcp-server")
+public void handleLoggingWithParams(LoggingLevel level, String logger, String data) {
+    System.out.println(String.format("[%s] %s: %s", level, logger, data));
+}
+----
+
+==== Client-Specific Handlers
+
+[source,java]
+----
+@McpLogging(clientId = "server1")
+public void handleServer1Logs(LoggingMessageNotification notification) {
+    // Handle logs from specific server
+    logToFile("server1.log", notification);
+}
+
+@McpLogging(clientId = "server2")
+public void handleServer2Logs(LoggingMessageNotification notification) {
+    // Handle logs from another server
+    logToDatabase("server2", notification);
+}
+----
+
+=== @McpSampling
+
+The `@McpSampling` annotation handles sampling requests from MCP servers for LLM completions.
+
+==== Synchronous Implementation
+
+[source,java]
+----
+@Component
+public class SamplingHandler {
+
+    @McpSampling(clientId = "llm-server")
+    public CreateMessageResult handleSamplingRequest(CreateMessageRequest request) {
+        // Process the request and generate a response
+        String response = generateLLMResponse(request);
+        
+        return CreateMessageResult.builder()
+            .role(Role.ASSISTANT)
+            .content(new TextContent(response))
+            .model("gpt-4")
+            .build();
+    }
+}
+----
+
+==== Asynchronous Implementation
+
+[source,java]
+----
+@Component
+public class AsyncSamplingHandler {
+
+    @McpSampling(clientId = "llm-server")
+    public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
+        return Mono.fromCallable(() -> {
+            String response = generateLLMResponse(request);
+            
+            return CreateMessageResult.builder()
+                .role(Role.ASSISTANT)
+                .content(new TextContent(response))
+                .model("gpt-4")
+                .build();
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+}
+----
+
+==== Client-Specific Sampling
+
+[source,java]
+----
+@McpSampling(clientId = "specialized-server")
+public CreateMessageResult handleSpecializedSampling(CreateMessageRequest request) {
+    // Use specialized model for this server
+    String response = generateSpecializedResponse(request);
+    
+    return CreateMessageResult.builder()
+        .role(Role.ASSISTANT)
+        .content(new TextContent(response))
+        .model("specialized-model")
+        .build();
+}
+----
+
+=== @McpElicitation
+
+The `@McpElicitation` annotation handles elicitation requests to gather additional information from users.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class ElicitationHandler {
+
+    @McpElicitation(clientId = "interactive-server")
+    public ElicitResult handleElicitationRequest(ElicitRequest request) {
+        // Present the request to the user and gather input
+        Map<String, Object> userData = presentFormToUser(request.requestedSchema());
+        
+        if (userData != null) {
+            return new ElicitResult(ElicitResult.Action.ACCEPT, userData);
+        } else {
+            return new ElicitResult(ElicitResult.Action.DECLINE, null);
+        }
+    }
+}
+----
+
+==== With User Interaction
+
+[source,java]
+----
+@McpElicitation(clientId = "interactive-server")
+public ElicitResult handleInteractiveElicitation(ElicitRequest request) {
+    Map<String, Object> schema = request.requestedSchema();
+    Map<String, Object> userData = new HashMap<>();
+    
+    // Check what information is being requested
+    if (schema != null && schema.containsKey("properties")) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        
+        // Gather user input based on schema
+        if (properties.containsKey("name")) {
+            userData.put("name", promptUser("Enter your name:"));
+        }
+        if (properties.containsKey("email")) {
+            userData.put("email", promptUser("Enter your email:"));
+        }
+        if (properties.containsKey("preferences")) {
+            userData.put("preferences", gatherPreferences());
+        }
+    }
+    
+    return new ElicitResult(ElicitResult.Action.ACCEPT, userData);
+}
+----
+
+==== Async Elicitation
+
+[source,java]
+----
+@McpElicitation(clientId = "interactive-server")
+public Mono<ElicitResult> handleAsyncElicitation(ElicitRequest request) {
+    return Mono.fromCallable(() -> {
+        // Async user interaction
+        Map<String, Object> userData = asyncGatherUserInput(request);
+        return new ElicitResult(ElicitResult.Action.ACCEPT, userData);
+    }).timeout(Duration.ofSeconds(30))
+      .onErrorReturn(new ElicitResult(ElicitResult.Action.CANCEL, null));
+}
+----
+
+=== @McpProgress
+
+The `@McpProgress` annotation handles progress notifications for long-running operations.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class ProgressHandler {
+
+    @McpProgress(clientId = "my-mcp-server")
+    public void handleProgressNotification(ProgressNotification notification) {
+        double percentage = notification.progress() * 100;
+        System.out.println(String.format("Progress: %.2f%% - %s", 
+            percentage, notification.message()));
+    }
+}
+----
+
+==== With Individual Parameters
+
+[source,java]
+----
+@McpProgress(clientId = "my-mcp-server")
+public void handleProgressWithDetails(
+        String progressToken, 
+        double progress, 
+        Double total, 
+        String message) {
+    
+    if (total != null) {
+        System.out.println(String.format("[%s] %.0f/%.0f - %s", 
+            progressToken, progress, total, message));
+    } else {
+        System.out.println(String.format("[%s] %.2f%% - %s", 
+            progressToken, progress * 100, message));
+    }
+    
+    // Update UI progress bar
+    updateProgressBar(progressToken, progress);
+}
+----
+
+==== Client-Specific Progress
+
+[source,java]
+----
+@McpProgress(clientId = "long-running-server")
+public void handleLongRunningProgress(ProgressNotification notification) {
+    // Track progress for specific server
+    progressTracker.update("long-running-server", notification);
+    
+    // Send notifications if needed
+    if (notification.progress() >= 1.0) {
+        notifyCompletion(notification.progressToken());
+    }
+}
+----
+
+=== @McpToolListChanged
+
+The `@McpToolListChanged` annotation handles notifications when the server's tool list changes.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class ToolListChangedHandler {
+
+    @McpToolListChanged(clientId = "tool-server")
+    public void handleToolListChanged(List<McpSchema.Tool> updatedTools) {
+        System.out.println("Tool list updated: " + updatedTools.size() + " tools available");
+        
+        // Update local tool registry
+        toolRegistry.updateTools(updatedTools);
+        
+        // Log new tools
+        for (McpSchema.Tool tool : updatedTools) {
+            System.out.println("  - " + tool.name() + ": " + tool.description());
+        }
+    }
+}
+----
+
+==== Async Handling
+
+[source,java]
+----
+@McpToolListChanged(clientId = "tool-server")
+public Mono<Void> handleAsyncToolListChanged(List<McpSchema.Tool> updatedTools) {
+    return Mono.fromRunnable(() -> {
+        // Process tool list update asynchronously
+        processToolListUpdate(updatedTools);
+        
+        // Notify interested components
+        eventBus.publish(new ToolListUpdatedEvent(updatedTools));
+    }).then();
+}
+----
+
+==== Client-Specific Tool Updates
+
+[source,java]
+----
+@McpToolListChanged(clientId = "dynamic-server")
+public void handleDynamicServerToolUpdate(List<McpSchema.Tool> updatedTools) {
+    // Handle tools from a specific server that frequently changes its tools
+    dynamicToolManager.updateServerTools("dynamic-server", updatedTools);
+    
+    // Re-evaluate tool availability
+    reevaluateToolCapabilities();
+}
+----
+
+=== @McpResourceListChanged
+
+The `@McpResourceListChanged` annotation handles notifications when the server's resource list changes.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class ResourceListChangedHandler {
+
+    @McpResourceListChanged(clientId = "resource-server")
+    public void handleResourceListChanged(List<McpSchema.Resource> updatedResources) {
+        System.out.println("Resources updated: " + updatedResources.size());
+        
+        // Update resource cache
+        resourceCache.clear();
+        for (McpSchema.Resource resource : updatedResources) {
+            resourceCache.register(resource);
+        }
+    }
+}
+----
+
+==== With Resource Analysis
+
+[source,java]
+----
+@McpResourceListChanged(clientId = "resource-server")
+public void analyzeResourceChanges(List<McpSchema.Resource> updatedResources) {
+    // Analyze what changed
+    Set<String> newUris = updatedResources.stream()
+        .map(McpSchema.Resource::uri)
+        .collect(Collectors.toSet());
+    
+    Set<String> removedUris = previousUris.stream()
+        .filter(uri -> !newUris.contains(uri))
+        .collect(Collectors.toSet());
+    
+    if (!removedUris.isEmpty()) {
+        handleRemovedResources(removedUris);
+    }
+    
+    // Update tracking
+    previousUris = newUris;
+}
+----
+
+=== @McpPromptListChanged
+
+The `@McpPromptListChanged` annotation handles notifications when the server's prompt list changes.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class PromptListChangedHandler {
+
+    @McpPromptListChanged(clientId = "prompt-server")
+    public void handlePromptListChanged(List<McpSchema.Prompt> updatedPrompts) {
+        System.out.println("Prompts updated: " + updatedPrompts.size());
+        
+        // Update prompt catalog
+        promptCatalog.updatePrompts(updatedPrompts);
+        
+        // Refresh UI if needed
+        if (uiController != null) {
+            uiController.refreshPromptList(updatedPrompts);
+        }
+    }
+}
+----
+
+==== Async Processing
+
+[source,java]
+----
+@McpPromptListChanged(clientId = "prompt-server")
+public Mono<Void> handleAsyncPromptUpdate(List<McpSchema.Prompt> updatedPrompts) {
+    return Flux.fromIterable(updatedPrompts)
+        .flatMap(prompt -> validatePrompt(prompt))
+        .collectList()
+        .doOnNext(validPrompts -> {
+            promptRepository.saveAll(validPrompts);
+        })
+        .then();
+}
+----
+
+== Spring Boot Integration
+
+With Spring Boot auto-configuration, client handlers are automatically detected and registered:
+
+[source,java]
+----
+@SpringBootApplication
+public class McpClientApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(McpClientApplication.class, args);
+    }
+}
+
+@Component
+public class MyClientHandlers {
+    
+    @McpLogging(clientId = "my-server")
+    public void handleLogs(LoggingMessageNotification notification) {
+        // Handle logs
+    }
+    
+    @McpSampling(clientId = "my-server")
+    public CreateMessageResult handleSampling(CreateMessageRequest request) {
+        // Handle sampling
+    }
+    
+    @McpProgress(clientId = "my-server")
+    public void handleProgress(ProgressNotification notification) {
+        // Handle progress
+    }
+}
+----
+
+The auto-configuration will:
+
+1. Scan for beans with MCP client annotations
+2. Create appropriate specifications
+3. Register them with the MCP client
+4. Support both sync and async implementations
+5. Handle multiple clients with client-specific handlers
+
+== Configuration Properties
+
+Configure the client annotation scanner and client connections:
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      client:
+        type: SYNC  # or ASYNC
+        annotation-scanner:
+          enabled: true
+        # Configure client connections - the connection names become clientId values
+        sse:
+          connections:
+            my-server:  # This becomes the clientId
+              url: http://localhost:8080
+            tool-server:  # Another clientId
+              url: http://localhost:8081
+        stdio:
+          connections:
+            local-server:  # This becomes the clientId
+              command: /path/to/mcp-server
+              args:
+                - --mode=production
+----
+
+[IMPORTANT]
+The `clientId` parameter in annotations must match the connection names defined in your configuration. In the example above, valid `clientId` values would be: `"my-server"`, `"tool-server"`, and `"local-server"`.
+
+== Usage with MCP Client
+
+The annotated handlers are automatically integrated with the MCP client:
+
+[source,java]
+----
+@Autowired
+private List<McpSyncClient> mcpClients;
+
+// The clients will automatically use your annotated handlers based on clientId
+// No manual registration needed - handlers are matched to clients by name
+----
+
+For each MCP client connection, handlers with matching `clientId` will be automatically registered and invoked when the corresponding events occur.
+
+== Additional Resources
+
+* xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations Overview]
+* xref:api/mcp/mcp-annotations-server.adoc[Server Annotations]
+* xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters]
+* xref:api/mcp/mcp-client-boot-starter-docs.adoc[MCP Client Boot Starter]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
@@ -1,0 +1,916 @@
+= MCP Annotations Examples
+
+This page provides comprehensive examples of using MCP annotations in Spring AI applications.
+
+== Complete Application Examples
+
+=== Simple Calculator Server
+
+A complete example of an MCP server providing calculator tools:
+
+[source,java]
+----
+@SpringBootApplication
+public class CalculatorServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CalculatorServerApplication.class, args);
+    }
+}
+
+@Component
+public class CalculatorTools {
+
+    @McpTool(name = "add", description = "Add two numbers")
+    public double add(
+            @McpToolParam(description = "First number", required = true) double a,
+            @McpToolParam(description = "Second number", required = true) double b) {
+        return a + b;
+    }
+
+    @McpTool(name = "subtract", description = "Subtract two numbers")
+    public double subtract(
+            @McpToolParam(description = "First number", required = true) double a,
+            @McpToolParam(description = "Second number", required = true) double b) {
+        return a - b;
+    }
+
+    @McpTool(name = "multiply", description = "Multiply two numbers")
+    public double multiply(
+            @McpToolParam(description = "First number", required = true) double a,
+            @McpToolParam(description = "Second number", required = true) double b) {
+        return a * b;
+    }
+
+    @McpTool(name = "divide", description = "Divide two numbers")
+    public double divide(
+            @McpToolParam(description = "Dividend", required = true) double dividend,
+            @McpToolParam(description = "Divisor", required = true) double divisor) {
+        if (divisor == 0) {
+            throw new IllegalArgumentException("Division by zero");
+        }
+        return dividend / divisor;
+    }
+
+    @McpTool(name = "calculate-expression", 
+             description = "Calculate a complex mathematical expression")
+    public CallToolResult calculateExpression(
+            CallToolRequest request,
+            McpSyncServerExchange exchange) {
+        
+        Map<String, Object> args = request.arguments();
+        String expression = (String) args.get("expression");
+        
+        exchange.loggingNotification(LoggingMessageNotification.builder()
+            .level(LoggingLevel.INFO)
+            .data("Calculating: " + expression)
+            .build());
+        
+        try {
+            double result = evaluateExpression(expression);
+            return CallToolResult.builder()
+                .addTextContent("Result: " + result)
+                .build();
+        } catch (Exception e) {
+            return CallToolResult.builder()
+                .isError(true)
+                .addTextContent("Error: " + e.getMessage())
+                .build();
+        }
+    }
+}
+----
+
+Configuration:
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      server:
+        name: calculator-server
+        version: 1.0.0
+        type: SYNC
+        protocol: SSE  # or STDIO, STREAMABLE
+        capabilities:
+          tools: true
+          logging: true
+----
+
+=== Document Processing Server
+
+An example of a document processing server with resources and prompts:
+
+[source,java]
+----
+@Component
+public class DocumentServer {
+
+    private final Map<String, Document> documents = new ConcurrentHashMap<>();
+
+    @McpResource(
+        uri = "document://{id}", 
+        name = "Document", 
+        description = "Access stored documents")
+    public ReadResourceResult getDocument(String id, McpMeta meta) {
+        Document doc = documents.get(id);
+        
+        if (doc == null) {
+            return new ReadResourceResult(List.of(
+                new TextResourceContents("document://" + id, 
+                    "text/plain", "Document not found")
+            ));
+        }
+        
+        // Check access permissions from metadata
+        String accessLevel = (String) meta.get("accessLevel");
+        if ("restricted".equals(doc.getClassification()) && 
+            !"admin".equals(accessLevel)) {
+            return new ReadResourceResult(List.of(
+                new TextResourceContents("document://" + id, 
+                    "text/plain", "Access denied")
+            ));
+        }
+        
+        return new ReadResourceResult(List.of(
+            new TextResourceContents("document://" + id, 
+                doc.getMimeType(), doc.getContent())
+        ));
+    }
+
+    @McpTool(name = "analyze-document", 
+             description = "Analyze document content")
+    public String analyzeDocument(
+            @McpProgressToken String progressToken,
+            @McpToolParam(description = "Document ID", required = true) String docId,
+            @McpToolParam(description = "Analysis type", required = false) String type,
+            McpSyncServerExchange exchange) {
+        
+        Document doc = documents.get(docId);
+        if (doc == null) {
+            return "Document not found";
+        }
+        
+        if (progressToken != null) {
+            exchange.progressNotification(new ProgressNotification(
+                progressToken, 0.0, 1.0, "Starting analysis"));
+        }
+        
+        // Perform analysis
+        String analysisType = type != null ? type : "summary";
+        String result = performAnalysis(doc, analysisType);
+        
+        if (progressToken != null) {
+            exchange.progressNotification(new ProgressNotification(
+                progressToken, 1.0, 1.0, "Analysis complete"));
+        }
+        
+        return result;
+    }
+
+    @McpPrompt(
+        name = "document-summary", 
+        description = "Generate document summary prompt")
+    public GetPromptResult documentSummaryPrompt(
+            @McpArg(name = "docId", required = true) String docId,
+            @McpArg(name = "length", required = false) String length) {
+        
+        Document doc = documents.get(docId);
+        if (doc == null) {
+            return new GetPromptResult("Error",
+                List.of(new PromptMessage(Role.SYSTEM, 
+                    new TextContent("Document not found"))));
+        }
+        
+        String promptText = String.format(
+            "Please summarize the following document in %s:\n\n%s",
+            length != null ? length : "a few paragraphs",
+            doc.getContent()
+        );
+        
+        return new GetPromptResult("Document Summary",
+            List.of(new PromptMessage(Role.USER, new TextContent(promptText))));
+    }
+
+    @McpComplete(prompt = "document-summary")
+    public List<String> completeDocumentId(String prefix) {
+        return documents.keySet().stream()
+            .filter(id -> id.startsWith(prefix))
+            .sorted()
+            .limit(10)
+            .toList();
+    }
+}
+----
+
+=== MCP Client with Handlers
+
+A complete MCP client application with various handlers:
+
+[source,java]
+----
+@SpringBootApplication
+public class McpClientApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(McpClientApplication.class, args);
+    }
+}
+
+@Component
+public class ClientHandlers {
+
+    private final Logger logger = LoggerFactory.getLogger(ClientHandlers.class);
+    private final ProgressTracker progressTracker = new ProgressTracker();
+    private final ChatModel chatModel;
+
+    public ClientHandlers(ChatModel chatModel) {
+        this.chatModel = chatModel;
+    }
+
+    @McpLogging(clientId = "server1")
+    public void handleLogging(LoggingMessageNotification notification) {
+        switch (notification.level()) {
+            case ERROR:
+                logger.error("[MCP] {} - {}", notification.logger(), notification.data());
+                break;
+            case WARNING:
+                logger.warn("[MCP] {} - {}", notification.logger(), notification.data());
+                break;
+            case INFO:
+                logger.info("[MCP] {} - {}", notification.logger(), notification.data());
+                break;
+            default:
+                logger.debug("[MCP] {} - {}", notification.logger(), notification.data());
+        }
+    }
+
+    @McpSampling(clientId = "server1")
+    public CreateMessageResult handleSampling(CreateMessageRequest request) {
+        // Use Spring AI ChatModel for sampling
+        List<Message> messages = request.messages().stream()
+            .map(msg -> {
+                if (msg.role() == Role.USER) {
+                    return new UserMessage(((TextContent) msg.content()).text());
+                } else {
+                    return new AssistantMessage(((TextContent) msg.content()).text());
+                }
+            })
+            .toList();
+        
+        ChatResponse response = chatModel.call(new Prompt(messages));
+        
+        return CreateMessageResult.builder()
+            .role(Role.ASSISTANT)
+            .content(new TextContent(response.getResult().getOutput().getContent()))
+            .model(request.modelPreferences().hints().get(0).name())
+            .build();
+    }
+
+    @McpElicitation(clientId = "server1")
+    public ElicitResult handleElicitation(ElicitRequest request) {
+        // In a real application, this would show a UI dialog
+        Map<String, Object> userData = new HashMap<>();
+        
+        logger.info("Elicitation requested: {}", request.message());
+        
+        // Simulate user input based on schema
+        Map<String, Object> schema = request.requestedSchema();
+        if (schema != null && schema.containsKey("properties")) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+            
+            properties.forEach((key, value) -> {
+                // In real app, prompt user for each field
+                userData.put(key, getDefaultValueForProperty(key, value));
+            });
+        }
+        
+        return new ElicitResult(ElicitResult.Action.ACCEPT, userData);
+    }
+
+    @McpProgress(clientId = "server1")
+    public void handleProgress(ProgressNotification notification) {
+        progressTracker.update(
+            notification.progressToken(),
+            notification.progress(),
+            notification.total(),
+            notification.message()
+        );
+        
+        // Update UI or send websocket notification
+        broadcastProgress(notification);
+    }
+
+    @McpToolListChanged(clientId = "server1")
+    public void handleServer1ToolsChanged(List<McpSchema.Tool> tools) {
+        logger.info("Server1 tools updated: {} tools available", tools.size());
+        
+        // Update tool registry
+        toolRegistry.updateServerTools("server1", tools);
+        
+        // Notify UI to refresh tool list
+        eventBus.publish(new ToolsUpdatedEvent("server1", tools));
+    }
+
+    @McpResourceListChanged(clientId = "server1")
+    public void handleServer1ResourcesChanged(List<McpSchema.Resource> resources) {
+        logger.info("Server1 resources updated: {} resources available", resources.size());
+        
+        // Clear resource cache for this server
+        resourceCache.clearServer("server1");
+        
+        // Register new resources
+        resources.forEach(resource -> 
+            resourceCache.register("server1", resource));
+    }
+}
+----
+
+Configuration:
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      client:
+        type: SYNC
+        initialized: true
+        request-timeout: 30s
+        annotation-scanner:
+          enabled: true
+        sse:
+          connections:
+            server1:
+              url: http://localhost:8080
+        stdio:
+          connections:
+            local-tool:
+              command: /usr/local/bin/mcp-tool
+              args:
+                - --mode=production
+----
+
+== Async Examples
+
+=== Async Tool Server
+
+[source,java]
+----
+@Component
+public class AsyncDataProcessor {
+
+    @McpTool(name = "fetch-data", description = "Fetch data from external source")
+    public Mono<DataResult> fetchData(
+            @McpToolParam(description = "Data source URL", required = true) String url,
+            @McpToolParam(description = "Timeout in seconds", required = false) Integer timeout) {
+        
+        Duration timeoutDuration = Duration.ofSeconds(timeout != null ? timeout : 30);
+        
+        return WebClient.create()
+            .get()
+            .uri(url)
+            .retrieve()
+            .bodyToMono(String.class)
+            .map(data -> new DataResult(url, data, System.currentTimeMillis()))
+            .timeout(timeoutDuration)
+            .onErrorReturn(new DataResult(url, "Error fetching data", 0L));
+    }
+
+    @McpTool(name = "process-stream", description = "Process data stream")
+    public Flux<String> processStream(
+            @McpToolParam(description = "Item count", required = true) int count,
+            @McpProgressToken String progressToken,
+            McpAsyncServerExchange exchange) {
+        
+        return Flux.range(1, count)
+            .delayElements(Duration.ofMillis(100))
+            .doOnNext(i -> {
+                if (progressToken != null) {
+                    double progress = (double) i / count;
+                    exchange.progressNotification(new ProgressNotification(
+                        progressToken, progress, 1.0, 
+                        "Processing item " + i));
+                }
+            })
+            .map(i -> "Processed item " + i);
+    }
+
+    @McpResource(uri = "async-data://{id}", name = "Async Data")
+    public Mono<ReadResourceResult> getAsyncData(String id) {
+        return Mono.fromCallable(() -> loadDataAsync(id))
+            .subscribeOn(Schedulers.boundedElastic())
+            .map(data -> new ReadResourceResult(List.of(
+                new TextResourceContents("async-data://" + id, 
+                    "application/json", data)
+            )));
+    }
+}
+----
+
+=== Async Client Handlers
+
+[source,java]
+----
+@Component
+public class AsyncClientHandlers {
+
+    @McpSampling(clientId = "async-server")
+    public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
+        return Mono.fromCallable(() -> {
+            // Prepare request for LLM
+            String prompt = extractPrompt(request);
+            return prompt;
+        })
+        .flatMap(prompt -> callLLMAsync(prompt))
+        .map(response -> CreateMessageResult.builder()
+            .role(Role.ASSISTANT)
+            .content(new TextContent(response))
+            .model("gpt-4")
+            .build())
+        .timeout(Duration.ofSeconds(30));
+    }
+
+    @McpProgress(clientId = "async-server")
+    public Mono<Void> handleAsyncProgress(ProgressNotification notification) {
+        return Mono.fromRunnable(() -> {
+            // Update progress tracking
+            updateProgressAsync(notification);
+        })
+        .then(broadcastProgressAsync(notification))
+        .subscribeOn(Schedulers.parallel());
+    }
+
+    @McpElicitation(clientId = "async-server")
+    public Mono<ElicitResult> handleAsyncElicitation(ElicitRequest request) {
+        return showUserDialogAsync(request)
+            .map(userData -> {
+                if (userData != null && !userData.isEmpty()) {
+                    return new ElicitResult(ElicitResult.Action.ACCEPT, userData);
+                } else {
+                    return new ElicitResult(ElicitResult.Action.DECLINE, null);
+                }
+            })
+            .timeout(Duration.ofMinutes(5))
+            .onErrorReturn(new ElicitResult(ElicitResult.Action.CANCEL, null));
+    }
+}
+----
+
+== Stateless Server Examples
+
+[source,java]
+----
+@Component
+public class StatelessTools {
+
+    // Simple stateless tool
+    @McpTool(name = "format-text", description = "Format text")
+    public String formatText(
+            @McpToolParam(description = "Text to format", required = true) String text,
+            @McpToolParam(description = "Format type", required = true) String format) {
+        
+        return switch (format.toLowerCase()) {
+            case "uppercase" -> text.toUpperCase();
+            case "lowercase" -> text.toLowerCase();
+            case "title" -> toTitleCase(text);
+            case "reverse" -> new StringBuilder(text).reverse().toString();
+            default -> text;
+        };
+    }
+
+    // Stateless with transport context
+    @McpTool(name = "validate-json", description = "Validate JSON")
+    public CallToolResult validateJson(
+            McpTransportContext context,
+            @McpToolParam(description = "JSON string", required = true) String json) {
+        
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.readTree(json);
+            
+            return CallToolResult.builder()
+                .addTextContent("Valid JSON")
+                .structuredContent(Map.of("valid", true))
+                .build();
+        } catch (Exception e) {
+            return CallToolResult.builder()
+                .addTextContent("Invalid JSON: " + e.getMessage())
+                .structuredContent(Map.of("valid", false, "error", e.getMessage()))
+                .build();
+        }
+    }
+
+    @McpResource(uri = "static://{path}", name = "Static Resource")
+    public String getStaticResource(String path) {
+        // Simple stateless resource
+        return loadStaticContent(path);
+    }
+
+    @McpPrompt(name = "template", description = "Template prompt")
+    public GetPromptResult templatePrompt(
+            @McpArg(name = "template", required = true) String templateName,
+            @McpArg(name = "variables", required = false) String variables) {
+        
+        String template = loadTemplate(templateName);
+        if (variables != null) {
+            template = substituteVariables(template, variables);
+        }
+        
+        return new GetPromptResult("Template: " + templateName,
+            List.of(new PromptMessage(Role.USER, new TextContent(template))));
+    }
+}
+----
+
+== MCP Sampling with Multiple LLM Providers
+
+This example demonstrates how to use MCP Sampling to generate creative content from multiple LLM providers, showcasing the annotation-based approach for both server and client implementations.
+
+=== Sampling Server Implementation
+
+The server provides a weather tool that uses MCP Sampling to generate poems from different LLM providers:
+
+[source,java]
+----
+@Service
+public class WeatherService {
+
+    private final RestClient restClient = RestClient.create();
+
+    public record WeatherResponse(Current current) {
+        public record Current(LocalDateTime time, int interval, double temperature_2m) {
+        }
+    }
+
+    @McpTool(description = "Get the temperature (in celsius) for a specific location")
+    public String getTemperature2(McpSyncServerExchange exchange,
+            @McpToolParam(description = "The location latitude") double latitude,
+            @McpToolParam(description = "The location longitude") double longitude) {
+
+        // Fetch weather data
+        WeatherResponse weatherResponse = restClient
+                .get()
+                .uri("https://api.open-meteo.com/v1/forecast?latitude={latitude}&longitude={longitude}&current=temperature_2m",
+                        latitude, longitude)
+                .retrieve()
+                .body(WeatherResponse.class);
+
+        StringBuilder openAiWeatherPoem = new StringBuilder();
+        StringBuilder anthropicWeatherPoem = new StringBuilder();
+
+        // Send logging notification
+        exchange.loggingNotification(LoggingMessageNotification.builder()
+                .level(LoggingLevel.INFO)
+                .data("Start sampling")
+                .build());
+
+        // Check if client supports sampling
+        if (exchange.getClientCapabilities().sampling() != null) {
+            var messageRequestBuilder = McpSchema.CreateMessageRequest.builder()
+                    .systemPrompt("You are a poet!")
+                    .messages(List.of(new McpSchema.SamplingMessage(McpSchema.Role.USER,
+                            new McpSchema.TextContent(
+                                    "Please write a poem about this weather forecast (temperature is in Celsius). Use markdown format :\n "
+                                            + ModelOptionsUtils.toJsonStringPrettyPrinter(weatherResponse)))));
+
+            // Request poem from OpenAI
+            var openAiLlmMessageRequest = messageRequestBuilder
+                    .modelPreferences(ModelPreferences.builder().addHint("openai").build())
+                    .build();
+            CreateMessageResult openAiLlmResponse = exchange.createMessage(openAiLlmMessageRequest);
+            openAiWeatherPoem.append(((McpSchema.TextContent) openAiLlmResponse.content()).text());
+
+            // Request poem from Anthropic
+            var anthropicLlmMessageRequest = messageRequestBuilder
+                    .modelPreferences(ModelPreferences.builder().addHint("anthropic").build())
+                    .build();
+            CreateMessageResult anthropicAiLlmResponse = exchange.createMessage(anthropicLlmMessageRequest);
+            anthropicWeatherPoem.append(((McpSchema.TextContent) anthropicAiLlmResponse.content()).text());
+        }
+
+        exchange.loggingNotification(LoggingMessageNotification.builder()
+                .level(LoggingLevel.INFO)
+                .data("Finish Sampling")
+                .build());
+
+        // Combine results
+        String responseWithPoems = "OpenAI poem about the weather: " + openAiWeatherPoem.toString() + "\n\n" +
+                "Anthropic poem about the weather: " + anthropicWeatherPoem.toString() + "\n"
+                + ModelOptionsUtils.toJsonStringPrettyPrinter(weatherResponse);
+
+        return responseWithPoems;
+    }
+}
+----
+
+=== Sampling Client Implementation
+
+The client handles sampling requests by routing them to appropriate LLM providers based on model hints:
+
+[source,java]
+----
+@Service
+public class McpClientHandlers {
+
+    private static final Logger logger = LoggerFactory.getLogger(McpClientHandlers.class);
+
+    @Autowired
+    Map<String, ChatClient> chatClients;
+
+    @McpProgress(clientId = "server1")
+    public void progressHandler(ProgressNotification progressNotification) {
+        logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
+                progressNotification.progressToken(), progressNotification.progress(),
+                progressNotification.total(), progressNotification.message());
+    }
+
+    @McpLogging(clientId = "server1")
+    public void loggingHandler(LoggingMessageNotification loggingMessage) {
+        logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
+    }
+
+    @McpSampling(clientId = "server1")
+    public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
+        logger.info("MCP SAMPLING: {}", llmRequest);
+
+        // Extract user prompt and model hint
+        var userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
+        String modelHint = llmRequest.modelPreferences().hints().get(0).name();
+
+        // Find appropriate ChatClient based on model hint
+        ChatClient hintedChatClient = chatClients.entrySet().stream()
+                .filter(e -> e.getKey().contains(modelHint))
+                .findFirst()
+                .orElseThrow()
+                .getValue();
+
+        // Generate response using the selected model
+        String response = hintedChatClient.prompt()
+                .system(llmRequest.systemPrompt())
+                .user(userPrompt)
+                .call()
+                .content();
+
+        return CreateMessageResult.builder()
+                .content(new McpSchema.TextContent(response))
+                .build();
+    }
+}
+----
+
+=== Client Application Setup
+
+The client application configures multiple ChatClient instances for different LLM providers:
+
+[source,java]
+----
+@SpringBootApplication
+public class McpClientApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(McpClientApplication.class, args).close();
+    }
+
+    @Bean
+    public CommandLineRunner predefinedQuestions(OpenAiChatModel openAiChatModel,
+            List<McpSyncClient> mcpClients) {
+
+        return args -> {
+            var mcpToolProvider = new SyncMcpToolCallbackProvider(mcpClients);
+
+            ChatClient chatClient = ChatClient.builder(openAiChatModel)
+                    .defaultToolCallbacks(mcpToolProvider)
+                    .build();
+
+            String userQuestion = """
+                    What is the weather in Amsterdam right now?
+                    Please incorporate all creative responses from all LLM providers.
+                    After the other providers add a poem that synthesizes the poems from all the other providers.
+                    """;
+
+            System.out.println("> USER: " + userQuestion);
+            System.out.println("> ASSISTANT: " + chatClient.prompt(userQuestion).call().content());
+        };
+    }
+
+    @Bean
+    public Map<String, ChatClient> chatClients(List<ChatModel> chatModels) {
+        return chatModels.stream()
+                .collect(Collectors.toMap(
+                    model -> model.getClass().getSimpleName().toLowerCase(),
+                    model -> ChatClient.builder(model).build()));
+    }
+}
+----
+
+=== Configuration
+
+==== Server Configuration
+
+[source,yaml]
+----
+# Server application.properties
+spring.ai.mcp.server.name=mcp-sampling-server-annotations
+spring.ai.mcp.server.version=0.0.1
+spring.ai.mcp.server.protocol=STREAMABLE
+spring.main.banner-mode=off
+----
+
+==== Client Configuration
+
+[source,yaml]
+----
+# Client application.properties
+spring.application.name=mcp
+spring.main.web-application-type=none
+
+# Disable default chat client auto-configuration for multiple models
+spring.ai.chat.client.enabled=false
+
+# API keys
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.anthropic.api-key=${ANTHROPIC_API_KEY}
+
+# MCP client connection using stateless-http transport
+spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:8080
+
+# Disable tool callback to prevent cyclic dependencies
+spring.ai.mcp.client.toolcallback.enabled=false
+----
+
+=== Key Features Demonstrated
+
+1. **Multi-Model Sampling**: Server requests content from multiple LLM providers using model hints
+2. **Annotation-Based Handlers**: Client uses `@McpSampling`, `@McpLogging`, and `@McpProgress` annotations
+3. **Stateless HTTP Transport**: Uses the streamable protocol for communication
+4. **Creative Content Generation**: Generates poems about weather data from different models
+5. **Unified Response Handling**: Combines responses from multiple providers into a single result
+
+=== Sample Output
+
+When running the client, you'll see output like:
+
+```
+> USER: What is the weather in Amsterdam right now?
+Please incorporate all creative responses from all LLM providers.
+After the other providers add a poem that synthesizes the poems from all the other providers.
+
+> ASSISTANT: 
+OpenAI poem about the weather:
+**Amsterdam's Winter Whisper**
+*Temperature: 4.2°C*
+
+In Amsterdam's embrace, where canals reflect the sky,
+A gentle chill of 4.2 degrees drifts by...
+
+Anthropic poem about the weather:
+**Canal-Side Contemplation**
+*Current conditions: 4.2°C*
+
+Along the waterways where bicycles rest,
+The winter air puts Amsterdam to test...
+
+Weather Data:
+{
+  "current": {
+    "time": "2025-01-23T11:00",
+    "interval": 900,
+    "temperature_2m": 4.2
+  }
+}
+```
+
+== Integration with Spring AI
+
+Example showing MCP tools integrated with Spring AI's function calling:
+
+[source,java]
+----
+@RestController
+@RequestMapping("/chat")
+public class ChatController {
+
+    private final ChatModel chatModel;
+    private final SyncMcpToolCallbackProvider toolCallbackProvider;
+
+    public ChatController(ChatModel chatModel, 
+                          SyncMcpToolCallbackProvider toolCallbackProvider) {
+        this.chatModel = chatModel;
+        this.toolCallbackProvider = toolCallbackProvider;
+    }
+
+    @PostMapping
+    public ChatResponse chat(@RequestBody ChatRequest request) {
+        // Get MCP tools as Spring AI function callbacks
+        ToolCallback[] mcpTools = toolCallbackProvider.getToolCallbacks();
+        
+        // Create prompt with MCP tools
+        Prompt prompt = new Prompt(
+            request.getMessage(),
+            ChatOptionsBuilder.builder()
+                .withTools(mcpTools)
+                .build()
+        );
+        
+        // Call chat model with MCP tools available
+        return chatModel.call(prompt);
+    }
+}
+
+@Component
+public class WeatherTools {
+
+    @McpTool(name = "get-weather", description = "Get current weather")
+    public WeatherInfo getWeather(
+            @McpToolParam(description = "City name", required = true) String city,
+            @McpToolParam(description = "Units (metric/imperial)", required = false) String units) {
+        
+        String unit = units != null ? units : "metric";
+        
+        // Call weather API
+        return weatherService.getCurrentWeather(city, unit);
+    }
+
+    @McpTool(name = "get-forecast", description = "Get weather forecast")
+    public ForecastInfo getForecast(
+            @McpToolParam(description = "City name", required = true) String city,
+            @McpToolParam(description = "Days (1-7)", required = false) Integer days) {
+        
+        int forecastDays = days != null ? days : 3;
+        
+        return weatherService.getForecast(city, forecastDays);
+    }
+}
+----
+
+== Testing MCP Annotations
+
+Example test cases for MCP annotated components:
+
+[source,java]
+----
+@SpringBootTest
+@AutoConfigureMockMvc
+class McpAnnotationTest {
+
+    @Autowired
+    private List<McpSyncClient> mcpClients;
+    
+    @MockBean
+    private WeatherService weatherService;
+
+    @Test
+    void testToolAnnotation() {
+        // Given
+        when(weatherService.getCurrentWeather("London", "metric"))
+            .thenReturn(new WeatherInfo("London", 20.0, "Cloudy"));
+        
+        // When
+        McpSyncClient client = mcpClients.get(0);
+        CallToolResult result = client.callTool(
+            new CallToolRequest("get-weather", 
+                Map.of("city", "London", "units", "metric")));
+        
+        // Then
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).isNotEmpty();
+    }
+
+    @Test
+    void testResourceAnnotation() {
+        // When
+        McpSyncClient client = mcpClients.get(0);
+        ReadResourceResult result = client.readResource(
+            new ReadResourceRequest("document://test-doc"));
+        
+        // Then
+        assertThat(result.contents()).isNotEmpty();
+        assertThat(result.contents().get(0).uri()).isEqualTo("document://test-doc");
+    }
+
+    @Test
+    void testClientHandlers() {
+        // Given
+        LoggingMessageNotification notification = LoggingMessageNotification.builder()
+            .level(LoggingLevel.INFO)
+            .logger("test")
+            .data("Test message")
+            .build();
+        
+        // When
+        // Handlers are automatically invoked by the MCP client
+        
+        // Then
+        // Verify handler was called (check logs, database, etc.)
+    }
+}
+----
+
+== Additional Resources
+
+* xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations Overview]
+* xref:api/mcp/mcp-annotations-server.adoc[Server Annotations Reference]
+* xref:api/mcp/mcp-annotations-client.adoc[Client Annotations Reference]
+* xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters Reference]
+* link:https://github.com/spring-projects/spring-ai-examples/tree/main/model-context-protocol[Spring AI MCP Examples on GitHub]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc
@@ -227,7 +227,7 @@ public class ClientHandlers {
         this.chatModel = chatModel;
     }
 
-    @McpLogging(clientId = "server1")
+    @McpLogging(clients = "server1")
     public void handleLogging(LoggingMessageNotification notification) {
         switch (notification.level()) {
             case ERROR:
@@ -244,7 +244,7 @@ public class ClientHandlers {
         }
     }
 
-    @McpSampling(clientId = "server1")
+    @McpSampling(clients = "server1")
     public CreateMessageResult handleSampling(CreateMessageRequest request) {
         // Use Spring AI ChatModel for sampling
         List<Message> messages = request.messages().stream()
@@ -266,7 +266,7 @@ public class ClientHandlers {
             .build();
     }
 
-    @McpElicitation(clientId = "server1")
+    @McpElicitation(clients = "server1")
     public ElicitResult handleElicitation(ElicitRequest request) {
         // In a real application, this would show a UI dialog
         Map<String, Object> userData = new HashMap<>();
@@ -288,7 +288,7 @@ public class ClientHandlers {
         return new ElicitResult(ElicitResult.Action.ACCEPT, userData);
     }
 
-    @McpProgress(clientId = "server1")
+    @McpProgress(clients = "server1")
     public void handleProgress(ProgressNotification notification) {
         progressTracker.update(
             notification.progressToken(),
@@ -301,7 +301,7 @@ public class ClientHandlers {
         broadcastProgress(notification);
     }
 
-    @McpToolListChanged(clientId = "server1")
+    @McpToolListChanged(clients = "server1")
     public void handleServer1ToolsChanged(List<McpSchema.Tool> tools) {
         logger.info("Server1 tools updated: {} tools available", tools.size());
         
@@ -312,7 +312,7 @@ public class ClientHandlers {
         eventBus.publish(new ToolsUpdatedEvent("server1", tools));
     }
 
-    @McpResourceListChanged(clientId = "server1")
+    @McpResourceListChanged(clients = "server1")
     public void handleServer1ResourcesChanged(List<McpSchema.Resource> resources) {
         logger.info("Server1 resources updated: {} resources available", resources.size());
         
@@ -415,7 +415,7 @@ public class AsyncDataProcessor {
 @Component
 public class AsyncClientHandlers {
 
-    @McpSampling(clientId = "async-server")
+    @McpSampling(clients = "async-server")
     public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
         return Mono.fromCallable(() -> {
             // Prepare request for LLM
@@ -431,7 +431,7 @@ public class AsyncClientHandlers {
         .timeout(Duration.ofSeconds(30));
     }
 
-    @McpProgress(clientId = "async-server")
+    @McpProgress(clients = "async-server")
     public Mono<Void> handleAsyncProgress(ProgressNotification notification) {
         return Mono.fromRunnable(() -> {
             // Update progress tracking
@@ -441,7 +441,7 @@ public class AsyncClientHandlers {
         .subscribeOn(Schedulers.parallel());
     }
 
-    @McpElicitation(clientId = "async-server")
+    @McpElicitation(clients = "async-server")
     public Mono<ElicitResult> handleAsyncElicitation(ElicitRequest request) {
         return showUserDialogAsync(request)
             .map(userData -> {
@@ -618,19 +618,19 @@ public class McpClientHandlers {
     @Autowired
     Map<String, ChatClient> chatClients;
 
-    @McpProgress(clientId = "server1")
+    @McpProgress(clients = "server1")
     public void progressHandler(ProgressNotification progressNotification) {
         logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
                 progressNotification.progressToken(), progressNotification.progress(),
                 progressNotification.total(), progressNotification.message());
     }
 
-    @McpLogging(clientId = "server1")
+    @McpLogging(clients = "server1")
     public void loggingHandler(LoggingMessageNotification loggingMessage) {
         logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
     }
 
-    @McpSampling(clientId = "server1")
+    @McpSampling(clients = "server1")
     public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
         logger.info("MCP SAMPLING: {}", llmRequest);
 
@@ -840,69 +840,6 @@ public class WeatherTools {
         int forecastDays = days != null ? days : 3;
         
         return weatherService.getForecast(city, forecastDays);
-    }
-}
-----
-
-== Testing MCP Annotations
-
-Example test cases for MCP annotated components:
-
-[source,java]
-----
-@SpringBootTest
-@AutoConfigureMockMvc
-class McpAnnotationTest {
-
-    @Autowired
-    private List<McpSyncClient> mcpClients;
-    
-    @MockBean
-    private WeatherService weatherService;
-
-    @Test
-    void testToolAnnotation() {
-        // Given
-        when(weatherService.getCurrentWeather("London", "metric"))
-            .thenReturn(new WeatherInfo("London", 20.0, "Cloudy"));
-        
-        // When
-        McpSyncClient client = mcpClients.get(0);
-        CallToolResult result = client.callTool(
-            new CallToolRequest("get-weather", 
-                Map.of("city", "London", "units", "metric")));
-        
-        // Then
-        assertThat(result.isError()).isFalse();
-        assertThat(result.content()).isNotEmpty();
-    }
-
-    @Test
-    void testResourceAnnotation() {
-        // When
-        McpSyncClient client = mcpClients.get(0);
-        ReadResourceResult result = client.readResource(
-            new ReadResourceRequest("document://test-doc"));
-        
-        // Then
-        assertThat(result.contents()).isNotEmpty();
-        assertThat(result.contents().get(0).uri()).isEqualTo("document://test-doc");
-    }
-
-    @Test
-    void testClientHandlers() {
-        // Given
-        LoggingMessageNotification notification = LoggingMessageNotification.builder()
-            .level(LoggingLevel.INFO)
-            .logger("test")
-            .data("Test message")
-            .build();
-        
-        // When
-        // Handlers are automatically invoked by the MCP client
-        
-        // Then
-        // Verify handler was called (check logs, database, etc.)
     }
 }
 ----

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
@@ -1,0 +1,150 @@
+= MCP Annotations
+
+The Spring AI MCP Annotations module provides annotation-based method handling for link:https://github.com/modelcontextprotocol/spec[Model Context Protocol (MCP)] servers and clients in Java. 
+It simplifies the creation and registration of MCP server methods and client handlers through a clean, declarative approach using Java annotations.
+
+
+The MCP Annotations enables developers to easily create and register methods for handling MCP operations using simple annotations. 
+It provides a clean, declarative approach to implementing MCP server and client functionality, reducing boilerplate code and improving maintainability.
+
+This library builds on top of the link:https://github.com/modelcontextprotocol/sdk-java[MCP Java SDK] to provide a higher-level, annotation-based programming model for implementing MCP servers and clients.
+
+== Architecture
+
+The MCP Annotations module consists of:
+
+=== Server Annotations
+
+For MCP Servers, the following annotations are provided:
+
+* `@McpTool` - Implements MCP tools with automatic JSON schema generation
+* `@McpResource` - Provides access to resources via URI templates
+* `@McpPrompt` - Generates prompt messages
+* `@McpComplete` - Provides auto-completion functionality
+
+=== Client Annotations
+
+For MCP Clients, the following annotations are provided:
+
+* `@McpLogging` - Handles logging message notifications
+* `@McpSampling` - Handles sampling requests
+* `@McpElicitation` - Handles elicitation requests for gathering additional information
+* `@McpProgress` - Handles progress notifications during long-running operations
+* `@McpToolListChanged` - Handles tool list change notifications
+* `@McpResourceListChanged` - Handles resource list change notifications
+* `@McpPromptListChanged` - Handles prompt list change notifications
+
+
+=== Special Parameters and Annotations
+
+* `McpSyncServerExchange` - Special parameter type for stateful synchronous operations that provides access to server exchange functionality including logging notifications, progress updates, and other server-side operations. This parameter is automatically injected and excluded from JSON schema generation
+* `McpAsyncServerExchange` - Special parameter type for stateful asynchronous operations that provides access to server exchange functionality with reactive support. This parameter is automatically injected and excluded from JSON schema generation
+* `McpTransportContext` - Special parameter type for stateless operations that provides lightweight access to transport-level context without full server exchange functionality. This parameter is automatically injected and excluded from JSON schema generation
+* `@McpProgressToken` - Marks a method parameter to receive the progress token from the request. This parameter is automatically injected and excluded from the generated JSON schema
+* `McpMeta` - Special parameter type that provides access to metadata from MCP requests, notifications, and results. This parameter is automatically injected and excluded from parameter count limits and JSON schema generation
+
+== Getting Started
+
+=== Dependencies
+
+Add the MCP annotations dependency to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-mcp-annotations</artifactId>
+</dependency>
+----
+
+The MCP annotations are automatically included when you use any of the MCP Boot Starters:
+
+* `spring-ai-starter-mcp-client`
+* `spring-ai-starter-mcp-client-webflux`
+* `spring-ai-starter-mcp-server`
+* `spring-ai-starter-mcp-server-webflux`
+* `spring-ai-starter-mcp-server-webmvc`
+
+=== Configuration
+
+The annotation scanning is enabled by default when using the MCP Boot Starters. You can configure the scanning behavior using the following properties:
+
+==== Client Annotation Scanner
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      client:
+        annotation-scanner:
+          enabled: true  # Enable/disable annotation scanning
+----
+
+==== Server Annotation Scanner
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      server:
+        annotation-scanner:
+          enabled: true  # Enable/disable annotation scanning
+----
+
+== Quick Example
+
+Here's a simple example of using MCP annotations to create a calculator tool:
+
+[source,java]
+----
+@Component
+public class CalculatorTools {
+
+    @McpTool(name = "add", description = "Add two numbers together")
+    public int add(
+            @McpToolParam(description = "First number", required = true) int a,
+            @McpToolParam(description = "Second number", required = true) int b) {
+        return a + b;
+    }
+
+    @McpTool(name = "multiply", description = "Multiply two numbers")
+    public double multiply(
+            @McpToolParam(description = "First number", required = true) double x,
+            @McpToolParam(description = "Second number", required = true) double y) {
+        return x * y;
+    }
+}
+----
+
+And a simple client handler for logging:
+
+[source,java]
+----
+@Component
+public class LoggingHandler {
+
+    @McpLogging
+    public void handleLoggingMessage(LoggingMessageNotification notification) {
+        System.out.println("Received log: " + notification.level() + 
+                          " - " + notification.data());
+    }
+}
+----
+
+With Spring Boot auto-configuration, these annotated beans are automatically detected and registered with the MCP server or client.
+
+== Documentation
+
+* xref:api/mcp/mcp-annotations-client.adoc[Client Annotations] - Detailed guide for client-side annotations
+* xref:api/mcp/mcp-annotations-server.adoc[Server Annotations] - Detailed guide for server-side annotations
+* xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters] - Guide for special parameter types
+* xref:api/mcp/mcp-annotations-examples.adoc[Examples] - Comprehensive examples and use cases
+
+== Additional Resources
+
+* xref:api/mcp/mcp-overview.adoc[MCP Overview]
+* xref:api/mcp/mcp-client-boot-starter-docs.adoc[MCP Client Boot Starter]
+* xref:api/mcp/mcp-server-boot-starter-docs.adoc[MCP Server Boot Starter]
+* link:https://modelcontextprotocol.github.io/specification/[Model Context Protocol Specification]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc
@@ -1,0 +1,434 @@
+= MCP Server Annotations
+
+The MCP Server Annotations provide a declarative way to implement MCP server functionality using Java annotations. 
+These annotations simplify the creation of tools, resources, prompts, and completion handlers.
+
+== Server Annotations
+
+=== @McpTool
+
+The `@McpTool` annotation marks a method as an MCP tool implementation with automatic JSON schema generation.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class CalculatorTools {
+
+    @McpTool(name = "add", description = "Add two numbers together")
+    public int add(
+            @McpToolParam(description = "First number", required = true) int a,
+            @McpToolParam(description = "Second number", required = true) int b) {
+        return a + b;
+    }
+}
+----
+
+==== Advanced Features
+
+[source,java]
+----
+@McpTool(name = "calculate-area", 
+         description = "Calculate the area of a rectangle",
+         annotations = @McpTool.McpAnnotations(
+             title = "Rectangle Area Calculator",
+             readOnlyHint = true,
+             destructiveHint = false,
+             idempotentHint = true
+         ))
+public AreaResult calculateRectangleArea(
+        @McpToolParam(description = "Width", required = true) double width,
+        @McpToolParam(description = "Height", required = true) double height) {
+    
+    return new AreaResult(width * height, "square units");
+}
+----
+
+==== With Server Exchange
+
+Tools can access the server exchange for advanced operations:
+
+[source,java]
+----
+@McpTool(name = "process-data", description = "Process data with server context")
+public String processData(
+        McpSyncServerExchange exchange,
+        @McpToolParam(description = "Data to process", required = true) String data) {
+    
+    // Send logging notification
+    exchange.loggingNotification(LoggingMessageNotification.builder()
+        .level(LoggingLevel.INFO)
+        .data("Processing data: " + data)
+        .build());
+    
+    // Send progress notification if progress token is available
+    exchange.progressNotification(new ProgressNotification(
+        progressToken, 0.5, 1.0, "Processing..."));
+    
+    return "Processed: " + data.toUpperCase();
+}
+----
+
+==== Dynamic Schema Support
+
+Tools can accept `CallToolRequest` for runtime schema handling:
+
+[source,java]
+----
+@McpTool(name = "flexible-tool", description = "Process dynamic schema")
+public CallToolResult processDynamic(CallToolRequest request) {
+    Map<String, Object> args = request.arguments();
+    
+    // Process based on runtime schema
+    String result = "Processed " + args.size() + " arguments dynamically";
+    
+    return CallToolResult.builder()
+        .addTextContent(result)
+        .build();
+}
+----
+
+==== Progress Tracking
+
+Tools can receive progress tokens for tracking long-running operations:
+
+[source,java]
+----
+@McpTool(name = "long-task", description = "Long-running task with progress")
+public String performLongTask(
+        @McpProgressToken String progressToken,
+        @McpToolParam(description = "Task name", required = true) String taskName,
+        McpSyncServerExchange exchange) {
+    
+    if (progressToken != null) {
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 0.0, 1.0, "Starting task"));
+        
+        // Perform work...
+        
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 1.0, 1.0, "Task completed"));
+    }
+    
+    return "Task " + taskName + " completed";
+}
+----
+
+=== @McpResource
+
+The `@McpResource` annotation provides access to resources via URI templates.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class ResourceProvider {
+
+    @McpResource(
+        uri = "config://{key}", 
+        name = "Configuration", 
+        description = "Provides configuration data")
+    public String getConfig(String key) {
+        return configData.get(key);
+    }
+}
+----
+
+==== With ReadResourceResult
+
+[source,java]
+----
+@McpResource(
+    uri = "user-profile://{username}", 
+    name = "User Profile", 
+    description = "Provides user profile information")
+public ReadResourceResult getUserProfile(String username) {
+    String profileData = loadUserProfile(username);
+    
+    return new ReadResourceResult(List.of(
+        new TextResourceContents(
+            "user-profile://" + username,
+            "application/json", 
+            profileData)
+    ));
+}
+----
+
+==== With Server Exchange
+
+[source,java]
+----
+@McpResource(
+    uri = "data://{id}", 
+    name = "Data Resource", 
+    description = "Resource with server context")
+public ReadResourceResult getData(
+        McpSyncServerExchange exchange, 
+        String id) {
+    
+    exchange.loggingNotification(LoggingMessageNotification.builder()
+        .level(LoggingLevel.INFO)
+        .data("Accessing resource: " + id)
+        .build());
+    
+    String data = fetchData(id);
+    
+    return new ReadResourceResult(List.of(
+        new TextResourceContents("data://" + id, "text/plain", data)
+    ));
+}
+----
+
+=== @McpPrompt
+
+The `@McpPrompt` annotation generates prompt messages for AI interactions.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class PromptProvider {
+
+    @McpPrompt(
+        name = "greeting", 
+        description = "Generate a greeting message")
+    public GetPromptResult greeting(
+            @McpArg(name = "name", description = "User's name", required = true) 
+            String name) {
+        
+        String message = "Hello, " + name + "! How can I help you today?";
+        
+        return new GetPromptResult(
+            "Greeting",
+            List.of(new PromptMessage(Role.ASSISTANT, new TextContent(message)))
+        );
+    }
+}
+----
+
+==== With Optional Arguments
+
+[source,java]
+----
+@McpPrompt(
+    name = "personalized-message",
+    description = "Generate a personalized message")
+public GetPromptResult personalizedMessage(
+        @McpArg(name = "name", required = true) String name,
+        @McpArg(name = "age", required = false) Integer age,
+        @McpArg(name = "interests", required = false) String interests) {
+    
+    StringBuilder message = new StringBuilder();
+    message.append("Hello, ").append(name).append("!\n\n");
+    
+    if (age != null) {
+        message.append("At ").append(age).append(" years old, ");
+        // Add age-specific content
+    }
+    
+    if (interests != null && !interests.isEmpty()) {
+        message.append("Your interest in ").append(interests);
+        // Add interest-specific content
+    }
+    
+    return new GetPromptResult(
+        "Personalized Message",
+        List.of(new PromptMessage(Role.ASSISTANT, new TextContent(message.toString())))
+    );
+}
+----
+
+=== @McpComplete
+
+The `@McpComplete` annotation provides auto-completion functionality for prompts.
+
+==== Basic Usage
+
+[source,java]
+----
+@Component
+public class CompletionProvider {
+
+    @McpComplete(prompt = "city-search")
+    public List<String> completeCityName(String prefix) {
+        return cities.stream()
+            .filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+            .limit(10)
+            .toList();
+    }
+}
+----
+
+==== With CompleteRequest.CompleteArgument
+
+[source,java]
+----
+@McpComplete(prompt = "travel-planner")
+public List<String> completeTravelDestination(CompleteRequest.CompleteArgument argument) {
+    String prefix = argument.value().toLowerCase();
+    String argumentName = argument.name();
+    
+    // Different completions based on argument name
+    if ("city".equals(argumentName)) {
+        return completeCities(prefix);
+    } else if ("country".equals(argumentName)) {
+        return completeCountries(prefix);
+    }
+    
+    return List.of();
+}
+----
+
+==== With CompleteResult
+
+[source,java]
+----
+@McpComplete(prompt = "code-completion")
+public CompleteResult completeCode(String prefix) {
+    List<String> completions = generateCodeCompletions(prefix);
+    
+    return new CompleteResult(
+        new CompleteResult.CompleteCompletion(
+            completions,
+            completions.size(),  // total
+            hasMoreCompletions   // hasMore flag
+        )
+    );
+}
+----
+
+== Stateless vs Stateful Implementations
+
+=== Stateful (with McpSyncServerExchange/McpAsyncServerExchange)
+
+Stateful implementations have access to the full server exchange context:
+
+[source,java]
+----
+@McpTool(name = "stateful-tool", description = "Tool with server exchange")
+public String statefulTool(
+        McpSyncServerExchange exchange,
+        @McpToolParam(description = "Input", required = true) String input) {
+    
+    // Access server exchange features
+    exchange.loggingNotification(...);
+    exchange.progressNotification(...);
+    exchange.ping();
+    
+    // Can call client methods
+    CreateMessageResult result = exchange.createMessage(...);
+    ElicitResult elicitResult = exchange.createElicitation(...);
+    
+    return "Processed with full context";
+}
+----
+
+=== Stateless (with McpTransportContext or without)
+
+Stateless implementations are simpler and don't require server exchange:
+
+[source,java]
+----
+@McpTool(name = "stateless-tool", description = "Simple stateless tool")
+public int simpleAdd(
+        @McpToolParam(description = "First number", required = true) int a,
+        @McpToolParam(description = "Second number", required = true) int b) {
+    return a + b;
+}
+
+// With transport context if needed
+@McpTool(name = "stateless-with-context", description = "Stateless with context")
+public String withContext(
+        McpTransportContext context,
+        @McpToolParam(description = "Input", required = true) String input) {
+    // Limited context access
+    return "Processed: " + input;
+}
+----
+
+== Async Support
+
+All server annotations support asynchronous implementations using Reactor:
+
+[source,java]
+----
+@Component
+public class AsyncTools {
+
+    @McpTool(name = "async-fetch", description = "Fetch data asynchronously")
+    public Mono<String> asyncFetch(
+            @McpToolParam(description = "URL", required = true) String url) {
+        
+        return Mono.fromCallable(() -> {
+            // Simulate async operation
+            return fetchFromUrl(url);
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @McpResource(uri = "async-data://{id}", name = "Async Data")
+    public Mono<ReadResourceResult> asyncResource(String id) {
+        return Mono.fromCallable(() -> {
+            String data = loadData(id);
+            return new ReadResourceResult(List.of(
+                new TextResourceContents("async-data://" + id, "text/plain", data)
+            ));
+        }).delayElement(Duration.ofMillis(100));
+    }
+}
+----
+
+== Spring Boot Integration
+
+With Spring Boot auto-configuration, annotated beans are automatically detected and registered:
+
+[source,java]
+----
+@SpringBootApplication
+public class McpServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(McpServerApplication.class, args);
+    }
+}
+
+@Component
+public class MyMcpTools {
+    // Your @McpTool annotated methods
+}
+
+@Component
+public class MyMcpResources {
+    // Your @McpResource annotated methods
+}
+----
+
+The auto-configuration will:
+
+1. Scan for beans with MCP annotations
+2. Create appropriate specifications
+3. Register them with the MCP server
+4. Handle both sync and async implementations based on configuration
+
+== Configuration Properties
+
+Configure the server annotation scanner:
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      server:
+        type: SYNC  # or ASYNC
+        annotation-scanner:
+          enabled: true
+----
+
+== Additional Resources
+
+* xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations Overview]
+* xref:api/mcp/mcp-annotations-client.adoc[Client Annotations]
+* xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters]
+* xref:api/mcp/mcp-server-boot-starter-docs.adoc[MCP Server Boot Starter]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-special-params.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-special-params.adoc
@@ -1,0 +1,470 @@
+= MCP Annotations Special Parameters
+
+The MCP Annotations support several special parameter types that provide additional context and functionality to annotated methods. 
+These parameters are automatically injected by the framework and are excluded from JSON schema generation.
+
+== Special Parameter Types
+
+=== McpMeta
+
+The `McpMeta` class provides access to metadata from MCP requests, notifications, and results.
+
+==== Overview
+
+* Automatically injected when used as a method parameter
+* Excluded from parameter count limits and JSON schema generation
+* Provides convenient access to metadata through the `get(String key)` method
+* If no metadata is present in the request, an empty `McpMeta` object is injected
+
+==== Usage in Tools
+
+[source,java]
+----
+@McpTool(name = "contextual-tool", description = "Tool with metadata access")
+public String processWithContext(
+        @McpToolParam(description = "Input data", required = true) String data,
+        McpMeta meta) {
+    
+    // Access metadata from the request
+    String userId = (String) meta.get("userId");
+    String sessionId = (String) meta.get("sessionId");
+    String userRole = (String) meta.get("userRole");
+    
+    // Use metadata to customize behavior
+    if ("admin".equals(userRole)) {
+        return processAsAdmin(data, userId);
+    } else {
+        return processAsUser(data, userId);
+    }
+}
+----
+
+==== Usage in Resources
+
+[source,java]
+----
+@McpResource(uri = "secure-data://{id}", name = "Secure Data")
+public ReadResourceResult getSecureData(String id, McpMeta meta) {
+    
+    String requestingUser = (String) meta.get("requestingUser");
+    String accessLevel = (String) meta.get("accessLevel");
+    
+    // Check access permissions using metadata
+    if (!"admin".equals(accessLevel)) {
+        return new ReadResourceResult(List.of(
+            new TextResourceContents("secure-data://" + id, 
+                "text/plain", "Access denied")
+        ));
+    }
+    
+    String data = loadSecureData(id);
+    return new ReadResourceResult(List.of(
+        new TextResourceContents("secure-data://" + id, 
+            "text/plain", data)
+    ));
+}
+----
+
+==== Usage in Prompts
+
+[source,java]
+----
+@McpPrompt(name = "localized-prompt", description = "Localized prompt generation")
+public GetPromptResult localizedPrompt(
+        @McpArg(name = "topic", required = true) String topic,
+        McpMeta meta) {
+    
+    String language = (String) meta.get("language");
+    String region = (String) meta.get("region");
+    
+    // Generate localized content based on metadata
+    String message = generateLocalizedMessage(topic, language, region);
+    
+    return new GetPromptResult("Localized Prompt",
+        List.of(new PromptMessage(Role.ASSISTANT, new TextContent(message)))
+    );
+}
+----
+
+=== @McpProgressToken
+
+The `@McpProgressToken` annotation marks a parameter to receive progress tokens from MCP requests.
+
+==== Overview
+
+* Parameter type should be `String`
+* Automatically receives the progress token value from the request
+* Excluded from the generated JSON schema
+* If no progress token is present, `null` is injected
+* Used for tracking long-running operations
+
+==== Usage in Tools
+
+[source,java]
+----
+@McpTool(name = "long-operation", description = "Long-running operation with progress")
+public String performLongOperation(
+        @McpProgressToken String progressToken,
+        @McpToolParam(description = "Operation name", required = true) String operation,
+        @McpToolParam(description = "Duration in seconds", required = true) int duration,
+        McpSyncServerExchange exchange) {
+    
+    if (progressToken != null) {
+        // Send initial progress
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 0.0, 1.0, "Starting " + operation));
+        
+        // Simulate work with progress updates
+        for (int i = 1; i <= duration; i++) {
+            Thread.sleep(1000);
+            double progress = (double) i / duration;
+            
+            exchange.progressNotification(new ProgressNotification(
+                progressToken, progress, 1.0, 
+                String.format("Processing... %d%%", (int)(progress * 100))));
+        }
+    }
+    
+    return "Operation " + operation + " completed";
+}
+----
+
+==== Usage in Resources
+
+[source,java]
+----
+@McpResource(uri = "large-file://{path}", name = "Large File Resource")
+public ReadResourceResult getLargeFile(
+        @McpProgressToken String progressToken,
+        String path,
+        McpSyncServerExchange exchange) {
+    
+    File file = new File(path);
+    long fileSize = file.length();
+    
+    if (progressToken != null) {
+        // Track file reading progress
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 0.0, fileSize, "Reading file"));
+    }
+    
+    String content = readFileWithProgress(file, progressToken, exchange);
+    
+    if (progressToken != null) {
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, fileSize, fileSize, "File read complete"));
+    }
+    
+    return new ReadResourceResult(List.of(
+        new TextResourceContents("large-file://" + path, "text/plain", content)
+    ));
+}
+----
+
+=== McpSyncServerExchange / McpAsyncServerExchange
+
+Server exchange objects provide full access to server-side MCP operations.
+
+==== Overview
+
+* Provides stateful context for server operations
+* Automatically injected when used as a parameter
+* Excluded from JSON schema generation
+* Enables advanced features like logging, progress notifications, and client calls
+
+==== McpSyncServerExchange Features
+
+[source,java]
+----
+@McpTool(name = "advanced-tool", description = "Tool with full server capabilities")
+public String advancedTool(
+        McpSyncServerExchange exchange,
+        @McpToolParam(description = "Input", required = true) String input) {
+    
+    // Send logging notification
+    exchange.loggingNotification(LoggingMessageNotification.builder()
+        .level(LoggingLevel.INFO)
+        .logger("advanced-tool")
+        .data("Processing: " + input)
+        .build());
+    
+    // Ping the client
+    exchange.ping();
+    
+    // Request additional information from user
+    ElicitRequest elicitRequest = ElicitRequest.builder()
+        .message("Need additional information")
+        .requestedSchema(Map.of(
+            "type", "object",
+            "properties", Map.of(
+                "confirmation", Map.of("type", "boolean")
+            )
+        ))
+        .build();
+    
+    ElicitResult elicitResult = exchange.createElicitation(elicitRequest);
+    
+    // Request LLM sampling
+    CreateMessageRequest messageRequest = CreateMessageRequest.builder()
+        .messages(List.of(new SamplingMessage(Role.USER, 
+            new TextContent("Process: " + input))))
+        .modelPreferences(ModelPreferences.builder()
+            .hints(List.of(ModelHint.of("gpt-4")))
+            .build())
+        .build();
+    
+    CreateMessageResult samplingResult = exchange.createMessage(messageRequest);
+    
+    return "Processed with advanced features";
+}
+----
+
+==== McpAsyncServerExchange Features
+
+[source,java]
+----
+@McpTool(name = "async-advanced-tool", description = "Async tool with server capabilities")
+public Mono<String> asyncAdvancedTool(
+        McpAsyncServerExchange exchange,
+        @McpToolParam(description = "Input", required = true) String input) {
+    
+    return Mono.fromCallable(() -> {
+        // Send async logging
+        exchange.loggingNotification(LoggingMessageNotification.builder()
+            .level(LoggingLevel.INFO)
+            .data("Async processing: " + input)
+            .build());
+        
+        return "Started processing";
+    })
+    .flatMap(msg -> {
+        // Chain async operations
+        return exchange.createMessage(/* request */)
+            .map(result -> "Completed: " + result);
+    });
+}
+----
+
+=== McpTransportContext
+
+Lightweight context for stateless operations.
+
+==== Overview
+
+* Provides minimal context without full server exchange
+* Used in stateless implementations
+* Automatically injected when used as a parameter
+* Excluded from JSON schema generation
+
+==== Usage Example
+
+[source,java]
+----
+@McpTool(name = "stateless-tool", description = "Stateless tool with context")
+public String statelessTool(
+        McpTransportContext context,
+        @McpToolParam(description = "Input", required = true) String input) {
+    
+    // Limited context access
+    // Useful for transport-level operations
+    
+    return "Processed in stateless mode: " + input;
+}
+
+@McpResource(uri = "stateless://{id}", name = "Stateless Resource")
+public ReadResourceResult statelessResource(
+        McpTransportContext context,
+        String id) {
+    
+    // Access transport context if needed
+    String data = loadData(id);
+    
+    return new ReadResourceResult(List.of(
+        new TextResourceContents("stateless://" + id, "text/plain", data)
+    ));
+}
+----
+
+=== CallToolRequest
+
+Special parameter for tools that need access to the full request with dynamic schema.
+
+==== Overview
+
+* Provides access to the complete tool request
+* Enables dynamic schema handling at runtime
+* Automatically injected and excluded from schema generation
+* Useful for flexible tools that adapt to different input schemas
+
+==== Usage Examples
+
+[source,java]
+----
+@McpTool(name = "dynamic-tool", description = "Tool with dynamic schema support")
+public CallToolResult processDynamicSchema(CallToolRequest request) {
+    Map<String, Object> args = request.arguments();
+    
+    // Process based on whatever schema was provided at runtime
+    StringBuilder result = new StringBuilder("Processed:\n");
+    
+    for (Map.Entry<String, Object> entry : args.entrySet()) {
+        result.append("  ").append(entry.getKey())
+              .append(": ").append(entry.getValue()).append("\n");
+    }
+    
+    return CallToolResult.builder()
+        .addTextContent(result.toString())
+        .build();
+}
+----
+
+==== Mixed Parameters
+
+[source,java]
+----
+@McpTool(name = "hybrid-tool", description = "Tool with typed and dynamic parameters")
+public String processHybrid(
+        @McpToolParam(description = "Operation", required = true) String operation,
+        @McpToolParam(description = "Priority", required = false) Integer priority,
+        CallToolRequest request) {
+    
+    // Use typed parameters for known fields
+    String result = "Operation: " + operation;
+    if (priority != null) {
+        result += " (Priority: " + priority + ")";
+    }
+    
+    // Access additional dynamic arguments
+    Map<String, Object> allArgs = request.arguments();
+    
+    // Remove known parameters to get only additional ones
+    Map<String, Object> additionalArgs = new HashMap<>(allArgs);
+    additionalArgs.remove("operation");
+    additionalArgs.remove("priority");
+    
+    if (!additionalArgs.isEmpty()) {
+        result += " with " + additionalArgs.size() + " additional parameters";
+    }
+    
+    return result;
+}
+----
+
+==== With Progress Token
+
+[source,java]
+----
+@McpTool(name = "flexible-with-progress", description = "Flexible tool with progress")
+public CallToolResult flexibleWithProgress(
+        @McpProgressToken String progressToken,
+        CallToolRequest request,
+        McpSyncServerExchange exchange) {
+    
+    Map<String, Object> args = request.arguments();
+    
+    if (progressToken != null) {
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 0.0, 1.0, "Processing dynamic request"));
+    }
+    
+    // Process dynamic arguments
+    String result = processDynamicArgs(args);
+    
+    if (progressToken != null) {
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 1.0, 1.0, "Complete"));
+    }
+    
+    return CallToolResult.builder()
+        .addTextContent(result)
+        .build();
+}
+----
+
+== Parameter Injection Rules
+
+=== Automatic Injection
+
+The following parameters are automatically injected by the framework:
+
+1. `McpMeta` - Metadata from the request
+2. `@McpProgressToken String` - Progress token if available
+3. `McpSyncServerExchange` / `McpAsyncServerExchange` - Server exchange context
+4. `McpTransportContext` - Transport context for stateless operations
+5. `CallToolRequest` - Full tool request for dynamic schema
+
+=== Schema Generation
+
+Special parameters are excluded from JSON schema generation:
+
+* They don't appear in the tool's input schema
+* They don't count towards parameter limits
+* They're not visible to MCP clients
+
+=== Null Handling
+
+* `McpMeta` - Never null, empty object if no metadata
+* `@McpProgressToken` - Can be null if no token provided
+* Server exchanges - Never null when properly configured
+* `CallToolRequest` - Never null for tool methods
+
+== Best Practices
+
+=== Use McpMeta for Context
+
+[source,java]
+----
+@McpTool(name = "context-aware", description = "Context-aware tool")
+public String contextAware(
+        @McpToolParam(description = "Data", required = true) String data,
+        McpMeta meta) {
+    
+    // Always check for null values in metadata
+    String userId = (String) meta.get("userId");
+    if (userId == null) {
+        userId = "anonymous";
+    }
+    
+    return processForUser(data, userId);
+}
+----
+
+=== Progress Token Null Checks
+
+[source,java]
+----
+@McpTool(name = "safe-progress", description = "Safe progress handling")
+public String safeProgress(
+        @McpProgressToken String progressToken,
+        @McpToolParam(description = "Task", required = true) String task,
+        McpSyncServerExchange exchange) {
+    
+    // Always check if progress token is available
+    if (progressToken != null) {
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 0.0, 1.0, "Starting"));
+    }
+    
+    // Perform work...
+    
+    if (progressToken != null) {
+        exchange.progressNotification(new ProgressNotification(
+            progressToken, 1.0, 1.0, "Complete"));
+    }
+    
+    return "Task completed";
+}
+----
+
+=== Choose the Right Context
+
+* Use `McpSyncServerExchange` / `McpAsyncServerExchange` for stateful operations
+* Use `McpTransportContext` for simple stateless operations
+* Omit context parameters entirely for the simplest cases
+
+== Additional Resources
+
+* xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations Overview]
+* xref:api/mcp/mcp-annotations-server.adoc[Server Annotations]
+* xref:api/mcp/mcp-annotations-client.adoc[Client Annotations]
+* xref:api/mcp/mcp-annotations-examples.adoc[Examples]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -85,6 +85,20 @@ The common properties are prefixed with `spring.ai.mcp.client`:
 |`true`
 |===
 
+=== MCP Annotations Properties
+
+MCP Client Annotations provide a declarative way to implement MCP client handlers using Java annotations.
+The client mcp-annotations properties are prefixed with `spring.ai.mcp.client.annotation-scanner`:
+
+[cols="3,4,3"]
+|===
+|Property |Description |Default Value
+
+|`enabled`
+|Enable/disable the MCP client annotations auto-scanning
+|`true`
+|===
+
 === Stdio Transport Properties
 
 Properties for Standard I/O transport are prefixed with `spring.ai.mcp.client.stdio`:
@@ -367,6 +381,84 @@ The auto-configuration supports multiple transport types:
 
 The starter can configure tool callbacks that integrate with Spring AI's tool execution framework, allowing MCP tools to be used as part of AI interactions. 
 This integration is enabled by default and can be disabled by setting the `spring.ai.mcp.client.toolcallback.enabled=false` property.
+
+== MCP Client Annotations
+
+The MCP Client Boot Starter automatically detects and registers annotated methods for handling various MCP client operations:
+
+* *@McpLogging* - Handles logging message notifications from MCP servers
+* *@McpSampling* - Handles sampling requests from MCP servers for LLM completions
+* *@McpElicitation* - Handles elicitation requests to gather additional information from users
+* *@McpProgress* - Handles progress notifications for long-running operations
+* *@McpToolListChanged* - Handles notifications when the server's tool list changes
+* *@McpResourceListChanged* - Handles notifications when the server's resource list changes
+* *@McpPromptListChanged* - Handles notifications when the server's prompt list changes
+
+Example usage:
+
+[source,java]
+----
+@Component
+public class McpClientHandlers {
+
+    @McpLogging
+    public void handleLoggingMessage(LoggingMessageNotification notification) {
+        System.out.println("Received log: " + notification.level() + 
+                          " - " + notification.data());
+    }
+
+    @McpSampling
+    public CreateMessageResult handleSamplingRequest(CreateMessageRequest request) {
+        // Process the request and generate a response
+        String response = generateLLMResponse(request);
+        
+        return CreateMessageResult.builder()
+            .role(Role.ASSISTANT)
+            .content(new TextContent(response))
+            .model("gpt-4")
+            .build();
+    }
+
+    @McpProgress
+    public void handleProgressNotification(ProgressNotification notification) {
+        double percentage = notification.progress() * 100;
+        System.out.println(String.format("Progress: %.2f%% - %s", 
+            percentage, notification.message()));
+    }
+
+    @McpToolListChanged
+    public void handleToolListChanged(List<McpSchema.Tool> updatedTools) {
+        System.out.println("Tool list updated: " + updatedTools.size() + " tools available");
+        // Update local tool registry
+        toolRegistry.updateTools(updatedTools);
+    }
+}
+----
+
+The annotations support both synchronous and asynchronous implementations, and can be configured for specific clients using the `clientId` parameter:
+
+[source,java]
+----
+@McpLogging(clientId = "server1")
+public void handleServer1Logs(LoggingMessageNotification notification) {
+    // Handle logs from specific server
+    logToFile("server1.log", notification);
+}
+
+@McpSampling
+public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
+    return Mono.fromCallable(() -> {
+        String response = generateLLMResponse(request);
+        return CreateMessageResult.builder()
+            .role(Role.ASSISTANT)
+            .content(new TextContent(response))
+            .model("gpt-4")
+            .build();
+    }).subscribeOn(Schedulers.boundedElastic());
+}
+----
+
+For detailed information about all available annotations and their usage patterns, see the xref:api/mcp/mcp-annotations-client.adoc[MCP Client Annotations] documentation.
 
 == Usage Example
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -401,13 +401,13 @@ Example usage:
 @Component
 public class McpClientHandlers {
 
-    @McpLogging
+    @McpLogging(clients = "server1")
     public void handleLoggingMessage(LoggingMessageNotification notification) {
         System.out.println("Received log: " + notification.level() + 
                           " - " + notification.data());
     }
 
-    @McpSampling
+    @McpSampling(clients = "server1")
     public CreateMessageResult handleSamplingRequest(CreateMessageRequest request) {
         // Process the request and generate a response
         String response = generateLLMResponse(request);
@@ -419,14 +419,14 @@ public class McpClientHandlers {
             .build();
     }
 
-    @McpProgress
+    @McpProgress(clients = "server1")
     public void handleProgressNotification(ProgressNotification notification) {
         double percentage = notification.progress() * 100;
         System.out.println(String.format("Progress: %.2f%% - %s", 
             percentage, notification.message()));
     }
 
-    @McpToolListChanged
+    @McpToolListChanged(clients = "server1")
     public void handleToolListChanged(List<McpSchema.Tool> updatedTools) {
         System.out.println("Tool list updated: " + updatedTools.size() + " tools available");
         // Update local tool registry
@@ -445,7 +445,7 @@ public void handleServer1Logs(LoggingMessageNotification notification) {
     logToFile("server1.log", notification);
 }
 
-@McpSampling
+@McpSampling(clients = "server1")
 public Mono<CreateMessageResult> handleAsyncSampling(CreateMessageRequest request) {
     return Mono.fromCallable(() -> {
         String response = generateLLMResponse(request);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -435,11 +435,11 @@ public class McpClientHandlers {
 }
 ----
 
-The annotations support both synchronous and asynchronous implementations, and can be configured for specific clients using the `clientId` parameter:
+The annotations support both synchronous and asynchronous implementations, and can be configured for specific clients using the `clients` parameter:
 
 [source,java]
 ----
-@McpLogging(clientId = "server1")
+@McpLogging(clients = "server1")
 public void handleServer1Logs(LoggingMessageNotification notification) {
     // Handle logs from specific server
     logToFile("server1.log", notification);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
@@ -82,21 +82,55 @@ Spring AI provides MCP integration through the following Spring Boot starters:
 
 === link:mcp-server-boot-starter-docs.html[Server Starters]
 
-==== STDIO and SSE MCP Servers
-* `spring-ai-starter-mcp-server` - Core server with `STDIO` transport support
-* `spring-ai-starter-mcp-server-webmvc` - Spring MVC-based `SSE` transport implementation
-* `spring-ai-starter-mcp-server-webflux` - WebFlux-based `SSE` transport implementation
+==== STDIO
 
-==== Streamable MCP Servers
-* `spring-ai-starter-mcp-server-streamable-webmvc` - Spring MVC-based `Streamable-HTTP` server with change notifications
-* `spring-ai-starter-mcp-server-streamable-webflux` - WebFlux-based `Streamable-HTTP` server with change notifications
+[options="header"]
+|===
+|Server Type | Dependency | Property
+| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc[Standard Input/Output (STDIO)] | `spring-ai-starter-mcp-server` | `spring.ai.mcp.server.stdio=true`
+|===
 
-==== Stateless MCP Servers
-* `spring-ai-starter-mcp-server-stateless-webmvc` - Spring MVC-based `Stateless` server for simplified deployments
-* `spring-ai-starter-mcp-server-stateless-webflux` - WebFlux-based `Stateless` server for simplified deployments
+==== WebMVC
+
+|===
+|Server Type | Dependency | Property
+| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webmvc_serve[SSE WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=SSE` or empty
+| xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc#_streamable_http_webmvc_server[Streamable-HTTP WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=STREAMABLE`
+| xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc#_stateless_webmvc_server[Stateless WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=STATLESS`
+|===
+
+==== WebMVC (Reactive)
+|===
+|Server Type | Dependency | Property
+| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webflux_serve[SSE WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=SSE` or empty
+| xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc#_streamable_http_webflux_server[Streamable-HTTP WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=STREAMABLE`
+| xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc#_stateless_webflux_server[Stateless WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=STATLESS`
+|===
+
+== xref:api/mcp/mcp-annotations-overview.adoc[Spring AI MCP Annotations]
+
+In addition to the programmatic MCP client & server configuration, Spring AI provides annotation-based method handling for MCP servers and clients through the xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations] module. 
+This approach simplifies the creation and registration of MCP operations using a clean, declarative programming model with Java annotations.
+
+The MCP Annotations module enables developers to:
+
+* Create MCP tools, resources, and prompts using simple annotations
+* Handle client-side notifications and requests declaratively
+* Reduce boilerplate code and improve maintainability
+* Automatically generate JSON schemas for tool parameters
+* Access special parameters and context information
+
+Key features include:   
+
+* xref:api/mcp/mcp-annotations-server.adoc[Server Annotations]: `@McpTool`, `@McpResource`, `@McpPrompt`, `@McpComplete`
+* xref:api/mcp/mcp-annotations-client.adoc[Client Annotations]: `@McpLogging`, `@McpSampling`, `@McpElicitation`, `@McpProgress`
+* xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters]: `McpSyncServerExchange`, `McpAsyncServerExchange`, `McpTransportContext`, `McpMeta`
+* **Automatic Discovery**: Annotation scanning with configurable package inclusion/exclusion
+* **Spring Boot Integration**: Seamless integration with MCP Boot Starters
 
 == Additional Resources
 
+* xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations Documentation]
 * link:mcp-client-boot-starter-docs.html[MCP Client Boot Starters Documentation]
 * link:mcp-server-boot-starter-docs.html[MCP Server Boot Starters Documentation]
 * link:mcp-helpers.html[MCP Utilities Documentation]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -14,6 +14,7 @@ The MCP Server Boot Starters offer:
 * Multiple transport layer options
 * Flexible tool, resource, and prompt specification
 * Change notification capabilities
+* xref:api/mcp/mcp-annotations-server.adoc[Annotation-based server development] with automatic bean scanning and registration
 
 == MCP Server Boot Starters
 
@@ -82,6 +83,90 @@ When activated, it automatically handles the configuration of synchronous tool s
 To enable this server type, configure your application with `spring.ai.mcp.server.type=ASYNC`.
 This server type automatically sets up asynchronous tool specifications with built-in Project Reactor support.
 
+== MCP Server Annotations
+
+The MCP Server Boot Starters provide comprehensive support for annotation-based server development, allowing you to create MCP servers using declarative Java annotations instead of manual configuration.
+
+=== Key Annotations
+
+* **xref:api/mcp/mcp-annotations-server.adoc#_mcptool[@McpTool]** - Mark methods as MCP tools with automatic JSON schema generation
+* **xref:api/mcp/mcp-annotations-server.adoc#_mcpresource[@McpResource]** - Provide access to resources via URI templates  
+* **xref:api/mcp/mcp-annotations-server.adoc#_mcpprompt[@McpPrompt]** - Generate prompt messages for AI interactions
+* **xref:api/mcp/mcp-annotations-server.adoc#_mcpcomplete[@McpComplete]** - Provide auto-completion functionality for prompts
+
+=== Special Parameters
+
+The annotation system supports xref:api/mcp/mcp-annotations-special-params.adoc[special parameter types] that provide additional context:
+
+* **`McpMeta`** - Access metadata from MCP requests
+* **`@McpProgressToken`** - Receive progress tokens for long-running operations
+* **`McpSyncServerExchange`/`McpAsyncServerExchange`** - Full server context for advanced operations
+* **`McpTransportContext`** - Lightweight context for stateless operations
+* **`CallToolRequest`** - Dynamic schema support for flexible tools
+
+=== Simple Example
+
+[source,java]
+----
+@Component
+public class CalculatorTools {
+
+    @McpTool(name = "add", description = "Add two numbers together")
+    public int add(
+            @McpToolParam(description = "First number", required = true) int a,
+            @McpToolParam(description = "Second number", required = true) int b) {
+        return a + b;
+    }
+
+    @McpResource(uri = "config://{key}", name = "Configuration")
+    public String getConfig(String key) {
+        return configData.get(key);
+    }
+}
+----
+
+=== Auto-Configuration
+
+With Spring Boot auto-configuration, annotated beans are automatically detected and registered:
+
+[source,java]
+----
+@SpringBootApplication
+public class McpServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(McpServerApplication.class, args);
+    }
+}
+----
+
+The auto-configuration will:
+
+1. Scan for beans with MCP annotations
+2. Create appropriate specifications  
+3. Register them with the MCP server
+4. Handle both sync and async implementations based on configuration
+
+=== Configuration Properties
+
+Configure the server annotation scanner:
+
+[source,yaml]
+----
+spring:
+  ai:
+    mcp:
+      server:
+        type: SYNC  # or ASYNC
+        annotation-scanner:
+          enabled: true
+----
+
+=== Additional Resources
+
+* xref:api/mcp/mcp-annotations-server.adoc[Server Annotations Reference] - Complete guide to server annotations
+* xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters] - Advanced parameter injection
+* xref:api/mcp/mcp-annotations-examples.adoc[Examples] - Comprehensive examples and use cases
+
 
 == Example Applications
 
@@ -93,6 +178,9 @@ This server type automatically sets up asynchronous tool specifications with bui
 
 == Additional Resources
 
+* xref:api/mcp/mcp-annotations-server.adoc[MCP Server Annotations] - Declarative server development with annotations
+* xref:api/mcp/mcp-annotations-special-params.adoc[Special Parameters] - Advanced parameter injection and context access
+* xref:api/mcp/mcp-annotations-examples.adoc[MCP Annotations Examples] - Comprehensive examples and use cases
 * link:https://docs.spring.io/spring-ai/reference/[Spring AI Documentation]
 * link:https://modelcontextprotocol.io/specification[Model Context Protocol Specification]
 * link:https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.developing-auto-configuration[Spring Boot Auto-configuration]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
@@ -76,6 +76,22 @@ All Common properties are prefixed with `spring.ai.mcp.server`:
 |`request-timeout` |Request timeout duration |`20 seconds`
 |===
 
+=== MCP Annotations Properties
+
+MCP Server Annotations provide a declarative way to implement MCP server handlers using Java annotations.
+
+The server mcp-annotations properties are prefixed with `spring.ai.mcp.server.annotation-scanner`:
+
+[cols="3,4,3"]
+|===
+|Property |Description |Default Value
+
+|`enabled`
+|Enable/disable the MCP server annotations auto-scanning
+|`true`
+
+|===
+
 === Stateless Connection Properties
 
 All connection properties are prefixed with `spring.ai.mcp.server.stateless`:

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
@@ -92,6 +92,22 @@ All Common properties are prefixed with `spring.ai.mcp.server`:
 |`request-timeout` |Duration to wait for server responses before timing out requests. Applies to all requests made through the client, including tool calls, resource access, and prompt operations |`20 seconds`
 |===
 
+=== MCP Annotations Properties
+
+MCP Server Annotations provide a declarative way to implement MCP server handlers using Java annotations.
+
+The server mcp-annotations properties are prefixed with `spring.ai.mcp.server.annotation-scanner`:
+
+[cols="3,4,3"]
+|===
+|Property |Description |Default Value
+
+|`enabled`
+|Enable/disable the MCP server annotations auto-scanning
+|`true`
+
+|===
+
 === SSE Properties
 
 All SSE properties are prefixed with `spring.ai.mcp.server`:

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
@@ -72,6 +72,22 @@ All common properties are prefixed with `spring.ai.mcp.server`:
 |`request-timeout` |Request timeout duration |`20 seconds`
 |===
 
+=== MCP Annotations Properties
+
+MCP Server Annotations provide a declarative way to implement MCP server handlers using Java annotations.
+
+The server mcp-annotations properties are prefixed with `spring.ai.mcp.server.annotation-scanner`:
+
+[cols="3,4,3"]
+|===
+|Property |Description |Default Value
+
+|`enabled`
+|Enable/disable the MCP server annotations auto-scanning
+|`true`
+
+|===
+
 === Streamable-HTTP Properties
 
 All streamable-HTTP properties are prefixed with `spring.ai.mcp.server.streamable-http`:

--- a/spring-ai-spring-boot-starters/spring-ai-starter-mcp-client-webflux/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-mcp-client-webflux/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-mcp-annotations</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-spring-webflux</artifactId>
         </dependency>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-mcp-client/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-mcp-client/pom.xml
@@ -53,6 +53,13 @@
             <artifactId>spring-ai-mcp</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-mcp-annotations</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server-webflux/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server-webflux/pom.xml
@@ -57,6 +57,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-mcp-annotations</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+
+        <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-spring-webflux</artifactId>
         </dependency>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server-webmvc/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server-webmvc/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-mcp-annotations</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-spring-webmvc</artifactId>
         </dependency>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server/pom.xml
@@ -53,6 +53,13 @@
             <artifactId>spring-ai-mcp</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-mcp-annotations</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
- Introduce  module for declarative MCP configuration
- Create new mcp-annotations-spring module
- Add annotation scanners to auto-discover MCP annotated beans and methods
- Support MCP annotations: @McpTool, @McpResource, @McpPrompt, @McpComplete for servers
- Support MCP annotations: @McpLogging, @McpSampling, @McpElicitation, @McpProgress for clients
- Implement customizers to automatically register annotated specifications
  - Introduce McpAsyncAnnotationCustomizer and McpSyncAnnotationCustomizer for annotation-driven client configuration
- Add Spring-aware annotation providers for both sync and async MCP operations
- Include comprehensive integration tests for annotation-based MCP configuration
- Update all MCP starter dependencies to include the new annotations module
- Update BOM and parent POM to include mcp-annotations dependency version management
- Include comprehensive integration test StreamableMcpAnnotationsIT demonstrating annotation usage

This enhancement simplifies MCP setup by allowing developers to use annotations instead of manual bean configuration, improving developer experience and reducing boilerplate code.