### PR TITLE
GH-4251 Add the capability to parse required variables from templates to `TemplateRenderer`

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiCompatibleChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiCompatibleChatModelIT.java
@@ -68,7 +68,7 @@ public class OpenAiCompatibleChatModelIT {
 				.openAiApi(OpenAiApi.builder()
 					.baseUrl("https://api.groq.com/openai")
 					.apiKey(System.getenv("GROQ_API_KEY"))
-					.build()) 
+					.build())
 				.defaultOptions(forModelName("llama3-8b-8192"))
 				.build());
 		}

--- a/spring-ai-commons/src/main/java/org/springframework/ai/template/NoOpTemplateRenderer.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/template/NoOpTemplateRenderer.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.template;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.util.Assert;
 
@@ -34,6 +35,11 @@ public class NoOpTemplateRenderer implements TemplateRenderer {
 		Assert.notNull(variables, "variables cannot be null");
 		Assert.noNullElements(variables.keySet(), "variables keys cannot be null");
 		return template;
+	}
+
+	@Override
+	public Set<String> getRequiredVariables(String template) {
+		return Set.of();
 	}
 
 }

--- a/spring-ai-commons/src/main/java/org/springframework/ai/template/TemplateRenderer.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/template/TemplateRenderer.java
@@ -17,17 +17,21 @@
 package org.springframework.ai.template;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 /**
  * Renders a template using a given strategy.
  *
  * @author Thomas Vitale
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public interface TemplateRenderer extends BiFunction<String, Map<String, Object>, String> {
 
 	@Override
 	String apply(String template, Map<String, Object> variables);
+
+	Set<String> getRequiredVariables(String template);
 
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.prompt;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -314,6 +315,11 @@ class PromptTemplateTests {
 			// Simple renderer that just appends a marker
 			// Note: This simple renderer ignores the model map for test purposes.
 			return template + " (Rendered by Custom)";
+		}
+
+		@Override
+		public Set<String> getRequiredVariables(String template) {
+			return Set.of();
 		}
 
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/SystemPromptTemplateTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/SystemPromptTemplateTests.java
@@ -26,6 +26,7 @@ import org.springframework.core.io.Resource;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -322,6 +323,11 @@ class SystemPromptTemplateTests {
 			// Simple renderer that just appends a marker
 			// Note: This simple renderer ignores the model map for test purposes.
 			return template + " (Rendered by Custom)";
+		}
+
+		@Override
+		public Set<String> getRequiredVariables(String template) {
+			return Set.of();
 		}
 
 	}

--- a/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
+++ b/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  * is shared between threads.
  *
  * @author Thomas Vitale
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public class StTemplateRenderer implements TemplateRenderer {
@@ -108,6 +109,11 @@ public class StTemplateRenderer implements TemplateRenderer {
 			validate(st, variables);
 		}
 		return st.render();
+	}
+
+	@Override
+	public Set<String> getRequiredVariables(String template) {
+		return getInputVariables(createST(template));
 	}
 
 	private ST createST(String template) {

--- a/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
+++ b/spring-ai-template-st/src/test/java/org/springframework/ai/template/st/StTemplateRendererTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.template.st;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Unit tests for {@link StTemplateRenderer}.
  *
  * @author Thomas Vitale
+ * @author Sun Yuhan
  */
 class StTemplateRendererTests {
 
@@ -295,6 +297,18 @@ class StTemplateRendererTests {
 		String result = renderer.apply(template, variables);
 
 		assertThat(result).isEqualTo("Hello!");
+	}
+
+	/**
+	 * Test whether the required variables can be correctly extracted from the template.
+	 */
+	@Test
+	void shouldCorrectlyExtractedRequiredVariables() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		String template = "Person: {name}, Age: {age}";
+		Set<String> requiredVariables = renderer.getRequiredVariables(template);
+
+		assertThat(requiredVariables).contains("name", "age");
 	}
 
 }


### PR DESCRIPTION
As mentioned in the issue, `TemplateRenderer` currently only supports rendering templates. The ability to also parse and extract the required variables from a given template would be highly beneficial, especially for proactively validating template correctness. This PR implements that capability. 

Specifically, it: 

1. Adds a `getRequiredVariables` method to `TemplateRenderer` to extract the variable names required by the template; 

3. Includes corresponding unit tests to ensure correctness and stability.

Fixes #4251