### PR TITLE
Update docker services documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/docker-compose.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/docker-compose.adoc
@@ -55,3 +55,5 @@ The following service connection factories are provided in the `spring-ai-spring
 | `WeaviateConnectionDetails`
 | Containers named `semitechnologies/weaviate`, `cr.weaviate.io/semitechnologies/weaviate`
 |====
+
+More service connections are provided by the spring boot module `spring-boot-docker-compose`. Refer to the https://docs.spring.io/spring-boot/reference/features/dev-services.html#features.dev-services.docker-compose[Docker Compose Support] documentation page for the full list.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testcontainers.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/testcontainers.adoc
@@ -59,3 +59,5 @@ The following service connection factories are provided in the `spring-ai-spring
 | `WeaviateConnectionDetails`
 | Containers of type `WeaviateContainer`
 |====
+
+More service connections are provided by the spring boot module `spring-boot-testcontainers`. Refer to the https://docs.spring.io/spring-boot/reference/testing/testcontainers.html#testing.testcontainers.service-connections[Testcontainers Service Connections] documentation page for the full list.


### PR DESCRIPTION
As discussed in https://github.com/spring-projects/spring-ai/pull/4241, the current documentation doesn't explain that any service connection from spring boot can be used in spring ai. Updating the documentation to link to the matching spring boot documentation.