### PR TITLE
GH-4205 Optimized the `getClassOrNull` method in `ToolCallingAutoConfiguration`

### DIFF
--- a/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.java
+++ b/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.java
@@ -126,10 +126,19 @@ public class ToolCallingAutoConfiguration {
 
 	private static Class<? extends RuntimeException> getClassOrNull(String className) {
 		try {
-			return (Class<? extends RuntimeException>) ClassUtils.forName(className, null);
+			Class<?> clazz = ClassUtils.forName(className, null);
+			if (RuntimeException.class.isAssignableFrom(clazz)) {
+				return (Class<? extends RuntimeException>) clazz;
+			}
+			else {
+				logger.debug("Class {} is not a subclass of RuntimeException", className);
+			}
 		}
 		catch (ClassNotFoundException e) {
-			logger.debug("Cannot load class", e);
+			logger.debug("Cannot load class: {}", className);
+		}
+		catch (Exception e) {
+			logger.debug("Error loading class: {}", className, e);
 		}
 		return null;
 	}


### PR DESCRIPTION
The original intent of the `ToolCallingAutoConfiguration#getClassOrNull` method is to attempt loading a specified class, returning `null` if the class cannot be found. However, the current implementation prints the full stack trace when a `ClassNotFoundException` is thrown, which may mislead users into thinking there is a real problem (while in fact, this is an expected and normal behavior). This PR improves the exception handling in the method, so that when a `ClassNotFoundException` occurs, only the class name is logged instead of the entire stack trace, thereby avoiding confusion and improving log clarity.

Fixes #4205
Fixes #4249