### PR TITLE
test: Add unit tests for the `spring-ai-mcp-annotations` module

### DIFF
--- a/mcp/mcp-annotations-spring/pom.xml
+++ b/mcp/mcp-annotations-spring/pom.xml
@@ -41,6 +41,25 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 

--- a/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/AnnotationProviderUtilTests.java
+++ b/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/AnnotationProviderUtilTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.AopUtils;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit Tests for {@link AnnotationProviderUtil}.
+ *
+ * @author Sun Yuhan
+ */
+@ExtendWith(MockitoExtension.class)
+class AnnotationProviderUtilTests {
+
+	@Test
+	void beanMethodsWithNormalClassReturnsSortedMethods() {
+		TestClass testBean = new TestClass();
+
+		Method[] methods = AnnotationProviderUtil.beanMethods(testBean);
+
+		assertThat(methods).isNotNull();
+		assertThat(methods.length).isEqualTo(3);
+
+		assertThat(methods[0].getName()).isEqualTo("aaaMethod");
+		assertThat(methods[1].getName()).isEqualTo("bbbMethod");
+		assertThat(methods[2].getName()).isEqualTo("cccMethod");
+
+		Arrays.stream(methods).forEach(method -> assertThat(method.getDeclaringClass()).isEqualTo(TestClass.class));
+	}
+
+	@Test
+	void beanMethodsWithAopProxyReturnsTargetClassMethods() {
+		TestClass target = new TestClass();
+		ProxyFactory proxyFactory = new ProxyFactory(target);
+		Object proxy = proxyFactory.getProxy();
+
+		Method[] methods = AnnotationProviderUtil.beanMethods(proxy);
+
+		assertThat(methods).isNotNull();
+		assertThat(methods.length).isEqualTo(3);
+
+		Arrays.stream(methods).forEach(method -> assertThat(method.getDeclaringClass()).isEqualTo(TestClass.class));
+	}
+
+	@Test
+	void beanMethodsWithMockedAopProxyReturnsTargetClassMethods() {
+		Object proxy = mock(Object.class);
+
+		try (MockedStatic<AopUtils> mockedAopUtils = mockStatic(AopUtils.class)) {
+			mockedAopUtils.when(() -> AopUtils.isAopProxy(proxy)).thenReturn(true);
+			mockedAopUtils.when(() -> AopUtils.getTargetClass(proxy)).thenReturn(TestClass.class);
+
+			Method[] methods = AnnotationProviderUtil.beanMethods(proxy);
+
+			assertThat(methods).isNotNull();
+			assertThat(methods.length).isEqualTo(3);
+
+			mockedAopUtils.verify(() -> AopUtils.isAopProxy(proxy));
+			mockedAopUtils.verify(() -> AopUtils.getTargetClass(proxy));
+		}
+	}
+
+	@Test
+	void beanMethodsWithNoDeclaredMethodsReturnsEmptyArray() {
+		NoMethodClass testBean = new NoMethodClass();
+
+		Method[] methods = AnnotationProviderUtil.beanMethods(testBean);
+
+		assertThat(methods).isNotNull();
+		assertThat(methods).isEmpty();
+	}
+
+	@Test
+	void beanMethodsWithOverloadedMethodsReturnsCorrectlySortedMethods() {
+		OverloadedMethodClass testBean = new OverloadedMethodClass();
+
+		Method[] methods = AnnotationProviderUtil.beanMethods(testBean);
+
+		assertThat(methods).isNotNull();
+		assertThat(methods.length).isEqualTo(3);
+
+		assertThat(methods[0].getName()).isEqualTo("overloadedMethod");
+		assertThat(methods[0].getParameterCount()).isEqualTo(0);
+
+		assertThat(methods[1].getName()).isEqualTo("overloadedMethod");
+		assertThat(methods[1].getParameterCount()).isEqualTo(1);
+
+		assertThat(methods[2].getName()).isEqualTo("simpleMethod");
+	}
+
+	static class TestClass {
+
+		public void cccMethod() {
+		}
+
+		public void aaaMethod() {
+		}
+
+		public void bbbMethod() {
+		}
+
+	}
+
+	static class NoMethodClass {
+
+	}
+
+	static class OverloadedMethodClass {
+
+		public void simpleMethod() {
+		}
+
+		public void overloadedMethod(String param) {
+		}
+
+		public void overloadedMethod() {
+		}
+
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProvidersTests.java
+++ b/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProvidersTests.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.AsyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.AsyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.AsyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.AsyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit Tests for {@link AsyncMcpAnnotationProviders}.
+ *
+ * @author Sun Yuhan
+ */
+@ExtendWith(MockitoExtension.class)
+class AsyncMcpAnnotationProvidersTests {
+
+	@Test
+	void testLoggingSpecifications() {
+		List<Object> loggingObjects = new ArrayList<>();
+		loggingObjects.add(new Object());
+
+		List<AsyncLoggingSpecification> result = AsyncMcpAnnotationProviders.loggingSpecifications(loggingObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testLoggingSpecificationsWithEmptyList() {
+		List<Object> loggingObjects = new ArrayList<>();
+
+		List<AsyncLoggingSpecification> result = AsyncMcpAnnotationProviders.loggingSpecifications(loggingObjects);
+
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void testSamplingSpecifications() {
+		List<Object> samplingObjects = new ArrayList<>();
+		samplingObjects.add(new Object());
+
+		List<AsyncSamplingSpecification> result = AsyncMcpAnnotationProviders.samplingSpecifications(samplingObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testElicitationSpecifications() {
+		List<Object> elicitationObjects = new ArrayList<>();
+		elicitationObjects.add(new Object());
+
+		List<AsyncElicitationSpecification> result = AsyncMcpAnnotationProviders
+			.elicitationSpecifications(elicitationObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testProgressSpecifications() {
+		List<Object> progressObjects = new ArrayList<>();
+		progressObjects.add(new Object());
+
+		List<AsyncProgressSpecification> result = AsyncMcpAnnotationProviders.progressSpecifications(progressObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testToolSpecifications() {
+		List<Object> toolObjects = new ArrayList<>();
+		toolObjects.add(new Object());
+
+		List<McpServerFeatures.AsyncToolSpecification> result = AsyncMcpAnnotationProviders
+			.toolSpecifications(toolObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testStatelessToolSpecifications() {
+
+		List<Object> toolObjects = new ArrayList<>();
+		toolObjects.add(new Object());
+
+		List<McpStatelessServerFeatures.AsyncToolSpecification> result = AsyncMcpAnnotationProviders
+			.statelessToolSpecifications(toolObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testCompleteSpecifications() {
+		List<Object> completeObjects = new ArrayList<>();
+		completeObjects.add(new Object());
+
+		List<McpServerFeatures.AsyncCompletionSpecification> result = AsyncMcpAnnotationProviders
+			.completeSpecifications(completeObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testStatelessCompleteSpecifications() {
+		List<Object> completeObjects = new ArrayList<>();
+		completeObjects.add(new Object());
+
+		List<McpStatelessServerFeatures.AsyncCompletionSpecification> result = AsyncMcpAnnotationProviders
+			.statelessCompleteSpecifications(completeObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testPromptSpecifications() {
+		List<Object> promptObjects = new ArrayList<>();
+		promptObjects.add(new Object());
+
+		List<McpServerFeatures.AsyncPromptSpecification> result = AsyncMcpAnnotationProviders
+			.promptSpecifications(promptObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testStatelessPromptSpecifications() {
+		List<Object> promptObjects = new ArrayList<>();
+		promptObjects.add(new Object());
+
+		List<McpStatelessServerFeatures.AsyncPromptSpecification> result = AsyncMcpAnnotationProviders
+			.statelessPromptSpecifications(promptObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testResourceSpecifications() {
+		List<Object> resourceObjects = new ArrayList<>();
+		resourceObjects.add(new Object());
+
+		List<McpServerFeatures.AsyncResourceSpecification> result = AsyncMcpAnnotationProviders
+			.resourceSpecifications(resourceObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testStatelessResourceSpecifications() {
+		List<Object> resourceObjects = new ArrayList<>();
+		resourceObjects.add(new Object());
+
+		List<McpStatelessServerFeatures.AsyncResourceSpecification> result = AsyncMcpAnnotationProviders
+			.statelessResourceSpecifications(resourceObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testResourceListChangedSpecifications() {
+		List<Object> resourceListChangedObjects = new ArrayList<>();
+		resourceListChangedObjects.add(new Object());
+
+		List<AsyncResourceListChangedSpecification> result = AsyncMcpAnnotationProviders
+			.resourceListChangedSpecifications(resourceListChangedObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testToolListChangedSpecifications() {
+		List<Object> toolListChangedObjects = new ArrayList<>();
+		toolListChangedObjects.add(new Object());
+
+		List<AsyncToolListChangedSpecification> result = AsyncMcpAnnotationProviders
+			.toolListChangedSpecifications(toolListChangedObjects);
+
+		assertNotNull(result);
+	}
+
+	@Test
+	void testPromptListChangedSpecifications() {
+		List<Object> promptListChangedObjects = new ArrayList<>();
+		promptListChangedObjects.add(new Object());
+
+		List<AsyncPromptListChangedSpecification> result = AsyncMcpAnnotationProviders
+			.promptListChangedSpecifications(promptListChangedObjects);
+
+		assertNotNull(result);
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProvidersTests.java
+++ b/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProvidersTests.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.resource.SyncResourceListChangedSpecification;
+import org.springaicommunity.mcp.method.changed.tool.SyncToolListChangedSpecification;
+import org.springaicommunity.mcp.method.elicitation.SyncElicitationSpecification;
+import org.springaicommunity.mcp.method.logging.SyncLoggingSpecification;
+import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
+import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Unit Tests for {@link SyncMcpAnnotationProviders}.
+ *
+ * @author Sun Yuhan
+ */
+
+@ExtendWith(MockitoExtension.class)
+class SyncMcpAnnotationProvidersTests {
+
+	@Test
+	void testToolSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> toolObjects = new ArrayList<>();
+		toolObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpServerFeatures.SyncToolSpecification> result = SyncMcpAnnotationProviders
+				.toolSpecifications(toolObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testToolSpecificationsWithEmptyListReturnsEmptyList() {
+		List<Object> toolObjects = new ArrayList<>();
+
+		List<McpServerFeatures.SyncToolSpecification> result = SyncMcpAnnotationProviders
+			.toolSpecifications(toolObjects);
+
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void testStatelessToolSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> toolObjects = new ArrayList<>();
+		toolObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpStatelessServerFeatures.SyncToolSpecification> result = SyncMcpAnnotationProviders
+				.statelessToolSpecifications(toolObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testStatelessToolSpecificationsWithEmptyListReturnsEmptyList() {
+		List<Object> toolObjects = new ArrayList<>();
+
+		List<McpStatelessServerFeatures.SyncToolSpecification> result = SyncMcpAnnotationProviders
+			.statelessToolSpecifications(toolObjects);
+
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void testCompleteSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> completeObjects = new ArrayList<>();
+		completeObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpServerFeatures.SyncCompletionSpecification> result = SyncMcpAnnotationProviders
+				.completeSpecifications(completeObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testStatelessCompleteSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> completeObjects = new ArrayList<>();
+		completeObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpStatelessServerFeatures.SyncCompletionSpecification> result = SyncMcpAnnotationProviders
+				.statelessCompleteSpecifications(completeObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testPromptSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> promptObjects = new ArrayList<>();
+		promptObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpServerFeatures.SyncPromptSpecification> result = SyncMcpAnnotationProviders
+				.promptSpecifications(promptObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testStatelessPromptSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> promptObjects = new ArrayList<>();
+		promptObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpStatelessServerFeatures.SyncPromptSpecification> result = SyncMcpAnnotationProviders
+				.statelessPromptSpecifications(promptObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testResourceSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> resourceObjects = new ArrayList<>();
+		resourceObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpServerFeatures.SyncResourceSpecification> result = SyncMcpAnnotationProviders
+				.resourceSpecifications(resourceObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testStatelessResourceSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> resourceObjects = new ArrayList<>();
+		resourceObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<McpStatelessServerFeatures.SyncResourceSpecification> result = SyncMcpAnnotationProviders
+				.statelessResourceSpecifications(resourceObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testLoggingSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> loggingObjects = new ArrayList<>();
+		loggingObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<SyncLoggingSpecification> result = SyncMcpAnnotationProviders.loggingSpecifications(loggingObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testSamplingSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> samplingObjects = new ArrayList<>();
+		samplingObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<SyncSamplingSpecification> result = SyncMcpAnnotationProviders.samplingSpecifications(samplingObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testElicitationSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> elicitationObjects = new ArrayList<>();
+		elicitationObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<SyncElicitationSpecification> result = SyncMcpAnnotationProviders
+				.elicitationSpecifications(elicitationObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testProgressSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> progressObjects = new ArrayList<>();
+		progressObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<SyncProgressSpecification> result = SyncMcpAnnotationProviders.progressSpecifications(progressObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testToolListChangedSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> toolListChangedObjects = new ArrayList<>();
+		toolListChangedObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<SyncToolListChangedSpecification> result = SyncMcpAnnotationProviders
+				.toolListChangedSpecifications(toolListChangedObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testResourceListChangedSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> resourceListChangedObjects = new ArrayList<>();
+		resourceListChangedObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<SyncResourceListChangedSpecification> result = SyncMcpAnnotationProviders
+				.resourceListChangedSpecifications(resourceListChangedObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+	@Test
+	void testPromptListChangedSpecificationsWithValidObjectsReturnsSpecifications() {
+		List<Object> promptListChangedObjects = new ArrayList<>();
+		promptListChangedObjects.add(new Object());
+
+		try (MockedStatic<AnnotationProviderUtil> mockedUtil = mockStatic(AnnotationProviderUtil.class)) {
+			mockedUtil.when(() -> AnnotationProviderUtil.beanMethods(any())).thenReturn(new Method[0]);
+
+			List<SyncPromptListChangedSpecification> result = SyncMcpAnnotationProviders
+				.promptListChangedSpecifications(promptListChangedObjects);
+
+			assertNotNull(result);
+		}
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessorTests.java
+++ b/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractAnnotatedMethodBeanPostProcessorTests.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring.scan;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.aop.framework.ProxyFactory;
+
+import java.lang.annotation.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit Tests for {@link AbstractAnnotatedMethodBeanPostProcessor}.
+ *
+ * @author Sun Yuhan
+ */
+@ExtendWith(MockitoExtension.class)
+class AbstractAnnotatedMethodBeanPostProcessorTests {
+
+	@Mock
+	private AbstractMcpAnnotatedBeans registry;
+
+	private Set<Class<? extends Annotation>> targetAnnotations;
+
+	private AbstractAnnotatedMethodBeanPostProcessor processor;
+
+	@BeforeEach
+	void setUp() {
+		targetAnnotations = new HashSet<>();
+		targetAnnotations.add(TestAnnotation.class);
+
+		processor = new AbstractAnnotatedMethodBeanPostProcessor(registry, targetAnnotations) {
+		};
+	}
+
+	@Test
+	void testConstructorWithNullRegistry() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			new AbstractAnnotatedMethodBeanPostProcessor(null, targetAnnotations) {
+			};
+		});
+		assertEquals("AnnotatedBeanRegistry must not be null", exception.getMessage());
+	}
+
+	@Test
+	void testConstructorWithEmptyTargetAnnotations() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			new AbstractAnnotatedMethodBeanPostProcessor(registry, Collections.emptySet()) {
+			};
+		});
+		assertEquals("Target annotations must not be empty", exception.getMessage());
+	}
+
+	@Test
+	void testPostProcessAfterInitializationWithoutAnnotations() {
+		NoAnnotationBean bean = new NoAnnotationBean();
+
+		Object result = processor.postProcessAfterInitialization(bean, "testBean");
+
+		assertSame(bean, result);
+		verify(registry, never()).addMcpAnnotatedBean(any(), any());
+	}
+
+	@Test
+	void testPostProcessAfterInitializationWithAnnotations() {
+		AnnotatedBean bean = new AnnotatedBean();
+
+		Object result = processor.postProcessAfterInitialization(bean, "testBean");
+
+		assertSame(bean, result);
+		verify(registry, times(1)).addMcpAnnotatedBean(any(), any());
+	}
+
+	@Test
+	void testPostProcessAfterInitializationWithMultipleMethods() {
+		MultipleAnnotationBean bean = new MultipleAnnotationBean();
+
+		Object result = processor.postProcessAfterInitialization(bean, "testBean");
+
+		assertSame(bean, result);
+		verify(registry, times(1)).addMcpAnnotatedBean(any(), any());
+	}
+
+	@Test
+	void testPostProcessAfterInitializationWithProxy() {
+		AnnotatedBean target = new AnnotatedBean();
+		ProxyFactory proxyFactory = new ProxyFactory(target);
+		proxyFactory.setProxyTargetClass(true);
+		Object proxy = proxyFactory.getProxy();
+
+		Object result = processor.postProcessAfterInitialization(proxy, "testBean");
+
+		assertSame(proxy, result);
+		verify(registry, times(1)).addMcpAnnotatedBean(any(), any());
+	}
+
+	@Test
+	void testCorrectAnnotationsAreCaptured() {
+		AnnotatedBean bean = new AnnotatedBean();
+
+		processor.postProcessAfterInitialization(bean, "testBean");
+
+		ArgumentCaptor<Set<Class<? extends Annotation>>> annotationsCaptor = ArgumentCaptor.forClass(Set.class);
+		verify(registry).addMcpAnnotatedBean(same(bean), annotationsCaptor.capture());
+
+		Set<Class<? extends java.lang.annotation.Annotation>> capturedAnnotations = annotationsCaptor.getValue();
+		assertEquals(1, capturedAnnotations.size());
+		assertTrue(capturedAnnotations.contains(TestAnnotation.class));
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	@interface TestAnnotation {
+
+	}
+
+	static class NoAnnotationBean {
+
+		void methodWithoutAnnotation() {
+		}
+
+	}
+
+	static class AnnotatedBean {
+
+		@TestAnnotation
+		void methodWithAnnotation() {
+		}
+
+	}
+
+	static class MultipleAnnotationBean {
+
+		@TestAnnotation
+		void methodWithAnnotation() {
+		}
+
+		void methodWithoutAnnotation() {
+		}
+
+	}
+
+}

--- a/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeansTests.java
+++ b/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/scan/AbstractMcpAnnotatedBeansTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring.scan;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit Tests for {@link AbstractMcpAnnotatedBeans}.
+ *
+ * @author Sun Yuhan
+ */
+class AbstractMcpAnnotatedBeansTests {
+
+	private AbstractMcpAnnotatedBeans annotatedBeans;
+
+	@BeforeEach
+	void setUp() {
+		annotatedBeans = new AbstractMcpAnnotatedBeans() {
+		};
+	}
+
+	@Test
+	void testAddMcpAnnotatedBean() {
+		Object bean = new Object();
+		Set<Class<? extends Annotation>> annotations = new HashSet<>();
+		annotations.add(Deprecated.class);
+		annotations.add(Override.class);
+
+		annotatedBeans.addMcpAnnotatedBean(bean, annotations);
+
+		assertEquals(1, annotatedBeans.getCount());
+		assertTrue(annotatedBeans.getAllAnnotatedBeans().contains(bean));
+		assertTrue(annotatedBeans.getBeansByAnnotation(Deprecated.class).contains(bean));
+		assertTrue(annotatedBeans.getBeansByAnnotation(Override.class).contains(bean));
+	}
+
+	@Test
+	void testGetAllAnnotatedBeans() {
+		Object bean1 = new Object();
+		Object bean2 = new Object();
+
+		annotatedBeans.addMcpAnnotatedBean(bean1, Collections.singleton(Deprecated.class));
+		annotatedBeans.addMcpAnnotatedBean(bean2, Collections.singleton(Override.class));
+
+		List<Object> allBeans = annotatedBeans.getAllAnnotatedBeans();
+		assertEquals(2, allBeans.size());
+		assertTrue(allBeans.contains(bean1));
+		assertTrue(allBeans.contains(bean2));
+
+		allBeans.clear();
+		assertEquals(2, annotatedBeans.getCount());
+	}
+
+	@Test
+	void testGetBeansByAnnotation() {
+		Object bean1 = new Object();
+		Object bean2 = new Object();
+
+		annotatedBeans.addMcpAnnotatedBean(bean1, Collections.singleton(Deprecated.class));
+		annotatedBeans.addMcpAnnotatedBean(bean2, Set.of(Deprecated.class, Override.class));
+
+		List<Object> deprecatedBeans = annotatedBeans.getBeansByAnnotation(Deprecated.class);
+		assertEquals(2, deprecatedBeans.size());
+		assertTrue(deprecatedBeans.contains(bean1));
+		assertTrue(deprecatedBeans.contains(bean2));
+
+		List<Object> overrideBeans = annotatedBeans.getBeansByAnnotation(Override.class);
+		assertEquals(1, overrideBeans.size());
+		assertTrue(overrideBeans.contains(bean2));
+
+		List<Object> emptyList = annotatedBeans.getBeansByAnnotation(SuppressWarnings.class);
+		assertTrue(emptyList.isEmpty());
+	}
+
+	@Test
+	void testGetCount() {
+		assertEquals(0, annotatedBeans.getCount());
+
+		annotatedBeans.addMcpAnnotatedBean(new Object(), Collections.singleton(Deprecated.class));
+		assertEquals(1, annotatedBeans.getCount());
+
+		annotatedBeans.addMcpAnnotatedBean(new Object(), Collections.singleton(Override.class));
+		assertEquals(2, annotatedBeans.getCount());
+	}
+
+}


### PR DESCRIPTION
I noticed that the newly migrated `spring-ai-mcp-annotations` module does not yet have unit tests. This PR adds unit tests to the module.