### PR TITLE
Fix: handle JSON parse error in streaming tool calls

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolOnFinishPredicate.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/ToolOnFinishPredicate.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.tool;
+
+import java.util.List;
+import java.util.function.BiPredicate;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+/**
+ * Executes tools only when the assistant signals completion (finishReason = "tool_calls"
+ * or "stop").
+ */
+public final class ToolOnFinishPredicate implements ToolExecutionEligibilityPredicate {
+
+	@Override
+	public boolean isToolExecutionRequired(ChatOptions opts, ChatResponse resp) {
+		List<Generation> gens = resp.getResults();
+		if (gens.isEmpty()) {
+			return false;
+		}
+
+		Generation gen = gens.get(0);
+		boolean hasToolCalls = !gen.getOutput().getToolCalls().isEmpty();
+		String finish = String.valueOf(gen.getMetadata().get("finishReason"));
+
+		return hasToolCalls && ("tool_calls".equalsIgnoreCase(finish) || "stop".equalsIgnoreCase(finish));
+	}
+
+	@Override
+	public boolean test(ChatOptions chatOptions, ChatResponse chatResponse) {
+		return false;
+	}
+
+	@NotNull
+	@Override
+	public BiPredicate<ChatOptions, ChatResponse> and(
+			@NotNull BiPredicate<? super ChatOptions, ? super ChatResponse> other) {
+		return ToolExecutionEligibilityPredicate.super.and(other);
+	}
+
+	@NotNull
+	@Override
+	public BiPredicate<ChatOptions, ChatResponse> negate() {
+		return ToolExecutionEligibilityPredicate.super.negate();
+	}
+
+	@NotNull
+	@Override
+	public BiPredicate<ChatOptions, ChatResponse> or(
+			@NotNull BiPredicate<? super ChatOptions, ? super ChatResponse> other) {
+		return ToolExecutionEligibilityPredicate.super.or(other);
+	}
+
+}


### PR DESCRIPTION
## Overview
This PR fixes a JSON parsing error that occurs when handling **streaming tool calls** in Spring AI.

 Related issue: [spring-projects/spring-ai#4250](https://github.com/spring-projects/spring-ai/issues/4250?utm_source=chatgpt.com)

---

## Why
- In streaming mode, tool call JSON fragments can arrive incomplete.  
- This results in Jackson throwing errors such as: `com.fasterxml.jackson.core.JsonParseException: Unexpected close marker ']': expected '}'`
- The issue only occurs in streaming (`stream()`) calls.  
- Synchronous calls (`call()`) are not affected.  
- This prevents users from reliably using tool callbacks with streaming responses.  

---

## What Changed
- Added a new `ToolExecutionEligibilityPredicate` implementation: **`ToolOnFinishPredicate`**.  
- Ensures tool execution only runs after the assistant signals completion (`finishReason = "tool_calls"` or `"stop"`).  
- Prevents premature execution and malformed JSON during streaming tool calls.  

---

## How to Use
Example usage:

```java
ChatClient client = ChatClient.create(openAiChatModel);

String result = client.prompt()
  .user("Migrate node cluster xx")
  .toolCallbacks(ToolCallbacks.from(new MyTool()))
  .options(OpenAiChatOptions.builder()
      .toolExecutionEligibilityPredicate(new ToolOnFinishPredicate())
      .build())
  .stream()
  .content();
