### PR TITLE
Bump MCP to 0.12.0-SNAPSHOT

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -23,9 +23,9 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
-import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
@@ -87,17 +87,17 @@ public class SseHttpClientTransportAutoConfiguration {
 	 * @param sseProperties the SSE client properties containing server configurations
 	 * @param objectMapperProvider the provider for ObjectMapper or a new instance if not
 	 * available
-	 * @param syncHttpRequestCustomizer provider for {@link SyncHttpRequestCustomizer} if
-	 * available
-	 * @param asyncHttpRequestCustomizer provider fo {@link AsyncHttpRequestCustomizer} if
-	 * available
+	 * @param syncHttpRequestCustomizer provider for
+	 * {@link McpSyncHttpClientRequestCustomizer} if available
+	 * @param asyncHttpRequestCustomizer provider fo
+	 * {@link McpAsyncHttpClientRequestCustomizer} if available
 	 * @return list of named MCP transports
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> sseHttpClientTransports(McpSseClientProperties sseProperties,
 			ObjectProvider<ObjectMapper> objectMapperProvider,
-			ObjectProvider<SyncHttpRequestCustomizer> syncHttpRequestCustomizer,
-			ObjectProvider<AsyncHttpRequestCustomizer> asyncHttpRequestCustomizer) {
+			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
+			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
 
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
@@ -117,9 +117,9 @@ public class SseHttpClientTransportAutoConfiguration {
 			syncHttpRequestCustomizer.ifUnique(transportBuilder::httpRequestCustomizer);
 			if (asyncHttpRequestCustomizer.getIfUnique() != null && syncHttpRequestCustomizer.getIfUnique() != null) {
 				logger.warn("Found beans of type %s and %s. Using %s.".formatted(
-						AsyncHttpRequestCustomizer.class.getSimpleName(),
-						SyncHttpRequestCustomizer.class.getSimpleName(),
-						SyncHttpRequestCustomizer.class.getSimpleName()));
+						McpAsyncHttpClientRequestCustomizer.class.getSimpleName(),
+						McpSyncHttpClientRequestCustomizer.class.getSimpleName(),
+						McpSyncHttpClientRequestCustomizer.class.getSimpleName()));
 			}
 
 			HttpClientSseClientTransport transport = transportBuilder.build();

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
@@ -23,9 +23,9 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
-import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
@@ -90,17 +90,17 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 	 * configurations
 	 * @param objectMapperProvider the provider for ObjectMapper or a new instance if not
 	 * available
-	 * @param syncHttpRequestCustomizer provider for {@link SyncHttpRequestCustomizer} if
-	 * available
-	 * @param asyncHttpRequestCustomizer provider fo {@link AsyncHttpRequestCustomizer} if
-	 * available
+	 * @param syncHttpRequestCustomizer provider for
+	 * {@link McpSyncHttpClientRequestCustomizer} if available
+	 * @param asyncHttpRequestCustomizer provider fo
+	 * {@link McpAsyncHttpClientRequestCustomizer} if available
 	 * @return list of named MCP transports
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> streamableHttpHttpClientTransports(
 			McpStreamableHttpClientProperties streamableProperties, ObjectProvider<ObjectMapper> objectMapperProvider,
-			ObjectProvider<SyncHttpRequestCustomizer> syncHttpRequestCustomizer,
-			ObjectProvider<AsyncHttpRequestCustomizer> asyncHttpRequestCustomizer) {
+			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
+			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
 
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
@@ -123,9 +123,9 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 			syncHttpRequestCustomizer.ifUnique(transportBuilder::httpRequestCustomizer);
 			if (asyncHttpRequestCustomizer.getIfUnique() != null && syncHttpRequestCustomizer.getIfUnique() != null) {
 				logger.warn("Found beans of type %s and %s. Using %s.".formatted(
-						AsyncHttpRequestCustomizer.class.getSimpleName(),
-						SyncHttpRequestCustomizer.class.getSimpleName(),
-						SyncHttpRequestCustomizer.class.getSimpleName()));
+						McpAsyncHttpClientRequestCustomizer.class.getSimpleName(),
+						McpSyncHttpClientRequestCustomizer.class.getSimpleName(),
+						McpSyncHttpClientRequestCustomizer.class.getSimpleName()));
 			}
 
 			HttpClientStreamableHttpTransport transport = transportBuilder.build();

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationIT.java
@@ -19,8 +19,8 @@ package org.springframework.ai.mcp.client.autoconfigure;
 import java.util.List;
 
 import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
-import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -121,9 +121,9 @@ public class SseHttpClientTransportAutoConfigurationIT {
 
 				mcpClient.ping();
 
-				verify(context.getBean(SyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
-						any());
-				verifyNoInteractions(context.getBean(AsyncHttpRequestCustomizer.class));
+				verify(context.getBean(McpSyncHttpClientRequestCustomizer.class), atLeastOnce()).customize(any(), any(),
+						any(), any(), any());
+				verifyNoInteractions(context.getBean(McpAsyncHttpClientRequestCustomizer.class));
 			});
 	}
 
@@ -140,8 +140,8 @@ public class SseHttpClientTransportAutoConfigurationIT {
 
 				mcpClient.ping();
 
-				verify(context.getBean(AsyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
-						any());
+				verify(context.getBean(McpAsyncHttpClientRequestCustomizer.class), atLeastOnce()).customize(any(),
+						any(), any(), any(), any());
 			});
 	}
 
@@ -149,8 +149,8 @@ public class SseHttpClientTransportAutoConfigurationIT {
 	static class SyncRequestCustomizerConfiguration {
 
 		@Bean
-		SyncHttpRequestCustomizer syncHttpRequestCustomizer() {
-			return mock(SyncHttpRequestCustomizer.class);
+		McpSyncHttpClientRequestCustomizer syncHttpRequestCustomizer() {
+			return mock(McpSyncHttpClientRequestCustomizer.class);
 		}
 
 	}
@@ -159,9 +159,9 @@ public class SseHttpClientTransportAutoConfigurationIT {
 	static class AsyncRequestCustomizerConfiguration {
 
 		@Bean
-		AsyncHttpRequestCustomizer asyncHttpRequestCustomizer() {
-			AsyncHttpRequestCustomizer requestCustomizerMock = mock(AsyncHttpRequestCustomizer.class);
-			when(requestCustomizerMock.customize(any(), any(), any(), any()))
+		McpAsyncHttpClientRequestCustomizer asyncHttpRequestCustomizer() {
+			McpAsyncHttpClientRequestCustomizer requestCustomizerMock = mock(McpAsyncHttpClientRequestCustomizer.class);
+			when(requestCustomizerMock.customize(any(), any(), any(), any(), any()))
 				.thenAnswer(invocation -> Mono.just(invocation.getArguments()[0]));
 			return requestCustomizerMock;
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationIT.java
@@ -19,8 +19,8 @@ package org.springframework.ai.mcp.client.autoconfigure;
 import java.util.List;
 
 import io.modelcontextprotocol.client.McpSyncClient;
-import io.modelcontextprotocol.client.transport.AsyncHttpRequestCustomizer;
-import io.modelcontextprotocol.client.transport.SyncHttpRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -122,9 +122,9 @@ public class StreamableHttpHttpClientTransportAutoConfigurationIT {
 
 				mcpClient.ping();
 
-				verify(context.getBean(SyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
-						any());
-				verifyNoInteractions(context.getBean(AsyncHttpRequestCustomizer.class));
+				verify(context.getBean(McpSyncHttpClientRequestCustomizer.class), atLeastOnce()).customize(any(), any(),
+						any(), any(), any());
+				verifyNoInteractions(context.getBean(McpAsyncHttpClientRequestCustomizer.class));
 			});
 	}
 
@@ -141,8 +141,8 @@ public class StreamableHttpHttpClientTransportAutoConfigurationIT {
 
 				mcpClient.ping();
 
-				verify(context.getBean(AsyncHttpRequestCustomizer.class), atLeastOnce()).customize(any(), any(), any(),
-						any());
+				verify(context.getBean(McpAsyncHttpClientRequestCustomizer.class), atLeastOnce()).customize(any(),
+						any(), any(), any(), any());
 			});
 	}
 
@@ -150,8 +150,8 @@ public class StreamableHttpHttpClientTransportAutoConfigurationIT {
 	static class SyncRequestCustomizerConfiguration {
 
 		@Bean
-		SyncHttpRequestCustomizer syncHttpRequestCustomizer() {
-			return mock(SyncHttpRequestCustomizer.class);
+		McpSyncHttpClientRequestCustomizer syncHttpRequestCustomizer() {
+			return mock(McpSyncHttpClientRequestCustomizer.class);
 		}
 
 	}
@@ -160,9 +160,9 @@ public class StreamableHttpHttpClientTransportAutoConfigurationIT {
 	static class AsyncRequestCustomizerConfiguration {
 
 		@Bean
-		AsyncHttpRequestCustomizer asyncHttpRequestCustomizer() {
-			AsyncHttpRequestCustomizer requestCustomizerMock = mock(AsyncHttpRequestCustomizer.class);
-			when(requestCustomizerMock.customize(any(), any(), any(), any()))
+		McpAsyncHttpClientRequestCustomizer asyncHttpRequestCustomizer() {
+			McpAsyncHttpClientRequestCustomizer requestCustomizerMock = mock(McpAsyncHttpClientRequestCustomizer.class);
+			when(requestCustomizerMock.customize(any(), any(), any(), any(), any()))
 				.thenAnswer(invocation -> Mono.just(invocation.getArguments()[0]));
 			return requestCustomizerMock;
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -21,6 +21,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessAsyncServer;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncCompletionSpecification;
@@ -31,7 +32,6 @@ import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceSpe
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
-import io.modelcontextprotocol.server.McpTransportContext;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
 import org.junit.jupiter.api.Test;

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -331,7 +331,7 @@ public final class McpToolUtils {
 
 		return new McpStatelessServerFeatures.AsyncToolSpecification(statelessSyncToolSpecification.tool(),
 				(context, request) -> Mono
-					.fromCallable(() -> statelessSyncToolSpecification.callHandler().apply(context.copy(), request))
+					.fromCallable(() -> statelessSyncToolSpecification.callHandler().apply(context, request))
 					.subscribeOn(Schedulers.boundedElastic()));
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.11.3</mcp.sdk.version>
+		<mcp.sdk.version>0.12.0-SNAPSHOT</mcp.sdk.version>
 		<mcp-annotations.version>0.3.0-SNAPSHOT</mcp-annotations.version>
 
 		<!-- plugin versions -->


### PR DESCRIPTION
This PR adds support for `io.modelcontextprotocol.sdk:mcp:0.12.0-SNAPSHOT` once this PR is merged: https://github.com/modelcontextprotocol/java-sdk/pull/522 ; it will only compile once that the MCP PR lands.

Tagging @tzolov 