### PR TITLE
remove redundant try-catch in JdbcChatMemoryRepository

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepository.java
@@ -218,12 +218,7 @@ public final class JdbcChatMemoryRepository implements ChatMemoryRepository {
 
 		private JdbcChatMemoryRepositoryDialect resolveDialect(DataSource dataSource) {
 			if (this.dialect == null) {
-				try {
-					return JdbcChatMemoryRepositoryDialect.from(dataSource);
-				}
-				catch (Exception ex) {
-					throw new IllegalStateException("Could not detect dialect from datasource", ex);
-				}
+				return JdbcChatMemoryRepositoryDialect.from(dataSource);
 			}
 			else {
 				warnIfDialectMismatch(dataSource, this.dialect);
@@ -236,15 +231,10 @@ public final class JdbcChatMemoryRepository implements ChatMemoryRepository {
 		 * from the DataSource.
 		 */
 		private void warnIfDialectMismatch(DataSource dataSource, JdbcChatMemoryRepositoryDialect explicitDialect) {
-			try {
-				JdbcChatMemoryRepositoryDialect detected = JdbcChatMemoryRepositoryDialect.from(dataSource);
-				if (!detected.getClass().equals(explicitDialect.getClass())) {
-					logger.warn("Explicitly set dialect {} will be used instead of detected dialect {} from datasource",
-							explicitDialect.getClass().getSimpleName(), detected.getClass().getSimpleName());
-				}
-			}
-			catch (Exception ex) {
-				logger.debug("Could not detect dialect from datasource", ex);
+			JdbcChatMemoryRepositoryDialect detected = JdbcChatMemoryRepositoryDialect.from(dataSource);
+			if (!detected.getClass().equals(explicitDialect.getClass())) {
+				logger.warn("Explicitly set dialect {} will be used instead of detected dialect {} from datasource",
+						explicitDialect.getClass().getSimpleName(), detected.getClass().getSimpleName());
 			}
 		}
 


### PR DESCRIPTION
The inner method JdbcChatMemoryRepositoryDialect#from already contains exception handling logic. The outer try-catch block is unnecessary and can be safely removed to avoid redundant exception handling and improve code clarity.