### PR TITLE
GH-4289 Optimized `JdbcChatMemoryRepositoryDialect#from`

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
@@ -16,13 +16,10 @@
 
 package org.springframework.ai.chat.memory.repository.jdbc;
 
-import org.springframework.jdbc.support.JdbcUtils;
-import org.springframework.jdbc.support.MetaDataAccessException;
-
-import java.sql.Connection;
+import javax.sql.DataSource;
 import java.sql.DatabaseMetaData;
 
-import javax.sql.DataSource;
+import org.springframework.jdbc.support.JdbcUtils;
 
 /**
  * Abstraction for database-specific SQL for chat memory repository.

--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
@@ -16,8 +16,8 @@
 
 package org.springframework.ai.chat.memory.repository.jdbc;
 
-import javax.sql.DataSource;
 import java.sql.DatabaseMetaData;
+import javax.sql.DataSource;
 
 import org.springframework.jdbc.support.JdbcUtils;
 

--- a/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/chat/memory/repository/jdbc/JdbcChatMemoryRepositoryDialect.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.chat.memory.repository.jdbc;
 
 import java.sql.DatabaseMetaData;
+
 import javax.sql.DataSource;
 
 import org.springframework.jdbc.support.JdbcUtils;


### PR DESCRIPTION
As mentioned in the issue, the current implementation of `JdbcChatMemoryRepositoryDialect#from` has room for improvement in both exception handling and JDBC vendor detection logic. This PR refactors the method with the following changes:

1. Rewrote the method to use `org.springframework.jdbc.support.JdbcUtils#extractDatabaseMetaData` for extracting database metadata from the `dataSource`, and obtain the database vendor name from the JDBC driver, improving accuracy and robustness;
2. Enhanced exception handling: instead of silently ignoring exceptions, it now explicitly reports encountered issues, helping users identify problems and select the appropriate dialect more easily;
3. All related unit tests have been executed and passed, ensuring that the changes do not introduce regressions.

Fixes #4289