### PR TITLE
refactor: remove obsolete templateRenderer from AdvisorChain

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -1008,7 +1008,6 @@ public class DefaultChatClient implements ChatClient {
 
 			return DefaultAroundAdvisorChain.builder(this.observationRegistry)
 				.pushAll(this.advisors)
-				.templateRenderer(this.templateRenderer)
 				.build();
 		}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
@@ -68,9 +68,7 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 
 	private final ObservationRegistry observationRegistry;
 
-	private final TemplateRenderer templateRenderer;
-
-	DefaultAroundAdvisorChain(ObservationRegistry observationRegistry, @Nullable TemplateRenderer templateRenderer,
+	DefaultAroundAdvisorChain(ObservationRegistry observationRegistry,
 			Deque<CallAdvisor> callAdvisors, Deque<StreamAdvisor> streamAdvisors) {
 
 		Assert.notNull(observationRegistry, "the observationRegistry must be non-null");
@@ -78,7 +76,6 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 		Assert.notNull(streamAdvisors, "the streamAdvisors must be non-null");
 
 		this.observationRegistry = observationRegistry;
-		this.templateRenderer = templateRenderer != null ? templateRenderer : DEFAULT_TEMPLATE_RENDERER;
 		this.callAdvisors = callAdvisors;
 		this.streamAdvisors = streamAdvisors;
 		this.originalCallAdvisors = List.copyOf(callAdvisors);
@@ -164,17 +161,10 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 
 		private final Deque<StreamAdvisor> streamAdvisors;
 
-		private TemplateRenderer templateRenderer;
-
 		public Builder(ObservationRegistry observationRegistry) {
 			this.observationRegistry = observationRegistry;
 			this.callAdvisors = new ConcurrentLinkedDeque<>();
 			this.streamAdvisors = new ConcurrentLinkedDeque<>();
-		}
-
-		public Builder templateRenderer(TemplateRenderer templateRenderer) {
-			this.templateRenderer = templateRenderer;
-			return this;
 		}
 
 		public Builder push(Advisor advisor) {
@@ -225,7 +215,7 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 		}
 
 		public DefaultAroundAdvisorChain build() {
-			return new DefaultAroundAdvisorChain(this.observationRegistry, this.templateRenderer, this.callAdvisors,
+			return new DefaultAroundAdvisorChain(this.observationRegistry, this.callAdvisors,
 					this.streamAdvisors);
 		}
 


### PR DESCRIPTION
The templateRenderer is no longer required within the AdvisorChain itself, as template rendering now occurs during the construction of the ChatClientRequest. This field was unused and has been removed to clean up the code.