### PR TITLE
Use message type during message creation of Mistral AI chat model

### DIFF
--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTest.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTest.java
@@ -16,32 +16,53 @@
 
 package org.springframework.ai.mistralai;
 
+import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import org.springframework.ai.chat.messages.AbstractMessage;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.ai.content.MediaContent;
 import org.springframework.ai.mistralai.api.MistralAiApi;
+import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionMessage;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Ricken Bazolo
  * @author Alexandros Pappas
  * @author Thomas Vitale
+ * @author Nicolas Krier
  * @since 0.8.1
  */
-@SpringBootTest(classes = MistralAiTestConfiguration.class)
-@EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
-public class MistralAiChatCompletionRequestTest {
+class MistralAiChatCompletionRequestTest {
 
-	MistralAiChatModel chatModel = MistralAiChatModel.builder().mistralAiApi(new MistralAiApi("test")).build();
+	private static final String BASE_URL = "https://faked.url";
+
+	private static final String API_KEY = "FAKED_API_KEY";
+
+	private static final String TEXT_CONTENT = "Hello world!";
+
+	private static final String IMAGE_URL = "https://example.com/image.png";
+
+	private static final Media IMAGE_MEDIA = new Media(Media.Format.IMAGE_PNG, URI.create(IMAGE_URL));
+
+	private final MistralAiChatModel chatModel = MistralAiChatModel.builder()
+		.mistralAiApi(new MistralAiApi(BASE_URL, API_KEY))
+		.build();
 
 	@Test
 	void chatCompletionDefaultRequestTest() {
@@ -62,7 +83,7 @@ public class MistralAiChatCompletionRequestTest {
 		var prompt = this.chatModel.buildRequestPrompt(new Prompt("test content", options));
 		var request = this.chatModel.createRequest(prompt, true);
 
-		assertThat(request.messages().size()).isEqualTo(1);
+		assertThat(request.messages()).hasSize(1);
 		assertThat(request.topP()).isEqualTo(0.8);
 		assertThat(request.temperature()).isEqualTo(0.5);
 		assertThat(request.stream()).isTrue();
@@ -78,8 +99,8 @@ public class MistralAiChatCompletionRequestTest {
 			.toolContext(Map.of("key1", "value1", "key2", "valueA"))
 			.build();
 
-		MistralAiChatModel chatModel = MistralAiChatModel.builder()
-			.mistralAiApi(new MistralAiApi("test"))
+		MistralAiChatModel anotherChatModel = MistralAiChatModel.builder()
+			.mistralAiApi(new MistralAiApi(BASE_URL, API_KEY))
 			.defaultOptions(defaultOptions)
 			.build();
 
@@ -89,7 +110,7 @@ public class MistralAiChatCompletionRequestTest {
 			.toolNames("tool3")
 			.toolContext(Map.of("key2", "valueB"))
 			.build();
-		Prompt prompt = chatModel.buildRequestPrompt(new Prompt("Test message content", runtimeOptions));
+		Prompt prompt = anotherChatModel.buildRequestPrompt(new Prompt("Test message content", runtimeOptions));
 
 		assertThat(((ToolCallingChatOptions) prompt.getOptions())).isNotNull();
 		assertThat(((ToolCallingChatOptions) prompt.getOptions()).getInternalToolExecutionEnabled()).isFalse();
@@ -100,6 +121,181 @@ public class MistralAiChatCompletionRequestTest {
 		assertThat(((ToolCallingChatOptions) prompt.getOptions()).getToolNames()).containsExactlyInAnyOrder("tool3");
 		assertThat(((ToolCallingChatOptions) prompt.getOptions()).getToolContext()).containsEntry("key1", "value1")
 			.containsEntry("key2", "valueB");
+	}
+
+	@Test
+	void createMessagesWithUserMessage() {
+		var userMessage = new UserMessage(TEXT_CONTENT);
+		userMessage.getMedia().add(IMAGE_MEDIA);
+		var chatCompletionMessages = this.chatModel.createMessages(userMessage).toList();
+		verifyUserChatCompletionMessages(chatCompletionMessages);
+	}
+
+	@Test
+	void createMessagesWithAnotherUserMessage() {
+		var anotherUserMessage = new AnotherUserMessage(TEXT_CONTENT, List.of(IMAGE_MEDIA));
+		var chatCompletionMessages = this.chatModel.createMessages(anotherUserMessage).toList();
+		verifyUserChatCompletionMessages(chatCompletionMessages);
+	}
+
+	@Test
+	void createMessagesWithSimpleUserMessage() {
+		var simpleUserMessage = new SimpleMessage(MessageType.USER, TEXT_CONTENT);
+		var chatCompletionMessages = this.chatModel.createMessages(simpleUserMessage).toList();
+		assertThat(chatCompletionMessages).hasSize(1);
+		var chatCompletionMessage = chatCompletionMessages.get(0);
+		assertThat(chatCompletionMessage.role()).isEqualTo(ChatCompletionMessage.Role.USER);
+		assertThat(chatCompletionMessage.content()).isEqualTo(TEXT_CONTENT);
+	}
+
+	@Test
+	void createMessagesWithSystemMessage() {
+		var systemMessage = new SystemMessage(TEXT_CONTENT);
+		var chatCompletionMessages = this.chatModel.createMessages(systemMessage).toList();
+		verifySystemChatCompletionMessages(chatCompletionMessages);
+	}
+
+	@Test
+	void createMessagesWithSimpleSystemMessage() {
+		var simpleSystemMessage = new SimpleMessage(MessageType.SYSTEM, TEXT_CONTENT);
+		var chatCompletionMessages = this.chatModel.createMessages(simpleSystemMessage).toList();
+		verifySystemChatCompletionMessages(chatCompletionMessages);
+	}
+
+	@Test
+	void createMessagesWithAssistantMessage() {
+		var toolCall1 = createToolCall(1);
+		var toolCall2 = createToolCall(2);
+		var toolCall3 = createToolCall(3);
+		var assistantMessage = new AssistantMessage(TEXT_CONTENT, Map.of(), List.of(toolCall1, toolCall2, toolCall3));
+		var chatCompletionMessages = this.chatModel.createMessages(assistantMessage).toList();
+		assertThat(chatCompletionMessages).hasSize(1);
+		var chatCompletionMessage = chatCompletionMessages.get(0);
+		assertThat(chatCompletionMessage.role()).isEqualTo(ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(chatCompletionMessage.content()).isEqualTo(TEXT_CONTENT);
+		var toolCalls = chatCompletionMessage.toolCalls();
+		assertThat(toolCalls).hasSize(3);
+		verifyToolCall(toolCalls.get(0), toolCall1);
+		verifyToolCall(toolCalls.get(1), toolCall2);
+		verifyToolCall(toolCalls.get(2), toolCall3);
+	}
+
+	@Test
+	void createMessagesWithSimpleAssistantMessage() {
+		var simpleAssistantMessage = new SimpleMessage(MessageType.ASSISTANT, TEXT_CONTENT);
+		assertThatThrownBy(() -> this.chatModel.createMessages(simpleAssistantMessage))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Unexpected assistant message class: " + SimpleMessage.class.getName());
+	}
+
+	@Test
+	void createMessagesWithToolResponseMessage() {
+		var toolResponse1 = createToolResponse(1);
+		var toolResponse2 = createToolResponse(2);
+		var toolResponse3 = createToolResponse(3);
+		var toolResponseMessage = new ToolResponseMessage(List.of(toolResponse1, toolResponse2, toolResponse3));
+		var chatCompletionMessages = this.chatModel.createMessages(toolResponseMessage).toList();
+		assertThat(chatCompletionMessages).hasSize(3);
+		verifyToolChatCompletionMessage(chatCompletionMessages.get(0), toolResponse1);
+		verifyToolChatCompletionMessage(chatCompletionMessages.get(1), toolResponse2);
+		verifyToolChatCompletionMessage(chatCompletionMessages.get(2), toolResponse3);
+	}
+
+	@Test
+	void createMessagesWithInvalidToolResponseMessage() {
+		var toolResponse = new ToolResponseMessage.ToolResponse(null, null, null);
+		var toolResponseMessage = new ToolResponseMessage(List.of(toolResponse));
+		assertThatThrownBy(() -> this.chatModel.createMessages(toolResponseMessage))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("ToolResponseMessage must have an id");
+	}
+
+	@Test
+	void createMessagesWithSimpleToolMessage() {
+		var simpleToolMessage = new SimpleMessage(MessageType.TOOL, TEXT_CONTENT);
+		assertThatThrownBy(() -> this.chatModel.createMessages(simpleToolMessage))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Unexpected tool message class: " + SimpleMessage.class.getName());
+	}
+
+	private static void verifyToolChatCompletionMessage(ChatCompletionMessage chatCompletionMessage,
+			ToolResponseMessage.ToolResponse toolResponse) {
+		assertThat(chatCompletionMessage.role()).isEqualTo(ChatCompletionMessage.Role.TOOL);
+		assertThat(chatCompletionMessage.content()).isEqualTo(toolResponse.responseData());
+		assertThat(chatCompletionMessage.name()).isEqualTo(toolResponse.name());
+		assertThat(chatCompletionMessage.toolCalls()).isNull();
+		assertThat(chatCompletionMessage.toolCallId()).isEqualTo(toolResponse.id());
+	}
+
+	private static ToolResponseMessage.ToolResponse createToolResponse(int number) {
+		return new ToolResponseMessage.ToolResponse("id" + number, "name" + number, "responseData" + number);
+	}
+
+	private static void verifyToolCall(ChatCompletionMessage.ToolCall mistralToolCall,
+			AssistantMessage.ToolCall toolCall) {
+		assertThat(mistralToolCall.id()).isEqualTo(toolCall.id());
+		assertThat(mistralToolCall.type()).isEqualTo(toolCall.type());
+		var function = mistralToolCall.function();
+		assertThat(function.name()).isEqualTo(toolCall.name());
+		assertThat(function.arguments()).isEqualTo(toolCall.arguments());
+	}
+
+	private static AssistantMessage.ToolCall createToolCall(int number) {
+		return new AssistantMessage.ToolCall("id" + number, "type" + number, "name" + number, "arguments " + number);
+	}
+
+	private static void verifySystemChatCompletionMessages(List<ChatCompletionMessage> chatCompletionMessages) {
+		assertThat(chatCompletionMessages).hasSize(1);
+		var chatCompletionMessage = chatCompletionMessages.get(0);
+		assertThat(chatCompletionMessage.role()).isEqualTo(ChatCompletionMessage.Role.SYSTEM);
+		assertThat(chatCompletionMessage.content()).isEqualTo(TEXT_CONTENT);
+	}
+
+	private static void verifyUserChatCompletionMessages(List<ChatCompletionMessage> chatCompletionMessages) {
+		assertThat(chatCompletionMessages).hasSize(1);
+		var chatCompletionMessage = chatCompletionMessages.get(0);
+		assertThat(chatCompletionMessage.role()).isEqualTo(ChatCompletionMessage.Role.USER);
+		var rawContent = chatCompletionMessage.rawContent();
+		assertThat(rawContent).isNotNull();
+		var mediaContents = (List<ChatCompletionMessage.MediaContent>) rawContent;
+		assertThat(mediaContents).hasSize(2);
+		var textMediaContent = mediaContents.get(0);
+		assertThat(textMediaContent).isNotNull();
+		assertThat(textMediaContent.type()).isEqualTo("text");
+		assertThat(textMediaContent.text()).isEqualTo(TEXT_CONTENT);
+		assertThat(textMediaContent.imageUrl()).isNull();
+		var imageUrlMediaContent = mediaContents.get(1);
+		assertThat(imageUrlMediaContent).isNotNull();
+		assertThat(imageUrlMediaContent.type()).isEqualTo("image_url");
+		assertThat(imageUrlMediaContent.text()).isNull();
+		var imageUrl = imageUrlMediaContent.imageUrl();
+		assertThat(imageUrl).isNotNull();
+		assertThat(imageUrl.url()).isEqualTo(IMAGE_URL);
+		assertThat(imageUrl.detail()).isNull();
+	}
+
+	static class SimpleMessage extends AbstractMessage {
+
+		SimpleMessage(MessageType messageType, String textContent) {
+			super(messageType, textContent, Map.of());
+		}
+
+	}
+
+	static class AnotherUserMessage extends AbstractMessage implements MediaContent {
+
+		private final List<Media> media;
+
+		AnotherUserMessage(String textContent, List<Media> media) {
+			super(MessageType.USER, textContent, Map.of());
+			this.media = List.copyOf(media);
+		}
+
+		@Override
+		public List<Media> getMedia() {
+			return this.media;
+		}
+
 	}
 
 	static class TestToolCallback implements ToolCallback {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
@@ -165,7 +165,12 @@ class MistralAiChatCompletionRequestTests {
 		var toolCall1 = createToolCall(1);
 		var toolCall2 = createToolCall(2);
 		var toolCall3 = createToolCall(3);
-		var assistantMessage = new AssistantMessage(TEXT_CONTENT, Map.of(), List.of(toolCall1, toolCall2, toolCall3));
+		// @formatter:off
+		var assistantMessage = AssistantMessage.builder()
+				.content(TEXT_CONTENT)
+				.toolCalls(List.of(toolCall1, toolCall2, toolCall3))
+				.build();
+		// @formatter:on
 		var prompt = createPrompt(assistantMessage);
 		var chatCompletionRequest = this.chatModel.createRequest(prompt, false);
 		var chatCompletionMessages = chatCompletionRequest.messages();

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Nicolas Krier
  * @since 0.8.1
  */
-class MistralAiChatCompletionRequestTest {
+class MistralAiChatCompletionRequestTests {
 
 	private static final String BASE_URL = "https://faked.url";
 


### PR DESCRIPTION
## Description
Providers like **Azure OpenAI** already support flexible conversion of **Spring AI** messages to provider-specific formats, enabling custom message types.
This PR adds the same capability for **Mistral AI**, introducing a dedicated conversion method to ensure consistency across the project.

## Key Changes
1. **New Conversion Method**
   - Added `createChatCompletionMessages` in `MistralAiChatModel` to map Spring AI `Message` objects to Mistral AI’s `ChatCompletionMessage` stream, based on `MessageType`.
   - Follows the established pattern in [Azure OpenAI’s implementation](https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java#L568-L614).

2. **Unit Tests**
   - Added comprehensive tests for the new conversion method, covering:
     - Standard Spring AI messages.
     - Custom message types.
   - Improved existing tests by:
     - Removing redundant `@SpringBootTest` annotation.
     - Addressing minor **code smells**.
     - Aligning test class name with project conventions.

3. **Backward Compatibility**
   - **No breaking changes**: All existing unit and integration tests pass.

## Related Work
This PR aligns with **[#3999](https://github.com/spring-projects/spring-ai/pull/3999)**, which implements a similar conversion mechanism for **Ollama**.
The goal is to **standardize message handling** across all LLM providers in Spring AI.