### PR TITLE
GH-4331 improve token estimation for binary data

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/tokenizer/JTokkitTokenCountEstimator.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/tokenizer/JTokkitTokenCountEstimator.java
@@ -24,6 +24,8 @@ import org.springframework.ai.content.Media;
 import org.springframework.ai.content.MediaContent;
 import org.springframework.util.CollectionUtils;
 
+import java.util.Base64;
+
 /**
  * Estimates the number of tokens in a given text or message using the JTokkit encoding
  * library.
@@ -70,7 +72,8 @@ public class JTokkitTokenCountEstimator implements TokenCountEstimator {
 					tokenCount += this.estimate(textData);
 				}
 				else if (media.getData() instanceof byte[] binaryData) {
-					tokenCount += binaryData.length; // This is likely incorrect.
+					String base64 = Base64.getEncoder().encodeToString(binaryData);
+					tokenCount += this.estimate(base64);
 				}
 			}
 		}

--- a/spring-ai-commons/src/main/java/org/springframework/ai/tokenizer/JTokkitTokenCountEstimator.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/tokenizer/JTokkitTokenCountEstimator.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.tokenizer;
 
+import java.util.Base64;
+
 import com.knuddels.jtokkit.Encodings;
 import com.knuddels.jtokkit.api.Encoding;
 import com.knuddels.jtokkit.api.EncodingType;
@@ -23,8 +25,6 @@ import com.knuddels.jtokkit.api.EncodingType;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.content.MediaContent;
 import org.springframework.util.CollectionUtils;
-
-import java.util.Base64;
 
 /**
  * Estimates the number of tokens in a given text or message using the JTokkit encoding
@@ -36,18 +36,28 @@ import java.util.Base64;
  */
 public class JTokkitTokenCountEstimator implements TokenCountEstimator {
 
+	/**
+	 * The JTokkit encoding instance used for token counting.
+	 */
 	private final Encoding estimator;
 
+	/**
+	 * Creates a new JTokkitTokenCountEstimator with default CL100K_BASE encoding.
+	 */
 	public JTokkitTokenCountEstimator() {
 		this(EncodingType.CL100K_BASE);
 	}
 
-	public JTokkitTokenCountEstimator(EncodingType tokenEncodingType) {
+	/**
+	 * Creates a new JTokkitTokenCountEstimator with the specified encoding type.
+	 * @param tokenEncodingType the encoding type to use for token counting
+	 */
+	public JTokkitTokenCountEstimator(final EncodingType tokenEncodingType) {
 		this.estimator = Encodings.newLazyEncodingRegistry().getEncoding(tokenEncodingType);
 	}
 
 	@Override
-	public int estimate(String text) {
+	public int estimate(final String text) {
 		if (text == null) {
 			return 0;
 		}
@@ -55,7 +65,7 @@ public class JTokkitTokenCountEstimator implements TokenCountEstimator {
 	}
 
 	@Override
-	public int estimate(MediaContent content) {
+	public int estimate(final MediaContent content) {
 		int tokenCount = 0;
 
 		if (content.getText() != null) {
@@ -63,9 +73,7 @@ public class JTokkitTokenCountEstimator implements TokenCountEstimator {
 		}
 
 		if (!CollectionUtils.isEmpty(content.getMedia())) {
-
 			for (Media media : content.getMedia()) {
-
 				tokenCount += this.estimate(media.getMimeType().toString());
 
 				if (media.getData() instanceof String textData) {
@@ -82,7 +90,7 @@ public class JTokkitTokenCountEstimator implements TokenCountEstimator {
 	}
 
 	@Override
-	public int estimate(Iterable<MediaContent> contents) {
+	public int estimate(final Iterable<MediaContent> contents) {
 		int totalSize = 0;
 		for (MediaContent mediaContent : contents) {
 			totalSize += this.estimate(mediaContent);


### PR DESCRIPTION
### Summary
This PR improves the JTokkitTokenCountEstimator by converting binary data to a Base64 string for more accurate token estimation. This change aligns the logic with how most multimodal LLMs actually process this data type, leading to better cost predictions.

### Changes
- Enhancement: The estimate() method now handles byte[] data by converting it to a Base64 string before token counting. **This directly addresses the previous inaccurate behavior of adding the raw byte array length, as noted by the original code comment** `// This is likely incorrect.`

- Validation: Existing tests in TokenCountBatchingStrategyTests have been verified to ensure no regressions.

### Key Features
- Accurate Estimation: Provides a more realistic token count for binary data.

- LLM Alignment: The new approach mirrors the Base64 encoding used by most multimodal models.

- Backward Compatibility: This is an internal change and does not affect the public API.

Closes: #4331