### PR TITLE
gh-4325: Enhance cache management for Anthropic API by introducing per-message TTL and configurable content block usage optimization.

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -42,7 +42,9 @@ import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock;
 import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock.Source;
 import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock.Type;
 import org.springframework.ai.anthropic.api.AnthropicApi.Role;
-import org.springframework.ai.anthropic.api.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions;
+import org.springframework.ai.anthropic.api.AnthropicCacheTtl;
+import org.springframework.ai.anthropic.api.utils.CacheEligibilityResolver;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
@@ -93,6 +95,7 @@ import org.springframework.util.StringUtils;
  * @author Alexandros Pappas
  * @author Jonghoon Park
  * @author Soby Chacko
+ * @author Austin Dase
  * @since 1.0.0
  */
 public class AnthropicChatModel implements ChatModel {
@@ -463,11 +466,9 @@ public class AnthropicChatModel implements ChatModel {
 			requestOptions.setToolContext(ToolCallingChatOptions.mergeToolContext(runtimeOptions.getToolContext(),
 					this.defaultOptions.getToolContext()));
 
-			// Merge cache strategy and TTL (also @JsonIgnore fields)
-			requestOptions.setCacheStrategy(runtimeOptions.getCacheStrategy() != null
-					? runtimeOptions.getCacheStrategy() : this.defaultOptions.getCacheStrategy());
-			requestOptions.setCacheTtl(runtimeOptions.getCacheTtl() != null ? runtimeOptions.getCacheTtl()
-					: this.defaultOptions.getCacheTtl());
+			// Merge cache options that are Json-ignored
+			requestOptions.setCacheOptions(runtimeOptions.getCacheOptions() != null ? runtimeOptions.getCacheOptions()
+					: this.defaultOptions.getCacheOptions());
 		}
 		else {
 			requestOptions.setHttpHeaders(this.defaultOptions.getHttpHeaders());
@@ -498,41 +499,23 @@ public class AnthropicChatModel implements ChatModel {
 		AnthropicChatOptions requestOptions = null;
 		if (prompt.getOptions() instanceof AnthropicChatOptions) {
 			requestOptions = (AnthropicChatOptions) prompt.getOptions();
-			logger.debug("DEBUGINFO: Found AnthropicChatOptions - cacheStrategy: {}, cacheTtl: {}",
-					requestOptions.getCacheStrategy(), requestOptions.getCacheTtl());
+			logger.debug("DEBUGINFO: Found AnthropicChatOptions - cacheOptions {}", requestOptions.getCacheOptions());
 		}
 		else {
 			logger.debug("DEBUGINFO: Options is NOT AnthropicChatOptions, it's: {}",
 					prompt.getOptions() != null ? prompt.getOptions().getClass().getName() : "null");
 		}
 
-		AnthropicCacheStrategy strategy = requestOptions != null ? requestOptions.getCacheStrategy()
-				: AnthropicCacheStrategy.NONE;
-		String cacheTtl = requestOptions != null ? requestOptions.getCacheTtl() : "5m";
+		AnthropicCacheOptions cacheOptions = requestOptions != null ? requestOptions.getCacheOptions()
+				: AnthropicCacheOptions.DISABLED;
 
-		logger.debug("Cache strategy: {}, TTL: {}", strategy, cacheTtl);
-
-		// Track how many breakpoints we've used (max 4)
-		CacheBreakpointTracker breakpointsUsed = new CacheBreakpointTracker();
-		ChatCompletionRequest.CacheControl cacheControl = null;
-
-		if (strategy != AnthropicCacheStrategy.NONE) {
-			// Create cache control with TTL if specified, otherwise use default 5m
-			if (cacheTtl != null && !cacheTtl.equals("5m")) {
-				cacheControl = new ChatCompletionRequest.CacheControl("ephemeral", cacheTtl);
-				logger.debug("Created cache control with TTL: type={}, ttl={}", "ephemeral", cacheTtl);
-			}
-			else {
-				cacheControl = new ChatCompletionRequest.CacheControl("ephemeral");
-				logger.debug("Created cache control with default TTL: type={}, ttl={}", "ephemeral", "5m");
-			}
-		}
-
-		// Build messages WITHOUT blanket cache control - strategic placement only
-		List<AnthropicMessage> userMessages = buildMessages(prompt, strategy, cacheControl, breakpointsUsed);
+		CacheEligibilityResolver cacheEligibilityResolver = CacheEligibilityResolver.from(cacheOptions);
 
 		// Process system - as array if caching, string otherwise
-		Object systemContent = buildSystemContent(prompt, strategy, cacheControl, breakpointsUsed);
+		Object systemContent = buildSystemContent(prompt, cacheEligibilityResolver);
+
+		// Build messages WITHOUT blanket cache control - strategic placement only
+		List<AnthropicMessage> userMessages = buildMessages(prompt, cacheEligibilityResolver);
 
 		// Build base request
 		ChatCompletionRequest request = new ChatCompletionRequest(this.defaultOptions.getModel(), userMessages,
@@ -547,22 +530,42 @@ public class AnthropicChatModel implements ChatModel {
 			List<AnthropicApi.Tool> tools = getFunctionTools(toolDefinitions);
 
 			// Apply caching to tools if strategy includes them
-			if ((strategy == AnthropicCacheStrategy.SYSTEM_AND_TOOLS
-					|| strategy == AnthropicCacheStrategy.CONVERSATION_HISTORY) && breakpointsUsed.canUse()) {
-				tools = addCacheToLastTool(tools, cacheControl, breakpointsUsed);
-			}
+			tools = addCacheToLastTool(tools, cacheEligibilityResolver);
 
 			request = ChatCompletionRequest.from(request).tools(tools).build();
 		}
 
 		// Add beta header for 1-hour TTL if needed
-		if ("1h".equals(cacheTtl) && requestOptions != null) {
+		if (cacheOptions.getMessageTypeTtl().containsValue(AnthropicCacheTtl.ONE_HOUR)) {
 			Map<String, String> headers = new HashMap<>(requestOptions.getHttpHeaders());
 			headers.put("anthropic-beta", AnthropicApi.BETA_EXTENDED_CACHE_TTL);
 			requestOptions.setHttpHeaders(headers);
 		}
 
 		return request;
+	}
+
+	private static ContentBlock cacheAwareContentBlock(ContentBlock contentBlock, MessageType messageType,
+			CacheEligibilityResolver cacheEligibilityResolver) {
+		String basisForLength = switch (contentBlock.type()) {
+			case TEXT, TEXT_DELTA -> contentBlock.text();
+			case TOOL_RESULT -> contentBlock.content();
+			case TOOL_USE -> JsonParser.toJson(contentBlock.input());
+			case THINKING, THINKING_DELTA -> contentBlock.thinking();
+			case REDACTED_THINKING -> contentBlock.data();
+			default -> null;
+		};
+		return cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver, basisForLength);
+	}
+
+	private static ContentBlock cacheAwareContentBlock(ContentBlock contentBlock, MessageType messageType,
+			CacheEligibilityResolver cacheEligibilityResolver, String basisForLength) {
+		ChatCompletionRequest.CacheControl cacheControl = cacheEligibilityResolver.resolve(messageType, basisForLength);
+		if (cacheControl == null) {
+			return contentBlock;
+		}
+		cacheEligibilityResolver.useCacheBlock();
+		return ContentBlock.from(contentBlock).cacheControl(cacheControl).build();
 	}
 
 	private List<AnthropicApi.Tool> getFunctionTools(List<ToolDefinition> toolDefinitions) {
@@ -579,8 +582,7 @@ public class AnthropicChatModel implements ChatModel {
 	 * Build messages strategically, applying cache control only where specified by the
 	 * strategy.
 	 */
-	private List<AnthropicMessage> buildMessages(Prompt prompt, AnthropicCacheStrategy strategy,
-			ChatCompletionRequest.CacheControl cacheControl, CacheBreakpointTracker breakpointsUsed) {
+	private List<AnthropicMessage> buildMessages(Prompt prompt, CacheEligibilityResolver cacheEligibilityResolver) {
 
 		List<Message> allMessages = prompt.getInstructions()
 			.stream()
@@ -589,7 +591,7 @@ public class AnthropicChatModel implements ChatModel {
 
 		// Find the last user message (current question) for CONVERSATION_HISTORY strategy
 		int lastUserIndex = -1;
-		if (strategy == AnthropicCacheStrategy.CONVERSATION_HISTORY) {
+		if (cacheEligibilityResolver.isCachingEnabled()) {
 			for (int i = allMessages.size() - 1; i >= 0; i--) {
 				if (allMessages.get(i).getMessageType() == MessageType.USER) {
 					lastUserIndex = i;
@@ -601,32 +603,25 @@ public class AnthropicChatModel implements ChatModel {
 		List<AnthropicMessage> result = new ArrayList<>();
 		for (int i = 0; i < allMessages.size(); i++) {
 			Message message = allMessages.get(i);
-			boolean shouldApplyCache = false;
-
-			// Apply cache to history tail (message before current question) for
-			// CONVERSATION_HISTORY
-			if (strategy == AnthropicCacheStrategy.CONVERSATION_HISTORY && breakpointsUsed.canUse()) {
-				if (lastUserIndex > 0) {
-					// Cache the message immediately before the last user message
-					// (multi-turn conversation)
-					shouldApplyCache = (i == lastUserIndex - 1);
-				}
-				if (shouldApplyCache) {
-					breakpointsUsed.use();
-				}
-			}
-
-			if (message.getMessageType() == MessageType.USER) {
-				List<ContentBlock> contents = new ArrayList<>();
-
-				// Apply cache control strategically, not to all user messages
-				if (shouldApplyCache && cacheControl != null) {
-					contents.add(new ContentBlock(message.getText(), cacheControl));
+			MessageType messageType = message.getMessageType();
+			if (messageType == MessageType.USER) {
+				List<ContentBlock> contentBlocks = new ArrayList<>();
+				String content = message.getText();
+				// For conversation history caching, apply cache control to the
+				// message immediately before the last user message.
+				boolean isPenultimateUserMessage = (lastUserIndex > 0) && (i == lastUserIndex - 1);
+				ContentBlock contentBlock = new ContentBlock(content);
+				if (isPenultimateUserMessage && cacheEligibilityResolver.isCachingEnabled()) {
+					// Combine text from all user messages except the last one (current
+					// question)
+					// as the basis for cache eligibility checks
+					String combinedUserMessagesText = combineEligibleUserMessagesText(allMessages, lastUserIndex);
+					contentBlocks.add(cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver,
+							combinedUserMessagesText));
 				}
 				else {
-					contents.add(new ContentBlock(message.getText()));
+					contentBlocks.add(contentBlock);
 				}
-
 				if (message instanceof UserMessage userMessage) {
 					if (!CollectionUtils.isEmpty(userMessage.getMedia())) {
 						List<ContentBlock> mediaContent = userMessage.getMedia().stream().map(media -> {
@@ -634,30 +629,33 @@ public class AnthropicChatModel implements ChatModel {
 							var source = getSourceByMedia(media);
 							return new ContentBlock(contentBlockType, source);
 						}).toList();
-						contents.addAll(mediaContent);
+						contentBlocks.addAll(mediaContent);
 					}
 				}
-				result.add(new AnthropicMessage(contents, Role.valueOf(message.getMessageType().name())));
+				result.add(new AnthropicMessage(contentBlocks, Role.valueOf(message.getMessageType().name())));
 			}
-			else if (message.getMessageType() == MessageType.ASSISTANT) {
+			else if (messageType == MessageType.ASSISTANT) {
 				AssistantMessage assistantMessage = (AssistantMessage) message;
 				List<ContentBlock> contentBlocks = new ArrayList<>();
 				if (StringUtils.hasText(message.getText())) {
-					contentBlocks.add(new ContentBlock(message.getText()));
+					ContentBlock contentBlock = new ContentBlock(message.getText());
+					contentBlocks.add(cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver));
 				}
 				if (!CollectionUtils.isEmpty(assistantMessage.getToolCalls())) {
 					for (AssistantMessage.ToolCall toolCall : assistantMessage.getToolCalls()) {
-						contentBlocks.add(new ContentBlock(Type.TOOL_USE, toolCall.id(), toolCall.name(),
-								ModelOptionsUtils.jsonToMap(toolCall.arguments())));
+						ContentBlock contentBlock = new ContentBlock(Type.TOOL_USE, toolCall.id(), toolCall.name(),
+								ModelOptionsUtils.jsonToMap(toolCall.arguments()));
+						contentBlocks.add(cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver));
 					}
 				}
 				result.add(new AnthropicMessage(contentBlocks, Role.ASSISTANT));
 			}
-			else if (message.getMessageType() == MessageType.TOOL) {
+			else if (messageType == MessageType.TOOL) {
 				List<ContentBlock> toolResponses = ((ToolResponseMessage) message).getResponses()
 					.stream()
 					.map(toolResponse -> new ContentBlock(Type.TOOL_RESULT, toolResponse.id(),
 							toolResponse.responseData()))
+					.map(contentBlock -> cacheAwareContentBlock(contentBlock, messageType, cacheEligibilityResolver))
 					.toList();
 				result.add(new AnthropicMessage(toolResponses, Role.USER));
 			}
@@ -668,11 +666,26 @@ public class AnthropicChatModel implements ChatModel {
 		return result;
 	}
 
+	private String combineEligibleUserMessagesText(List<Message> userMessages, int lastUserIndex) {
+		List<Message> userMessagesForEligibility = new ArrayList<>();
+		// Only 20 content blocks are considered by anthropic, so limit the number of
+		// message content to consider
+		int startIndex = Math.max(0, lastUserIndex - 20);
+		for (int i = startIndex; i < lastUserIndex; i++) {
+			Message message = userMessages.get(i);
+			if (message.getMessageType() == MessageType.USER) {
+				userMessagesForEligibility.add(message);
+			}
+		}
+		StringBuilder sb = new StringBuilder();
+		userMessagesForEligibility.stream().map(Message::getText).filter(StringUtils::hasText).forEach(sb::append);
+		return sb.toString();
+	}
+
 	/**
 	 * Build system content - as array if caching, string otherwise.
 	 */
-	private Object buildSystemContent(Prompt prompt, AnthropicCacheStrategy strategy,
-			ChatCompletionRequest.CacheControl cacheControl, CacheBreakpointTracker breakpointsUsed) {
+	private Object buildSystemContent(Prompt prompt, CacheEligibilityResolver cacheEligibilityResolver) {
 
 		String systemText = prompt.getInstructions()
 			.stream()
@@ -685,15 +698,9 @@ public class AnthropicChatModel implements ChatModel {
 		}
 
 		// Use array format when caching system
-		if ((strategy == AnthropicCacheStrategy.SYSTEM_ONLY || strategy == AnthropicCacheStrategy.SYSTEM_AND_TOOLS
-				|| strategy == AnthropicCacheStrategy.CONVERSATION_HISTORY) && breakpointsUsed.canUse()
-				&& cacheControl != null) {
-
-			logger.debug("Applying cache control to system message - strategy: {}, cacheControl: {}", strategy,
-					cacheControl);
-			List<ContentBlock> systemBlocks = List.of(new ContentBlock(systemText, cacheControl));
-			breakpointsUsed.use();
-			return systemBlocks;
+		if (cacheEligibilityResolver.isCachingEnabled()) {
+			return List
+				.of(cacheAwareContentBlock(new ContentBlock(systemText), MessageType.SYSTEM, cacheEligibilityResolver));
 		}
 
 		// Use string format when not caching (backward compatible)
@@ -704,9 +711,11 @@ public class AnthropicChatModel implements ChatModel {
 	 * Add cache control to the last tool for deterministic caching.
 	 */
 	private List<AnthropicApi.Tool> addCacheToLastTool(List<AnthropicApi.Tool> tools,
-			ChatCompletionRequest.CacheControl cacheControl, CacheBreakpointTracker breakpointsUsed) {
+			CacheEligibilityResolver cacheEligibilityResolver) {
 
-		if (tools == null || tools.isEmpty() || !breakpointsUsed.canUse() || cacheControl == null) {
+		ChatCompletionRequest.CacheControl cacheControl = cacheEligibilityResolver.resolveToolCacheControl();
+
+		if (cacheControl == null || tools == null || tools.isEmpty()) {
 			return tools;
 		}
 
@@ -716,7 +725,7 @@ public class AnthropicChatModel implements ChatModel {
 			if (i == tools.size() - 1) {
 				// Add cache control to last tool
 				tool = new AnthropicApi.Tool(tool.name(), tool.description(), tool.inputSchema(), cacheControl);
-				breakpointsUsed.use();
+				cacheEligibilityResolver.useCacheBlock();
 			}
 			modifiedTools.add(tool);
 		}
@@ -800,38 +809,6 @@ public class AnthropicChatModel implements ChatModel {
 			}
 			return new AnthropicChatModel(this.anthropicApi, this.defaultOptions, DEFAULT_TOOL_CALLING_MANAGER,
 					this.retryTemplate, this.observationRegistry, this.toolExecutionEligibilityPredicate);
-		}
-
-	}
-
-	/**
-	 * Tracks cache breakpoints used (max 4 allowed by Anthropic). Non-static to ensure
-	 * each request has its own instance.
-	 */
-	private class CacheBreakpointTracker {
-
-		private int count = 0;
-
-		private boolean hasWarned = false;
-
-		public boolean canUse() {
-			return this.count < 4;
-		}
-
-		public void use() {
-			if (this.count < 4) {
-				this.count++;
-			}
-			else if (!this.hasWarned) {
-				logger.warn(
-						"Anthropic cache breakpoint limit (4) reached. Additional cache_control directives will be ignored. "
-								+ "Consider using fewer cache strategies or simpler content structure.");
-				this.hasWarned = true;
-			}
-		}
-
-		public int getCount() {
-			return this.count;
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.ai.anthropic.api.AnthropicApi;
 import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionRequest;
-import org.springframework.ai.anthropic.api.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.lang.Nullable;
@@ -46,6 +46,7 @@ import org.springframework.util.Assert;
  * @author Alexandros Pappas
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
+ * @author Austin Dase
  * @since 1.0.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -61,35 +62,16 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	private @JsonProperty("top_k") Integer topK;
 	private @JsonProperty("thinking") ChatCompletionRequest.ThinkingConfig thinking;
 
-	/**
-	 * The caching strategy to use. Defines which parts of the prompt should be cached.
-	 */
 	@JsonIgnore
-	private AnthropicCacheStrategy cacheStrategy = AnthropicCacheStrategy.NONE;
+	private AnthropicCacheOptions cacheOptions = AnthropicCacheOptions.DISABLED;
 
-	/**
-	 * Cache time-to-live. Either "5m" (5 minutes, default) or "1h" (1 hour).
-	 * The 1-hour cache requires a beta header.
-	 */
-	@JsonIgnore
-	private String cacheTtl = "5m";
-
-	public AnthropicCacheStrategy getCacheStrategy() {
-		return this.cacheStrategy;
+	public AnthropicCacheOptions getCacheOptions() {
+		return this.cacheOptions;
 	}
 
-	public void setCacheStrategy(AnthropicCacheStrategy cacheStrategy) {
-		this.cacheStrategy = cacheStrategy;
+	public void setCacheOptions(AnthropicCacheOptions cacheOptions) {
+		this.cacheOptions = cacheOptions;
 	}
-
-	public String getCacheTtl() {
-		return this.cacheTtl;
-	}
-
-	public void setCacheTtl(String cacheTtl) {
-		this.cacheTtl = cacheTtl;
-	}
-
 	/**
 	 * Collection of {@link ToolCallback}s to be used for tool calling in the chat
 	 * completion requests.
@@ -142,8 +124,7 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
 			.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
 			.httpHeaders(fromOptions.getHttpHeaders() != null ? new HashMap<>(fromOptions.getHttpHeaders()) : null)
-			.cacheStrategy(fromOptions.getCacheStrategy())
-			.cacheTtl(fromOptions.getCacheTtl())
+			.cacheOptions(fromOptions.getCacheOptions())
 			.build();
 	}
 
@@ -316,15 +297,14 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
 				&& Objects.equals(this.toolContext, that.toolContext)
 				&& Objects.equals(this.httpHeaders, that.httpHeaders)
-				&& Objects.equals(this.cacheStrategy, that.cacheStrategy)
-				&& Objects.equals(this.cacheTtl, that.cacheTtl);
+				&& Objects.equals(this.cacheOptions, that.cacheOptions);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.model, this.maxTokens, this.metadata, this.stopSequences, this.temperature, this.topP,
 				this.topK, this.thinking, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
-				this.toolContext, this.httpHeaders, this.cacheStrategy, this.cacheTtl);
+				this.toolContext, this.httpHeaders, this.cacheOptions);
 	}
 
 	public static class Builder {
@@ -424,19 +404,8 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 			return this;
 		}
 
-		/**
-		 * Set the caching strategy to use.
-		 */
-		public Builder cacheStrategy(AnthropicCacheStrategy cacheStrategy) {
-			this.options.cacheStrategy = cacheStrategy;
-			return this;
-		}
-
-		/**
-		 * Set the cache time-to-live. Either "5m" (5 minutes, default) or "1h" (1 hour).
-		 */
-		public Builder cacheTtl(String cacheTtl) {
-			this.options.cacheTtl = cacheTtl;
+		public Builder cacheOptions(AnthropicCacheOptions cacheOptions) {
+			this.options.setCacheOptions(cacheOptions);
 			return this;
 		}
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -67,6 +67,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Claudio Silva Junior
  * @author Filip Hrisafov
  * @author Soby Chacko
+ * @author Austin Dase
  * @since 1.0.0
  */
 public final class AnthropicApi {
@@ -860,6 +861,10 @@ public final class AnthropicApi {
 			this(type, null, null, null, id, name, input, null, null, null, null, null, null);
 		}
 
+		public static ContentBlockBuilder from(ContentBlock contentBlock) {
+			return new ContentBlockBuilder(contentBlock);
+		}
+
 		/**
 		 * The ContentBlock type.
 		 */
@@ -984,6 +989,121 @@ public final class AnthropicApi {
 
 		}
 
+		public static class ContentBlockBuilder {
+
+			private Type type;
+
+			private Source source;
+
+			private String text;
+
+			private Integer index;
+
+			private String id;
+
+			private String name;
+
+			private Map<String, Object> input;
+
+			private String toolUseId;
+
+			private String content;
+
+			private String signature;
+
+			private String thinking;
+
+			private String data;
+
+			private CacheControl cacheControl;
+
+			public ContentBlockBuilder(ContentBlock contentBlock) {
+				this.type = contentBlock.type;
+				this.source = contentBlock.source;
+				this.text = contentBlock.text;
+				this.index = contentBlock.index;
+				this.id = contentBlock.id;
+				this.name = contentBlock.name;
+				this.input = contentBlock.input;
+				this.toolUseId = contentBlock.toolUseId;
+				this.content = contentBlock.content;
+				this.signature = contentBlock.signature;
+				this.thinking = contentBlock.thinking;
+				this.data = contentBlock.data;
+				this.cacheControl = contentBlock.cacheControl;
+			}
+
+			public ContentBlockBuilder type(Type type) {
+				this.type = type;
+				return this;
+			}
+
+			public ContentBlockBuilder source(Source source) {
+				this.source = source;
+				return this;
+			}
+
+			public ContentBlockBuilder text(String text) {
+				this.text = text;
+				return this;
+			}
+
+			public ContentBlockBuilder index(Integer index) {
+				this.index = index;
+				return this;
+			}
+
+			public ContentBlockBuilder id(String id) {
+				this.id = id;
+				return this;
+			}
+
+			public ContentBlockBuilder name(String name) {
+				this.name = name;
+				return this;
+			}
+
+			public ContentBlockBuilder input(Map<String, Object> input) {
+				this.input = input;
+				return this;
+			}
+
+			public ContentBlockBuilder toolUseId(String toolUseId) {
+				this.toolUseId = toolUseId;
+				return this;
+			}
+
+			public ContentBlockBuilder content(String content) {
+				this.content = content;
+				return this;
+			}
+
+			public ContentBlockBuilder signature(String signature) {
+				this.signature = signature;
+				return this;
+			}
+
+			public ContentBlockBuilder thinking(String thinking) {
+				this.thinking = thinking;
+				return this;
+			}
+
+			public ContentBlockBuilder data(String data) {
+				this.data = data;
+				return this;
+			}
+
+			public ContentBlockBuilder cacheControl(CacheControl cacheControl) {
+				this.cacheControl = cacheControl;
+				return this;
+			}
+
+			public ContentBlock build() {
+				return new ContentBlock(this.type, this.source, this.text, this.index, this.id, this.name, this.input,
+						this.toolUseId, this.content, this.signature, this.thinking, this.data, this.cacheControl);
+			}
+
+		}
 	}
 
 	///////////////////////////////////////

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheOptions.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.ai.chat.messages.MessageType;
+
+/**
+ * Anthropic cache options for configuring prompt caching behavior.
+ *
+ * @author Austin Dase
+ * @since 1.1.0
+ **/
+public class AnthropicCacheOptions {
+
+	public static AnthropicCacheOptions DISABLED = new AnthropicCacheOptions();
+
+	private static final int DEFAULT_MIN_CONTENT_LENGTH = 1;
+
+	private AnthropicCacheStrategy strategy = AnthropicCacheStrategy.NONE;
+
+	/**
+	 * Function to determine the content length of a message. Defaults to the length of
+	 * the string, or {@code 0} if the string is {@code null}. This is used as a proxy for
+	 * number of tokens because Anthropic does document that messages with too few tokens
+	 * are not eligible for caching - see <a href=
+	 * "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#cache-limitations">Anthropic
+	 * Caching Limitations</a>. Further, the function can be customized to use a more
+	 * accurate token count if desired.
+	 */
+	private Function<String, Integer> contentLengthFunction = s -> s != null ? s.length() : 0;
+
+	/**
+	 * Configure on a per {@link MessageType} basis the TTL (time-to-live) for cached
+	 * prompts. Defaults to {@link AnthropicCacheTtl#FIVE_MINUTES}. Note that different
+	 * caches have different write costs, see <a href=
+	 * "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#understanding-cache-breakpoint-costs">Anthropic
+	 * Cache Breakpoint Costs</a>
+	 */
+	private Map<MessageType, AnthropicCacheTtl> messageTypeTtl = Stream.of(MessageType.values())
+		.collect(Collectors.toMap(mt -> mt, mt -> AnthropicCacheTtl.FIVE_MINUTES, (m1, m2) -> m1, HashMap::new));
+
+	/**
+	 * Configure on a per {@link MessageType} basis the minimum content length required to
+	 * consider a message for caching. Defaults to {@code 1}. This is used in conjunction
+	 * with the {@link #contentLengthFunction} to determine if a message is eligible for
+	 * caching based on its content length. Helping to optimize the usage of the limited
+	 * cache breakpoints (4 max) allowed by Anthropic.
+	 */
+	private Map<MessageType, Integer> messageTypeMinContentLengths = Stream.of(MessageType.values())
+		.collect(Collectors.toMap(mt -> mt, mt -> DEFAULT_MIN_CONTENT_LENGTH, (m1, m2) -> m1, HashMap::new));
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public AnthropicCacheStrategy getStrategy() {
+		return this.strategy;
+	}
+
+	public void setStrategy(AnthropicCacheStrategy strategy) {
+		this.strategy = strategy;
+	}
+
+	public Function<String, Integer> getContentLengthFunction() {
+		return this.contentLengthFunction;
+	}
+
+	public void setContentLengthFunction(Function<String, Integer> contentLengthFunction) {
+		this.contentLengthFunction = contentLengthFunction;
+	}
+
+	public Map<MessageType, AnthropicCacheTtl> getMessageTypeTtl() {
+		return this.messageTypeTtl;
+	}
+
+	public void setMessageTypeTtl(Map<MessageType, AnthropicCacheTtl> messageTypeTtl) {
+		this.messageTypeTtl = messageTypeTtl;
+	}
+
+	public Map<MessageType, Integer> getMessageTypeMinContentLengths() {
+		return this.messageTypeMinContentLengths;
+	}
+
+	public void setMessageTypeMinContentLengths(Map<MessageType, Integer> messageTypeMinContentLengths) {
+		this.messageTypeMinContentLengths = messageTypeMinContentLengths;
+	}
+
+	@Override
+	public String toString() {
+		return "AnthropicCacheOptions{" + "strategy=" + this.strategy + ", contentLengthFunction="
+				+ this.contentLengthFunction + ", messageTypeTtl=" + this.messageTypeTtl
+				+ ", messageTypeMinContentLengths=" + this.messageTypeMinContentLengths + '}';
+	}
+
+	public static class Builder {
+
+		private final AnthropicCacheOptions options = new AnthropicCacheOptions();
+
+		public Builder strategy(AnthropicCacheStrategy strategy) {
+			this.options.setStrategy(strategy);
+			return this;
+		}
+
+		public Builder contentLengthFunction(Function<String, Integer> contentLengthFunction) {
+			this.options.setContentLengthFunction(contentLengthFunction);
+			return this;
+		}
+
+		public Builder messageTypeTtl(Map<MessageType, AnthropicCacheTtl> messageTypeTtl) {
+			this.options.setMessageTypeTtl(messageTypeTtl);
+			return this;
+		}
+
+		public Builder messageTypeTtl(MessageType messageType, AnthropicCacheTtl ttl) {
+			this.options.messageTypeTtl.put(messageType, ttl);
+			return this;
+		}
+
+		public Builder messageTypeMinContentLengths(Map<MessageType, Integer> messageTypeMinContentLengths) {
+			this.options.setMessageTypeMinContentLengths(messageTypeMinContentLengths);
+			return this;
+		}
+
+		public Builder messageTypeMinContentLength(MessageType messageType, Integer minContentLength) {
+			this.options.messageTypeMinContentLengths.put(messageType, minContentLength);
+			return this;
+		}
+
+		public AnthropicCacheOptions build() {
+			return this.options;
+		}
+
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheTtl.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheTtl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api;
+
+/**
+ * Anthropic cache TTL (time-to-live) options for specifying how long cached prompts See
+ * the Anthropic documentation for more details: <a href=
+ * "https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#1-hour-cache-duration">Anthropic
+ * Prompt Caching</a>
+ *
+ * @author Austin Dase
+ * @since 1.1.0
+ **/
+public enum AnthropicCacheTtl {
+
+	FIVE_MINUTES("5m"), ONE_HOUR("1h");
+
+	private final String value;
+
+	AnthropicCacheTtl(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return this.value;
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheType.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicCacheType.java
@@ -16,7 +16,7 @@
 
 package org.springframework.ai.anthropic.api;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionRequest.CacheControl;
 
@@ -32,17 +32,18 @@ import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionRequest.C
  * Caching</a>
  * @author Claudio Silva Junior
  * @author Soby Chacko
+ * @author Austin Dase
  */
 public enum AnthropicCacheType {
 
 	/**
 	 * Ephemeral cache with 5-minute lifetime, refreshed on each use.
 	 */
-	EPHEMERAL(() -> new CacheControl("ephemeral"));
+	EPHEMERAL(ttl -> new CacheControl("ephemeral", ttl));
 
-	private final Supplier<CacheControl> value;
+	private final Function<String, CacheControl> value;
 
-	AnthropicCacheType(Supplier<CacheControl> value) {
+	AnthropicCacheType(Function<String, CacheControl> value) {
 		this.value = value;
 	}
 
@@ -51,7 +52,17 @@ public enum AnthropicCacheType {
 	 * @return a CacheControl instance configured for this cache type
 	 */
 	public CacheControl cacheControl() {
-		return this.value.get();
+		return this.value.apply(null);
+	}
+
+	/**
+	 * Returns a new CacheControl instance for this cache type with the specified TTL.
+	 * @param ttl the time-to-live for the cache entry (e.g., "5m" for 5 minutes, "1h" for
+	 * 1 hour)
+	 * @return a CacheControl instance configured for this cache type and TTL
+	 */
+	public CacheControl cacheControl(String ttl) {
+		return this.value.apply(ttl);
 	}
 
 }

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheBreakpointTracker.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheBreakpointTracker.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks cache breakpoints used (max 4 allowed by Anthropic). Non-static to ensure each
+ * request has its own instance.
+ *
+ * @author Austin Dase
+ */
+class CacheBreakpointTracker {
+
+	private static final Logger logger = LoggerFactory.getLogger(CacheBreakpointTracker.class);
+
+	private int count = 0;
+
+	private boolean hasWarned = false;
+
+	public boolean canUse() {
+		return this.count < 4;
+	}
+
+	public boolean allBreakpointsAreUsed() {
+		return !this.canUse();
+	}
+
+	public void use() {
+		if (this.count < 4) {
+			this.count++;
+		}
+		else if (!this.hasWarned) {
+			logger.warn(
+					"Anthropic cache breakpoint limit (4) reached. Additional cache_control directives will be ignored. "
+							+ "Consider using fewer cache strategies or simpler content structure.");
+			this.hasWarned = true;
+		}
+	}
+
+	public int getCount() {
+		return this.count;
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolver.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolver.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api.utils;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions;
+import org.springframework.ai.anthropic.api.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.api.AnthropicCacheTtl;
+import org.springframework.ai.anthropic.api.AnthropicCacheType;
+import org.springframework.ai.chat.messages.MessageType;
+
+/**
+ * Resolves cache eligibility for messages based on the provided
+ * {@link AnthropicCacheOptions}.
+ *
+ * Note: Tool definition messages are always considered for caching if the strategy
+ * includes system messages. The minimum content length check is not applied to tool
+ * definition messages.
+ *
+ * @author Austin Dase
+ * @since 1.1.0
+ **/
+public class CacheEligibilityResolver {
+
+	private static final Logger logger = LoggerFactory.getLogger(CacheEligibilityResolver.class);
+
+	// Tool definition messages are always considered for caching if the strategy
+	// includes system messages.
+	private static final MessageType TOOL_DEFINITION_MESSAGE_TYPE = MessageType.SYSTEM;
+
+	private final CacheBreakpointTracker cacheBreakpointTracker = new CacheBreakpointTracker();
+
+	private final AnthropicCacheType anthropicCacheType = AnthropicCacheType.EPHEMERAL;
+
+	private final AnthropicCacheStrategy cacheStrategy;
+
+	private final Map<MessageType, AnthropicCacheTtl> messageTypeTtl;
+
+	private final Map<MessageType, Integer> messageTypeMinContentLengths;
+
+	private final Function<String, Integer> contentLengthFunction;
+
+	private final Set<MessageType> cacheEligibleMessageTypes;
+
+	public CacheEligibilityResolver(AnthropicCacheStrategy cacheStrategy,
+			Map<MessageType, AnthropicCacheTtl> messageTypeTtl, Map<MessageType, Integer> messageTypeMinContentLengths,
+			Function<String, Integer> contentLengthFunction, Set<MessageType> cacheEligibleMessageTypes) {
+		this.cacheStrategy = cacheStrategy;
+		this.messageTypeTtl = messageTypeTtl;
+		this.messageTypeMinContentLengths = messageTypeMinContentLengths;
+		this.contentLengthFunction = contentLengthFunction;
+		this.cacheEligibleMessageTypes = cacheEligibleMessageTypes;
+	}
+
+	public static CacheEligibilityResolver from(AnthropicCacheOptions anthropicCacheOptions) {
+		AnthropicCacheStrategy strategy = anthropicCacheOptions.getStrategy();
+		return new CacheEligibilityResolver(strategy, anthropicCacheOptions.getMessageTypeTtl(),
+				anthropicCacheOptions.getMessageTypeMinContentLengths(),
+				anthropicCacheOptions.getContentLengthFunction(), extractEligibleMessageTypes(strategy));
+	}
+
+	private static Set<MessageType> extractEligibleMessageTypes(AnthropicCacheStrategy anthropicCacheStrategy) {
+		return switch (anthropicCacheStrategy) {
+			case NONE -> Set.of();
+			case SYSTEM_ONLY, SYSTEM_AND_TOOLS -> Set.of(MessageType.SYSTEM);
+			case CONVERSATION_HISTORY -> Set.of(MessageType.values());
+		};
+	}
+
+	public AnthropicApi.ChatCompletionRequest.CacheControl resolve(MessageType messageType, String content) {
+		Integer length = this.contentLengthFunction.apply(content);
+		if (this.cacheStrategy == AnthropicCacheStrategy.NONE || !this.cacheEligibleMessageTypes.contains(messageType)
+				|| length == null || length < this.messageTypeMinContentLengths.get(messageType)
+				|| this.cacheBreakpointTracker.allBreakpointsAreUsed()) {
+			logger.debug(
+					"Caching not enabled for messageType={}, contentLength={}, minContentLength={}, cacheStrategy={}, usedBreakpoints={}",
+					messageType, length, this.messageTypeMinContentLengths.get(messageType), this.cacheStrategy,
+					this.cacheBreakpointTracker.getCount());
+			return null;
+		}
+
+		AnthropicCacheTtl anthropicCacheTtl = this.messageTypeTtl.get(messageType);
+
+		logger.debug("Caching enabled for messageType={}, ttl={}", messageType, anthropicCacheTtl);
+
+		return this.anthropicCacheType.cacheControl(anthropicCacheTtl.getValue());
+	}
+
+	public AnthropicApi.ChatCompletionRequest.CacheControl resolveToolCacheControl() {
+		// Tool definitions are only cache-eligible when caching is enabled and
+		// the strategy includes SYSTEM messages (SYSTEM_ONLY, SYSTEM_AND_TOOLS, or
+		// CONVERSATION_HISTORY). When NONE, tools must not be cached.
+		if (!isCachingEnabled() || !this.cacheEligibleMessageTypes.contains(TOOL_DEFINITION_MESSAGE_TYPE)
+				|| this.cacheBreakpointTracker.allBreakpointsAreUsed()) {
+			logger.debug("Caching not enabled for tool definition, usedBreakpoints={}",
+					this.cacheBreakpointTracker.getCount());
+			return null;
+		}
+
+		AnthropicCacheTtl anthropicCacheTtl = this.messageTypeTtl.get(TOOL_DEFINITION_MESSAGE_TYPE);
+
+		logger.debug("Caching enabled for tool definition, ttl={}", anthropicCacheTtl);
+
+		return this.anthropicCacheType.cacheControl(anthropicCacheTtl.getValue());
+	}
+
+	public boolean isCachingEnabled() {
+		return this.cacheStrategy != AnthropicCacheStrategy.NONE;
+	}
+
+	public void useCacheBlock() {
+		this.cacheBreakpointTracker.use();
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicCacheOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicCacheOptionsTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.MessageType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AnthropicCacheOptions}.
+ *
+ * @author Austin Dase
+ */
+class AnthropicCacheOptionsTests {
+
+	@Test
+	void defaultsAreSane() {
+		AnthropicCacheOptions options = new AnthropicCacheOptions();
+		assertThat(options.getStrategy()).isEqualTo(AnthropicCacheStrategy.NONE);
+		// All message types default to FIVE_MINUTES and min content length 1
+		for (MessageType mt : MessageType.values()) {
+			assertThat(options.getMessageTypeTtl().get(mt)).isEqualTo(AnthropicCacheTtl.FIVE_MINUTES);
+			assertThat(options.getMessageTypeMinContentLengths().get(mt)).isEqualTo(1);
+		}
+		// Default content length function returns string length (null -> 0)
+		assertThat(options.getContentLengthFunction().apply("abc")).isEqualTo(3);
+		assertThat(options.getContentLengthFunction().apply(null)).isEqualTo(0);
+	}
+
+	@Test
+	void builderOverrides() {
+		Function<String, Integer> clf = s -> 123;
+		AnthropicCacheOptions options = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)
+			.messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
+			.messageTypeMinContentLength(MessageType.SYSTEM, 100)
+			.contentLengthFunction(clf)
+			.build();
+
+		assertThat(options.getStrategy()).isEqualTo(AnthropicCacheStrategy.SYSTEM_AND_TOOLS);
+		assertThat(options.getMessageTypeTtl().get(MessageType.SYSTEM)).isEqualTo(AnthropicCacheTtl.ONE_HOUR);
+		assertThat(options.getMessageTypeMinContentLengths().get(MessageType.SYSTEM)).isEqualTo(100);
+		assertThat(options.getContentLengthFunction()).isSameAs(clf);
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolverTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/utils/CacheEligibilityResolverTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api.utils;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions;
+import org.springframework.ai.anthropic.api.AnthropicCacheStrategy;
+import org.springframework.ai.anthropic.api.AnthropicCacheTtl;
+import org.springframework.ai.chat.messages.MessageType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CacheEligibilityResolver}.
+ *
+ * @author Austin Dase
+ */
+class CacheEligibilityResolverTests {
+
+	@Test
+	void noCachingWhenStrategyNone() {
+		AnthropicCacheOptions options = AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.NONE).build();
+		CacheEligibilityResolver resolver = CacheEligibilityResolver.from(options);
+		assertThat(resolver.isCachingEnabled()).isFalse();
+		assertThat(resolver.resolve(MessageType.SYSTEM, "some text")).isNull();
+		assertThat(resolver.resolveToolCacheControl()).isNull();
+	}
+
+	@Test
+	void systemCachingRespectsMinLength() {
+		AnthropicCacheOptions options = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+			.messageTypeMinContentLength(MessageType.SYSTEM, 10)
+			.build();
+		CacheEligibilityResolver resolver = CacheEligibilityResolver.from(options);
+
+		// Below min length -> no cache
+		assertThat(resolver.resolve(MessageType.SYSTEM, "short")).isNull();
+
+		// Above min length -> cache control with default TTL
+		AnthropicApi.ChatCompletionRequest.CacheControl cc = resolver.resolve(MessageType.SYSTEM, "01234567890");
+		assertThat(cc).isNotNull();
+		assertThat(cc.type()).isEqualTo("ephemeral");
+		assertThat(cc.ttl()).isEqualTo(AnthropicCacheTtl.FIVE_MINUTES.getValue());
+	}
+
+	@Test
+	void emptyTextShouldNotBeCachedEvenIfMinIsZero() {
+		AnthropicCacheOptions options = AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+			// default min content length is 0
+			.build();
+		CacheEligibilityResolver resolver = CacheEligibilityResolver.from(options);
+		assertThat(resolver.resolve(MessageType.SYSTEM, "")).isNull();
+		assertThat(resolver.resolve(MessageType.SYSTEM, null)).isNull();
+	}
+
+	@Test
+	void toolCacheControlRespectsStrategy() {
+		// NONE -> no tool caching
+		CacheEligibilityResolver none = CacheEligibilityResolver
+			.from(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.NONE).build());
+		assertThat(none.resolveToolCacheControl()).isNull();
+
+		// SYSTEM_ONLY -> tool caching enabled (uses SYSTEM TTL)
+		CacheEligibilityResolver sys = CacheEligibilityResolver.from(AnthropicCacheOptions.builder()
+			.strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+			.messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
+			.build());
+		var cc = sys.resolveToolCacheControl();
+		assertThat(cc).isNotNull();
+		assertThat(cc.ttl()).isEqualTo(AnthropicCacheTtl.ONE_HOUR.getValue());
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -216,14 +216,14 @@ Spring AI provides strategic cache placement through the `AnthropicCacheStrategy
 
 * `NONE`: Disables prompt caching completely
 * `SYSTEM_ONLY`: Caches only the system message content  
-* `SYSTEM_AND_TOOLS`: Caches system message and tool definitions
+* `SYSTEM_AND_TOOLS`: Caches system message and the last tool definition
 * `CONVERSATION_HISTORY`: Caches conversation history in chat memory scenarios
 
 This strategic approach ensures optimal cache breakpoint placement while staying within Anthropic's 4-breakpoint limit.
 
 === Enabling Prompt Caching
 
-To enable prompt caching, use the `cacheStrategy()` method in `AnthropicChatOptions`:
+Enable prompt caching by setting `cacheOptions` on `AnthropicChatOptions` and choosing a `strategy`.
 
 ==== System-Only Caching
 
@@ -238,7 +238,9 @@ ChatResponse response = chatModel.call(
         ),
         AnthropicChatOptions.builder()
             .model("claude-sonnet-4")
-            .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+            .cacheOptions(AnthropicCacheOptions.builder()
+                .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                .build())
             .maxTokens(500)
             .build()
     )
@@ -249,7 +251,7 @@ ChatResponse response = chatModel.call(
 
 [source,java]
 ----
-// Cache system message and tool definitions
+// Cache system message and the last tool definition
 ChatResponse response = chatModel.call(
     new Prompt(
         List.of(
@@ -258,7 +260,9 @@ ChatResponse response = chatModel.call(
         ),
         AnthropicChatOptions.builder()
             .model("claude-sonnet-4") 
-            .cacheStrategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)
+            .cacheOptions(AnthropicCacheOptions.builder()
+                .strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)
+                .build())
             .toolCallbacks(weatherToolCallback)
             .maxTokens(500)
             .build()
@@ -270,7 +274,7 @@ ChatResponse response = chatModel.call(
 
 [source,java]
 ----
-// Cache conversation history with ChatClient and memory
+// Cache conversation history with ChatClient and memory (latest user question is not cached)
 ChatClient chatClient = ChatClient.builder(chatModel)
     .defaultSystem("You are a personalized career counselor...")
     .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory)
@@ -282,7 +286,9 @@ String response = chatClient.prompt()
     .user("What career advice would you give me?")
     .options(AnthropicChatOptions.builder()
         .model("claude-sonnet-4")
-        .cacheStrategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+        .cacheOptions(AnthropicCacheOptions.builder()
+            .strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+            .build())
         .maxTokens(500)
         .build())
     .call()
@@ -299,7 +305,9 @@ String response = ChatClient.create(chatModel)
     .user("Analyze this large document: " + document)
     .options(AnthropicChatOptions.builder()
         .model("claude-sonnet-4")
-        .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+        .cacheOptions(AnthropicCacheOptions.builder()
+            .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+            .build())
         .build())
     .call()
     .content();
@@ -307,9 +315,9 @@ String response = ChatClient.create(chatModel)
 
 === Advanced Caching Options
 
-==== Extended TTL Caching
+==== Per-Message TTL (5m or 1h)
 
-For longer cache lifetimes, you can specify a custom TTL (requires beta features):
+By default, cached content uses a 5-minute TTL. You can set a 1-hour TTL for specific message types. When 1-hour TTL is used, Spring AI automatically sets the required Anthropic beta header.
 
 [source,java]
 ----
@@ -318,13 +326,44 @@ ChatResponse response = chatModel.call(
         List.of(new SystemMessage(largeSystemPrompt)),
         AnthropicChatOptions.builder()
             .model("claude-sonnet-4")
-            .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
-            .cacheTtl("1h")  // 1-hour cache lifetime
+            .cacheOptions(AnthropicCacheOptions.builder()
+                .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                .messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
+                .build())
             .maxTokens(500)
             .build()
     )
 );
 ----
+
+NOTE: Extended TTL uses Anthropic beta feature `extended-cache-ttl-2025-04-11`.
+
+==== Cache Eligibility Filters
+
+Control when cache breakpoints are used by setting minimum content lengths and an optional token-based length function:
+
+[source,java]
+----
+AnthropicCacheOptions cache = AnthropicCacheOptions.builder()
+    .strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
+    .messageTypeMinContentLength(MessageType.SYSTEM, 1024)
+    .messageTypeMinContentLength(MessageType.USER, 1024)
+    .messageTypeMinContentLength(MessageType.ASSISTANT, 1024)
+    .contentLengthFunction(text -> MyTokenCounter.count(text))
+    .build();
+
+ChatResponse response = chatModel.call(
+    new Prompt(
+        List.of(/* messages */),
+        AnthropicChatOptions.builder()
+            .model("claude-sonnet-4")
+            .cacheOptions(cache)
+            .build()
+    )
+);
+----
+
+NOTE: Tool Definitions are always considered for caching if `SYSTEM_AND_TOOLS` strategy is used, regardless of content length.
 
 === Usage Example
 
@@ -344,7 +383,9 @@ ChatResponse firstResponse = chatModel.call(
         ),
         AnthropicChatOptions.builder()
             .model("claude-sonnet-4")
-            .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+            .cacheOptions(AnthropicCacheOptions.builder()
+                .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                .build())
             .maxTokens(500)
             .build()
     )
@@ -366,7 +407,9 @@ ChatResponse secondResponse = chatModel.call(
         ),
         AnthropicChatOptions.builder()
             .model("claude-sonnet-4")
-            .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+            .cacheOptions(AnthropicCacheOptions.builder()
+                .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                .build())
             .maxTokens(500)
             .build()
     )
@@ -428,7 +471,9 @@ ChatResponse riskAnalysis = chatModel.call(
         ),
         AnthropicChatOptions.builder()
             .model("claude-sonnet-4")
-            .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+            .cacheOptions(AnthropicCacheOptions.builder()
+                .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                .build())
             .maxTokens(1000)
             .build()
     )
@@ -443,7 +488,9 @@ ChatResponse obligationAnalysis = chatModel.call(
         ),
         AnthropicChatOptions.builder()
             .model("claude-sonnet-4")
-            .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+            .cacheOptions(AnthropicCacheOptions.builder()
+                .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                .build())
             .maxTokens(1000)
             .build()
     )
@@ -483,7 +530,9 @@ for (String filename : codeFiles) {
             ),
             AnthropicChatOptions.builder()
                 .model("claude-sonnet-4")
-                .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                .cacheOptions(AnthropicCacheOptions.builder()
+                    .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                    .build())
                 .maxTokens(800)
                 .build()
         )
@@ -524,7 +573,9 @@ public class CustomerSupportService {
                 ),
                 AnthropicChatOptions.builder()
                     .model("claude-sonnet-4")
-                    .cacheStrategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                    .cacheOptions(AnthropicCacheOptions.builder()
+                        .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
+                        .build())
                     .maxTokens(600)
                     .build()
             )
@@ -542,7 +593,7 @@ public class CustomerSupportService {
 
 1. **Choose the Right Strategy**: 
    - Use `SYSTEM_ONLY` for reusable system prompts and instructions
-   - Use `SYSTEM_AND_TOOLS` when you have both system content and tool definitions to cache
+   - Use `SYSTEM_AND_TOOLS` when you have both system content and tool definitions to cache (the last tool definition is cached)
    - Use `CONVERSATION_HISTORY` with ChatClient memory for multi-turn conversations
    - Use `NONE` to explicitly disable caching
 
@@ -562,8 +613,7 @@ Even small changes will require a new cache entry.
 
 5. **Strategic Cache Placement**: The implementation automatically places cache breakpoints at optimal locations based on your chosen strategy, ensuring compliance with Anthropic's 4-breakpoint limit.
 
-6. **Cache Lifetime**: Default caches expire after 5 minutes of inactivity (can be extended to 1 hour with `cacheTtl()`).
-Each time cached content is accessed, the timer resets.
+6. **Cache Lifetime**: Default TTL is 5 minutes; set 1-hour TTL per message type via `messageTypeTtl(...)`. Each cache access resets the timer.
 
 7. **Tool Caching Limitations**: Be aware that tool-based interactions may not provide cache usage metadata in the response.
 


### PR DESCRIPTION
# Summary: 
Introduces a structured prompt caching API for Anthropic via AnthropicCacheOptions, applies cache_control deterministically, adds per-message TTLs (5m/1h), content-length eligibility, and clarifies tool caching behavior. Updates docs and adds tests to validate wire format, headers, and limits.

# API

   - AnthropicChatOptions: adds cacheOptions(AnthropicCacheOptions); default remains no caching.
  - AnthropicCacheOptions: strategy (NONE, SYSTEM_ONLY, SYSTEM_AND_TOOLS, CONVERSATION_HISTORY); per-message TTLs via AnthropicCacheTtl (FIVE_MINUTES, ONE_HOUR);
messageTypeMinContentLength; contentLengthFunction for custom token estimates.
  - AnthropicChatModel: applies cache_control only when eligible; caches the last tool definition; never caches the latest user question; uses array system format when caching;
auto-sets Anthropic beta header for 1h TTL.
  - AnthropicApi: models cache_control on content blocks and tools; exposes Usage cacheCreationInputTokens and cacheReadInputTokens.
  - Utilities: CacheEligibilityResolver (with CacheBreakpointTracker) enforces Anthropic’s 4-breakpoint limit.
  

# Tests

  - Unit: AnthropicCacheOptionsTests; CacheEligibilityResolverTests; AnthropicPromptCachingMockTest (wire format, TTL beta header, 4-breakpoint limit).
  - IT: AnthropicPromptCachingIT (guarded by ANTHROPIC_API_KEY; validates real usage fields when available).

# Documentation

  - Updates spring-ai-docs Anthropic page to use cacheOptions with strategy examples.
  - Adds per-message TTL examples (1h) and notes automatic beta header.
  - Adds eligibility guidance (min lengths, custom `contentLengthFunction`).
  - Clarifies tool caching (last tool definition) and that latest user message is not cached in conversation history.

# Compatibility:
  - Default behavior unchanged (caching disabled unless cacheOptions provided).
  - Prior doc examples using cacheStrategy/cacheTtl are replaced with cacheOptions; docs updated accordingly.

Closes: #4325