### PR TITLE
bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ To clone it you have to either:
 
 ## Building
 
+You'll have the best luck compiling against Java 17.
+
 To build with running unit tests
 
 ```shell
@@ -101,9 +103,10 @@ A full integration test is done twice a day in the [Spring AI Integration Test R
 One way to run integration tests on part of the code is to first do a quick compile and install of the project
 
 ```shell
-./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true
+./mvnw -DskipTests  -Dmaven.javadoc.skip=true  -Ddisable.checks=true spring-javaformat:apply clean  install
 ```
 Then run the integration test for a specific module using the `-pl` option
+
 ```shell
 ./mvnw verify -Pintegration-tests -pl spring-ai-spring-boot-testcontainers
 ```

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingProperties.java
@@ -35,6 +35,11 @@ public class BedrockCohereEmbeddingProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.bedrock.cohere.embedding";
 
 	/**
+	 * whether Cohere functionality should be enabled.
+	 */
+	private boolean enabled;
+
+	/**
 	 * Bedrock Cohere Embedding generative name. Defaults to
 	 * 'cohere.embed-multilingual-v3'.
 	 */
@@ -60,6 +65,14 @@ public class BedrockCohereEmbeddingProperties {
 
 	public void setOptions(BedrockCohereEmbeddingOptions options) {
 		this.options = options;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
@@ -25,12 +25,18 @@ import org.springframework.util.Assert;
  * Configuration properties for Bedrock Converse.
  *
  * @author Christian Tzolov
+ * @author Josh Long
  * @since 1.0.0
  */
 @ConfigurationProperties(BedrockConverseProxyChatProperties.CONFIG_PREFIX)
 public class BedrockConverseProxyChatProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.bedrock.converse.chat";
+
+	/**
+	 * whether Bedrock functionality should be enabled.
+	 */
+	private boolean enabled;
 
 	@NestedConfigurationProperty
 	private BedrockChatOptions options = BedrockChatOptions.builder().temperature(0.7).maxTokens(300).build();
@@ -42,6 +48,14 @@ public class BedrockConverseProxyChatProperties {
 	public void setOptions(BedrockChatOptions options) {
 		Assert.notNull(options, "BedrockChatOptions must not be null");
 		this.options = options;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 
 }


### PR DESCRIPTION
certain properties related to bedrock are invisible in the autocompletion and the models don't work unless u know to spelunk the source code for these properties