### PR TITLE
Change hsqldb scope from runtime to test in spring-ai-autoconfigure-model-chat-memory-repository-jdbc

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<scope>runtime</scope>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
`spring-ai-autoconfigure-model-chat-memory-repository-jdbc` has a runtime-scope dependency on hsqldb, so when I use `spring-ai-starter-model-chat-memory-repository-jdbc` it pulls in hsqldb, which is not normally needed.

This pull request changes hsqldb scope from runtime to test.