### PR TITLE
refactor: Improve MCP tool name prefix generation with automatic duplicate handling

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/StatelessToolCallbackConverterAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/StatelessToolCallbackConverterAutoConfigurationIT.java
@@ -127,8 +127,9 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 
 			@SuppressWarnings("unchecked")
 			List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
-			// Tools have different client prefixes, so both should be present
-			assertThat(syncTools).hasSize(2);
+
+			// On duplicate key, keep the existing tool
+			assertThat(syncTools).hasSize(1);
 		});
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackConverterAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackConverterAutoConfigurationIT.java
@@ -127,8 +127,9 @@ public class ToolCallbackConverterAutoConfigurationIT {
 
 			@SuppressWarnings("unchecked")
 			List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
-			// Tools have different client prefixes, so both should be present
-			assertThat(syncTools).hasSize(2);
+
+			// On duplicate key, keep the existing tool
+			assertThat(syncTools).hasSize(1);
 		});
 	}
 

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
@@ -227,11 +227,7 @@ public class AsyncMcpToolCallback implements ToolCallback {
 
 			// Apply defaults if not specified
 			if (this.prefixedToolName == null) {
-				this.prefixedToolName = McpToolNamePrefixGenerator.defaultGenerator()
-					.prefixedToolName(McpConnectionInfo.builder()
-						.clientCapabilities(this.mcpClient.getClientCapabilities())
-						.clientInfo(this.mcpClient.getClientInfo())
-						.build(), this.tool);
+				this.prefixedToolName = McpToolUtils.format(this.tool.name());
 			}
 
 			return new AsyncMcpToolCallback(this.mcpClient, this.tool, this.prefixedToolName,

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
@@ -57,8 +57,8 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider {
 	 */
 	@Deprecated
 	public AsyncMcpToolCallbackProvider(McpToolFilter toolFilter, List<McpAsyncClient> mcpClients) {
-		this(toolFilter, McpToolNamePrefixGenerator.defaultGenerator(),
-				ToolContextToMcpMetaConverter.defaultConverter(), mcpClients);
+		this(toolFilter, McpToolNamePrefixGenerator.noPrefix(), ToolContextToMcpMetaConverter.defaultConverter(),
+				mcpClients);
 	}
 
 	/**
@@ -203,7 +203,7 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider {
 
 		private List<McpAsyncClient> mcpClients;
 
-		private McpToolNamePrefixGenerator toolNamePrefixGenerator = McpToolNamePrefixGenerator.defaultGenerator();
+		private McpToolNamePrefixGenerator toolNamePrefixGenerator = new DefaultMcpToolNamePrefixGenerator();
 
 		private ToolContextToMcpMetaConverter toolContextToMcpMetaConverter = ToolContextToMcpMetaConverter
 			.defaultConverter();

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/DefaultMcpToolNamePrefixGenerator.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/DefaultMcpToolNamePrefixGenerator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.Implementation;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link McpToolNamePrefixGenerator} that ensures unique tool
+ * names for all client/server connections.
+ *
+ * <p>
+ * This implementation ensures that tool names are unique across different MCP clients and
+ * servers by tracking existing connections and appending a counter to duplicate tool
+ * names.
+ *
+ * <p>
+ * For each unique combination of (client, server, tool), e.g. each connection, the tool
+ * name is generated only once. If a tool name has already been used, a prefix with a
+ * counter is added to make it unique (e.g., "dp_1_toolName", "dp_2_toolName", etc.).
+ *
+ * <p>
+ * This implementation is thread-safe.
+ *
+ * @author Christian Tzolov
+ */
+public class DefaultMcpToolNamePrefixGenerator implements McpToolNamePrefixGenerator {
+
+	private static final Logger logger = LoggerFactory.getLogger(DefaultMcpToolNamePrefixGenerator.class);
+
+	// Idempotency tracking. For a given combination of (client, server, tool) we will
+	// generate a unique tool name only once.
+	private Set<ConnectionId> existingConnections = ConcurrentHashMap.newKeySet();
+
+	private Set<String> allUsedToolNames = ConcurrentHashMap.newKeySet();
+
+	private AtomicInteger counter = new AtomicInteger(1);
+
+	@Override
+	public String prefixedToolName(McpConnectionInfo mcpConnectionInfo, McpSchema.Tool tool) {
+
+		String uniqueToolName = McpToolUtils.format(tool.name());
+
+		if (this.existingConnections
+			.add(new ConnectionId(mcpConnectionInfo.clientInfo(), (mcpConnectionInfo.initializeResult() != null)
+					? mcpConnectionInfo.initializeResult().serverInfo() : null, tool))) {
+			if (!this.allUsedToolNames.add(uniqueToolName)) {
+				uniqueToolName = "dp_" + this.counter.getAndIncrement() + "_" + uniqueToolName;
+				this.allUsedToolNames.add(uniqueToolName);
+				logger.warn("Tool name '{}' already exists. Using unique tool name '{}'", tool.name(), uniqueToolName);
+			}
+		}
+
+		return uniqueToolName;
+	}
+
+	private record ConnectionId(Implementation clientInfo, Implementation serverInfo, Tool tool) {
+	}
+
+}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolNamePrefixGenerator.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolNamePrefixGenerator.java
@@ -45,10 +45,11 @@ public interface McpToolNamePrefixGenerator {
 	 * name.
 	 * @return the default prefix generator
 	 */
-	static McpToolNamePrefixGenerator defaultGenerator() {
-		return (mcpConnectionIfo, tool) -> McpToolUtils.prefixedToolName(mcpConnectionIfo.clientInfo().name(),
-				mcpConnectionIfo.clientInfo().title(), tool.name());
-	}
+	// static McpToolNamePrefixGenerator defaultGenerator() {
+	// return (mcpConnectionIfo, tool) ->
+	// McpToolUtils.prefixedToolName(mcpConnectionIfo.clientInfo().name(),
+	// mcpConnectionIfo.clientInfo().title(), tool.name());
+	// }
 
 	/**
 	 * Static factory method to create a no-op prefix generator that returns the tool name

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -106,7 +106,7 @@ public final class McpToolUtils {
 		return prefixedToolName(prefix, null, toolName);
 	}
 
-	private static String format(String input) {
+	public static String format(String input) {
 		// Replace any character that isn't alphanumeric, underscore, or hyphen with
 		// concatenation. Support Han script + CJK blocks for complete Chinese character
 		// coverage

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
@@ -224,11 +224,7 @@ public class SyncMcpToolCallback implements ToolCallback {
 
 			// Apply defaults if not specified
 			if (this.prefixedToolName == null) {
-				this.prefixedToolName = McpToolNamePrefixGenerator.defaultGenerator()
-					.prefixedToolName(McpConnectionInfo.builder()
-						.clientCapabilities(this.mcpClient.getClientCapabilities())
-						.clientInfo(this.mcpClient.getClientInfo())
-						.build(), this.tool);
+				this.prefixedToolName = McpToolUtils.format(this.tool.name());
 			}
 
 			return new SyncMcpToolCallback(this.mcpClient, this.tool, this.prefixedToolName,

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallbackProvider.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallbackProvider.java
@@ -55,7 +55,7 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider {
 	 */
 	@Deprecated
 	public SyncMcpToolCallbackProvider(McpToolFilter toolFilter, List<McpSyncClient> mcpClients) {
-		this(toolFilter, McpToolNamePrefixGenerator.defaultGenerator(), mcpClients,
+		this(toolFilter, McpToolNamePrefixGenerator.noPrefix(), mcpClients,
 				ToolContextToMcpMetaConverter.defaultConverter());
 	}
 
@@ -114,6 +114,7 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider {
 
 	@Override
 	public ToolCallback[] getToolCallbacks() {
+
 		var array = this.mcpClients.stream()
 			.flatMap(mcpClient -> mcpClient.listTools()
 				.tools()
@@ -184,7 +185,7 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider {
 
 		private McpToolFilter toolFilter = (mcpClient, tool) -> true;
 
-		private McpToolNamePrefixGenerator toolNamePrefixGenerator = McpToolNamePrefixGenerator.defaultGenerator();
+		private McpToolNamePrefixGenerator toolNamePrefixGenerator = new DefaultMcpToolNamePrefixGenerator();
 
 		private ToolContextToMcpMetaConverter toolContextToMcpMetaConverter = ToolContextToMcpMetaConverter
 			.defaultConverter();

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProviderTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProviderTests.java
@@ -105,12 +105,23 @@ class AsyncMcpToolCallbackProviderTests {
 		when(listToolsResult.tools()).thenReturn(List.of(tool1, tool2));
 		when(this.mcpClient.listTools()).thenReturn(Mono.just(listToolsResult));
 
-		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
+		AsyncMcpToolCallbackProvider provider1 = AsyncMcpToolCallbackProvider.builder()
+			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.noPrefix())
 			.mcpClients(this.mcpClient)
 			.build();
 
-		assertThatThrownBy(() -> provider.getToolCallbacks()).isInstanceOf(IllegalStateException.class)
+		assertThatThrownBy(() -> provider1.getToolCallbacks()).isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("Multiple tools with the same name");
+
+		AsyncMcpToolCallbackProvider provider2 = AsyncMcpToolCallbackProvider.builder()
+			.mcpClients(this.mcpClient)
+			.build();
+
+		var toolCallbacks = provider2.getToolCallbacks();
+		assertThat(toolCallbacks).hasSize(2);
+		assertThat(toolCallbacks[0].getToolDefinition().name()).isEqualTo("sameName");
+		assertThat(toolCallbacks[1].getToolDefinition().name()).isEqualTo("dp_1_sameName");
+
 	}
 
 	@Test
@@ -186,7 +197,7 @@ class AsyncMcpToolCallbackProviderTests {
 
 		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
 			.toolFilter(rejectAllFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(this.mcpClient)
 			.build();
 
@@ -218,15 +229,15 @@ class AsyncMcpToolCallbackProviderTests {
 
 		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
 			.toolFilter(nameFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(this.mcpClient)
 			.build();
 
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).hasSize(2);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("t_tool2");
-		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("t_tool3");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("tool2");
+		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("tool3");
 	}
 
 	@Test
@@ -259,14 +270,14 @@ class AsyncMcpToolCallbackProviderTests {
 
 		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
 			.toolFilter(clientFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(mcpClient1, mcpClient2)
 			.build();
 
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).hasSize(1);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("t_tool1");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("tool1");
 	}
 
 	@Test
@@ -292,14 +303,14 @@ class AsyncMcpToolCallbackProviderTests {
 
 		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
 			.toolFilter(complexFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(weatherClient)
 			.build();
 
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).hasSize(1);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("w_s_weather");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("weather");
 	}
 
 	@Test

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -238,9 +238,6 @@ class AsyncMcpToolCallbackTest {
 	@Test
 	void builderShouldGeneratePrefixedToolNameWhenNotProvided() {
 		when(this.tool.name()).thenReturn("testTool");
-		var clientInfo = new Implementation("testClient", "1.0.0");
-		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
-		when(this.mcpClient.getClientCapabilities()).thenReturn(mock(McpSchema.ClientCapabilities.class));
 
 		// Act
 		var callback = AsyncMcpToolCallback.builder().mcpClient(this.mcpClient).tool(this.tool).build();

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackBuilderTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackBuilderTest.java
@@ -44,12 +44,16 @@ class SyncMcpToolCallbackBuilderTest {
 		when(tool.name()).thenReturn("test-tool");
 		when(tool.description()).thenReturn("Test tool description");
 
-		SyncMcpToolCallback callback = SyncMcpToolCallback.builder().mcpClient(mcpClient).tool(tool).build();
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(mcpClient)
+
+			.tool(tool)
+			.build();
 
 		assertThat(callback).isNotNull();
 		assertThat(callback.getOriginalToolName()).isEqualTo("test-tool");
 		assertThat(callback.getToolDefinition()).isNotNull();
-		assertThat(callback.getToolDefinition().name()).isEqualTo("t_c_test_tool");
+		assertThat(callback.getToolDefinition().name()).isEqualTo("test_tool");
 		assertThat(callback.getToolDefinition().description()).isEqualTo("Test tool description");
 	}
 

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderBuilderTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderBuilderTest.java
@@ -47,7 +47,7 @@ class SyncMcpToolCallbackProviderBuilderTest {
 		assertThat(provider).isNotNull();
 		ToolCallback[] callbacks = provider.getToolCallbacks();
 		assertThat(callbacks).hasSize(1);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("t_c_test_tool");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("test_tool");
 	}
 
 	@Test
@@ -64,8 +64,8 @@ class SyncMcpToolCallbackProviderBuilderTest {
 		assertThat(provider).isNotNull();
 		ToolCallback[] callbacks = provider.getToolCallbacks();
 		assertThat(callbacks).hasSize(2);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("c_tool1");
-		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("c_tool2");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("tool1");
+		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("tool2");
 	}
 
 	@Test
@@ -111,7 +111,7 @@ class SyncMcpToolCallbackProviderBuilderTest {
 		assertThat(provider).isNotNull();
 		ToolCallback[] callbacks = provider.getToolCallbacks();
 		assertThat(callbacks).hasSize(1);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("c_filtered_tool");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("filtered_tool");
 	}
 
 	@Test
@@ -201,7 +201,7 @@ class SyncMcpToolCallbackProviderBuilderTest {
 		McpSyncClient client1 = createMockClient("client1", "tool1");
 		McpSyncClient client2 = createMockClient("client2", "tool2");
 		McpToolFilter filter = (connectionInfo, tool) -> true;
-		McpToolNamePrefixGenerator generator = McpToolNamePrefixGenerator.defaultGenerator();
+		McpToolNamePrefixGenerator generator = new DefaultMcpToolNamePrefixGenerator();
 
 		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
 			.addMcpClient(client1)
@@ -230,8 +230,8 @@ class SyncMcpToolCallbackProviderBuilderTest {
 		assertThat(provider).isNotNull();
 		ToolCallback[] callbacks = provider.getToolCallbacks();
 		assertThat(callbacks).hasSize(2);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("c_tool2");
-		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("c_tool3");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("tool2");
+		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("tool3");
 	}
 
 	private McpSyncClient createMockClient(String clientName, String toolName) {

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
@@ -99,7 +99,17 @@ class SyncMcpToolCallbackProviderTests {
 
 		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder().mcpClients(this.mcpClient).build();
 
-		assertThatThrownBy(() -> provider.getToolCallbacks()).isInstanceOf(IllegalStateException.class)
+		var toolCallbacks = provider.getToolCallbacks();
+		assertThat(toolCallbacks).hasSize(2);
+		assertThat(toolCallbacks[0].getToolDefinition().name()).isEqualTo("sameName");
+		assertThat(toolCallbacks[1].getToolDefinition().name()).isEqualTo("dp_1_sameName");
+
+		SyncMcpToolCallbackProvider provider2 = SyncMcpToolCallbackProvider.builder()
+			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.noPrefix())
+			.mcpClients(this.mcpClient)
+			.build();
+
+		assertThatThrownBy(() -> provider2.getToolCallbacks()).isInstanceOf(IllegalStateException.class)
 			.hasMessageContaining("Multiple tools with the same name");
 	}
 
@@ -174,7 +184,7 @@ class SyncMcpToolCallbackProviderTests {
 
 		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
 			.toolFilter(rejectAllFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(this.mcpClient)
 			.build();
 
@@ -206,15 +216,15 @@ class SyncMcpToolCallbackProviderTests {
 
 		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
 			.toolFilter(nameFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(this.mcpClient)
 			.build();
 
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).hasSize(2);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("t_tool2");
-		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("t_tool3");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("tool2");
+		assertThat(callbacks[1].getToolDefinition().name()).isEqualTo("tool3");
 	}
 
 	@Test
@@ -246,14 +256,14 @@ class SyncMcpToolCallbackProviderTests {
 
 		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
 			.toolFilter(clientFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(mcpClient1, mcpClient2)
 			.build();
 
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).hasSize(1);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("t_tool1");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("tool1");
 	}
 
 	@Test
@@ -279,14 +289,14 @@ class SyncMcpToolCallbackProviderTests {
 
 		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
 			.toolFilter(complexFilter)
-			.toolNamePrefixGenerator(McpToolNamePrefixGenerator.defaultGenerator())
+			.toolNamePrefixGenerator(new DefaultMcpToolNamePrefixGenerator())
 			.mcpClients(weatherClient)
 			.build();
 
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).hasSize(1);
-		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("w_s_weather");
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("weather");
 	}
 
 	@Test

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -248,8 +248,6 @@ class SyncMcpToolCallbackTests {
 	@Test
 	void builderShouldUseDefaultPrefixWhenNotSpecified() {
 		when(this.tool.name()).thenReturn("testTool");
-		when(this.mcpClient.getClientCapabilities()).thenReturn(null);
-		when(this.mcpClient.getClientInfo()).thenReturn(new Implementation("testClient", "1.0.0"));
 
 		SyncMcpToolCallback callback = SyncMcpToolCallback.builder().mcpClient(this.mcpClient).tool(this.tool).build();
 

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -359,14 +359,14 @@ class ToolUtilsTests {
 		List<ToolCallback> result = McpToolUtils.getToolCallbacksFromSyncClients(mockClient);
 
 		assertThat(result).hasSize(2);
-		assertThat(result.get(0).getToolDefinition().name()).isEqualTo("t_c_tool1");
-		assertThat(result.get(1).getToolDefinition().name()).isEqualTo("t_c_tool2");
+		assertThat(result.get(0).getToolDefinition().name()).isEqualTo("tool1");
+		assertThat(result.get(1).getToolDefinition().name()).isEqualTo("tool2");
 
 		List<ToolCallback> result2 = McpToolUtils.getToolCallbacksFromSyncClients(List.of(mockClient));
 
 		assertThat(result2).hasSize(2);
-		assertThat(result2.get(0).getToolDefinition().name()).isEqualTo("t_c_tool1");
-		assertThat(result2.get(1).getToolDefinition().name()).isEqualTo("t_c_tool2");
+		assertThat(result2.get(0).getToolDefinition().name()).isEqualTo("tool1");
+		assertThat(result2.get(1).getToolDefinition().name()).isEqualTo("tool2");
 	}
 
 	@Test
@@ -401,14 +401,14 @@ class ToolUtilsTests {
 		List<ToolCallback> result = McpToolUtils.getToolCallbacksFromSyncClients(mockClient1, mockClient2);
 
 		assertThat(result).hasSize(2);
-		assertThat(result.get(0).getToolDefinition().name()).isEqualTo("c_tool1");
-		assertThat(result.get(1).getToolDefinition().name()).isEqualTo("c_tool2");
+		assertThat(result.get(0).getToolDefinition().name()).isEqualTo("tool1");
+		assertThat(result.get(1).getToolDefinition().name()).isEqualTo("tool2");
 
 		List<ToolCallback> result2 = McpToolUtils.getToolCallbacksFromSyncClients(List.of(mockClient1, mockClient2));
 
 		assertThat(result2).hasSize(2);
-		assertThat(result2.get(0).getToolDefinition().name()).isEqualTo("c_tool1");
-		assertThat(result2.get(1).getToolDefinition().name()).isEqualTo("c_tool2");
+		assertThat(result2.get(0).getToolDefinition().name()).isEqualTo("tool1");
+		assertThat(result2.get(1).getToolDefinition().name()).isEqualTo("tool2");
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -435,16 +435,18 @@ If multiple filters are needed, combine them into a single composite filter impl
 
 The MCP Client Boot Starter supports customizable tool name prefix generation through the `McpToolNamePrefixGenerator` interface. This feature helps avoid naming conflicts when integrating tools from multiple MCP servers by adding unique prefixes to tool names.
 
-By default, if no custom `McpToolNamePrefixGenerator` bean is provided, the starter uses `McpToolNamePrefixGenerator.defaultGenerator()` which generates a prefix from the MCP client name and title. The default generator:
+By default, if no custom `McpToolNamePrefixGenerator` bean is provided, the starter uses `DefaultMcpToolNamePrefixGenerator` which ensures unique tool names across all MCP client connections. The default generator:
 
-* Shortens the client name by taking the first letter of each word (separated by underscores). The Spring AI injects the connection name at the end of the client name by default.
-* Includes the server title (if available) without shortening. Spring AI sets the title to the connection name by default.
-* Formats the final tool name as: `shortened_prefix_title_toolName`
+* Tracks all existing connections and tool names to ensure uniqueness
+* Formats tool names by replacing non-alphanumeric characters with underscores (e.g., `my-tool` becomes `my_tool`)
+* When duplicate tool names are detected across different connections, adds a counter prefix (e.g., `dp_1_toolName`, `dp_2_toolName`)
+* Is thread-safe and maintains idempotency - the same combination of (client, server, tool) always gets the same unique name
 * Ensures the final name doesn't exceed 64 characters (truncating from the beginning if necessary)
 
 For example:
-* Client name: `spring_ai_mcp_client_server1`, Title: `server1`, Tool: `search` → `s_a_m_c_s_server1_search`
-* Client name: `weather_service`, Title: (none), Tool: `forecast` → `w_s_forecast`
+* First occurrence of tool `search` → `search`
+* Second occurrence of tool `search` from a different connection → `dp_1_search`
+* Tool with special characters `my-special-tool` → `my_special_tool`
 
 You can customize this behavior by providing your own implementation:
 
@@ -475,10 +477,10 @@ The `McpConnectionInfo` record provides comprehensive information about the MCP 
 
 The framework provides several built-in prefix generators:
 
-* `McpToolNamePrefixGenerator.defaultGenerator()` - Uses shortened client name and title as prefix (used by default if no custom bean is provided)
-* `McpToolNamePrefixGenerator.noPrefix()` - Returns tool names without any prefix
+* `DefaultMcpToolNamePrefixGenerator` - Ensures unique tool names by tracking duplicates and adding counter prefixes when needed (used by default if no custom bean is provided)
+* `McpToolNamePrefixGenerator.noPrefix()` - Returns tool names without any prefix (may cause conflicts if multiple servers provide tools with the same name)
 
-To disable prefixing entirely, register the no-prefix generator as a bean:
+To disable prefixing entirely and use raw tool names (not recommended if using multiple MCP servers), register the no-prefix generator as a bean:
 
 [source,java]
 ----
@@ -493,7 +495,9 @@ public class McpConfiguration {
 ----
 
 The prefix generator is automatically detected and applied to both synchronous and asynchronous MCP tool callback providers through Spring's `ObjectProvider` mechanism.
-If no custom generator bean is provided, the default generator is used automatically.
+If no custom generator bean is provided, the `DefaultMcpToolNamePrefixGenerator` is used automatically.
+
+WARNING: When using `McpToolNamePrefixGenerator.noPrefix()` with multiple MCP servers, duplicate tool names will cause an `IllegalStateException`. The default `DefaultMcpToolNamePrefixGenerator` prevents this by automatically adding unique prefixes to duplicate tool names.
 
 === Tool Context to MCP Meta Converter
 


### PR DESCRIPTION
- Introduce DefaultMcpToolNamePrefixGenerator to ensure unique tool names across MCP connections
- Replace default prefix generation strategy from client/title-based to duplicate detection
- Automatically add counter prefixes (dp_1_, dp_2_) when duplicate tool names are detected
- Track existing connections and tool names to maintain idempotency
- Update tests to reflect new duplicate handling behavior (keep existing tool on duplicate)
- Update documentation to describe the new default generator behavior
- Change default from McpToolNamePrefixGenerator.defaultGenerator() to new DefaultMcpToolNamePrefixGenerator

BREAKING CHANGE: The default tool name generation strategy has changed. Tools now use their original names by default, with automatic prefixing only when duplicates are detected across different connections.