### PR TITLE
Polish McpServerAutoConfiguration

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
@@ -112,7 +112,7 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions,
-			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
+			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumer,
 			Optional<McpSyncServerCustomizer> mcpSyncServerCustomizer) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
@@ -198,10 +198,8 @@ public class McpServerAutoConfiguration {
 			}
 		}
 
-		rootsChangeConsumers.ifAvailable(consumer -> {
-			BiConsumer<McpSyncServerExchange, List<McpSchema.Root>> syncConsumer = (exchange, roots) -> consumer
-				.accept(exchange, roots);
-			serverBuilder.rootsChangeHandler(syncConsumer);
+		rootsChangeConsumer.ifAvailable(consumer -> {
+			serverBuilder.rootsChangeHandler(consumer);
 			logger.info("Registered roots change consumer");
 		});
 


### PR DESCRIPTION
1. Rename method parameter `rootsChangeConsumers` to align `mcpSyncServer` with `mcpAsyncServer`.
2. Simplify lambda.