### PR TITLE
docs(zhipu): fix zhipuai-chat.adoc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/zhipuai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/zhipuai-chat.adoc
@@ -102,7 +102,7 @@ The prefix `spring.ai.retry` is used as the property prefix that lets you config
 
 ==== Connection Properties
 
-The prefix `spring.ai.zhiPu` is used as the property prefix that lets you connect to ZhiPuAI.
+The prefix `spring.ai.zhipuai` is used as the property prefix that lets you connect to ZhiPuAI.
 
 [cols="3,5,1", stripes=even]
 |====
@@ -133,9 +133,9 @@ The prefix `spring.ai.zhipuai.chat` is the property prefix that lets you configu
 
 | spring.ai.zhipuai.chat.enabled (Removed and no longer valid) | Enable ZhiPuAI chat model.  | true
 | spring.ai.model.chat | Enable ZhiPuAI chat model.  | zhipuai
-| spring.ai.zhipuai.chat.base-url | Optional overrides the spring.ai.zhipuai.base-url to provide chat specific url |  https://open.bigmodel.cn/api/paas
-| spring.ai.zhipuai.chat.api-key | Optional overrides the spring.ai.zhipuai.api-key to provide chat specific api-key |  -
-| spring.ai.zhipuai.chat.options.model | This is the ZhiPuAI Chat model to use | `GLM-3-Turbo` (the `GLM-3-Turbo`, `GLM-4`, `GLM-4-Air`, `GLM-4-AirX`, `GLM-4-Flash`, and `GLM-4V` point to the latest model versions)
+| spring.ai.zhipuai.chat.base-url | Optional overrides the spring.ai.zhipuai.base-url to provide chat specific url. |  https://open.bigmodel.cn/api/paas
+| spring.ai.zhipuai.chat.api-key | Optional overrides the spring.ai.zhipuai.api-key to provide chat specific api-key. |  -
+| spring.ai.zhipuai.chat.options.model | This is the ZhiPuAI Chat model to use. You can select between models such as: `glm-4.5`, `glm-4.5-air`, `glm-4-air`, and more. | `glm-4-air`
 | spring.ai.zhipuai.chat.options.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
 | spring.ai.zhipuai.chat.options.temperature | What sampling temperature to use, between 0 and 1. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both. | 0.7
 | spring.ai.zhipuai.chat.options.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.. | 1.0
@@ -169,7 +169,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         ZhiPuAiChatOptions.builder()
-            .model(ZhiPuAiApi.ChatModel.GLM_3_Turbo.getValue())
+            .model(ZhiPuAiApi.ChatModel.GLM_4_Air.getValue())
             .temperature(0.5)
         .build()
     ));
@@ -252,7 +252,7 @@ Next, create a `ZhiPuAiChatModel` and use it for text generations:
 var zhiPuAiApi = new ZhiPuAiApi(System.getenv("ZHIPU_AI_API_KEY"));
 
 var chatModel = new ZhiPuAiChatModel(this.zhiPuAiApi, ZhiPuAiChatOptions.builder()
-                .model(ZhiPuAiApi.ChatModel.GLM_3_Turbo.getValue())
+                .model(ZhiPuAiApi.ChatModel.GLM_4_Air.getValue())
                 .temperature(0.4)
                 .maxTokens(200)
                 .build());
@@ -284,11 +284,11 @@ ChatCompletionMessage chatCompletionMessage =
 
 // Sync request
 ResponseEntity<ChatCompletion> response = this.zhiPuAiApi.chatCompletionEntity(
-    new ChatCompletionRequest(List.of(this.chatCompletionMessage), ZhiPuAiApi.ChatModel.GLM_3_Turbo.getValue(), 0.7, false));
+    new ChatCompletionRequest(List.of(this.chatCompletionMessage), ZhiPuAiApi.ChatModel.GLM_4_Air.getValue(), 0.7, false));
 
 // Streaming request
 Flux<ChatCompletionChunk> streamResponse = this.zhiPuAiApi.chatCompletionStream(
-        new ChatCompletionRequest(List.of(this.chatCompletionMessage), ZhiPuAiApi.ChatModel.GLM_3_Turbo.getValue(), 0.7, true));
+        new ChatCompletionRequest(List.of(this.chatCompletionMessage), ZhiPuAiApi.ChatModel.GLM_4_Air.getValue(), 0.7, true));
 ----
 
 Follow the https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java[ZhiPuAiApi.java]'s JavaDoc for further information.


### PR DESCRIPTION
- Change default model from 'GLM-3-Turbo' to 'glm-4-air' in doc
- Fix formatting consistency in documentation


The current default model is glm-4-air: 
https://github.com/spring-projects/spring-ai/blob/c7b7d691e409ebdbbd4407451fbcbc6125ee5a8a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java#L74