### PR TITLE
fix: Stateless mcp server registration tools failed

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server.common.autoconfigure.annotations;
 
 import java.util.List;
 
-import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import org.springaicommunity.mcp.annotation.McpComplete;
 import org.springaicommunity.mcp.annotation.McpPrompt;
@@ -76,10 +75,10 @@ public class StatelessServerSpecificationFactoryAutoConfiguration {
 		}
 
 		@Bean
-		public List<McpServerFeatures.SyncToolSpecification> toolSpecs(
+		public List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecs(
 				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
 			return SyncMcpAnnotationProviders
-				.toolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+				.statelessToolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -18,4 +18,5 @@ org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAuto
 org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration
 org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration
 org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration
+org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration
 org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
@@ -17,8 +17,11 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.modelcontextprotocol.client.McpSyncClient;
@@ -26,6 +29,8 @@ import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
@@ -39,9 +44,17 @@ import io.modelcontextprotocol.spec.McpServerTransport;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
 import reactor.core.publisher.Mono;
 
 import org.springframework.ai.mcp.SyncMcpToolCallback;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerChangeNotificationProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.tool.ToolCallback;
@@ -50,6 +63,8 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -345,6 +360,72 @@ public class McpServerAutoConfigurationIT {
 			.run(context -> assertThat(context).hasSingleBean(ToolCallbackProvider.class));
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void syncServerSpecificationConfiguration() {
+		this.contextRunner
+			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
+					McpServerSpecificationFactoryAutoConfiguration.class)
+			.withBean(SyncTestMcpSpecsComponent.class)
+			.run(context -> {
+				McpSyncServer syncServer = context.getBean(McpSyncServer.class);
+				McpAsyncServer asyncServer = (McpAsyncServer) ReflectionTestUtils.getField(syncServer, "asyncServer");
+
+				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "tools");
+				assertThat(tools).hasSize(1);
+				assertThat(tools.get(0).tool().name()).isEqualTo("add");
+
+				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resources");
+				assertThat(resources).hasSize(1);
+				assertThat(resources.get("config://{key}")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "prompts");
+				assertThat(prompts).hasSize(1);
+				assertThat(prompts.get("greeting")).isNotNull();
+
+				ConcurrentHashMap<McpSchema.CompleteReference, AsyncCompletionSpecification> completions = (ConcurrentHashMap<McpSchema.CompleteReference, AsyncCompletionSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "completions");
+				assertThat(completions).hasSize(1);
+				assertThat(completions.keySet().iterator().next()).isInstanceOf(McpSchema.CompleteReference.class);
+			});
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void asyncServerSpecificationConfiguration() {
+		this.contextRunner
+			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
+					McpServerSpecificationFactoryAutoConfiguration.class)
+			.withBean(AsyncTestMcpSpecsComponent.class)
+			.withPropertyValues("spring.ai.mcp.server.type=async")
+			.run(context -> {
+				McpAsyncServer asyncServer = context.getBean(McpAsyncServer.class);
+
+				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "tools");
+				assertThat(tools).hasSize(1);
+				assertThat(tools.get(0).tool().name()).isEqualTo("add");
+
+				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resources");
+				assertThat(resources).hasSize(1);
+				assertThat(resources.get("config://{key}")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "prompts");
+				assertThat(prompts).hasSize(1);
+				assertThat(prompts.get("greeting")).isNotNull();
+
+				ConcurrentHashMap<McpSchema.CompleteReference, AsyncCompletionSpecification> completions = (ConcurrentHashMap<McpSchema.CompleteReference, AsyncCompletionSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "completions");
+				assertThat(completions).hasSize(1);
+				assertThat(completions.keySet().iterator().next()).isInstanceOf(McpSchema.CompleteReference.class);
+			});
+	}
+
 	@Configuration
 	static class TestResourceConfiguration {
 
@@ -512,6 +593,78 @@ public class McpServerAutoConfigurationIT {
 		@Bean
 		McpServerTransport customTransport() {
 			return new CustomServerTransport();
+		}
+
+	}
+
+	@Component
+	static class SyncTestMcpSpecsComponent {
+
+		@McpTool(name = "add", description = "Add two numbers together", title = "Add Two Numbers Together",
+				annotations = @McpTool.McpAnnotations(title = "Rectangle Area Calculator", readOnlyHint = true,
+						destructiveHint = false, idempotentHint = true))
+		public int add(@McpToolParam(description = "First number", required = true) int a,
+				@McpToolParam(description = "Second number", required = true) int b) {
+			return a + b;
+		}
+
+		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")
+		public String getConfig(String key) {
+			return "config value";
+		}
+
+		@McpPrompt(name = "greeting", description = "Generate a greeting message")
+		public McpSchema.GetPromptResult greeting(
+				@McpArg(name = "name", description = "User's name", required = true) String name) {
+
+			String message = "Hello, " + name + "! How can I help you today?";
+
+			return new McpSchema.GetPromptResult("Greeting",
+					List.of(new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent(message))));
+		}
+
+		@McpComplete(prompt = "city-search")
+		public List<String> completeCityName(String prefix) {
+			return Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
+				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.limit(10)
+				.toList();
+		}
+
+	}
+
+	@Component
+	static class AsyncTestMcpSpecsComponent {
+
+		@McpTool(name = "add", description = "Add two numbers together", title = "Add Two Numbers Together",
+				annotations = @McpTool.McpAnnotations(title = "Rectangle Area Calculator", readOnlyHint = true,
+						destructiveHint = false, idempotentHint = true))
+		public Mono<Integer> add(@McpToolParam(description = "First number", required = true) int a,
+				@McpToolParam(description = "Second number", required = true) int b) {
+			return Mono.just(a + b);
+		}
+
+		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")
+		public Mono<String> getConfig(String key) {
+			return Mono.just("config value");
+		}
+
+		@McpPrompt(name = "greeting", description = "Generate a greeting message")
+		public Mono<McpSchema.GetPromptResult> greeting(
+				@McpArg(name = "name", description = "User's name", required = true) String name) {
+
+			String message = "Hello, " + name + "! How can I help you today?";
+
+			return Mono.just(new McpSchema.GetPromptResult("Greeting", List
+				.of(new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent(message)))));
+		}
+
+		@McpComplete(prompt = "city-search")
+		public Mono<List<String>> completeCityName(String prefix) {
+			return Mono.just(Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
+				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.limit(10)
+				.toList());
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -17,14 +17,19 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessAsyncServer;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncPromptSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncPromptSpecification;
@@ -36,9 +41,17 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springaicommunity.mcp.annotation.McpArg;
+import org.springaicommunity.mcp.annotation.McpComplete;
+import org.springaicommunity.mcp.annotation.McpPrompt;
+import org.springaicommunity.mcp.annotation.McpResource;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
 import reactor.core.publisher.Mono;
 
 import org.springframework.ai.mcp.SyncMcpToolCallback;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -47,6 +60,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -295,6 +310,73 @@ public class McpStatelessServerAutoConfigurationIT {
 			.run(context -> assertThat(context).hasSingleBean(ToolCallbackProvider.class));
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void syncStatelessServerSpecificationConfiguration() {
+		this.contextRunner
+			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
+					StatelessServerSpecificationFactoryAutoConfiguration.class)
+			.withBean(SyncTestMcpSpecsComponent.class)
+			.run(context -> {
+				McpStatelessSyncServer syncServer = context.getBean(McpStatelessSyncServer.class);
+				McpStatelessAsyncServer asyncServer = (McpStatelessAsyncServer) ReflectionTestUtils.getField(syncServer,
+						"asyncServer");
+
+				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "tools");
+				assertThat(tools).hasSize(1);
+				assertThat(tools.get(0).tool().name()).isEqualTo("add");
+
+				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resources");
+				assertThat(resources).hasSize(1);
+				assertThat(resources.get("config://{key}")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "prompts");
+				assertThat(prompts).hasSize(1);
+				assertThat(prompts.get("greeting")).isNotNull();
+
+				ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions = (ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "completions");
+				assertThat(completions).hasSize(1);
+				assertThat(completions.keySet().iterator().next()).isInstanceOf(McpSchema.CompleteReference.class);
+			});
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void asyncStatelessServerSpecificationConfiguration() {
+		this.contextRunner
+			.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class,
+					StatelessServerSpecificationFactoryAutoConfiguration.class)
+			.withBean(AsyncTestMcpSpecsComponent.class)
+			.withPropertyValues("spring.ai.mcp.server.type=async")
+			.run(context -> {
+				McpStatelessAsyncServer asyncServer = context.getBean(McpStatelessAsyncServer.class);
+
+				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "tools");
+				assertThat(tools).hasSize(1);
+				assertThat(tools.get(0).tool().name()).isEqualTo("add");
+
+				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resources");
+				assertThat(resources).hasSize(1);
+				assertThat(resources.get("config://{key}")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "prompts");
+				assertThat(prompts).hasSize(1);
+				assertThat(prompts.get("greeting")).isNotNull();
+
+				ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification> completions = (ConcurrentHashMap<McpSchema.CompleteReference, McpStatelessServerFeatures.AsyncCompletionSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "completions");
+				assertThat(completions).hasSize(1);
+				assertThat(completions.keySet().iterator().next()).isInstanceOf(McpSchema.CompleteReference.class);
+			});
+	}
+
 	@Configuration
 	static class TestResourceConfiguration {
 
@@ -433,6 +515,78 @@ public class McpStatelessServerAutoConfigurationIT {
 				matchIfMissing = true)
 		public McpStatelessServerTransport statelessTransport() {
 			return Mockito.mock(McpStatelessServerTransport.class);
+		}
+
+	}
+
+	@Component
+	static class SyncTestMcpSpecsComponent {
+
+		@McpTool(name = "add", description = "Add two numbers together", title = "Add Two Numbers Together",
+				annotations = @McpTool.McpAnnotations(title = "Rectangle Area Calculator", readOnlyHint = true,
+						destructiveHint = false, idempotentHint = true))
+		public int add(@McpToolParam(description = "First number", required = true) int a,
+				@McpToolParam(description = "Second number", required = true) int b) {
+			return a + b;
+		}
+
+		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")
+		public String getConfig(String key) {
+			return "config value";
+		}
+
+		@McpPrompt(name = "greeting", description = "Generate a greeting message")
+		public McpSchema.GetPromptResult greeting(
+				@McpArg(name = "name", description = "User's name", required = true) String name) {
+
+			String message = "Hello, " + name + "! How can I help you today?";
+
+			return new McpSchema.GetPromptResult("Greeting",
+					List.of(new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent(message))));
+		}
+
+		@McpComplete(prompt = "city-search")
+		public List<String> completeCityName(String prefix) {
+			return Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
+				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.limit(10)
+				.toList();
+		}
+
+	}
+
+	@Component
+	static class AsyncTestMcpSpecsComponent {
+
+		@McpTool(name = "add", description = "Add two numbers together", title = "Add Two Numbers Together",
+				annotations = @McpTool.McpAnnotations(title = "Rectangle Area Calculator", readOnlyHint = true,
+						destructiveHint = false, idempotentHint = true))
+		public Mono<Integer> add(@McpToolParam(description = "First number", required = true) int a,
+				@McpToolParam(description = "Second number", required = true) int b) {
+			return Mono.just(a + b);
+		}
+
+		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")
+		public Mono<String> getConfig(String key) {
+			return Mono.just("config value");
+		}
+
+		@McpPrompt(name = "greeting", description = "Generate a greeting message")
+		public Mono<McpSchema.GetPromptResult> greeting(
+				@McpArg(name = "name", description = "User's name", required = true) String name) {
+
+			String message = "Hello, " + name + "! How can I help you today?";
+
+			return Mono.just(new McpSchema.GetPromptResult("Greeting", List
+				.of(new McpSchema.PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent(message)))));
+		}
+
+		@McpComplete(prompt = "city-search")
+		public Mono<List<String>> completeCityName(String prefix) {
+			return Mono.just(Stream.of("New York", "Los Angeles", "Chicago", "Houston", "Phoenix")
+				.filter(city -> city.toLowerCase().startsWith(prefix.toLowerCase()))
+				.limit(10)
+				.toList());
 		}
 
 	}


### PR DESCRIPTION
- Fix StatelessServerSpecificationFactoryAutoConfiguration.toolSpecs method signature to use McpStatelessServerFeatures.SyncToolSpecification
- Add StatelessServerSpecificationFactoryAutoConfiguration to spring imports
- Update McpStatelessServerAutoConfigurationIT and McpServerAutoConfigurationIT

This PR fixes Stateless mcp server registration tools failed.

## Steps to reproduce
1. clone https://github.com/YunKuiLu/spring-ai-issue-4396
2. run `SpringAiIssue4396Application.java`
3. execute
```
curl --location --request POST 'http://127.0.0.1:8080/mcp' \ 
--header 'Accept: application/json,text/event-stream' \
--header 'Content-Type: application/json' \
--data-raw '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/list",
  "params": {
  }
}'
```
Then you will get:
```
{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}
```
The expected output is
```
{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"getCurrentTime","title":"getCurrentTime","description":"","inputSchema":{"type":"object","properties":{},"required":[]},"annotations":{"title":"","readOnlyHint":false,"destructiveHint":true,"idempotentHint":false,"openWorldHint":true}}]}}
```