### PR TITLE
test: Add comprehensive test coverage for runtime hints and bindings processors

### DIFF
--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/aot/AzureOpenAiRuntimeHintsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/aot/AzureOpenAiRuntimeHintsTests.java
@@ -169,4 +169,42 @@ class AzureOpenAiRuntimeHintsTests {
 		assertThat(this.runtimeHints).matches(reflection().onType(OpenAIAsyncClient.class));
 	}
 
+	@Test
+	void verifyNoSerializationHintsAreRegistered() {
+		this.azureOpenAiRuntimeHints.registerHints(this.runtimeHints, null);
+
+		// Azure OpenAI should only register reflection and resource hints, not serialization hints
+		assertThat(this.runtimeHints.serialization().javaSerializationHints().count()).isEqualTo(0);
+	}
+
+	@Test
+	void verifyRegistrationWithDifferentRuntimeHintsInstances() {
+		RuntimeHints hints1 = new RuntimeHints();
+		RuntimeHints hints2 = new RuntimeHints();
+
+		this.azureOpenAiRuntimeHints.registerHints(hints1, null);
+		this.azureOpenAiRuntimeHints.registerHints(hints2, null);
+
+		// Both instances should have same number of reflection hints
+		long count1 = hints1.reflection().typeHints().count();
+		long count2 = hints2.reflection().typeHints().count();
+
+		assertThat(count1).isEqualTo(count2);
+		assertThat(count1).isGreaterThan(0);
+	}
+
+	@Test
+	void verifyEnumTypesInAzurePackageAreRegistered() {
+		this.azureOpenAiRuntimeHints.registerHints(this.runtimeHints, null);
+
+		Set<TypeReference> registeredTypes = new HashSet<>();
+		this.runtimeHints.reflection().typeHints().forEach(typeHint -> registeredTypes.add(typeHint.getType()));
+
+		// Verify that enum types from Azure OpenAI package are registered
+		boolean hasEnumTypes = registeredTypes.stream()
+				.anyMatch(tr -> tr.getName().contains("com.azure.ai.openai.models") &&
+						tr.getName().toLowerCase().contains("choice"));
+
+		assertThat(hasEnumTypes).as("Azure OpenAI enum types should be registered").isTrue();
+	}
 }

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/aot/AzureOpenAiRuntimeHintsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/aot/AzureOpenAiRuntimeHintsTests.java
@@ -173,7 +173,8 @@ class AzureOpenAiRuntimeHintsTests {
 	void verifyNoSerializationHintsAreRegistered() {
 		this.azureOpenAiRuntimeHints.registerHints(this.runtimeHints, null);
 
-		// Azure OpenAI should only register reflection and resource hints, not serialization hints
+		// Azure OpenAI should only register reflection and resource hints, not
+		// serialization hints
 		assertThat(this.runtimeHints.serialization().javaSerializationHints().count()).isEqualTo(0);
 	}
 
@@ -202,9 +203,10 @@ class AzureOpenAiRuntimeHintsTests {
 
 		// Verify that enum types from Azure OpenAI package are registered
 		boolean hasEnumTypes = registeredTypes.stream()
-				.anyMatch(tr -> tr.getName().contains("com.azure.ai.openai.models") &&
-						tr.getName().toLowerCase().contains("choice"));
+			.anyMatch(tr -> tr.getName().contains("com.azure.ai.openai.models")
+					&& tr.getName().toLowerCase().contains("choice"));
 
 		assertThat(hasEnumTypes).as("Azure OpenAI enum types should be registered").isTrue();
 	}
+
 }

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/aot/MistralAiRuntimeHintsTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/aot/MistralAiRuntimeHintsTests.java
@@ -181,8 +181,7 @@ class MistralAiRuntimeHintsTests {
 		MistralAiRuntimeHints mistralAiRuntimeHints = new MistralAiRuntimeHints();
 
 		// Should not throw any exception even with empty runtime hints
-		assertThatCode(() -> mistralAiRuntimeHints.registerHints(emptyRuntimeHints, null))
-				.doesNotThrowAnyException();
+		assertThatCode(() -> mistralAiRuntimeHints.registerHints(emptyRuntimeHints, null)).doesNotThrowAnyException();
 
 		assertThat(emptyRuntimeHints.reflection().typeHints().count()).isGreaterThan(0);
 	}
@@ -218,12 +217,12 @@ class MistralAiRuntimeHintsTests {
 
 		// Verify response wrapper types are registered
 		assertThat(registeredTypes.stream().anyMatch(tr -> tr.getName().contains("EmbeddingList")))
-				.as("EmbeddingList response type should be registered")
-				.isTrue();
+			.as("EmbeddingList response type should be registered")
+			.isTrue();
 
 		assertThat(registeredTypes.stream().anyMatch(tr -> tr.getName().contains("ChatCompletion")))
-				.as("ChatCompletion response type should be registered")
-				.isTrue();
+			.as("ChatCompletion response type should be registered")
+			.isTrue();
 	}
 
 	@Test
@@ -242,4 +241,5 @@ class MistralAiRuntimeHintsTests {
 
 		assertThat(count1).isEqualTo(count2);
 	}
+
 }

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/aot/MistralAiRuntimeHintsTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/aot/MistralAiRuntimeHintsTests.java
@@ -28,6 +28,7 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeReference;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.springframework.ai.aot.AiRuntimeHints.findJsonAnnotatedClassesInPackage;
 
 class MistralAiRuntimeHintsTests {
@@ -174,4 +175,71 @@ class MistralAiRuntimeHintsTests {
 		assertThat(hasConstructorHints).as("Should register constructor hints for JSON deserialization").isTrue();
 	}
 
+	@Test
+	void verifyNoExceptionThrownWithEmptyRuntimeHints() {
+		RuntimeHints emptyRuntimeHints = new RuntimeHints();
+		MistralAiRuntimeHints mistralAiRuntimeHints = new MistralAiRuntimeHints();
+
+		// Should not throw any exception even with empty runtime hints
+		assertThatCode(() -> mistralAiRuntimeHints.registerHints(emptyRuntimeHints, null))
+				.doesNotThrowAnyException();
+
+		assertThat(emptyRuntimeHints.reflection().typeHints().count()).isGreaterThan(0);
+	}
+
+	@Test
+	void verifyProxyHintsAreNotRegistered() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		MistralAiRuntimeHints mistralAiRuntimeHints = new MistralAiRuntimeHints();
+		mistralAiRuntimeHints.registerHints(runtimeHints, null);
+
+		// MistralAi should only register reflection hints, not proxy hints
+		assertThat(runtimeHints.proxies().jdkProxyHints().count()).isEqualTo(0);
+	}
+
+	@Test
+	void verifySerializationHintsAreNotRegistered() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		MistralAiRuntimeHints mistralAiRuntimeHints = new MistralAiRuntimeHints();
+		mistralAiRuntimeHints.registerHints(runtimeHints, null);
+
+		// MistralAi should only register reflection hints, not serialization hints
+		assertThat(runtimeHints.serialization().javaSerializationHints().count()).isEqualTo(0);
+	}
+
+	@Test
+	void verifyResponseTypesAreRegistered() {
+		RuntimeHints runtimeHints = new RuntimeHints();
+		MistralAiRuntimeHints mistralAiRuntimeHints = new MistralAiRuntimeHints();
+		mistralAiRuntimeHints.registerHints(runtimeHints, null);
+
+		Set<TypeReference> registeredTypes = new HashSet<>();
+		runtimeHints.reflection().typeHints().forEach(typeHint -> registeredTypes.add(typeHint.getType()));
+
+		// Verify response wrapper types are registered
+		assertThat(registeredTypes.stream().anyMatch(tr -> tr.getName().contains("EmbeddingList")))
+				.as("EmbeddingList response type should be registered")
+				.isTrue();
+
+		assertThat(registeredTypes.stream().anyMatch(tr -> tr.getName().contains("ChatCompletion")))
+				.as("ChatCompletion response type should be registered")
+				.isTrue();
+	}
+
+	@Test
+	void verifyMultipleInstancesRegisterSameHints() {
+		RuntimeHints runtimeHints1 = new RuntimeHints();
+		RuntimeHints runtimeHints2 = new RuntimeHints();
+
+		MistralAiRuntimeHints hints1 = new MistralAiRuntimeHints();
+		MistralAiRuntimeHints hints2 = new MistralAiRuntimeHints();
+
+		hints1.registerHints(runtimeHints1, null);
+		hints2.registerHints(runtimeHints2, null);
+
+		long count1 = runtimeHints1.reflection().typeHints().count();
+		long count2 = runtimeHints2.reflection().typeHints().count();
+
+		assertThat(count1).isEqualTo(count2);
+	}
 }

--- a/spring-ai-spring-cloud-bindings/src/test/java/org/springframework/ai/bindings/MistralAiBindingsPropertiesProcessorTests.java
+++ b/spring-ai-spring-cloud-bindings/src/test/java/org/springframework/ai/bindings/MistralAiBindingsPropertiesProcessorTests.java
@@ -131,8 +131,8 @@ class MistralAiBindingsPropertiesProcessorTests {
 
 	@Test
 	void onlyUriWithoutApiKeyShouldSetBothProperties() {
-		Bindings bindingsWithOnlyUri = new Bindings(new Binding("test-name", Paths.get("test-path"),
-				Map.of(Binding.TYPE, MistralAiBindingsPropertiesProcessor.TYPE, "uri", "https://custom.mistralai.com")));
+		Bindings bindingsWithOnlyUri = new Bindings(new Binding("test-name", Paths.get("test-path"), Map
+			.of(Binding.TYPE, MistralAiBindingsPropertiesProcessor.TYPE, "uri", "https://custom.mistralai.com")));
 
 		new MistralAiBindingsPropertiesProcessor().process(this.environment, bindingsWithOnlyUri, this.properties);
 
@@ -150,4 +150,5 @@ class MistralAiBindingsPropertiesProcessorTests {
 		assertThat(this.properties).containsEntry("spring.ai.mistralai.api-key", "secret-key");
 		assertThat(this.properties).containsEntry("spring.ai.mistralai.base-url", null);
 	}
+
 }

--- a/spring-ai-spring-cloud-bindings/src/test/java/org/springframework/ai/bindings/MistralAiBindingsPropertiesProcessorTests.java
+++ b/spring-ai-spring-cloud-bindings/src/test/java/org/springframework/ai/bindings/MistralAiBindingsPropertiesProcessorTests.java
@@ -120,4 +120,34 @@ class MistralAiBindingsPropertiesProcessorTests {
 		assertThat(this.properties).isEmpty();
 	}
 
+	@Test
+	void emptyBindingsShouldNotThrowException() {
+		Bindings emptyBindings = new Bindings();
+
+		new MistralAiBindingsPropertiesProcessor().process(this.environment, emptyBindings, this.properties);
+
+		assertThat(this.properties).isEmpty();
+	}
+
+	@Test
+	void onlyUriWithoutApiKeyShouldSetBothProperties() {
+		Bindings bindingsWithOnlyUri = new Bindings(new Binding("test-name", Paths.get("test-path"),
+				Map.of(Binding.TYPE, MistralAiBindingsPropertiesProcessor.TYPE, "uri", "https://custom.mistralai.com")));
+
+		new MistralAiBindingsPropertiesProcessor().process(this.environment, bindingsWithOnlyUri, this.properties);
+
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.base-url", "https://custom.mistralai.com");
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.api-key", null);
+	}
+
+	@Test
+	void onlyApiKeyWithoutUriShouldSetBothProperties() {
+		Bindings bindingsWithOnlyApiKey = new Bindings(new Binding("test-name", Paths.get("test-path"),
+				Map.of(Binding.TYPE, MistralAiBindingsPropertiesProcessor.TYPE, "api-key", "secret-key")));
+
+		new MistralAiBindingsPropertiesProcessor().process(this.environment, bindingsWithOnlyApiKey, this.properties);
+
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.api-key", "secret-key");
+		assertThat(this.properties).containsEntry("spring.ai.mistralai.base-url", null);
+	}
 }


### PR DESCRIPTION
This PR enhances test coverage for the Spring AI Azure OpenAI and MistralAI modules by adding comprehensive tests for runtime hints registration and bindings property processing.

**Changes Made**

**Azure OpenAI Runtime Hints Tests**

- Added verification that serialization hints are not registered (only reflection and resource hints should be)
- Added test for consistent hint registration across different RuntimeHints instances
- Added validation for Azure OpenAI enum type registration

**MistralAI Runtime Hints Tests**

- Added test ensuring no exceptions are thrown with empty RuntimeHints
- Added verification that proxy hints are not registered
- Added verification that serialization hints are not registered
- Added validation for response type registration (EmbeddingList, ChatCompletion)
- Added test for consistent behavior across multiple MistralAiRuntimeHints instances

**MistralAI Bindings Properties Processor Tests**

- Added test for handling empty bindings without exceptions
- Added test for URI-only bindings setting both properties correctly
- Added test for API-key-only bindings setting both properties correctly

**Testing**

All new tests pass and verify:

- Proper isolation of hint types
- Robust handling of edge cases and null values
- Correct property mapping for various binding configurations

**Benefits**

These tests improve the reliability and maintainability of the runtime hints and bindings functionality by ensuring:

- Native image compatibility is properly tested
- Edge cases are handled gracefully
- The codebase is more resilient to future changes