### PR TITLE
Make default MethodToolCallbackProvider configurable

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -307,6 +307,22 @@ public interface ChatClient {
 
 		Builder defaultToolContext(Map<String, Object> toolContext);
 
+		/**
+		 * Sets a default
+		 * {@link org.springframework.ai.tool.execution.ToolCallResultConverter} to be
+		 * used for all tools created via the {@code tools()} method.
+		 * <p>
+		 * This converter will be used to serialize tool results before sending them back
+		 * to the AI model. Tools created with {@code toolCallbacks()} must have their
+		 * converter set at callback creation time.
+		 * </p>
+		 * @param converter the converter to use for tool results, or null to use the
+		 * default
+		 * @return this builder
+		 * @since 1.0.0
+		 */
+		Builder defaultToolCallResultConverter(org.springframework.ai.tool.execution.ToolCallResultConverter converter);
+
 		Builder clone();
 
 		ChatClient build();

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -36,6 +36,7 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.execution.ToolCallResultConverter;
 import org.springframework.core.io.Resource;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -66,7 +67,7 @@ public class DefaultChatClientBuilder implements Builder {
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), Map.of(), null, Map.of(),
 				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
-				customObservationConvention, Map.of(), null);
+				customObservationConvention, Map.of(), null, null);
 	}
 
 	public ChatClient build() {
@@ -181,6 +182,12 @@ public class DefaultChatClientBuilder implements Builder {
 
 	public Builder defaultToolContext(Map<String, Object> toolContext) {
 		this.defaultRequest.toolContext(toolContext);
+		return this;
+	}
+
+	@Override
+	public Builder defaultToolCallResultConverter(ToolCallResultConverter converter) {
+		this.defaultRequest.toolCallResultConverter(converter);
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1474,7 +1474,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
 				chatModel, null, Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(),
-				List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null);
+				List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null);
 		assertThat(spec).isNotNull();
 	}
 
@@ -1482,7 +1482,7 @@ class DefaultChatClientTests {
 	void whenChatModelIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), Map.of(),
 				null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
-				ObservationRegistry.NOOP, null, Map.of(), null))
+				ObservationRegistry.NOOP, null, Map.of(), null, null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
 	}
@@ -1491,7 +1491,7 @@ class DefaultChatClientTests {
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mock(ChatModel.class), null,
 				Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), null,
-				List.of(), Map.of(), null, null, Map.of(), null))
+				List.of(), Map.of(), null, null, Map.of(), null, null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/support/ToolCallbacks.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/support/ToolCallbacks.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.support;
 
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.execution.ToolCallResultConverter;
 import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.lang.Nullable;
 
 /**
  * Provides {@link ToolCallback} instances for tools defined in different sources.
@@ -31,7 +33,23 @@ public final class ToolCallbacks {
 	}
 
 	public static ToolCallback[] from(Object... sources) {
-		return MethodToolCallbackProvider.builder().toolObjects(sources).build().getToolCallbacks();
+		return from(null, sources);
+	}
+
+	/**
+	 * Creates {@link ToolCallback} instances from the provided sources using a custom
+	 * {@link ToolCallResultConverter}.
+	 * @param converter the converter to use for tool results, or null to use the default
+	 * @param sources the tool objects containing @Tool annotated methods
+	 * @return an array of ToolCallback instances
+	 * @since 1.0.0
+	 */
+	public static ToolCallback[] from(@Nullable ToolCallResultConverter converter, Object... sources) {
+		return MethodToolCallbackProvider.builder()
+			.toolObjects(sources)
+			.toolCallResultConverter(converter)
+			.build()
+			.getToolCallbacks();
 	}
 
 }


### PR DESCRIPTION
This PR is an attempt at fixing #4390

1. MethodToolCallbackProvider.Builder (spring-ai-model)

- Added toolCallResultConverter field
- Added toolCallResultConverter(ToolCallResultConverter) method
- Updated constructor to accept converter parameter
- Modified getToolCallbacks() to use custom converter when provided, fallback to ToolUtils.getToolCallResultConverter() otherwise

2. ToolCallbacks.from() (spring-ai-model)

- Added overloaded method from(ToolCallResultConverter, Object...)
- Original from(Object...) now delegates to new method with null converter

3. ChatClient.Builder Interface (spring-ai-client-chat)

- Added defaultToolCallResultConverter(ToolCallResultConverter) method

4. DefaultChatClientBuilder (spring-ai-client-chat)

- Implemented defaultToolCallResultConverter() method

5. DefaultChatClient (spring-ai-client-chat)

- Added toolCallResultConverter field to DefaultChatClientRequestSpec
- Updated constructors to accept converter parameter
- Modified tools() method to pass converter to ToolCallbacks.from()
- Added toolCallResultConverter() method to request spec
- Updated mutate() to preserve converter

6. Test Coverage (spring-ai-model)

- Added test whenCustomToolCallResultConverterIsProvidedThenUsesIt()
- Added ToolWithAnnotations test class

Usage

    // Option 1: Global via ChatClient
    ChatClient.builder(chatModel)
        .defaultToolCallResultConverter(customConverter)
        .build();

    // Option 2: Per provider
    MethodToolCallbackProvider.builder()
        .toolObjects(tools)
        .toolCallResultConverter(customConverter)
        .build();
        
Feel free to give me feedback on this change.