### PR TITLE
fix returnDirect attribute default value change false to true

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/metadata/ToolMetadata.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/metadata/ToolMetadata.java
@@ -33,7 +33,7 @@ public interface ToolMetadata {
 	 * Whether the tool result should be returned directly or passed back to the model.
 	 */
 	default boolean returnDirect() {
-		return false;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
The default value of the returnDirect attribute in the @Tool annotation has been changed to true. Users may not want the model to request the same thing twice, and by default, they expect that the return value of a method annotated with @Tool will be returned directly to them. Setting the default of the returnDirect attribute to false would be unintuitive.

Furthermore, the majority of open-source tool creators focus on the tool performing some action, rather than having the return value interpreted differently through multiple models. Since the results can vary greatly depending on the model, it is preferable for the tool’s return value to provide a clear and direct answer to the user.

same issue : https://github.com/spring-projects/spring-ai/issues/3481