### PR TITLE
refactor: simplify assistant message extraction using Optional chaining

### DIFF
--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/PromptChatMemoryAdvisorTests.java
@@ -16,23 +16,34 @@
 
 package org.springframework.ai.chat.client.advisor;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import reactor.core.scheduler.Schedulers;
 
+import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link PromptChatMemoryAdvisor}.
  *
  * @author Mark Pollack
  * @author Thomas Vitale
+ * @author Soby Chacko
  */
 public class PromptChatMemoryAdvisorTests {
 
@@ -136,6 +147,122 @@ public class PromptChatMemoryAdvisorTests {
 		// Verify default values
 		assertThat(advisor).isNotNull();
 		assertThat(advisor.getOrder()).isEqualTo(Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER);
+	}
+
+	@Test
+	void testAfterMethodHandlesSingleGeneration() {
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+
+		PromptChatMemoryAdvisor advisor = PromptChatMemoryAdvisor.builder(chatMemory)
+			.conversationId("test-conversation")
+			.build();
+
+		ChatClientResponse mockResponse = mock(ChatClientResponse.class);
+		ChatResponse mockChatResponse = mock(ChatResponse.class);
+		Generation mockGeneration = mock(Generation.class);
+		AdvisorChain mockChain = mock(AdvisorChain.class);
+
+		when(mockResponse.chatResponse()).thenReturn(mockChatResponse);
+		when(mockChatResponse.getResults()).thenReturn(List.of(mockGeneration)); // Single
+																					// result
+		when(mockGeneration.getOutput()).thenReturn(new AssistantMessage("Single response"));
+
+		ChatClientResponse result = advisor.after(mockResponse, mockChain);
+
+		assertThat(result).isEqualTo(mockResponse); // Should return the same response
+
+		// Verify single message stored in memory
+		List<Message> messages = chatMemory.get("test-conversation");
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0).getText()).isEqualTo("Single response");
+	}
+
+	@Test
+	void testAfterMethodHandlesMultipleGenerations() {
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+
+		PromptChatMemoryAdvisor advisor = PromptChatMemoryAdvisor.builder(chatMemory)
+			.conversationId("test-conversation")
+			.build();
+
+		ChatClientResponse mockResponse = mock(ChatClientResponse.class);
+		ChatResponse mockChatResponse = mock(ChatResponse.class);
+		Generation mockGen1 = mock(Generation.class);
+		Generation mockGen2 = mock(Generation.class);
+		Generation mockGen3 = mock(Generation.class);
+		AdvisorChain mockChain = mock(AdvisorChain.class);
+
+		when(mockResponse.chatResponse()).thenReturn(mockChatResponse);
+		when(mockChatResponse.getResults()).thenReturn(List.of(mockGen1, mockGen2, mockGen3)); // Multiple
+																								// results
+		when(mockGen1.getOutput()).thenReturn(new AssistantMessage("Response 1"));
+		when(mockGen2.getOutput()).thenReturn(new AssistantMessage("Response 2"));
+		when(mockGen3.getOutput()).thenReturn(new AssistantMessage("Response 3"));
+
+		ChatClientResponse result = advisor.after(mockResponse, mockChain);
+
+		assertThat(result).isEqualTo(mockResponse); // Should return the same response
+
+		// Verify all messages were stored in memory
+		List<Message> messages = chatMemory.get("test-conversation");
+		assertThat(messages).hasSize(3);
+		assertThat(messages.get(0).getText()).isEqualTo("Response 1");
+		assertThat(messages.get(1).getText()).isEqualTo("Response 2");
+		assertThat(messages.get(2).getText()).isEqualTo("Response 3");
+	}
+
+	@Test
+	void testAfterMethodHandlesEmptyResults() {
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+
+		PromptChatMemoryAdvisor advisor = PromptChatMemoryAdvisor.builder(chatMemory)
+			.conversationId("test-conversation")
+			.build();
+
+		ChatClientResponse mockResponse = mock(ChatClientResponse.class);
+		ChatResponse mockChatResponse = mock(ChatResponse.class);
+		AdvisorChain mockChain = mock(AdvisorChain.class);
+
+		when(mockResponse.chatResponse()).thenReturn(mockChatResponse);
+		when(mockChatResponse.getResults()).thenReturn(List.of());
+
+		ChatClientResponse result = advisor.after(mockResponse, mockChain);
+
+		assertThat(result).isEqualTo(mockResponse);
+
+		// Verify no messages were stored in memory
+		List<Message> messages = chatMemory.get("test-conversation");
+		assertThat(messages).isEmpty();
+	}
+
+	@Test
+	void testAfterMethodHandlesNullChatResponse() {
+		ChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(new InMemoryChatMemoryRepository())
+			.build();
+
+		PromptChatMemoryAdvisor advisor = PromptChatMemoryAdvisor.builder(chatMemory)
+			.conversationId("test-conversation")
+			.build();
+
+		ChatClientResponse mockResponse = mock(ChatClientResponse.class);
+		AdvisorChain mockChain = mock(AdvisorChain.class);
+
+		when(mockResponse.chatResponse()).thenReturn(null);
+
+		ChatClientResponse result = advisor.after(mockResponse, mockChain);
+
+		assertThat(result).isEqualTo(mockResponse);
+
+		// Verify no messages were stored in memory
+		List<Message> messages = chatMemory.get("test-conversation");
+		assertThat(messages).isEmpty();
 	}
 
 }


### PR DESCRIPTION
Replace nested null checks and redundant branching with streamlined Optional-based approach. Since getResult() == getResults().get(0), processing all results handles both single and multiple result cases.

Fixes #4292

The original code had an unreachable `else` condition. This PR attempts to fix this unreachability. Once this PR is merged, we can close this one: https://github.com/spring-projects/spring-ai/pull/4292