### PR TITLE
Log chat client completion data and make the response text available in the Observation Context

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderProperties.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientBuilderProperties.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Josh Long
  * @author Arjen Poutsma
  * @author Thomas Vitale
+ * @author Jonatan Ivanov
  * @since 1.0.0
  */
 @ConfigurationProperties(ChatClientBuilderProperties.CONFIG_PREFIX)
@@ -59,12 +60,34 @@ public class ChatClientBuilderProperties {
 		 */
 		private boolean logPrompt = false;
 
+		/**
+		 * Whether to log the completion content in the observations.
+		 * @since 1.1.0
+		 */
+		private boolean logCompletion = false;
+
 		public boolean isLogPrompt() {
 			return this.logPrompt;
 		}
 
+		/**
+		 * @return Whether logging completion data is enabled or not.
+		 * @since 1.1.0
+		 */
+		public boolean isLogCompletion() {
+			return this.logCompletion;
+		}
+
 		public void setLogPrompt(boolean logPrompt) {
 			this.logPrompt = logPrompt;
+		}
+
+		/**
+		 * @param logCompletion should completion data logging be enabled or not.
+		 * @since 1.1.0
+		 */
+		public void setLogCompletion(boolean logCompletion) {
+			this.logCompletion = logCompletion;
 		}
 
 	}

--- a/spring-ai-client-chat/pom.xml
+++ b/spring-ai-client-chat/pom.xml
@@ -105,6 +105,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-kotlin</artifactId>
 			<scope>test</scope>

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/ChatClientCompletionObservationHandler.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/ChatClientCompletionObservationHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.observation;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.observation.ObservabilityHelper;
+import org.springframework.util.StringUtils;
+
+/**
+ * Handler for emitting the chat client completion content to logs.
+ *
+ * @author Jonatan Ivanov
+ * @since 1.1.0
+ */
+public class ChatClientCompletionObservationHandler implements ObservationHandler<ChatClientObservationContext> {
+
+	private static final Logger logger = LoggerFactory.getLogger(ChatClientCompletionObservationHandler.class);
+
+	@Override
+	public void onStop(ChatClientObservationContext context) {
+		logger.info("Chat Client Completion:\n{}", ObservabilityHelper.concatenateStrings(completion(context)));
+	}
+
+	private List<String> completion(ChatClientObservationContext context) {
+		if (context.getResponseText() == null) {
+			return List.of();
+		}
+		else if (!StringUtils.hasText(context.getResponseText())) {
+			return List.of();
+		}
+
+		return Collections.singletonList(context.getResponseText());
+	}
+
+	@Override
+	public boolean supportsContext(Observation.Context context) {
+		return context instanceof ChatClientObservationContext;
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/ChatClientCompletionObservationHandlerTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/ChatClientCompletionObservationHandlerTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.observation;
+
+import java.util.List;
+
+import io.micrometer.observation.Observation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ChatClientCompletionObservationHandler}.
+ *
+ * @author Jonatan Ivanov
+ */
+@ExtendWith(OutputCaptureExtension.class)
+class ChatClientCompletionObservationHandlerTests {
+
+	private final ChatClientCompletionObservationHandler observationHandler = new ChatClientCompletionObservationHandler();
+
+	@Test
+	void whenNotSupportedObservationContextThenReturnFalse() {
+		var context = new Observation.Context();
+		assertThat(this.observationHandler.supportsContext(context)).isFalse();
+	}
+
+	@Test
+	void whenSupportedObservationContextThenReturnTrue() {
+		var context = ChatClientObservationContext.builder()
+			.request(ChatClientRequest.builder().prompt(new Prompt(List.of())).build())
+			.build();
+		assertThat(this.observationHandler.supportsContext(context)).isTrue();
+	}
+
+	@Test
+	void whenEmptyResponseThenOutputNothing(CapturedOutput output) {
+		var context = ChatClientObservationContext.builder()
+			.request(ChatClientRequest.builder().prompt(new Prompt(List.of())).build())
+			.build();
+		var response = ChatClientResponse.builder()
+			.chatResponse(ChatResponse.builder().generations(List.of(new Generation(new AssistantMessage("")))).build())
+			.build();
+		context.setResponse(response);
+
+		this.observationHandler.onStop(context);
+		assertThat(output).contains("""
+				INFO  o.s.a.c.c.o.ChatClientCompletionObservationHandler -- Chat Client Completion:
+				[]
+				""");
+	}
+
+	@Test
+	void whenNullResponseThenOutputNothing(CapturedOutput output) {
+		var context = ChatClientObservationContext.builder()
+			.request(ChatClientRequest.builder().prompt(new Prompt(List.of())).build())
+			.build();
+
+		this.observationHandler.onStop(context);
+		assertThat(output).contains("""
+				INFO  o.s.a.c.c.o.ChatClientCompletionObservationHandler -- Chat Client Completion:
+				[]
+				""");
+	}
+
+	@Test
+	void whenResponseWithTextThenOutputIt(CapturedOutput output) {
+		var context = ChatClientObservationContext.builder()
+			.request(ChatClientRequest.builder().prompt(new Prompt(List.of())).build())
+			.build();
+		var response = ChatClientResponse.builder()
+			.chatResponse(ChatResponse.builder()
+				.generations(List.of(new Generation(new AssistantMessage("Test message"))))
+				.build())
+			.build();
+		context.setResponse(response);
+
+		this.observationHandler.onStop(context);
+		assertThat(output).contains("""
+				INFO  o.s.a.c.c.o.ChatClientCompletionObservationHandler -- Chat Client Completion:
+				["Test message"]
+				""");
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -54,21 +54,22 @@ They measure the time spent performing the invocation and propagate the related 
 |`spring.ai.chat.client.user.text` (deprecated) | Chat client user text. Optional. Superseded by `gen_ai.prompt`.
 |===
 
-=== Prompt Content
+=== Prompt and Completion Data
 
-The `ChatClient` prompt content is typically big and possibly containing sensitive information.
+The `ChatClient` prompt and completion data is typically big and possibly containing sensitive information.
 For those reasons, it is not exported by default.
 
-Spring AI supports logging the prompt content to help with debugging and troubleshooting.
+Spring AI supports logging the prompt and completion data to help with debugging and troubleshooting.
 
 [cols="6,3,1", stripes=even]
 |====
 | Property | Description | Default
 
 | `spring.ai.chat.client.observations.log-prompt` |  Whether to log the chat client prompt content. | `false`
+| `spring.ai.chat.client.observations.log-completion` |  Whether to log the chat client completion content. | `false`
 |====
 
-WARNING: If you enable logging of the chat client prompt content, there's a risk of exposing sensitive or private information. Please, be careful!
+WARNING: If you enable logging of the chat client prompt and completion data, there's a risk of exposing sensitive or private information. Please, be careful!
 
 === Input Data (Deprecated)
 


### PR DESCRIPTION
The main driver of this change to make the response test available in the Chat Client Observation Context in `call()` and `stream()` scenarios.
This also introduces chat client log completion which was missing before mainly because the response text was not available in the `stream()` use-case.