### PR TITLE
refactor: Refactored the `initializeContainer` method of `CosmosDBVectorStore`

### DIFF
--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
@@ -128,31 +128,27 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 			logger.error("Error creating database: {}", e.getMessage());
 		}
 
-		initializeContainer(this.containerName, this.databaseName, this.vectorStoreThroughput, this.vectorDimensions,
-				this.partitionKeyPath);
+		initializeContainer();
 	}
 
 	public static Builder builder(CosmosAsyncClient cosmosClient, EmbeddingModel embeddingModel) {
 		return new Builder(cosmosClient, embeddingModel);
 	}
 
-	private void initializeContainer(String containerName, String databaseName, int vectorStoreThroughput,
-			long vectorDimensions, String partitionKeyPath) {
+	private void initializeContainer() {
 
 		// Set defaults if not provided
 		if (this.vectorStoreThroughput == 0) {
 			this.vectorStoreThroughput = 400;
-			vectorStoreThroughput = this.vectorStoreThroughput;
 		}
 		if (this.partitionKeyPath == null) {
 			this.partitionKeyPath = "/id";
-			partitionKeyPath = this.partitionKeyPath;
 		}
 
 		// handle hierarchical partition key
 		PartitionKeyDefinition subPartitionKeyDefinition = new PartitionKeyDefinition();
 		List<String> pathsFromCommaSeparatedList = new ArrayList<>();
-		String[] subPartitionKeyPaths = partitionKeyPath.split(",");
+		String[] subPartitionKeyPaths = this.partitionKeyPath.split(",");
 		Collections.addAll(pathsFromCommaSeparatedList, subPartitionKeyPaths);
 		if (subPartitionKeyPaths.length > 1) {
 			subPartitionKeyDefinition.setPaths(pathsFromCommaSeparatedList);


### PR DESCRIPTION
The `initializeContainer` method of `CosmosDBVectorStore` has some issues:  
1. Most of the parameters in the method signature are not used, and these parameters don't need to be passed as arguments since they have already been assigned to instance properties in the constructor and can be directly accessed.  
2. The reassignment of parameters within the method is meaningless.  

### This PR makes the following changes:  
1. Removed all parameters from the method signature, as they are already accessible via instance properties.  
2. Eliminated meaningless reassignments of method parameters.