### PR TITLE
fix: improve configuration metadata generation for IDE auto-completion

### DIFF
--- a/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryProperties.java
+++ b/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryProperties.java
@@ -42,7 +42,7 @@ public class SpringAiRetryProperties {
 	 * Exponential Backoff properties.
 	 */
 	@NestedConfigurationProperty
-	private Backoff backoff = new Backoff();
+	private final Backoff backoff = new Backoff();
 
 	/**
 	 * If false, throw a NonTransientAiException, and do not attempt retry for 4xx client

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatProperties.java
@@ -39,7 +39,7 @@ public class AnthropicChatProperties {
 	 * generative's defaults.
 	 */
 	@NestedConfigurationProperty
-	private AnthropicChatOptions options = AnthropicChatOptions.builder()
+	private final AnthropicChatOptions options = AnthropicChatOptions.builder()
 		.model(AnthropicChatModel.DEFAULT_MODEL_NAME)
 		.maxTokens(AnthropicChatModel.DEFAULT_MAX_TOKENS)
 		.temperature(AnthropicChatModel.DEFAULT_TEMPERATURE)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiAudioTranscriptionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiAudioTranscriptionProperties.java
@@ -31,14 +31,10 @@ public class AzureOpenAiAudioTranscriptionProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.audio.transcription";
 
 	@NestedConfigurationProperty
-	private AzureOpenAiAudioTranscriptionOptions options = AzureOpenAiAudioTranscriptionOptions.builder().build();
+	private final AzureOpenAiAudioTranscriptionOptions options = AzureOpenAiAudioTranscriptionOptions.builder().build();
 
 	public AzureOpenAiAudioTranscriptionOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(AzureOpenAiAudioTranscriptionOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiChatProperties.java
@@ -30,17 +30,13 @@ public class AzureOpenAiChatProperties {
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
 	@NestedConfigurationProperty
-	private AzureOpenAiChatOptions options = AzureOpenAiChatOptions.builder()
+	private final AzureOpenAiChatOptions options = AzureOpenAiChatOptions.builder()
 		.deploymentName(DEFAULT_DEPLOYMENT_NAME)
 		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public AzureOpenAiChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(AzureOpenAiChatOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiEmbeddingProperties.java
@@ -28,7 +28,7 @@ public class AzureOpenAiEmbeddingProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.embedding";
 
 	@NestedConfigurationProperty
-	private AzureOpenAiEmbeddingOptions options = AzureOpenAiEmbeddingOptions.builder()
+	private final AzureOpenAiEmbeddingOptions options = AzureOpenAiEmbeddingOptions.builder()
 		.deploymentName("text-embedding-ada-002")
 		.build();
 
@@ -36,11 +36,6 @@ public class AzureOpenAiEmbeddingProperties {
 
 	public AzureOpenAiEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(AzureOpenAiEmbeddingOptions options) {
-		Assert.notNull(options, "Options must not be null");
-		this.options = options;
 	}
 
 	public MetadataMode getMetadataMode() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiImageOptionsProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-azure-openai/src/main/java/org/springframework/ai/model/azure/openai/autoconfigure/AzureOpenAiImageOptionsProperties.java
@@ -32,14 +32,10 @@ public class AzureOpenAiImageOptionsProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.azure.openai.image";
 
 	@NestedConfigurationProperty
-	private AzureOpenAiImageOptions options = AzureOpenAiImageOptions.builder().build();
+	private final AzureOpenAiImageOptions options = AzureOpenAiImageOptions.builder().build();
 
 	public AzureOpenAiImageOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(AzureOpenAiImageOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/cohere/autoconfigure/BedrockCohereEmbeddingProperties.java
@@ -46,7 +46,7 @@ public class BedrockCohereEmbeddingProperties {
 	private String model = CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3.id();
 
 	@NestedConfigurationProperty
-	private BedrockCohereEmbeddingOptions options = BedrockCohereEmbeddingOptions.builder()
+	private final BedrockCohereEmbeddingOptions options = BedrockCohereEmbeddingOptions.builder()
 		.inputType(InputType.SEARCH_DOCUMENT)
 		.truncate(CohereEmbeddingRequest.Truncate.NONE)
 		.build();
@@ -61,10 +61,6 @@ public class BedrockCohereEmbeddingProperties {
 
 	public BedrockCohereEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(BedrockCohereEmbeddingOptions options) {
-		this.options = options;
 	}
 
 	public boolean isEnabled() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
@@ -19,7 +19,6 @@ package org.springframework.ai.model.bedrock.converse.autoconfigure;
 import org.springframework.ai.bedrock.converse.BedrockChatOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.util.Assert;
 
 /**
  * Configuration properties for Bedrock Converse.
@@ -39,15 +38,10 @@ public class BedrockConverseProxyChatProperties {
 	private boolean enabled;
 
 	@NestedConfigurationProperty
-	private BedrockChatOptions options = BedrockChatOptions.builder().temperature(0.7).maxTokens(300).build();
+	private final BedrockChatOptions options = BedrockChatOptions.builder().temperature(0.7).maxTokens(300).build();
 
 	public BedrockChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(BedrockChatOptions options) {
-		Assert.notNull(options, "BedrockChatOptions must not be null");
-		this.options = options;
 	}
 
 	public boolean isEnabled() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatProperties.java
@@ -49,17 +49,13 @@ public class DeepSeekChatProperties extends DeepSeekParentProperties {
 	private String betaPrefixPath = DEFAULT_BETA_PREFIX_PATH;
 
 	@NestedConfigurationProperty
-	private DeepSeekChatOptions options = DeepSeekChatOptions.builder()
+	private final DeepSeekChatOptions options = DeepSeekChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
 		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public DeepSeekChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(DeepSeekChatOptions options) {
-		this.options = options;
 	}
 
 	public boolean isEnabled() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsSpeechProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsSpeechProperties.java
@@ -43,7 +43,7 @@ public class ElevenLabsSpeechProperties {
 	private boolean enabled = true;
 
 	@NestedConfigurationProperty
-	private ElevenLabsTextToSpeechOptions options = ElevenLabsTextToSpeechOptions.builder()
+	private final ElevenLabsTextToSpeechOptions options = ElevenLabsTextToSpeechOptions.builder()
 		.modelId(DEFAULT_MODEL_ID)
 		.voiceId(DEFAULT_VOICE_ID)
 		.outputFormat(DEFAULT_OUTPUT_FORMAT.getValue())
@@ -51,10 +51,6 @@ public class ElevenLabsSpeechProperties {
 
 	public ElevenLabsTextToSpeechOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(ElevenLabsTextToSpeechOptions options) {
-		this.options = options;
 	}
 
 	public boolean isEnabled() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatProperties.java
@@ -39,7 +39,7 @@ public class GoogleGenAiChatProperties {
 	 * Google GenAI API generative options.
 	 */
 	@NestedConfigurationProperty
-	private GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+	private final GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
 		.temperature(0.7)
 		.candidateCount(1)
 		.model(DEFAULT_MODEL)
@@ -47,10 +47,6 @@ public class GoogleGenAiChatProperties {
 
 	public GoogleGenAiChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(GoogleGenAiChatOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiTextEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/embedding/GoogleGenAiTextEmbeddingProperties.java
@@ -40,16 +40,12 @@ public class GoogleGenAiTextEmbeddingProperties {
 	 * Google GenAI Text Embedding API options.
 	 */
 	@NestedConfigurationProperty
-	private GoogleGenAiTextEmbeddingOptions options = GoogleGenAiTextEmbeddingOptions.builder()
+	private final GoogleGenAiTextEmbeddingOptions options = GoogleGenAiTextEmbeddingOptions.builder()
 		.model(DEFAULT_MODEL)
 		.build();
 
 	public GoogleGenAiTextEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(GoogleGenAiTextEmbeddingOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatProperties.java
@@ -36,17 +36,13 @@ public class MiniMaxChatProperties extends MiniMaxParentProperties {
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
 	@NestedConfigurationProperty
-	private MiniMaxChatOptions options = MiniMaxChatOptions.builder()
+	private final MiniMaxChatOptions options = MiniMaxChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
 		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public MiniMaxChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(MiniMaxChatOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxEmbeddingProperties.java
@@ -37,14 +37,12 @@ public class MiniMaxEmbeddingProperties extends MiniMaxParentProperties {
 	private MetadataMode metadataMode = MetadataMode.EMBED;
 
 	@NestedConfigurationProperty
-	private MiniMaxEmbeddingOptions options = MiniMaxEmbeddingOptions.builder().model(DEFAULT_EMBEDDING_MODEL).build();
+	private final MiniMaxEmbeddingOptions options = MiniMaxEmbeddingOptions.builder()
+		.model(DEFAULT_EMBEDDING_MODEL)
+		.build();
 
 	public MiniMaxEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(MiniMaxEmbeddingOptions options) {
-		this.options = options;
 	}
 
 	public MetadataMode getMetadataMode() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiChatProperties.java
@@ -44,7 +44,7 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 	private static final Boolean IS_ENABLED = false;
 
 	@NestedConfigurationProperty
-	private MistralAiChatOptions options = MistralAiChatOptions.builder()
+	private final MistralAiChatOptions options = MistralAiChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
 		.temperature(DEFAULT_TEMPERATURE)
 		.safePrompt(!IS_ENABLED)
@@ -57,10 +57,6 @@ public class MistralAiChatProperties extends MistralAiParentProperties {
 
 	public MistralAiChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(MistralAiChatOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiEmbeddingProperties.java
@@ -40,7 +40,7 @@ public class MistralAiEmbeddingProperties extends MistralAiParentProperties {
 	public MetadataMode metadataMode = MetadataMode.EMBED;
 
 	@NestedConfigurationProperty
-	private MistralAiEmbeddingOptions options = MistralAiEmbeddingOptions.builder()
+	private final MistralAiEmbeddingOptions options = MistralAiEmbeddingOptions.builder()
 		.withModel(DEFAULT_EMBEDDING_MODEL)
 		.withEncodingFormat(DEFAULT_ENCODING_FORMAT)
 		.build();
@@ -51,10 +51,6 @@ public class MistralAiEmbeddingProperties extends MistralAiParentProperties {
 
 	public MistralAiEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(MistralAiEmbeddingOptions options) {
-		this.options = options;
 	}
 
 	public MetadataMode getMetadataMode() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiModerationProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiModerationProperties.java
@@ -32,7 +32,7 @@ public class MistralAiModerationProperties extends MistralAiParentProperties {
 	private static final String DEFAULT_MODERATION_MODEL = MistralAiModerationApi.Model.MISTRAL_MODERATION.getValue();
 
 	@NestedConfigurationProperty
-	private MistralAiModerationOptions options = MistralAiModerationOptions.builder()
+	private final MistralAiModerationOptions options = MistralAiModerationOptions.builder()
 		.model(DEFAULT_MODERATION_MODEL)
 		.build();
 
@@ -42,10 +42,6 @@ public class MistralAiModerationProperties extends MistralAiParentProperties {
 
 	public MistralAiModerationOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(MistralAiModerationOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrProperties.java
@@ -35,7 +35,7 @@ public class MistralAiOcrProperties extends MistralAiParentProperties {
 	public static final String DEFAULT_OCR_MODEL = MistralOcrApi.OCRModel.MISTRAL_OCR_LATEST.getValue();
 
 	@NestedConfigurationProperty
-	private MistralAiOcrOptions options = MistralAiOcrOptions.builder().model(DEFAULT_OCR_MODEL).build();
+	private final MistralAiOcrOptions options = MistralAiOcrOptions.builder().model(DEFAULT_OCR_MODEL).build();
 
 	public MistralAiOcrProperties() {
 		super.setBaseUrl(MistralAiCommonProperties.DEFAULT_BASE_URL);
@@ -43,10 +43,6 @@ public class MistralAiOcrProperties extends MistralAiParentProperties {
 
 	public MistralAiOcrOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(MistralAiOcrOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java
@@ -35,17 +35,13 @@ public class OCICohereChatModelProperties {
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
 	@NestedConfigurationProperty
-	private OCICohereChatOptions options = OCICohereChatOptions.builder()
+	private final OCICohereChatOptions options = OCICohereChatOptions.builder()
 		.servingMode(DEFAULT_SERVING_MODE)
 		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public OCICohereChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(OCICohereChatOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaChatProperties.java
@@ -38,7 +38,7 @@ public class OllamaChatProperties {
 	 * generative's defaults.
 	 */
 	@NestedConfigurationProperty
-	private OllamaChatOptions options = OllamaChatOptions.builder().model(OllamaModel.MISTRAL.id()).build();
+	private final OllamaChatOptions options = OllamaChatOptions.builder().model(OllamaModel.MISTRAL.id()).build();
 
 	public String getModel() {
 		return this.options.getModel();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaEmbeddingProperties.java
@@ -38,7 +38,7 @@ public class OllamaEmbeddingProperties {
 	 * generative's defaults.
 	 */
 	@NestedConfigurationProperty
-	private OllamaEmbeddingOptions options = OllamaEmbeddingOptions.builder()
+	private final OllamaEmbeddingOptions options = OllamaEmbeddingOptions.builder()
 		.model(OllamaModel.MXBAI_EMBED_LARGE.id())
 		.build();
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechProperties.java
@@ -45,7 +45,7 @@ public class OpenAiAudioSpeechProperties extends OpenAiParentProperties {
 	private static final OpenAiAudioApi.SpeechRequest.AudioResponseFormat DEFAULT_RESPONSE_FORMAT = OpenAiAudioApi.SpeechRequest.AudioResponseFormat.MP3;
 
 	@NestedConfigurationProperty
-	private OpenAiAudioSpeechOptions options = OpenAiAudioSpeechOptions.builder()
+	private final OpenAiAudioSpeechOptions options = OpenAiAudioSpeechOptions.builder()
 		.model(DEFAULT_SPEECH_MODEL)
 		.responseFormat(DEFAULT_RESPONSE_FORMAT)
 		.voice(VOICE)
@@ -54,10 +54,6 @@ public class OpenAiAudioSpeechProperties extends OpenAiParentProperties {
 
 	public OpenAiAudioSpeechOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(OpenAiAudioSpeechOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionProperties.java
@@ -33,7 +33,7 @@ public class OpenAiAudioTranscriptionProperties extends OpenAiParentProperties {
 	private static final OpenAiAudioApi.TranscriptResponseFormat DEFAULT_RESPONSE_FORMAT = OpenAiAudioApi.TranscriptResponseFormat.TEXT;
 
 	@NestedConfigurationProperty
-	private OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
+	private final OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
 		.model(DEFAULT_TRANSCRIPTION_MODEL)
 		.temperature(DEFAULT_TEMPERATURE.floatValue())
 		.responseFormat(DEFAULT_RESPONSE_FORMAT)
@@ -41,10 +41,6 @@ public class OpenAiAudioTranscriptionProperties extends OpenAiParentProperties {
 
 	public OpenAiAudioTranscriptionOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(OpenAiAudioTranscriptionOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
@@ -34,17 +34,13 @@ public class OpenAiChatProperties extends OpenAiParentProperties {
 	private String completionsPath = DEFAULT_COMPLETIONS_PATH;
 
 	@NestedConfigurationProperty
-	private OpenAiChatOptions options = OpenAiChatOptions.builder()
+	private final OpenAiChatOptions options = OpenAiChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
 		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public OpenAiChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(OpenAiChatOptions options) {
-		this.options = options;
 	}
 
 	public String getCompletionsPath() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingProperties.java
@@ -35,14 +35,12 @@ public class OpenAiEmbeddingProperties extends OpenAiParentProperties {
 	private String embeddingsPath = DEFAULT_EMBEDDINGS_PATH;
 
 	@NestedConfigurationProperty
-	private OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder().model(DEFAULT_EMBEDDING_MODEL).build();
+	private final OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder()
+		.model(DEFAULT_EMBEDDING_MODEL)
+		.build();
 
 	public OpenAiEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(OpenAiEmbeddingOptions options) {
-		this.options = options;
 	}
 
 	public MetadataMode getMetadataMode() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageProperties.java
@@ -43,14 +43,10 @@ public class OpenAiImageProperties extends OpenAiParentProperties {
 	 * Options for OpenAI Image API.
 	 */
 	@NestedConfigurationProperty
-	private OpenAiImageOptions options = OpenAiImageOptions.builder().model(DEFAULT_IMAGE_MODEL).build();
+	private final OpenAiImageOptions options = OpenAiImageOptions.builder().model(DEFAULT_IMAGE_MODEL).build();
 
 	public OpenAiImageOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(OpenAiImageOptions options) {
-		this.options = options;
 	}
 
 	public String getImagesPath() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationProperties.java
@@ -35,14 +35,10 @@ public class OpenAiModerationProperties extends OpenAiParentProperties {
 	 * Options for OpenAI Moderation API.
 	 */
 	@NestedConfigurationProperty
-	private OpenAiModerationOptions options = OpenAiModerationOptions.builder().build();
+	private final OpenAiModerationOptions options = OpenAiModerationOptions.builder().build();
 
 	public OpenAiModerationOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(OpenAiModerationOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingProperties.java
@@ -23,7 +23,6 @@ import org.springframework.ai.postgresml.PostgresMlEmbeddingModel;
 import org.springframework.ai.postgresml.PostgresMlEmbeddingOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.util.Assert;
 
 /**
  * Configuration properties for Postgres ML.
@@ -42,7 +41,7 @@ public class PostgresMlEmbeddingProperties {
 	private boolean createExtension;
 
 	@NestedConfigurationProperty
-	private PostgresMlEmbeddingOptions options = PostgresMlEmbeddingOptions.builder()
+	private final PostgresMlEmbeddingOptions options = PostgresMlEmbeddingOptions.builder()
 		.transformer(PostgresMlEmbeddingModel.DEFAULT_TRANSFORMER_MODEL)
 		.vectorType(PostgresMlEmbeddingModel.VectorType.PG_ARRAY)
 		.kwargs(Map.of())
@@ -51,16 +50,6 @@ public class PostgresMlEmbeddingProperties {
 
 	public PostgresMlEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(PostgresMlEmbeddingOptions options) {
-		Assert.notNull(options, "options must not be null.");
-		Assert.notNull(options.getTransformer(), "transformer must not be null.");
-		Assert.notNull(options.getVectorType(), "vectorType must not be null.");
-		Assert.notNull(options.getKwargs(), "kwargs must not be null.");
-		Assert.notNull(options.getMetadataMode(), "metadataMode must not be null.");
-
-		this.options = options;
 	}
 
 	public boolean isCreateExtension() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageProperties.java
@@ -33,18 +33,10 @@ public class StabilityAiImageProperties extends StabilityAiParentProperties {
 	public static final String CONFIG_PREFIX = "spring.ai.stabilityai.image";
 
 	@NestedConfigurationProperty
-	private StabilityAiImageOptions options = StabilityAiImageOptions.builder().build(); // stable-diffusion-v1-6
-
-	// is
-	// default
-	// model
+	private final StabilityAiImageOptions options = StabilityAiImageOptions.builder().build(); // stable-diffusion-v1-6
 
 	public StabilityAiImageOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(StabilityAiImageOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-transformers/src/main/java/org/springframework/ai/model/transformers/autoconfigure/TransformersEmbeddingModelProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-transformers/src/main/java/org/springframework/ai/model/transformers/autoconfigure/TransformersEmbeddingModelProperties.java
@@ -103,7 +103,7 @@ public class TransformersEmbeddingModelProperties {
 		 * empty to fall back to the defaults.
 		 */
 		@NestedConfigurationProperty
-		private Map<String, String> options = new HashMap<>();
+		private final Map<String, String> options = new HashMap<>();
 
 		public String getUri() {
 			return this.uri;
@@ -115,10 +115,6 @@ public class TransformersEmbeddingModelProperties {
 
 		public Map<String, String> getOptions() {
 			return this.options;
-		}
-
-		public void setOptions(Map<String, String> options) {
-			this.options = options;
 		}
 
 	}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultimodalEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultimodalEmbeddingProperties.java
@@ -18,6 +18,7 @@ package org.springframework.ai.model.vertexai.autoconfigure.embedding;
 
 import org.springframework.ai.vertexai.embedding.multimodal.VertexAiMultimodalEmbeddingOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Configuration properties for Vertex AI Gemini Chat.
@@ -33,16 +34,13 @@ public class VertexAiMultimodalEmbeddingProperties {
 	/**
 	 * Vertex AI Text Embedding API options.
 	 */
-	private VertexAiMultimodalEmbeddingOptions options = VertexAiMultimodalEmbeddingOptions.builder()
+	@NestedConfigurationProperty
+	private final VertexAiMultimodalEmbeddingOptions options = VertexAiMultimodalEmbeddingOptions.builder()
 		.model(VertexAiMultimodalEmbeddingOptions.DEFAULT_MODEL_NAME)
 		.build();
 
 	public VertexAiMultimodalEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(VertexAiMultimodalEmbeddingOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingProperties.java
@@ -18,6 +18,7 @@ package org.springframework.ai.model.vertexai.autoconfigure.embedding;
 
 import org.springframework.ai.vertexai.embedding.text.VertexAiTextEmbeddingOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Configuration properties for Vertex AI Gemini Chat.
@@ -33,17 +34,14 @@ public class VertexAiTextEmbeddingProperties {
 	/**
 	 * Vertex AI Text Embedding API options.
 	 */
-	private VertexAiTextEmbeddingOptions options = VertexAiTextEmbeddingOptions.builder()
+	@NestedConfigurationProperty
+	private final VertexAiTextEmbeddingOptions options = VertexAiTextEmbeddingOptions.builder()
 		.taskType(VertexAiTextEmbeddingOptions.TaskType.RETRIEVAL_DOCUMENT)
 		.model(VertexAiTextEmbeddingOptions.DEFAULT_MODEL_NAME)
 		.build();
 
 	public VertexAiTextEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(VertexAiTextEmbeddingOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatProperties.java
@@ -39,7 +39,7 @@ public class VertexAiGeminiChatProperties {
 	 * Vertex AI Gemini API generative options.
 	 */
 	@NestedConfigurationProperty
-	private VertexAiGeminiChatOptions options = VertexAiGeminiChatOptions.builder()
+	private final VertexAiGeminiChatOptions options = VertexAiGeminiChatOptions.builder()
 		.temperature(0.7)
 		.candidateCount(1)
 		.model(DEFAULT_MODEL)
@@ -47,10 +47,6 @@ public class VertexAiGeminiChatProperties {
 
 	public VertexAiGeminiChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(VertexAiGeminiChatOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatProperties.java
@@ -36,17 +36,13 @@ public class ZhiPuAiChatProperties extends ZhiPuAiParentProperties {
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
 	@NestedConfigurationProperty
-	private ZhiPuAiChatOptions options = ZhiPuAiChatOptions.builder()
+	private final ZhiPuAiChatOptions options = ZhiPuAiChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
 		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public ZhiPuAiChatOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(ZhiPuAiChatOptions options) {
-		this.options = options;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingProperties.java
@@ -37,14 +37,12 @@ public class ZhiPuAiEmbeddingProperties extends ZhiPuAiParentProperties {
 	private MetadataMode metadataMode = MetadataMode.EMBED;
 
 	@NestedConfigurationProperty
-	private ZhiPuAiEmbeddingOptions options = ZhiPuAiEmbeddingOptions.builder().model(DEFAULT_EMBEDDING_MODEL).build();
+	private final ZhiPuAiEmbeddingOptions options = ZhiPuAiEmbeddingOptions.builder()
+		.model(DEFAULT_EMBEDDING_MODEL)
+		.build();
 
 	public ZhiPuAiEmbeddingOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(ZhiPuAiEmbeddingOptions options) {
-		this.options = options;
 	}
 
 	public MetadataMode getMetadataMode() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageProperties.java
@@ -34,14 +34,10 @@ public class ZhiPuAiImageProperties extends ZhiPuAiParentProperties {
 	 * Options for ZhiPuAI Image API.
 	 */
 	@NestedConfigurationProperty
-	private ZhiPuAiImageOptions options = ZhiPuAiImageOptions.builder().build();
+	private final ZhiPuAiImageOptions options = ZhiPuAiImageOptions.builder().build();
 
 	public ZhiPuAiImageOptions getOptions() {
 		return this.options;
-	}
-
-	public void setOptions(ZhiPuAiImageOptions options) {
-		this.options = options;
 	}
 
 }


### PR DESCRIPTION
- Make @NestedConfigurationProperty fields final to fix metadata generation
- Remove setters for nested configuration properties ensuring immutability
- Add missing @NestedConfigurationProperty annotations where needed

This fixes Spring Boot's configuration processor to properly generate metadata for nested properties, enabling better IDE auto-completion and contextual help in application.properties/yaml files for all Spring AI model configurations.