### PR TITLE
[Fixes #4436] Fix Typo in the OCI GenAI Cohere Chat Documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/oci-genai/cohere-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/oci-genai/cohere-chat.adoc
@@ -78,34 +78,34 @@ To disable, spring.ai.model.chat=none (or any value which doesn't match oci-gena
 This change is done to allow configuration of multiple models.
 ====
 
-The prefix `spring.ai.oci.genai.chat.cohere` is the property prefix that configures the `ChatModel` implementation for OCI GenAI Cohere Chat.
+The prefix `spring.ai.oci.genai.cohere.chat` is the property prefix that configures the `ChatModel` implementation for OCI GenAI Cohere Chat.
 
 [cols="3,5,1", stripes=even]
 |====
 | Property | Description | Default
 
 | spring.ai.model.chat | Enable OCI GenAI Cohere chat model.  | oci-genai
-| spring.ai.oci.genai.chat.cohere.enabled (no longer valid) | Enable OCI GenAI Cohere chat model.  | true
-| spring.ai.oci.genai.chat.cohere.options.model | Model OCID or endpoint | -
-| spring.ai.oci.genai.chat.cohere.options.compartment | Model compartment OCID.  | -
-| spring.ai.oci.genai.chat.cohere.options.servingMode | The model serving mode to be used. May be `on-demand`, or `dedicated`.  | on-demand
-| spring.ai.oci.genai.chat.cohere.options.preambleOverride | Override the chat model's prompt preamble | -
-| spring.ai.oci.genai.chat.cohere.options.temperature | Inference temperature | -
-| spring.ai.oci.genai.chat.cohere.options.topP | Top P parameter | -
-| spring.ai.oci.genai.chat.cohere.options.topK | Top K parameter | -
-| spring.ai.oci.genai.chat.cohere.options.frequencyPenalty | Higher values will reduce repeated tokens and outputs will be more random. | -
-| spring.ai.oci.genai.chat.cohere.options.presencePenalty | Higher values encourage generating outputs with tokens that haven't been used. | -
-| spring.ai.oci.genai.chat.cohere.options.stop | List of textual sequences that will end completions generation. | -
-| spring.ai.oci.genai.chat.cohere.options.documents | List of documents used in chat context. | -
+| spring.ai.oci.genai.cohere.chat.enabled (no longer valid) | Enable OCI GenAI Cohere chat model.  | true
+| spring.ai.oci.genai.cohere.chat.options.model | Model OCID or endpoint | -
+| spring.ai.oci.genai.cohere.chat.options.compartment | Model compartment OCID.  | -
+| spring.ai.oci.genai.cohere.chat.options.servingMode | The model serving mode to be used. May be `on-demand`, or `dedicated`.  | on-demand
+| spring.ai.oci.genai.cohere.chat.options.preambleOverride | Override the chat model's prompt preamble | -
+| spring.ai.oci.genai.cohere.chat.options.temperature | Inference temperature | -
+| spring.ai.oci.genai.cohere.chat.options.topP | Top P parameter | -
+| spring.ai.oci.genai.cohere.chat.options.topK | Top K parameter | -
+| spring.ai.oci.genai.cohere.chat.options.frequencyPenalty | Higher values will reduce repeated tokens and outputs will be more random. | -
+| spring.ai.oci.genai.cohere.chat.options.presencePenalty | Higher values encourage generating outputs with tokens that haven't been used. | -
+| spring.ai.oci.genai.cohere.chat.options.stop | List of textual sequences that will end completions generation. | -
+| spring.ai.oci.genai.cohere.chat.options.documents | List of documents used in chat context. | -
 |====
 
-TIP: All properties prefixed with `spring.ai.oci.genai.chat.cohere.options` can be overridden at runtime by adding a request specific <<chat-options>> to the `Prompt` call.
+TIP: All properties prefixed with `spring.ai.oci.genai.cohere.chat.options` can be overridden at runtime by adding a request specific <<chat-options>> to the `Prompt` call.
 
 == Runtime Options [[chat-options]]
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatOptions.java[OCICohereChatOptions.java] provides model configurations, such as the model to use, the temperature, the frequency penalty, etc.
 
-On start-up, the default options can be configured with the `OCICohereChatModel(api, options)` constructor or the `spring.ai.oci.genai.chat.cohere.options.*` properties.
+On start-up, the default options can be configured with the `OCICohereChatModel(api, options)` constructor or the `spring.ai.oci.genai.cohere.chat.options.*` properties.
 
 At run-time you can override the default options by adding new, request specific, options to the `Prompt` call.
 For example to override the default model and temperature for a specific request:


### PR DESCRIPTION
The OCI Cohere Chat documentation currently lists the property prefix as `spring.ai.oci.genai.chat.cohere`. However, the `OCICohereChatModelProperties`
class expects `spring.ai.oci.genai.cohere.chat` instead.

This PR corrects the documentation so that the prefix matches the code.

References:
- Documentation showing incorrect prefix: [https://docs.spring.io/spring-ai/reference/api/chat/oci-genai/cohere-chat.html](https://docs.spring.io/spring-ai/reference/api/chat/oci-genai/cohere-chat.html)
- Javadoc showing correct prefix: [https://github.com/spring-projects/spring-ai/blob/main/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java#L31](https://github.com/spring-projects/spring-ai/blob/main/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java#L31)

Signed-off-by: Albert Attard <albertattard@gmail.com>