### PR TITLE
GH-4452 Added Builder pattern support for `DeepSeekAssistantMessage`

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekAssistantMessage.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekAssistantMessage.java
@@ -119,35 +119,35 @@ public class DeepSeekAssistantMessage extends AssistantMessage {
 				+ this.prefix + ", metadata=" + this.metadata + "]";
 	}
 
-	public static Builder builder() {
-		return new Builder();
-	}
+	public static final class Builder {
 
-	public static final class Builder extends AssistantMessage.Builder {
+		private String content;
+
+		private Map<String, Object> properties = Map.of();
+
+		private List<ToolCall> toolCalls = List.of();
+
+		private List<Media> media = List.of();
 
 		private Boolean prefix;
 
 		private String reasoningContent;
 
-		@Override
 		public Builder content(String content) {
 			this.content = content;
 			return this;
 		}
 
-		@Override
 		public Builder properties(Map<String, Object> properties) {
 			this.properties = properties;
 			return this;
 		}
 
-		@Override
 		public Builder toolCalls(List<ToolCall> toolCalls) {
 			this.toolCalls = toolCalls;
 			return this;
 		}
 
-		@Override
 		public Builder media(List<Media> media) {
 			this.media = media;
 			return this;

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -340,8 +340,8 @@ public class DeepSeekChatModel implements ChatModel {
 		String textContent = choice.message().content();
 		String reasoningContent = choice.message().reasoningContent();
 
-		DeepSeekAssistantMessage assistantMessage = DeepSeekAssistantMessage.builder()
-			.content(textContent)
+		DeepSeekAssistantMessage.Builder builder = new DeepSeekAssistantMessage.Builder();
+		DeepSeekAssistantMessage assistantMessage = builder.content(textContent)
 			.reasoningContent(reasoningContent)
 			.properties(metadata)
 			.toolCalls(toolCalls)

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekAssistantMessageTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekAssistantMessageTests.java
@@ -170,8 +170,8 @@ class DeepSeekAssistantMessageTests {
 		List<ToolCall> toolCalls = List.of(new ToolCall("1", "function", "testFunction", "{}"));
 		List<Media> media = List.of();
 
-		DeepSeekAssistantMessage message = DeepSeekAssistantMessage.builder()
-			.content("content")
+		DeepSeekAssistantMessage.Builder builder = new DeepSeekAssistantMessage.Builder();
+		DeepSeekAssistantMessage message = builder.content("content")
 			.reasoningContent("reasoning")
 			.prefix(true)
 			.properties(properties)

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
@@ -121,17 +121,17 @@ public class AssistantMessage extends AbstractMessage implements MediaContent {
 
 	}
 
-	public static class Builder {
+	public static final class Builder {
 
-		protected String content;
+		private String content;
 
-		protected Map<String, Object> properties = Map.of();
+		private Map<String, Object> properties = Map.of();
 
-		protected List<ToolCall> toolCalls = List.of();
+		private List<ToolCall> toolCalls = List.of();
 
-		protected List<Media> media = List.of();
+		private List<Media> media = List.of();
 
-		protected Builder() {
+		private Builder() {
 		}
 
 		public Builder content(String content) {


### PR DESCRIPTION
As mentioned in the issue, `DeepSeekAssistantMessage` also requires comprehensive Builder pattern support. 

This PR follows the approach proposed in #3529 and includes the following changes:  
1. Adjusted the visibility of some fields and methods in the `AssistantMessage` Builder to support inheritance in the `DeepSeekAssistantMessage` Builder.  
2. Added a Builder for `DeepSeekAssistantMessage`.  
3. Added relevant unit tests.
4. Fixed the bug in the `toString` method

Fixes #4452