### PR TITLE
GH-4454 Added Builder pattern support for `ZhiPuAiAssistantMessage`

### DIFF
--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
@@ -25,6 +25,7 @@ import org.springframework.ai.content.Media;
 
 /**
  * @author YunKui Lu
+ * @author Sun Yuhan
  */
 public class ZhiPuAiAssistantMessage extends AssistantMessage {
 
@@ -76,6 +77,50 @@ public class ZhiPuAiAssistantMessage extends AssistantMessage {
 		return "ZhiPuAiAssistantMessage{" + "media=" + this.media + ", messageType=" + this.messageType + ", metadata="
 				+ this.metadata + ", reasoningContent='" + this.reasoningContent + '\'' + ", textContent='"
 				+ this.textContent + '\'' + '}';
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder extends AssistantMessage.Builder {
+
+		private String reasoningContent;
+
+		@Override
+		public Builder content(String content) {
+			this.content = content;
+			return this;
+		}
+
+		@Override
+		public Builder properties(Map<String, Object> properties) {
+			this.properties = properties;
+			return this;
+		}
+
+		@Override
+		public Builder toolCalls(List<ToolCall> toolCalls) {
+			this.toolCalls = toolCalls;
+			return this;
+		}
+
+		@Override
+		public Builder media(List<Media> media) {
+			this.media = media;
+			return this;
+		}
+
+		public Builder reasoningContent(String reasoningContent) {
+			this.reasoningContent = reasoningContent;
+			return this;
+		}
+
+		public ZhiPuAiAssistantMessage build() {
+			return new ZhiPuAiAssistantMessage(this.content, this.reasoningContent, this.properties, this.toolCalls,
+					this.media);
+		}
+
 	}
 
 }

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
@@ -79,33 +79,33 @@ public class ZhiPuAiAssistantMessage extends AssistantMessage {
 				+ this.textContent + '\'' + '}';
 	}
 
-	public static Builder builder() {
-		return new Builder();
-	}
+	public static final class Builder {
 
-	public static final class Builder extends AssistantMessage.Builder {
+		private String content;
+
+		private Map<String, Object> properties = Map.of();
+
+		private List<ToolCall> toolCalls = List.of();
+
+		private List<Media> media = List.of();
 
 		private String reasoningContent;
 
-		@Override
 		public Builder content(String content) {
 			this.content = content;
 			return this;
 		}
 
-		@Override
 		public Builder properties(Map<String, Object> properties) {
 			this.properties = properties;
 			return this;
 		}
 
-		@Override
 		public Builder toolCalls(List<ToolCall> toolCalls) {
 			this.toolCalls = toolCalls;
 			return this;
 		}
 
-		@Override
 		public Builder media(List<Media> media) {
 			this.media = media;
 			return this;

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -230,8 +230,8 @@ public class ZhiPuAiChatModel implements ChatModel {
 		String textContent = choice.message().content();
 		String reasoningContent = choice.message().reasoningContent();
 
-		var assistantMessage = ZhiPuAiAssistantMessage.builder()
-			.content(textContent)
+		ZhiPuAiAssistantMessage.Builder builder = new ZhiPuAiAssistantMessage.Builder();
+		var assistantMessage = builder.content(textContent)
 			.reasoningContent(reasoningContent)
 			.properties(metadata)
 			.toolCalls(toolCalls)

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -230,8 +230,14 @@ public class ZhiPuAiChatModel implements ChatModel {
 		String textContent = choice.message().content();
 		String reasoningContent = choice.message().reasoningContent();
 
-		var assistantMessage = new ZhiPuAiAssistantMessage(textContent, reasoningContent, metadata, toolCalls,
-				List.of());
+		var assistantMessage = ZhiPuAiAssistantMessage.builder()
+			.content(textContent)
+			.reasoningContent(reasoningContent)
+			.properties(metadata)
+			.toolCalls(toolCalls)
+			.media(List.of())
+			.build();
+
 		String finishReason = (choice.finishReason() != null ? choice.finishReason().name() : "");
 		var generationMetadata = ChatGenerationMetadata.builder().finishReason(finishReason).build();
 		return new Generation(assistantMessage, generationMetadata);

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessageTests.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessageTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.zhipuai;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
+import org.springframework.ai.content.Media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Tests for {@link ZhiPuAiAssistantMessage}.
+ *
+ * @author Sun Yuhan
+ */
+class ZhiPuAiAssistantMessageTests {
+
+	@Test
+	public void testConstructorWithContentOnly() {
+		String content = "Hello, world!";
+		ZhiPuAiAssistantMessage message = new ZhiPuAiAssistantMessage(content);
+
+		assertThat(message.getText()).isEqualTo(content);
+		assertThat(message.getReasoningContent()).isNull();
+	}
+
+	@Test
+	public void testConstructorWithAllParameters() {
+		String content = "Hello, world!";
+		String reasoningContent = "This is my reasoning";
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("key1", "value1");
+		List<ToolCall> toolCalls = List.of(new ToolCall("1", "function", "myFunction", "{}"));
+		List<Media> media = List.of();
+
+		ZhiPuAiAssistantMessage message = new ZhiPuAiAssistantMessage(content, reasoningContent, properties, toolCalls,
+				media);
+
+		assertThat(message.getText()).isEqualTo(content);
+		assertThat(message.getReasoningContent()).isEqualTo(reasoningContent);
+		assertThat(message.getMetadata()).containsAllEntriesOf(properties);
+		assertThat(message.getToolCalls()).isEqualTo(toolCalls);
+	}
+
+	@Test
+	public void testSettersAndGetters() {
+		ZhiPuAiAssistantMessage message = new ZhiPuAiAssistantMessage("test");
+
+		String reasoningContent = "New reasoning content";
+
+		message.setReasoningContent(reasoningContent);
+
+		assertThat(message.getReasoningContent()).isEqualTo(reasoningContent);
+	}
+
+	@Test
+	public void testEqualsAndHashCode() {
+		String content = "Hello, world!";
+		String reasoningContent = "This is my reasoning";
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("key1", "value1");
+		List<ToolCall> toolCalls = List.of(new ToolCall("1", "function", "myFunction", "{}"));
+		List<Media> media = List.of();
+
+		ZhiPuAiAssistantMessage message1 = new ZhiPuAiAssistantMessage(content, reasoningContent, properties, toolCalls,
+				media);
+		ZhiPuAiAssistantMessage message2 = new ZhiPuAiAssistantMessage(content, reasoningContent, properties, toolCalls,
+				media);
+
+		assertThat(message1).isEqualTo(message2);
+		assertThat(message1.hashCode()).isEqualTo(message2.hashCode());
+
+		ZhiPuAiAssistantMessage message3 = new ZhiPuAiAssistantMessage(content, "different reasoning", properties,
+				toolCalls, media);
+		assertThat(message1).isNotEqualTo(message3);
+	}
+
+	@Test
+	public void testToString() {
+		String content = "Hello, world!";
+		String reasoningContent = "This is my reasoning";
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("key1", "value1");
+		List<ToolCall> toolCalls = List.of(new ToolCall("1", "function", "myFunction", "{}"));
+		List<Media> media = List.of();
+
+		ZhiPuAiAssistantMessage message = new ZhiPuAiAssistantMessage(content, reasoningContent, properties, toolCalls,
+				media);
+
+		assertThatNoException().isThrownBy(message::toString);
+		assertThat(message.toString()).contains(content, reasoningContent);
+	}
+
+	@Test
+	public void testBuilderComplete() {
+		Map<String, Object> properties = Map.of("key", "value");
+		List<ToolCall> toolCalls = List.of(new ToolCall("1", "function", "testFunction", "{}"));
+		List<Media> media = List.of();
+
+		ZhiPuAiAssistantMessage message = ZhiPuAiAssistantMessage.builder()
+			.content("content")
+			.reasoningContent("reasoning")
+			.properties(properties)
+			.toolCalls(toolCalls)
+			.media(media)
+			.build();
+
+		assertThat(message.getText()).isEqualTo("content");
+		assertThat(message.getReasoningContent()).isEqualTo("reasoning");
+		assertThat(message.getMetadata()).containsAllEntriesOf(properties);
+		assertThat(message.getToolCalls()).isEqualTo(toolCalls);
+		assertThat(message.getMedia()).isEqualTo(media);
+	}
+
+}

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessageTests.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessageTests.java
@@ -117,8 +117,8 @@ class ZhiPuAiAssistantMessageTests {
 		List<ToolCall> toolCalls = List.of(new ToolCall("1", "function", "testFunction", "{}"));
 		List<Media> media = List.of();
 
-		ZhiPuAiAssistantMessage message = ZhiPuAiAssistantMessage.builder()
-			.content("content")
+		ZhiPuAiAssistantMessage.Builder builder = new ZhiPuAiAssistantMessage.Builder();
+		ZhiPuAiAssistantMessage message = builder.content("content")
 			.reasoningContent("reasoning")
 			.properties(properties)
 			.toolCalls(toolCalls)

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
@@ -121,17 +121,17 @@ public class AssistantMessage extends AbstractMessage implements MediaContent {
 
 	}
 
-	public static final class Builder {
+	public static class Builder {
 
-		private String content;
+		protected String content;
 
-		private Map<String, Object> properties = Map.of();
+		protected Map<String, Object> properties = Map.of();
 
-		private List<ToolCall> toolCalls = List.of();
+		protected List<ToolCall> toolCalls = List.of();
 
-		private List<Media> media = List.of();
+		protected List<Media> media = List.of();
 
-		private Builder() {
+		protected Builder() {
 		}
 
 		public Builder content(String content) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AssistantMessage.java
@@ -121,17 +121,17 @@ public class AssistantMessage extends AbstractMessage implements MediaContent {
 
 	}
 
-	public static class Builder {
+	public static final class Builder {
 
-		protected String content;
+		private String content;
 
-		protected Map<String, Object> properties = Map.of();
+		private Map<String, Object> properties = Map.of();
 
-		protected List<ToolCall> toolCalls = List.of();
+		private List<ToolCall> toolCalls = List.of();
 
-		protected List<Media> media = List.of();
+		private List<Media> media = List.of();
 
-		protected Builder() {
+		private Builder() {
 		}
 
 		public Builder content(String content) {


### PR DESCRIPTION
As mentioned in the issue, `ZhiPuAiAssistantMessage` also requires comprehensive Builder pattern support. 

This PR follows the approach proposed in #3529 and includes the following changes:  
1. Adjusted the visibility of some fields and methods in the `AssistantMessage` Builder to support inheritance in the `ZhiPuAiAssistantMessage` Builder.  
2. Added a Builder for `ZhiPuAiAssistantMessage`.  
3. Added relevant unit tests.

Fixes #4454