### PR TITLE
GH-4433 Add a method to `ChatMemory` for retrieving all conversation IDs

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/ChatMemory.java
@@ -26,6 +26,7 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public interface ChatMemory {
@@ -60,5 +61,11 @@ public interface ChatMemory {
 	 * Clear the chat memory for the specified conversation.
 	 */
 	void clear(String conversationId);
+
+	/**
+	 * Get all conversation IDs
+	 * @return All conversation IDs
+	 */
+	List<String> getConversations();
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  *
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Sun Yuhan
  * @since 1.0.0
  */
 public final class MessageWindowChatMemory implements ChatMemory {
@@ -75,6 +76,11 @@ public final class MessageWindowChatMemory implements ChatMemory {
 	public void clear(String conversationId) {
 		Assert.hasText(conversationId, "conversationId cannot be null or empty");
 		this.chatMemoryRepository.deleteByConversationId(conversationId);
+	}
+
+	@Override
+	public List<String> getConversations() {
+		return this.chatMemoryRepository.findConversationIds();
 	}
 
 	private List<Message> process(List<Message> memoryMessages, List<Message> newMessages) {

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
@@ -292,4 +292,50 @@ public class MessageWindowChatMemoryTests {
 				new SystemMessage("System instruction 2"));
 	}
 
+	@Test
+	void getConversationsReturnsAllConversationIds() {
+		MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder().build();
+
+		String conversationId1 = UUID.randomUUID().toString();
+		String conversationId2 = UUID.randomUUID().toString();
+		String conversationId3 = UUID.randomUUID().toString();
+
+		chatMemory.add(conversationId1, new UserMessage("Hello from conversation 1"));
+		chatMemory.add(conversationId2, new UserMessage("Hello from conversation 2"));
+		chatMemory.add(conversationId3, new UserMessage("Hello from conversation 3"));
+
+		List<String> conversations = chatMemory.getConversations();
+
+		assertThat(conversations).contains(conversationId1, conversationId2, conversationId3);
+		assertThat(conversations).hasSize(3);
+	}
+
+	@Test
+	void getConversationsWithCustomRepository() {
+		InMemoryChatMemoryRepository customRepository = new InMemoryChatMemoryRepository();
+		MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder()
+			.chatMemoryRepository(customRepository)
+			.build();
+
+		String conversationId1 = UUID.randomUUID().toString();
+		String conversationId2 = UUID.randomUUID().toString();
+
+		chatMemory.add(conversationId1, new UserMessage("Message in conversation 1"));
+		chatMemory.add(conversationId2, new UserMessage("Message in conversation 2"));
+
+		List<String> conversations = chatMemory.getConversations();
+
+		assertThat(conversations).contains(conversationId1, conversationId2);
+		assertThat(conversations).hasSize(2);
+	}
+
+	@Test
+	void getConversationsReturnsEmptyListWhenNoConversations() {
+		MessageWindowChatMemory chatMemory = MessageWindowChatMemory.builder().build();
+
+		List<String> conversations = chatMemory.getConversations();
+
+		assertThat(conversations).isEmpty();
+	}
+
 }


### PR DESCRIPTION
As mentioned in the issue, retrieving all conversation IDs via `ChatMemory` should be a very common use case, especially when building applications such as chatbots. Since we already have solid support for this at the `ChatMemoryRepository` level, we should also add such a method to `ChatMemory`. 

This PR does the following:  
1. Adds a `getConversations()` method to `ChatMemory` to retrieve all conversation IDs.  
2. Adds corresponding unit tests.

Fixes #4433