### PR TITLE
fix: Fixed the example code error in multimodality doc

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/multimodality.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/multimodality.adoc
@@ -41,9 +41,10 @@ For most of the multimodal LLMs, the Spring AI code would look something like th
 ----
 var imageResource = new ClassPathResource("/multimodal.test.png");
 
-var userMessage = new UserMessage(
-	"Explain what do you see in this picture?", // content
-	new Media(MimeTypeUtils.IMAGE_PNG, this.imageResource)); // media
+var userMessage = UserMessage.builder()
+    .text("Explain what do you see in this picture?") // content
+    .media(new Media(MimeTypeUtils.IMAGE_PNG, this.imageResource)) // media
+    .build();
 
 ChatResponse response = chatModel.call(new Prompt(this.userMessage));
 ----


### PR DESCRIPTION
In the following section of the `Multimodality API` documentation, the constructor method for `UserMessage` used in the example code no longer exists: 

https://github.com/spring-projects/spring-ai/blob/f9071963c34dbdf836c9aeb2dfc7912281b6b083/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/multimodality.adoc?plain=1#L38-L50

The current PR modifies it to use the `Builder` pattern for construction.