### PR TITLE
Fixed the error in the example code for `CassandraChatMemoryRepository` in the documentation.

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -222,7 +222,7 @@ If you'd rather create the `CassandraChatMemoryRepository` manually, you can do 
 [source,java]
 ----
 ChatMemoryRepository chatMemoryRepository = CassandraChatMemoryRepository
-    .create(CassandraChatMemoryConfig.builder().withCqlSession(cqlSession));
+    .create(CassandraChatMemoryRepositoryConfig.builder().withCqlSession(cqlSession));
 
 ChatMemory chatMemory = MessageWindowChatMemory.builder()
     .chatMemoryRepository(chatMemoryRepository)


### PR DESCRIPTION
`CassandraChatMemoryConfig` has been renamed to `CassandraChatMemoryRepositoryConfig` in the code. This PR updates the example content to keep it synchronized with the code.