### PR TITLE
feat: Add MCP resource template support to server auto-configurations

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
@@ -31,10 +31,12 @@ import io.modelcontextprotocol.server.McpServer.SyncSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
@@ -111,6 +113,7 @@ public class McpServerAutoConfiguration {
 			McpServerChangeNotificationProperties changeNotificationProperties,
 			ObjectProvider<List<SyncToolSpecification>> tools,
 			ObjectProvider<List<SyncResourceSpecification>> resources,
+			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
@@ -154,6 +157,21 @@ public class McpServerAutoConfiguration {
 			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
 				serverBuilder.resources(resourceSpecifications);
 				logger.info("Registered resources: " + resourceSpecifications.size());
+			}
+		}
+
+		// Resources Templates
+		if (serverProperties.getCapabilities().isResource()) {
+			logger.info("Enable resources templates capabilities, notification: "
+					+ changeNotificationProperties.isResourceChangeNotification());
+			capabilitiesBuilder.resources(false, changeNotificationProperties.isResourceChangeNotification());
+
+			List<SyncResourceTemplateSpecification> resourceTemplateSpecifications = resourceTemplates.stream()
+				.flatMap(List::stream)
+				.toList();
+			if (!CollectionUtils.isEmpty(resourceTemplateSpecifications)) {
+				serverBuilder.resourceTemplates(resourceTemplateSpecifications);
+				logger.info("Registered resource templates: " + resourceTemplateSpecifications.size());
 			}
 		}
 
@@ -210,6 +228,7 @@ public class McpServerAutoConfiguration {
 			McpServerChangeNotificationProperties changeNotificationProperties,
 			ObjectProvider<List<AsyncToolSpecification>> tools,
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
+			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
 			ObjectProvider<List<AsyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpAsyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumer) {
@@ -252,6 +271,21 @@ public class McpServerAutoConfiguration {
 			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
 				serverBuilder.resources(resourceSpecifications);
 				logger.info("Registered resources: " + resourceSpecifications.size());
+			}
+		}
+
+		// Resources Templates
+		if (serverProperties.getCapabilities().isResource()) {
+			logger.info("Enable resources templates capabilities, notification: "
+					+ changeNotificationProperties.isResourceChangeNotification());
+			capabilitiesBuilder.resources(false, changeNotificationProperties.isResourceChangeNotification());
+
+			List<AsyncResourceTemplateSpecification> resourceTemplateSpecifications = resourceTemplates.stream()
+				.flatMap(List::stream)
+				.toList();
+			if (!CollectionUtils.isEmpty(resourceTemplateSpecifications)) {
+				serverBuilder.resourceTemplates(resourceTemplateSpecifications);
+				logger.info("Registered resources templates: " + resourceTemplateSpecifications.size());
 			}
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -26,10 +26,12 @@ import io.modelcontextprotocol.server.McpStatelessAsyncServer;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -80,6 +82,7 @@ public class McpServerStatelessAutoConfiguration {
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
 			ObjectProvider<List<SyncToolSpecification>> tools,
 			ObjectProvider<List<SyncResourceSpecification>> resources,
+			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment) {
 
@@ -110,6 +113,19 @@ public class McpServerStatelessAutoConfiguration {
 			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
 				serverBuilder.resources(resourceSpecifications);
 				logger.info("Registered resources: " + resourceSpecifications.size());
+			}
+		}
+
+		// Resources Templates
+		if (serverProperties.getCapabilities().isResource()) {
+			capabilitiesBuilder.resources(false, false);
+
+			List<SyncResourceTemplateSpecification> resourceSpecifications = resourceTemplates.stream()
+				.flatMap(List::stream)
+				.toList();
+			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
+				serverBuilder.resourceTemplates(resourceSpecifications);
+				logger.info("Registered resource templates: " + resourceSpecifications.size());
 			}
 		}
 
@@ -156,6 +172,7 @@ public class McpServerStatelessAutoConfiguration {
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
 			ObjectProvider<List<AsyncToolSpecification>> tools,
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
+			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
 			ObjectProvider<List<AsyncCompletionSpecification>> completions) {
 
@@ -186,6 +203,19 @@ public class McpServerStatelessAutoConfiguration {
 			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
 				serverBuilder.resources(resourceSpecifications);
 				logger.info("Registered resources: " + resourceSpecifications.size());
+			}
+		}
+
+		// Resources Templates
+		if (serverProperties.getCapabilities().isResource()) {
+			capabilitiesBuilder.resources(false, false);
+
+			List<AsyncResourceTemplateSpecification> resourceSpecifications = resourceTemplates.stream()
+				.flatMap(List::stream)
+				.toList();
+			if (!CollectionUtils.isEmpty(resourceSpecifications)) {
+				serverBuilder.resourceTemplates(resourceSpecifications);
+				logger.info("Registered resource templates: " + resourceSpecifications.size());
 			}
 		}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
@@ -61,6 +61,15 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 		}
 
 		@Bean
+		public List<McpServerFeatures.SyncResourceTemplateSpecification> resourceTemplateSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+
+			List<McpServerFeatures.SyncResourceTemplateSpecification> syncResourceSpecifications = SyncMcpAnnotationProviders
+				.resourceTemplateSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+			return syncResourceSpecifications;
+		}
+
+		@Bean
 		public List<McpServerFeatures.SyncPromptSpecification> promptSpecs(
 				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
 			return SyncMcpAnnotationProviders
@@ -94,6 +103,14 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
 			return AsyncMcpAnnotationProviders
 				.resourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+		}
+
+		@Bean
+		public List<McpServerFeatures.AsyncResourceTemplateSpecification> resourceTemplateSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+
+			return AsyncMcpAnnotationProviders
+				.resourceTemplateSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
 		}
 
 		@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -61,6 +61,13 @@ public class StatelessServerSpecificationFactoryAutoConfiguration {
 		}
 
 		@Bean
+		public List<McpStatelessServerFeatures.SyncResourceTemplateSpecification> resourceTemplateSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return SyncMcpAnnotationProviders.statelessResourceTemplateSpecifications(
+					beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+		}
+
+		@Bean
 		public List<McpStatelessServerFeatures.SyncPromptSpecification> promptSpecs(
 				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
 			return SyncMcpAnnotationProviders
@@ -94,6 +101,13 @@ public class StatelessServerSpecificationFactoryAutoConfiguration {
 				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
 			return AsyncMcpAnnotationProviders
 				.statelessResourceSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
+		}
+
+		@Bean
+		public List<McpStatelessServerFeatures.AsyncResourceTemplateSpecification> resourceTemplateSpecs(
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+			return AsyncMcpAnnotationProviders.statelessResourceTemplateSpecifications(
+					beansWithMcpMethodAnnotations.getBeansByAnnotation(McpResource.class));
 		}
 
 		@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
@@ -31,6 +31,7 @@ import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
@@ -379,7 +380,12 @@ public class McpServerAutoConfigurationIT {
 				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "resources");
 				assertThat(resources).hasSize(1);
-				assertThat(resources.get("config://{key}")).isNotNull();
+				assertThat(resources.get("simple://static")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncResourceTemplateSpecification> resourceTemplatess = (ConcurrentHashMap<String, AsyncResourceTemplateSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resourceTemplates");
+				assertThat(resourceTemplatess).hasSize(1);
+				assertThat(resourceTemplatess.get("config://{key}")).isNotNull();
 
 				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "prompts");
@@ -412,7 +418,12 @@ public class McpServerAutoConfigurationIT {
 				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "resources");
 				assertThat(resources).hasSize(1);
-				assertThat(resources.get("config://{key}")).isNotNull();
+				assertThat(resources.get("simple://static")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncResourceTemplateSpecification> resourceTemplatess = (ConcurrentHashMap<String, AsyncResourceTemplateSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resourceTemplates");
+				assertThat(resourceTemplatess).hasSize(1);
+				assertThat(resourceTemplatess.get("config://{key}")).isNotNull();
 
 				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "prompts");
@@ -608,6 +619,11 @@ public class McpServerAutoConfigurationIT {
 			return a + b;
 		}
 
+		@McpResource(uri = "simple://static", name = "Configuration", description = "Provides configuration data")
+		public String getSimple() {
+			return "Hi there!";
+		}
+
 		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")
 		public String getConfig(String key) {
 			return "config value";
@@ -642,6 +658,11 @@ public class McpServerAutoConfigurationIT {
 		public Mono<Integer> add(@McpToolParam(description = "First number", required = true) int a,
 				@McpToolParam(description = "Second number", required = true) int b) {
 			return Mono.just(a + b);
+		}
+
+		@McpResource(uri = "simple://static", name = "Configuration", description = "Provides configuration data")
+		public Mono<String> getSimple() {
+			return Mono.just("Hi there!");
 		}
 
 		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -30,6 +30,7 @@ import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncPromptSpecification;
@@ -330,7 +331,12 @@ public class McpStatelessServerAutoConfigurationIT {
 				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "resources");
 				assertThat(resources).hasSize(1);
-				assertThat(resources.get("config://{key}")).isNotNull();
+				assertThat(resources.get("simple://static")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncResourceTemplateSpecification> resourceTemplates = (ConcurrentHashMap<String, AsyncResourceTemplateSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resourceTemplates");
+				assertThat(resourceTemplates).hasSize(1);
+				assertThat(resourceTemplates.get("config://{key}")).isNotNull();
 
 				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "prompts");
@@ -363,7 +369,12 @@ public class McpStatelessServerAutoConfigurationIT {
 				ConcurrentHashMap<String, AsyncResourceSpecification> resources = (ConcurrentHashMap<String, AsyncResourceSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "resources");
 				assertThat(resources).hasSize(1);
-				assertThat(resources.get("config://{key}")).isNotNull();
+				assertThat(resources.get("simple://static")).isNotNull();
+
+				ConcurrentHashMap<String, AsyncResourceTemplateSpecification> resourceTemplates = (ConcurrentHashMap<String, AsyncResourceTemplateSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "resourceTemplates");
+				assertThat(resourceTemplates).hasSize(1);
+				assertThat(resourceTemplates.get("config://{key}")).isNotNull();
 
 				ConcurrentHashMap<String, AsyncPromptSpecification> prompts = (ConcurrentHashMap<String, AsyncPromptSpecification>) ReflectionTestUtils
 					.getField(asyncServer, "prompts");
@@ -530,6 +541,11 @@ public class McpStatelessServerAutoConfigurationIT {
 			return a + b;
 		}
 
+		@McpResource(uri = "simple://static", name = "Configuration", description = "Provides configuration data")
+		public String getSimple() {
+			return "Hi there!";
+		}
+
 		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")
 		public String getConfig(String key) {
 			return "config value";
@@ -564,6 +580,11 @@ public class McpStatelessServerAutoConfigurationIT {
 		public Mono<Integer> add(@McpToolParam(description = "First number", required = true) int a,
 				@McpToolParam(description = "Second number", required = true) int b) {
 			return Mono.just(a + b);
+		}
+
+		@McpResource(uri = "simple://static", name = "Configuration", description = "Provides configuration data")
+		public Mono<String> getSimple() {
+			return Mono.just("Hi there!");
 		}
 
 		@McpResource(uri = "config://{key}", name = "Configuration", description = "Provides configuration data")

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
@@ -22,6 +22,7 @@ import java.util.List;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
@@ -117,6 +118,17 @@ public final class AsyncMcpAnnotationProviders {
 	public static List<McpStatelessServerFeatures.AsyncResourceSpecification> statelessResourceSpecifications(
 			List<Object> resourceObjects) {
 		return new SpringAiAsyncStatelessResourceProvider(resourceObjects).getResourceSpecifications();
+	}
+
+	// RESOURCE TEMPLATE
+	public static List<AsyncResourceTemplateSpecification> resourceTemplateSpecifications(
+			List<Object> resourceObjects) {
+		return new SpringAiAsyncResourceProvider(resourceObjects).getResourceTemplateSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.AsyncResourceTemplateSpecification> statelessResourceTemplateSpecifications(
+			List<Object> resourceObjects) {
+		return new SpringAiAsyncStatelessResourceProvider(resourceObjects).getResourceTemplateSpecifications();
 	}
 
 	// RESOURCE LIST CHANGED

--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
@@ -22,6 +22,7 @@ import java.util.List;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
@@ -97,6 +98,16 @@ public final class SyncMcpAnnotationProviders {
 	public static List<McpStatelessServerFeatures.SyncResourceSpecification> statelessResourceSpecifications(
 			List<Object> resourceObjects) {
 		return new SpringAiSyncStatelessResourceProvider(resourceObjects).getResourceSpecifications();
+	}
+
+	// RESOURCE TEMPLATE
+	public static List<SyncResourceTemplateSpecification> resourceTemplateSpecifications(List<Object> resourceObjects) {
+		return new SpringAiSyncMcpResourceProvider(resourceObjects).getResourceTemplateSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.SyncResourceTemplateSpecification> statelessResourceTemplateSpecifications(
+			List<Object> resourceObjects) {
+		return new SpringAiSyncStatelessResourceProvider(resourceObjects).getResourceTemplateSpecifications();
 	}
 
 	// LOGGING (CLIENT)

--- a/pom.xml
+++ b/pom.xml
@@ -330,8 +330,8 @@
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.13.1</mcp.sdk.version>
-		<mcp-annotations.version>0.4.1</mcp-annotations.version>
+		<mcp.sdk.version>0.14.0-SNAPSHOT</mcp.sdk.version>
+		<mcp-annotations.version>0.5.0-SNAPSHOT</mcp-annotations.version>
 
 		<!-- plugin versions -->
 		<antlr.version>4.13.1</antlr.version>


### PR DESCRIPTION
- Add ResourceTemplateSpecification support for both sync and async servers
- Include resource template handling in stateful and stateless configurations
- Add resource template bean definitions and provider methods
- Update tests to verify resource template registration and functionality
- Upgrade MCP SDK to 0.14.0-SNAPSHOT and mcp-annotations to 0.5.0-SNAPSHOT

Depends on: https://github.com/modelcontextprotocol/java-sdk/pull/576 and https://github.com/spring-ai-community/mcp-annotations/pull/62