### PR TITLE
GH-4496 Fixed PromptTemplate Validation fails on valid StTemplate Templates

### DIFF
--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.prompt;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -306,6 +307,53 @@ class PromptTemplateTests {
 		assertThat(promptTemplate.render()).isEqualTo("Hello Builder from Resource!");
 	}
 
+	@Test
+	void renderWithSimpleValueType() {
+		String content = "Spring AI";
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("content", content);
+		variables.put("val", 5);
+		variables.put("d", 12.30d);
+		variables.put("l", 2025L);
+		variables.put("n", BigDecimal.ONE);
+
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template("Hello {content}, int:{val},double:{d},long:{l},n:{n}")
+			.variables(variables)
+			.build();
+
+		assertThat(promptTemplate.render()).isEqualTo("Hello Spring AI, int:5,double:12.3,long:2025,n:1");
+	}
+
+	@Test
+	void renderWithMap() {
+		String name = "Spring AI";
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("key", Map.of("name", name));
+
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template("Hello {key.name}!")
+			.variables(variables)
+			.build();
+
+		assertThat(promptTemplate.render()).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void renderWithBean() {
+		String name = "Spring AI";
+		BeanName bn = new BeanName(name);
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("key", bn);
+
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template("Hello {key.name}!")
+			.variables(variables)
+			.build();
+
+		assertThat(promptTemplate.render()).isEqualTo("Hello Spring AI!");
+	}
+
 	// Helper Custom Renderer for testing
 	private static class CustomTestRenderer implements TemplateRenderer {
 
@@ -314,6 +362,25 @@ class PromptTemplateTests {
 			// Simple renderer that just appends a marker
 			// Note: This simple renderer ignores the model map for test purposes.
 			return template + " (Rendered by Custom)";
+		}
+
+	}
+
+	/**
+	 * helper test bean name
+	 *
+	 * @author lance
+	 */
+	private static class BeanName {
+
+		private final String name;
+
+		BeanName(String name) {
+			this.name = name;
+		}
+
+		String getName() {
+			return this.name;
 		}
 
 	}

--- a/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
+++ b/spring-ai-template-st/src/main/java/org/springframework/ai/template/st/StTemplateRenderer.java
@@ -172,9 +172,11 @@ public class StTemplateRenderer implements TemplateRenderer {
 				// Only add as variable if:
 				// - Not a function call
 				// - Not a built-in function used as property (unless validateStFunctions)
-				if (!isFunctionCall && (!Compiler.funcs.containsKey(token.getText()) || this.validateStFunctions
-						|| !(isDotProperty && Compiler.funcs.containsKey(token.getText())))) {
-					inputVariables.add(token.getText());
+				if (!isFunctionCall && !isDotProperty) {
+					String name = token.getText();
+					if (!Compiler.funcs.containsKey(name) || this.validateStFunctions) {
+						inputVariables.add(name);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Updated the extraction condition to:

- Exclude identifiers immediately following a dot (i.e., only capture the top-level variable).
- Preserve existing behavior for function calls and built-in functions.


Related to https://github.com/spring-projects/spring-ai/issues/4496 -- PromptTemplate Validation fails on valid StTemplate Templates 

