### PR TITLE
Add User-Agent header with 'spring-ai' value to OpenAI API client

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -132,6 +132,7 @@ public class OpenAiApi {
 		// @formatter:off
 		Consumer<HttpHeaders> finalHeaders = h -> {
 			h.setContentType(MediaType.APPLICATION_JSON);
+			h.set("User-Agent", "spring-ai");
 			h.addAll(headers);
 		};
 		this.restClient = restClientBuilder.clone()


### PR DESCRIPTION
This change adds the User-Agent header with value 'spring-ai' to the OpenAI API client implementation, bringing it in line with the Azure OpenAI implementation for consistent API monitoring and identification.

## Changes Made
- Added User-Agent header with value 'spring-ai' to OpenAiApi constructor
- Maintains consistency with Azure OpenAI implementation
- Improves API monitoring and identification capabilities

## Testing
Code has been validated for syntax and follows existing repository patterns.