### PR TITLE
GH-4505 Fixed PromptTemplate: Parameterized render(Map) fails to handle Resource in…

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
@@ -123,9 +123,14 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 
 	@Override
 	public String render(Map<String, Object> additionalVariables) {
-		Map<String, Object> combinedVariables = new HashMap<>(this.variables);
+		Map<String, Object> combinedVariables = new HashMap<>();
+		Map<String, Object> mergedVariables = new HashMap<>(this.variables);
+		// variables + additionalVariables => mergedVariables
+		if (additionalVariables != null && !additionalVariables.isEmpty()) {
+			mergedVariables.putAll(additionalVariables);
+		}
 
-		for (Entry<String, Object> entry : additionalVariables.entrySet()) {
+		for (Entry<String, Object> entry : mergedVariables.entrySet()) {
 			if (entry.getValue() instanceof Resource resource) {
 				combinedVariables.put(entry.getKey(), renderResource(resource));
 			}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
@@ -26,6 +26,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.template.NoOpTemplateRenderer;
 import org.springframework.ai.template.TemplateRenderer;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -304,6 +305,19 @@ class PromptTemplateTests {
 		PromptTemplate promptTemplate = PromptTemplate.builder().resource(templateResource).variables(vars).build();
 
 		assertThat(promptTemplate.render()).isEqualTo("Hello Builder from Resource!");
+	}
+
+	@Test
+	void renderWithResourceFile() {
+		Resource resource = new ClassPathResource("prompt-user.txt");
+
+		// Build PromptTemplate: bind the Resource to "name" in this.variables
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template("How {name}")
+			.variables(Map.of("name", resource))
+			.build();
+
+		assertThat(promptTemplate.render(Map.of())).isEqualTo("How Hello, world!");
 	}
 
 	// Helper Custom Renderer for testing


### PR DESCRIPTION

Fix:
- this.variables are copied into mergedVariables
- additionalVariables are merged in, overriding existing keys if necessary
- the merged result is used for rendering

Fixes: https://github.com/spring-projects/spring-ai/issues/4505  - PromptTemplate: Parameterized 'render(Map)' fails to handle 'Resource' in this.variables (inconsistent with no-arg render)