### PR TITLE
test: add test coverage for SyncMcpToolCallback.Builder

### DIFF
--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackBuilderTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackBuilderTest.java
@@ -123,4 +123,95 @@ class SyncMcpToolCallbackBuilderTest {
 		assertThat(callback.getToolDefinition().name()).isEqualTo("chained_tool_name");
 	}
 
+	@Test
+	void builderShouldNormalizeToolNameWithSpecialCharacters() {
+		McpSyncClient mcpClient = Mockito.mock(McpSyncClient.class);
+		McpSchema.Implementation clientInfo = new McpSchema.Implementation("test-client", "1.0.0");
+		when(mcpClient.getClientInfo()).thenReturn(clientInfo);
+
+		Tool tool = Mockito.mock(Tool.class);
+		when(tool.name()).thenReturn("test-tool-with-dashes");
+		when(tool.description()).thenReturn("Test description");
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder().mcpClient(mcpClient).tool(tool).build();
+
+		assertThat(callback.getOriginalToolName()).isEqualTo("test-tool-with-dashes");
+		assertThat(callback.getToolDefinition().name()).isEqualTo("test_tool_with_dashes");
+	}
+
+	@Test
+	void builderShouldUseCustomPrefixedNameWithoutNormalization() {
+		McpSyncClient mcpClient = Mockito.mock(McpSyncClient.class);
+
+		Tool tool = Mockito.mock(Tool.class);
+		when(tool.name()).thenReturn("original-name");
+		when(tool.description()).thenReturn("Test description");
+
+		String customName = "custom-name-with-dashes";
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(mcpClient)
+			.tool(tool)
+			.prefixedToolName(customName)
+			.build();
+
+		assertThat(callback.getOriginalToolName()).isEqualTo("original-name");
+		assertThat(callback.getToolDefinition().name()).isEqualTo(customName);
+	}
+
+	@Test
+	void builderShouldHandlePrefixedToolNameAsNull() {
+		McpSyncClient mcpClient = Mockito.mock(McpSyncClient.class);
+		McpSchema.Implementation clientInfo = new McpSchema.Implementation("test-client", "1.0.0");
+		when(mcpClient.getClientInfo()).thenReturn(clientInfo);
+
+		Tool tool = Mockito.mock(Tool.class);
+		when(tool.name()).thenReturn("test-tool");
+		when(tool.description()).thenReturn("Description");
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(mcpClient)
+			.tool(tool)
+			.prefixedToolName(null)
+			.build();
+
+		// When null, it should use the default normalized name
+		assertThat(callback).isNotNull();
+		assertThat(callback.getToolDefinition().name()).isEqualTo("test_tool");
+	}
+
+	@Test
+	void builderShouldCreateNewInstancesForEachBuild() {
+		McpSyncClient mcpClient = Mockito.mock(McpSyncClient.class);
+		McpSchema.Implementation clientInfo = new McpSchema.Implementation("test-client", "1.0.0");
+		when(mcpClient.getClientInfo()).thenReturn(clientInfo);
+
+		Tool tool = Mockito.mock(Tool.class);
+		when(tool.name()).thenReturn("test-tool");
+		when(tool.description()).thenReturn("Test description");
+
+		SyncMcpToolCallback.Builder builder = SyncMcpToolCallback.builder().mcpClient(mcpClient).tool(tool);
+
+		SyncMcpToolCallback callback1 = builder.build();
+		SyncMcpToolCallback callback2 = builder.build();
+
+		assertThat(callback1).isNotSameAs(callback2);
+		assertThat(callback1.getOriginalToolName()).isEqualTo(callback2.getOriginalToolName());
+	}
+
+	@Test
+	void builderShouldThrowExceptionWhenToolContextConverterIsNull() {
+		McpSyncClient mcpClient = Mockito.mock(McpSyncClient.class);
+		Tool tool = Mockito.mock(Tool.class);
+		when(tool.name()).thenReturn("test-tool");
+		when(tool.description()).thenReturn("Test description");
+
+		assertThatThrownBy(() -> SyncMcpToolCallback.builder()
+			.mcpClient(mcpClient)
+			.tool(tool)
+			.toolContextToMcpMetaConverter(null)
+			.build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("ToolContextToMcpMetaConverter must not be null");
+	}
+
 }


### PR DESCRIPTION
**Description**
This PR adds comprehensive test coverage for the `SyncMcpToolCallback.Builder` class, focusing on tool name handling, validation, and builder behavior.

**Changes**
Added 5 new test methods to `SyncMcpToolCallbackBuilderTest`:

- Tool name normalization: Verifies that tool names with dashes are normalized to underscores
- Custom prefix bypass: Ensures custom prefixed names are used as-is without normalization
- Null prefix handling: Tests that null prefixed names fall back to normalized defaults
- Instance creation: Verifies the builder creates new instances for each build() call
- Converter validation: Ensures null converters are properly rejected with appropriate error message

**Impact**
The existing tests only covered basic builder functionality. These new tests add coverage for edge cases and special behaviors around tool name normalization, custom naming, and proper validation of required fields, ensuring the builder behaves correctly in all scenarios.