### PR TITLE
feat(anthropic): add new Claude models and update naming conventions

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -276,14 +276,24 @@ public final class AnthropicApi {
 
 		// @formatter:off
 		/**
+		 * The claude-sonnet-4-5 model.
+		 */
+		CLAUDE_SONNET_4_5("claude-sonnet-4-5"),
+
+		/**
+		 * The claude-opus-4-1 model.
+		 */
+		CLAUDE_OPUS_4_1("claude-opus-4-1"),
+
+		/**
 		 * The claude-opus-4-0 model.
 		 */
-		CLAUDE_OPUS_4("claude-opus-4-0"),
+		CLAUDE_OPUS_4_0("claude-opus-4-0"),
 
 		/**
 		 * The claude-sonnet-4-0 model.
 		 */
-		CLAUDE_SONNET_4("claude-sonnet-4-0"),
+		CLAUDE_SONNET_4_0("claude-sonnet-4-0"),
 
 		/**
 		 * The claude-3-7-sonnet-latest model.
@@ -313,18 +323,7 @@ public final class AnthropicApi {
 		/**
 		 * The CLAUDE_3_HAIKU
 		 */
-		CLAUDE_3_HAIKU("claude-3-haiku-20240307"),
-
-		// Legacy models
-		/**
-		 * The CLAUDE_2_1 (Deprecated. To be removed on July 21, 2025)
-		 */
-		CLAUDE_2_1("claude-2.1"),
-
-		/**
-		 * The CLAUDE_2_0 (Deprecated. To be removed on July 21, 2025)
-		 */
-		CLAUDE_2("claude-2.0");
+		CLAUDE_3_HAIKU("claude-3-haiku-20240307");
 
 		// @formatter:on
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicPromptCachingIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicPromptCachingIT.java
@@ -101,7 +101,7 @@ public class AnthropicPromptCachingIT {
 		String systemPrompt = loadPrompt("system-only-cache-prompt.txt");
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.SYSTEM_ONLY).build())
 			.maxTokens(150)
 			.temperature(0.3)
@@ -142,7 +142,7 @@ public class AnthropicPromptCachingIT {
 		MockWeatherService weatherService = new MockWeatherService();
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS).build())
 			.maxTokens(200)
 			.temperature(0.3)
@@ -233,7 +233,7 @@ public class AnthropicPromptCachingIT {
 		String response = chatClient.prompt()
 			.user("What career advice would you give me based on our conversation?")
 			.options(AnthropicChatOptions.builder()
-				.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+				.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 				.cacheOptions(
 						AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY).build())
 				.maxTokens(200)
@@ -258,7 +258,7 @@ public class AnthropicPromptCachingIT {
 		String systemPrompt = loadPrompt("system-only-cache-prompt.txt");
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder()
 				.strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
 				// Set min length above actual system prompt length to prevent caching
@@ -287,7 +287,7 @@ public class AnthropicPromptCachingIT {
 
 		// Set USER min length high so caching should not apply
 		AnthropicChatOptions noCacheOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder()
 				.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
 				.messageTypeMinContentLength(MessageType.USER, userMessage.length() + 1)
@@ -305,7 +305,7 @@ public class AnthropicPromptCachingIT {
 
 		// Now allow caching by lowering the USER min length
 		AnthropicChatOptions cacheOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder()
 				.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
 				.messageTypeMinContentLength(MessageType.USER, userMessage.length() - 1)
@@ -334,7 +334,7 @@ public class AnthropicPromptCachingIT {
 		// The combined length of the first two USER messages exceeds the min length,
 		// so caching should apply
 		AnthropicChatOptions cacheOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder()
 				.strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
 				.messageTypeMinContentLength(MessageType.USER, userMessage.length())
@@ -357,7 +357,7 @@ public class AnthropicPromptCachingIT {
 		String systemPrompt = loadPrompt("extended-ttl-cache-prompt.txt");
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder()
 				.strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
 				.messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
@@ -398,7 +398,7 @@ public class AnthropicPromptCachingIT {
 		String systemPrompt = "You are a helpful assistant.";
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 			.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.NONE).build())
 			.maxTokens(50)
 			.temperature(0.3)
@@ -428,7 +428,7 @@ public class AnthropicPromptCachingIT {
 		responses.add(this.chatModel.call(new Prompt(
 				List.of(new SystemMessage("You are a math tutor."), new UserMessage("What is calculus?")),
 				AnthropicChatOptions.builder()
-					.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+					.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 					.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.SYSTEM_ONLY).build())
 					.maxTokens(100)
 					.build())));
@@ -436,7 +436,7 @@ public class AnthropicPromptCachingIT {
 		// Second: No caching
 		responses.add(this.chatModel.call(new Prompt(List.of(new UserMessage("What's 5+5?")),
 				AnthropicChatOptions.builder()
-					.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4.getValue())
+					.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_0.getValue())
 					.cacheOptions(AnthropicCacheOptions.builder().strategy(AnthropicCacheStrategy.NONE).build())
 					.maxTokens(50)
 					.build())));


### PR DESCRIPTION
- Add CLAUDE_SONNET_4_5 and CLAUDE_OPUS_4_1 model constants
- Rename CLAUDE_OPUS_4 to CLAUDE_OPUS_4_0 and CLAUDE_SONNET_4 to CLAUDE_SONNET_4_0 for consistency
- Remove deprecated legacy models CLAUDE_2_1 and CLAUDE_2
- Update test references to use renamed CLAUDE_SONNET_4_0 constant
