### PR TITLE
Add fallback message for blank tool execution errors

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessor.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessor.java
@@ -72,9 +72,13 @@ public class DefaultToolExecutionExceptionProcessor implements ToolExecutionExce
 		if (this.alwaysThrow) {
 			throw exception;
 		}
-		logger.debug("Exception thrown by tool: {}. Message: {}", exception.getToolDefinition().name(),
-				exception.getMessage());
-		return exception.getMessage();
+		String message = exception.getMessage();
+		if (message == null || message.isBlank()) {
+			message = "Exception occurred in tool: " + exception.getToolDefinition().name() + " ("
+					+ cause.getClass().getSimpleName() + ")";
+		}
+		logger.debug("Exception thrown by tool: {}. Message: {}", exception.getToolDefinition().name(), message);
+		return message;
 	}
 
 	public static Builder builder() {

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessorTests.java
@@ -61,6 +61,28 @@ class DefaultToolExecutionExceptionProcessorTests {
 	}
 
 	@Test
+	void processReturnsFallbackMessageWhenNull() {
+		DefaultToolExecutionExceptionProcessor processor = DefaultToolExecutionExceptionProcessor.builder().build();
+
+		ToolExecutionException exception = new ToolExecutionException(this.toolDefinition, new IllegalStateException());
+
+		String result = processor.process(exception);
+
+		assertThat(result).isEqualTo("Exception occurred in tool: toolName (IllegalStateException)");
+	}
+
+	@Test
+	void processReturnsFallbackMessageWhenBlank() {
+		DefaultToolExecutionExceptionProcessor processor = DefaultToolExecutionExceptionProcessor.builder().build();
+
+		ToolExecutionException exception = new ToolExecutionException(this.toolDefinition, new RuntimeException(" "));
+
+		String result = processor.process(exception);
+
+		assertThat(result).isEqualTo("Exception occurred in tool: toolName (RuntimeException)");
+	}
+
+	@Test
 	void processAlwaysThrows() {
 		DefaultToolExecutionExceptionProcessor processor = DefaultToolExecutionExceptionProcessor.builder()
 			.alwaysThrow(true)


### PR DESCRIPTION
## Summary
- return a descriptive fallback when ToolExecutionException#getMessage() is null or blank
- include the tool name and originating exception type so downstream LLMs can detect failures
- cover the new behavior with dedicated unit tests

## Checklist
- [x] Signed-off-by line added to the commit (`git commit -s`)
- [x] Rebased on the latest `main` and squashed into a single commit
- [x] Unit tests updated to cover the new behavior
- [x] Build executed locally and tests pass
 
## Testing
- ./mvnw -pl spring-ai-model -Dtest=DefaultToolExecutionExceptionProcessorTests test

Fixes #4518
