### PR TITLE
Handle Vertex AI tool call JsonProcessingException fallback

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.cloud.vertexai.VertexAI;
 import com.google.cloud.vertexai.api.Candidate;
@@ -371,8 +372,11 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 
 			return structBuilder.build();
 		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
+		catch (JsonProcessingException ex) {
+			return Struct.newBuilder().putFields("result", Value.newBuilder().setStringValue(json).build()).build();
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Use DefaultToolExecutionExceptionProcessor(false) so that tool exceptions are not thrown but are converted into tool responses containing the exception message. This prevents exceptions from bubbling up through the streaming pipeline.
- If a tool exception were thrown outward, it would be hard to catch and turn into a user-friendly message at the right layer. So we treat the exception message as the tool’s output instead.
- However, Vertex AI expects tool responses to be valid JSON. If the exception message is plain text (i.e., not JSON), Vertex will throw another error. Therefore, when forwarding exception messages as tool responses, they must be wrapped/normalized into JSON (e.g., { "result": "<exception message>" }).
- ensure Vertex AI tool call responses fall back to the raw JSON payload when JsonProcessingException is raised during tool result conversion
- #3040
