### PR TITLE
test: add test coverage for MilvusSearchRequest builder

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusSearchRequestTest.java
+++ b/vector-stores/spring-ai-milvus-store/src/test/java/org/springframework/ai/vectorstore/milvus/MilvusSearchRequestTest.java
@@ -79,4 +79,72 @@ class MilvusSearchRequestTest {
 		assertThat(request.getSearchParamsJson()).isEqualTo(searchParamsJson);
 	}
 
+	@Test
+	void shouldBuildRequestWithOnlyQuery() {
+		String query = "test query";
+		MilvusSearchRequest request = MilvusSearchRequest.milvusBuilder().query(query).build();
+
+		assertThat(request.getQuery()).isEqualTo(query);
+		assertThat(request.getTopK()).isEqualTo(SearchRequest.DEFAULT_TOP_K);
+		assertThat(request.getSimilarityThreshold()).isEqualTo(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+		assertThat(request.getNativeExpression()).isNull();
+	}
+
+	@Test
+	void shouldBuildRequestWithOnlyTopK() {
+		int topK = 1;
+		MilvusSearchRequest request = MilvusSearchRequest.milvusBuilder().topK(topK).build();
+
+		assertThat(request.getQuery()).isEmpty();
+		assertThat(request.getTopK()).isEqualTo(topK);
+		assertThat(request.getSimilarityThreshold()).isEqualTo(SearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL);
+	}
+
+	@Test
+	void shouldBuildRequestWithOnlySimilarityThreshold() {
+		double threshold = 0.95;
+		MilvusSearchRequest request = MilvusSearchRequest.milvusBuilder().similarityThreshold(threshold).build();
+
+		assertThat(request.getQuery()).isEmpty();
+		assertThat(request.getTopK()).isEqualTo(SearchRequest.DEFAULT_TOP_K);
+		assertThat(request.getSimilarityThreshold()).isEqualTo(threshold);
+	}
+
+	@Test
+	void shouldHandleEmptyQuery() {
+		MilvusSearchRequest request = MilvusSearchRequest.milvusBuilder().query("").topK(1).build();
+
+		assertThat(request.getQuery()).isEmpty();
+		assertThat(request.getTopK()).isEqualTo(1);
+	}
+
+	@Test
+	void shouldHandleComplexNativeExpression() {
+		String complexExpression = "(level > 1 AND type = 'type1') OR (mode IN ['mode1'] AND value >= 0.1)";
+		MilvusSearchRequest request = MilvusSearchRequest.milvusBuilder().nativeExpression(complexExpression).build();
+
+		assertThat(request.getNativeExpression()).isEqualTo(complexExpression);
+	}
+
+	@Test
+	void shouldHandleComplexSearchParamsJson() {
+		String complexJson = "{\"values\":{\"value1\":1,\"value2\":1.1},\"value\":{\"value\":1,\"value\":1}}";
+		MilvusSearchRequest request = MilvusSearchRequest.milvusBuilder().searchParamsJson(complexJson).build();
+
+		assertThat(request.getSearchParamsJson()).isEqualTo(complexJson);
+	}
+
+	@Test
+	void shouldUpdateFieldsWithMultipleCalls() {
+		MilvusSearchRequest request = MilvusSearchRequest.milvusBuilder()
+			.query("initial")
+			.query("updated")
+			.topK(1)
+			.topK(1)
+			.build();
+
+		assertThat(request.getQuery()).isEqualTo("updated");
+		assertThat(request.getTopK()).isEqualTo(1);
+	}
+
 }


### PR DESCRIPTION
**Description**
This PR adds comprehensive test coverage for the `MilvusSearchRequest` builder class, focusing on various parameter combinations and edge cases.

**Changes**
Added 7 new test methods to `MilvusSearchRequestTest`:

- Single parameter tests: Verify builder behavior when setting only one parameter (query, topK, or similarity threshold) while others use defaults
- Empty query handling: Ensures empty strings are handled correctly
- Complex expressions: Tests storage of complex native Milvus expressions
- JSON parameters: Validates complex search parameters JSON handling
- Builder pattern behavior: Verifies that multiple calls to the same setter use the last value

**Impact**
The existing tests only covered basic scenarios with all parameters set. These new tests ensure the builder works correctly with partial configurations, validates default values are properly applied, and handles edge cases like empty queries and complex expressions.