### PR TITLE
Fix JsonSchemaGenerator for method input parameters

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -140,6 +140,8 @@ public final class JsonSchemaGenerator {
 				required.add(parameterName);
 			}
 			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			// Remove OpenAPI format as some LLMs (like Mistral) don't handle them.
+			parameterNode.remove("format");
 			String parameterDescription = getMethodParameterDescription(method, i);
 			if (StringUtils.hasText(parameterDescription)) {
 				parameterNode.put("description", parameterDescription);

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -62,8 +62,7 @@ class JsonSchemaGeneratorTests {
 				            "type": "string"
 				        },
 				        "age": {
-				            "type": "integer",
-				            "format": "int32"
+				            "type": "integer"
 				        }
 				    },
 				    "required": [
@@ -265,8 +264,7 @@ class JsonSchemaGeneratorTests {
 				            "type": "STRING"
 				        },
 				        "age": {
-				            "type": "INTEGER",
-				            "format": "int32"
+				            "type": "INTEGER"
 				        }
 				    },
 				    "required": [
@@ -348,16 +346,13 @@ class JsonSchemaGeneratorTests {
 				    "type": "object",
 				    "properties": {
 				        "duration": {
-				            "type": "string",
-				            "format": "duration"
+				            "type": "string"
 				        },
 				        "localDateTime": {
-				            "type": "string",
-				            "format": "date-time"
+				            "type": "string"
 				        },
 				        "instant": {
-				            "type": "string",
-				            "format": "date-time"
+				            "type": "string"
 				        }
 				    },
 				    "required": [
@@ -387,8 +382,7 @@ class JsonSchemaGeneratorTests {
 				            "type": "string"
 				        },
 				        "expectedDelivery": {
-				            "type": "string",
-				            "format": "date-time"
+				            "type": "string"
 				        }
 				    },
 				    "required": [


### PR DESCRIPTION
 - For method input parameters, if the JSON schema generator adds OpenAPI "format" property, some LLMs (ex: Mistral) fail to process the request. Hence, removing this specific property from the JSON schema
 - This issue was uncovered by MistralAiChatModelIT#chatMemoryWithTools where the method toolcallback is used

Auto-cherry-pick to 1.0.x
Fixes #4524 
