### PR TITLE
Update Spring Boot support message: 3.5 was released a while ago

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/getting-started.adoc
@@ -5,7 +5,7 @@ This section offers jumping off points for how to get started using Spring AI.
 
 You should follow the steps in each of the following sections according to your needs.
 
-NOTE: Spring AI supports Spring Boot 3.4.x.  When Spring Boot 3.5.x is released, we will support that as well.
+NOTE: Spring AI supports Spring Boot 3.4.x and 3.5.x.
 
 [[spring-initializr]]
 == Spring Initializr


### PR DESCRIPTION
Update support note to incorporate that Spring Boot 3.5.x is available.