### PR TITLE
Fix openai auto-configuration

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioSpeechAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.ai.openai.api.OpenAiAudioApi;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -47,6 +46,7 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
  * @author Stefan Vassilev
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class,
 		SpringAiRetryAutoConfiguration.class })
@@ -54,8 +54,6 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
 @ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_SPEECH_MODEL, havingValue = SpringAIModels.OPENAI,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ OpenAiConnectionProperties.class, OpenAiAudioSpeechProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
 public class OpenAiAudioSpeechAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAudioTranscriptionAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.ai.openai.api.OpenAiAudioApi;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -47,6 +46,7 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
  * @author Stefan Vassilev
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class,
 		SpringAiRetryAutoConfiguration.class })
@@ -54,8 +54,6 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
 @ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_TRANSCRIPTION_MODEL, havingValue = SpringAIModels.OPENAI,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ OpenAiConnectionProperties.class, OpenAiAudioTranscriptionProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
 public class OpenAiAudioTranscriptionAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
@@ -31,7 +31,6 @@ import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -53,6 +52,7 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
  * @author Stefan Vassilev
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class,
 		SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class })
@@ -60,8 +60,6 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
 @EnableConfigurationProperties({ OpenAiConnectionProperties.class, OpenAiChatProperties.class })
 @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.OPENAI,
 		matchIfMissing = true)
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class, ToolCallingAutoConfiguration.class })
 public class OpenAiChatAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -49,6 +48,7 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
  * @author Stefan Vassilev
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class,
 		SpringAiRetryAutoConfiguration.class })
@@ -56,8 +56,6 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
 @ConditionalOnProperty(name = SpringAIModelProperties.EMBEDDING_MODEL, havingValue = SpringAIModels.OPENAI,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ OpenAiConnectionProperties.class, OpenAiEmbeddingProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
 public class OpenAiEmbeddingAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiImageAutoConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.ai.openai.api.OpenAiImageApi;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -50,6 +49,7 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author lambochen
+ * @author Issam El-atif
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class,
 		SpringAiRetryAutoConfiguration.class })
@@ -57,8 +57,6 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
 @ConditionalOnProperty(name = SpringAIModelProperties.IMAGE_MODEL, havingValue = SpringAIModels.OPENAI,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ OpenAiConnectionProperties.class, OpenAiImageProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
 public class OpenAiImageAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModerationAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.ai.openai.api.OpenAiModerationApi;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -46,6 +45,7 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
  * @author Stefan Vassilev
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class,
 		SpringAiRetryAutoConfiguration.class })
@@ -53,8 +53,6 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
 @ConditionalOnProperty(name = SpringAIModelProperties.MODERATION_MODEL, havingValue = SpringAIModels.OPENAI,
 		matchIfMissing = true)
 @EnableConfigurationProperties({ OpenAiConnectionProperties.class, OpenAiModerationProperties.class })
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
 public class OpenAiModerationAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/ChatClientAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/ChatClientAutoConfigurationIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.ChatClientCustomizer;
 import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Issam El-atif
  */
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
 public class ChatClientAutoConfigurationIT {
@@ -46,9 +48,9 @@ public class ChatClientAutoConfigurationIT {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"),
 				"spring.ai.openai.chat.options.model=gpt-4o")
-		.withConfiguration(
-				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-						OpenAiChatAutoConfiguration.class, ChatClientAutoConfiguration.class));
+		.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
+				RestClientAutoConfiguration.class, ToolCallingAutoConfiguration.class,
+				OpenAiChatAutoConfiguration.class, ChatClientAutoConfiguration.class));
 
 	@Test
 	void implicitlyEnabled() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAutoConfigurationIT.java
@@ -24,6 +24,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.UserMessage;
@@ -52,7 +57,10 @@ public class OpenAiAutoConfigurationIT {
 	private static final Log logger = LogFactory.getLog(OpenAiAutoConfigurationIT.class);
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"));
+		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"))
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						WebClientAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
 	@Test
 	void chatCall() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.model.openai.autoconfigure;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiChatModel;
@@ -25,7 +26,10 @@ import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.ai.openai.OpenAiModerationModel;
 import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,11 +38,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit Tests for OpenAI auto configurations' conditional enabling of models.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 public class OpenAiModelConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL");
+		.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						WebClientAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
 	@Test
 	void chatModelActivation() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiPropertiesTests.java
@@ -16,11 +16,14 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiChatModel;
@@ -29,7 +32,10 @@ import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest.ToolChoiceBuilder;
 import org.springframework.ai.openai.api.OpenAiAudioApi;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,14 +47,19 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Jonghoon Park
+ * @author Issam El-atif
  * @since 0.8.0
  */
 public class OpenAiPropertiesTests {
 
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+			AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+					WebClientAutoConfiguration.class, ToolCallingAutoConfiguration.class));
+
 	@Test
 	public void chatProperties() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.base-url=TEST_BASE_URL",
 				"spring.ai.openai.api-key=abc123",
@@ -74,7 +85,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void transcriptionProperties() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 			"spring.ai.openai.base-url=TEST_BASE_URL",
 			"spring.ai.openai.api-key=abc123",
@@ -100,7 +111,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void chatOverrideConnectionProperties() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.base-url=TEST_BASE_URL",
 				"spring.ai.openai.api-key=abc123",
@@ -128,7 +139,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void transcriptionOverrideConnectionProperties() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.base-url=TEST_BASE_URL",
 						"spring.ai.openai.api-key=abc123",
@@ -156,7 +167,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void speechProperties() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.base-url=TEST_BASE_URL",
 						"spring.ai.openai.api-key=abc123",
@@ -187,7 +198,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	public void speechPropertiesTest() {
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.base-url=TEST_BASE_URL",
 						"spring.ai.openai.api-key=abc123",
@@ -215,7 +226,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	public void speechOverrideConnectionPropertiesTest() {
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.base-url=TEST_BASE_URL",
 						"spring.ai.openai.api-key=abc123",
@@ -249,7 +260,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void embeddingProperties() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.base-url=TEST_BASE_URL",
 				"spring.ai.openai.api-key=abc123",
@@ -273,7 +284,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void embeddingOverrideConnectionProperties() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.base-url=TEST_BASE_URL",
 				"spring.ai.openai.api-key=abc123",
@@ -298,7 +309,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	public void imageProperties() {
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.base-url=TEST_BASE_URL",
 						"spring.ai.openai.api-key=abc123",
@@ -323,7 +334,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	public void imageOverrideConnectionProperties() {
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.base-url=TEST_BASE_URL",
 						"spring.ai.openai.api-key=abc123",
@@ -351,7 +362,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void chatOptionsTest() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.api-key=API_KEY",
 				"spring.ai.openai.base-url=TEST_BASE_URL",
@@ -436,7 +447,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void transcriptionOptionsTest() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.api-key=API_KEY",
 						"spring.ai.openai.base-url=TEST_BASE_URL",
@@ -468,7 +479,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	public void embeddingOptionsTest() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.api-key=API_KEY",
 				"spring.ai.openai.base-url=TEST_BASE_URL",
@@ -494,7 +505,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	public void imageOptionsTest() {
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.api-key=API_KEY",
 						"spring.ai.openai.base-url=TEST_BASE_URL",
@@ -533,7 +544,7 @@ public class OpenAiPropertiesTests {
 	@Test
 	void embeddingActivation() {
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.embedding=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiEmbeddingAutoConfiguration.class))
@@ -542,7 +553,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiEmbeddingModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiEmbeddingAutoConfiguration.class))
 			.run(context -> {
@@ -550,7 +561,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiEmbeddingModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.embedding=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiEmbeddingAutoConfiguration.class))
@@ -562,7 +573,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	void chatActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.chat=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
@@ -571,7 +582,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiChatModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
 			.run(context -> {
@@ -579,7 +590,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiChatModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.chat=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
@@ -592,7 +603,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	void imageActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.image=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiImageAutoConfiguration.class))
@@ -601,7 +612,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiImageModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiImageAutoConfiguration.class))
 			.run(context -> {
@@ -609,7 +620,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiImageModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.image=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiImageAutoConfiguration.class))
@@ -622,7 +633,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	void audioSpeechActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.speech=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioSpeechAutoConfiguration.class))
@@ -631,7 +642,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioSpeechModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioSpeechAutoConfiguration.class))
 			.run(context -> {
@@ -639,7 +650,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioSpeechModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.speech=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioSpeechAutoConfiguration.class))
@@ -652,7 +663,7 @@ public class OpenAiPropertiesTests {
 
 	@Test
 	void audioTranscriptionActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.transcription=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioTranscriptionAutoConfiguration.class))
@@ -661,7 +672,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioTranscriptionModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioTranscriptionAutoConfiguration.class))
 			.run(context -> {
@@ -669,7 +680,7 @@ public class OpenAiPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioTranscriptionModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.transcription=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioTranscriptionAutoConfiguration.class))

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiResponseFormatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiResponseFormatPropertiesTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.openai.OpenAiAudioSpeechModel;
 import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
 import org.springframework.ai.openai.OpenAiChatModel;
@@ -25,7 +28,10 @@ import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.ai.openai.api.OpenAiAudioApi;
 import org.springframework.ai.openai.api.ResponseFormat;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,8 +40,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit Tests for {@link OpenAiChatProperties} #options#responseFormat support.
  *
  * @author Christian Tzolov
+ * @author Issam El-atif
  */
 public class OpenAiResponseFormatPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+			AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+					WebClientAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
 	@Test
 	public void responseFormatJsonSchema() {
@@ -53,7 +64,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				}
 				""";
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.api-key=API_KEY",
 
@@ -78,7 +89,7 @@ public class OpenAiResponseFormatPropertiesTests {
 	@Test
 	public void responseFormatJsonObject() {
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY",
 					"spring.ai.openai.chat.options.response-format.type=JSON_OBJECT")
 
@@ -94,7 +105,7 @@ public class OpenAiResponseFormatPropertiesTests {
 	@Test
 	public void emptyResponseFormat() {
 
-		new ApplicationContextRunner().withPropertyValues("spring.ai.openai.api-key=API_KEY")
+		this.contextRunner.withPropertyValues("spring.ai.openai.api-key=API_KEY")
 
 			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
 			.run(context -> {
@@ -107,7 +118,7 @@ public class OpenAiResponseFormatPropertiesTests {
 	@Test
 	public void transcriptionOptionsTest() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.api-key=API_KEY",
 						"spring.ai.openai.base-url=TEST_BASE_URL",
@@ -138,7 +149,7 @@ public class OpenAiResponseFormatPropertiesTests {
 	@Test
 	public void embeddingOptionsTest() {
 
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 				"spring.ai.openai.api-key=API_KEY",
 				"spring.ai.openai.base-url=TEST_BASE_URL",
@@ -164,7 +175,7 @@ public class OpenAiResponseFormatPropertiesTests {
 
 	@Test
 	public void imageOptionsTest() {
-		new ApplicationContextRunner().withPropertyValues(
+		this.contextRunner.withPropertyValues(
 		// @formatter:off
 						"spring.ai.openai.api-key=API_KEY",
 						"spring.ai.openai.base-url=TEST_BASE_URL",
@@ -203,7 +214,7 @@ public class OpenAiResponseFormatPropertiesTests {
 	@Test
 	void embeddingActivation() {
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.embedding=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiEmbeddingAutoConfiguration.class))
@@ -212,7 +223,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiEmbeddingModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiEmbeddingAutoConfiguration.class))
 			.run(context -> {
@@ -220,7 +231,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiEmbeddingModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.embedding=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiEmbeddingAutoConfiguration.class))
@@ -232,7 +243,7 @@ public class OpenAiResponseFormatPropertiesTests {
 
 	@Test
 	void chatActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.chat=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
@@ -241,7 +252,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiChatModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
 			.run(context -> {
@@ -249,7 +260,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiChatModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.chat=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
@@ -262,7 +273,7 @@ public class OpenAiResponseFormatPropertiesTests {
 
 	@Test
 	void imageActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.image=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiImageAutoConfiguration.class))
@@ -271,7 +282,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiImageModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiImageAutoConfiguration.class))
 			.run(context -> {
@@ -279,7 +290,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiImageModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.image=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiImageAutoConfiguration.class))
@@ -292,7 +303,7 @@ public class OpenAiResponseFormatPropertiesTests {
 
 	@Test
 	void audioSpeechActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.speech=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioSpeechAutoConfiguration.class))
@@ -301,7 +312,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioSpeechModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioSpeechAutoConfiguration.class))
 			.run(context -> {
@@ -309,7 +320,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioSpeechModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.speech=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioSpeechAutoConfiguration.class))
@@ -322,7 +333,7 @@ public class OpenAiResponseFormatPropertiesTests {
 
 	@Test
 	void audioTranscriptionActivation() {
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.transcription=none")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioTranscriptionAutoConfiguration.class))
@@ -331,7 +342,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioTranscriptionModel.class)).isEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioTranscriptionAutoConfiguration.class))
 			.run(context -> {
@@ -339,7 +350,7 @@ public class OpenAiResponseFormatPropertiesTests {
 				assertThat(context.getBeansOfType(OpenAiAudioTranscriptionModel.class)).isNotEmpty();
 			});
 
-		new ApplicationContextRunner()
+		this.contextRunner
 			.withPropertyValues("spring.ai.openai.api-key=API_KEY", "spring.ai.openai.base-url=TEST_BASE_URL",
 					"spring.ai.model.audio.transcription=openai")
 			.withConfiguration(AutoConfigurations.of(OpenAiAudioTranscriptionAutoConfiguration.class))

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackInPrompt2IT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackInPrompt2IT.java
@@ -27,10 +27,13 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.api.OpenAiApi.ChatModel;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +45,9 @@ public class FunctionCallbackInPrompt2IT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"))
-		.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class));
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, OpenAiChatAutoConfiguration.class));
 
 	@Test
 	void functionCallTest() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackInPromptIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackInPromptIT.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -47,7 +50,9 @@ public class FunctionCallbackInPromptIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"))
-		.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class));
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, OpenAiChatAutoConfiguration.class));
 
 	@Test
 	void functionCallTest() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -60,7 +63,9 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"),
 				"spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName())
-		.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, OpenAiChatAutoConfiguration.class))
 		.withUserConfiguration(Config.class);
 
 	private static Map<String, Object> feedback = new ConcurrentHashMap<>();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/OpenAiFunctionCallback2IT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/OpenAiFunctionCallback2IT.java
@@ -25,11 +25,14 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.api.OpenAiApi.ChatModel;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,7 +47,9 @@ public class OpenAiFunctionCallback2IT {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"),
 				"spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName())
-		.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, OpenAiChatAutoConfiguration.class))
 		.withUserConfiguration(Config.class);
 
 	@Test

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/OpenAiFunctionCallbackIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/OpenAiFunctionCallbackIT.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -51,7 +54,9 @@ public class OpenAiFunctionCallbackIT {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"),
 				"spring.ai.openai.chat.options.model=" + ChatModel.GPT_4_O_MINI.getName())
-		.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class))
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, OpenAiChatAutoConfiguration.class))
 		.withUserConfiguration(Config.class);
 
 	@Test


### PR DESCRIPTION
Fixes openai auto-configurations for #4494

#### Changes
- Removed unnecessary @ImportAutoConfiguration annotations from OpenAI auto-configuration classes.
- Add common auto-configurations to context runner of unit and integration tests.

#### Refactoring suggestion
I did not use a BaseIT class:

- Common auto-configurations are duplicated for each model.
- Using BaseIT in unit tests introduce a coupling between unit tests and integration tests

I suggest to isolate and centralise common auto-configurations in one place (may be in spring-ai-test).
Something like this

 ```java
public class SpringAiTestAutoConfigurations {  // we can use another name that reflects more the usage

	// Common spring ai auto-configurations
	static Class<?>[] commonAutoConfigurations = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
			WebClientAutoConfiguration.class, ToolCallingAutoConfiguration.class};

	public static AutoConfigurations of(Class<?>... additionalConfigurations) {
		Class<?>[] all = Stream.concat(Arrays.stream(commonAutoConfigurations), Arrays.stream(additionalConfigurations))
				.toArray(Class<?>[]::new);
		return AutoConfigurations.of(all);
	}

}
```
Then use it like this
```java
private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
		.withPropertyValues("spring.ai.openai.apiKey=" + System.getenv("OPENAI_API_KEY"),
				"spring.ai.openai.chat.options.model=gpt-4o")
		.withConfiguration(SpringAiTestAutoConfigurations.of(OpenAiChatAutoConfiguration.class,
				ChatClientAutoConfiguration.class));
```
@Kehrlann your thoughts