### PR TITLE
Ensure MCP Tools Autoconfiguration happens before ChatClient Autoconfiguration

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
@@ -42,7 +42,8 @@ import org.springframework.context.annotation.Conditional;
  * ToolCallbacksProviders. These providers are used by Spring AI to discover and execute
  * tools.
  */
-@AutoConfiguration(after = { McpClientAutoConfiguration.class })
+@AutoConfiguration(after = { McpClientAutoConfiguration.class },
+		beforeName = { "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration" })
 @EnableConfigurationProperties(McpClientCommonProperties.class)
 @Conditional(McpToolCallbackAutoConfiguration.McpToolCallbackAutoConfigurationCondition.class)
 public class McpToolCallbackAutoConfiguration {


### PR DESCRIPTION
Without this change, a `ChatClient` instance would be configured without the MCP capabilities expressed via `mcp-annotations`.

This surfaces when client-side MCP features are added such as **elicitation**, **sampling**, or **logging**.