### PR TITLE
Bump Kotlin to 2.2.20 from 1.9.25 so we can run tests with Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
 		<azure-open-ai-client.version>1.0.0-beta.16</azure-open-ai-client.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
 		<victools.version>4.37.0</victools.version>
-		<kotlin.version>1.9.25</kotlin.version>
+		<kotlin.version>2.2.20</kotlin.version>
 
 		<!-- NOTE: keep bedrockruntime and awssdk versions aligned -->
 		<bedrockruntime.version>2.31.65</bedrockruntime.version>


### PR DESCRIPTION
When you try to compile and run tests for Spring AI with Java 25, the build fails with error

```
Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:1.9.25:compile (compile) on project spring-ai-client-chat: Compilation failure
[ERROR] java.lang.IllegalArgumentException: 25
                           at com.intellij.util.lang.JavaVersion.parse(JavaVersion.java:305)
```

by updating to Kotlin 2.2.20, compiling and running tests on Java 25 complete successfully.