### PR TITLE
Fix OCI GenAI auto-configuration

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiChatAutoConfiguration.java
@@ -25,7 +25,6 @@ import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.oci.cohere.OCICohereChatModel;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -38,13 +37,13 @@ import org.springframework.context.annotation.Bean;
  *
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
-@AutoConfiguration
+@AutoConfiguration(after = OCIGenAiInferenceClientAutoConfiguration.class)
 @ConditionalOnClass(OCICohereChatModel.class)
 @EnableConfigurationProperties(OCICohereChatModelProperties.class)
 @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.OCI_GENAI,
 		matchIfMissing = true)
-@ImportAutoConfiguration(OCIGenAiInferenceClientAutoConfiguration.class)
 public class OCIGenAiChatAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiEmbeddingAutoConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.oci.OCIEmbeddingModel;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -35,13 +34,13 @@ import org.springframework.context.annotation.Bean;
  *
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
-@AutoConfiguration
+@AutoConfiguration(after = OCIGenAiInferenceClientAutoConfiguration.class)
 @ConditionalOnClass(OCIEmbeddingModel.class)
 @EnableConfigurationProperties(OCIEmbeddingModelProperties.class)
 @ConditionalOnProperty(name = SpringAIModelProperties.EMBEDDING_MODEL, havingValue = SpringAIModels.OCI_GENAI,
 		matchIfMissing = true)
-@ImportAutoConfiguration(OCIGenAiInferenceClientAutoConfiguration.class)
 public class OCIGenAiEmbeddingAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/test/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAIAutoConfigurationTest.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/test/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAIAutoConfigurationTest.java
@@ -56,7 +56,9 @@ class OCIGenAIAutoConfigurationTest {
 				"spring.ai.oci.genai.cohere.chat.options.frequencyPenalty=0.1",
 				"spring.ai.oci.genai.cohere.chat.options.presencePenalty=0.2"
 				// @formatter:on
-		).withConfiguration(AutoConfigurations.of(OCIGenAiChatAutoConfiguration.class));
+		)
+			.withConfiguration(AutoConfigurations.of(OCIGenAiInferenceClientAutoConfiguration.class,
+					OCIGenAiChatAutoConfiguration.class));
 
 		contextRunner.run(context -> {
 			OCICohereChatModel chatModel = context.getBean(OCICohereChatModel.class);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/test/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/test/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiAutoConfigurationIT.java
@@ -52,7 +52,9 @@ public class OCIGenAiAutoConfigurationIT {
 				"spring.ai.oci.genai.embedding.servingMode=on-demand",
 				"spring.ai.oci.genai.embedding.model=cohere.embed-english-light-v2.0"
 				// @formatter:on
-	).withConfiguration(AutoConfigurations.of(OCIGenAiEmbeddingAutoConfiguration.class));
+	)
+		.withConfiguration(AutoConfigurations.of(OCIGenAiInferenceClientAutoConfiguration.class,
+				OCIGenAiEmbeddingAutoConfiguration.class));
 
 	private final ApplicationContextRunner cohereChatContextRunner = new ApplicationContextRunner().withPropertyValues(
 	// @formatter:off
@@ -62,7 +64,9 @@ public class OCIGenAiAutoConfigurationIT {
 			"spring.ai.oci.genai.cohere.chat.options.servingMode=on-demand",
 			"spring.ai.oci.genai.cohere.chat.options.model=" + this.CHAT_MODEL_ID
 			// @formatter:on
-	).withConfiguration(AutoConfigurations.of(OCIGenAiChatAutoConfiguration.class));
+	)
+		.withConfiguration(AutoConfigurations.of(OCIGenAiInferenceClientAutoConfiguration.class,
+				OCIGenAiChatAutoConfiguration.class));
 
 	@Test
 	void embeddings() {


### PR DESCRIPTION
Fixes OCI GenAI auto-configurations for https://github.com/spring-projects/spring-ai/issues/4494

### Changes

- Removed unnecessary `@ImportAutoConfiguration` annotations from OCI GenAI auto-configuration classes.
- Add `OCIGenAiInferenceClientAutoConfiguration` auto-configuration to context runner of unit and integration tests.