### PR TITLE
Fix MiniMax model auto-configuration

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatAutoConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfigurat
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -48,6 +47,7 @@ import org.springframework.web.client.RestClient;
  *
  * @author Geng Rong
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class,
 		ToolCallingAutoConfiguration.class })
@@ -55,8 +55,6 @@ import org.springframework.web.client.RestClient;
 @EnableConfigurationProperties({ MiniMaxConnectionProperties.class, MiniMaxChatProperties.class })
 @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.MINIMAX,
 		matchIfMissing = true)
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		ToolCallingAutoConfiguration.class })
 public class MiniMaxChatAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackInPromptIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackInPromptIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Geng Rong
+ * @author Issam El-atif
  */
 @EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".*")
 public class FunctionCallbackInPromptIT {
@@ -50,8 +52,9 @@ public class FunctionCallbackInPromptIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.minimax.apiKey=" + System.getenv("MINIMAX_API_KEY"))
-		.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-				RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class));
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class));
 
 	@Test
 	void functionCallTest() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Geng Rong
+ * @author Issam El-atif
  */
 @EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".*")
 class FunctionCallbackWithPlainFunctionBeanIT {
@@ -54,8 +56,9 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.minimax.apiKey=" + System.getenv("MINIMAX_API_KEY"))
-		.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-				RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 		.withUserConfiguration(Config.class);
 
 	// FIXME: multiple function calls may stop prematurely due to model performance

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxAutoConfigurationIT.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.messages.UserMessage;
@@ -40,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Geng Rong
+ * @author Issam El-atif
  */
 @EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".*")
 public class MiniMaxAutoConfigurationIT {
@@ -51,9 +53,9 @@ public class MiniMaxAutoConfigurationIT {
 
 	@Test
 	void generate() {
-		this.contextRunner
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+		this.contextRunner.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 				String response = chatModel.call("Hello");
@@ -64,9 +66,9 @@ public class MiniMaxAutoConfigurationIT {
 
 	@Test
 	void generateStreaming() {
-		this.contextRunner
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+		this.contextRunner.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 				Flux<ChatResponse> responseFlux = chatModel.stream(new Prompt(new UserMessage("Hello")));
@@ -84,8 +86,9 @@ public class MiniMaxAutoConfigurationIT {
 	@Test
 	void embedding() {
 		this.contextRunner
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxEmbeddingAutoConfiguration.class))
+			.withConfiguration(
+					AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+							ToolCallingAutoConfiguration.class, MiniMaxEmbeddingAutoConfiguration.class))
 			.run(context -> {
 				MiniMaxEmbeddingModel embeddingModel = context.getBean(MiniMaxEmbeddingModel.class);
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxPropertiesTests.java
@@ -24,6 +24,7 @@ import org.springframework.ai.minimax.MiniMaxChatModel;
 import org.springframework.ai.minimax.MiniMaxEmbeddingModel;
 import org.springframework.ai.minimax.api.MiniMaxApi;
 import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@link MiniMaxEmbeddingProperties}.
  *
  * @author Geng Rong
+ * @author Issam El-atif
  */
 public class MiniMaxPropertiesTests {
 
@@ -49,8 +51,9 @@ public class MiniMaxPropertiesTests {
 				"spring.ai.minimax.chat.options.model=MODEL_XYZ",
 				"spring.ai.minimax.chat.options.temperature=0.55")
 				// @formatter:on
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+			.withConfiguration(
+					AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+							ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				var chatProperties = context.getBean(MiniMaxChatProperties.class);
 				var connectionProperties = context.getBean(MiniMaxConnectionProperties.class);
@@ -78,8 +81,9 @@ public class MiniMaxPropertiesTests {
 				"spring.ai.minimax.chat.options.model=MODEL_XYZ",
 				"spring.ai.minimax.chat.options.temperature=0.55")
 				// @formatter:on
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+			.withConfiguration(
+					AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+							ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				var chatProperties = context.getBean(MiniMaxChatProperties.class);
 				var connectionProperties = context.getBean(MiniMaxConnectionProperties.class);
@@ -198,8 +202,9 @@ public class MiniMaxPropertiesTests {
 					"""
 				)
 			// @formatter:on
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+			.withConfiguration(
+					AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+							ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				var chatProperties = context.getBean(MiniMaxChatProperties.class);
 				var connectionProperties = context.getBean(MiniMaxConnectionProperties.class);
@@ -295,8 +300,9 @@ public class MiniMaxPropertiesTests {
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.minimax.api-key=API_KEY", "spring.ai.minimax.base-url=TEST_BASE_URL",
 					"spring.ai.model.chat=none")
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+			.withConfiguration(
+					AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+							ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(MiniMaxChatProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(MiniMaxChatModel.class)).isEmpty();
@@ -304,8 +310,9 @@ public class MiniMaxPropertiesTests {
 
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.minimax.api-key=API_KEY", "spring.ai.minimax.base-url=TEST_BASE_URL")
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+			.withConfiguration(
+					AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+							ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(MiniMaxChatProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(MiniMaxChatModel.class)).isNotEmpty();
@@ -314,8 +321,9 @@ public class MiniMaxPropertiesTests {
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.minimax.api-key=API_KEY", "spring.ai.minimax.base-url=TEST_BASE_URL",
 					"spring.ai.model.chat=minimax")
-			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
-					RestClientAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+			.withConfiguration(
+					AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+							ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(MiniMaxChatProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(MiniMaxChatModel.class)).isNotEmpty();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MinimaxModelConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MinimaxModelConfigurationTests.java
@@ -20,8 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.minimax.MiniMaxChatModel;
 import org.springframework.ai.minimax.MiniMaxEmbeddingModel;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,29 +32,35 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit Tests for MiniMax auto-configurations' conditional enabling of models.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Issam El-atif
  */
 public class MinimaxModelConfigurationTests {
 
-	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class))
+	private final ApplicationContextRunner chatContextRunner = new ApplicationContextRunner()
+		.withConfiguration(
+				AutoConfigurations.of(SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+						ToolCallingAutoConfiguration.class, MiniMaxChatAutoConfiguration.class))
+		.withPropertyValues("spring.ai.minimax.api-key=API_KEY", "spring.ai.minimax.base-url=TEST_BASE_URL");
+
+	private final ApplicationContextRunner embeddingContextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class,
+				RestClientAutoConfiguration.class, MiniMaxEmbeddingAutoConfiguration.class))
 		.withPropertyValues("spring.ai.minimax.api-key=API_KEY", "spring.ai.minimax.base-url=TEST_BASE_URL");
 
 	@Test
 	void chatModelActivation() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MiniMaxChatAutoConfiguration.class)).run(context -> {
+		this.chatContextRunner.run(context -> {
 			assertThat(context.getBeansOfType(MiniMaxChatProperties.class)).isNotEmpty();
 			assertThat(context.getBeansOfType(MiniMaxChatModel.class)).isNotEmpty();
 		});
 
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MiniMaxChatAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=none", "spring.ai.model.embedding=none")
+		this.chatContextRunner.withPropertyValues("spring.ai.model.chat=none", "spring.ai.model.embedding=none")
 			.run(context -> {
 				assertThat(context.getBeansOfType(MiniMaxChatProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(MiniMaxChatModel.class)).isEmpty();
 			});
 
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MiniMaxChatAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.chat=minimax", "spring.ai.model.embedding=none")
+		this.chatContextRunner.withPropertyValues("spring.ai.model.chat=minimax", "spring.ai.model.embedding=none")
 			.run(context -> {
 				assertThat(context.getBeansOfType(MiniMaxChatProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(MiniMaxChatModel.class)).isNotEmpty();
@@ -61,25 +69,20 @@ public class MinimaxModelConfigurationTests {
 
 	@Test
 	void embeddingModelActivation() {
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MiniMaxEmbeddingAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(MiniMaxEmbeddingModel.class)).isNotEmpty();
-				assertThat(context.getBeansOfType(MiniMaxEmbeddingProperties.class)).isNotEmpty();
-			});
+		this.embeddingContextRunner.run(context -> {
+			assertThat(context.getBeansOfType(MiniMaxEmbeddingModel.class)).isNotEmpty();
+			assertThat(context.getBeansOfType(MiniMaxEmbeddingProperties.class)).isNotEmpty();
+		});
 
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MiniMaxEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.embedding=none")
-			.run(context -> {
-				assertThat(context.getBeansOfType(MiniMaxEmbeddingProperties.class)).isEmpty();
-				assertThat(context.getBeansOfType(MiniMaxEmbeddingModel.class)).isEmpty();
-			});
+		this.embeddingContextRunner.withPropertyValues("spring.ai.model.embedding=none").run(context -> {
+			assertThat(context.getBeansOfType(MiniMaxEmbeddingProperties.class)).isEmpty();
+			assertThat(context.getBeansOfType(MiniMaxEmbeddingModel.class)).isEmpty();
+		});
 
-		this.contextRunner.withConfiguration(AutoConfigurations.of(MiniMaxEmbeddingAutoConfiguration.class))
-			.withPropertyValues("spring.ai.model.embedding=minimax")
-			.run(context -> {
-				assertThat(context.getBeansOfType(MiniMaxEmbeddingProperties.class)).isNotEmpty();
-				assertThat(context.getBeansOfType(MiniMaxEmbeddingModel.class)).isNotEmpty();
-			});
+		this.embeddingContextRunner.withPropertyValues("spring.ai.model.embedding=minimax").run(context -> {
+			assertThat(context.getBeansOfType(MiniMaxEmbeddingProperties.class)).isNotEmpty();
+			assertThat(context.getBeansOfType(MiniMaxEmbeddingModel.class)).isNotEmpty();
+		});
 	}
 
 }


### PR DESCRIPTION
Fixes MiniMax model auto-configurations for https://github.com/spring-projects/spring-ai/issues/4494

### Changes

- Removed unnecessary @ImportAutoConfiguration annotations from `MiniMaxChatAutoConfiguration`.
- Add missing auto-configurations to the context runners of unit tests and integration tests.