### PR TITLE
GH-4494: Fix ElevenLabs auto-configuration

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsAutoConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.ai.elevenlabs.api.ElevenLabsApi;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -45,8 +44,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 @EnableConfigurationProperties({ ElevenLabsSpeechProperties.class, ElevenLabsConnectionProperties.class })
 @ConditionalOnProperty(prefix = ElevenLabsSpeechProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 		matchIfMissing = true)
-@ImportAutoConfiguration(classes = { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
-		WebClientAutoConfiguration.class })
 public class ElevenLabsAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsAutoConfigurationIT.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import org.springframework.ai.elevenlabs.ElevenLabsTextToSpeechModel;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +39,7 @@ public class ElevenLabsAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.elevenlabs.api-key=" + System.getenv("ELEVEN_LABS_API_KEY"))
-		.withConfiguration(AutoConfigurations.of(ElevenLabsAutoConfiguration.class));
+		.withConfiguration(ElevenLabsITUtil.elevenLabsAutoConfig(ElevenLabsAutoConfiguration.class));
 
 	@Test
 	void speech() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsITUtil.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsITUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.elevenlabs.autoconfigure;
+
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+
+/**
+ * Utility class for ElevenLabs integration tests.
+ *
+ * @author Pawel Potaczala
+ */
+public final class ElevenLabsITUtil {
+
+	private ElevenLabsITUtil() {
+	}
+
+	public static AutoConfigurations elevenLabsAutoConfig(Class<?>... additionalAutoConfigurations) {
+		Class<?>[] dependencies = new Class[] { SpringAiRetryAutoConfiguration.class, RestClientAutoConfiguration.class,
+				WebClientAutoConfiguration.class };
+		Class<?>[] allAutoConfigurations = new Class[dependencies.length + additionalAutoConfigurations.length];
+		System.arraycopy(dependencies, 0, allAutoConfigurations, 0, dependencies.length);
+		System.arraycopy(additionalAutoConfigurations, 0, allAutoConfigurations, dependencies.length,
+				additionalAutoConfigurations.length);
+
+		return AutoConfigurations.of(allAutoConfigurations);
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsPropertiesTests.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.elevenlabs.ElevenLabsTextToSpeechModel;
 import org.springframework.ai.elevenlabs.api.ElevenLabsApi;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +46,7 @@ public class ElevenLabsPropertiesTests {
 				"spring.ai.elevenlabs.tts.options.voice-settings.use-speaker-boost=false",
 				"spring.ai.elevenlabs.tts.options.voice-settings.speed=1.5"
 				// @formatter:on
-		).withConfiguration(AutoConfigurations.of(ElevenLabsAutoConfiguration.class)).run(context -> {
+		).withConfiguration(ElevenLabsITUtil.elevenLabsAutoConfig(ElevenLabsAutoConfiguration.class)).run(context -> {
 			var speechProperties = context.getBean(ElevenLabsSpeechProperties.class);
 			var connectionProperties = context.getBean(ElevenLabsConnectionProperties.class);
 
@@ -87,7 +86,7 @@ public class ElevenLabsPropertiesTests {
 				"spring.ai.elevenlabs.tts.options.apply-text-normalization=ON",
 				"spring.ai.elevenlabs.tts.options.apply-language-text-normalization=true"
 				// @formatter:on
-		).withConfiguration(AutoConfigurations.of(ElevenLabsAutoConfiguration.class)).run(context -> {
+		).withConfiguration(ElevenLabsITUtil.elevenLabsAutoConfig(ElevenLabsAutoConfiguration.class)).run(context -> {
 			var speechProperties = context.getBean(ElevenLabsSpeechProperties.class);
 
 			assertThat(speechProperties.getOptions().getModelId()).isEqualTo("custom-model");
@@ -114,7 +113,7 @@ public class ElevenLabsPropertiesTests {
 
 		// It is enabled by default
 		new ApplicationContextRunner().withPropertyValues("spring.ai.elevenlabs.api-key=YOUR_API_KEY")
-			.withConfiguration(AutoConfigurations.of(ElevenLabsAutoConfiguration.class))
+			.withConfiguration(ElevenLabsITUtil.elevenLabsAutoConfig(ElevenLabsAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(ElevenLabsSpeechProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(ElevenLabsTextToSpeechModel.class)).isNotEmpty();
@@ -123,7 +122,7 @@ public class ElevenLabsPropertiesTests {
 		// Explicitly enable the text-to-speech autoconfiguration.
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.elevenlabs.api-key=YOUR_API_KEY", "spring.ai.elevenlabs.tts.enabled=true")
-			.withConfiguration(AutoConfigurations.of(ElevenLabsAutoConfiguration.class))
+			.withConfiguration(ElevenLabsITUtil.elevenLabsAutoConfig(ElevenLabsAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(ElevenLabsSpeechProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(ElevenLabsTextToSpeechModel.class)).isNotEmpty();
@@ -132,7 +131,7 @@ public class ElevenLabsPropertiesTests {
 		// Explicitly disable the text-to-speech autoconfiguration.
 		new ApplicationContextRunner()
 			.withPropertyValues("spring.ai.elevenlabs.api-key=YOUR_API_KEY", "spring.ai.elevenlabs.tts.enabled=false")
-			.withConfiguration(AutoConfigurations.of(ElevenLabsAutoConfiguration.class))
+			.withConfiguration(ElevenLabsITUtil.elevenLabsAutoConfig(ElevenLabsAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(ElevenLabsSpeechProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(ElevenLabsTextToSpeechModel.class)).isEmpty();


### PR DESCRIPTION
Fix for ElevenLabs auto configuration imports, following https://github.com/spring-projects/spring-ai/issues/4494

@ilayaperumalg can you add `hacktoberfest-accepted` label?