### PR TITLE
[BUG] fix chroma api auth

### DIFF
--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaApi.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaApi.java
@@ -62,6 +62,8 @@ public class ChromaApi {
 	// Regular expression pattern that looks for a message.
 	private static final Pattern MESSAGE_ERROR_PATTERN = Pattern.compile("\"message\":\"(.*?)\"");
 
+	private static final String X_CHROMA_TOKEN_NAME = "x-chroma-token";
+
 	private final ObjectMapper objectMapper;
 
 	private RestClient restClient;
@@ -328,7 +330,7 @@ public class ChromaApi {
 
 	private void httpHeaders(HttpHeaders headers) {
 		if (StringUtils.hasText(this.keyToken)) {
-			headers.set("x-chroma-token", this.keyToken);
+			headers.set(X_CHROMA_TOKEN_NAME, this.keyToken);
 		}
 	}
 


### PR DESCRIPTION
Philip here from the Chroma team. 

This SDK currently authenticates via a bearer token.

However, Chroma uses the `x-chroma-token` header instead of bearer, leading all authenticated requests with this SDK to fail with a 401 error. (Details in the Chroma OpenAPI spec: https://api.trychroma.com/docs/ )

I've patched the authentication method in this PR. 

