### PR TITLE
Fix CosmosDBChatMemory javadoc

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryAutoConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Bean;
  * {@link AutoConfiguration Auto-configuration} for {@link CosmosDBChatMemoryRepository}.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 @AutoConfiguration
 @ConditionalOnClass({ CosmosDBChatMemoryRepository.class, CosmosAsyncClient.class })

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryProperties.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for CosmosDB chat memory.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 @ConfigurationProperties(CosmosDBChatMemoryRepositoryProperties.CONFIG_PREFIX)
 public class CosmosDBChatMemoryRepositoryProperties {

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/test/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryAutoConfigurationIT.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/test/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryAutoConfigurationIT.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link CosmosDBChatMemoryRepositoryAutoConfiguration}.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 @EnabledIfEnvironmentVariable(named = "AZURE_COSMOSDB_ENDPOINT", matches = ".+")
 class CosmosDBChatMemoryRepositoryAutoConfigurationIT {

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/test/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryPropertiesTest.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/test/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryPropertiesTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for {@link CosmosDBChatMemoryRepositoryProperties}.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 class CosmosDBChatMemoryRepositoryPropertiesTest {
 

--- a/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepository.java
@@ -51,7 +51,7 @@ import org.springframework.util.Assert;
  * An implementation of {@link ChatMemoryRepository} for Azure Cosmos DB.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 public final class CosmosDBChatMemoryRepository implements ChatMemoryRepository {
 

--- a/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepositoryConfig.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepositoryConfig.java
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
  * Configuration for the CosmosDB Chat Memory store.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 public final class CosmosDBChatMemoryRepositoryConfig {
 

--- a/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/test/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepositoryIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/test/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepositoryIT.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link CosmosDBChatMemoryRepository}.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 @EnabledIfEnvironmentVariable(named = "AZURE_COSMOSDB_ENDPOINT", matches = ".+")
 class CosmosDBChatMemoryRepositoryIT {

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverter.java
@@ -34,7 +34,7 @@ import static org.springframework.ai.vectorstore.filter.Filter.ExpressionType.OR
  * Cosmos DB NoSQL API where clauses.
  *
  * @author Theo van Kraay
- * @since 1.0.0
+ * @since 1.1.0
  */
 class CosmosDBFilterExpressionConverter extends AbstractFilterExpressionConverter {
 


### PR DESCRIPTION
CosmosDB Chat Memory wasn't available in 1.0.0, it was merged for 1.1.0-M3