### PR TITLE
GH-4494: Fix Bedrock Converse proxy auto-configuration

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -50,6 +49,7 @@ import org.springframework.context.annotation.Import;
  *
  * @author Christian Tzolov
  * @author Wei Jiang
+ * @author Pawel Potaczala
  */
 @AutoConfiguration(after = { ToolCallingAutoConfiguration.class })
 @EnableConfigurationProperties({ BedrockConverseProxyChatProperties.class, BedrockAwsConnectionConfiguration.class })
@@ -57,7 +57,6 @@ import org.springframework.context.annotation.Import;
 @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.BEDROCK_CONVERSE,
 		matchIfMissing = true)
 @Import(BedrockAwsConnectionConfiguration.class)
-@ImportAutoConfiguration({ ToolCallingAutoConfiguration.class })
 public class BedrockConverseProxyChatAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseModelConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseModelConfigurationTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.model.bedrock.converse.autoconfigure;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.bedrock.converse.BedrockProxyChatModel;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,11 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * of models.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Pawel Potaczala
  */
 public class BedrockConverseModelConfigurationTests {
 
-	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-		.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class));
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(
+			BedrockConverseProxyITUtil.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class));
 
 	@Test
 	void chatModelActivation() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfigurationIT.java
@@ -32,7 +32,6 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockTestUtils;
 import org.springframework.ai.model.bedrock.autoconfigure.RequiresAwsCredentials;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +45,8 @@ public class BedrockConverseProxyChatAutoConfigurationIT {
 		.withPropertyValues(
 				"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0",
 				"spring.ai.bedrock.converse.chat.options.temperature=0.5")
-		.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class));
+		.withConfiguration(BedrockConverseProxyITUtil
+			.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class));
 
 	@Test
 	void call() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
@@ -19,13 +19,13 @@ package org.springframework.ai.model.bedrock.converse.autoconfigure;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.bedrock.converse.BedrockProxyChatModel;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Pawel Potaczala
  *
  * Unit Tests for {@link BedrockConverseProxyChatProperties}.
  */
@@ -47,7 +47,8 @@ public class BedrockConverseProxyChatPropertiesTests {
 				"spring.ai.bedrock.converse.chat.options.top-k=100"
 				)
 			// @formatter:on
-			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class))
+			.withConfiguration(BedrockConverseProxyITUtil
+				.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class))
 			.run(context -> {
 				var chatProperties = context.getBean(BedrockConverseProxyChatProperties.class);
 
@@ -66,12 +67,14 @@ public class BedrockConverseProxyChatPropertiesTests {
 
 		// It is enabled by default
 		new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class))
+			.withConfiguration(BedrockConverseProxyITUtil
+				.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class))
 			.run(context -> assertThat(context.getBeansOfType(BedrockConverseProxyChatProperties.class)).isNotEmpty());
 
 		// Explicitly enable the chat auto-configuration.
 		new ApplicationContextRunner().withPropertyValues("spring.ai.model.chat=bedrock-converse")
-			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class))
+			.withConfiguration(BedrockConverseProxyITUtil
+				.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(BedrockConverseProxyChatProperties.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(BedrockProxyChatModel.class)).isNotEmpty();
@@ -79,7 +82,8 @@ public class BedrockConverseProxyChatPropertiesTests {
 
 		// Explicitly disable the chat auto-configuration.
 		new ApplicationContextRunner().withPropertyValues("spring.ai.model.chat=none")
-			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class))
+			.withConfiguration(BedrockConverseProxyITUtil
+				.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class))
 			.run(context -> {
 				assertThat(context.getBeansOfType(BedrockConverseProxyChatProperties.class)).isEmpty();
 				assertThat(context.getBeansOfType(BedrockProxyChatModel.class)).isEmpty();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyITUtil.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyITUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.bedrock.converse.autoconfigure;
+
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+
+/**
+ * Utility class for Bedrock Converse Proxy integration tests.
+ *
+ * @author Pawel Potaczala
+ */
+public final class BedrockConverseProxyITUtil {
+
+	private BedrockConverseProxyITUtil() {
+	}
+
+	public static AutoConfigurations bedrockConverseProxyAutoConfig(Class<?>... additionalAutoConfigurations) {
+		Class<?>[] dependencies = new Class[] { ToolCallingAutoConfiguration.class };
+		Class<?>[] allAutoConfigurations = new Class[dependencies.length + additionalAutoConfigurations.length];
+		System.arraycopy(dependencies, 0, allAutoConfigurations, 0, dependencies.length);
+		System.arraycopy(additionalAutoConfigurations, 0, allAutoConfigurations, dependencies.length,
+				additionalAutoConfigurations.length);
+
+		return AutoConfigurations.of(allAutoConfigurations);
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
@@ -33,7 +33,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockTestUtils;
 import org.springframework.ai.model.bedrock.autoconfigure.RequiresAwsCredentials;
 import org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyChatAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyITUtil;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -47,7 +47,8 @@ class FunctionCallWithFunctionBeanIT {
 	private final Logger logger = LoggerFactory.getLogger(FunctionCallWithFunctionBeanIT.class);
 
 	private final ApplicationContextRunner contextRunner = BedrockTestUtils.getContextRunner()
-		.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class))
+		.withConfiguration(BedrockConverseProxyITUtil
+			.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class))
 		.withUserConfiguration(Config.class);
 
 	@Test

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
@@ -30,8 +30,8 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockTestUtils;
 import org.springframework.ai.model.bedrock.autoconfigure.RequiresAwsCredentials;
 import org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyChatAutoConfiguration;
+import org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyITUtil;
 import org.springframework.ai.tool.function.FunctionToolCallback;
-import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +42,8 @@ public class FunctionCallWithPromptFunctionIT {
 	private final Logger logger = LoggerFactory.getLogger(FunctionCallWithPromptFunctionIT.class);
 
 	private final ApplicationContextRunner contextRunner = BedrockTestUtils.getContextRunner()
-		.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class));
+		.withConfiguration(BedrockConverseProxyITUtil
+			.bedrockConverseProxyAutoConfig(BedrockConverseProxyChatAutoConfiguration.class));
 
 	@Test
 	void functionCallTest() {


### PR DESCRIPTION
Fix for Bedrock Converse proxy auto configuration imports, following https://github.com/spring-projects/spring-ai/issues/4494