### PR TITLE
Avoid string concatenation in logging calls

### DIFF
--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/api/AbstractBedrockApi.java
@@ -287,7 +287,7 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 				.builder()
 				.onChunk(chunk -> {
 					try {
-						logger.debug("Received chunk: " + chunk.bytes().asString(StandardCharsets.UTF_8));
+						logger.debug("Received chunk: {}", chunk.bytes().asString(StandardCharsets.UTF_8));
 						SO response = this.objectMapper.readValue(chunk.bytes().asByteArray(), clazz);
 						eventSink.emitNext(response, DEFAULT_EMIT_FAILURE_HANDLER);
 					}
@@ -297,7 +297,7 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 					}
 				})
 				.onDefault(event -> {
-					logger.error("Unknown or unhandled event: " + event.toString());
+					logger.error("Unknown or unhandled event: {}", event.toString());
 					eventSink.emitError(new Throwable("Unknown or unhandled event: " + event.toString()), DEFAULT_EMIT_FAILURE_HANDLER);
 				})
 				.build();
@@ -310,7 +310,7 @@ public abstract class AbstractBedrockApi<I, O, SO> {
 							logger.info("Completed streaming response.");
 						})
 				.onError(error -> {
-					logger.error("\n\nError streaming response: " + error.getMessage());
+					logger.error("\n\nError streaming response: {}", error.getMessage());
 					eventSink.emitError(error, DEFAULT_EMIT_FAILURE_HANDLER);
 				})
 				.onEventStream(stream -> stream.subscribe(

--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TextSplitter.java
@@ -84,7 +84,7 @@ public abstract class TextSplitter implements DocumentTransformer {
 			Map<String, Object> metadata = metadataList.get(i);
 			List<String> chunks = splitText(text);
 			if (chunks.size() > 1) {
-				logger.info("Splitting up document into " + chunks.size() + " chunks.");
+				logger.info("Splitting up document into {} chunks.", chunks.size());
 			}
 			for (String chunk : chunks) {
 				// only primitive values are in here -

--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
@@ -88,7 +88,7 @@ public abstract class RetryUtils {
 			@Override
 			public <T extends Object, E extends Throwable> void onError(RetryContext context,
 					RetryCallback<T, E> callback, Throwable throwable) {
-				logger.warn("Retry error. Retry count:" + context.getRetryCount(), throwable);
+				logger.warn("Retry error. Retry count:{}", context.getRetryCount(), throwable);
 			}
 		})
 		.build();
@@ -107,7 +107,7 @@ public abstract class RetryUtils {
 			@Override
 			public <T extends Object, E extends Throwable> void onError(RetryContext context,
 					RetryCallback<T, E> callback, Throwable throwable) {
-				logger.warn("Retry error. Retry count:" + context.getRetryCount());
+				logger.warn("Retry error. Retry count:{}", context.getRetryCount());
 			}
 		})
 		.build();

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -303,7 +303,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 
 		SearchIndex index = this.searchIndexClient.createOrUpdateIndex(searchIndex);
 
-		logger.info("Created search index: " + index.getName());
+		logger.info("Created search index: {}", index.getName());
 
 		this.searchClient = this.searchIndexClient.getSearchClient(this.indexName);
 	}

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
@@ -189,7 +189,7 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 
 			Map<String, Object> whereClause = this.chromaApi.where(whereClauseStr);
 
-			logger.debug("Deleting with where clause: " + whereClause);
+			logger.debug("Deleting with where clause: {}", whereClause);
 
 			DeleteEmbeddingsRequest deleteRequest = new DeleteEmbeddingsRequest(null, whereClause);
 			this.chromaApi.deleteEmbeddings(this.tenantName, this.databaseName, this.collectionId, deleteRequest);

--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
@@ -72,7 +72,7 @@ public class MariaDBSchemaValidator {
 					schemaName, tableName);
 		}
 		catch (DataAccessException e) {
-			logger.error("Error while validating database vector support " + e.getMessage());
+			logger.error("Error while validating database vector support {}", e.getMessage());
 			logger.error("Failed to validate that database supports VECTOR.\n" + "Run the following SQL commands:\n"
 					+ "   SELECT @@version; \nAnd ensure that version is >= 11.7.1");
 			throw new IllegalStateException(e);
@@ -118,7 +118,7 @@ public class MariaDBSchemaValidator {
 
 		}
 		catch (DataAccessException | IllegalStateException e) {
-			logger.error("Error while validating table schema" + e.getMessage());
+			logger.error("Error while validating table schema{}", e.getMessage());
 			logger.error("Failed to operate with the specified table in the database. To resolve this issue,"
 					+ " please ensure the following steps are completed:\n"
 					+ "1. Verify that the table exists with the appropriate structure. If it does not"

--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBVectorStore.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBVectorStore.java
@@ -364,7 +364,7 @@ public class MariaDBVectorStore extends AbstractObservationVectorStore implement
 				this.idFieldName, this.contentFieldName, this.metadataFieldName, distanceType, this.embeddingFieldName,
 				getFullyQualifiedTableName(), jsonPathFilter);
 
-		logger.debug("SQL query: " + sql);
+		logger.debug("SQL query: {}", sql);
 
 		return this.jdbcTemplate.query(sql, new DocumentRowMapper(this.objectMapper), embedding, distance,
 				request.getTopK());

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -292,7 +292,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 
 		long deleteCount = status.getData().getDeleteCnt();
 		if (deleteCount != idList.size()) {
-			logger.warn(String.format("Deleted only %s entries from requested %s ", deleteCount, idList.size()));
+			logger.warn("Deleted only {} entries from requested {} ", deleteCount, idList.size());
 		}
 	}
 
@@ -544,8 +544,9 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			}
 		}
 		catch (Exception e) {
-			logger.warn("Failed to obtain the embedding dimensions from the embedding model and fall backs to default:"
-					+ this.embeddingDimension, e);
+			logger.warn(
+					"Failed to obtain the embedding dimensions from the embedding model and fall backs to default:{}",
+					this.embeddingDimension, e);
 		}
 		return OPENAI_EMBEDDING_DIMENSION_SIZE;
 	}

--- a/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
@@ -282,7 +282,7 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 			BasicQuery query = new BasicQuery(nativeFilterExpression);
 			DeleteResult deleteResult = this.mongoTemplate.remove(query, this.collectionName);
 
-			logger.debug("Deleted " + deleteResult.getDeletedCount() + " documents matching filter expression");
+			logger.debug("Deleted {} documents matching filter expression", deleteResult.getDeletedCount());
 		}
 		catch (Exception e) {
 			throw new IllegalStateException("Failed to delete documents by filter", e);

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -249,7 +249,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 				.build();
 
 			DeleteByQueryResponse response = this.openSearchClient.deleteByQuery(request);
-			logger.debug("Deleted " + response.deleted() + " documents matching filter expression");
+			logger.debug("Deleted {} documents matching filter expression", response.deleted());
 
 			if (!response.failures().isEmpty()) {
 				throw new IllegalStateException("Failed to delete some documents: " + response.failures());

--- a/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
+++ b/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
@@ -314,10 +314,10 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 			String jsonPath = this.filterExpressionConverter.convertExpression(filterExpression);
 			String sql = String.format("DELETE FROM %s WHERE JSON_EXISTS(metadata, '%s')", this.tableName, jsonPath);
 
-			logger.debug("Executing delete with filter: " + sql);
+			logger.debug("Executing delete with filter: {}", sql);
 
 			int deletedCount = this.jdbcTemplate.update(sql);
-			logger.debug("Deleted " + deletedCount + " documents matching filter expression");
+			logger.debug("Deleted {} documents matching filter expression", deletedCount);
 		}
 		catch (Exception e) {
 			logger.error("Failed to delete documents by filter: {}", e.getMessage(), e);
@@ -378,7 +378,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 								this.distanceType == OracleVectorStore.OracleVectorStoreDistanceType.DOT ? ")/2" : "",
 								this.tableName, jsonPathFilter, request.getTopK(), this.searchAccuracy);
 
-				logger.debug("SQL query: " + sql);
+				logger.debug("SQL query: {}", sql);
 
 				return this.jdbcTemplate.query(sql, new DocumentRowMapper(), embeddingVector);
 			}
@@ -397,7 +397,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 						this.distanceType == OracleVectorStore.OracleVectorStoreDistanceType.DOT ? ")/2" : "",
 						this.tableName, jsonPathFilter, request.getTopK());
 
-				logger.debug("SQL query: " + sql);
+				logger.debug("SQL query: {}", sql);
 
 				return this.jdbcTemplate.query(sql, new DocumentRowMapper(), embeddingVector);
 			}
@@ -453,7 +453,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 												fetch APPROXIMATE first %d rows only WITH TARGET ACCURACY %d""",
 										this.tableName, jsonPathFilter, request.getTopK(), this.searchAccuracy));
 
-				logger.debug("SQL query: " + sql);
+				logger.debug("SQL query: {}", sql);
 
 				return this.jdbcTemplate.query(sql, new DocumentRowMapper(), embeddingVector, embeddingVector,
 						distance);

--- a/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorSchemaValidator.java
+++ b/vector-stores/spring-ai-pgvector-store/src/main/java/org/springframework/ai/vectorstore/pgvector/PgVectorSchemaValidator.java
@@ -131,7 +131,7 @@ public class PgVectorSchemaValidator {
 
 		}
 		catch (DataAccessException | IllegalStateException e) {
-			logger.error("Error while validating table schema" + e.getMessage());
+			logger.error("Error while validating table schema{}", e.getMessage());
 			logger
 				.error("Failed to operate with the specified table in the database. To resolve this issue, please ensure the following steps are completed:\n"
 						+ "1. Ensure the necessary PostgreSQL extensions are enabled. Run the following SQL commands:\n"

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
@@ -283,8 +283,9 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 			}
 		}
 		catch (Exception e) {
-			logger.warn("Failed to obtain the embedding dimensions from the embedding model and fall backs to default:"
-					+ this.embeddingDimension, e);
+			logger.warn(
+					"Failed to obtain the embedding dimensions from the embedding model and fall backs to default:{}",
+					this.embeddingDimension, e);
 		}
 		return OPENAI_EMBEDDING_DIMENSION_SIZE;
 	}


### PR DESCRIPTION
Avoid string concatenation in logging calls. Logger accepts positional parameters which are evaluated lazily, so this avoids concatenating the strings especially in debug calls