### PR TITLE
Add comprehensive validation tests for MultiQueryExpander

### DIFF
--- a/spring-ai-rag/src/test/java/org/springframework/ai/rag/preretrieval/query/expansion/MultiQueryExpanderTests.java
+++ b/spring-ai-rag/src/test/java/org/springframework/ai/rag/preretrieval/query/expansion/MultiQueryExpanderTests.java
@@ -85,4 +85,66 @@ class MultiQueryExpanderTests {
 		assertThat(queryExpander).isNotNull();
 	}
 
+	@Test
+	void whenPromptTemplateHasBothPlaceholdersThenBuild() {
+		PromptTemplate validTemplate = new PromptTemplate("Generate {number} variations of: {query}");
+
+		MultiQueryExpander expander = MultiQueryExpander.builder()
+			.chatClientBuilder(mock(ChatClient.Builder.class))
+			.promptTemplate(validTemplate)
+			.build();
+
+		assertThat(expander).isNotNull();
+	}
+
+	@Test
+	void whenPromptTemplateHasExtraPlaceholdersThenBuild() {
+		PromptTemplate templateWithExtra = new PromptTemplate(
+				"Generate {number} variations of: {query}. Context: {context}");
+
+		MultiQueryExpander expander = MultiQueryExpander.builder()
+			.chatClientBuilder(mock(ChatClient.Builder.class))
+			.promptTemplate(templateWithExtra)
+			.build();
+
+		assertThat(expander).isNotNull();
+	}
+
+	@Test
+	void whenBuilderSetMultipleTimesThenUseLastValue() {
+		ChatClient.Builder firstBuilder = mock(ChatClient.Builder.class);
+		ChatClient.Builder secondBuilder = mock(ChatClient.Builder.class);
+
+		MultiQueryExpander expander = MultiQueryExpander.builder()
+			.chatClientBuilder(firstBuilder)
+			.chatClientBuilder(secondBuilder)
+			.build();
+
+		assertThat(expander).isNotNull();
+	}
+
+	@Test
+	void whenPromptTemplateSetToNullAfterValidTemplateThenUseDefault() {
+		PromptTemplate validTemplate = new PromptTemplate("Config: {number} values for {query}");
+
+		MultiQueryExpander expander = MultiQueryExpander.builder()
+			.chatClientBuilder(mock(ChatClient.Builder.class))
+			.promptTemplate(validTemplate)
+			.promptTemplate(null)
+			.build();
+
+		assertThat(expander).isNotNull();
+	}
+
+	@Test
+	void whenPromptTemplateHasPlaceholdersInDifferentCaseThenThrow() {
+		PromptTemplate templateWithWrongCase = new PromptTemplate("Generate {NUMBER} variations of: {QUERY}");
+
+		assertThatThrownBy(() -> MultiQueryExpander.builder()
+			.chatClientBuilder(mock(ChatClient.Builder.class))
+			.promptTemplate(templateWithWrongCase)
+			.build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("The following placeholders must be present in the prompt template");
+	}
+
 }


### PR DESCRIPTION
This PR adds additional test coverage for the `MultiQueryExpander` builder validation logic.

### Changes
- Added tests for valid prompt template configurations with both required placeholders
- Added tests for prompt templates containing extra placeholders beyond the required ones
- Added tests for builder behavior when properties are set multiple times
- Added tests for null prompt template handling after setting a valid template
- Added tests for case-sensitive placeholder validation

### Test Coverage
These tests complement the existing validation tests by covering:
- Positive cases: valid templates that should successfully build
- Edge cases: templates with extra placeholders, builder property overrides
- Negative cases: case-sensitivity of placeholder names

### Validation
All tests follow the existing test patterns and use consistent assertions with the current test suite.