### PR TITLE
Auto-config: Retries for network exceptions 

### DIFF
--- a/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryAutoConfiguration.java
+++ b/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.ai.retry.NonTransientAiException;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.retry.TransientAiException;
@@ -76,10 +77,10 @@ public class SpringAiRetryAutoConfiguration {
 				}
 			});
 
-		// Optionally add WebFlux pre-response network errors if present without hard dependency
+		// Optionally add WebFlux pre-response network errors if present
 		try {
 			Class<?> webClientRequestEx = Class
-					.forName("org.springframework.web.reactive.function.client.WebClientRequestException");
+				.forName("org.springframework.web.reactive.function.client.WebClientRequestException");
 			@SuppressWarnings("unchecked")
 			Class<? extends Throwable> exClass = (Class<? extends Throwable>) webClientRequestEx;
 			builder.retryOn(exClass);


### PR DESCRIPTION
related issue: #4567 

Auto-configured retry template now aligns with builder defaults by retrying on pre-response network exceptions. Previously, network connectivity errors like connection timeouts and connection refused were not retried in the auto-configuration path, causing inconsistent resilience behavior compared to the builder defaults.

## Problem

- Auto-configured `RetryTemplate` only retried on `TransientAiException` (HTTP-status-based)
- Pre-response network failures (e.g., `ResourceAccessException`, `WebClientRequestException`) bypassed `ResponseErrorHandler` and were not retried
- This created inconsistent resilience behavior between auto-configuration and builder paths
- Applications using auto-configuration experienced immediate failures on transient network issues

## Solution

- Added `ResourceAccessException` to retryable exceptions in auto-configured `RetryTemplate`
- Added optional `WebClientRequestException` retry support when WebFlux is present (via reflection)
- Maintained existing backoff/listener behavior and `ResponseErrorHandler` logic
- Used reflection to avoid hard dependency on WebFlux

## Impact

✅ Aligns auto-config retry behavior with `RetryUtils.DEFAULT_RETRY_TEMPLATE`  
✅ Retries pre-response network exceptions (connection timeouts, connection refused)  
✅ Optional WebFlux support without hard dependency  
✅ Maintains existing retry behavior for `TransientAiException`  
✅ No breaking changes - purely additive retry behavior  
✅ Comprehensive unit tests added for all scenarios  