### PR TITLE
Add timeout support for ChatClient API

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.anthropic;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -47,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
  * @author Austin Dase
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -102,6 +104,12 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Map<String, String> httpHeaders = new HashMap<>();
 
+	/**
+	 * The timeout duration for the chat request.
+	 */
+	@JsonIgnore
+	private Duration timeout;
+
 	// @formatter:on
 
 	public static Builder builder() {
@@ -125,6 +133,7 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 			.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
 			.httpHeaders(fromOptions.getHttpHeaders() != null ? new HashMap<>(fromOptions.getHttpHeaders()) : null)
 			.cacheOptions(fromOptions.getCacheOptions())
+			.timeout(fromOptions.getTimeout())
 			.build();
 	}
 
@@ -274,6 +283,17 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public AnthropicChatOptions copy() {
 		return fromOptions(this);
@@ -297,14 +317,14 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
 				&& Objects.equals(this.toolContext, that.toolContext)
 				&& Objects.equals(this.httpHeaders, that.httpHeaders)
-				&& Objects.equals(this.cacheOptions, that.cacheOptions);
+				&& Objects.equals(this.cacheOptions, that.cacheOptions) && Objects.equals(this.timeout, that.timeout);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.model, this.maxTokens, this.metadata, this.stopSequences, this.temperature, this.topP,
 				this.topK, this.thinking, this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled,
-				this.toolContext, this.httpHeaders, this.cacheOptions);
+				this.toolContext, this.httpHeaders, this.cacheOptions, this.timeout);
 	}
 
 	public static class Builder {
@@ -406,6 +426,11 @@ public class AnthropicChatOptions implements ToolCallingChatOptions {
 
 		public Builder cacheOptions(AnthropicCacheOptions cacheOptions) {
 			this.options.setCacheOptions(cacheOptions);
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.azure.openai;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -50,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  * @author Alexandros Pappas
  * @author Andres da Silva Santos
+ * @author Hyunsang Han
  */
 @JsonInclude(Include.NON_NULL)
 public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
@@ -223,6 +225,12 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	private Map<String, Object> toolContext = new HashMap<>();
 
 	/**
+	 * The timeout duration for the chat request.
+	 */
+	@JsonIgnore
+	private Duration timeout;
+
+	/**
 	 * Collection of {@link ToolCallback}s to be used for tool calling in the chat
 	 * completion requests.
 	 */
@@ -328,6 +336,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 			.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
 			.streamOptions(fromOptions.getStreamOptions())
+			.timeout(fromOptions.getTimeout())
 			.build();
 	}
 
@@ -522,6 +531,17 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 		this.toolContext = toolContext;
 	}
 
+	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
 	public ChatCompletionStreamOptions getStreamOptions() {
 		return this.streamOptions;
 	}
@@ -561,7 +581,8 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.maxCompletionTokens, that.maxCompletionTokens)
 				&& Objects.equals(this.frequencyPenalty, that.frequencyPenalty)
 				&& Objects.equals(this.presencePenalty, that.presencePenalty)
-				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP);
+				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP)
+				&& Objects.equals(this.timeout, that.timeout);
 	}
 
 	@Override
@@ -570,7 +591,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 				this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled, this.seed, this.logprobs,
 				this.topLogProbs, this.enhancements, this.streamOptions, this.reasoningEffort, this.enableStreamUsage,
 				this.toolContext, this.maxTokens, this.maxCompletionTokens, this.frequencyPenalty, this.presencePenalty,
-				this.temperature, this.topP);
+				this.temperature, this.topP, this.timeout);
 	}
 
 	public static class Builder {
@@ -775,6 +796,11 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.bedrock.converse;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import org.springframework.util.Assert;
  * The options to be used when sending a chat request to the Bedrock API.
  *
  * @author Sun Yuhan
+ * @author Hyunsang Han
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BedrockChatOptions implements ToolCallingChatOptions {
@@ -81,6 +83,9 @@ public class BedrockChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
 
+	@JsonIgnore
+	private Duration timeout;
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -101,6 +106,7 @@ public class BedrockChatOptions implements ToolCallingChatOptions {
 			.toolNames(new HashSet<>(fromOptions.getToolNames()))
 			.toolContext(new HashMap<>(fromOptions.getToolContext()))
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
+			.timeout(fromOptions.getTimeout())
 			.build();
 	}
 
@@ -238,6 +244,17 @@ public class BedrockChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public BedrockChatOptions copy() {
 		return fromOptions(this);
@@ -259,14 +276,15 @@ public class BedrockChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topK, that.topK)
 				&& Objects.equals(this.topP, that.topP) && Objects.equals(this.toolCallbacks, that.toolCallbacks)
 				&& Objects.equals(this.toolNames, that.toolNames) && Objects.equals(this.toolContext, that.toolContext)
-				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled);
+				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
+				&& Objects.equals(this.timeout, that.timeout);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
 				this.requestParameters, this.stopSequences, this.temperature, this.topK, this.topP, this.toolCallbacks,
-				this.toolNames, this.toolContext, this.internalToolExecutionEnabled);
+				this.toolNames, this.toolContext, this.internalToolExecutionEnabled, this.timeout);
 	}
 
 	public static class Builder {
@@ -353,6 +371,11 @@ public class BedrockChatOptions implements ToolCallingChatOptions {
 
 		public Builder internalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 			this.options.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.deepseek;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,6 +44,7 @@ import org.springframework.util.Assert;
  * chat completion</a>
  *
  * @author Geng Rong
+ * @author Hyunsang Han
  */
 @JsonInclude(Include.NON_NULL)
 public class DeepSeekChatOptions implements ToolCallingChatOptions {
@@ -143,7 +145,10 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 	private Set<String> toolNames = new HashSet<>();
 
 	@JsonIgnore
-	private Map<String, Object> toolContext = new HashMap<>();;
+	private Map<String, Object> toolContext = new HashMap<>();
+
+	@JsonIgnore
+	private Duration timeout;
 
 	public static Builder builder() {
 		return new Builder();
@@ -289,6 +294,17 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
 	}
 
+	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
 	public Boolean getLogprobs() {
 		return this.logprobs;
 	}
@@ -332,7 +348,7 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 		return Objects.hash(this.model, this.frequencyPenalty, this.logprobs, this.topLogprobs,
 				this.maxTokens,  this.presencePenalty, this.responseFormat,
 				this.stop, this.temperature, this.topP, this.tools, this.toolChoice,
-				this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled, this.toolContext);
+				this.toolCallbacks, this.toolNames, this.internalToolExecutionEnabled, this.toolContext, this.timeout);
 	}
 
 
@@ -357,7 +373,8 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolCallbacks, other.toolCallbacks)
 				&& Objects.equals(this.toolNames, other.toolNames)
 				&& Objects.equals(this.toolContext, other.toolContext)
-				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled);
+				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
+				&& Objects.equals(this.timeout, other.timeout);
 	}
 
 	public static DeepSeekChatOptions fromOptions(DeepSeekChatOptions fromOptions) {
@@ -379,6 +396,7 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 				.toolNames(fromOptions.getToolNames() != null ? new HashSet<>(fromOptions.getToolNames()) : null)
 				.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
 				.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
+				.timeout(fromOptions.getTimeout())
 				.build();
 	}
 
@@ -494,6 +512,11 @@ public class DeepSeekChatOptions implements ToolCallingChatOptions {
 			else {
 				this.options.toolContext.putAll(toolContext);
 			}
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.google.genai;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
  * @author Dan Dobrin
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -170,6 +172,12 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions {
 	private Map<String, Object> toolContext = new HashMap<>();
 
 	/**
+	 * The timeout duration for the chat request.
+	 */
+	@JsonIgnore
+	private Duration timeout;
+
+	/**
 	 * Use Google search Grounding feature
 	 */
 	@JsonIgnore
@@ -212,6 +220,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions {
 		options.setUseCachedContent(fromOptions.getUseCachedContent());
 		options.setAutoCacheThreshold(fromOptions.getAutoCacheThreshold());
 		options.setAutoCacheTtl(fromOptions.getAutoCacheTtl());
+		options.setTimeout(fromOptions.getTimeout());
 		return options;
 	}
 
@@ -434,6 +443,17 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
 			return true;
@@ -454,7 +474,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolNames, that.toolNames)
 				&& Objects.equals(this.safetySettings, that.safetySettings)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
-				&& Objects.equals(this.toolContext, that.toolContext) && Objects.equals(this.labels, that.labels);
+				&& Objects.equals(this.toolContext, that.toolContext) && Objects.equals(this.labels, that.labels)
+				&& Objects.equals(this.timeout, that.timeout);
 	}
 
 	@Override
@@ -462,7 +483,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions {
 		return Objects.hash(this.stopSequences, this.temperature, this.topP, this.topK, this.candidateCount,
 				this.frequencyPenalty, this.presencePenalty, this.thinkingBudget, this.maxOutputTokens, this.model,
 				this.responseMimeType, this.toolCallbacks, this.toolNames, this.googleSearchRetrieval,
-				this.safetySettings, this.internalToolExecutionEnabled, this.toolContext, this.labels);
+				this.safetySettings, this.internalToolExecutionEnabled, this.toolContext, this.labels, this.timeout);
 	}
 
 	@Override
@@ -630,6 +651,11 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder autoCacheTtl(java.time.Duration autoCacheTtl) {
 			this.options.setAutoCacheTtl(autoCacheTtl);
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.minimax;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,6 +49,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author Alexandros Pappas
+ * @author Hyunsang Han
  * @since 1.0.0 M1
  */
 @JsonInclude(Include.NON_NULL)
@@ -155,6 +157,9 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	 */
 	@JsonIgnore
 	private Boolean internalToolExecutionEnabled;
+
+	@JsonIgnore
+	private Duration timeout;
 
 	// @formatter:on
 
@@ -353,6 +358,17 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	public Map<String, Object> getToolContext() {
 		return (this.toolContext != null) ? Collections.unmodifiableMap(this.toolContext) : null;
 	}
@@ -509,6 +525,11 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 			else {
 				this.options.toolContext.putAll(toolContext);
 			}
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mistralai;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Alexandros Pappas
  * @author Jason Smith
+ * @author Hyunsang Han
  * @since 0.8.1
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -160,6 +162,9 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
 
+	@JsonIgnore
+	private Duration timeout;
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -183,6 +188,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 			.toolNames(fromOptions.getToolNames() != null ? new HashSet<>(fromOptions.getToolNames()) : null)
 			.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
 			.toolContext(fromOptions.getToolContext() != null ? new HashMap<>(fromOptions.getToolContext()) : null)
+			.timeout(fromOptions.getTimeout())
 			.build();
 	}
 
@@ -368,6 +374,17 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public MistralAiChatOptions copy() {
 		return fromOptions(this);
@@ -377,7 +394,8 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 	public int hashCode() {
 		return Objects.hash(this.model, this.temperature, this.topP, this.maxTokens, this.safePrompt, this.randomSeed,
 				this.responseFormat, this.stop, this.frequencyPenalty, this.presencePenalty, this.n, this.tools,
-				this.toolChoice, this.toolCallbacks, this.tools, this.internalToolExecutionEnabled, this.toolContext);
+				this.toolChoice, this.toolCallbacks, this.tools, this.internalToolExecutionEnabled, this.toolContext,
+				this.timeout);
 	}
 
 	@Override
@@ -403,7 +421,7 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.toolCallbacks, other.toolCallbacks)
 				&& Objects.equals(this.toolNames, other.toolNames)
 				&& Objects.equals(this.internalToolExecutionEnabled, other.internalToolExecutionEnabled)
-				&& Objects.equals(this.toolContext, other.toolContext);
+				&& Objects.equals(this.toolContext, other.toolContext) && Objects.equals(this.timeout, other.timeout);
 	}
 
 	public static final class Builder {
@@ -515,6 +533,11 @@ public class MistralAiChatOptions implements ToolCallingChatOptions {
 			else {
 				this.options.toolContext.putAll(toolContext);
 			}
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatOptions.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.oci.cohere;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -32,6 +33,7 @@ import org.springframework.ai.chat.prompt.ChatOptions;
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
  * @author Alexnadros Pappas
+ * @author Hyunsang Han
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OCICohereChatOptions implements ChatOptions {
@@ -118,6 +120,11 @@ public class OCICohereChatOptions implements ChatOptions {
 	@JsonProperty("tools")
 	private List<CohereTool> tools;
 
+	/**
+	 * The timeout duration for the chat request.
+	 */
+	private Duration timeout;
+
 	public static OCICohereChatOptions fromOptions(OCICohereChatOptions fromOptions) {
 		return builder().model(fromOptions.model)
 			.maxTokens(fromOptions.maxTokens)
@@ -132,6 +139,7 @@ public class OCICohereChatOptions implements ChatOptions {
 			.presencePenalty(fromOptions.presencePenalty)
 			.documents(fromOptions.documents != null ? new ArrayList<>(fromOptions.documents) : null)
 			.tools(fromOptions.tools != null ? new ArrayList<>(fromOptions.tools) : null)
+			.timeout(fromOptions.timeout)
 			.build();
 	}
 
@@ -260,6 +268,15 @@ public class OCICohereChatOptions implements ChatOptions {
 	}
 
 	@Override
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public ChatOptions copy() {
 		return fromOptions(this);
@@ -269,7 +286,7 @@ public class OCICohereChatOptions implements ChatOptions {
 	public int hashCode() {
 		return Objects.hash(this.model, this.maxTokens, this.compartment, this.servingMode, this.preambleOverride,
 				this.temperature, this.topP, this.topK, this.stop, this.frequencyPenalty, this.presencePenalty,
-				this.documents, this.tools);
+				this.documents, this.tools, this.timeout);
 	}
 
 	@Override
@@ -291,7 +308,8 @@ public class OCICohereChatOptions implements ChatOptions {
 				&& Objects.equals(this.topK, that.topK) && Objects.equals(this.stop, that.stop)
 				&& Objects.equals(this.frequencyPenalty, that.frequencyPenalty)
 				&& Objects.equals(this.presencePenalty, that.presencePenalty)
-				&& Objects.equals(this.documents, that.documents) && Objects.equals(this.tools, that.tools);
+				&& Objects.equals(this.documents, that.documents) && Objects.equals(this.tools, that.tools)
+				&& Objects.equals(this.timeout, that.timeout);
 	}
 
 	public static class Builder {
@@ -368,6 +386,11 @@ public class OCICohereChatOptions implements ChatOptions {
 
 		public Builder tools(List<CohereTool> tools) {
 			this.chatOptions.tools = tools;
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.chatOptions.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.ollama.api;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -43,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Hyunsang Han
  * @since 0.8.0
  * @see <a href=
  * "https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values">Ollama
@@ -343,6 +345,9 @@ public class OllamaChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
 
+	@JsonIgnore
+	private Duration timeout;
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -397,7 +402,8 @@ public class OllamaChatOptions implements ToolCallingChatOptions {
 				.toolNames(fromOptions.getToolNames())
 				.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
 				.toolCallbacks(fromOptions.getToolCallbacks())
-				.toolContext(fromOptions.getToolContext()).build();
+				.toolContext(fromOptions.getToolContext())
+				.timeout(fromOptions.getTimeout()).build();
 	}
 
 	public static OllamaChatOptions fromOptions(OllamaOptions fromOptions) {
@@ -439,7 +445,8 @@ public class OllamaChatOptions implements ToolCallingChatOptions {
 				.toolNames(fromOptions.getToolNames())
 				.internalToolExecutionEnabled(fromOptions.getInternalToolExecutionEnabled())
 				.toolCallbacks(fromOptions.getToolCallbacks())
-				.toolContext(fromOptions.getToolContext()).build();
+				.toolContext(fromOptions.getToolContext())
+				.timeout(fromOptions.getTimeout()).build();
 	}
 
 	// -------------------
@@ -799,6 +806,17 @@ public class OllamaChatOptions implements ToolCallingChatOptions {
 		this.toolContext = toolContext;
 	}
 
+	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
 	/**
 	 * Convert the {@link OllamaChatOptions} object to a {@link Map} of key/value pairs.
 	 * @return The {@link Map} of key/value pairs.
@@ -1071,6 +1089,11 @@ public class OllamaChatOptions implements ToolCallingChatOptions {
 			else {
 				this.options.toolContext.putAll(toolContext);
 			}
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.ollama.api;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -378,6 +379,12 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
+
+	/**
+	 * The timeout duration for the chat request.
+	 */
+	@JsonIgnore
+	private Duration timeout;
 
 	public static Builder builder() {
 		return new Builder();
@@ -887,6 +894,17 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 		this.toolContext = toolContext;
 	}
 
+	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
 	/**
 	 * Convert the {@link OllamaOptions} object to a {@link Map} of key/value pairs.
 	 * @return The {@link Map} of key/value pairs.
@@ -1204,6 +1222,11 @@ public class OllamaOptions implements ToolCallingChatOptions, EmbeddingOptions {
 			else {
 				this.options.toolContext.putAll(toolContext);
 			}
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.openai;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -52,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author lambochen
+ * @author Hyunsang Han
  * @since 0.8.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -238,6 +240,12 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	private @JsonProperty("service_tier") String serviceTier;
 
 	/**
+	 * The timeout duration for the chat request.
+	 */
+	@JsonIgnore
+	private Duration timeout;
+
+	/**
 	 * Collection of {@link ToolCallback}s to be used for tool calling in the chat completion requests.
 	 */
 	@JsonIgnore
@@ -306,6 +314,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 			.webSearchOptions(fromOptions.getWebSearchOptions())
 			.verbosity(fromOptions.getVerbosity())
 			.serviceTier(fromOptions.getServiceTier())
+			.timeout(fromOptions.getTimeout())
 			.build();
 	}
 
@@ -619,6 +628,17 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	public OpenAiChatOptions copy() {
 		return OpenAiChatOptions.fromOptions(this);
 	}
@@ -630,7 +650,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 				this.streamOptions, this.seed, this.stop, this.temperature, this.topP, this.tools, this.toolChoice,
 				this.user, this.parallelToolCalls, this.toolCallbacks, this.toolNames, this.httpHeaders,
 				this.internalToolExecutionEnabled, this.toolContext, this.outputModalities, this.outputAudio,
-				this.store, this.metadata, this.reasoningEffort, this.webSearchOptions, this.serviceTier);
+				this.store, this.metadata, this.reasoningEffort, this.webSearchOptions, this.serviceTier, this.timeout);
 	}
 
 	@Override
@@ -665,7 +685,7 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.reasoningEffort, other.reasoningEffort)
 				&& Objects.equals(this.webSearchOptions, other.webSearchOptions)
 				&& Objects.equals(this.verbosity, other.verbosity)
-				&& Objects.equals(this.serviceTier, other.serviceTier);
+				&& Objects.equals(this.serviceTier, other.serviceTier) && Objects.equals(this.timeout, other.timeout);
 	}
 
 	@Override
@@ -930,6 +950,11 @@ public class OpenAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder serviceTier(OpenAiApi.ServiceTier serviceTier) {
 			this.options.serviceTier = serviceTier.getValue();
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.vertexai.gemini;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import org.springframework.util.Assert;
  * @author Grogdunn
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 @JsonInclude(Include.NON_NULL)
@@ -149,6 +151,12 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 	private Map<String, Object> toolContext = new HashMap<>();
 
 	/**
+	 * The timeout duration for the chat request.
+	 */
+	@JsonIgnore
+	private Duration timeout;
+
+	/**
 	 * Use Google search Grounding feature
 	 */
 	@JsonIgnore
@@ -183,6 +191,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 		options.setToolContext(fromOptions.getToolContext());
 		options.setLogprobs(fromOptions.getLogprobs());
 		options.setResponseLogprobs(fromOptions.getResponseLogprobs());
+		options.setTimeout(fromOptions.getTimeout());
 		return options;
 	}
 
@@ -359,6 +368,17 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 		this.toolContext = toolContext;
 	}
 
+	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
 	public Integer getLogprobs() {
 		return this.logprobs;
 	}
@@ -393,7 +413,8 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 				&& Objects.equals(this.safetySettings, that.safetySettings)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
 				&& Objects.equals(this.toolContext, that.toolContext) && Objects.equals(this.logprobs, that.logprobs)
-				&& Objects.equals(this.responseLogprobs, that.responseLogprobs);
+				&& Objects.equals(this.responseLogprobs, that.responseLogprobs)
+				&& Objects.equals(this.timeout, that.timeout);
 	}
 
 	@Override
@@ -402,7 +423,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 				this.frequencyPenalty, this.presencePenalty, this.maxOutputTokens, this.model, this.responseMimeType,
 				this.responseSchema, this.toolCallbacks, this.toolNames, this.googleSearchRetrieval,
 				this.safetySettings, this.internalToolExecutionEnabled, this.toolContext, this.logprobs,
-				this.responseLogprobs);
+				this.responseLogprobs, this.timeout);
 	}
 
 	@Override
@@ -549,6 +570,11 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 
 		public Builder responseLogprobs(Boolean responseLogprobs) {
 			this.options.setResponseLogprobs(responseLogprobs);
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.zhipuai;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author YunKui Lu
+ * @author Hyunsang Han
  * @since 1.0.0 M1
  */
 @JsonInclude(Include.NON_NULL)
@@ -138,6 +140,9 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 
 	@JsonIgnore
 	private Map<String, Object> toolContext = new HashMap<>();
+
+	@JsonIgnore
+	private Duration timeout;
 	// @formatter:on
 
 	public static Builder builder() {
@@ -336,6 +341,17 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 	@JsonIgnore
 	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
 		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	@Override
+	@Nullable
+	@JsonIgnore
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
 	}
 
 	@Override
@@ -566,6 +582,11 @@ public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 
 		public Builder thinking(ChatCompletionRequest.Thinking thinking) {
 			this.options.thinking = thinking;
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			this.options.timeout = timeout;
 			return this;
 		}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client;
 
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -258,6 +259,8 @@ public interface ChatClient {
 
 		ChatClientRequestSpec templateRenderer(TemplateRenderer templateRenderer);
 
+		ChatClientRequestSpec timeout(Duration timeout);
+
 		CallResponseSpec call();
 
 		StreamResponseSpec stream();
@@ -306,6 +309,8 @@ public interface ChatClient {
 		Builder defaultToolCallbacks(ToolCallbackProvider... toolCallbackProviders);
 
 		Builder defaultToolContext(Map<String, Object> toolContext);
+
+		Builder defaultTimeout(Duration timeout);
 
 		Builder clone();
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientAttributes.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientAttributes.java
@@ -26,7 +26,9 @@ public enum ChatClientAttributes {
 
 	//@formatter:off
 
-	OUTPUT_FORMAT("spring.ai.chat.client.output.format");
+	OUTPUT_FORMAT("spring.ai.chat.client.output.format"),
+
+	TIMEOUT("spring.ai.chat.client.timeout");
 
 	//@formatter:on
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -645,12 +646,15 @@ public class DefaultChatClient implements ChatClient {
 		@Nullable
 		private ChatOptions chatOptions;
 
+		@Nullable
+		private Duration timeout;
+
 		/* copy constructor */
 		DefaultChatClientRequestSpec(DefaultChatClientRequestSpec ccr) {
 			this(ccr.chatModel, ccr.userText, ccr.userParams, ccr.userMetadata, ccr.systemText, ccr.systemParams,
 					ccr.systemMetadata, ccr.toolCallbacks, ccr.messages, ccr.toolNames, ccr.media, ccr.chatOptions,
 					ccr.advisors, ccr.advisorParams, ccr.observationRegistry, ccr.observationConvention,
-					ccr.toolContext, ccr.templateRenderer);
+					ccr.toolContext, ccr.templateRenderer, ccr.timeout);
 		}
 
 		public DefaultChatClientRequestSpec(ChatModel chatModel, @Nullable String userText,
@@ -659,7 +663,7 @@ public class DefaultChatClient implements ChatClient {
 				List<Message> messages, List<String> toolNames, List<Media> media, @Nullable ChatOptions chatOptions,
 				List<Advisor> advisors, Map<String, Object> advisorParams, ObservationRegistry observationRegistry,
 				@Nullable ChatClientObservationConvention observationConvention, Map<String, Object> toolContext,
-				@Nullable TemplateRenderer templateRenderer) {
+				@Nullable TemplateRenderer templateRenderer, @Nullable Duration timeout) {
 
 			Assert.notNull(chatModel, "chatModel cannot be null");
 			Assert.notNull(userParams, "userParams cannot be null");
@@ -698,6 +702,7 @@ public class DefaultChatClient implements ChatClient {
 					: DEFAULT_CHAT_CLIENT_OBSERVATION_CONVENTION;
 			this.toolContext.putAll(toolContext);
 			this.templateRenderer = templateRenderer != null ? templateRenderer : DEFAULT_TEMPLATE_RENDERER;
+			this.timeout = timeout;
 		}
 
 		@Nullable
@@ -761,6 +766,11 @@ public class DefaultChatClient implements ChatClient {
 
 		public TemplateRenderer getTemplateRenderer() {
 			return this.templateRenderer;
+		}
+
+		@Nullable
+		public Duration getTimeout() {
+			return this.timeout;
 		}
 
 		/**
@@ -983,6 +993,13 @@ public class DefaultChatClient implements ChatClient {
 		public ChatClientRequestSpec templateRenderer(TemplateRenderer templateRenderer) {
 			Assert.notNull(templateRenderer, "templateRenderer cannot be null");
 			this.templateRenderer = templateRenderer;
+			return this;
+		}
+
+		@Override
+		public ChatClientRequestSpec timeout(Duration timeout) {
+			Assert.notNull(timeout, "timeout cannot be null");
+			this.timeout = timeout;
 			return this;
 		}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -66,7 +67,7 @@ public class DefaultChatClientBuilder implements Builder {
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), Map.of(), null, Map.of(),
 				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
-				customObservationConvention, Map.of(), null);
+				customObservationConvention, Map.of(), null, null);
 	}
 
 	public ChatClient build() {
@@ -187,6 +188,12 @@ public class DefaultChatClientBuilder implements Builder {
 	public Builder defaultTemplateRenderer(TemplateRenderer templateRenderer) {
 		Assert.notNull(templateRenderer, "templateRenderer cannot be null");
 		this.defaultRequest.templateRenderer(templateRenderer);
+		return this;
+	}
+
+	public Builder defaultTimeout(Duration timeout) {
+		Assert.notNull(timeout, "timeout cannot be null");
+		this.defaultRequest.timeout(timeout);
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientTimeoutTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientTimeoutTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for timeout functionality in ChatClient.
+ *
+ * @author Hyunsang Han
+ */
+class ChatClientTimeoutTests {
+
+	@Test
+	void requestLevelTimeout() {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class))).thenReturn(mock(ChatResponse.class));
+
+		ChatClient chatClient = ChatClient.builder(chatModel).build();
+
+		ChatClientRequest request = DefaultChatClientUtils
+			.toChatClientRequest((DefaultChatClient.DefaultChatClientRequestSpec) chatClient.prompt("Hello")
+				.timeout(Duration.ofSeconds(30)));
+
+		// Verify timeout is stored in context
+		assertThat(request.context()).containsKey(ChatClientAttributes.TIMEOUT.getKey());
+		assertThat(request.context().get(ChatClientAttributes.TIMEOUT.getKey())).isEqualTo(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void builderDefaultTimeout() {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class))).thenReturn(mock(ChatResponse.class));
+
+		ChatClient chatClient = ChatClient.builder(chatModel).defaultTimeout(Duration.ofMinutes(2)).build();
+
+		ChatClientRequest request = DefaultChatClientUtils
+			.toChatClientRequest((DefaultChatClient.DefaultChatClientRequestSpec) chatClient.prompt("Hello"));
+
+		// Verify default timeout is stored in context
+		assertThat(request.context()).containsKey(ChatClientAttributes.TIMEOUT.getKey());
+		assertThat(request.context().get(ChatClientAttributes.TIMEOUT.getKey())).isEqualTo(Duration.ofMinutes(2));
+	}
+
+	@Test
+	void chatOptionsTimeout() {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class))).thenReturn(mock(ChatResponse.class));
+
+		ChatOptions options = ChatOptions.builder().timeout(Duration.ofMinutes(1)).build();
+
+		ChatClient chatClient = ChatClient.builder(chatModel).build();
+
+		ChatClientRequest request = DefaultChatClientUtils.toChatClientRequest(
+				(DefaultChatClient.DefaultChatClientRequestSpec) chatClient.prompt("Hello").options(options));
+
+		// Verify ChatOptions timeout is stored in context
+		assertThat(request.context()).containsKey(ChatClientAttributes.TIMEOUT.getKey());
+		assertThat(request.context().get(ChatClientAttributes.TIMEOUT.getKey())).isEqualTo(Duration.ofMinutes(1));
+	}
+
+	@Test
+	void timeoutPriority() {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class))).thenReturn(mock(ChatResponse.class));
+
+		ChatOptions options = ChatOptions.builder().timeout(Duration.ofMinutes(1)).build();
+
+		ChatClient chatClient = ChatClient.builder(chatModel).defaultTimeout(Duration.ofMinutes(2)).build();
+
+		ChatClientRequest request = DefaultChatClientUtils
+			.toChatClientRequest((DefaultChatClient.DefaultChatClientRequestSpec) chatClient.prompt("Hello")
+				.options(options)
+				.timeout(Duration.ofSeconds(30)));
+
+		// Request-level timeout should take precedence
+		assertThat(request.context()).containsKey(ChatClientAttributes.TIMEOUT.getKey());
+		assertThat(request.context().get(ChatClientAttributes.TIMEOUT.getKey())).isEqualTo(Duration.ofSeconds(30));
+	}
+
+	@Test
+	void noTimeoutWhenNotSet() {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.call(any(Prompt.class))).thenReturn(mock(ChatResponse.class));
+
+		ChatClient chatClient = ChatClient.builder(chatModel).build();
+
+		ChatClientRequest request = DefaultChatClientUtils
+			.toChatClientRequest((DefaultChatClient.DefaultChatClientRequestSpec) chatClient.prompt("Hello"));
+
+		// No timeout should be set in context
+		assertThat(request.context()).doesNotContainKey(ChatClientAttributes.TIMEOUT.getKey());
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1474,7 +1474,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
 				chatModel, null, Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(),
-				List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null);
+				List.of(), null, List.of(), Map.of(), ObservationRegistry.NOOP, null, Map.of(), null, null);
 		assertThat(spec).isNotNull();
 	}
 
@@ -1482,7 +1482,7 @@ class DefaultChatClientTests {
 	void whenChatModelIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), Map.of(),
 				null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
-				ObservationRegistry.NOOP, null, Map.of(), null))
+				ObservationRegistry.NOOP, null, Map.of(), null, null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
 	}
@@ -1491,7 +1491,7 @@ class DefaultChatClientTests {
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mock(ChatModel.class), null,
 				Map.of(), Map.of(), null, Map.of(), Map.of(), List.of(), List.of(), List.of(), List.of(), null,
-				List.of(), Map.of(), null, null, Map.of(), null))
+				List.of(), Map.of(), null, null, Map.of(), null, null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/ChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/ChatOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.prompt;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.springframework.ai.model.ModelOptions;
@@ -82,6 +83,13 @@ public interface ChatOptions extends ModelOptions {
 	 */
 	@Nullable
 	Double getTopP();
+
+	/**
+	 * Returns the timeout duration for the chat request.
+	 * @return the timeout duration for the chat request
+	 */
+	@Nullable
+	Duration getTimeout();
 
 	/**
 	 * Returns a copy of this {@link ChatOptions}.
@@ -157,6 +165,13 @@ public interface ChatOptions extends ModelOptions {
 		 * @return the builder.
 		 */
 		Builder topP(Double topP);
+
+		/**
+		 * Builds with the timeout duration for the chat request.
+		 * @param timeout
+		 * @return the builder.
+		 */
+		Builder timeout(Duration timeout);
 
 		/**
 		 * Build the {@link ChatOptions}.

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.prompt;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +41,8 @@ public class DefaultChatOptions implements ChatOptions {
 	private Integer topK;
 
 	private Double topP;
+
+	private Duration timeout;
 
 	@Override
 	public String getModel() {
@@ -114,6 +117,15 @@ public class DefaultChatOptions implements ChatOptions {
 	}
 
 	@Override
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public <T extends ChatOptions> T copy() {
 		DefaultChatOptions copy = new DefaultChatOptions();
@@ -125,6 +137,7 @@ public class DefaultChatOptions implements ChatOptions {
 		copy.setTemperature(this.getTemperature());
 		copy.setTopK(this.getTopK());
 		copy.setTopP(this.getTopP());
+		copy.setTimeout(this.getTimeout());
 		return (T) copy;
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.chat.prompt;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -70,6 +71,11 @@ public class DefaultChatOptionsBuilder implements ChatOptions.Builder {
 
 	public DefaultChatOptionsBuilder topP(Double topP) {
 		this.options.setTopP(topP);
+		return this;
+	}
+
+	public DefaultChatOptionsBuilder timeout(Duration timeout) {
+		this.options.setTimeout(timeout);
 		return this;
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingChatOptions.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.model.tool;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import org.springframework.util.Assert;
  * Default implementation of {@link ToolCallingChatOptions}.
  *
  * @author Thomas Vitale
+ * @author Hyunsang Han
  * @since 1.0.0
  */
 public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
@@ -69,6 +71,9 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 
 	@Nullable
 	private Double topP;
+
+	@Nullable
+	private Duration timeout;
 
 	@Override
 	public List<ToolCallback> getToolCallbacks() {
@@ -199,6 +204,16 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 	}
 
 	@Override
+	@Nullable
+	public Duration getTimeout() {
+		return this.timeout;
+	}
+
+	public void setTimeout(@Nullable Duration timeout) {
+		this.timeout = timeout;
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public <T extends ChatOptions> T copy() {
 		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
@@ -214,6 +229,7 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 		options.setTemperature(getTemperature());
 		options.setTopK(getTopK());
 		options.setTopP(getTopP());
+		options.setTimeout(getTimeout());
 		return (T) options;
 	}
 
@@ -322,6 +338,12 @@ public class DefaultToolCallingChatOptions implements ToolCallingChatOptions {
 		@Override
 		public ToolCallingChatOptions.Builder topP(@Nullable Double topP) {
 			this.options.setTopP(topP);
+			return this;
+		}
+
+		@Override
+		public ToolCallingChatOptions.Builder timeout(@Nullable Duration timeout) {
+			this.options.setTimeout(timeout);
 			return this;
 		}
 


### PR DESCRIPTION
Implemented timeout support for the ChatClient API.

```java
// Option 1: Per-request timeout (highest priority)
ChatResponse response = chatClient
    .prompt("Hello, world!")
    .options(chatOptions)
    .timeout(Duration.ofSeconds(30))
    .call();

// Option 2: ChatOptions integration (medium priority)
ChatOptions options = ChatOptions.builder()
    .temperature(0.7)
    .timeout(Duration.ofSeconds(10))
    .build();

// Option 3: Builder-level default timeout (lowest priority)
ChatClient client = ChatClient.builder(chatModel)
    .defaultTimeout(Duration.ofSeconds(30))
    .build();
```

The implementation introduces three levels of timeout configuration with proper priority handling:

1. **Request-level timeout**
   Added `timeout(Duration)` method to `ChatClientRequestSpec` for per-request configuration (highest priority).

2. **ChatOptions-level timeout**
   Added `getTimeout()` accessor and `timeout(Duration)` builder method to the `ChatOptions` interface (medium priority).

3. **Builder-level default timeout**
   Added `defaultTimeout(Duration)` method to the `ChatClient.Builder` for global default configuration (lowest priority).

I confirmed relevant tests are passed like below:

<img width="339" height="230" alt="image" src="https://github.com/user-attachments/assets/fc4ba6d4-a9ce-48d8-835f-b05ffc3bffb0" />
<img width="856" height="527" alt="image" src="https://github.com/user-attachments/assets/71cb3870-0aba-4556-973c-26d35a2632bf" />

Closes: #4103 