### PR TITLE
Safely merge empty tool call name case in streaming mode

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -129,9 +129,9 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 		Assert.notNull(chatResponse, "chatResponse cannot be null");
 
 		Optional<Generation> toolCallGeneration = chatResponse.getResults()
-				.stream()
-				.filter(g -> !CollectionUtils.isEmpty(g.getOutput().getToolCalls()))
-				.findFirst();
+			.stream()
+			.filter(g -> !CollectionUtils.isEmpty(g.getOutput().getToolCalls()))
+			.findFirst();
 
 		if (toolCallGeneration.isEmpty()) {
 			throw new IllegalStateException("No tool call requested by the chat model");
@@ -148,12 +148,13 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 				assistantMessage, internalToolExecutionResult.toolResponseMessage());
 
 		return ToolExecutionResult.builder()
-				.conversationHistory(conversationHistory)
-				.returnDirect(internalToolExecutionResult.returnDirect())
-				.build();
+			.conversationHistory(conversationHistory)
+			.returnDirect(internalToolExecutionResult.returnDirect())
+			.build();
 	}
 
-	private AssistantMessage safelyMergeAssistantMessageIfEmptyToolCallPresent(Optional<Generation> toolCallGeneration) {
+	private AssistantMessage safelyMergeAssistantMessageIfEmptyToolCallPresent(
+			Optional<Generation> toolCallGeneration) {
 		if (toolCallGeneration.isEmpty()) {
 			throw new IllegalStateException("No tool call requested by the chat model");
 		}
@@ -166,19 +167,19 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 		for (AssistantMessage.ToolCall toolCall : reversedToolCalls) {
 			args.append(toolCall.arguments());
 			if (StringUtils.hasText(toolCall.name())) {
-				AssistantMessage.ToolCall newToolCall = new AssistantMessage.ToolCall(
-						toolCall.id(), toolCall.type(), toolCall.name(), args.toString());
+				AssistantMessage.ToolCall newToolCall = new AssistantMessage.ToolCall(toolCall.id(), toolCall.type(),
+						toolCall.name(), args.toString());
 				newToolCalls.add(newToolCall);
 				args = new StringBuilder();
 			}
 		}
 		Collections.reverse(newToolCalls);
 		return AssistantMessage.builder()
-				.content(assistantMessage.getText())
-				.toolCalls(newToolCalls)
-				.media(assistantMessage.getMedia())
-				.properties(assistantMessage.getMetadata())
-				.build();
+			.content(assistantMessage.getText())
+			.toolCalls(newToolCalls)
+			.media(assistantMessage.getMedia())
+			.properties(assistantMessage.getMetadata())
+			.build();
 	}
 
 	private static ToolContext buildToolContext(Prompt prompt, AssistantMessage assistantMessage) {

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTest.java
@@ -429,10 +429,10 @@ class DefaultToolCallingManagerTest {
 			@Override
 			public ToolDefinition getToolDefinition() {
 				return DefaultToolDefinition.builder()
-						.name("multiGenTool")
-						.description("Tool for multiple generations")
-						.inputSchema("{}")
-						.build();
+					.name("multiGenTool")
+					.description("Tool for multiple generations")
+					.inputSchema("{}")
+					.build();
 			}
 
 			@Override
@@ -452,16 +452,16 @@ class DefaultToolCallingManagerTest {
 		AssistantMessage.ToolCall toolCall3 = new AssistantMessage.ToolCall("3", "function", "", "{}");
 
 		AssistantMessage assistantMessage1 = AssistantMessage.builder()
-				.content("")
-				.properties(Map.of())
-				.toolCalls(List.of(toolCall1))
-				.build();
+			.content("")
+			.properties(Map.of())
+			.toolCalls(List.of(toolCall1))
+			.build();
 
 		AssistantMessage assistantMessage2 = AssistantMessage.builder()
-				.content("")
-				.properties(Map.of())
-				.toolCalls(List.of(toolCall2, toolCall3))
-				.build();
+			.content("")
+			.properties(Map.of())
+			.toolCalls(List.of(toolCall2, toolCall3))
+			.build();
 
 		Generation generation1 = new Generation(assistantMessage1);
 		Generation generation2 = new Generation(assistantMessage2);
@@ -471,9 +471,9 @@ class DefaultToolCallingManagerTest {
 		Prompt prompt = new Prompt(List.of(new UserMessage("test multiple generations")));
 
 		DefaultToolCallingManager manager = DefaultToolCallingManager.builder()
-				.observationRegistry(ObservationRegistry.NOOP)
-				.toolCallbackResolver(toolName -> "multiGenTool".equals(toolName) ? toolCallback : null)
-				.build();
+			.observationRegistry(ObservationRegistry.NOOP)
+			.toolCallbackResolver(toolName -> "multiGenTool".equals(toolName) ? toolCallback : null)
+			.build();
 
 		assertThatNoException().isThrownBy(() -> manager.executeToolCalls(prompt, chatResponse));
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerTest.java
@@ -423,4 +423,59 @@ class DefaultToolCallingManagerTest {
 		assertThatNoException().isThrownBy(() -> manager.executeToolCalls(prompt, chatResponse));
 	}
 
+	@Test
+	void shouldHandleMultipleGenerationsWithToolCallsWhenNameIsEmpty() {
+		ToolCallback toolCallback = new ToolCallback() {
+			@Override
+			public ToolDefinition getToolDefinition() {
+				return DefaultToolDefinition.builder()
+						.name("multiGenTool")
+						.description("Tool for multiple generations")
+						.inputSchema("{}")
+						.build();
+			}
+
+			@Override
+			public ToolMetadata getToolMetadata() {
+				return ToolMetadata.builder().build();
+			}
+
+			@Override
+			public String call(String toolInput) {
+				return "{\"result\": \"success\"}";
+			}
+		};
+
+		// Create multiple generations with tool calls
+		AssistantMessage.ToolCall toolCall1 = new AssistantMessage.ToolCall("1", "function", "multiGenTool", "{}");
+		AssistantMessage.ToolCall toolCall2 = new AssistantMessage.ToolCall("2", "function", "multiGenTool", "{}");
+		AssistantMessage.ToolCall toolCall3 = new AssistantMessage.ToolCall("3", "function", "", "{}");
+
+		AssistantMessage assistantMessage1 = AssistantMessage.builder()
+				.content("")
+				.properties(Map.of())
+				.toolCalls(List.of(toolCall1))
+				.build();
+
+		AssistantMessage assistantMessage2 = AssistantMessage.builder()
+				.content("")
+				.properties(Map.of())
+				.toolCalls(List.of(toolCall2, toolCall3))
+				.build();
+
+		Generation generation1 = new Generation(assistantMessage1);
+		Generation generation2 = new Generation(assistantMessage2);
+
+		ChatResponse chatResponse = new ChatResponse(List.of(generation1, generation2));
+
+		Prompt prompt = new Prompt(List.of(new UserMessage("test multiple generations")));
+
+		DefaultToolCallingManager manager = DefaultToolCallingManager.builder()
+				.observationRegistry(ObservationRegistry.NOOP)
+				.toolCallbackResolver(toolName -> "multiGenTool".equals(toolName) ? toolCallback : null)
+				.build();
+
+		assertThatNoException().isThrownBy(() -> manager.executeToolCalls(prompt, chatResponse));
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Feng Xie<yxloveforever@gmail.com>

# Overview
The PR is to add a private method `safelyMergeAssistantMessageIfEmptyToolCallPresent` processes and merges tool calls in an AssistantMessage, particularly handling cases where tool calls might have empty name or fragmented arguments due to streaming or other processing issues.

### Key Logic of `safelyMergeAssistantMessageIfEmptyToolCallPresent`
- Reverses tool calls to process from last to first
- Accumulates arguments in StringBuilder
- **Critical**: `StringUtils.hasText(toolCall.name())` check **prevents invalid tool call exceptions**
- Only creates ToolCall objects when name has valid text content
- Reverses processed tool calls back to original order

### Safety Mechanism
`StringUtils.hasText(toolCall.name())` serves as a guard to:
- Prevent creating tool calls with null/empty names
- Avoid downstream execution exceptions
- Filter out malformed streaming data

### Result
Returns new AssistantMessage with merged tool calls, preserving original content, media, and metadata.
