### PR TITLE
Optimization: remove redundant check on each vector operation

### DIFF
--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
@@ -335,16 +335,13 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 	public void afterPropertiesSet() {
 		// For the index to be present, either it must be pre-created or set the
 		// initializeSchema to true.
-		if (!this.initializeSchema) {
-			boolean exists = indexExists();
-			if(!exists){
-				throw new IllegalArgumentException("Index not found");
-			}
+		if (indexExists()) {
 			return;
 		}
-		if (!indexExists()) {
-			createIndexMapping();
+		if (!this.initializeSchema) {
+			throw new IllegalArgumentException("Index not found");
 		}
+		createIndexMapping();
 	}
 
 	@Override


### PR DESCRIPTION
Each vector operation (such as `ElasticsearchVectorStore#doAdd`）calls  `ElasticsearchIndicesClient#exists`  via an HTTP request to check whether the index exists. This redundant check wastes performance, so a small refactor was performed to eliminate it.