### PR TITLE
Addressing the NPE risk in AnthropicChatModel#getDefaultUsage

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -229,7 +229,9 @@ public class AnthropicChatModel implements ChatModel {
 	}
 
 	private DefaultUsage getDefaultUsage(AnthropicApi.Usage usage) {
-		return new DefaultUsage(usage.inputTokens(), usage.outputTokens(), usage.inputTokens() + usage.outputTokens(),
+		Integer inputTokens = usage.inputTokens() != null ? usage.inputTokens() : 0;
+		Integer outputTokens = usage.outputTokens() != null ? usage.outputTokens() : 0;
+		return new DefaultUsage(inputTokens, outputTokens, inputTokens + outputTokens,
 				usage);
 	}
 


### PR DESCRIPTION
When either `usage.inputTokens` or `usage.outputTokens()` is null, `usage.inputTokens() + usage.outputTokens()` will throw an NPE.
