### PR TITLE
Fix missing OllamaApi bean

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -13,5 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+org.springframework.ai.model.ollama.autoconfigure.OllamaApiAutoConfiguration
 org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration
 org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration


### PR DESCRIPTION
## Description

After migrating an application from Spring AI 1.1.0-M2 to 1.1.0-M3, I encountered the following issue:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 0 of method ollamaChatModel in org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration required a bean of type 'org.springframework.ai.ollama.api.OllamaApi' that could not be found.


Action:

Consider defining a bean of type 'org.springframework.ai.ollama.api.OllamaApi' in your configuration.
```

## Key Changes

Add `OllamaApiAutoConfiguration` in **AutoConfiguration.imports** file from **spring-ai-autoconfigure-model-ollama**.

## Testing

I built Spring AI locally with this fix and verified it with the aforementioned application. Tests include:
- Verifying that the application starts correctly after the modification.
- Testing the behavior of this application using Ollama.