### PR TITLE
Fix Mistral AI OCR javadoc since version

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrAutoConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.web.client.RestClient;
  * OCR {@link AutoConfiguration Auto-configuration} for Mistral AI OCR.
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(MistralOcrApi.class)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * Configuration properties for Mistral AI OCR.
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 @ConfigurationProperties(MistralAiOcrProperties.CONFIG_PREFIX)
 public class MistralAiOcrProperties extends MistralAiParentProperties {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/test/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/test/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrAutoConfigurationTests.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * </p>
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 @EnabledIfEnvironmentVariable(named = MistralAiOcrAutoConfigurationTests.ENV_VAR_NAME, matches = ".*")
 class MistralAiOcrAutoConfigurationTests {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/test/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/test/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrPropertiesTests.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@link MistralAiCommonProperties}.
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 class MistralAiOcrPropertiesTests {
 

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/ocr/MistralAiOcrOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/ocr/MistralAiOcrOptions.java
@@ -30,7 +30,7 @@ import org.springframework.ai.model.ModelOptions;
  * OCR call.
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 @JsonInclude(Include.NON_NULL)
 public class MistralAiOcrOptions implements ModelOptions {

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/ocr/MistralOcrApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/ocr/MistralOcrApi.java
@@ -40,7 +40,7 @@ import org.springframework.web.client.RestClient;
  * along with information about extracted images.
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 public class MistralOcrApi {
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ocr/MistralAiOcrOptionsTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ocr/MistralAiOcrOptionsTests.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link MistralAiOcrOptions}.
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 class MistralAiOcrOptionsTests {
 

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ocr/MistralOcrApiIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/ocr/MistralOcrApiIT.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for the Mistral OCR API.
  *
  * @author Alexandros Pappas
- * @since 1.0.0
+ * @since 1.1.0
  */
 @EnabledIfEnvironmentVariable(named = "MISTRAL_AI_API_KEY", matches = ".+")
 class MistralOcrApiIT {


### PR DESCRIPTION
Fix Mistral AI OCR javadoc since version tag of all new classes introduced in [this commit](https://github.com/spring-projects/spring-ai/commit/0c1a089624244f3143f6cbcc45ccf85759139b9d).