### PR TITLE
feat: Add support for URLs with query parameters in MimeTypeDetector

### DIFF
--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/MimeTypeDetector.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/MimeTypeDetector.java
@@ -59,11 +59,11 @@ public abstract class MimeTypeDetector {
 	static final Map<String, MimeType> GEMINI_MIME_TYPES = new HashMap<>();
 
 	public static MimeType getMimeType(URL url) {
-		return getMimeType(url.getFile());
+		return getMimeType(url.getPath());
 	}
 
 	public static MimeType getMimeType(URI uri) {
-		return getMimeType(uri.toString());
+		return getMimeType(uri.getPath());
 	}
 
 	public static MimeType getMimeType(File file) {

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/MimeTypeDetectorTests.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/MimeTypeDetectorTests.java
@@ -107,14 +107,12 @@ class MimeTypeDetectorTests {
 	}
 
 	@Test
-	void getMimeTypeWithQueryParameters() {
-		URI uri = URI.create("https://example.com/styles.css?version=1.2&cache=false");
+	void getMimeTypeWithQueryParameters() throws MalformedURLException {
+		MimeType expectedJpg = MimeTypeDetector.GEMINI_MIME_TYPES.get("jpg");
+		URI uri = URI.create("https://example.com/image.jpg?version=1.2&cache=false");
 
-		assertThatThrownBy(() -> MimeTypeDetector.getMimeType(uri)).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("Unable to detect the MIME type");
-
-		assertThatThrownBy(() -> MimeTypeDetector.getMimeType(uri.toURL())).isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("Unable to detect the MIME type");
+		assertThat(MimeTypeDetector.getMimeType(uri)).isEqualTo(expectedJpg);
+		assertThat(MimeTypeDetector.getMimeType(uri.toURL())).isEqualTo(expectedJpg);
 	}
 
 }


### PR DESCRIPTION
This PR adds support for detecting MIME types from URLs that contain query parameters.

### Changes

**Implementation fix:**
- Changed `getMimeType(URI uri)` to use `uri.getPath()` instead of `uri.toString()`
- This strips query parameters before detecting the file extension
- Ensures URLs like `https://example.com/image.png?version=1.2` correctly detect as `image/png`

**Test coverage:**
- Added test verifying MIME type detection works with query parameters
- Tests both URI and URL inputs with query strings
- Validates that file extension is correctly extracted from the path

### Rationale

Previously, URLs with query parameters (e.g., image.jpg?version=1.2) would fail because the query string was included in MIME type detection. By using getPath() instead of toString(), we now strip query parameters and correctly detect the file extension.
