### PR TITLE
Fix PDF document reader's grouping logic to respect pagesPerDocument

### DIFF
--- a/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
+++ b/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Christian Tzolov
  * @author Tibor Tarnai
+ * @author Fu Jian
  */
 class PagePdfDocumentReaderTests {
 
@@ -69,6 +70,45 @@ class PagePdfDocumentReaderTests {
 			.get();
 
 		assertThat(documents).hasSize(64);
+	}
+
+	@Test
+	void testPagesPerDocument() {
+		// The test pdf contain 64 pages
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(32)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(2);
+	}
+
+	@Test
+	void testPagesPerDocumentNotDivisible() {
+		// The test pdf contain 64 pages
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(3)
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(22);
+	}
+
+	@Test
+	void testAllPagesPerDocument() {
+		// The test pdf contain 64 pages
+		var documents = new PagePdfDocumentReader("classpath:/sample2.pdf",
+				PdfDocumentReaderConfig.builder()
+					.withPageExtractedTextFormatter(ExtractedTextFormatter.builder().build())
+					.withPagesPerDocument(0) // all pages into one document
+					.build())
+			.get();
+
+		assertThat(documents).hasSize(1);
 	}
 
 }


### PR DESCRIPTION
Hi Team:
  The PDF parsing logic have one issue that it doesn’t always respect the pagesPerDocument setting. It couldn't pass the newly added unit test:
  https://github.com/spring-projects/spring-ai/pull/4627/files#diff-14539564bf2af8df87bbbc6cf120abd9e706d120ec581d95af53e502e1a9ed64R76

>   Error:  org.springframework.ai.reader.pdf.PagePdfDocumentReaderTests.testPagesPerDocument -- Time elapsed: 1.222 s <<< FAILURE!
> java.lang.AssertionError: 
> Expected size: 2 but was: 3 

So I refactor the code to clean it up and fix this issue at the same time.

Thanks for review！