### PR TITLE
Fix Issue #4638: BOM uses project.version in dependency management

### DIFF
--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -92,13 +92,13 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-commons</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-template-st</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI model -->
@@ -106,7 +106,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-model</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI vector store -->
@@ -114,7 +114,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-vector-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI RAG -->
@@ -122,7 +122,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-rag</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Vector Store based Advisors -->
@@ -130,7 +130,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-advisors-vector-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI retry -->
@@ -138,7 +138,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-retry</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI client chat -->
@@ -146,7 +146,7 @@
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-client-chat</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<!-- Spring AI MCP -->
@@ -154,7 +154,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-mcp</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Document Readers -->
@@ -162,25 +162,25 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-jsoup-document-reader</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-markdown-document-reader</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-pdf-document-reader</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-tika-document-reader</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Spring Cloud Bindings -->
@@ -188,7 +188,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-spring-cloud-bindings</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Chat memory implementations -->
@@ -196,31 +196,31 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-model-chat-memory</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-model-chat-memory-repository-cassandra</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-model-chat-memory-repository-cosmos-db</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-model-chat-memory-repository-jdbc</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-model-chat-memory-repository-neo4j</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Models -->
@@ -228,123 +228,123 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-anthropic</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-azure-openai</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-bedrock</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-bedrock-converse</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-elevenlabs</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 				<optional>true</optional>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-google-genai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-google-genai-embedding</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-huggingface</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-minimax</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-mistral-ai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-oci-genai</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-ollama</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-openai</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-postgresml</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-stability-ai</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-transformers</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-vertex-ai-embedding</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-vertex-ai-gemini</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-zhipuai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-deepseek</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <!-- Spring AI Vector Stores -->
@@ -352,127 +352,127 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-azure-cosmos-db-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-azure-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-cassandra-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-chroma-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-coherence-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-elasticsearch-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-gemfire-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-hanadb-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-mariadb-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-milvus-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-mongodb-atlas-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-neo4j-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-opensearch-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-oracle-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-pgvector-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-pinecone-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-qdrant-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-redis-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-typesense-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-weaviate-store</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-couchbase-store</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Spring Boot Auto-configurations -->
@@ -481,7 +481,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-retry</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Chat client autoconfiguration -->
@@ -489,7 +489,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Chat memory autoconfiguration -->
@@ -497,7 +497,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Chat memory Repository auto-configurations -->
@@ -505,25 +505,25 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-memory-repository-cassandra</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-memory-repository-jdbc</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-memory-repository-neo4j</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Chat model observation autoconfiguration -->
@@ -531,7 +531,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Embedding model observation autoconfiguration -->
@@ -539,7 +539,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Image model observation autoconfiguration -->
@@ -547,7 +547,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 
@@ -556,19 +556,19 @@
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-autoconfigure-mcp-client-httpclient</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-autoconfigure-mcp-client-webflux</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<!-- Spring AI MCP server autoconfigurations -->
@@ -576,19 +576,19 @@
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-autoconfigure-mcp-server-common</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-autoconfigure-mcp-server-webmvc</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-autoconfigure-mcp-server-webflux</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<!-- Spring AI model tool autoconfiguration -->
@@ -596,7 +596,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Model autoconfiguration -->
@@ -604,226 +604,226 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-anthropic</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-azure-openai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-bedrock-ai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-elevenlabs</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-google-genai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-huggingface</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-minimax</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-mistral-ai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-oci-genai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-ollama</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-openai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-postgresml-embedding</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-stability-ai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-transformers</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-vertex-ai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-zhipuai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-deepseek</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI vector store autoconfiguration -->
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-azure</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-azure-cosmos-db</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-cassandra</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-chroma</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-couchbase</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-elasticsearch</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-gemfire</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-mariadb</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-milvus</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-mongodb-atlas</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-neo4j</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-opensearch</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-oracle</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-pgvector</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-pinecone</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-qdrant</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-redis</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-typesense</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-vector-store-weaviate</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Spring Boot starters for the vector stores -->
@@ -831,121 +831,121 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-aws-opensearch</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-azure</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-azure-cosmos-db</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-cassandra</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-chroma</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-couchbase</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-elasticsearch</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-gemfire</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-mariadb</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-milvus</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-mongodb-atlas</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-neo4j</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-opensearch</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-oracle</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-pgvector</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-pinecone</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-qdrant</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-redis</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-typesense</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-vector-store-weaviate</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Spring Boot starters for the Models -->
@@ -953,123 +953,123 @@
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-starter-model-anthropic</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-starter-model-azure-openai</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-starter-model-bedrock</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-huggingface</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-elevenlabs</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-minimax</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-mistral-ai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-oci-genai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-ollama</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-openai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-postgresml-embedding</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-stability-ai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-transformers</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-vertex-ai-embedding</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-google-genai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-google-genai-embedding</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-zhipuai</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-deepseek</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Starters for MCP -->
@@ -1077,43 +1077,43 @@
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-starter-mcp-client</artifactId>
-                <version>${project.version}</version>
+                <version>1.1.0-SNAPSHOT</version>
             </dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-mcp-client-webflux</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-mcp-server-common</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-mcp-server</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-mcp-server-webflux</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-mcp-annotations</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 
@@ -1122,7 +1122,7 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-chat-memory</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Spring AI Spring Boot starters for Chat Memory Repository -->
@@ -1130,19 +1130,19 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-chat-memory-repository-cassandra</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-chat-memory-repository-jdbc</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-chat-memory-repository-neo4j</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<!-- Utilities -->
@@ -1150,19 +1150,19 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-test</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-spring-boot-docker-compose</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-spring-boot-testcontainers</artifactId>
-				<version>${project.version}</version>
+				<version>1.1.0-SNAPSHOT</version>
 			</dependency>
 
         </dependencies>


### PR DESCRIPTION
Fixed the BOM file not to use ${project.version} so it becomes useful