### PR TITLE
docs: remove wrong note about activation order for mcp clients

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -49,12 +49,8 @@ import org.springframework.core.log.LogAccessor;
  *
  * <p>
  * This configuration class sets up the necessary beans for SSE-based HTTP client
- * transport when WebFlux is not available. It provides HTTP client-based SSE transport
- * implementation for MCP client communication.
- *
- * <p>
- * The configuration is activated after the WebFlux SSE transport auto-configuration to
- * ensure proper fallback behavior when WebFlux is not available.
+ * transport. It provides HTTP client-based SSE transport implementation for MCP client
+ * communication.
  *
  * <p>
  * Key features:

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
@@ -47,12 +47,8 @@ import org.springframework.core.log.LogAccessor;
  *
  * <p>
  * This configuration class sets up the necessary beans for Streamable HTTP client
- * transport when WebFlux is not available. It provides HTTP client-based Streamable HTTP
- * transport implementation for MCP client communication.
- *
- * <p>
- * The configuration is activated after the WebFlux Streamable HTTP transport
- * auto-configuration to ensure proper fallback behavior when WebFlux is not available.
+ * transport. It provides HTTP client-based Streamable HTTP transport implementation for
+ * MCP client communication.
  *
  * <p>
  * Key features:


### PR DESCRIPTION
After splitting the MCP clients/packages, the order is no longer used (useless) and has been removed from the implementation. So the current description of the order doesn’t match what actually happens. So propose to remove the description.
FYI:
https://github.com/spring-projects/spring-ai/pull/3823/files#diff-537607bc8950c21f4af68adc6a0eb8d47730de22883e9714e1e3da17bf8e1caaL64