### PR TITLE
Lazy mcp client and toolcallback resolution

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
@@ -23,6 +23,15 @@ import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpPromptListChanged;
+import org.springaicommunity.mcp.annotation.McpResourceListChanged;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.annotation.McpToolListChanged;
 import org.springaicommunity.mcp.method.changed.prompt.AsyncPromptListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.prompt.SyncPromptListChangedSpecification;
 import org.springaicommunity.mcp.method.changed.resource.AsyncResourceListChangedSpecification;
@@ -38,7 +47,10 @@ import org.springaicommunity.mcp.method.progress.SyncProgressSpecification;
 import org.springaicommunity.mcp.method.sampling.AsyncSamplingSpecification;
 import org.springaicommunity.mcp.method.sampling.SyncSamplingSpecification;
 
+import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
+import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpAsyncAnnotationCustomizer;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpClientAnnotationScannerAutoConfiguration.ClientMcpAnnotatedBeans;
 import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpSyncAnnotationCustomizer;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpAsyncClientConfigurer;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpSyncClientConfigurer;
@@ -46,6 +58,7 @@ import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClie
 import org.springframework.ai.mcp.customizer.McpAsyncClientCustomizer;
 import org.springframework.ai.mcp.customizer.McpSyncClientCustomizer;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -137,60 +150,45 @@ public class McpClientAutoConfiguration {
 	}
 
 	/**
-	 * Creates a list of {@link McpSyncClient} instances based on the available
-	 * transports.
+	 * Creates a {@link McpSyncClientInitializer} that defers client creation until all
+	 * singleton beans have been initialized.
 	 *
 	 * <p>
-	 * Each client is configured with:
-	 * <ul>
-	 * <li>Client information (name and version) from common properties
-	 * <li>Request timeout settings
-	 * <li>Custom configurations through {@link McpSyncClientConfigurer}
-	 * </ul>
-	 *
-	 * <p>
-	 * If initialization is enabled in properties, the clients are automatically
-	 * initialized.
+	 * This ensures that all beans with MCP annotations have been scanned and registered
+	 * before the clients are created, preventing a timing issue where late-initialized
+	 * beans might miss registration.
 	 * @param mcpSyncClientConfigurer the configurer for customizing client creation
 	 * @param commonProperties common MCP client properties
 	 * @param transportsProvider provider of named MCP transports
+	 * @param annotatedBeans registry of beans with MCP annotations
+	 * @return the client initializer that creates clients after singleton instantiation
+	 */
+	@Bean
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
+			matchIfMissing = true)
+	public McpSyncClientInitializer mcpSyncClientInitializer(McpSyncClientConfigurer mcpSyncClientConfigurer,
+			McpClientCommonProperties commonProperties,
+			ObjectProvider<List<NamedClientMcpTransport>> transportsProvider,
+			ObjectProvider<ClientMcpAnnotatedBeans> annotatedBeansProvider) {
+		return new McpSyncClientInitializer(this, mcpSyncClientConfigurer, commonProperties, transportsProvider,
+				annotatedBeansProvider);
+	}
+
+	/**
+	 * Provides the list of {@link McpSyncClient} instances created by the initializer.
+	 *
+	 * <p>
+	 * This bean is available after all singleton beans have been initialized.
+	 * @param initializer the client initializer
 	 * @return list of configured MCP sync clients
 	 */
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
-	public List<McpSyncClient> mcpSyncClients(McpSyncClientConfigurer mcpSyncClientConfigurer,
-			McpClientCommonProperties commonProperties,
-			ObjectProvider<List<NamedClientMcpTransport>> transportsProvider) {
-
-		List<McpSyncClient> mcpSyncClients = new ArrayList<>();
-
-		List<NamedClientMcpTransport> namedTransports = transportsProvider.stream().flatMap(List::stream).toList();
-
-		if (!CollectionUtils.isEmpty(namedTransports)) {
-			for (NamedClientMcpTransport namedTransport : namedTransports) {
-
-				McpSchema.Implementation clientInfo = new McpSchema.Implementation(
-						this.connectedClientName(commonProperties.getName(), namedTransport.name()),
-						namedTransport.name(), commonProperties.getVersion());
-
-				McpClient.SyncSpec spec = McpClient.sync(namedTransport.transport())
-					.clientInfo(clientInfo)
-					.requestTimeout(commonProperties.getRequestTimeout());
-
-				spec = mcpSyncClientConfigurer.configure(namedTransport.name(), spec);
-
-				var client = spec.build();
-
-				if (commonProperties.isInitialized()) {
-					client.initialize();
-				}
-
-				mcpSyncClients.add(client);
-			}
-		}
-
-		return mcpSyncClients;
+	public List<McpSyncClient> mcpSyncClients(McpSyncClientInitializer initializer) {
+		// Return the client list directly - it will be populated by
+		// SmartInitializingSingleton
+		return initializer.getClients();
 	}
 
 	/**
@@ -222,56 +220,46 @@ public class McpClientAutoConfiguration {
 		return new McpSyncClientConfigurer(customizerProvider.orderedStream().toList());
 	}
 
-	@Bean
-	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
-			matchIfMissing = true)
-	public McpSyncClientCustomizer mcpAnnotationMcpSyncClientCustomizer(List<SyncLoggingSpecification> loggingSpecs,
-			List<SyncSamplingSpecification> samplingSpecs, List<SyncElicitationSpecification> elicitationSpecs,
-			List<SyncProgressSpecification> progressSpecs,
-			List<SyncToolListChangedSpecification> syncToolListChangedSpecifications,
-			List<SyncResourceListChangedSpecification> syncResourceListChangedSpecifications,
-			List<SyncPromptListChangedSpecification> syncPromptListChangedSpecifications) {
-		return new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs, elicitationSpecs, progressSpecs,
-				syncToolListChangedSpecifications, syncResourceListChangedSpecifications,
-				syncPromptListChangedSpecifications);
-	}
-
 	// Async client configuration
 
+	/**
+	 * Creates a {@link McpAsyncClientInitializer} that defers client creation until all
+	 * singleton beans have been initialized.
+	 *
+	 * <p>
+	 * This ensures that all beans with MCP annotations have been scanned and registered
+	 * before the clients are created, preventing a timing issue where late-initialized
+	 * beans might miss registration.
+	 * @param mcpAsyncClientConfigurer the configurer for customizing client creation
+	 * @param commonProperties common MCP client properties
+	 * @param transportsProvider provider of named MCP transports
+	 * @param annotatedBeans registry of beans with MCP annotations
+	 * @return the client initializer that creates clients after singleton instantiation
+	 */
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public List<McpAsyncClient> mcpAsyncClients(McpAsyncClientConfigurer mcpAsyncClientConfigurer,
+	public McpAsyncClientInitializer mcpAsyncClientInitializer(McpAsyncClientConfigurer mcpAsyncClientConfigurer,
 			McpClientCommonProperties commonProperties,
-			ObjectProvider<List<NamedClientMcpTransport>> transportsProvider) {
+			ObjectProvider<List<NamedClientMcpTransport>> transportsProvider,
+			ObjectProvider<ClientMcpAnnotatedBeans> annotatedBeansProvider) {
+		return new McpAsyncClientInitializer(this, mcpAsyncClientConfigurer, commonProperties, transportsProvider,
+				annotatedBeansProvider);
+	}
 
-		List<McpAsyncClient> mcpAsyncClients = new ArrayList<>();
-
-		List<NamedClientMcpTransport> namedTransports = transportsProvider.stream().flatMap(List::stream).toList();
-
-		if (!CollectionUtils.isEmpty(namedTransports)) {
-			for (NamedClientMcpTransport namedTransport : namedTransports) {
-
-				McpSchema.Implementation clientInfo = new McpSchema.Implementation(
-						this.connectedClientName(commonProperties.getName(), namedTransport.name()),
-						commonProperties.getVersion());
-
-				McpClient.AsyncSpec spec = McpClient.async(namedTransport.transport())
-					.clientInfo(clientInfo)
-					.requestTimeout(commonProperties.getRequestTimeout());
-
-				spec = mcpAsyncClientConfigurer.configure(namedTransport.name(), spec);
-
-				var client = spec.build();
-
-				if (commonProperties.isInitialized()) {
-					client.initialize().block();
-				}
-
-				mcpAsyncClients.add(client);
-			}
-		}
-
-		return mcpAsyncClients;
+	/**
+	 * Provides the list of {@link McpAsyncClient} instances created by the initializer.
+	 *
+	 * <p>
+	 * This bean is available after all singleton beans have been initialized.
+	 * @param initializer the client initializer
+	 * @return list of configured MCP async clients
+	 */
+	@Bean
+	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
+	public List<McpAsyncClient> mcpAsyncClients(McpAsyncClientInitializer initializer) {
+		// Return the client list directly - it will be populated by
+		// SmartInitializingSingleton
+		return initializer.getClients();
 	}
 
 	@Bean
@@ -287,16 +275,286 @@ public class McpClientAutoConfiguration {
 		return new McpAsyncClientConfigurer(customizerProvider.orderedStream().toList());
 	}
 
-	@Bean
-	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public McpAsyncClientCustomizer mcpAnnotationMcpAsyncClientCustomizer(List<AsyncLoggingSpecification> loggingSpecs,
-			List<AsyncSamplingSpecification> samplingSpecs, List<AsyncElicitationSpecification> elicitationSpecs,
-			List<AsyncProgressSpecification> progressSpecs,
-			List<AsyncToolListChangedSpecification> toolListChangedSpecs,
-			List<AsyncResourceListChangedSpecification> resourceListChangedSpecs,
-			List<AsyncPromptListChangedSpecification> promptListChangedSpecs) {
-		return new McpAsyncAnnotationCustomizer(samplingSpecs, loggingSpecs, elicitationSpecs, progressSpecs,
-				toolListChangedSpecs, resourceListChangedSpecs, promptListChangedSpecs);
+	/**
+	 * Initializer for MCP synchronous clients that implements
+	 * {@link SmartInitializingSingleton}.
+	 *
+	 * <p>
+	 * This class defers the creation of MCP sync clients until after all singleton beans
+	 * have been initialized. This ensures that all beans with MCP-annotated methods have
+	 * been scanned and registered in the {@link ClientMcpAnnotatedBeans} registry before
+	 * the specifications are created and clients are configured.
+	 *
+	 * <p>
+	 * The initialization process:
+	 * <ol>
+	 * <li>Wait for all singleton beans to be instantiated
+	 * <li>Re-evaluate specifications from the complete registry
+	 * <li>Create and configure MCP clients with all registered specifications
+	 * <li>Initialize clients if configured to do so
+	 * </ol>
+	 */
+	public static class McpSyncClientInitializer implements SmartInitializingSingleton {
+
+		private static final Logger logger = LoggerFactory.getLogger(McpSyncClientInitializer.class);
+
+		private final McpClientAutoConfiguration configuration;
+
+		private final McpSyncClientConfigurer configurer;
+
+		private final McpClientCommonProperties properties;
+
+		private final ObjectProvider<List<NamedClientMcpTransport>> transportsProvider;
+
+		private final ObjectProvider<ClientMcpAnnotatedBeans> annotatedBeansProvider;
+
+		final List<McpSyncClient> clients = new ArrayList<>();
+
+		private long initializationTimestamp = -1;
+
+		public McpSyncClientInitializer(McpClientAutoConfiguration configuration, McpSyncClientConfigurer configurer,
+				McpClientCommonProperties properties, ObjectProvider<List<NamedClientMcpTransport>> transportsProvider,
+				ObjectProvider<ClientMcpAnnotatedBeans> annotatedBeansProvider) {
+			this.configuration = configuration;
+			this.configurer = configurer;
+			this.properties = properties;
+			this.transportsProvider = transportsProvider;
+			this.annotatedBeansProvider = annotatedBeansProvider;
+		}
+
+		@Override
+		public void afterSingletonsInstantiated() {
+			// Record when initialization starts
+			this.initializationTimestamp = System.nanoTime();
+
+			logger.debug("Creating MCP sync clients after all singleton beans have been instantiated");
+
+			McpSyncClientCustomizer annotationCustomizer = null;
+
+			// Only create annotation customizer if annotated beans registry is available
+			ClientMcpAnnotatedBeans annotatedBeans = this.annotatedBeansProvider.getIfAvailable();
+			if (annotatedBeans != null) {
+				// Re-create specifications from the now-complete registry
+				List<SyncLoggingSpecification> loggingSpecs = SyncMcpAnnotationProviders
+					.loggingSpecifications(annotatedBeans.getBeansByAnnotation(McpLogging.class));
+
+				List<SyncSamplingSpecification> samplingSpecs = SyncMcpAnnotationProviders
+					.samplingSpecifications(annotatedBeans.getBeansByAnnotation(McpSampling.class));
+
+				List<SyncElicitationSpecification> elicitationSpecs = SyncMcpAnnotationProviders
+					.elicitationSpecifications(annotatedBeans.getBeansByAnnotation(McpElicitation.class));
+
+				List<SyncProgressSpecification> progressSpecs = SyncMcpAnnotationProviders
+					.progressSpecifications(annotatedBeans.getBeansByAnnotation(McpProgress.class));
+
+				List<SyncToolListChangedSpecification> toolListChangedSpecs = SyncMcpAnnotationProviders
+					.toolListChangedSpecifications(annotatedBeans.getBeansByAnnotation(McpToolListChanged.class));
+
+				List<SyncResourceListChangedSpecification> resourceListChangedSpecs = SyncMcpAnnotationProviders
+					.resourceListChangedSpecifications(
+							annotatedBeans.getBeansByAnnotation(McpResourceListChanged.class));
+
+				List<SyncPromptListChangedSpecification> promptListChangedSpecs = SyncMcpAnnotationProviders
+					.promptListChangedSpecifications(annotatedBeans.getBeansByAnnotation(McpPromptListChanged.class));
+
+				// Create the annotation customizer with fresh specifications
+				annotationCustomizer = new McpSyncAnnotationCustomizer(samplingSpecs, loggingSpecs, elicitationSpecs,
+						progressSpecs, toolListChangedSpecs, resourceListChangedSpecs, promptListChangedSpecs);
+			}
+
+			// Create the clients using the base configurer and annotation customizer (if
+			// available)
+			List<McpSyncClient> createdClients = createClients(this.configurer, annotationCustomizer);
+			this.clients.addAll(createdClients);
+
+			logger.info("Created {} MCP sync client(s)", this.clients.size());
+		}
+
+		private List<McpSyncClient> createClients(McpSyncClientConfigurer configurer,
+				McpSyncClientCustomizer annotationCustomizer) {
+			List<McpSyncClient> mcpSyncClients = new ArrayList<>();
+
+			List<NamedClientMcpTransport> namedTransports = this.transportsProvider.stream()
+				.flatMap(List::stream)
+				.toList();
+
+			if (!CollectionUtils.isEmpty(namedTransports)) {
+				for (NamedClientMcpTransport namedTransport : namedTransports) {
+
+					McpSchema.Implementation clientInfo = new McpSchema.Implementation(
+							this.configuration.connectedClientName(this.properties.getName(), namedTransport.name()),
+							namedTransport.name(), this.properties.getVersion());
+
+					McpClient.SyncSpec spec = McpClient.sync(namedTransport.transport())
+						.clientInfo(clientInfo)
+						.requestTimeout(this.properties.getRequestTimeout());
+
+					spec = configurer.configure(namedTransport.name(), spec);
+
+					// Apply annotation customizer after other customizers (if available)
+					if (annotationCustomizer != null) {
+						annotationCustomizer.customize(namedTransport.name(), spec);
+					}
+
+					var client = spec.build();
+
+					if (this.properties.isInitialized()) {
+						client.initialize();
+					}
+
+					mcpSyncClients.add(client);
+				}
+			}
+
+			return mcpSyncClients;
+		}
+
+		public List<McpSyncClient> getClients() {
+			if (this.clients == null) {
+				throw new IllegalStateException(
+						"MCP sync clients not yet initialized. They are created after all singleton beans are instantiated.");
+			}
+			return this.clients;
+		}
+
+		/**
+		 * Returns the timestamp (in nanoseconds) when afterSingletonsInstantiated() was
+		 * called. This can be used in tests to verify SmartInitializingSingleton timing.
+		 * @return the initialization timestamp, or -1 if not yet initialized
+		 */
+		public long getInitializationTimestamp() {
+			return this.initializationTimestamp;
+		}
+
+	}
+
+	/**
+	 * Initializer for MCP asynchronous clients that implements
+	 * {@link SmartInitializingSingleton}.
+	 *
+	 * <p>
+	 * This class defers the creation of MCP async clients until after all singleton beans
+	 * have been initialized. This ensures that all beans with MCP-annotated methods have
+	 * been scanned and registered in the {@link ClientMcpAnnotatedBeans} registry before
+	 * the specifications are created and clients are configured.
+	 */
+	public static class McpAsyncClientInitializer implements SmartInitializingSingleton {
+
+		private static final Logger logger = LoggerFactory.getLogger(McpAsyncClientInitializer.class);
+
+		private final McpClientAutoConfiguration configuration;
+
+		private final McpAsyncClientConfigurer configurer;
+
+		private final McpClientCommonProperties properties;
+
+		private final ObjectProvider<List<NamedClientMcpTransport>> transportsProvider;
+
+		private final ObjectProvider<ClientMcpAnnotatedBeans> annotatedBeansProvider;
+
+		final List<McpAsyncClient> clients = new ArrayList<>();
+
+		public McpAsyncClientInitializer(McpClientAutoConfiguration configuration, McpAsyncClientConfigurer configurer,
+				McpClientCommonProperties properties, ObjectProvider<List<NamedClientMcpTransport>> transportsProvider,
+				ObjectProvider<ClientMcpAnnotatedBeans> annotatedBeansProvider) {
+			this.configuration = configuration;
+			this.configurer = configurer;
+			this.properties = properties;
+			this.transportsProvider = transportsProvider;
+			this.annotatedBeansProvider = annotatedBeansProvider;
+		}
+
+		@Override
+		public void afterSingletonsInstantiated() {
+			logger.debug("Creating MCP async clients after all singleton beans have been instantiated");
+
+			McpAsyncClientCustomizer annotationCustomizer = null;
+
+			// Only create annotation customizer if annotated beans registry is available
+			ClientMcpAnnotatedBeans annotatedBeans = this.annotatedBeansProvider.getIfAvailable();
+			if (annotatedBeans != null) {
+				// Re-create specifications from the now-complete registry
+				List<AsyncLoggingSpecification> loggingSpecs = AsyncMcpAnnotationProviders
+					.loggingSpecifications(annotatedBeans.getAllAnnotatedBeans());
+
+				List<AsyncSamplingSpecification> samplingSpecs = AsyncMcpAnnotationProviders
+					.samplingSpecifications(annotatedBeans.getAllAnnotatedBeans());
+
+				List<AsyncElicitationSpecification> elicitationSpecs = AsyncMcpAnnotationProviders
+					.elicitationSpecifications(annotatedBeans.getAllAnnotatedBeans());
+
+				List<AsyncProgressSpecification> progressSpecs = AsyncMcpAnnotationProviders
+					.progressSpecifications(annotatedBeans.getAllAnnotatedBeans());
+
+				List<AsyncToolListChangedSpecification> toolListChangedSpecs = AsyncMcpAnnotationProviders
+					.toolListChangedSpecifications(annotatedBeans.getAllAnnotatedBeans());
+
+				List<AsyncResourceListChangedSpecification> resourceListChangedSpecs = AsyncMcpAnnotationProviders
+					.resourceListChangedSpecifications(annotatedBeans.getAllAnnotatedBeans());
+
+				List<AsyncPromptListChangedSpecification> promptListChangedSpecs = AsyncMcpAnnotationProviders
+					.promptListChangedSpecifications(annotatedBeans.getAllAnnotatedBeans());
+
+				// Create the annotation customizer with fresh specifications
+				annotationCustomizer = new McpAsyncAnnotationCustomizer(samplingSpecs, loggingSpecs, elicitationSpecs,
+						progressSpecs, toolListChangedSpecs, resourceListChangedSpecs, promptListChangedSpecs);
+			}
+
+			// Create the clients using the base configurer and annotation customizer (if
+			// available)
+			List<McpAsyncClient> createdClients = createClients(this.configurer, annotationCustomizer);
+			this.clients.addAll(createdClients);
+
+			logger.info("Created {} MCP async client(s)", this.clients.size());
+		}
+
+		private List<McpAsyncClient> createClients(McpAsyncClientConfigurer configurer,
+				McpAsyncClientCustomizer annotationCustomizer) {
+			List<McpAsyncClient> mcpAsyncClients = new ArrayList<>();
+
+			List<NamedClientMcpTransport> namedTransports = this.transportsProvider.stream()
+				.flatMap(List::stream)
+				.toList();
+
+			if (!CollectionUtils.isEmpty(namedTransports)) {
+				for (NamedClientMcpTransport namedTransport : namedTransports) {
+
+					McpSchema.Implementation clientInfo = new McpSchema.Implementation(
+							this.configuration.connectedClientName(this.properties.getName(), namedTransport.name()),
+							this.properties.getVersion());
+
+					McpClient.AsyncSpec spec = McpClient.async(namedTransport.transport())
+						.clientInfo(clientInfo)
+						.requestTimeout(this.properties.getRequestTimeout());
+
+					spec = configurer.configure(namedTransport.name(), spec);
+
+					// Apply annotation customizer after other customizers (if available)
+					if (annotationCustomizer != null) {
+						annotationCustomizer.customize(namedTransport.name(), spec);
+					}
+
+					var client = spec.build();
+
+					if (this.properties.isInitialized()) {
+						client.initialize().block();
+					}
+
+					mcpAsyncClients.add(client);
+				}
+			}
+
+			return mcpAsyncClients;
+		}
+
+		public List<McpAsyncClient> getClients() {
+			if (this.clients == null) {
+				throw new IllegalStateException(
+						"MCP async clients not yet initialized. They are created after all singleton beans are instantiated.");
+			}
+			return this.clients;
+		}
+
 	}
 
 	/**
@@ -313,13 +571,24 @@ public class McpClientAutoConfiguration {
 		public void close() {
 			this.clients.forEach(McpSyncClient::close);
 		}
+
 	}
 
+	/**
+	 * Record class that implements {@link AutoCloseable} to ensure proper cleanup of MCP
+	 * async clients.
+	 *
+	 * <p>
+	 * This class is responsible for closing all MCP async clients when the application
+	 * context is closed, preventing resource leaks.
+	 */
 	public record CloseableMcpAsyncClients(List<McpAsyncClient> clients) implements AutoCloseable {
+
 		@Override
 		public void close() {
 			this.clients.forEach(McpAsyncClient::close);
 		}
+
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpClientSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/annotations/McpClientSpecificationFactoryAutoConfiguration.java
@@ -51,13 +51,33 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
+ * Auto-configuration for MCP client specification factory.
+ *
+ * <p>
+ * <strong>Note:</strong> This configuration is now obsolete and disabled by default.
+ * Specification creation has been moved to
+ * {@link org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration.McpSyncClientInitializer}
+ * and
+ * {@link org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration.McpAsyncClientInitializer}
+ * which use {@link org.springframework.beans.factory.SmartInitializingSingleton} to defer
+ * client creation until after all singleton beans have been initialized. This ensures
+ * that all beans with MCP-annotated methods are scanned before specifications are
+ * created.
+ *
+ * <p>
+ * This class is kept for backwards compatibility but can be safely removed in future
+ * versions.
+ *
  * @author Christian Tzolov
  * @author Fu Jian
+ * @deprecated Since 1.1.0, specifications are now created dynamically after all singleton
+ * beans are initialized. This class will be removed in a future release.
  */
+@Deprecated(since = "1.1.0", forRemoval = true)
 @AutoConfiguration(after = McpClientAnnotationScannerAutoConfiguration.class)
 @ConditionalOnClass(McpLogging.class)
 @ConditionalOnProperty(prefix = McpClientAnnotationScannerProperties.CONFIG_PREFIX, name = "enabled",
-		havingValue = "true", matchIfMissing = true)
+		havingValue = "false") // Disabled by default - changed from "true" to "false"
 public class McpClientSpecificationFactoryAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.autoconfigure;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageRequest;
+import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
+import io.modelcontextprotocol.spec.McpSchema.LoggingMessageNotification;
+import io.modelcontextprotocol.spec.McpSchema.ProgressNotification;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.mcp.annotation.McpElicitation;
+import org.springaicommunity.mcp.annotation.McpLogging;
+import org.springaicommunity.mcp.annotation.McpProgress;
+import org.springaicommunity.mcp.annotation.McpSampling;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springaicommunity.mcp.context.McpSyncRequestContext;
+import org.springaicommunity.mcp.context.StructuredElicitResult;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpClientAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpToolCallbackAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpClientAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpClientSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.client.webflux.autoconfigure.StreamableHttpWebFluxTransportAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration;
+import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.test.util.TestSocketUtils;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".*")
+public class StreamableMcpAnnotationsWithLLMIT {
+
+	private final ApplicationContextRunner serverContextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.mcp.server.protocol=STREAMABLE")
+		.withConfiguration(AutoConfigurations.of(McpServerAutoConfiguration.class,
+				ToolCallbackConverterAutoConfiguration.class, McpServerStreamableHttpWebFluxAutoConfiguration.class,
+				McpServerAnnotationScannerAutoConfiguration.class,
+				McpServerSpecificationFactoryAutoConfiguration.class));
+
+	private final ApplicationContextRunner clientApplicationContext = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.anthropic.apiKey=" + System.getenv("ANTHROPIC_API_KEY"))
+		.withConfiguration(anthropicAutoConfig(McpToolCallbackAutoConfiguration.class, McpClientAutoConfiguration.class,
+				StreamableHttpWebFluxTransportAutoConfiguration.class,
+				McpClientAnnotationScannerAutoConfiguration.class, McpClientSpecificationFactoryAutoConfiguration.class,
+				AnthropicChatAutoConfiguration.class, ChatClientAutoConfiguration.class));
+
+	private static AutoConfigurations anthropicAutoConfig(Class<?>... additional) {
+		Class<?>[] dependencies = { SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class,
+				RestClientAutoConfiguration.class, WebClientAutoConfiguration.class };
+		Class<?>[] all = Stream.concat(Arrays.stream(dependencies), Arrays.stream(additional)).toArray(Class<?>[]::new);
+		return AutoConfigurations.of(all);
+	}
+
+	private static AtomicInteger toolCouter = new AtomicInteger(0);
+
+	@Test
+	void clientServerCapabilities() {
+
+		int serverPort = TestSocketUtils.findAvailableTcpPort();
+
+		this.serverContextRunner.withUserConfiguration(TestMcpServerConfiguration.class)
+			.withPropertyValues(// @formatter:off
+				"spring.ai.mcp.server.name=test-mcp-server",
+				"spring.ai.mcp.server.version=1.0.0",
+				"spring.ai.mcp.server.streamable-http.keep-alive-interval=1s",
+				"spring.ai.mcp.server.streamable-http.mcp-endpoint=/mcp") // @formatter:on
+			.run(serverContext -> {
+				// Verify all required beans are present
+				assertThat(serverContext).hasSingleBean(WebFluxStreamableServerTransportProvider.class);
+				assertThat(serverContext).hasSingleBean(RouterFunction.class);
+				assertThat(serverContext).hasSingleBean(McpSyncServer.class);
+
+				// Verify server properties are configured correctly
+				McpServerProperties properties = serverContext.getBean(McpServerProperties.class);
+				assertThat(properties.getName()).isEqualTo("test-mcp-server");
+				assertThat(properties.getVersion()).isEqualTo("1.0.0");
+
+				McpServerStreamableHttpProperties streamableHttpProperties = serverContext
+					.getBean(McpServerStreamableHttpProperties.class);
+				assertThat(streamableHttpProperties.getMcpEndpoint()).isEqualTo("/mcp");
+				assertThat(streamableHttpProperties.getKeepAliveInterval()).isEqualTo(Duration.ofSeconds(1));
+
+				var httpServer = startHttpServer(serverContext, serverPort);
+
+				this.clientApplicationContext.withUserConfiguration(TestMcpClientConfiguration.class)
+					.withPropertyValues(// @formatter:off
+						"spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:" + serverPort,
+						"spring.ai.mcp.client.initialized=false") // @formatter:on
+					.run(clientContext -> {
+
+						ChatClient.Builder builder = clientContext.getBean(ChatClient.Builder.class);
+
+						ToolCallbackProvider tcp = clientContext.getBean(ToolCallbackProvider.class);
+
+						assertThat(builder).isNotNull();
+
+						ChatClient chatClient = builder.defaultToolCallbacks(tcp)
+							.defaultToolContext(Map.of("progressToken", "test-progress-token"))
+							.build();
+
+						String cResponse = chatClient.prompt()
+							.user("What is the weather in Amsterdam right now")
+							.call()
+							.content();
+
+						assertThat(cResponse).isNotEmpty();
+						assertThat(cResponse).contains("22");
+
+						assertThat(toolCouter.get()).isEqualTo(1);
+
+						// PROGRESS
+						TestMcpClientConfiguration.TestContext testContext = clientContext
+							.getBean(TestMcpClientConfiguration.TestContext.class);
+						assertThat(testContext.progressLatch.await(5, TimeUnit.SECONDS))
+							.as("Should receive progress notifications in reasonable time")
+							.isTrue();
+						assertThat(testContext.progressNotifications).hasSize(3);
+
+						Map<String, McpSchema.ProgressNotification> notificationMap = testContext.progressNotifications
+							.stream()
+							.collect(Collectors.toMap(n -> n.message(), n -> n));
+
+						// First notification should be 0.0/1.0 progress
+						assertThat(notificationMap.get("tool call start").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("tool call start").progress()).isEqualTo(0.0);
+						assertThat(notificationMap.get("tool call start").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("tool call start").message()).isEqualTo("tool call start");
+
+						// Second notification should be 1.0/1.0 progress
+						assertThat(notificationMap.get("elicitation completed").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("elicitation completed").progress()).isEqualTo(0.5);
+						assertThat(notificationMap.get("elicitation completed").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("elicitation completed").message())
+							.isEqualTo("elicitation completed");
+
+						// Third notification should be 0.5/1.0 progress
+						assertThat(notificationMap.get("sampling completed").progressToken())
+							.isEqualTo("test-progress-token");
+						assertThat(notificationMap.get("sampling completed").progress()).isEqualTo(1.0);
+						assertThat(notificationMap.get("sampling completed").total()).isEqualTo(1.0);
+						assertThat(notificationMap.get("sampling completed").message()).isEqualTo("sampling completed");
+
+					});
+
+				stopHttpServer(httpServer);
+			});
+	}
+
+	// Helper methods to start and stop the HTTP server
+	private static DisposableServer startHttpServer(ApplicationContext serverContext, int port) {
+		WebFluxStreamableServerTransportProvider mcpStreamableServerTransport = serverContext
+			.getBean(WebFluxStreamableServerTransportProvider.class);
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(mcpStreamableServerTransport.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		return HttpServer.create().port(port).handle(adapter).bindNow();
+	}
+
+	private static void stopHttpServer(DisposableServer server) {
+		if (server != null) {
+			server.disposeNow();
+		}
+	}
+
+	record ElicitInput(String message) {
+	}
+
+	public static class TestMcpServerConfiguration {
+
+		@Bean
+		public McpServerHandlers serverSideSpecProviders() {
+			return new McpServerHandlers();
+		}
+
+		public static class McpServerHandlers {
+
+			@McpTool(description = "Provides weather information by city name")
+			public String weather(McpSyncRequestContext ctx, @McpToolParam String cityName) {
+
+				toolCouter.incrementAndGet();
+
+				ctx.info("Weather called!");
+
+				ctx.progress(p -> p.progress(0.0).total(1.0).message("tool call start"));
+
+				ctx.ping(); // call client ping
+
+				// call elicitation
+				var elicitationResult = ctx.elicit(e -> e.message("Test message"), ElicitInput.class);
+
+				ctx.progress(p -> p.progress(0.50).total(1.0).message("elicitation completed"));
+
+				// call sampling
+				CreateMessageResult samplingResponse = ctx.sample(s -> s.message("Test Sampling Message")
+					.modelPreferences(pref -> pref.modelHints("OpenAi", "Ollama")
+						.costPriority(1.0)
+						.speedPriority(1.0)
+						.intelligencePriority(1.0)));
+
+				ctx.progress(p -> p.progress(1.0).total(1.0).message("sampling completed"));
+
+				ctx.info("Tool1 Done!");
+
+				return "Weahter is 22C with rain " + samplingResponse.toString() + ", " + elicitationResult.toString();
+			}
+
+		}
+
+	}
+
+	public static class TestMcpClientConfiguration {
+
+		@Bean
+		public TestContext testContext() {
+			return new TestContext();
+		}
+
+		@Bean
+		public TestMcpClientHandlers mcpClientHandlers(TestContext testContext) {
+			return new TestMcpClientHandlers(testContext);
+		}
+
+		public static class TestContext {
+
+			final AtomicReference<LoggingMessageNotification> loggingNotificationRef = new AtomicReference<>();
+
+			final CountDownLatch progressLatch = new CountDownLatch(3);
+
+			final List<McpSchema.ProgressNotification> progressNotifications = new CopyOnWriteArrayList<>();
+
+		}
+
+		public static class TestMcpClientHandlers {
+
+			private static final Logger logger = LoggerFactory.getLogger(TestMcpClientHandlers.class);
+
+			private TestContext testContext;
+
+			public TestMcpClientHandlers(TestContext testContext) {
+				this.testContext = testContext;
+			}
+
+			@McpProgress(clients = "server1")
+			public void progressHandler(ProgressNotification progressNotification) {
+				logger.info("MCP PROGRESS: [{}] progress: {} total: {} message: {}",
+						progressNotification.progressToken(), progressNotification.progress(),
+						progressNotification.total(), progressNotification.message());
+				this.testContext.progressNotifications.add(progressNotification);
+				this.testContext.progressLatch.countDown();
+			}
+
+			@McpLogging(clients = "server1")
+			public void loggingHandler(LoggingMessageNotification loggingMessage) {
+				this.testContext.loggingNotificationRef.set(loggingMessage);
+				logger.info("MCP LOGGING: [{}] {}", loggingMessage.level(), loggingMessage.data());
+			}
+
+			@McpSampling(clients = "server1")
+			public CreateMessageResult samplingHandler(CreateMessageRequest llmRequest) {
+				logger.info("MCP SAMPLING: {}", llmRequest);
+
+				String userPrompt = ((McpSchema.TextContent) llmRequest.messages().get(0).content()).text();
+				String modelHint = llmRequest.modelPreferences().hints().get(0).name();
+
+				return CreateMessageResult.builder()
+					.content(new McpSchema.TextContent("Response " + userPrompt + " with model hint " + modelHint))
+					.build();
+			}
+
+			@McpElicitation(clients = "server1")
+			public StructuredElicitResult<ElicitInput> elicitationHandler(McpSchema.ElicitRequest request) {
+				logger.info("MCP ELICITATION: {}", request);
+				ElicitInput elicitData = new ElicitInput(request.message());
+				return StructuredElicitResult.builder().structuredContent(elicitData).build();
+			}
+
+		}
+
+	}
+
+}

--- a/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.java
+++ b/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.java
@@ -66,7 +66,11 @@ public class ToolCallingAutoConfiguration {
 			List<ToolCallback> toolCallbacks, List<ToolCallbackProvider> tcbProviders) {
 
 		List<ToolCallback> allFunctionAndToolCallbacks = new ArrayList<>(toolCallbacks);
-		tcbProviders.stream().map(pr -> List.of(pr.getToolCallbacks())).forEach(allFunctionAndToolCallbacks::addAll);
+		tcbProviders.stream()
+			.filter(pr -> !pr.getClass().getSimpleName().equals("SyncMcpToolCallbackProvider"))
+			.filter(pr -> !pr.getClass().getSimpleName().equals("AsyncMcpToolCallbackProvider"))
+			.map(pr -> List.of(pr.getToolCallbacks()))
+			.forEach(allFunctionAndToolCallbacks::addAll);
 
 		var staticToolCallbackResolver = new StaticToolCallbackResolver(allFunctionAndToolCallbacks);
 

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProvider.java
@@ -223,7 +223,25 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider {
 		}
 
 		/**
-		 * Sets MCP clients.
+		 * Sets MCP clients by reference - the list reference will be shared.
+		 * <p>
+		 * Use this method when the list will be populated later (e.g., by
+		 * {@code SmartInitializingSingleton}). The provider will see any clients added to
+		 * the list after construction.
+		 * @param mcpClients list of MCP clients (reference will be stored)
+		 * @return this builder
+		 */
+		public Builder mcpClientsReference(List<McpAsyncClient> mcpClients) {
+			Assert.notNull(mcpClients, "MCP clients list must not be null");
+			this.mcpClients = mcpClients;
+			return this;
+		}
+
+		/**
+		 * Sets MCP clients for tool discovery (stores reference directly).
+		 * <p>
+		 * Note: Unlike the sync version, this method does not create a defensive copy.
+		 * Use {@link #mcpClientsReference(List)} for clarity when sharing references.
 		 * @param mcpClients list of MCP clients
 		 * @return this builder
 		 */
@@ -237,7 +255,9 @@ public class AsyncMcpToolCallbackProvider implements ToolCallbackProvider {
 		 * Sets MCP clients.
 		 * @param mcpClients MCP clients as varargs
 		 * @return this builder
+		 * @deprecated Plese use the mcpClientsReference instead!
 		 */
+		@Deprecated
 		public Builder mcpClients(McpAsyncClient... mcpClients) {
 			Assert.notNull(mcpClients, "MCP clients must not be null");
 			this.mcpClients = List.of(mcpClients);

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallbackProvider.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallbackProvider.java
@@ -191,10 +191,30 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider {
 			.defaultConverter();
 
 		/**
-		 * Sets MCP clients for tool discovery (replaces existing).
-		 * @param mcpClients list of MCP clients
+		 * Sets MCP clients by reference - the list reference will be shared.
+		 * <p>
+		 * Use this method when the list will be populated later (e.g., by
+		 * {@code SmartInitializingSingleton}). The provider will see any clients added to
+		 * the list after construction.
+		 * @param mcpClients list of MCP clients (reference will be stored)
 		 * @return this builder
 		 */
+		public Builder mcpClientsReference(List<McpSyncClient> mcpClients) {
+			Assert.notNull(mcpClients, "MCP clients list must not be null");
+			this.mcpClients = mcpClients;
+			return this;
+		}
+
+		/**
+		 * Sets MCP clients for tool discovery (creates defensive copy).
+		 * <p>
+		 * Use this method when passing a fully populated, immutable list. A defensive
+		 * copy will be created to prevent external modifications.
+		 * @param mcpClients list of MCP clients
+		 * @return this builder
+		 * @deprecated Plese use the mcpClientsReference instead!
+		 */
+		@Deprecated
 		public Builder mcpClients(List<McpSyncClient> mcpClients) {
 			Assert.notNull(mcpClients, "MCP clients list must not be null");
 			this.mcpClients = new ArrayList<>(mcpClients);
@@ -205,7 +225,9 @@ public class SyncMcpToolCallbackProvider implements ToolCallbackProvider {
 		 * Sets MCP clients for tool discovery (replaces existing).
 		 * @param mcpClients MCP clients array
 		 * @return this builder
+		 * @deprecated Plese use the mcpClientsReference instead!
 		 */
+		@Deprecated
 		public Builder mcpClients(McpSyncClient... mcpClients) {
 			Assert.notNull(mcpClients, "MCP clients array must not be null");
 			this.mcpClients = new java.util.ArrayList<>(List.of(mcpClients));

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProviderListReferenceTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackProviderListReferenceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.ai.tool.ToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link AsyncMcpToolCallbackProvider} correctly maintains list references
+ * when using {@code mcpClientsReference()}.
+ *
+ * @author Christian Tzolov
+ */
+class AsyncMcpToolCallbackProviderListReferenceTest {
+
+	@Test
+	void testMcpClientsReferenceSharesList() {
+		// Create an empty list that will be populated later
+		List<McpAsyncClient> clientsList = new ArrayList<>();
+
+		// Create provider with reference to empty list
+		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder()
+			.mcpClientsReference(clientsList)
+			.build();
+
+		// Initially, no tool callbacks should be available
+		ToolCallback[] callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).isEmpty();
+
+		// Now simulate SmartInitializingSingleton populating the list
+		McpAsyncClient mockClient = mock(McpAsyncClient.class);
+		McpSchema.Tool mockTool = mock(McpSchema.Tool.class);
+		when(mockTool.name()).thenReturn("test_tool");
+		when(mockTool.description()).thenReturn("Test tool");
+
+		McpSchema.ListToolsResult toolsResult = mock(McpSchema.ListToolsResult.class);
+		when(toolsResult.tools()).thenReturn(List.of(mockTool));
+		when(mockClient.listTools()).thenReturn(Mono.just(toolsResult));
+
+		// Mock connection info
+		when(mockClient.getClientCapabilities()).thenReturn(mock(McpSchema.ClientCapabilities.class));
+		when(mockClient.getClientInfo()).thenReturn(mock(McpSchema.Implementation.class));
+		when(mockClient.getCurrentInitializationResult()).thenReturn(mock(McpSchema.InitializeResult.class));
+
+		clientsList.add(mockClient);
+
+		// Now the provider should see the client and return tool callbacks
+		callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("test_tool");
+	}
+
+	@Test
+	void testMcpClientsStoresReference() {
+		// Create a list with a client
+		McpAsyncClient mockClient = mock(McpAsyncClient.class);
+		McpSchema.Tool mockTool = mock(McpSchema.Tool.class);
+		when(mockTool.name()).thenReturn("test_tool");
+		when(mockTool.description()).thenReturn("Test tool");
+
+		McpSchema.ListToolsResult toolsResult = mock(McpSchema.ListToolsResult.class);
+		when(toolsResult.tools()).thenReturn(List.of(mockTool));
+		when(mockClient.listTools()).thenReturn(Mono.just(toolsResult));
+
+		// Mock connection info
+		when(mockClient.getClientCapabilities()).thenReturn(mock(McpSchema.ClientCapabilities.class));
+		when(mockClient.getClientInfo()).thenReturn(mock(McpSchema.Implementation.class));
+		when(mockClient.getCurrentInitializationResult()).thenReturn(mock(McpSchema.InitializeResult.class));
+
+		List<McpAsyncClient> clientsList = new ArrayList<>();
+		clientsList.add(mockClient);
+
+		// Create provider - async version stores reference (no defensive copy)
+		AsyncMcpToolCallbackProvider provider = AsyncMcpToolCallbackProvider.builder().mcpClients(clientsList).build();
+
+		// Provider should see the initial client
+		ToolCallback[] callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+
+		// Add another client to the original list
+		McpAsyncClient mockClient2 = mock(McpAsyncClient.class);
+		McpSchema.Tool mockTool2 = mock(McpSchema.Tool.class);
+		when(mockTool2.name()).thenReturn("test_tool_2");
+		when(mockTool2.description()).thenReturn("Test tool 2");
+
+		McpSchema.ListToolsResult toolsResult2 = mock(McpSchema.ListToolsResult.class);
+		when(toolsResult2.tools()).thenReturn(List.of(mockTool2));
+		when(mockClient2.listTools()).thenReturn(Mono.just(toolsResult2));
+
+		when(mockClient2.getClientCapabilities()).thenReturn(mock(McpSchema.ClientCapabilities.class));
+		when(mockClient2.getClientInfo()).thenReturn(mock(McpSchema.Implementation.class));
+		when(mockClient2.getCurrentInitializationResult()).thenReturn(mock(McpSchema.InitializeResult.class));
+
+		clientsList.add(mockClient2);
+
+		// Provider shares the reference, so should see both clients
+		callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(2);
+	}
+
+}

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderListReferenceTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderListReferenceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.tool.ToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link SyncMcpToolCallbackProvider} correctly maintains list references when
+ * using {@code mcpClientsReference()}.
+ *
+ * @author Christian Tzolov
+ */
+class SyncMcpToolCallbackProviderListReferenceTest {
+
+	@Test
+	void testMcpClientsReferenceSharesList() {
+		// Create an empty list that will be populated later
+		List<McpSyncClient> clientsList = new ArrayList<>();
+
+		// Create provider with reference to empty list
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
+			.mcpClientsReference(clientsList)
+			.build();
+
+		// Initially, no tool callbacks should be available
+		ToolCallback[] callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).isEmpty();
+
+		// Now simulate SmartInitializingSingleton populating the list
+		McpSyncClient mockClient = mock(McpSyncClient.class);
+		McpSchema.Tool mockTool = mock(McpSchema.Tool.class);
+		when(mockTool.name()).thenReturn("test_tool");
+		when(mockTool.description()).thenReturn("Test tool");
+
+		McpSchema.ListToolsResult toolsResult = mock(McpSchema.ListToolsResult.class);
+		when(toolsResult.tools()).thenReturn(List.of(mockTool));
+		when(mockClient.listTools()).thenReturn(toolsResult);
+
+		// Mock connection info
+		when(mockClient.getClientCapabilities()).thenReturn(mock(McpSchema.ClientCapabilities.class));
+		when(mockClient.getClientInfo()).thenReturn(mock(McpSchema.Implementation.class));
+		when(mockClient.getCurrentInitializationResult()).thenReturn(mock(McpSchema.InitializeResult.class));
+
+		clientsList.add(mockClient);
+
+		// Now the provider should see the client and return tool callbacks
+		callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+		assertThat(callbacks[0].getToolDefinition().name()).isEqualTo("test_tool");
+	}
+
+	@Test
+	void testMcpClientsCreatesCopy() {
+		// Create a list with a client
+		McpSyncClient mockClient = mock(McpSyncClient.class);
+		McpSchema.Tool mockTool = mock(McpSchema.Tool.class);
+		when(mockTool.name()).thenReturn("test_tool");
+		when(mockTool.description()).thenReturn("Test tool");
+
+		McpSchema.ListToolsResult toolsResult = mock(McpSchema.ListToolsResult.class);
+		when(toolsResult.tools()).thenReturn(List.of(mockTool));
+		when(mockClient.listTools()).thenReturn(toolsResult);
+
+		// Mock connection info
+		when(mockClient.getClientCapabilities()).thenReturn(mock(McpSchema.ClientCapabilities.class));
+		when(mockClient.getClientInfo()).thenReturn(mock(McpSchema.Implementation.class));
+		when(mockClient.getCurrentInitializationResult()).thenReturn(mock(McpSchema.InitializeResult.class));
+
+		List<McpSyncClient> clientsList = new ArrayList<>();
+		clientsList.add(mockClient);
+
+		// Create provider with defensive copy
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder().mcpClients(clientsList).build();
+
+		// Provider should see the initial client
+		ToolCallback[] callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+
+		// Clear the original list
+		clientsList.clear();
+
+		// Provider still has its copy, so should still return the tool
+		callbacks = provider.getToolCallbacks();
+		assertThat(callbacks).hasSize(1);
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -65,8 +65,8 @@ public class DefaultChatClientBuilder implements Builder {
 		Assert.notNull(chatModel, "the " + ChatModel.class.getName() + " must be non-null");
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), Map.of(), null, Map.of(),
-				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
-				customObservationConvention, Map.of(), null);
+				Map.of(), List.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
+				observationRegistry, customObservationConvention, Map.of(), null);
 	}
 
 	public ChatClient build() {


### PR DESCRIPTION
Fixes critical timing issues where MCP clients were created before all annotated beans were scanned, and tool callbacks were resolved too early during ChatClient configuration.

## Problems Fixed
1. **MCP Client Timing** - Clients created before all singleton beans initialized, missing late-initializing beans with MCP annotations
2. **Eager Tool Resolution** - Tool callback providers resolved during configuration instead of execution
3. **Static Resolver Pollution** - MCP providers incorrectly included in static resolver instead of lazy resolution
4. **List Reference Semantics** - Inconsistent handling prevented reference sharing needed for deferred initialization

## Solution
- **SmartInitializingSingleton Pattern**: New `McpSyncClientInitializer` and `McpAsyncClientInitializer` classes defer client creation until after all singletons are instantiated
- **Lazy Resolution**: ChatClient now stores providers and resolves them at execution time (`call()`/`stream()`)
- **MCP Provider Filtering**: Excluded from `StaticToolCallbackResolver` to enable lazy resolution
- **Reference Sharing**: Added `mcpClientsReference()` methods to properly share list references

## Key Changes
**Configuration:**
- `McpClientAutoConfiguration.java` - Added initializer classes
- `McpToolCallbackAutoConfiguration.java` - Uses reference sharing
- `McpClientSpecificationFactoryAutoConfiguration.java` - Deprecated (disabled by default)

**Tool Resolution:**
- `DefaultChatClient.java` - Lazy provider resolution
- `ToolCallingAutoConfiguration.java` - MCP provider filtering

**Providers:**
- Added `mcpClientsReference()` to `SyncMcpToolCallbackProvider` and `AsyncMcpToolCallbackProvider`

## Breaking Changes
**Deprecated (still functional):**
- `mcpClients(List)` and `mcpClients(varargs)` → Use `mcpClientsReference(List)` instead

**Behavioral (transparent to users):**
- MCP clients created after all singleton beans instantiated
- Tool callbacks resolved at execution time, not configuration time
- MCP providers excluded from static resolver

## Migration
**Most users**: No changes required - fixes are transparent and backward compatible.
**Custom MCP providers**: Update to use `mcpClientsReference()` instead of deprecated `mcpClients()` methods.


Resolves: #4670, #4618