### PR TITLE
test: Enhance PostgresMlEmbeddingOptions test coverage

### DIFF
--- a/models/spring-ai-postgresml/src/test/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptionsTests.java
+++ b/models/spring-ai-postgresml/src/test/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptionsTests.java
@@ -203,4 +203,67 @@ public class PostgresMlEmbeddingOptionsTests {
 		assertThat(options.getKwargs()).doesNotContainKey("key1");
 	}
 
+	@Test
+	public void settersModifyOptions() {
+		PostgresMlEmbeddingOptions options = new PostgresMlEmbeddingOptions();
+
+		options.setVectorType(PostgresMlEmbeddingModel.VectorType.PG_VECTOR);
+		options.setKwargs(Map.of("key", "value"));
+		options.setMetadataMode(org.springframework.ai.document.MetadataMode.NONE);
+
+		assertThat(options.getVectorType()).isEqualTo(PostgresMlEmbeddingModel.VectorType.PG_VECTOR);
+		assertThat(options.getKwargs()).containsEntry("key", "value");
+		assertThat(options.getMetadataMode()).isEqualTo(org.springframework.ai.document.MetadataMode.NONE);
+	}
+
+	@Test
+	public void getModelReturnsNull() {
+		PostgresMlEmbeddingOptions options = PostgresMlEmbeddingOptions.builder().build();
+
+		assertThat(options.getModel()).isNull();
+	}
+
+	@Test
+	public void getDimensionsReturnsNull() {
+		PostgresMlEmbeddingOptions options = PostgresMlEmbeddingOptions.builder().build();
+
+		assertThat(options.getDimensions()).isNull();
+	}
+
+	@Test
+	public void builderReturnsSameInstance() {
+		PostgresMlEmbeddingOptions.Builder builder = PostgresMlEmbeddingOptions.builder().transformer("model-1");
+
+		PostgresMlEmbeddingOptions options1 = builder.build();
+		PostgresMlEmbeddingOptions options2 = builder.build();
+
+		// Builder returns the same instance on multiple build() calls
+		assertThat(options1).isSameAs(options2);
+		assertThat(options1.getTransformer()).isEqualTo(options2.getTransformer());
+	}
+
+	@Test
+	public void modifyingBuilderAfterBuildAffectsPreviousInstance() {
+		PostgresMlEmbeddingOptions.Builder builder = PostgresMlEmbeddingOptions.builder().transformer("model-1");
+
+		PostgresMlEmbeddingOptions options1 = builder.build();
+
+		// Modifying builder after build
+		builder.transformer("model-2");
+		PostgresMlEmbeddingOptions options2 = builder.build();
+
+		// Both instances are the same and have the updated value
+		assertThat(options1).isSameAs(options2);
+		assertThat(options1.getTransformer()).isEqualTo("model-2");
+		assertThat(options2.getTransformer()).isEqualTo("model-2");
+	}
+
+	@Test
+	public void setAdditionalParametersAcceptsNull() {
+		PostgresMlEmbeddingOptions options = new PostgresMlEmbeddingOptions();
+		options.setKwargs(null);
+
+		assertThat(options.getKwargs()).isNull();
+	}
+
 }


### PR DESCRIPTION
## Description
This PR enhances test coverage for `PostgresMlEmbeddingOptions` by adding tests for previously untested methods and documenting important builder behavior.

## Changes
- Added 6 new test cases covering setters, interface methods, and builder behavior
- Documents that builder reuses the same instance (not creating new ones on each build())
- Validates edge cases and null handling

## Test Coverage Added

- **Setter functionality** - Validates setters work directly on options instance
- **Interface compliance** - Tests `getModel()` and `getDimensions()` return null as designed  
- **Builder behavior** - Documents that builder returns same instance on multiple `build()` calls
- **Builder mutation** - Shows that modifying builder after build affects previous instances
- **Null handling** - Verifies kwargs setter accepts null values

## Value
The tests reveal that the builder pattern implementation reuses the same options instance rather than creating new instances on each `build()` call. This behavior is now explicitly tested and documented, which is important for developers to understand as it differs from typical builder pattern expectations.