### PR TITLE
Revise FactCheckingEvaluator

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java
@@ -62,6 +62,7 @@ import org.springframework.util.Assert;
  * @author Eddú Meléndez
  * @author Mark Pollack
  * @author guan xu
+ * @author Yanming Zhou
  * @see Evaluator
  * @see EvaluationRequest
  * @see EvaluationResponse
@@ -97,7 +98,9 @@ public class FactCheckingEvaluator implements Evaluator {
 	 * the default evaluation prompt suitable for general purpose LLMs.
 	 * @param chatClientBuilder The builder for the ChatClient used to perform the
 	 * evaluation
+	 * @deprecated in favor of {@link #builder(ChatClient.Builder)}
 	 */
+	@Deprecated(forRemoval = true)
 	public FactCheckingEvaluator(ChatClient.Builder chatClientBuilder) {
 		this(chatClientBuilder, null);
 	}
@@ -108,7 +111,9 @@ public class FactCheckingEvaluator implements Evaluator {
 	 * @param chatClientBuilder The builder for the ChatClient used to perform the
 	 * evaluation
 	 * @param evaluationPrompt The prompt text to use for evaluation
+	 * @deprecated in favor of {@link #builder(ChatClient.Builder)}
 	 */
+	@Deprecated
 	public FactCheckingEvaluator(ChatClient.Builder chatClientBuilder, @Nullable String evaluationPrompt) {
 		Assert.notNull(chatClientBuilder, "chatClientBuilder cannot be null");
 		this.chatClientBuilder = chatClientBuilder;
@@ -123,7 +128,9 @@ public class FactCheckingEvaluator implements Evaluator {
 	 * @return A FactCheckingEvaluator configured for Bespoke Minicheck
 	 */
 	public static FactCheckingEvaluator forBespokeMinicheck(ChatClient.Builder chatClientBuilder) {
-		return new FactCheckingEvaluator(chatClientBuilder, BESPOKE_EVALUATION_PROMPT_TEXT);
+		return FactCheckingEvaluator.builder(chatClientBuilder)
+			.evaluationPrompt(BESPOKE_EVALUATION_PROMPT_TEXT)
+			.build();
 	}
 
 	/**
@@ -149,8 +156,8 @@ public class FactCheckingEvaluator implements Evaluator {
 		return new EvaluationResponse(passing, "", Collections.emptyMap());
 	}
 
-	public static FactCheckingEvaluator.Builder builder() {
-		return new FactCheckingEvaluator.Builder();
+	public static FactCheckingEvaluator.Builder builder(ChatClient.Builder chatClientBuilder) {
+		return new FactCheckingEvaluator.Builder().chatClientBuilder(chatClientBuilder);
 	}
 
 	public static final class Builder {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluatorTests.java
@@ -29,27 +29,28 @@ import static org.mockito.Mockito.mock;
  * Unit tests for {@link FactCheckingEvaluator}.
  *
  * @author guan xu
+ * @author Yanming Zhou
  */
 class FactCheckingEvaluatorTests {
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void whenChatClientBuilderIsNullThenThrow() {
 		assertThatThrownBy(() -> new FactCheckingEvaluator(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("chatClientBuilder cannot be null");
 
-		assertThatThrownBy(() -> FactCheckingEvaluator.builder().chatClientBuilder(null).build())
+		assertThatThrownBy(() -> FactCheckingEvaluator.builder(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("chatClientBuilder cannot be null");
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void whenEvaluationPromptIsNullThenUseDefaultEvaluationPromptText() {
 		FactCheckingEvaluator evaluator = new FactCheckingEvaluator(ChatClient.builder(mock(ChatModel.class)));
 		assertThat(evaluator).isNotNull();
 
-		evaluator = FactCheckingEvaluator.builder()
-			.chatClientBuilder(ChatClient.builder(mock(ChatModel.class)))
-			.build();
+		evaluator = FactCheckingEvaluator.builder(ChatClient.builder(mock(ChatModel.class))).build();
 		assertThat(evaluator).isNotNull();
 	}
 


### PR DESCRIPTION
1. use required arguments as parameters of `builder()`.
2. deprecate constructors.

See #4652