### PR TITLE
chore(ollama): remove unused parameters of request record

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -685,12 +685,10 @@ public final class OllamaApi {
 	@JsonInclude(Include.NON_NULL)
 	public record ShowModelRequest(
 			@JsonProperty("model") String model,
-			@JsonProperty("system") String system,
-			@JsonProperty("verbose") Boolean verbose,
-			@JsonProperty("options") Map<String, Object> options
+			@JsonProperty("verbose") Boolean verbose
 	) {
 		public ShowModelRequest(String model) {
-			this(model, null, null, null);
+			this(model, null);
 		}
 	}
 
@@ -725,8 +723,7 @@ public final class OllamaApi {
 	public record PullModelRequest(
 			@JsonProperty("model") String model,
 			@JsonProperty("insecure") boolean insecure,
-			@JsonProperty("username") String username,
-			@JsonProperty("password") String password,
+
 			@JsonProperty("stream") boolean stream
 	) {
 		public PullModelRequest {
@@ -737,7 +734,7 @@ public final class OllamaApi {
 		}
 
 		public PullModelRequest(String model) {
-			this(model, false, null, null, true);
+			this(model, false, true);
 		}
 	}
 


### PR DESCRIPTION
https://github.com/ollama/ollama/issues/1053#issuecomment-2558705136

> Hi folks, ......, we try to keep Ollama focused on serving an http API that can be fronted by a number of proxy servers such as nginx, caddy and more, ...... This allows the maintainer team to focus on core model serving.

I removed the parameters `username` and `password` from `PullModelRequest` for authentication because the project member want to focus on core model serving and leave the authentication service to nginx, caddy, and others. At the same time, I removed the `system` and `options` parameters from `ShowModelRequest` because they are not mentioned in the Ollama doc.

