### PR TITLE
Polish BedrockAwsConnectionConfiguration

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Wei Jiang
  * @author Baojun Jiang
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(BedrockAwsConnectionProperties.class)
 public class BedrockAwsConnectionConfiguration {
 


### PR DESCRIPTION
It's recommended to use `@Configuration(proxyBeanMethods = false)`, align with other configuration classes.