### PR TITLE
fix(chroma): handle collection not found exception during initialization

### DIFF
--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
@@ -48,6 +48,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.client.HttpClientErrorException;
 
 /**
  * {@link ChromaVectorStore} is a concrete implementation of the {@link VectorStore}
@@ -117,7 +118,16 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		if (!this.initialized) {
-			var collection = this.chromaApi.getCollection(this.tenantName, this.databaseName, this.collectionName);
+			//if the collection doesn't exist, chromaApi.getCollection will throw an exception
+			ChromaApi.Collection collection = null;
+			try {
+				collection = this.chromaApi.getCollection(this.tenantName, this.databaseName, this.collectionName);
+			}
+			catch (Exception ex) {
+				if (!(ex.getCause() instanceof HttpClientErrorException.NotFound)) {
+					throw ex;
+				}
+			}
 			if (collection == null) {
 				if (this.initializeSchema) {
 					var tenant = this.chromaApi.getTenant(this.tenantName);


### PR DESCRIPTION
Fix collection existence check broken by error message change in Chroma API.

The Chroma backend recently changed its error message from:
  "Collection [...] does not exists"
to:
  "Collection [...] does not exist"

This broke the string-based detection in `getCollection()`, causing 404s to be treated as unexpected errors and preventing initialization.

This PR replaces fragile string matching with reliable HTTP 404 status code checking via `HttpClientErrorException.NotFound`.
