### PR TITLE
Update from text-moderation-latest to omni-moderation - https://githu…

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiModerationApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiModerationApi.java
@@ -47,7 +47,7 @@ import org.springframework.web.client.RestClient;
  */
 public class OpenAiModerationApi {
 
-	public static final String DEFAULT_MODERATION_MODEL = "omni-moderation";
+	public static final String DEFAULT_MODERATION_MODEL = "omni-moderation-latest";
 
 	private static final String DEFAULT_BASE_URL = "https://api.openai.com";
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
@@ -79,7 +79,7 @@ The prefix spring.ai.openai.moderation is used as the property prefix for config
 | spring.ai.openai.moderation.api-key    | The API Key           |  -
 | spring.ai.openai.moderation.organization-id | Optionally you can specify which organization is used for an API request. |  -
 | spring.ai.openai.moderation.project-id      | Optionally, you can specify which project is used for an API request. |  -
-| spring.ai.openai.moderation.options.model  | ID of the model to use for moderation. | omni-moderation
+| spring.ai.openai.moderation.options.model  | ID of the model to use for moderation. | omni-moderation-latest
 |====
 
 NOTE: You can override the common `spring.ai.openai.base-url`, `spring.ai.openai.api-key`, `spring.ai.openai.organization-id` and `spring.ai.openai.project-id` properties.
@@ -97,7 +97,7 @@ For example:
 [source,java]
 ----
 OpenAiModerationOptions moderationOptions = OpenAiModerationOptions.builder()
-    .model("omni-moderation")
+    .model("omni-moderation-latest")
     .build();
 
 ModerationPrompt moderationPrompt = new ModerationPrompt("Text to be moderated", this.moderationOptions);
@@ -180,7 +180,7 @@ OpenAiModerationApi openAiModerationApi = new OpenAiModerationApi(System.getenv(
 OpenAiModerationModel openAiModerationModel = new OpenAiModerationModel(this.openAiModerationApi);
 
 OpenAiModerationOptions moderationOptions = OpenAiModerationOptions.builder()
-    .model("omni-moderation")
+    .model("omni-moderation-latest")
     .build();
 
 ModerationPrompt moderationPrompt = new ModerationPrompt("Text to be moderated", this.moderationOptions);


### PR DESCRIPTION
Updates the default moderation model for OpenAI from `text-moderation-latest` to `omni-moderation` since `text-moderation-latest` is being removed by Open AI (Please see https://platform.openai.com/docs/deprecations#2025-04-28-text-moderation)

Fixes Github issue https://github.com/spring-projects/spring-ai/issues/4709