### PR TITLE
Add bedrock profile autoconfiguration support

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionConfiguration.java
@@ -16,11 +16,15 @@
 
 package org.springframework.ai.model.bedrock.autoconfigure;
 
+import java.nio.file.Paths;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
@@ -36,6 +40,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christian Tzolov
  * @author Wei Jiang
+ * @author Baojun Jiang
  */
 @Configuration
 @EnableConfigurationProperties(BedrockAwsConnectionProperties.class)
@@ -44,19 +49,46 @@ public class BedrockAwsConnectionConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public AwsCredentialsProvider credentialsProvider(BedrockAwsConnectionProperties properties) {
-
 		if (StringUtils.hasText(properties.getAccessKey()) && StringUtils.hasText(properties.getSecretKey())) {
-
+			// Security key
 			if (StringUtils.hasText(properties.getSessionToken())) {
 				return StaticCredentialsProvider.create(AwsSessionCredentials.create(properties.getAccessKey(),
 						properties.getSecretKey(), properties.getSessionToken()));
 			}
-
 			return StaticCredentialsProvider
 				.create(AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey()));
 		}
-
-		return DefaultCredentialsProvider.create();
+		else if (properties.getProfile() != null && StringUtils.hasText(properties.getProfile().getName())) {
+			// Profile
+			ProfileProperties profile = properties.getProfile();
+			String configurationPath = profile.getConfigurationPath();
+			String credentialsPath = profile.getCredentialsPath();
+			boolean hasCredentials = StringUtils.hasText(credentialsPath);
+			boolean hasConfig = StringUtils.hasText(configurationPath);
+			ProfileCredentialsProvider.Builder providerBuilder = ProfileCredentialsProvider.builder();
+			if (hasCredentials || hasConfig) {
+				ProfileFile.Aggregator aggregator = ProfileFile.aggregator();
+				if (hasCredentials) {
+					ProfileFile profileFile = ProfileFile.builder()
+						.content(Paths.get(credentialsPath))
+						.type(ProfileFile.Type.CREDENTIALS)
+						.build();
+					aggregator.addFile(profileFile);
+				}
+				if (hasConfig) {
+					ProfileFile configFile = ProfileFile.builder()
+						.content(Paths.get(configurationPath))
+						.type(ProfileFile.Type.CONFIGURATION)
+						.build();
+					aggregator.addFile(configFile);
+				}
+				ProfileFile aggregatedProfileFile = aggregator.build();
+				providerBuilder.profileFile(aggregatedProfileFile);
+			}
+			return providerBuilder.profileName(profile.getName()).build();
+		}
+		// IAM Role
+		return DefaultCredentialsProvider.builder().build();
 	}
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionProperties.java
@@ -19,11 +19,13 @@ package org.springframework.ai.model.bedrock.autoconfigure;
 import java.time.Duration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Configuration properties for Bedrock AWS connection.
  *
  * @author Christian Tzolov
+ * @author Baojun Jiang
  * @since 0.8.0
  */
 @ConfigurationProperties(BedrockAwsConnectionProperties.CONFIG_PREFIX)
@@ -48,9 +50,16 @@ public class BedrockAwsConnectionProperties {
 
 	/**
 	 * AWS session token. (optional) When provided the AwsSessionCredentials are used.
-	 * Otherwise the AwsBasicCredentials are used.
+	 * Otherwise, the AwsBasicCredentials are used.
 	 */
 	private String sessionToken;
+
+	/**
+	 * Aws profile. (optional) When the {@link #accessKey} and {@link #secretKey} are not
+	 * declared. Otherwise, the AwsBasicCredentials are used.
+	 */
+	@NestedConfigurationProperty
+	private ProfileProperties profile;
 
 	/**
 	 * Maximum duration of the entire API call operation.
@@ -147,6 +156,14 @@ public class BedrockAwsConnectionProperties {
 
 	public void setSessionToken(String sessionToken) {
 		this.sessionToken = sessionToken;
+	}
+
+	public ProfileProperties getProfile() {
+		return this.profile;
+	}
+
+	public void setProfile(ProfileProperties profile) {
+		this.profile = profile;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/ProfileProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/ProfileProperties.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.bedrock.autoconfigure;
+
+/**
+ * Configuration properties for Bedrock AWS connection using profile.
+ *
+ * @author Baojun Jiang
+ * @since 1.1.0
+ */
+public class ProfileProperties {
+
+	/**
+	 * Name of the profile to use.
+	 */
+	private String name;
+
+	/**
+	 * (optional) Path to the credentials file. default: ~/.aws/credentials
+	 */
+	private String credentialsPath;
+
+	/**
+	 * (optional) Path to the configuration file. default: ~/.aws/config
+	 */
+	private String configurationPath;
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getCredentialsPath() {
+		return this.credentialsPath;
+	}
+
+	public void setCredentialsPath(String credentialsPath) {
+		this.credentialsPath = credentialsPath;
+	}
+
+	public String getConfigurationPath() {
+		return this.configurationPath;
+	}
+
+	public void setConfigurationPath(String configurationPath) {
+		this.configurationPath = configurationPath;
+	}
+
+}


### PR DESCRIPTION
Update autoconfiguration, meets the requirements of three connection methods: security key,  profile,  and IAM Role 

**example configuration**

spring:
  ai:
    bedrock:
      aws:
        profile:
          # (require) profile name
          name: my-profile-name
          # (optional) if not declared, use ~/.aws/credentials
          credentials-path: /develop/data/aws/credentials
          # (optional) if not declared, use ~/.aws/config
          configuration-path: /develop/data/aws/config