### PR TITLE
(R) Add bedrock profile autoconfiguration support and replace deprecated

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/BedrockAwsConnectionProperties.java
@@ -19,11 +19,13 @@ package org.springframework.ai.model.bedrock.autoconfigure;
 import java.time.Duration;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Configuration properties for Bedrock AWS connection.
  *
  * @author Christian Tzolov
+ * @author Baojun Jiang
  * @since 0.8.0
  */
 @ConfigurationProperties(BedrockAwsConnectionProperties.CONFIG_PREFIX)
@@ -48,9 +50,16 @@ public class BedrockAwsConnectionProperties {
 
 	/**
 	 * AWS session token. (optional) When provided the AwsSessionCredentials are used.
-	 * Otherwise the AwsBasicCredentials are used.
+	 * Otherwise, the AwsBasicCredentials are used.
 	 */
 	private String sessionToken;
+
+	/**
+	 * Aws profile. (optional) When the {@link #accessKey} and {@link #secretKey} are not
+	 * declared. Otherwise, the AwsBasicCredentials are used.
+	 */
+	@NestedConfigurationProperty
+	private ProfileProperties profile;
 
 	/**
 	 * Maximum duration of the entire API call operation.
@@ -147,6 +156,14 @@ public class BedrockAwsConnectionProperties {
 
 	public void setSessionToken(String sessionToken) {
 		this.sessionToken = sessionToken;
+	}
+
+	public ProfileProperties getProfile() {
+		return this.profile;
+	}
+
+	public void setProfile(ProfileProperties profile) {
+		this.profile = profile;
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/ProfileProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/autoconfigure/ProfileProperties.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.bedrock.autoconfigure;
+
+/**
+ * Configuration properties for Bedrock AWS connection using profile.
+ *
+ * @author Baojun Jiang
+ */
+public class ProfileProperties {
+
+	/**
+	 * Name of the profile to use.
+	 */
+	private String name;
+
+	/**
+	 * (optional) Path to the credentials file. default: ~/.aws/credentials
+	 */
+	private String credentialsPath;
+
+	/**
+	 * (optional) Path to the configuration file. default: ~/.aws/config
+	 */
+	private String configurationPath;
+
+	public String getName() {
+		return this.name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getCredentialsPath() {
+		return this.credentialsPath;
+	}
+
+	public void setCredentialsPath(String credentialsPath) {
+		this.credentialsPath = credentialsPath;
+	}
+
+	public String getConfigurationPath() {
+		return this.configurationPath;
+	}
+
+	public void setConfigurationPath(String configurationPath) {
+		this.configurationPath = configurationPath;
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/bedrock.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/bedrock.adoc
@@ -64,6 +64,10 @@ spring.ai.bedrock.aws.region=us-east-1
 spring.ai.bedrock.aws.access-key=YOUR_ACCESS_KEY
 spring.ai.bedrock.aws.secret-key=YOUR_SECRET_KEY
 
+spring.ai.bedrock.aws.profile.name=YOUR_PROFILE_NAME
+spring.ai.bedrock.aws.profile.credentials-path=YOUR_CREDENTIALS_PATH
+spring.ai.bedrock.aws.profile.configuration-path=YOUR_CONFIGURATION_PATH
+
 spring.ai.bedrock.aws.timeout=10m
 ----
 
@@ -72,12 +76,13 @@ The `region` property is compulsory.
 AWS credentials are resolved in the following order:
 
 1. Spring-AI Bedrock `spring.ai.bedrock.aws.access-key` and `spring.ai.bedrock.aws.secret-key` properties.
-2. Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`.
-3. Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-4. Web Identity Token credentials from system properties or environment variables.
-5. Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI.
-6. Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable.
-7. Instance profile credentials delivered through the Amazon EC2 metadata service or set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+2. Spring-AI Bedrock `spring.ai.bedrock.aws.profile.name`, If `spring.ai.bedrock.aws.profile.credentials-path` and `spring.ai.bedrock.aws.profile.configuration-path` are not specified, Spring AI use the standard AWS shared files: `~/.aws/credentials` for credentials and `~/.aws/config` for configuration.
+3. Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`.
+4. Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+5. Web Identity Token credentials from system properties or environment variables.
+6. Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI.
+7. Credentials delivered through the Amazon EC2 container service if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and the security manager has permission to access the variable.
+8. Instance profile credentials delivered through the Amazon EC2 metadata service or set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
 
 AWS region is resolved in the following order:
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -81,6 +81,9 @@ The prefix `spring.ai.bedrock.aws` is the property prefix to configure the conne
 | spring.ai.bedrock.aws.access-key | AWS access key  | -
 | spring.ai.bedrock.aws.secret-key | AWS secret key  | -
 | spring.ai.bedrock.aws.session-token | AWS session token for temporary credentials | -
+| spring.ai.bedrock.aws.profile.name | AWS profile name.  | -
+| spring.ai.bedrock.aws.profile.credentials-path | AWS credentials file path.  | -
+| spring.ai.bedrock.aws.profile.configuration-path | AWS config file path.  | -
 |====
 
 [NOTE]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-cohere-embedding.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-cohere-embedding.adoc
@@ -90,6 +90,9 @@ The prefix `spring.ai.bedrock.aws` is the property prefix to configure the conne
 | spring.ai.bedrock.aws.region     | AWS region to use. | us-east-1
 | spring.ai.bedrock.aws.access-key | AWS access key.  | -
 | spring.ai.bedrock.aws.secret-key | AWS secret key.  | -
+| spring.ai.bedrock.aws.profile.name | AWS profile name.  | -
+| spring.ai.bedrock.aws.profile.credentials-path | AWS credentials file path.  | -
+| spring.ai.bedrock.aws.profile.configuration-path | AWS config file path.  | -
 |====
 
 [NOTE]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc
@@ -97,6 +97,9 @@ The prefix `spring.ai.bedrock.aws` is the property prefix to configure the conne
 | spring.ai.bedrock.aws.region     | AWS region to use. | us-east-1
 | spring.ai.bedrock.aws.access-key | AWS access key.  | -
 | spring.ai.bedrock.aws.secret-key | AWS secret key.  | -
+| spring.ai.bedrock.aws.profile.name | AWS profile name.  | -
+| spring.ai.bedrock.aws.profile.credentials-path | AWS credentials file path.  | -
+| spring.ai.bedrock.aws.profile.configuration-path | AWS config file path.  | -
 |====
 
 [NOTE]


### PR DESCRIPTION
@tzolov  Update autoconfiguration, meets the requirements of three connection methods: security key,  profile,  and IAM Role 
`DefaultCredentialsProvider.create()` was deprecated, replace with `DefaultCredentialsProvider.builder().build()`

**example configuration**

```yaml
spring:
  ai:
    bedrock:
      aws:
        profile:
          # (require) profile name
          name: my-profile-name
          # (optional) if not declared, use ~/.aws/credentials
          credentials-path: /develop/data/aws/credentials
          # (optional) if not declared, use ~/.aws/config
          configuration-path: /develop/data/aws/config
```