### PR TITLE
Docs: Fix broken link

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -4,7 +4,7 @@ The https://ai.google.dev/gemini-api/docs[Google GenAI API] allows developers to
 The Google GenAI API supports multimodal prompts as input and outputs text or code.
 A multimodal model is capable of processing information from multiple modalities, including images, videos, and text. For example, you can send the model a photo of a plate of cookies and ask it to give you a recipe for those cookies.
 
-Gemini is a family of generative AI models developed by Google DeepMind that is designed for multimodal use cases. The Gemini API gives you access to link:https://ai.google.dev/gemini-api/docs/models/gemini/2-0-flash[Gemini 2.0 Flash], link:https://ai.google.dev/gemini-api/docs/models/gemini/2-0-flash-lite[Gemini 2.0 Flash-Lite], and link:https://ai.google.dev/gemini-api/docs/models/gemini-pro[Gemini Pro] models.
+Gemini is a family of generative AI models developed by Google DeepMind that is designed for multimodal use cases. The Gemini API gives you access to link:https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash[Gemini 2.0 Flash], link:https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash-lite[Gemini 2.0 Flash-Lite], and link:https://ai.google.dev/gemini-api/docs/models[Gemini Pro] models.
 
 This implementation provides two authentication modes:
 


### PR DESCRIPTION
The link for the 'Gemini API Reference' in `google-genai-chat.adoc` was pointing to an old URL and resulted in a 404 error.

This commit updates the URL to the correct destination.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc