### PR TITLE
Simplify filtering MCP ToolCallbackProviders for ToolCallingAutoConfiguration

### DIFF
--- a/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.java
+++ b/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/src/main/java/org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.java
@@ -52,6 +52,7 @@ import org.springframework.util.ClassUtils;
  * @author Thomas Vitale
  * @author Christian Tzolov
  * @author Daniel Garnier-Moiroux
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 @AutoConfiguration
@@ -70,10 +71,9 @@ public class ToolCallingAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	ToolCallbackResolver toolCallbackResolver(GenericApplicationContext applicationContext,
-			List<ToolCallback> toolCallbacks, List<ToolCallbackProvider> tcbProviders) {
+			List<ToolCallback> toolCallbacks, ObjectProvider<ToolCallbackProvider> tcbProviders) {
 		List<ToolCallback> allFunctionAndToolCallbacks = new ArrayList<>(toolCallbacks);
-		tcbProviders.stream()
-			.filter(pr -> !isMcpToolCallbackProvider(ResolvableType.forInstance(pr)))
+		tcbProviders.stream(clazz -> !isMcpToolCallbackProvider(ResolvableType.forClass(clazz)))
 			.map(pr -> List.of(pr.getToolCallbacks()))
 			.forEach(allFunctionAndToolCallbacks::addAll);
 


### PR DESCRIPTION
I think https://github.com/spring-projects/spring-ai/commit/febf86c08d6c6b8bf318d468deec4f0231fbd9fb introduced unnecessary complexity, this commit make the code more simple and readable.

Did I miss something? @Kehrlann 