### PR TITLE
feat: Add getTextContent method to retrieve message text content

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AbstractMessage.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/messages/AbstractMessage.java
@@ -109,6 +109,15 @@ public abstract class AbstractMessage implements Message {
 	}
 
 	/**
+	 * Get the text content of the message.
+	 * @return the text content of the message
+	 */
+	@Nullable
+	public String getTextContent() {
+		return this.textContent;
+	}
+
+	/**
 	 * Get the metadata of the message.
 	 * @return the metadata of the message
 	 */


### PR DESCRIPTION
Close #4735


Add getTextContent() method to AbstractMessage class to comply with JavaBean naming conventions.
This ensures that the textContent field is properly serialized by standard JSON serialization libraries.

Changes:
- Added getTextContent() getter method in AbstractMessage
- Method is inherited by all Message implementation classes (UserMessage, AssistantMessage, SystemMessage, etc.)
- Maintains backward compatibility with existing getText() method
