### PR TITLE
feat(zhipuai): Add `prompt_tokens_details` and update default chat options for tests

### DIFF
--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -1077,13 +1077,31 @@ public class ZhiPuAiApi {
 	 * @param promptTokens Number of tokens in the prompt.
 	 * @param totalTokens Total number of tokens used in the request (prompt +
 	 * completion).
+	 * @param promptTokensDetails Details about the prompt tokens used. Support for
+	 * GLM-4.5 and later models.
 	 */
 	@JsonInclude(Include.NON_NULL)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public record Usage(// @formatter:off
 			@JsonProperty("completion_tokens") Integer completionTokens,
 			@JsonProperty("prompt_tokens") Integer promptTokens,
-			@JsonProperty("total_tokens") Integer totalTokens) { // @formatter:on
+			@JsonProperty("total_tokens") Integer totalTokens,
+			@JsonProperty("prompt_tokens_details") PromptTokensDetails promptTokensDetails) { // @formatter:on
+
+		public Usage(Integer completionTokens, Integer promptTokens, Integer totalTokens) {
+			this(completionTokens, promptTokens, totalTokens, null);
+		}
+
+		/**
+		 * Details about the prompt tokens used.
+		 *
+		 * @param cachedTokens Number of tokens in the prompt that were cached.
+		 */
+		@JsonInclude(Include.NON_NULL)
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		public record PromptTokensDetails(// @formatter:off
+			@JsonProperty("cached_tokens") Integer cachedTokens) { // @formatter:on
+		}
 
 	}
 


### PR DESCRIPTION
- Introduced `prompt_tokens_details` with `cached_tokens` field to `ZhiPuAiApi.Usage`
- Updated test cases to replace inline `ChatOptions` with `DEFAULT_CHAT_OPTIONS`
- Refactored test models to ensure usage of `glm-4-flash` and `glm-4v-flash` as defaults

The `usage.prompt_tokens_details.cached_tokens` field is used to display the number of tokens served from cache.
Related documentation: https://docs.z.ai/api-reference/llm/chat-completion
<img width="1198" height="878" alt="image" src="https://github.com/user-attachments/assets/4ecd476b-68c5-4e6e-a519-0330029cd57a" />


All the tests have been passed：

<img width="396" height="695" alt="image" src="https://github.com/user-attachments/assets/eb7ea2c0-9dbd-4d17-84a0-6d6360c27c12" />
