### PR TITLE
GH-4787: Include exception in call to logger when tool execution fails

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessor.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/execution/DefaultToolExecutionExceptionProcessor.java
@@ -77,7 +77,8 @@ public class DefaultToolExecutionExceptionProcessor implements ToolExecutionExce
 			message = "Exception occurred in tool: " + exception.getToolDefinition().name() + " ("
 					+ cause.getClass().getSimpleName() + ")";
 		}
-		logger.debug("Exception thrown by tool: {}. Message: {}", exception.getToolDefinition().name(), message);
+		logger.debug("Exception thrown by tool: {}. Message: {}", exception.getToolDefinition().name(), message,
+				exception);
 		return message;
 	}
 


### PR DESCRIPTION
Add exception as argument to logger call when tool execution fails.

Issue: https://github.com/spring-projects/spring-ai/issues/4787