### PR TITLE
Fix incorrect MCP Java SDK URL in documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc
@@ -6,7 +6,7 @@ It simplifies the creation and registration of MCP server methods and client han
  The MCP Annotations enable developers to create and register MCP operation handlers using declarative annotations.
 This approach simplifies implementing MCP server and client functionality by reducing boilerplate code and improving maintainability.
 
-This library builds on top of the link:https://github.com/modelcontextprotocol/sdk-java[MCP Java SDK] to provide a higher-level, annotation-based programming model for implementing MCP servers and clients.
+This library builds on top of the link:https://github.com/modelcontextprotocol/java-sdk[MCP Java SDK] to provide a higher-level, annotation-based programming model for implementing MCP servers and clients.
 
 == Architecture
 


### PR DESCRIPTION
Fixes the invalid URL reference to the MCP Java SDK project in the documentation. The URL was pointing to a non-existent repository.

* Change from: https://github.com/modelcontextprotocol/sdk-java
* Change to: https://github.com/modelcontextprotocol/java-sdk
