### PR TITLE
Fix streaming tool call merge for Qwen and OpenAI-compatible APIs

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
@@ -86,44 +86,56 @@ public class DeepSeekStreamFunctionCallingHelper {
 		String toolCallId = (current.toolCallId() != null ? current.toolCallId() : previous.toolCallId());
 
 		List<ToolCall> toolCalls = new ArrayList<>();
-		ToolCall lastPreviousTooCall = null;
 		if (!CollectionUtils.isEmpty(previous.toolCalls())) {
-			lastPreviousTooCall = previous.toolCalls().get(previous.toolCalls().size() - 1);
-			if (previous.toolCalls().size() > 1) {
-				toolCalls.addAll(previous.toolCalls().subList(0, previous.toolCalls().size() - 1));
-			}
+			toolCalls.addAll(previous.toolCalls());
 		}
 		if (!CollectionUtils.isEmpty(current.toolCalls())) {
 			if (current.toolCalls().size() > 1) {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (StringUtils.hasText(currentToolCall.id())) {
-				if (lastPreviousTooCall != null) {
-					toolCalls.add(lastPreviousTooCall);
-				}
-				toolCalls.add(currentToolCall);
+			int mergeIndex = findMergeIndex(toolCalls, currentToolCall);
+			if (mergeIndex >= 0) {
+				toolCalls.set(mergeIndex, merge(toolCalls.get(mergeIndex), currentToolCall));
 			}
 			else {
-				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
-			}
-		}
-		else {
-			if (lastPreviousTooCall != null) {
-				toolCalls.add(lastPreviousTooCall);
+				toolCalls.add(currentToolCall);
 			}
 		}
 		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls);
+	}
+
+	private int findMergeIndex(List<ToolCall> toolCalls, ToolCall currentToolCall) {
+		Integer currentIndex = currentToolCall.index();
+		if (currentIndex != null) {
+			for (int i = 0; i < toolCalls.size(); i++) {
+				if (currentIndex.equals(toolCalls.get(i).index())) {
+					return i;
+				}
+			}
+		}
+		if (StringUtils.hasText(currentToolCall.id())) {
+			for (int i = 0; i < toolCalls.size(); i++) {
+				ToolCall previousToolCall = toolCalls.get(i);
+				if (currentToolCall.id().equals(previousToolCall.id())
+						&& (currentIndex == null || previousToolCall.index() == null)) {
+					return i;
+				}
+			}
+		}
+		return currentIndex == null && !StringUtils.hasText(currentToolCall.id()) && !toolCalls.isEmpty()
+				? toolCalls.size() - 1 : -1;
 	}
 
 	private ToolCall merge(ToolCall previous, ToolCall current) {
 		if (previous == null) {
 			return current;
 		}
+		Integer index = (current.index() != null ? current.index() : previous.index());
 		String id = (StringUtils.hasText(current.id()) ? current.id() : previous.id());
 		String type = (current.type() != null ? current.type() : previous.type());
 		ChatCompletionFunction function = merge(previous.function(), current.function());
-		return new ToolCall(id, type, function);
+		return new ToolCall(index, id, type, function);
 	}
 
 	private ChatCompletionFunction merge(ChatCompletionFunction previous, ChatCompletionFunction current) {

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
@@ -211,4 +211,58 @@ class DeepSeekStreamFunctionCallingHelperTest {
 		assertThat(result).isNotNull();
 	}
 
+	@Test
+	void mergeSameToolCallIndexWithRepeatedIdShouldMerge() {
+		ChatCompletionChunk chunk1 = toolCallChunk(0, "call_123", "todoList", null);
+		ChatCompletionChunk chunk2 = toolCallChunk(0, "call_123", null, "{\"page");
+		ChatCompletionChunk chunk3 = toolCallChunk(0, "call_123", null, "No\":1}");
+
+		ChatCompletionChunk merged1 = this.helper.merge(chunk1, chunk2);
+		ChatCompletionChunk merged2 = this.helper.merge(merged1, chunk3);
+
+		List<ToolCall> toolCalls = merged2.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).index()).isEqualTo(0);
+		assertThat(toolCalls.get(0).id()).isEqualTo("call_123");
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("todoList");
+		assertThat(toolCalls.get(0).function().arguments()).isEqualTo("{\"pageNo\":1}");
+	}
+
+	@Test
+	void mergeDifferentToolCallIndexesShouldRemainSeparate() {
+		ChatCompletionChunk chunk1 = toolCallChunk(0, "call_1", "getWeather", "{\"city\":\"Seoul\"}");
+		ChatCompletionChunk chunk2 = toolCallChunk(1, "call_2", "getTime", "{\"timezone\":\"KST\"}");
+
+		ChatCompletionChunk merged = this.helper.merge(chunk1, chunk2);
+
+		List<ToolCall> toolCalls = merged.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(2);
+		assertThat(toolCalls.get(0).index()).isEqualTo(0);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("getWeather");
+		assertThat(toolCalls.get(1).index()).isEqualTo(1);
+		assertThat(toolCalls.get(1).function().name()).isEqualTo("getTime");
+	}
+
+	@Test
+	void mergeToolCallIndexShouldTakePrecedenceOverRepeatedId() {
+		ChatCompletionChunk chunk1 = toolCallChunk(0, "call_123", "getWeather", "{\"city\":\"Seoul\"}");
+		ChatCompletionChunk chunk2 = toolCallChunk(1, "call_123", "getTime", "{\"timezone\":\"KST\"}");
+
+		ChatCompletionChunk merged = this.helper.merge(chunk1, chunk2);
+
+		List<ToolCall> toolCalls = merged.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(2);
+		assertThat(toolCalls.get(0).index()).isEqualTo(0);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("getWeather");
+		assertThat(toolCalls.get(1).index()).isEqualTo(1);
+		assertThat(toolCalls.get(1).function().name()).isEqualTo("getTime");
+	}
+
+	private ChatCompletionChunk toolCallChunk(Integer toolCallIndex, String id, String name, String arguments) {
+		ToolCall toolCall = new ToolCall(toolCallIndex, id, "function", new ChatCompletionFunction(name, arguments));
+		ChatCompletionMessage msg = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall));
+		return new ChatCompletionChunk("id", List.of(new ChatCompletionChunk.ChunkChoice(null, 0, msg, null)), 123L,
+				"model", null, null, null, null);
+	}
+
 }

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
@@ -114,45 +114,57 @@ public class OpenAiStreamFunctionCallingHelper {
 				: previous.annotations());
 
 		List<ToolCall> toolCalls = new ArrayList<>();
-		ToolCall lastPreviousTooCall = null;
 		if (previous.toolCalls() != null && !previous.toolCalls().isEmpty()) {
-			lastPreviousTooCall = previous.toolCalls().get(previous.toolCalls().size() - 1);
-			if (previous.toolCalls().size() > 1) {
-				toolCalls.addAll(previous.toolCalls().subList(0, previous.toolCalls().size() - 1));
-			}
+			toolCalls.addAll(previous.toolCalls());
 		}
 		if (current.toolCalls() != null && !current.toolCalls().isEmpty()) {
 			if (current.toolCalls().size() > 1) {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (StringUtils.hasText(currentToolCall.id())) {
-				if (lastPreviousTooCall != null) {
-					toolCalls.add(lastPreviousTooCall);
-				}
-				toolCalls.add(currentToolCall);
+			int mergeIndex = findMergeIndex(toolCalls, currentToolCall);
+			if (mergeIndex >= 0) {
+				toolCalls.set(mergeIndex, merge(toolCalls.get(mergeIndex), currentToolCall));
 			}
 			else {
-				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
-			}
-		}
-		else {
-			if (lastPreviousTooCall != null) {
-				toolCalls.add(lastPreviousTooCall);
+				toolCalls.add(currentToolCall);
 			}
 		}
 		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, refusal, audioOutput, annotations,
 				reasoningContent);
 	}
 
+	private int findMergeIndex(List<ToolCall> toolCalls, ToolCall currentToolCall) {
+		Integer currentIndex = currentToolCall.index();
+		if (currentIndex != null) {
+			for (int i = 0; i < toolCalls.size(); i++) {
+				if (currentIndex.equals(toolCalls.get(i).index())) {
+					return i;
+				}
+			}
+		}
+		if (StringUtils.hasText(currentToolCall.id())) {
+			for (int i = 0; i < toolCalls.size(); i++) {
+				ToolCall previousToolCall = toolCalls.get(i);
+				if (currentToolCall.id().equals(previousToolCall.id())
+						&& (currentIndex == null || previousToolCall.index() == null)) {
+					return i;
+				}
+			}
+		}
+		return currentIndex == null && !StringUtils.hasText(currentToolCall.id()) && !toolCalls.isEmpty()
+				? toolCalls.size() - 1 : -1;
+	}
+
 	private ToolCall merge(ToolCall previous, ToolCall current) {
 		if (previous == null) {
 			return current;
 		}
+		Integer index = (current.index() != null ? current.index() : previous.index());
 		String id = (StringUtils.hasText(current.id()) ? current.id() : previous.id());
 		String type = (current.type() != null ? current.type() : previous.type());
 		ChatCompletionFunction function = merge(previous.function(), current.function());
-		return new ToolCall(id, type, function);
+		return new ToolCall(index, id, type, function);
 	}
 
 	private ChatCompletionFunction merge(ChatCompletionFunction previous, ChatCompletionFunction current) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelperTest.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelperTest.java
@@ -335,4 +335,61 @@ public class OpenAiStreamFunctionCallingHelperTest {
 		assertThat(this.helper.isStreamingToolFunctionCall(chunk)).isFalse();
 	}
 
+	@Test
+	public void merge_sameToolCallIndexWithRepeatedId_shouldMerge() {
+		var chunk1 = toolCallChunk(0, "call_123", "get_weather", "");
+		var chunk2 = toolCallChunk(0, "call_123", "", "{\"city\"");
+		var chunk3 = toolCallChunk(0, "", "", ":\"Seoul\"}");
+
+		var merged1 = this.helper.merge(chunk1, chunk2);
+		var merged2 = this.helper.merge(merged1, chunk3);
+
+		var toolCalls = merged2.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).index()).isEqualTo(0);
+		assertThat(toolCalls.get(0).id()).isEqualTo("call_123");
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("get_weather");
+		assertThat(toolCalls.get(0).function().arguments()).isEqualTo("{\"city\":\"Seoul\"}");
+	}
+
+	@Test
+	public void merge_differentToolCallIndexes_shouldRemainSeparate() {
+		var chunk1 = toolCallChunk(0, "call_1", "get_weather", "{\"city\":\"Seoul\"}");
+		var chunk2 = toolCallChunk(1, "call_2", "get_time", "{\"timezone\":\"KST\"}");
+
+		var merged = this.helper.merge(chunk1, chunk2);
+
+		var toolCalls = merged.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(2);
+		assertThat(toolCalls.get(0).index()).isEqualTo(0);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("get_weather");
+		assertThat(toolCalls.get(1).index()).isEqualTo(1);
+		assertThat(toolCalls.get(1).function().name()).isEqualTo("get_time");
+	}
+
+	@Test
+	public void merge_toolCallIndexShouldTakePrecedenceOverRepeatedId() {
+		var chunk1 = toolCallChunk(0, "call_123", "get_weather", "{\"city\":\"Seoul\"}");
+		var chunk2 = toolCallChunk(1, "call_123", "get_time", "{\"timezone\":\"KST\"}");
+
+		var merged = this.helper.merge(chunk1, chunk2);
+
+		var toolCalls = merged.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(2);
+		assertThat(toolCalls.get(0).index()).isEqualTo(0);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("get_weather");
+		assertThat(toolCalls.get(1).index()).isEqualTo(1);
+		assertThat(toolCalls.get(1).function().name()).isEqualTo("get_time");
+	}
+
+	private OpenAiApi.ChatCompletionChunk toolCallChunk(Integer toolCallIndex, String id, String name,
+			String arguments) {
+		var function = new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction(name, arguments);
+		var toolCall = new OpenAiApi.ChatCompletionMessage.ToolCall(toolCallIndex, id, "function", function);
+		var delta = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall), null, null, null,
+				null);
+		var choice = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta, null);
+		return new OpenAiApi.ChatCompletionChunk("chat-1", List.of(choice), 1L, "model", null, null, null, null);
+	}
+
 }


### PR DESCRIPTION
Fixes #4790

## Problem

Some OpenAI-compatible providers stream tool calls across multiple chunks. The
first chunk can contain the tool-call id and function name, while later chunks may
repeat the same id or omit the id/name fields and only append arguments.

In the 1.1.x streaming helpers, a repeated non-empty id could be treated as a new
tool call boundary instead of a continuation of the same indexed tool call. That
can leave a partial tool call with an empty or null function name and fail with:

```text
IllegalArgumentException: toolName cannot be null or empty
```

## Solution

Keep the fix in the existing streaming helper layer on `1.1.x`.

- OpenAI: merge streaming tool-call chunks by tool-call index first.
- DeepSeek: apply the same merge rule for the reported DeepSeek pattern.
- Keep same-id and id-less continuation handling as fallback behavior.

The previous `MessageAggregator` fallback is not included in this refreshed PR.
This keeps the change focused on merging tool-call chunks before tool execution.

## Changes

- Update `OpenAiStreamFunctionCallingHelper` to merge streaming tool-call chunks by
  tool-call index first.
- Update `DeepSeekStreamFunctionCallingHelper` with the same merge behavior.
- Preserve fallback handling for same-id chunks and id-less continuation chunks.
- Add regression tests for repeated-id chunks, multiple tool-call indexes, and
  index precedence.

## Testing

Unit tests:

- `OpenAiStreamFunctionCallingHelperTest`
- `DeepSeekStreamFunctionCallingHelperTest`

Coverage includes repeated-id chunks, multiple tool-call indexes, index precedence
over repeated ids, and id-less continuation chunks.
