### PR TITLE
fix: VertixAiEmbeddingConnectionDetails not injected when using spring-ai-starter-model-vertex-ai-embedding

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiEmbeddingConnectionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiEmbeddingConnectionAutoConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.ai.model.vertexai.autoconfigure.embedding;
 
-import com.google.cloud.vertexai.VertexAI;
-
 import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingConnectionDetails;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -26,6 +24,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import com.google.cloud.aiplatform.v1.PredictionServiceSettings;
 
 /**
  * Auto-configuration for Vertex AI Embedding Connection.
@@ -36,7 +35,7 @@ import org.springframework.util.StringUtils;
  * @since 1.0.0
  */
 @AutoConfiguration
-@ConditionalOnClass(VertexAI.class)
+@ConditionalOnClass(PredictionServiceSettings.class)
 @EnableConfigurationProperties(VertexAiEmbeddingConnectionProperties.class)
 public class VertexAiEmbeddingConnectionAutoConfiguration {
 


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc


Related: #4800 