### PR TITLE
[minor-fix, google genai] use lazy load for unknown embedding dimensions and cache results

### DIFF
--- a/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
+++ b/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
@@ -259,7 +259,7 @@ public class GoogleGenAiTextEmbeddingModel extends AbstractEmbeddingModel {
 
 	@Override
 	public int dimensions() {
-		return KNOWN_EMBEDDING_DIMENSIONS.getOrDefault(this.defaultOptions.getModel(), super.dimensions());
+		return KNOWN_EMBEDDING_DIMENSIONS.computeIfAbsent(this.defaultOptions.getModel(), model -> super.dimensions());
 	}
 
 	/**


### PR DESCRIPTION
**Context**
`super.dimensions()` calls the embedding model API to know actual dimensions number even if model exists in KNOWN_EMBEDDING_DIMENSIONS map.
This leads to unnecessary expenses and problems during testing.

**Solutions**
1. Compute dimensions number lazily.
2. Cache results (questionable, can change to `if res != null res else compute()`)