### PR TITLE
GH-4807: Fix property prefix in OpenAI TTS configuration documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
@@ -95,7 +95,7 @@ NOTE: You can override the common `spring.ai.openai.base-url`, `spring.ai.openai
 The `spring.ai.openai.audio.speech.base-url`, `spring.ai.openai.audio.speech.api-key`, `spring.ai.openai.audio.speech.organization-id` and `spring.ai.openai.audio.speech.project-id` properties if set take precedence over the common properties.
 This is useful if you want to use different OpenAI accounts for different models and different model endpoints.
 
-TIP: All properties prefixed with `spring.ai.openai.image.options` can be overridden at runtime.
+TIP: All properties prefixed with `spring.ai.openai.audio.speech.options` can be overridden at runtime.
 
 == Runtime Options [[speech-options]]
 


### PR DESCRIPTION
Fix property prefix in OpenAI TTS configuration documentation

Fixes GitHub issue #4807