### PR TITLE
Remove redundant check from `ResponseErrorHandler::handleError`

### DIFF
--- a/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryAutoConfiguration.java
+++ b/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.ResponseErrorHandler;
 
@@ -51,6 +52,7 @@ import org.springframework.web.client.ResponseErrorHandler;
  * @author Christian Tzolov
  * @author SriVarshan P
  * @author Seunggyu Lee
+ * @author Yanming Zhou
  */
 @AutoConfiguration
 @ConditionalOnClass(RetryUtils.class)
@@ -100,14 +102,10 @@ public class SpringAiRetryAutoConfiguration {
 				handleError(response);
 			}
 
-			@SuppressWarnings("removal")
 			public void handleError(ClientHttpResponse response) throws IOException {
-				if (!response.getStatusCode().isError()) {
-					return;
-				}
 
 				String error = StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8);
-				if (error == null || error.isEmpty()) {
+				if (!StringUtils.hasLength(error)) {
 					error = "No response body available";
 				}
 

--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
@@ -43,6 +43,7 @@ import org.springframework.web.client.ResponseErrorHandler;
  *
  * @author Christian Tzolov
  * @author Soby Chacko
+ * @author Yanming Zhou
  * @since 0.8.1
  */
 public abstract class RetryUtils {
@@ -75,22 +76,19 @@ public abstract class RetryUtils {
 			handleError(response);
 		}
 
-		@SuppressWarnings("removal")
 		public void handleError(final ClientHttpResponse response) throws IOException {
-			if (response.getStatusCode().isError()) {
-				String error = StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8);
-				String message = String.format("%s - %s", response.getStatusCode().value(), error);
-				/*
-				 * Thrown on 4xx client errors, such as 401 - Incorrect API key provided,
-				 * 401 - You must be a member of an organization to use the API, 429 -
-				 * Rate limit reached for requests, 429 - You exceeded your current quota,
-				 * please check your plan and billing details.
-				 */
-				if (response.getStatusCode().is4xxClientError()) {
-					throw new NonTransientAiException(message);
-				}
-				throw new TransientAiException(message);
+			String error = StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8);
+			String message = String.format("%s - %s", response.getStatusCode().value(), error);
+			/*
+			 * Thrown on 4xx client errors, such as 401 - Incorrect API key provided, 401
+			 * - You must be a member of an organization to use the API, 429 - Rate limit
+			 * reached for requests, 429 - You exceeded your current quota, please check
+			 * your plan and billing details.
+			 */
+			if (response.getStatusCode().is4xxClientError()) {
+				throw new NonTransientAiException(message);
 			}
+			throw new TransientAiException(message);
 		}
 
 	};


### PR DESCRIPTION
`handleError()` is called only if `hasError()` returns true.