### PR TITLE
Provide detailed Exception message when token count exceeds max

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/embedding/MaxTokenCountExceededException.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/embedding/MaxTokenCountExceededException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.embedding;
+
+import org.springframework.ai.document.Document;
+
+/**
+ * {@link RuntimeException} thrown when the token count of the provided content exceeds
+ * the configured maximum.
+ *
+ * @author John Blum
+ * @see IllegalArgumentException
+ * @since 1.1.0
+ */
+@SuppressWarnings("unused")
+public class MaxTokenCountExceededException extends IllegalArgumentException {
+
+	public static MaxTokenCountExceededException because(Document document, int tokenCount, int maxTokenCount) {
+		String message = "Tokens [%d] from Document [%s] exceeds the configured maximum number of input tokens allowed [%d]"
+			.formatted(tokenCount, document.getId(), maxTokenCount);
+		return new MaxTokenCountExceededException(message);
+	}
+
+	public MaxTokenCountExceededException() {
+
+	}
+
+	public MaxTokenCountExceededException(String message) {
+		super(message);
+	}
+
+	public MaxTokenCountExceededException(Throwable cause) {
+		super(cause);
+	}
+
+	public MaxTokenCountExceededException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/spring-ai-commons/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Laura Trotta
  * @author Jihoon Kim
  * @author Yanming Zhou
+ * @author John Blum
  * @since 1.0.0
  */
 public class TokenCountBatchingStrategy implements BatchingStrategy {
@@ -148,8 +149,7 @@ public class TokenCountBatchingStrategy implements BatchingStrategy {
 			int tokenCount = this.tokenCountEstimator
 				.estimate(document.getFormattedContent(this.contentFormatter, this.metadataMode));
 			if (tokenCount > this.maxInputTokenCount) {
-				throw new IllegalArgumentException(
-						"Tokens in a single document exceeds the maximum number of allowed input tokens");
+				throw MaxTokenCountExceededException.because(document, tokenCount, this.maxInputTokenCount);
 			}
 			documentTokens.put(document, tokenCount);
 		}


### PR DESCRIPTION
Closes #4835

As a developer, it would be really helpful to know when the (default) max token count is exceeded, what was the configured max value and what was the token count of the Document by ID that exceeded it.

This sort of diagnostic information should be given in any Exception to avoid having to resort to "debugging" to get it.

