### PR TITLE
fix: Correct UserMessage example to use builder

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -209,8 +209,10 @@ Below is a simple code example extracted from https://github.com/spring-projects
 ----
 byte[] data = new ClassPathResource("/vertex-test.png").getContentAsByteArray();
 
-var userMessage = new UserMessage("Explain what do you see on this picture?",
-        List.of(new Media(MimeTypeUtils.IMAGE_PNG, this.data)));
+var userMessage = UserMessage.builder()
+			.text("Explain what do you see o this picture?")
+			.media(List.of(new Media(MimeTypeUtils.IMAGE_PNG, data)))
+			.build();
 
 ChatResponse response = chatModel.call(new Prompt(List.of(this.userMessage)));
 ----
@@ -224,9 +226,10 @@ Use the `application/pdf` media type to attach a PDF file to the message:
 ----
 var pdfData = new ClassPathResource("/spring-ai-reference-overview.pdf");
 
-var userMessage = new UserMessage(
-        "You are a very professional document summarization specialist. Please summarize the given document.",
-        List.of(new Media(new MimeType("application", "pdf"), pdfData)));
+var userMessage = UserMessage.builder()
+			.text("You are a very professional document summarization specialist. Please summarize the given document.")
+			.media(List.of(new Media(new MimeType("application", "pdf"), pdfData)))
+			.build();
 
 var response = this.chatModel.call(new Prompt(List.of(userMessage)));
 ----


### PR DESCRIPTION
The documentation example for UserMessage incorrectly used a private constructor. This commit updates the example to use the public `builder()` method, making the code functional.

---

I've submitted this fix because the example as written used a private constructor and appeared to be non-functional.

However, I did consider that this might have been an **intentional choice**—perhaps to show a simpler, POJO-like constructor pattern for teaching purposes, even if it wasn't runnable.

If that is the case and you'd prefer to keep the original example for pedagogical reasons, please let me know, and I'll be happy to close this pull request.