### PR TITLE
Polish OpenAiChatAutoConfiguration and OpenAiEmbeddingAutoConfiguration

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
@@ -53,6 +53,7 @@ import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfig
  * @author Stefan Vassilev
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Yanming Zhou
  * @author Issam El-atif
  * @author Yanming Zhou
  */
@@ -79,7 +80,6 @@ public class OpenAiChatAutoConfiguration {
 			.apiKey(new SimpleApiKey(resolved.apiKey()))
 			.headers(resolved.headers())
 			.completionsPath(chatProperties.getCompletionsPath())
-			.embeddingsPath(OpenAiEmbeddingProperties.DEFAULT_EMBEDDINGS_PATH)
 			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
 			.webClientBuilder(webClientBuilderProvider.getIfAvailable(WebClient::builder))
 			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiEmbeddingAutoConfiguration.java
@@ -69,7 +69,7 @@ public class OpenAiEmbeddingAutoConfiguration {
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<EmbeddingModelObservationConvention> observationConvention) {
 
-		var openAiApi = openAiApi(embeddingProperties, commonProperties,
+		var openAiApi = openAiApi(commonProperties, embeddingProperties,
 				restClientBuilderProvider.getIfAvailable(RestClient::builder),
 				webClientBuilderProvider.getIfAvailable(WebClient::builder), responseErrorHandler, "embedding");
 
@@ -82,8 +82,8 @@ public class OpenAiEmbeddingAutoConfiguration {
 		return embeddingModel;
 	}
 
-	private OpenAiApi openAiApi(OpenAiEmbeddingProperties embeddingProperties,
-			OpenAiConnectionProperties commonProperties, RestClient.Builder restClientBuilder,
+	private OpenAiApi openAiApi(OpenAiConnectionProperties commonProperties,
+			OpenAiEmbeddingProperties embeddingProperties, RestClient.Builder restClientBuilder,
 			WebClient.Builder webClientBuilder, ObjectProvider<ResponseErrorHandler> responseErrorHandler,
 			String modelType) {
 
@@ -94,7 +94,6 @@ public class OpenAiEmbeddingAutoConfiguration {
 			.baseUrl(resolved.baseUrl())
 			.apiKey(new SimpleApiKey(resolved.apiKey()))
 			.headers(resolved.headers())
-			.completionsPath(OpenAiChatProperties.DEFAULT_COMPLETIONS_PATH)
 			.embeddingsPath(embeddingProperties.getEmbeddingsPath())
 			.restClientBuilder(restClientBuilder)
 			.webClientBuilder(webClientBuilder)


### PR DESCRIPTION
1. Remove `embeddingsPath` setting from `OpenAiChatAutoConfiguration` since it is not used by chat model.
2. Remove `completionsPath` setting from `OpenAiEmbeddingAutoConfiguration` since it is not used by embedding model.
3. Reorder method parameters for consistency.

See GH-4789