### PR TITLE
fix: Fix MongoChatMemoryIndexCreator not being scanned

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreator.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreator.java
@@ -20,16 +20,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.memory.repository.mongo.Conversation;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.Index;
-import org.springframework.stereotype.Component;
 
 /**
- * Class responsible for creating MongoDB proper indices for the ChatMemory. Creates a
+ * Class responsible for creating proper MongoDB indices for the ChatMemory. Creates a
  * main index on the conversationId and timestamp fields, and a TTL index on the timestamp
  * field if the TTL is set in properties.
  *
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Component;
  * @see MongoChatMemoryProperties
  * @since 1.1.0
  */
-@Component
+@AutoConfiguration
 @ConditionalOnProperty(value = "spring.ai.chat.memory.repository.mongo.create-indices", havingValue = "true")
 public class MongoChatMemoryIndexCreator {
 

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 org.springframework.ai.model.chat.memory.repository.mongo.autoconfigure.MongoChatMemoryAutoConfiguration
+org.springframework.ai.model.chat.memory.repository.mongo.autoconfigure.MongoChatMemoryIndexCreator


### PR DESCRIPTION
Change `MongoChatMemoryIndexCreator` into an auto configuration class, so it get picked up when used from outside the library itself.

Fixes #4839
