### PR TITLE
Fix extraBody loss during ModelOptionsUtils.merge()

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -628,14 +628,15 @@ public class OpenAiChatModel implements ChatModel {
 		ChatCompletionRequest request = new ChatCompletionRequest(chatCompletionMessages, stream);
 
 		OpenAiChatOptions requestOptions = (OpenAiChatOptions) prompt.getOptions();
-		request = ModelOptionsUtils.merge(requestOptions, request, ChatCompletionRequest.class);
+		request = ModelOptionsUtils.merge(requestOptions, request, ChatCompletionRequest.class,
+				ChatCompletionRequest.getMergableFieldNames());
 
 		// Add the tool definitions to the request's tools parameter.
 		List<ToolDefinition> toolDefinitions = this.toolCallingManager.resolveToolDefinitions(requestOptions);
 		if (!CollectionUtils.isEmpty(toolDefinitions)) {
 			request = ModelOptionsUtils.merge(
 					OpenAiChatOptions.builder().tools(this.getFunctionTools(toolDefinitions)).build(), request,
-					ChatCompletionRequest.class);
+					ChatCompletionRequest.class, ChatCompletionRequest.getMergableFieldNames());
 		}
 
 		// Remove `streamOptions` from the request if it is not a streaming request

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.openai.api;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -1259,6 +1261,29 @@ public class OpenAiApi {
 			if (this.extraBody != null) {
 				this.extraBody.put(key, value);
 			}
+		}
+
+		/**
+		 * Returns the list of field names that can be merged with other ChatCompletionRequest instances.
+		 * This includes all @JsonProperty annotated fields plus special fields like extra_body
+		 * that use @JsonAnyGetter/@JsonAnySetter.
+		 * @return list of mergeable field names
+		 */
+		public static List<String> getMergableFieldNames() {
+			List<String> fieldNames = new ArrayList<>();
+
+			// Get all @JsonProperty annotated fields
+			for (Field field : ChatCompletionRequest.class.getDeclaredFields()) {
+				JsonProperty jsonPropertyAnnotation = field.getAnnotation(JsonProperty.class);
+				if (jsonPropertyAnnotation != null) {
+					fieldNames.add(jsonPropertyAnnotation.value());
+				}
+			}
+
+			// Add extra_body field (uses @JsonAnyGetter/@JsonAnySetter, not @JsonProperty)
+			fieldNames.add("extra_body");
+
+			return fieldNames;
 		}
 
 		/**

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/ExtraBodyMergeTest.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/ExtraBodyMergeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests to verify that extraBody is preserved when using ModelOptionsUtils.merge().
+ *
+ * @author senrey_song
+ */
+class ExtraBodyMergeTest {
+
+	@Test
+	void shouldPreserveExtraBodyAfterMerge() {
+		List<ChatCompletionMessage> messages = List
+			.of(new ChatCompletionMessage("test message", OpenAiApi.ChatCompletionMessage.Role.USER));
+		ChatCompletionRequest request = new ChatCompletionRequest(messages, false);
+
+		OpenAiChatOptions requestOptions = OpenAiChatOptions.builder()
+			.extraBody(Map.of("top_k", 50, "repetition_penalty", 1.1, "custom_param", "custom_value"))
+			.build();
+
+		request = ModelOptionsUtils.merge(requestOptions, request, ChatCompletionRequest.class,
+				ChatCompletionRequest.getMergableFieldNames());
+
+		assertThat(request.extraBody()).isNotNull();
+		@SuppressWarnings("unchecked")
+		Map<String, Object> extraBodyMap = (Map<String, Object>) request.extraBody().get("extra_body");
+		assertThat(extraBodyMap).hasSize(3)
+			.containsEntry("top_k", 50)
+			.containsEntry("repetition_penalty", 1.1)
+			.containsEntry("custom_param", "custom_value");
+	}
+
+}


### PR DESCRIPTION
The extraBody field was being lost when merging OpenAiChatOptions into ChatCompletionRequest using ModelOptionsUtils.merge(). This fix ensures that extraBody parameters (like top_k, repetition_penalty, etc.) are properly preserved during the merge operation.

Added test ExtraBodyMergeTest to verify the fix.
