### PR TITLE
Remove unused json-path dependency from spring-ai-anthropic module

### DIFF
--- a/models/spring-ai-anthropic/pom.xml
+++ b/models/spring-ai-anthropic/pom.xml
@@ -56,11 +56,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.rest-assured</groupId>
-			<artifactId>json-path</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.github.victools</groupId>
 			<artifactId>jsonschema-generator</artifactId>
 			<version>${jsonschema.version}</version>


### PR DESCRIPTION
Similar to https://github.com/spring-projects/spring-ai/pull/2363, remove unused json-path dependency in spring-ai-anthropic module as well