### PR TITLE
Fix null response for OpenAI gpt-oss models on Amazon Bedrock

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -670,6 +670,7 @@ public class BedrockProxyChatModel implements ChatModel {
 		List<Generation> generations = message.content()
 			.stream()
 			.filter(content -> content.type() != ContentBlock.Type.TOOL_USE)
+			.filter(content -> content.text() != null)
 			.map(content -> new Generation(
 					AssistantMessage.builder().content(content.text()).properties(Map.of()).build(),
 					ChatGenerationMetadata.builder().finishReason(response.stopReasonAsString()).build()))


### PR DESCRIPTION
Add filter to skip ContentBlocks with null text content when processing responses. OpenAI gpt-oss models return multiple ContentBlocks including ReasoningContent (null) and Text blocks. The fix ensures only blocks with actual text content are processed.

Fixes #4861
