### PR TITLE
Fix : MongoDB index creation API compatibility across Spring Data Mongo…

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreatorAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/model/chat/memory/repository/mongo/autoconfigure/MongoChatMemoryIndexCreatorAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.model.chat.memory.repository.mongo.autoconfigure;
 
+import java.lang.reflect.Method;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,11 +29,13 @@ import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.mongodb.core.index.IndexOperations;
 
 /**
  * Class responsible for creating proper MongoDB indices for the ChatMemory. Creates a
- * main index on the conversationId and timestamp fields, and a TTL index on the timestamp
- * field if the TTL is set in properties.
+ * main index on the conversationId and timestamp fields, and a TTL index on the
+ * timestamp field if the TTL is set in properties.
  *
  * @author Łukasz Jernaś
  * @see MongoChatMemoryProperties
@@ -41,41 +45,97 @@ import org.springframework.data.mongodb.core.index.Index;
 @ConditionalOnProperty(value = "spring.ai.chat.memory.repository.mongo.create-indices", havingValue = "true")
 public class MongoChatMemoryIndexCreatorAutoConfiguration {
 
-	private static final Logger logger = LoggerFactory.getLogger(MongoChatMemoryIndexCreatorAutoConfiguration.class);
+	private static final Logger logger = LoggerFactory
+			.getLogger(MongoChatMemoryIndexCreatorAutoConfiguration.class);
 
 	private final MongoTemplate mongoTemplate;
 
 	private final MongoChatMemoryProperties mongoChatMemoryProperties;
 
-	public MongoChatMemoryIndexCreatorAutoConfiguration(MongoTemplate mongoTemplate,
-			MongoChatMemoryProperties mongoChatMemoryProperties) {
+	public MongoChatMemoryIndexCreatorAutoConfiguration(final MongoTemplate mongoTemplate,
+			final MongoChatMemoryProperties mongoChatMemoryProperties) {
 		this.mongoTemplate = mongoTemplate;
 		this.mongoChatMemoryProperties = mongoChatMemoryProperties;
 	}
 
+	/**
+	 * Initializes MongoDB indices after application context refresh.
+	 */
 	@EventListener(ContextRefreshedEvent.class)
 	public void initIndicesAfterStartup() {
 		logger.info("Creating MongoDB indices for ChatMemory");
 		// Create a main index
-		this.mongoTemplate.indexOps(Conversation.class)
-			.createIndex(new Index().on("conversationId", Sort.Direction.ASC).on("timestamp", Sort.Direction.DESC));
-
+		createMainIndex();
 		createOrUpdateTtlIndex();
+	}
+
+	private void createMainIndex() {
+		var indexOps = this.mongoTemplate.indexOps(Conversation.class);
+		var index = new Index().on("conversationId", Sort.Direction.ASC)
+				.on("timestamp", Sort.Direction.DESC);
+
+		// Use reflection to handle API differences across Spring Data MongoDB versions
+		createIndexSafely(indexOps, index);
 	}
 
 	private void createOrUpdateTtlIndex() {
 		if (!this.mongoChatMemoryProperties.getTtl().isZero()) {
+			var indexOps = this.mongoTemplate.indexOps(Conversation.class);
 			// Check for existing TTL index
-			this.mongoTemplate.indexOps(Conversation.class).getIndexInfo().forEach(idx -> {
+			indexOps.getIndexInfo().forEach(idx -> {
 				if (idx.getExpireAfter().isPresent()
-						&& !idx.getExpireAfter().get().equals(this.mongoChatMemoryProperties.getTtl())) {
+						&& !idx.getExpireAfter().get()
+								.equals(this.mongoChatMemoryProperties.getTtl())) {
 					logger.warn("Dropping existing TTL index, because TTL is different");
-					this.mongoTemplate.indexOps(Conversation.class).dropIndex(idx.getName());
+					indexOps.dropIndex(idx.getName());
 				}
 			});
-			this.mongoTemplate.indexOps(Conversation.class)
-				.createIndex(new Index().on("timestamp", Sort.Direction.ASC)
+			// Use reflection to handle API differences across Spring Data MongoDB
+			// versions
+			createIndexSafely(indexOps, new Index().on("timestamp", Sort.Direction.ASC)
 					.expire(this.mongoChatMemoryProperties.getTtl()));
+		}
+	}
+
+	/**
+	 * Creates an index using reflection to handle API changes across different Spring
+	 * Data MongoDB versions:
+	 * <ul>
+	 * <li>Spring Data MongoDB 4.2.x - 4.4.x: only {@code ensureIndex(IndexDefinition)}
+	 * is available.</li>
+	 * <li>Spring Data MongoDB 4.5.x+: {@code createIndex(IndexDefinition)} is the new
+	 * API, {@code ensureIndex} is deprecated.</li>
+	 * </ul>
+	 * @param indexOps the IndexOperations instance
+	 * @param index the index definition
+	 * @throws IllegalStateException if neither method is available or invocation fails
+	 */
+	private void createIndexSafely(final IndexOperations indexOps, final IndexDefinition index) {
+		try {
+			// Try new API (Spring Data MongoDB 4.5.x+)
+			Method method = IndexOperations.class.getMethod("createIndex", IndexDefinition.class);
+			method.invoke(indexOps, index);
+			logger.debug("Created index using createIndex() method");
+		}
+		catch (NoSuchMethodException createIndexNotFound) {
+			// Fall back to old API (Spring Data MongoDB 4.2.x - 4.4.x)
+			try {
+				Method method = IndexOperations.class.getMethod("ensureIndex", IndexDefinition.class);
+				method.invoke(indexOps, index);
+				logger.debug("Created index using ensureIndex() method");
+			}
+			catch (NoSuchMethodException ensureIndexNotFound) {
+				throw new IllegalStateException(
+						"Neither createIndex() nor ensureIndex() method found on IndexOperations. "
+								+ "This may indicate an unsupported Spring Data MongoDB version.",
+						ensureIndexNotFound);
+			}
+			catch (ReflectiveOperationException ex) {
+				throw new IllegalStateException("Failed to invoke ensureIndex() method", ex);
+			}
+		}
+		catch (ReflectiveOperationException ex) {
+			throw new IllegalStateException("Failed to invoke createIndex() method", ex);
 		}
 	}
 


### PR DESCRIPTION

## Fix MongoDB index creation API compatibility across Spring Data MongoDB versions

### Problem

Spring AI 1.1.0 fails to start when `spring.ai.chat.memory.repository.mongo.create-indices=true` is configured with Spring Boot 3.4.x, throwing:

```
java.lang.NoSuchMethodError: 'java.lang.String org.springframework.data.mongodb.core.index.IndexOperations.createIndex(org.springframework.data.mongodb.core.index.IndexDefinition)'
```

**Root Cause:**

Spring Data MongoDB changed its index creation API between versions:
- **4.2.x - 4.4.x** (Spring Boot 3.2.x - 3.4.x): Only `ensureIndex(IndexDefinition)` is available
- **4.5.x+** (Spring Boot 3.5.x+): `createIndex(IndexDefinition)` is the new API, `ensureIndex` is deprecated

The original code in `MongoChatMemoryIndexCreatorAutoConfiguration` hardcoded `createIndex()`, which doesn't exist in MongoDB 4.2.x - 4.4.x, causing runtime errors for users on officially supported Spring Boot versions.

### Solution

Implemented a **reflection-based fallback strategy** to dynamically choose the correct method at runtime:

1. **Try `createIndex()` first** (for Spring Data MongoDB 4.5.x+)
2. **Fall back to `ensureIndex()`** if `NoSuchMethodException` occurs (for 4.2.x - 4.4.x)
3. **Throw `IllegalStateException`** with clear error message if neither method is available

This approach follows Spring AI's existing pattern for handling optional dependencies (see `SpringAiRetryAutoConfiguration`).

### Testing

Successfully tested across multiple Spring Boot versions:

| Spring Boot | Spring Data MongoDB | Method Used | Result |
|------------|---------------------|-------------|--------|
| 3.2.4 | 4.2.4 | `ensureIndex()` | ✅ Pass |
| 3.3.4 | 4.3.4 | `ensureIndex()` | ✅ Pass |
| 3.4.1 | 4.4.1 | `ensureIndex()` | ✅ Pass |
| 3.5.4 | 4.5.2 | `createIndex()` | ✅ Pass |

Test command:
```bash
mvn clean test -pl auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb
```

### Impact

- ✅ **Backward compatible**: Works with Spring Data MongoDB 4.2.x - 4.4.x
- ✅ **Forward compatible**: Works with Spring Data MongoDB 4.5.x+
- ✅ **No breaking changes**: Existing functionality preserved
- ✅ **Minimal performance impact**: Reflection only executed twice during application startup
- ✅ **Clear error handling**: Provides actionable error messages if unsupported MongoDB version is detected

### Related Issues

Fixes #4884

---

## Checklist

- [x] I have signed the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin) with `Signed-off-by` line
- [x] My changes are rebased on the latest `main` branch
- [x] My commits are squashed into a single commit
- [x] Code follows Spring AI coding standards (reflection pattern consistent with `SpringAiRetryAutoConfiguration`)
- [x] Tests pass locally across Spring Boot 3.2.x - 3.5.x
- [x] No new dependencies added
- [x] JavaDoc updated to explain the API version differences

