### PR TITLE
Change method "before/after" of BaseAdvisor to default

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/ReReadingAdvisor.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/ReReadingAdvisor.java
@@ -19,7 +19,6 @@ package org.springframework.ai.openai.chat.client;
 import java.util.Map;
 
 import org.springframework.ai.chat.client.ChatClientRequest;
-import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.prompt.PromptTemplate;
@@ -33,6 +32,7 @@ import org.springframework.ai.chat.prompt.PromptTemplate;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 public class ReReadingAdvisor implements BaseAdvisor {
@@ -65,11 +65,6 @@ public class ReReadingAdvisor implements BaseAdvisor {
 		return chatClientRequest.mutate()
 			.prompt(chatClientRequest.prompt().augmentUserMessage(augmentedUserText))
 			.build();
-	}
-
-	@Override
-	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
-		return chatClientResponse;
 	}
 
 	@Override

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/api/BaseAdvisor.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  * {@link #after(ChatClientResponse, AdvisorChain advisorChain)} methods.
  *
  * @author Thomas Vitale
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 public interface BaseAdvisor extends CallAdvisor, StreamAdvisor {
@@ -81,12 +82,16 @@ public interface BaseAdvisor extends CallAdvisor, StreamAdvisor {
 	/**
 	 * Logic to be executed before the rest of the advisor chain is called.
 	 */
-	ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain);
+	default ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		return chatClientRequest;
+	}
 
 	/**
 	 * Logic to be executed after the rest of the advisor chain is called.
 	 */
-	ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain);
+	default ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
 
 	/**
 	 * Scheduler used for processing the advisor logic when streaming.


### PR DESCRIPTION
Some Advisors are focus on either `before` or `after` processing, we could eliminate the other empty method implementation.