### PR TITLE
Add "eos_token" to OpenAI "finish_reason"

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -787,7 +787,13 @@ public class OpenAiApi {
 		 * Only for compatibility with Mistral AI API.
 		 */
 		@JsonProperty("tool_call")
-		TOOL_CALL
+		TOOL_CALL,
+		/**
+		 * End of Sequence indicates sequence of text has finished in open-ended
+		 * generation task
+		 */
+		@JsonProperty("eos_token")
+		EOS_TOKEN,
 
 	}
 


### PR DESCRIPTION
OpenAI model can user "eos_token" as "finish_reason" when the model reached end of sequence for open-ended generation task

For example, when asking "What tools are available?"