### PR TITLE
Configure ErrorProne + Nullaway

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -317,7 +317,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 				.collect(Collectors.joining());
 			logger.info("Response: {}", content);
 
-			assertThat(content).isNotEmpty().withFailMessage("Content returned from OpenAI model is empty");
+			assertThat(content).withFailMessage("Content returned from OpenAI model is empty").isNotEmpty();
 			assertThat(content).contains("30", "10", "15");
 
 		});

--- a/memory/repository/spring-ai-model-chat-memory-repository-cassandra/src/test/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-cassandra/src/test/java/org/springframework/ai/chat/memory/repository/cassandra/CassandraChatMemoryRepositoryIT.java
@@ -73,7 +73,7 @@ class CassandraChatMemoryRepositoryIT {
 	void add_shouldInsertSingleMessage(String content, MessageType messageType) {
 		this.contextRunner.run(context -> {
 			var chatMemory = context.getBean(ChatMemoryRepository.class);
-			assertThat(chatMemory instanceof CassandraChatMemoryRepository);
+			assertThat(chatMemory).isInstanceOf(CassandraChatMemoryRepository.class);
 			var sessionId = UUID.randomUUID().toString();
 			var message = switch (messageType) {
 				case ASSISTANT -> new AssistantMessage(content);
@@ -109,7 +109,7 @@ class CassandraChatMemoryRepositoryIT {
 	void add_shouldInsertMessages() {
 		this.contextRunner.run(context -> {
 			var chatMemory = context.getBean(ChatMemoryRepository.class);
-			assertThat(chatMemory instanceof CassandraChatMemoryRepository);
+			assertThat(chatMemory).isInstanceOf(CassandraChatMemoryRepository.class);
 			var sessionId = UUID.randomUUID().toString();
 			var messages = List.<Message>of(new AssistantMessage("Message from assistant"),
 					new UserMessage("Message from user"));
@@ -147,7 +147,7 @@ class CassandraChatMemoryRepositoryIT {
 	void get_shouldReturnMessages() {
 		this.contextRunner.run(context -> {
 			var chatMemory = context.getBean(ChatMemoryRepository.class);
-			assertThat(chatMemory instanceof CassandraChatMemoryRepository);
+			assertThat(chatMemory).isInstanceOf(CassandraChatMemoryRepository.class);
 			var sessionId = UUID.randomUUID().toString();
 
 			var messages = List.<Message>of(new AssistantMessage("Message from assistant 1 - " + sessionId),
@@ -174,7 +174,7 @@ class CassandraChatMemoryRepositoryIT {
 	void get_afterMultipleAdds_shouldReturnMessagesInSameOrder() {
 		this.contextRunner.run(context -> {
 			var chatMemory = context.getBean(ChatMemoryRepository.class);
-			assertThat(chatMemory instanceof CassandraChatMemoryRepository);
+			assertThat(chatMemory).isInstanceOf(CassandraChatMemoryRepository.class);
 			var sessionId = UUID.randomUUID().toString();
 			var userMessage = new UserMessage("Message from user - " + sessionId);
 			var assistantMessage = new AssistantMessage("Message from assistant - " + sessionId);
@@ -200,7 +200,7 @@ class CassandraChatMemoryRepositoryIT {
 	void clear_shouldDeleteMessages() {
 		this.contextRunner.run(context -> {
 			var chatMemory = context.getBean(ChatMemoryRepository.class);
-			assertThat(chatMemory instanceof CassandraChatMemoryRepository);
+			assertThat(chatMemory).isInstanceOf(CassandraChatMemoryRepository.class);
 			var sessionId = UUID.randomUUID().toString();
 
 			var messages = List.<Message>of(new AssistantMessage("Message from assistant - " + sessionId),

--- a/memory/repository/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryIT.java
@@ -306,6 +306,7 @@ class Neo4jChatMemoryRepositoryIT {
 	}
 
 	@Test
+	@SuppressWarnings("DoubleBraceInitialization")
 	void saveAndFindSystemMessageWithMetadata() {
 		var conversationId = UUID.randomUUID().toString();
 		Map<String, Object> customMetadata = Map.of("priority", "high", "source", "test");

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -424,6 +424,7 @@ class AnthropicChatOptionsTests {
 	}
 
 	@Test
+	@SuppressWarnings("SelfAssertion")
 	void testEqualsWithSelf() {
 		AnthropicChatOptions options = AnthropicChatOptions.builder().model("test").build();
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicPromptCachingMockTest.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicPromptCachingMockTest.java
@@ -540,8 +540,9 @@ class AnthropicPromptCachingMockTest {
 		int cacheControlCount = countCacheControlOccurrences(requestBody);
 
 		// Verify we don't exceed Anthropic's 4-breakpoint limit
-		assertThat(cacheControlCount).isLessThanOrEqualTo(4)
-			.withFailMessage("Cache breakpoints should not exceed 4, but found %d", cacheControlCount);
+		assertThat(cacheControlCount)
+			.withFailMessage("Cache breakpoints should not exceed 4, but found %d", cacheControlCount)
+			.isLessThanOrEqualTo(4);
 	}
 
 	@Test
@@ -608,8 +609,9 @@ class AnthropicPromptCachingMockTest {
 			// Simple text system message should still have cache_control applied at the
 			// message level
 			// Check if there's a cache_control field at the system level or in a wrapper
-			assertThat(requestBody.toString()).contains("cache_control")
-				.withFailMessage("SYSTEM_ONLY strategy should include cache_control in wire format");
+			assertThat(requestBody.toString())
+				.withFailMessage("SYSTEM_ONLY strategy should include cache_control in wire format")
+				.contains("cache_control");
 		}
 	}
 
@@ -690,8 +692,9 @@ class AnthropicPromptCachingMockTest {
 
 		// Verify proper ordering and cache control placement
 		int cacheControlCount = countCacheControlOccurrences(requestBody);
-		assertThat(cacheControlCount).isLessThanOrEqualTo(4)
-			.withFailMessage("Complex scenario should not exceed 4 cache breakpoints, found %d", cacheControlCount);
+		assertThat(cacheControlCount)
+			.withFailMessage("Complex scenario should not exceed 4 cache breakpoints, found %d", cacheControlCount)
+			.isLessThanOrEqualTo(4);
 
 		// Verify cache_control is only on the LAST blocks of each section (system, tools)
 		// This ensures proper breakpoint placement according to Anthropic's requirements
@@ -732,9 +735,9 @@ class AnthropicPromptCachingMockTest {
 			if (systemNode.isArray()) {
 				for (int i = 0; i < systemNode.size() - 1; i++) {
 					JsonNode systemBlock = systemNode.get(i);
-					assertThat(systemBlock.has("cache_control")).isFalse()
-						.withFailMessage("Only the last system block should have cache_control, but block %d has it",
-								i);
+					assertThat(systemBlock.has("cache_control"))
+						.withFailMessage("Only the last system block should have cache_control, but block %d has it", i)
+						.isFalse();
 				}
 			}
 		}
@@ -745,8 +748,9 @@ class AnthropicPromptCachingMockTest {
 			if (toolsArray.isArray()) {
 				for (int i = 0; i < toolsArray.size() - 1; i++) {
 					JsonNode tool = toolsArray.get(i);
-					assertThat(tool.has("cache_control")).isFalse()
-						.withFailMessage("Only the last tool should have cache_control, but tool %d has it", i);
+					assertThat(tool.has("cache_control"))
+						.withFailMessage("Only the last tool should have cache_control, but tool %d has it", i)
+						.isFalse();
 				}
 			}
 		}
@@ -767,9 +771,10 @@ class AnthropicPromptCachingMockTest {
 							if (i != messagesArray.size() - 2 || j != contentArray.size() - 1) {
 								// Only the last content block of the second-to-last
 								// message should have cache_control
-								assertThat(contentBlock.has("cache_control")).isFalse()
+								assertThat(contentBlock.has("cache_control"))
 									.withFailMessage(
-											"Unexpected cache_control placement in message %d, content block %d", i, j);
+											"Unexpected cache_control placement in message %d, content block %d", i, j)
+									.isFalse();
 							}
 						}
 					}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatModelIT.java
@@ -123,7 +123,7 @@ class AzureOpenAiChatModelIT {
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
-		assertThat(counter.get()).isGreaterThan(8).as("More than 8 chuncks because there are 8 planets");
+		assertThat(counter.get()).withFailMessage("More than 8 chunks because there are 8 planets").isGreaterThan(8);
 
 		assertThat(content).contains("Earth", "Mars", "Jupiter");
 	}

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/function/AzureOpenAiChatModelFunctionCallIT.java
@@ -139,7 +139,8 @@ class AzureOpenAiChatModelFunctionCallIT {
 			.collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
-		assertThat(counter.get()).isGreaterThan(30).as("The response should be chunked in more than 30 messages");
+		assertThat(counter.get()).withFailMessage("The response should be chunked in more than 30 messages")
+			.isGreaterThan(30);
 
 		assertThat(content).contains("30", "10", "15");
 

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
@@ -155,10 +155,9 @@ class DeepSeekChatModelFunctionCallingIT {
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
 		assertThat(chatResponse).isNotNull();
-		assertThat(chatResponse.getResult().getOutput());
+		assertThat(chatResponse.getResult().getOutput()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).contains("San Francisco");
 		assertThat(chatResponse.getResult().getOutput().getText()).contains("30");
-		// 这个 total token 是第一次 chat 以及 tool call 之后的两次请求 token 总和
 
 		// the total token is first chat and tool call request
 		assertThat(chatResponse.getMetadata().getUsage().getTotalTokens()).isLessThan(700).isGreaterThan(280);

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelIT.java
@@ -229,7 +229,7 @@ class DeepSeekChatModelIT {
 			.build();
 		Prompt prompt = new Prompt(List.of(userMessage, assistantMessage));
 		ChatResponse response = this.chatModel.call(prompt);
-		assertThat(response.getResult().getOutput().getText().equals(",2,3]}}"));
+		assertThat(response.getResult().getOutput().getText()).isEqualTo(",2,3]}}");
 	}
 
 	/**

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -441,7 +441,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions {
 		if (!(o instanceof GoogleGenAiChatOptions that)) {
 			return false;
 		}
-		return this.googleSearchRetrieval == that.googleSearchRetrieval
+		return Objects.equals(this.googleSearchRetrieval, that.googleSearchRetrieval)
 				&& Objects.equals(this.stopSequences, that.stopSequences)
 				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP)
 				&& Objects.equals(this.topK, that.topK) && Objects.equals(this.candidateCount, that.candidateCount)

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiModerationModelIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiModerationModelIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mistralai;
 
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
@@ -64,15 +65,8 @@ public class MistralAiModerationModelIT {
 		assertThat(result.isFlagged()).isTrue();
 
 		CategoryScores scores = result.getCategoryScores();
-		assertThat(scores.getSexual()).isNotNull();
-		assertThat(scores.getHate()).isNotNull();
-		assertThat(scores.getViolence()).isNotNull();
-		assertThat(scores.getDangerousAndCriminalContent()).isNotNull();
-		assertThat(scores.getSelfHarm()).isNotNull();
-		assertThat(scores.getHealth()).isNotNull();
-		assertThat(scores.getFinancial()).isNotNull();
-		assertThat(scores.getLaw()).isNotNull();
-		assertThat(scores.getPii()).isNotNull();
+		assertThat(scores.getSexual()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getViolence()).isCloseTo(1.0d, Offset.offset(0.2d));
 	}
 
 }

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMetadataTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMetadataTests.java
@@ -66,7 +66,7 @@ class OllamaChatModelMetadataTests extends BaseOllamaIT {
 		chatResponse.getResults().forEach(generation -> {
 			ChatGenerationMetadata chatGenerationMetadata = generation.getMetadata();
 			assertThat(chatGenerationMetadata).isNotNull();
-			assertThat(chatGenerationMetadata.containsKey("thinking"));
+			assertThat(chatGenerationMetadata.containsKey("thinking")).isTrue();
 		});
 	}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatOptionsTests.java
@@ -293,6 +293,7 @@ class OpenAiChatOptionsTests {
 	}
 
 	@Test
+	@SuppressWarnings("SelfAssertion")
 	void testEqualsAndHashCode() {
 		OpenAiChatOptions options1 = OpenAiChatOptions.builder()
 			.model("test-model")

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiImageOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiImageOptionsTests.java
@@ -152,6 +152,7 @@ class OpenAiImageOptionsTests {
 	}
 
 	@Test
+	@SuppressWarnings("SelfAssertion")
 	void testEqualsAndHashCode() {
 		OpenAiImageOptions options1 = OpenAiImageOptions.builder()
 			.N(2)

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelResponseFormatIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelResponseFormatIT.java
@@ -264,7 +264,7 @@ public class OpenAiChatModelResponseFormatIT {
 
 		// Check if the order is correct as specified in the schema. Steps should come
 		// first before final answer.
-		assertThat(content.startsWith("{\"steps\":{\"items\":["));
+		assertThat(content).startsWith("{\"steps\":{\"items\":[");
 
 		MathReasoning mathReasoning = outputConverter.convert(content);
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/OpenAiModerationModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/moderation/OpenAiModerationModelIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.openai.moderation;
 
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
@@ -59,7 +60,6 @@ public class OpenAiModerationModelIT extends AbstractIT {
 		assertThat(moderation.getId()).isNotEmpty();
 		assertThat(moderation.getResults()).isNotNull();
 		assertThat(moderation.getResults().size()).isNotZero();
-		System.out.println(moderation.getResults().toString());
 
 		assertThat(moderation.getId()).isNotNull();
 		assertThat(moderation.getModel()).isNotNull();
@@ -68,30 +68,11 @@ public class OpenAiModerationModelIT extends AbstractIT {
 		assertThat(result.isFlagged()).isTrue();
 		Categories categories = result.getCategories();
 		assertThat(categories).isNotNull();
-		assertThat(categories.isSexual()).isNotNull();
-		assertThat(categories.isHate()).isNotNull();
-		assertThat(categories.isHarassment()).isNotNull();
-		assertThat(categories.isSelfHarm()).isNotNull();
-		assertThat(categories.isSexualMinors()).isNotNull();
-		assertThat(categories.isHateThreatening()).isNotNull();
-		assertThat(categories.isViolenceGraphic()).isNotNull();
-		assertThat(categories.isSelfHarmIntent()).isNotNull();
-		assertThat(categories.isSelfHarmInstructions()).isNotNull();
-		assertThat(categories.isHarassmentThreatening()).isNotNull();
 		assertThat(categories.isViolence()).isTrue();
 
 		CategoryScores scores = result.getCategoryScores();
-		assertThat(scores.getSexual()).isNotNull();
-		assertThat(scores.getHate()).isNotNull();
-		assertThat(scores.getHarassment()).isNotNull();
-		assertThat(scores.getSelfHarm()).isNotNull();
-		assertThat(scores.getSexualMinors()).isNotNull();
-		assertThat(scores.getHateThreatening()).isNotNull();
-		assertThat(scores.getViolenceGraphic()).isNotNull();
-		assertThat(scores.getSelfHarmIntent()).isNotNull();
-		assertThat(scores.getSelfHarmInstructions()).isNotNull();
-		assertThat(scores.getHarassmentThreatening()).isNotNull();
-		assertThat(scores.getViolence()).isNotNull();
+		assertThat(scores.getSexual()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getViolence()).isCloseTo(1.0d, Offset.offset(0.2d));
 
 	}
 
@@ -113,7 +94,6 @@ public class OpenAiModerationModelIT extends AbstractIT {
 		assertThat(moderation.getId()).isNotEmpty();
 		assertThat(moderation.getResults()).isNotNull();
 		assertThat(moderation.getResults().size()).isNotZero();
-		System.out.println(moderation.getResults().toString());
 
 		assertThat(moderation.getId()).isNotNull();
 		assertThat(moderation.getModel()).isNotNull();
@@ -134,17 +114,17 @@ public class OpenAiModerationModelIT extends AbstractIT {
 		assertThat(categories.isViolence()).isFalse();
 
 		CategoryScores scores = result.getCategoryScores();
-		assertThat(scores.getSexual()).isNotNull();
-		assertThat(scores.getHate()).isNotNull();
-		assertThat(scores.getHarassment()).isNotNull();
-		assertThat(scores.getSelfHarm()).isNotNull();
-		assertThat(scores.getSexualMinors()).isNotNull();
-		assertThat(scores.getHateThreatening()).isNotNull();
-		assertThat(scores.getViolenceGraphic()).isNotNull();
-		assertThat(scores.getSelfHarmIntent()).isNotNull();
-		assertThat(scores.getSelfHarmInstructions()).isNotNull();
-		assertThat(scores.getHarassmentThreatening()).isNotNull();
-		assertThat(scores.getViolence()).isNotNull();
+		assertThat(scores.getSexual()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getHate()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getHarassment()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getSelfHarm()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getSexualMinors()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getHateThreatening()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getViolenceGraphic()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getSelfHarmIntent()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getSelfHarmInstructions()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getHarassmentThreatening()).isCloseTo(0.0d, Offset.offset(0.1d));
+		assertThat(scores.getViolence()).isCloseTo(0.0d, Offset.offset(0.1d));
 
 	}
 

--- a/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/ResourceCacheServiceTests.java
+++ b/models/spring-ai-transformers/src/test/java/org/springframework/ai/transformers/ResourceCacheServiceTests.java
@@ -19,7 +19,9 @@ package org.springframework.ai.transformers;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,7 +46,9 @@ public class ResourceCacheServiceTests {
 		var cachedResource = cache.getCachedResource(originalResourceUri);
 
 		assertThat(cachedResource).isEqualTo(new DefaultResourceLoader().getResource(originalResourceUri));
-		assertThat(Files.list(this.tempDir.toPath()).count()).isEqualTo(0);
+		try (Stream<Path> paths = Files.list(this.tempDir.toPath())) {
+			assertThat(paths.count()).isEqualTo(0);
+		}
 	}
 
 	@Test
@@ -58,8 +62,8 @@ public class ResourceCacheServiceTests {
 		var cachedResource1 = cache.getCachedResource(originalResourceUri);
 
 		assertThat(cachedResource1).isNotEqualTo(new DefaultResourceLoader().getResource(originalResourceUri));
-		assertThat(Files.list(this.tempDir.toPath()).count()).isEqualTo(1);
-		assertThat(Files.list(Files.list(this.tempDir.toPath()).iterator().next()).count()).isEqualTo(1);
+		assertThat(this.tempDir.listFiles()).hasSize(1);
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(1);
 
 		// Attempt to cache the same resource again should return the already cached
 		// resource.
@@ -68,8 +72,8 @@ public class ResourceCacheServiceTests {
 		assertThat(cachedResource2).isNotEqualTo(new DefaultResourceLoader().getResource(originalResourceUri));
 		assertThat(cachedResource2).isEqualTo(cachedResource1);
 
-		assertThat(Files.list(this.tempDir.toPath()).count()).isEqualTo(1);
-		assertThat(Files.list(Files.list(this.tempDir.toPath()).iterator().next()).count()).isEqualTo(1);
+		assertThat(this.tempDir.listFiles()).hasSize(1);
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(1);
 
 	}
 
@@ -91,11 +95,10 @@ public class ResourceCacheServiceTests {
 		assertThat(cachedResource2).isNotEqualTo(new DefaultResourceLoader().getResource(originalResourceUri1));
 		assertThat(cachedResource2).isNotEqualTo(cachedResource1);
 
-		assertThat(Files.list(this.tempDir.toPath()).count()).isEqualTo(1)
+		assertThat(this.tempDir.listFiles()).hasSize(1)
 			.describedAs(
 					"As both resources come from the same parent segments they should be cached in a single common parent.");
-		assertThat(Files.list(Files.list(this.tempDir.toPath()).iterator().next()).count()).isEqualTo(2);
-
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(2);
 	}
 
 	@Test
@@ -106,8 +109,8 @@ public class ResourceCacheServiceTests {
 		var cachedResource1 = cache.getCachedResource(originalResourceUri1);
 
 		assertThat(cachedResource1).isNotEqualTo(new DefaultResourceLoader().getResource(originalResourceUri1));
-		assertThat(Files.list(this.tempDir.toPath()).count()).isEqualTo(1);
-		assertThat(Files.list(Files.list(this.tempDir.toPath()).iterator().next()).count()).isEqualTo(1);
+		assertThat(this.tempDir.listFiles()).hasSize(1);
+		assertThat(this.tempDir.listFiles()[0].listFiles()).hasSize(1);
 	}
 
 	@Test

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -61,7 +61,6 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
-import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -404,9 +403,7 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 						.toList();
 
 					GenerateContentResponse.UsageMetadata usage = generateContentResponse.getUsageMetadata();
-					Usage currentUsage = (usage != null)
-							? new DefaultUsage(usage.getPromptTokenCount(), usage.getCandidatesTokenCount())
-							: new EmptyUsage();
+					Usage currentUsage = new DefaultUsage(usage.getPromptTokenCount(), usage.getCandidatesTokenCount());
 					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
 					ChatResponse chatResponse = new ChatResponse(generations, toChatResponseMetadata(cumulativeUsage));
 
@@ -520,7 +517,7 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 						.toList();
 
 					GenerateContentResponse.UsageMetadata usage = response.getUsageMetadata();
-					Usage currentUsage = (usage != null) ? getDefaultUsage(usage) : new EmptyUsage();
+					Usage currentUsage = getDefaultUsage(usage);
 					Usage cumulativeUsage = UsageCalculator.getCumulativeUsage(currentUsage, previousChatResponse);
 					ChatResponse chatResponse = new ChatResponse(generations, toChatResponseMetadata(cumulativeUsage));
 					return Flux.just(chatResponse);

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -379,7 +379,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions {
 		if (!(o instanceof VertexAiGeminiChatOptions that)) {
 			return false;
 		}
-		return this.googleSearchRetrieval == that.googleSearchRetrieval
+		return Objects.equals(this.googleSearchRetrieval, that.googleSearchRetrieval)
 				&& Objects.equals(this.stopSequences, that.stopSequences)
 				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP)
 				&& Objects.equals(this.topK, that.topK) && Objects.equals(this.candidateCount, that.candidateCount)

--- a/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/CreateGeminiRequestTests.java
+++ b/models/spring-ai-vertex-ai-gemini/src/test/java/org/springframework/ai/vertexai/gemini/CreateGeminiRequestTests.java
@@ -134,7 +134,6 @@ public class CreateGeminiRequestTests {
 		assertThat(textPart.getText()).isEqualTo("User Message Text");
 
 		Part mediaPart = content.getParts(1);
-		assertThat(mediaPart.getFileData()).isNotNull();
 		assertThat(mediaPart.getFileData().getFileUri()).isEqualTo("http://example.com");
 		assertThat(mediaPart.getFileData().getMimeType()).isEqualTo(MimeTypeUtils.IMAGE_PNG.toString());
 		System.out.println(mediaPart);

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptionsTests.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptionsTests.java
@@ -183,6 +183,7 @@ class ZhiPuAiChatOptionsTests {
 	}
 
 	@Test
+	@SuppressWarnings("SelfAssertion")
 	void testEqualsAndHashCode() {
 		ZhiPuAiChatOptions options1 = ZhiPuAiChatOptions.builder()
 			.model("test-model")

--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,9 @@
 		<spring-javaformat-checkstyle.version>0.0.43</spring-javaformat-checkstyle.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
 
+		<error-prone.version>2.44.0</error-prone.version>
+		<nullaway.version>0.12.12</nullaway.version>
+
 		<disable.checks>false</disable.checks>
 
 	</properties>
@@ -483,9 +486,35 @@
 				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
 					<release>${java.version}</release>
+					<fork>true</fork>
 					<compilerArgs>
-						<compilerArg>-parameters</compilerArg>
+						<arg>-parameters</arg>
+						<arg>-XDcompilePolicy=simple</arg>
+						<arg>--should-stop=ifError=FLOW</arg>
+						<arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked -XepOpt:NullAway:JSpecifyMode=true</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+						<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+						<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
 					</compilerArgs>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>com.google.errorprone</groupId>
+							<artifactId>error_prone_core</artifactId>
+							<version>${error-prone.version}</version>
+						</path>
+						<path>
+							<groupId>com.uber.nullaway</groupId>
+							<artifactId>nullaway</artifactId>
+							<version>${nullaway.version}</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 				<executions>
 					<!-- Replacing default-compile as it is treated specially by Maven -->

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/metadata/DefaultUsageTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/metadata/DefaultUsageTests.java
@@ -183,6 +183,7 @@ public class DefaultUsageTests {
 	}
 
 	@Test
+	@SuppressWarnings("SelfAssertion")
 	void testEqualsAndHashCode() {
 		DefaultUsage usage1 = new DefaultUsage(Integer.valueOf(100), Integer.valueOf(50), Integer.valueOf(150));
 		DefaultUsage usage2 = new DefaultUsage(Integer.valueOf(100), Integer.valueOf(50), Integer.valueOf(150));

--- a/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBStoreTests.java
+++ b/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBStoreTests.java
@@ -51,7 +51,7 @@ public class MariaDBStoreTests {
 			"user_data, false, user_data", "test123, false, test123", "valid_table_name, false, valid_table_name",
 			"1234567890123456789012345678901234567890123456789012345678901234, false, `1234567890123456789012345678901234567890123456789012345678901234`" })
 	void enquoteIdentifier(String tableName, boolean alwaysQuote, String expected) {
-		assertThat(MariaDBSchemaValidator.validateAndEnquoteIdentifier(tableName, alwaysQuote));
+		assertThat(MariaDBSchemaValidator.validateAndEnquoteIdentifier(tableName, alwaysQuote)).isEqualTo(expected);
 	}
 
 	@ParameterizedTest(name = "{0} - error identifier validation")


### PR DESCRIPTION
Configure ErrorProne + NullAway on the codebase.

Fix various ErrorProne issues across the codebase.

This is the first step towards implementing JSpecify null safety gradually.
This first commit focuses solely on setting up ErrorProne. In doing so, it caught a handful
of issues with our tests, that this commit fixes.

There are also many warnings that may be of interest.
