### PR TITLE
refactor: centralize retry exception handling across AI models

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -66,7 +66,6 @@ import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
-import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
@@ -166,18 +165,8 @@ public class DeepSeekChatModel implements ChatModel {
 					this.observationRegistry)
 			.observe(() -> {
 
-				ResponseEntity<ChatCompletion> completionEntity = null;
-				try {
-					completionEntity = this.retryTemplate.execute(() -> this.deepSeekApi.chatCompletionEntity(request));
-				}
-				catch (RetryException e) {
-					if (e.getCause() instanceof RuntimeException r) {
-						throw r;
-					}
-					else {
-						throw new RuntimeException(e.getCause());
-					}
-				}
+				ResponseEntity<ChatCompletion> completionEntity = RetryUtils.execute(this.retryTemplate,
+						() -> this.deepSeekApi.chatCompletionEntity(request));
 
 				var chatCompletion = completionEntity.getBody();
 

--- a/models/spring-ai-elevenlabs/src/main/java/org/springframework/ai/elevenlabs/ElevenLabsTextToSpeechModel.java
+++ b/models/spring-ai-elevenlabs/src/main/java/org/springframework/ai/elevenlabs/ElevenLabsTextToSpeechModel.java
@@ -28,7 +28,6 @@ import org.springframework.ai.audio.tts.TextToSpeechPrompt;
 import org.springframework.ai.audio.tts.TextToSpeechResponse;
 import org.springframework.ai.elevenlabs.api.ElevenLabsApi;
 import org.springframework.ai.retry.RetryUtils;
-import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
@@ -72,26 +71,15 @@ public class ElevenLabsTextToSpeechModel implements TextToSpeechModel {
 	public TextToSpeechResponse call(TextToSpeechPrompt prompt) {
 		RequestContext requestContext = prepareRequest(prompt);
 
-		byte[] audioData = null;
-		try {
-			audioData = this.retryTemplate.execute(() -> {
-				var response = this.elevenLabsApi.textToSpeech(requestContext.request, requestContext.voiceId,
-						requestContext.queryParameters);
-				if (response.getBody() == null) {
-					logger.warn("No speech response returned for request: {}", requestContext.request);
-					return new byte[0];
-				}
-				return response.getBody();
-			});
-		}
-		catch (RetryException e) {
-			if (e.getCause() instanceof RuntimeException r) {
-				throw r;
+		byte[] audioData = RetryUtils.execute(this.retryTemplate, () -> {
+			var response = this.elevenLabsApi.textToSpeech(requestContext.request, requestContext.voiceId,
+					requestContext.queryParameters);
+			if (response.getBody() == null) {
+				logger.warn("No speech response returned for request: {}", requestContext.request);
+				return new byte[0];
 			}
-			else {
-				throw new RuntimeException(e.getCause());
-			}
-		}
+			return response.getBody();
+		});
 
 		return new TextToSpeechResponse(List.of(new Speech(audioData)));
 	}
@@ -100,19 +88,10 @@ public class ElevenLabsTextToSpeechModel implements TextToSpeechModel {
 	public Flux<TextToSpeechResponse> stream(TextToSpeechPrompt prompt) {
 		RequestContext requestContext = prepareRequest(prompt);
 
-		try {
-			return this.retryTemplate.execute(() -> this.elevenLabsApi
-				.textToSpeechStream(requestContext.request, requestContext.voiceId, requestContext.queryParameters)
-				.map(entity -> new TextToSpeechResponse(List.of(new Speech(entity.getBody())))));
-		}
-		catch (RetryException e) {
-			if (e.getCause() instanceof RuntimeException r) {
-				throw r;
-			}
-			else {
-				throw new RuntimeException(e.getCause());
-			}
-		}
+		return RetryUtils.execute(this.retryTemplate,
+				() -> this.elevenLabsApi
+					.textToSpeechStream(requestContext.request, requestContext.voiceId, requestContext.queryParameters)
+					.map(entity -> new TextToSpeechResponse(List.of(new Speech(entity.getBody())))));
 	}
 
 	private RequestContext prepareRequest(TextToSpeechPrompt prompt) {

--- a/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
+++ b/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
@@ -46,7 +46,6 @@ import org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.retry.RetryUtils;
-import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -169,19 +168,8 @@ public class GoogleGenAiTextEmbeddingModel extends AbstractEmbeddingModel {
 				}
 
 				// Call the embedding API with retry
-				EmbedContentResponse embeddingResponse = null;
-				try {
-					embeddingResponse = this.retryTemplate
-						.execute(() -> this.genAiClient.models.embedContent(modelName, validTexts, config));
-				}
-				catch (RetryException e) {
-					if (e.getCause() instanceof RuntimeException r) {
-						throw r;
-					}
-					else {
-						throw new RuntimeException(e.getCause());
-					}
-				}
+				EmbedContentResponse embeddingResponse = RetryUtils.execute(this.retryTemplate,
+						() -> this.genAiClient.models.embedContent(modelName, validTexts, config));
 
 				// Process the response
 				// Note: We need to handle the case where some texts were filtered out

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioSpeechModel.java
@@ -129,13 +129,8 @@ public class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 		OpenAiAudioApi.SpeechRequest speechRequest = createRequest(prompt);
 
-		ResponseEntity<byte[]> speechEntity;
-		try {
-			speechEntity = this.retryTemplate.execute(() -> this.audioApi.createSpeech(speechRequest));
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Error calling OpenAI audio speech API", e);
-		}
+		ResponseEntity<byte[]> speechEntity = RetryUtils.execute(this.retryTemplate,
+				() -> this.audioApi.createSpeech(speechRequest));
 
 		var speech = speechEntity.getBody();
 
@@ -161,13 +156,8 @@ public class OpenAiAudioSpeechModel implements TextToSpeechModel {
 
 		OpenAiAudioApi.SpeechRequest speechRequest = createRequest(prompt);
 
-		Flux<ResponseEntity<byte[]>> speechEntity;
-		try {
-			speechEntity = this.retryTemplate.execute(() -> this.audioApi.stream(speechRequest));
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Error calling OpenAI audio speech streaming API", e);
-		}
+		Flux<ResponseEntity<byte[]>> speechEntity = RetryUtils.execute(this.retryTemplate,
+				() -> this.audioApi.stream(speechRequest));
 
 		return speechEntity.map(entity -> new TextToSpeechResponse(List.of(new Speech(entity.getBody())),
 				new OpenAiAudioSpeechResponseMetadata(OpenAiResponseHeaderExtractor.extractAiResponseHeaders(entity))));

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -195,14 +195,8 @@ public class OpenAiChatModel implements ChatModel {
 					this.observationRegistry)
 			.observe(() -> {
 
-				ResponseEntity<ChatCompletion> completionEntity;
-				try {
-					completionEntity = this.retryTemplate
-						.execute(() -> this.openAiApi.chatCompletionEntity(request, getAdditionalHttpHeaders(prompt)));
-				}
-				catch (Exception e) {
-					throw new RuntimeException("Error calling OpenAI chat completion API", e);
-				}
+				ResponseEntity<ChatCompletion> completionEntity = RetryUtils.execute(this.retryTemplate,
+						() -> this.openAiApi.chatCompletionEntity(request, getAdditionalHttpHeaders(prompt)));
 
 				var chatCompletion = completionEntity.getBody();
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -164,14 +164,8 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 			.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
 					this.observationRegistry)
 			.observe(() -> {
-				EmbeddingList<OpenAiApi.Embedding> apiEmbeddingResponse;
-				try {
-					apiEmbeddingResponse = this.retryTemplate
-						.execute(() -> this.openAiApi.embeddings(apiRequest).getBody());
-				}
-				catch (Exception e) {
-					throw new RuntimeException("Error calling OpenAI embedding API", e);
-				}
+				EmbeddingList<OpenAiApi.Embedding> apiEmbeddingResponse = RetryUtils.execute(this.retryTemplate,
+						() -> this.openAiApi.embeddings(apiRequest).getBody());
 
 				if (apiEmbeddingResponse == null) {
 					logger.warn("No embeddings returned for request: {}", request);

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
@@ -141,14 +141,8 @@ public class OpenAiImageModel implements ImageModel {
 			.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
 					this.observationRegistry)
 			.observe(() -> {
-				ResponseEntity<OpenAiImageApi.OpenAiImageResponse> imageResponseEntity;
-				try {
-					imageResponseEntity = this.retryTemplate
-						.execute(() -> this.openAiImageApi.createImage(imageRequest));
-				}
-				catch (Exception e) {
-					throw new RuntimeException("Error calling OpenAI image API", e);
-				}
+				ResponseEntity<OpenAiImageApi.OpenAiImageResponse> imageResponseEntity = RetryUtils
+					.execute(this.retryTemplate, () -> this.openAiImageApi.createImage(imageRequest));
 
 				ImageResponse imageResponse = convertResponse(imageResponseEntity, imageRequest);
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
@@ -77,34 +77,28 @@ public class OpenAiModerationModel implements ModerationModel {
 
 	@Override
 	public ModerationResponse call(ModerationPrompt moderationPrompt) {
-		try {
-			return this.retryTemplate.execute(() -> {
+		return RetryUtils.execute(this.retryTemplate, () -> {
 
-				String instructions = moderationPrompt.getInstructions().getText();
+			String instructions = moderationPrompt.getInstructions().getText();
 
-				OpenAiModerationApi.OpenAiModerationRequest moderationRequest = new OpenAiModerationApi.OpenAiModerationRequest(
-						instructions);
+			OpenAiModerationApi.OpenAiModerationRequest moderationRequest = new OpenAiModerationApi.OpenAiModerationRequest(
+					instructions);
 
-				if (this.defaultOptions != null) {
-					moderationRequest = ModelOptionsUtils.merge(this.defaultOptions, moderationRequest,
-							OpenAiModerationApi.OpenAiModerationRequest.class);
-				}
+			if (this.defaultOptions != null) {
+				moderationRequest = ModelOptionsUtils.merge(this.defaultOptions, moderationRequest,
+						OpenAiModerationApi.OpenAiModerationRequest.class);
+			}
 
-				if (moderationPrompt.getOptions() != null) {
-					moderationRequest = ModelOptionsUtils.merge(
-							toOpenAiModerationOptions(moderationPrompt.getOptions()), moderationRequest,
-							OpenAiModerationApi.OpenAiModerationRequest.class);
-				}
+			if (moderationPrompt.getOptions() != null) {
+				moderationRequest = ModelOptionsUtils.merge(toOpenAiModerationOptions(moderationPrompt.getOptions()),
+						moderationRequest, OpenAiModerationApi.OpenAiModerationRequest.class);
+			}
 
-				ResponseEntity<OpenAiModerationApi.OpenAiModerationResponse> moderationResponseEntity = this.openAiModerationApi
-					.createModeration(moderationRequest);
+			ResponseEntity<OpenAiModerationApi.OpenAiModerationResponse> moderationResponseEntity = this.openAiModerationApi
+				.createModeration(moderationRequest);
 
-				return convertResponse(moderationResponseEntity, moderationRequest);
-			});
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Error calling OpenAI moderation API", e);
-		}
+			return convertResponse(moderationResponseEntity, moderationRequest);
+		});
 	}
 
 	private ModerationResponse convertResponse(

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
@@ -50,7 +50,6 @@ import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingConnectionDeta
 import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingUtils;
 import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingUtils.TextInstanceBuilder;
 import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingUtils.TextParametersBuilder;
-import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -139,8 +138,8 @@ public class VertexAiTextEmbeddingModel extends AbstractEmbeddingModel {
 					PredictRequest.Builder predictRequestBuilder = getPredictRequestBuilder(request, endpointName,
 							(VertexAiTextEmbeddingOptions) options);
 
-					PredictResponse embeddingResponse = this.retryTemplate
-						.execute(() -> getPredictResponse(client, predictRequestBuilder));
+					PredictResponse embeddingResponse = RetryUtils.execute(this.retryTemplate,
+							() -> getPredictResponse(client, predictRequestBuilder));
 
 					int index = 0;
 					int totalTokenCount = 0;
@@ -163,14 +162,6 @@ public class VertexAiTextEmbeddingModel extends AbstractEmbeddingModel {
 					observationContext.setResponse(response);
 
 					return response;
-				}
-				catch (RetryException e) {
-					if (e.getCause() instanceof RuntimeException r) {
-						throw r;
-					}
-					else {
-						throw new RuntimeException(e.getCause());
-					}
 				}
 			});
 	}

--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
@@ -22,9 +22,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
@@ -153,6 +155,23 @@ public abstract class RetryUtils {
 			}
 		});
 		return retryTemplate;
+	}
+
+	/**
+	 * Generic execute method to run retryable operations with the provided RetryTemplate.
+	 * @param <R> the return type
+	 * @param retryTemplate the RetryTemplate to use for executing the retryable operation
+	 * @param retryable the operation to be retried
+	 * @return the result of the retryable operation
+	 */
+	public static <R extends @Nullable Object> R execute(RetryTemplate retryTemplate, Retryable<R> retryable) {
+		try {
+			return retryTemplate.execute(retryable);
+		}
+		catch (RetryException e) {
+			throw (e.getCause() instanceof RuntimeException runtime) ? runtime
+					: new RuntimeException(e.getMessage(), e.getCause());
+		}
 	}
 
 }


### PR DESCRIPTION
- Add RetryUtils.execute() method to handle RetryException uniformly
- Replace duplicate exception handling code in all model implementations
- Affects Anthropic, DeepSeek, ElevenLabs, Google GenAI, MiniMax, Mistral AI, Ollama, OpenAI, Vertex AI, and ZhiPu AI models
- Remove unused RetryException imports