### PR TITLE
Improve JdbcChatMemoryRepositorySchemaInitializer

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/model/chat/memory/repository/jdbc/autoconfigure/JdbcChatMemoryRepositoryProperties.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/model/chat/memory/repository/jdbc/autoconfigure/JdbcChatMemoryRepositoryProperties.java
@@ -17,7 +17,7 @@
 package org.springframework.ai.model.chat.memory.repository.jdbc.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.sql.init.DatabaseInitializationMode;
+import org.springframework.boot.jdbc.init.DatabaseInitializationProperties;
 
 /**
  * @author Jonathan Leijendekker
@@ -26,52 +26,15 @@ import org.springframework.boot.sql.init.DatabaseInitializationMode;
  * @since 1.0.0
  */
 @ConfigurationProperties(JdbcChatMemoryRepositoryProperties.CONFIG_PREFIX)
-public class JdbcChatMemoryRepositoryProperties {
+public class JdbcChatMemoryRepositoryProperties extends DatabaseInitializationProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.jdbc";
 
 	private static final String DEFAULT_SCHEMA_LOCATION = "classpath:org/springframework/ai/chat/memory/repository/jdbc/schema-@@platform@@.sql";
 
-	/**
-	 * Whether to initialize the schema on startup. Values: embedded, always, never.
-	 * Default is embedded.
-	 */
-	private DatabaseInitializationMode initializeSchema = DatabaseInitializationMode.EMBEDDED;
-
-	/**
-	 * Locations of schema (DDL) scripts. Supports comma-separated list. Default is
-	 * classpath:org/springframework/ai/chat/memory/repository/jdbc/schema-@@platform@@.sql
-	 */
-	private String schema = DEFAULT_SCHEMA_LOCATION;
-
-	/**
-	 * Platform to use in initialization scripts if the @@platform@@ placeholder is used.
-	 * Auto-detected by default.
-	 */
-	private String platform;
-
-	public DatabaseInitializationMode getInitializeSchema() {
-		return this.initializeSchema;
-	}
-
-	public void setInitializeSchema(DatabaseInitializationMode initializeSchema) {
-		this.initializeSchema = initializeSchema;
-	}
-
-	public String getPlatform() {
-		return this.platform;
-	}
-
-	public void setPlatform(String platform) {
-		this.platform = platform;
-	}
-
-	public String getSchema() {
-		return this.schema;
-	}
-
-	public void setSchema(String schema) {
-		this.schema = schema;
+	@Override
+	public String getDefaultSchemaLocation() {
+		return DEFAULT_SCHEMA_LOCATION;
 	}
 
 }

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/model/chat/memory/repository/jdbc/autoconfigure/JdbcChatMemoryRepositorySchemaInitializer.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/src/main/java/org/springframework/ai/model/chat/memory/repository/jdbc/autoconfigure/JdbcChatMemoryRepositorySchemaInitializer.java
@@ -16,14 +16,9 @@
 
 package org.springframework.ai.model.chat.memory.repository.jdbc.autoconfigure;
 
-import java.util.List;
-
 import javax.sql.DataSource;
 
-import org.springframework.boot.jdbc.init.DataSourceScriptDatabaseInitializer;
-import org.springframework.boot.jdbc.init.PlatformPlaceholderDatabaseDriverResolver;
-import org.springframework.boot.sql.init.DatabaseInitializationSettings;
-import org.springframework.util.StringUtils;
+import org.springframework.boot.jdbc.init.PropertiesBasedDataSourceScriptDatabaseInitializer;
 
 /**
  * Performs database initialization for the JDBC Chat Memory Repository.
@@ -32,28 +27,11 @@ import org.springframework.util.StringUtils;
  * @author Yanming Zhou
  * @since 1.0.0
  */
-class JdbcChatMemoryRepositorySchemaInitializer extends DataSourceScriptDatabaseInitializer {
+class JdbcChatMemoryRepositorySchemaInitializer
+		extends PropertiesBasedDataSourceScriptDatabaseInitializer<JdbcChatMemoryRepositoryProperties> {
 
 	JdbcChatMemoryRepositorySchemaInitializer(DataSource dataSource, JdbcChatMemoryRepositoryProperties properties) {
-		super(dataSource, getSettings(dataSource, properties));
-	}
-
-	static DatabaseInitializationSettings getSettings(DataSource dataSource,
-			JdbcChatMemoryRepositoryProperties properties) {
-		var settings = new DatabaseInitializationSettings();
-		settings.setSchemaLocations(resolveSchemaLocations(dataSource, properties));
-		settings.setMode(properties.getInitializeSchema());
-		settings.setContinueOnError(true);
-		return settings;
-	}
-
-	private static List<String> resolveSchemaLocations(DataSource dataSource,
-			JdbcChatMemoryRepositoryProperties properties) {
-		PlatformPlaceholderDatabaseDriverResolver platformResolver = new PlatformPlaceholderDatabaseDriverResolver();
-		if (StringUtils.hasText(properties.getPlatform())) {
-			return platformResolver.resolveAll(properties.getPlatform(), properties.getSchema());
-		}
-		return platformResolver.resolveAll(dataSource, properties.getSchema());
+		super(dataSource, properties);
 	}
 
 }

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/model/chat/memory/repository/jdbc/autoconfigure/JdbcChatMemoryRepositorySchemaInitializerPostgresqlTests.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/src/test/java/org/springframework/ai/model/chat/memory/repository/jdbc/autoconfigure/JdbcChatMemoryRepositorySchemaInitializerPostgresqlTests.java
@@ -16,8 +16,7 @@
 
 package org.springframework.ai.model.chat.memory.repository.jdbc.autoconfigure;
 
-import javax.sql.DataSource;
-
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Jonathan Leijendekker
+ * @author Yanming Zhou
  */
 @Testcontainers
 class JdbcChatMemoryRepositorySchemaInitializerPostgresqlTests {
@@ -55,15 +55,10 @@ class JdbcChatMemoryRepositorySchemaInitializerPostgresqlTests {
 
 	@Test
 	void getSettings_shouldHaveSchemaLocations() {
-		this.contextRunner.run(context -> {
-			var dataSource = context.getBean(DataSource.class);
-			// Use new signature: requires JdbcChatMemoryRepositoryProperties
-			var settings = JdbcChatMemoryRepositorySchemaInitializer.getSettings(dataSource,
-					new JdbcChatMemoryRepositoryProperties());
-
-			assertThat(settings.getSchemaLocations())
-				.containsOnly("classpath:org/springframework/ai/chat/memory/repository/jdbc/schema-postgresql.sql");
-		});
+		this.contextRunner.run(context -> assertThat(context.getBean(JdbcChatMemoryRepositorySchemaInitializer.class))
+			.extracting("settings.schemaLocations")
+			.asInstanceOf(InstanceOfAssertFactories.LIST)
+			.containsOnly("classpath:org/springframework/ai/chat/memory/repository/jdbc/schema-postgresql.sql"));
 	}
 
 }


### PR DESCRIPTION
Make it extending from `PropertiesBasedDataSourceScriptDatabaseInitializer` which introduced by Spring Boot 4.0 to eliminate boilerplate codes.