### PR TITLE
fix: SimpleVectorStoreFilterExpressionConverter incorrectly treats "in" substring inside metadata key as IN operator

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/SimpleVectorStoreFilterExpressionConverter.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/converter/SimpleVectorStoreFilterExpressionConverter.java
@@ -85,7 +85,11 @@ public class SimpleVectorStoreFilterExpressionConverter extends AbstractFilterEx
 			}
 			formattedList.append("}");
 
-			if (context.lastIndexOf("in ") == -1) {
+			String ctx = context.toString().trim();
+			boolean isInClause = ctx.endsWith(" in");
+			boolean isNotInClause = ctx.endsWith(" not in");
+
+			if (!isInClause && !isNotInClause) {
 				context.append(formattedList);
 			}
 			else {

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/converter/SimpleVectorStoreFilterExpressionConverterTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/converter/SimpleVectorStoreFilterExpressionConverterTests.java
@@ -217,4 +217,17 @@ public class SimpleVectorStoreFilterExpressionConverterTests {
 		Assertions.assertEquals(Boolean.TRUE, parser.parseExpression(vectorExpr).getValue(context, Boolean.class));
 	}
 
+	@Test
+	void eqExpressionWithListAndKeyContainingInSpaceShouldNotUseContains() {
+		Filter.Expression expr = new Filter.Expression(
+				Filter.ExpressionType.EQ,
+				new Filter.Key("pin code"),
+				new Filter.Value(List.of("1234", "5678"))
+		);
+
+		String result = converter.convertExpression(expr);
+
+		Assertions.assertEquals("#metadata['pin code'] == {'1234','5678'}", result);
+	}
+
 }


### PR DESCRIPTION
#### Summary
This PR fixes a substring–based bug in SimpleVectorStoreFilterExpressionConverter where metadata keys containing "in" were incorrectly interpreted as IN operators.

The fix ensures that only real IN / NOT IN operators trigger the contains() conversion logic.

#### Changes
Updated doValue() to detect true IN operators using more precise checks:

```java
String ctx = context.toString().trim();
boolean isInClause = ctx.endsWith(" in");
boolean isNotInClause = ctx.endsWith(" not in");

if (!isInClause && !isNotInClause) {
    context.append(formattedList);
} else {
    appendSpELContains(formattedList, context);
}
```

Closes: https://github.com/spring-projects/spring-ai/issues/4908