### PR TITLE
Fix extraBody loss during ModelOptionsUtils.merge()

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -629,6 +629,9 @@ public class OpenAiChatModel implements ChatModel {
 
 		OpenAiChatOptions requestOptions = (OpenAiChatOptions) prompt.getOptions();
 		request = ModelOptionsUtils.merge(requestOptions, request, ChatCompletionRequest.class);
+		if (!CollectionUtils.isEmpty(requestOptions.getExtraBody())) {
+			request.extraBody().putAll(requestOptions.getExtraBody());
+		}
 
 		// Add the tool definitions to the request's tools parameter.
 		List<ToolDefinition> toolDefinitions = this.toolCallingManager.resolveToolDefinitions(requestOptions);


### PR DESCRIPTION
The extraBody field was being lost when merging OpenAiChatOptions into ChatCompletionRequest using ModelOptionsUtils.merge(). This fix ensures that extraBody parameters (like enable_thinking.) are properly preserved during the merge operation.