### PR TITLE
ClientMcp*HandlersRegistry: support beans with unresolvable types

### DIFF
--- a/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AbstractClientMcpHandlerRegistry.java
+++ b/mcp/mcp-annotations-spring/src/main/java/org/springframework/ai/mcp/annotation/spring/AbstractClientMcpHandlerRegistry.java
@@ -74,7 +74,14 @@ abstract class AbstractClientMcpHandlerRegistry implements BeanFactoryPostProces
 				// Only process singleton beans, not scoped beans
 				continue;
 			}
-			var foundAnnotations = this.scan(AutoProxyUtils.determineTargetClass(beanFactory, beanName));
+			Class<?> beanClass = AutoProxyUtils.determineTargetClass(beanFactory, beanName);
+			if (beanClass == null) {
+				// If we cannot determine the bean class, we cannot scan it before
+				// it is really resolved. This is very likely an infrastructure-level
+				// bean, not a "service" type, skip it entirely.
+				continue;
+			}
+			var foundAnnotations = this.scan(beanClass);
 			if (!foundAnnotations.isEmpty()) {
 				this.allAnnotatedBeans.add(beanName);
 			}

--- a/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/ClientMcpAsyncHandlersRegistryTests.java
+++ b/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/ClientMcpAsyncHandlersRegistryTests.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
@@ -338,6 +339,16 @@ class ClientMcpAsyncHandlersRegistryTests {
 		registry.postProcessBeanFactory(beanFactory);
 
 		assertThat(registry.getCapabilities("client-1").elicitation()).isNotNull();
+	}
+
+	@Test
+	void skipsUnknownBeanClass() {
+		var registry = new ClientMcpAsyncHandlersRegistry();
+		var beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition("myConfig",
+				BeanDefinitionBuilder.genericBeanDefinition().getBeanDefinition());
+
+		assertThatNoException().isThrownBy(() -> registry.postProcessBeanFactory(beanFactory));
 	}
 
 	static class ClientCapabilitiesConfiguration {

--- a/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/ClientMcpSyncHandlersRegistryTests.java
+++ b/mcp/mcp-annotations-spring/src/test/java/org/springframework/ai/mcp/annotation/spring/ClientMcpSyncHandlersRegistryTests.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
@@ -330,6 +331,16 @@ class ClientMcpSyncHandlersRegistryTests {
 		registry.postProcessBeanFactory(beanFactory);
 
 		assertThat(registry.getCapabilities("client-1").elicitation()).isNotNull();
+	}
+
+	@Test
+	void skipsUnknownBeanClass() {
+		var registry = new ClientMcpAsyncHandlersRegistry();
+		var beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerBeanDefinition("myConfig",
+				BeanDefinitionBuilder.genericBeanDefinition().getBeanDefinition());
+
+		assertThatNoException().isThrownBy(() -> registry.postProcessBeanFactory(beanFactory));
 	}
 
 	static class ClientCapabilitiesConfiguration {


### PR DESCRIPTION
- Fixes gh-4917