### PR TITLE
fix: Fix MariaDBSchemaValidator misleading escaped space error

### DIFF
--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBSchemaValidator.java
@@ -76,7 +76,7 @@ public class MariaDBSchemaValidator {
 			logger.error("""
 					Failed to validate that database supports VECTOR.
 					Run the following SQL commands:
-					   SELECT @@version;\s
+					   SELECT @@version;
 					And ensure that version is >= 11.7.1""");
 			throw new IllegalStateException(e);
 		}


### PR DESCRIPTION
Fixes an issue in MariaDBSchemaValidator where a text block contained
a misleading escaped space (\s) not at the end of a line, causing
compilation errors like:
[MisleadingEscapedSpace] Using \s anywhere except at the end of a line
in a text block is potentially misleading.

