### PR TITLE
feat(ollama): Support Olama API key authentication

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionDetails.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionDetails.java
@@ -27,4 +27,12 @@ public interface OllamaConnectionDetails extends ConnectionDetails {
 
 	String getBaseUrl();
 
+	/**
+	 * Returns the API key for authenticating requests.
+	 * @return the API key, or null if no authentication is required
+	 */
+	default String getApiKey() {
+		return null;
+	}
+
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/main/java/org/springframework/ai/model/ollama/autoconfigure/OllamaConnectionProperties.java
@@ -34,12 +34,26 @@ public class OllamaConnectionProperties {
 	 */
 	private String baseUrl = "http://localhost:11434";
 
+	/**
+	 * API key for authenticating requests to Ollama API server.
+	 * If provided, it will be sent as a Bearer token in the Authorization header.
+	 */
+	private String apiKey;
+
 	public String getBaseUrl() {
 		return this.baseUrl;
 	}
 
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
+	}
+
+	public String getApiKey() {
+		return this.apiKey;
+	}
+
+	public void setApiKey(String apiKey) {
+		this.apiKey = apiKey;
 	}
 
 }


### PR DESCRIPTION
## Summary
Adds support for Ollama Cloud integration in Spring AI by enabling API key-based authentication and allowing configuration of remote Ollama endpoints (e.g., https://ollama.com/api). This enables users to seamlessly use Ollama’s cloud-hosted large language models—such as gpt-oss:120b-cloud or qwen3-coder:480b-cloud—within Spring AI applications without requiring local GPU resources.
> See [Ollama Cloud documentation](https://docs.ollama.com/cloud) for details on available cloud models and authentication requirements.

## Changes
- Added `spring.ai.ollama.api-key` configuration property
- Extended [OllamaConnectionDetails] interface with [getApiKey()] method (default null)
- Modified [OllamaApiAutoConfiguration] to inject `Authorization: Bearer` header when API key is present

## Configuration Example
```yaml
spring:
  ai:
    ollama:
      base-url: https://ollama.com/api
      api-key: ${OLLAMA_API_KEY}