### PR TITLE
Fix Advisor NPEs by enforcing non-null context in ChatClientRequest/Response

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientRequest.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientRequest.java
@@ -37,6 +37,7 @@ public record ChatClientRequest(Prompt prompt, Map<String, Object> context) {
 		Assert.notNull(prompt, "prompt cannot be null");
 		Assert.notNull(context, "context cannot be null");
 		Assert.noNullElements(context.keySet(), "context keys cannot be null");
+		Assert.noNullElements(context.values(), "context values cannot be null");
 	}
 
 	public ChatClientRequest copy() {
@@ -68,12 +69,15 @@ public record ChatClientRequest(Prompt prompt, Map<String, Object> context) {
 
 		public Builder context(Map<String, Object> context) {
 			Assert.notNull(context, "context cannot be null");
+			Assert.noNullElements(context.keySet(), "context keys cannot be null");
+			Assert.noNullElements(context.values(), "context values cannot be null");
 			this.context.putAll(context);
 			return this;
 		}
 
 		public Builder context(String key, Object value) {
 			Assert.notNull(key, "key cannot be null");
+			Assert.notNull(value, "value cannot be null");
 			this.context.put(key, value);
 			return this;
 		}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientResponse.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientResponse.java
@@ -36,6 +36,7 @@ public record ChatClientResponse(@Nullable ChatResponse chatResponse, Map<String
 	public ChatClientResponse {
 		Assert.notNull(context, "context cannot be null");
 		Assert.noNullElements(context.keySet(), "context keys cannot be null");
+		Assert.noNullElements(context.values(), "context values cannot be null");
 	}
 
 	public ChatClientResponse copy() {
@@ -66,12 +67,15 @@ public record ChatClientResponse(@Nullable ChatResponse chatResponse, Map<String
 
 		public Builder context(Map<String, Object> context) {
 			Assert.notNull(context, "context cannot be null");
+			Assert.noNullElements(context.keySet(), "context keys cannot be null");
+			Assert.noNullElements(context.values(), "context values cannot be null");
 			this.context.putAll(context);
 			return this;
 		}
 
 		public Builder context(String key, Object value) {
 			Assert.notNull(key, "key cannot be null");
+			Assert.notNull(value, "value cannot be null");
 			this.context.put(key, value);
 			return this;
 		}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientRequestTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientRequestTests.java
@@ -63,6 +63,30 @@ class ChatClientRequestTests {
 	}
 
 	@Test
+	void whenContextHasNullValuesThenThrow() {
+		Map<String, Object> context = new HashMap<>();
+		context.put("key", null);
+
+		assertThatThrownBy(() -> new ChatClientRequest(new Prompt(), context))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values cannot be null");
+
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context(context).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values cannot be null");
+	}
+
+	@Test
+	void whenBuilderContextMapHasNullKeyThenThrow() {
+		Map<String, Object> context = new HashMap<>();
+		context.put(null, "value");
+
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context(context).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context keys cannot be null");
+	}
+
+	@Test
 	void whenCopyThenImmutableContext() {
 		Map<String, Object> context = new HashMap<>();
 		context.put("key", "value");
@@ -84,6 +108,13 @@ class ChatClientRequestTests {
 
 		assertThat(request.context()).isEqualTo(Map.of("key", "value"));
 		assertThat(copy.context()).isEqualTo(Map.of("key", "newValue"));
+	}
+
+	@Test
+	void whenBuilderAddsNullValueThenThrow() {
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context("key", null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("value cannot be null");
 	}
 
 	@Test

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseTests.java
@@ -54,6 +54,19 @@ class ChatClientResponseTests {
 	}
 
 	@Test
+	void whenContextHasNullValuesThenThrow() {
+		Map<String, Object> context = new HashMap<>();
+		context.put("key", null);
+
+		assertThatThrownBy(() -> new ChatClientResponse(null, context)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values cannot be null");
+
+		assertThatThrownBy(() -> ChatClientResponse.builder().chatResponse(null).context(context).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values cannot be null");
+	}
+
+	@Test
 	void whenCopyThenImmutableContext() {
 		Map<String, Object> context = new HashMap<>();
 		context.put("key", "value");
@@ -120,16 +133,15 @@ class ChatClientResponseTests {
 	}
 
 	@Test
-	void whenContextWithNullValuesThenCreateSuccessfully() {
+	void whenContextWithNullValuesThenThrow() {
 		ChatResponse chatResponse = mock(ChatResponse.class);
 		Map<String, Object> context = new HashMap<>();
 		context.put("key1", "value1");
 		context.put("key2", null);
 
-		ChatClientResponse response = new ChatClientResponse(chatResponse, context);
-
-		assertThat(response.context()).containsEntry("key1", "value1");
-		assertThat(response.context()).containsEntry("key2", null);
+		assertThatThrownBy(() -> new ChatClientResponse(chatResponse, context))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values cannot be null");
 	}
 
 	@Test
@@ -164,6 +176,23 @@ class ChatClientResponseTests {
 		ChatClientResponse response = ChatClientResponse.builder().context(context).build();
 
 		assertThat(response.chatResponse()).isNull();
+	}
+
+	@Test
+	void whenBuilderContextMapHasNullKeyThenThrow() {
+		Map<String, Object> context = new HashMap<>();
+		context.put(null, "value");
+
+		assertThatThrownBy(() -> ChatClientResponse.builder().context(context).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context keys cannot be null");
+	}
+
+	@Test
+	void whenBuilderAddsNullValueThenThrow() {
+		assertThatThrownBy(() -> ChatClientResponse.builder().context("key", null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("value cannot be null");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #4952

### Approach
- Fail fast on bad input by disallowing null context keys/values in `ChatClientRequest`.
- Extend the same guardrails to `ChatClientResponse` for consistency, so direct response creation can’t sneak in nulls.
- Keep advisor code unchanged; they can continue to use `Map.copyOf` safely.

### Scope
1) `ChatClientRequest`: constructor/builder enforce non-null keys and values (including single key/value adder).  
2) `ChatClientResponse`: constructor/builder enforce non-null keys and values for symmetry.  
3) Tests:  
   - Requests: null keys/values throw clear `IllegalArgumentException`.  
   - Responses: null keys/values throw clear `IllegalArgumentException`.  
   - Valid inputs still succeed; immutability semantics remain.

### Test plan
- `./mvnw -pl spring-ai-client-chat -DskipITs test` (module scope).  
- Unit tests in `ChatClientRequestTests` and `ChatClientResponseTests` cover null key/value rejection.

### Backward compatibility
- This change enforces non-null values in the context map.
- Existing code that passes `null` values will now throw `IllegalArgumentException` immediately at construction time, rather than causing an NPE later in Advisors.