### PR TITLE
Signed-off-by: 819318216 <819318216@qq.com> Modified additional parameters that cannot be assigned values

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -1139,7 +1139,7 @@ public class OpenAiApi {
 			@JsonProperty("verbosity") String verbosity,
 			@JsonProperty("prompt_cache_key") String promptCacheKey,
 			@JsonProperty("safety_identifier") String safetyIdentifier,
-			Map<String, Object> extraBody) {
+			@JsonProperty("extra_body") Map<String, Object> extraBody) {
 
 		/**
 		 * Compact constructor that ensures extraBody is initialized as a mutable HashMap

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/ChatCompletionRequestTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/ChatCompletionRequestTests.java
@@ -76,9 +76,13 @@ class ChatCompletionRequestTests {
 	@Test
 	void createRequestWithChatOptions() {
 		var client = OpenAiChatModel.builder()
-			.openAiApi(OpenAiApi.builder().apiKey("TEST").build())
-			.defaultOptions(OpenAiChatOptions.builder().model("DEFAULT_MODEL").temperature(66.6).build())
-			.build();
+				.openAiApi(OpenAiApi.builder().apiKey("TEST").build())
+				.defaultOptions(OpenAiChatOptions.builder()
+						.model("DEFAULT_MODEL")
+						.temperature(66.6)
+						.extraBody(Map.of("key1", "value1"))
+						.build())
+				.build();
 
 		var prompt = client.buildRequestPrompt(new Prompt("Test message content"));
 
@@ -89,6 +93,8 @@ class ChatCompletionRequestTests {
 
 		assertThat(request.model()).isEqualTo("DEFAULT_MODEL");
 		assertThat(request.temperature()).isEqualTo(66.6);
+
+		assertThat(request.extraBody().get("key1")).isEqualTo("value1");
 
 		request = client.createRequest(new Prompt("Test message content",
 				OpenAiChatOptions.builder().model("PROMPT_MODEL").temperature(99.9).build()), true);


### PR DESCRIPTION
fix:Modified the ChatCompletionRequest object, where the field extraBody does not have the @ JsonProperty ("extra-body") annotation, resulting in assignment failure

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc