### PR TITLE
Bump io.swagger.core.v3:swagger-annotations to 2.2.38 from 2.2.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2023-2024 the original author or authors.
+  ~ Copyright 2023-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -296,7 +296,7 @@
 		<com.google.genai.version>1.17.0</com.google.genai.version>
 		<ibm.sdk.version>9.20.0</ibm.sdk.version>
 		<jsonschema.version>4.38.0</jsonschema.version>
-		<swagger-annotations.version>2.2.30</swagger-annotations.version>
+		<swagger-annotations.version>2.2.38</swagger-annotations.version>
 		<mockk-jvm.version>1.13.13</mockk-jvm.version>
 		<spring-cloud-bindings.version>2.0.3</spring-cloud-bindings.version>
 


### PR DESCRIPTION
Align with latest version springdoc-openapi uses to avoid exception:

`java.lang.NoSuchMethodError: 'java.lang.String io.swagger.v3.oas.annotations.media.Schema.$dynamicRef()'`

Please consider backport to 1.1.x 