### PR TITLE
Fix incorrect MCP server stateless connection properties prefix - Fix…

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
@@ -94,7 +94,7 @@ The server mcp-annotations properties are prefixed with `spring.ai.mcp.server.an
 
 === Stateless Connection Properties
 
-All connection properties are prefixed with `spring.ai.mcp.server.stateless`:
+All connection properties are prefixed with `spring.ai.mcp.server.streamable-http`:
 
 [options="header"]
 |===


### PR DESCRIPTION
Fixes the incorrect property prefix in MCP server stateless connection documentation.

Changed `spring.ai.mcp.server.stateless` to `spring.ai.mcp.server.streamable-http` in line 97.

Closes #4967