### PR TITLE
build: Use jackson-module-jsonSchema-jakarta instead of jackson-module-jsonSchema

### DIFF
--- a/spring-ai-client-chat/pom.xml
+++ b/spring-ai-client-chat/pom.xml
@@ -52,7 +52,7 @@
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
-			<artifactId>jackson-module-jsonSchema</artifactId>
+			<artifactId>jackson-module-jsonSchema-jakarta</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-ai-commons/pom.xml
+++ b/spring-ai-commons/pom.xml
@@ -67,7 +67,7 @@
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
-			<artifactId>jackson-module-jsonSchema</artifactId>
+			<artifactId>jackson-module-jsonSchema-jakarta</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updates the dependency from `jackson-module-jsonSchema` to the Jakarta-based `jackson-module-jsonSchema-jakarta`.

Spring AI is aligned with Spring Boot 3.4+, which uses the Jakarta namespace.
To avoid mixing `javax.*` and `jakarta.*`, this change adopts the recommended Jakarta variant.

The functionality remains the same. This update follows the same direction as #3498 for consistency.


**Reference**

* https://github.com/FasterXML/jackson-module-jsonSchema/tree/2.x?tab=readme-ov-file#two-modules-with-jackson-215
