### PR TITLE
Fix extraBody serialization by adding @JsonProperty annotation

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -1160,7 +1160,7 @@ public class OpenAiApi {
 			@JsonProperty("verbosity") String verbosity,
 			@JsonProperty("prompt_cache_key") String promptCacheKey,
 			@JsonProperty("safety_identifier") String safetyIdentifier,
-			Map<String, Object> extraBody) {
+			@JsonProperty("extra_body") Map<String, Object> extraBody) {
 
 		/**
 		 * Compact constructor that ensures extraBody is initialized as a mutable HashMap

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/ExtraBodySerializationTest.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/ExtraBodySerializationTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -206,6 +208,27 @@ class ExtraBodySerializationTest {
 		// Assert: Complex types should be preserved as String/List
 		assertThat(request.extraBody().get("guided_json")).isInstanceOf(String.class);
 		assertThat(request.extraBody().get("stop_token_ids")).isInstanceOf(List.class);
+	}
+
+	@Test
+	void testMergeWithExtraBody() throws Exception {
+		// Arrange: Create OpenAiChatOptions with extraBody
+		OpenAiChatOptions requestOptions = OpenAiChatOptions.builder()
+				.model("test-model")
+				.extraBody(Map.of("enable_thinking", true, "max_depth", 10))
+				.build();
+
+		// Create empty ChatCompletionRequest
+		ChatCompletionRequest request = new ChatCompletionRequest(null, null);
+		
+		// Act: Merge options into request
+		request = ModelOptionsUtils.merge(requestOptions, request, ChatCompletionRequest.class);
+
+		// Assert: Verify extraBody was successfully merged
+		assertThat(request.extraBody()).isNotNull();
+		assertThat(request.extraBody()).containsEntry("enable_thinking", true);
+		assertThat(request.extraBody()).containsEntry("max_depth", 10);
+		assertThat(request.model()).isEqualTo("test-model");
 	}
 
 }


### PR DESCRIPTION
## Description
Fixes the issue where `extraBody` parameters are lost during `ModelOptionsUtils.merge()` operation due to missing `@JsonProperty` annotation.

## Changes
- Added `@JsonProperty("extra_body")` annotation to `extraBody` parameter in `ChatCompletionRequest` constructor
- Added test case `testMergeWithExtraBody()` to verify `extraBody` is correctly merged from `OpenAiChatOptions` to `ChatCompletionRequest`

## Related Issue
Fixes #4966

## Checklist
- [x] Code follows project style
- [x] Commit messages include DCO sign-off
- [x] Added unit tests
- [x] All tests pass locally