### PR TITLE
[Feature] Fixes #4983 - Add ThinkingLevel support in ThinkingConfig

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.ai.google.genai.GoogleGenAiChatModel.ChatModel;
 import org.springframework.ai.google.genai.common.GoogleGenAiSafetySetting;
+import org.springframework.ai.google.genai.common.GoogleGenAiThinkingLevel;
 import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
@@ -133,6 +134,13 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	private @JsonProperty("includeThoughts") Boolean includeThoughts;
 
 	/**
+	 * Optional. The level of thinking tokens the model should generate.
+	 * LOW = minimal thinking, HIGH = extensive thinking.
+	 * This is part of the thinkingConfig in GenerationConfig.
+	 */
+	private @JsonProperty("thinkingLevel") GoogleGenAiThinkingLevel thinkingLevel;
+
+	/**
 	 * Optional. Whether to include extended usage metadata in responses.
 	 * When true, includes thinking tokens, cached content, tool-use tokens, and modality details.
 	 * Defaults to true for full metadata access.
@@ -226,6 +234,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		options.setToolContext(fromOptions.getToolContext());
 		options.setThinkingBudget(fromOptions.getThinkingBudget());
 		options.setIncludeThoughts(fromOptions.getIncludeThoughts());
+		options.setThinkingLevel(fromOptions.getThinkingLevel());
 		options.setLabels(fromOptions.getLabels());
 		options.setIncludeExtendedUsageMetadata(fromOptions.getIncludeExtendedUsageMetadata());
 		options.setCachedContentName(fromOptions.getCachedContentName());
@@ -393,6 +402,14 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		this.includeThoughts = includeThoughts;
 	}
 
+	public GoogleGenAiThinkingLevel getThinkingLevel() {
+		return this.thinkingLevel;
+	}
+
+	public void setThinkingLevel(GoogleGenAiThinkingLevel thinkingLevel) {
+		this.thinkingLevel = thinkingLevel;
+	}
+
 	public Boolean getIncludeExtendedUsageMetadata() {
 		return this.includeExtendedUsageMetadata;
 	}
@@ -497,6 +514,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 				&& Objects.equals(this.presencePenalty, that.presencePenalty)
 				&& Objects.equals(this.thinkingBudget, that.thinkingBudget)
 				&& Objects.equals(this.includeThoughts, that.includeThoughts)
+				&& this.thinkingLevel == that.thinkingLevel
 				&& Objects.equals(this.maxOutputTokens, that.maxOutputTokens) && Objects.equals(this.model, that.model)
 				&& Objects.equals(this.responseMimeType, that.responseMimeType)
 				&& Objects.equals(this.responseSchema, that.responseSchema)
@@ -511,9 +529,9 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	public int hashCode() {
 		return Objects.hash(this.stopSequences, this.temperature, this.topP, this.topK, this.candidateCount,
 				this.frequencyPenalty, this.presencePenalty, this.thinkingBudget, this.includeThoughts,
-				this.maxOutputTokens, this.model, this.responseMimeType, this.responseSchema, this.toolCallbacks,
-				this.toolNames, this.googleSearchRetrieval, this.safetySettings, this.internalToolExecutionEnabled,
-				this.toolContext, this.labels);
+				this.thinkingLevel, this.maxOutputTokens, this.model, this.responseMimeType, this.responseSchema,
+				this.toolCallbacks, this.toolNames, this.googleSearchRetrieval, this.safetySettings,
+				this.internalToolExecutionEnabled, this.toolContext, this.labels);
 	}
 
 	@Override
@@ -521,11 +539,12 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		return "GoogleGenAiChatOptions{" + "stopSequences=" + this.stopSequences + ", temperature=" + this.temperature
 				+ ", topP=" + this.topP + ", topK=" + this.topK + ", frequencyPenalty=" + this.frequencyPenalty
 				+ ", presencePenalty=" + this.presencePenalty + ", thinkingBudget=" + this.thinkingBudget
-				+ ", includeThoughts=" + this.includeThoughts + ", candidateCount=" + this.candidateCount
-				+ ", maxOutputTokens=" + this.maxOutputTokens + ", model='" + this.model + '\'' + ", responseMimeType='"
-				+ this.responseMimeType + '\'' + ", toolCallbacks=" + this.toolCallbacks + ", toolNames="
-				+ this.toolNames + ", googleSearchRetrieval=" + this.googleSearchRetrieval + ", safetySettings="
-				+ this.safetySettings + ", labels=" + this.labels + '}';
+				+ ", includeThoughts=" + this.includeThoughts + ", thinkingLevel=" + this.thinkingLevel
+				+ ", candidateCount=" + this.candidateCount + ", maxOutputTokens=" + this.maxOutputTokens + ", model='"
+				+ this.model + '\'' + ", responseMimeType='" + this.responseMimeType + '\'' + ", toolCallbacks="
+				+ this.toolCallbacks + ", toolNames=" + this.toolNames + ", googleSearchRetrieval="
+				+ this.googleSearchRetrieval + ", safetySettings=" + this.safetySettings + ", labels=" + this.labels
+				+ '}';
 	}
 
 	@Override
@@ -665,6 +684,11 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 
 		public Builder includeThoughts(Boolean includeThoughts) {
 			this.options.setIncludeThoughts(includeThoughts);
+			return this;
+		}
+
+		public Builder thinkingLevel(GoogleGenAiThinkingLevel thinkingLevel) {
+			this.options.setThinkingLevel(thinkingLevel);
 			return this;
 		}
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/common/GoogleGenAiThinkingLevel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/common/GoogleGenAiThinkingLevel.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.common;
+
+/**
+ * Enum representing the level of thinking tokens the model should generate. This controls
+ * the depth of reasoning the model applies during generation.
+ *
+ * @author Dan Dobrin
+ * @since 1.1.0
+ */
+public enum GoogleGenAiThinkingLevel {
+
+	/**
+	 * Unspecified thinking level. The model uses its default behavior.
+	 */
+	THINKING_LEVEL_UNSPECIFIED,
+
+	/**
+	 * Low thinking level. Minimal reasoning tokens are generated. Use for simple queries
+	 * where speed is preferred over deep analysis.
+	 */
+	LOW,
+
+	/**
+	 * High thinking level. Extensive reasoning tokens are generated. Use for complex
+	 * problems requiring deep analysis and step-by-step reasoning.
+	 */
+	HIGH
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.google.genai.common.GoogleGenAiThinkingLevel;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -165,6 +167,118 @@ public class GoogleGenAiChatOptionsTest {
 		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder().labels(Map.of()).build();
 
 		assertThat(options.getLabels()).isEmpty();
+	}
+
+	@Test
+	public void testThinkingLevelGetterSetter() {
+		GoogleGenAiChatOptions options = new GoogleGenAiChatOptions();
+
+		assertThat(options.getThinkingLevel()).isNull();
+
+		options.setThinkingLevel(GoogleGenAiThinkingLevel.HIGH);
+		assertThat(options.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.HIGH);
+
+		options.setThinkingLevel(GoogleGenAiThinkingLevel.LOW);
+		assertThat(options.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.LOW);
+
+		options.setThinkingLevel(null);
+		assertThat(options.getThinkingLevel()).isNull();
+	}
+
+	@Test
+	public void testThinkingLevelWithBuilder() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.build();
+
+		assertThat(options.getModel()).isEqualTo("test-model");
+		assertThat(options.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.HIGH);
+	}
+
+	@Test
+	public void testFromOptionsWithThinkingLevel() {
+		GoogleGenAiChatOptions original = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingLevel(GoogleGenAiThinkingLevel.LOW)
+			.build();
+
+		GoogleGenAiChatOptions copy = GoogleGenAiChatOptions.fromOptions(original);
+
+		assertThat(copy.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.LOW);
+		assertThat(copy).isNotSameAs(original);
+	}
+
+	@Test
+	public void testCopyWithThinkingLevel() {
+		GoogleGenAiChatOptions original = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.build();
+
+		GoogleGenAiChatOptions copy = original.copy();
+
+		assertThat(copy.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.HIGH);
+		assertThat(copy).isNotSameAs(original);
+	}
+
+	@Test
+	public void testEqualsAndHashCodeWithThinkingLevel() {
+		GoogleGenAiChatOptions options1 = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.build();
+
+		GoogleGenAiChatOptions options2 = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.build();
+
+		GoogleGenAiChatOptions options3 = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingLevel(GoogleGenAiThinkingLevel.LOW)
+			.build();
+
+		assertThat(options1).isEqualTo(options2);
+		assertThat(options1.hashCode()).isEqualTo(options2.hashCode());
+		assertThat(options1).isNotEqualTo(options3);
+	}
+
+	@Test
+	public void testToStringWithThinkingLevel() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.build();
+
+		String toString = options.toString();
+		assertThat(toString).contains("thinkingLevel=HIGH");
+	}
+
+	@Test
+	public void testThinkingLevelWithBudgetAndIncludeThoughts() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.thinkingBudget(8192)
+			.includeThoughts(true)
+			.thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+			.build();
+
+		assertThat(options.getThinkingBudget()).isEqualTo(8192);
+		assertThat(options.getIncludeThoughts()).isTrue();
+		assertThat(options.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.HIGH);
+	}
+
+	@Test
+	public void testAllThinkingLevelValues() {
+		// Test all enum values work correctly
+		for (GoogleGenAiThinkingLevel level : GoogleGenAiThinkingLevel.values()) {
+			GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+				.model("test-model")
+				.thinkingLevel(level)
+				.build();
+			assertThat(options.getThinkingLevel()).isEqualTo(level);
+		}
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -115,7 +115,8 @@ The prefix `spring.ai.google.genai.chat` is the property prefix that lets you co
 | spring.ai.google.genai.chat.options.max-output-tokens | The maximum number of tokens to generate. | -
 | spring.ai.google.genai.chat.options.frequency-penalty | Frequency penalties for reducing repetition. | -
 | spring.ai.google.genai.chat.options.presence-penalty | Presence penalties for reducing repetition. | -
-| spring.ai.google.genai.chat.options.thinking-budget | Thinking budget for the thinking process. | -
+| spring.ai.google.genai.chat.options.thinking-budget | Thinking budget for the thinking process. See <<thinking-config>>. | -
+| spring.ai.google.genai.chat.options.thinking-level | The level of thinking tokens the model should generate. Valid values: `LOW`, `HIGH`, `THINKING_LEVEL_UNSPECIFIED`. See <<thinking-config>>. | -
 | spring.ai.google.genai.chat.options.include-thoughts | Enable thought signatures for function calling. **Required** for Gemini 3 Pro to avoid validation errors during the internal tool execution loop. See <<thought-signatures>>. | false
 | spring.ai.google.genai.chat.options.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
 | spring.ai.google.genai.chat.options.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
@@ -195,6 +196,94 @@ String response = ChatClient.create(this.chatModel)
 ----
 
 Find more in xref:api/tools.adoc[Tools] documentation.
+
+== Thinking Configuration [[thinking-config]]
+
+Gemini models support a "thinking" capability that allows the model to perform deeper reasoning before generating responses. This is controlled through the `ThinkingConfig` which includes three related options: `thinkingBudget`, `thinkingLevel`, and `includeThoughts`.
+
+=== Thinking Level
+
+The `thinkingLevel` option controls the depth of reasoning tokens the model generates. This is available for models that support thinking (e.g., Gemini 3 Pro Preview).
+
+[cols="1,3", stripes=even]
+|====
+| Value | Description
+
+| `LOW` | Minimal thinking. Use for simple queries where speed is preferred over deep analysis.
+| `HIGH` | Extensive thinking. Use for complex problems requiring deep analysis and step-by-step reasoning.
+| `THINKING_LEVEL_UNSPECIFIED` | The model uses its default behavior.
+|====
+
+==== Configuration via Properties
+
+[source,application.properties]
+----
+spring.ai.google.genai.chat.options.model=gemini-3-pro-preview
+spring.ai.google.genai.chat.options.thinking-level=HIGH
+----
+
+==== Programmatic Configuration
+
+[source,java]
+----
+import org.springframework.ai.google.genai.common.GoogleGenAiThinkingLevel;
+
+ChatResponse response = chatModel.call(
+    new Prompt(
+        "Explain the theory of relativity in simple terms.",
+        GoogleGenAiChatOptions.builder()
+            .model("gemini-3-pro-preview")
+            .thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+            .build()
+    ));
+----
+
+=== Thinking Budget
+
+The `thinkingBudget` option sets a token budget for the thinking process:
+
+- **Positive value**: Maximum number of tokens for thinking (e.g., `8192`)
+- **Zero (`0`)**: Disables thinking entirely
+- **Not set**: Model decides automatically based on query complexity
+
+[source,java]
+----
+ChatResponse response = chatModel.call(
+    new Prompt(
+        "Solve this complex math problem step by step.",
+        GoogleGenAiChatOptions.builder()
+            .model("gemini-2.5-pro")
+            .thinkingBudget(8192)
+            .build()
+    ));
+----
+
+=== Combining Thinking Options
+
+You can combine `thinkingLevel`, `thinkingBudget`, and `includeThoughts` for fine-grained control:
+
+[source,java]
+----
+ChatResponse response = chatModel.call(
+    new Prompt(
+        "Analyze this complex scenario.",
+        GoogleGenAiChatOptions.builder()
+            .model("gemini-3-pro-preview")
+            .thinkingLevel(GoogleGenAiThinkingLevel.HIGH)
+            .thinkingBudget(4096)
+            .includeThoughts(true)
+            .build()
+    ));
+----
+
+=== Model Support
+
+[IMPORTANT]
+====
+`thinkingLevel` is only supported by specific models (e.g., Gemini 3 Pro Preview). Using it with unsupported models will result in an error. Check the https://ai.google.dev/gemini-api/docs/models[Google GenAI documentation] for the latest model capabilities.
+====
+
+NOTE: Enabling thinking features increases token usage and API costs. Use appropriately based on the complexity of your queries.
 
 == Thought Signatures [[thought-signatures]]
 


### PR DESCRIPTION
Notes: @markpollack @ilayaperumalg 
- this PR is sent to  complement the [thought signature in Google GenAI PR](https://github.com/spring-projects/spring-ai/pull/4977) with support for thinking levels
- if its too late to be included in the upcoming milestones, it can be added to the subsequent one

  Add support for ThinkingLevel (LOW, HIGH, THINKING_LEVEL_UNSPECIFIED)
  to control the depth of reasoning tokens generated by Gemini models.

  - Create GoogleGenAiThinkingLevel enum for type-safe thinking level values
  - Add thinkingLevel field to GoogleGenAiChatOptions with builder support
  - Add mapping method to convert Spring AI enum to SDK ThinkingLevel.Known
  - Update createGeminiRequest() to include thinkingLevel in ThinkingConfig
  - Add comprehensive unit tests for options and request building
  - Add integration tests for thinkingLevel with Gemini 3 Pro Preview
  - Document changes

