### PR TITLE
Fix typo in DefaultChatClientUtils comment (gh-4886)

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
@@ -82,7 +82,7 @@ final class DefaultChatClientUtils {
 			processedMessages.addAll(inputRequest.getMessages());
 		}
 
-		// User Test => Last in the list
+		// User Text => Last in the list
 		String processedUserText = inputRequest.getUserText();
 		if (StringUtils.hasText(processedUserText)) {
 			if (!CollectionUtils.isEmpty(inputRequest.getUserParams())) {


### PR DESCRIPTION
This PR fixes a small typo in `DefaultChatClientUtils` where the comment
currently says `User Test` instead of `User Text`.

The comment now reads:

```java
// User Text => Last in the list