### PR TITLE
[java doc] outdated Redis search query documentation link

### DIFF
--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisFilterExpressionConverter.java
@@ -31,8 +31,8 @@ import org.springframework.ai.vectorstore.filter.converter.AbstractFilterExpress
 import org.springframework.ai.vectorstore.redis.RedisVectorStore.MetadataField;
 
 /**
- * Converts {@link Expression} into Redis search filter expression format.
- * (<a href="https://redis.io/docs/latest/develop/ai/search-and-query/">search-and-query</a>)
+ * Converts {@link Expression} into Redis search filter expression format. (<a href=
+ * "https://redis.io/docs/latest/develop/ai/search-and-query/">search-and-query</a>)
  *
  * @author Julien Ruaux
  */


### PR DESCRIPTION
This PR updates the Redis documentation URL referenced in the Javadoc of `RedisFilterExpressionConverter`. The previous link is no longer valid and returns 404. The new link points to the current Redis search and query documentation.