### PR TITLE
issue-4999: remove DEFAULT_TEMPERATURE usage

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatProperties.java
@@ -29,14 +29,11 @@ public class OpenAiChatProperties extends OpenAiParentProperties {
 
 	public static final String DEFAULT_COMPLETIONS_PATH = "/v1/chat/completions";
 
-	private static final Double DEFAULT_TEMPERATURE = 0.7;
-
 	private String completionsPath = DEFAULT_COMPLETIONS_PATH;
 
 	@NestedConfigurationProperty
 	private final OpenAiChatOptions options = OpenAiChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
-		.temperature(DEFAULT_TEMPERATURE)
 		.build();
 
 	public OpenAiChatOptions getOptions() {


### PR DESCRIPTION
This PR removes the use of DEFAULT_TEMPERATURE from OpenAiChatProperties so no explicit default temperature is set for OpenAiChatOptions.

Changes:

- Deleted DEFAULT_TEMPERATURE constant from OpenAiChatProperties.
- Removed .temperature(...) call from OpenAiChatOptions builder so no default temperature is set.

Fixes #4999

Signed-off-by: Mark Pollack <mark.pollack@broadcom.com>