### PR TITLE
Fix TokenTextSplitter for punctuation marks handling

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -108,13 +108,18 @@ public class TokenTextSplitter extends TextSplitter {
 				continue;
 			}
 
-			// Find the last period or punctuation mark in the chunk
-			int lastPunctuation = Math.max(chunkText.lastIndexOf('.'), Math.max(chunkText.lastIndexOf('?'),
-					Math.max(chunkText.lastIndexOf('!'), chunkText.lastIndexOf('\n'))));
+			// Only apply punctuation-based truncation if we have more tokens than the
+			// chunk size
+			// This prevents unnecessary splitting of small texts
+			if (tokens.size() > chunkSize) {
+				// Find the last period or punctuation mark in the chunk
+				int lastPunctuation = Math.max(chunkText.lastIndexOf('.'), Math.max(chunkText.lastIndexOf('?'),
+						Math.max(chunkText.lastIndexOf('!'), chunkText.lastIndexOf('\n'))));
 
-			if (lastPunctuation != -1 && lastPunctuation > this.minChunkSizeChars) {
-				// Truncate the chunk text at the punctuation mark
-				chunkText = chunkText.substring(0, lastPunctuation + 1);
+				if (lastPunctuation != -1 && lastPunctuation > this.minChunkSizeChars) {
+					// Truncate the chunk text at the punctuation mark
+					chunkText = chunkText.substring(0, lastPunctuation + 1);
+				}
 			}
 
 			String chunkTextToAppend = (this.keepSeparator) ? chunkText.trim()


### PR DESCRIPTION
 - The TokenTextSplitter was incorrectly splitting small text into multiple chunks when punctuation marks were present, even when the entire text was well below the configured chunk size.

 - Only apply punctuation-based truncation when the remaining tokens exceed the chunk size (tokens.size() > chunkSize). This ensures small texts remain as single chunks while preserving correct splitting behavior for larger texts.

Fixes #4981

