### PR TITLE
Adapt Kotlin compiler version to using JDK 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,7 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
+		<kotlin.compiler.version>2.2.21</kotlin.compiler.version>
 
 		<!-- production dependencies -->
 		<spring-boot.version>3.5.7</spring-boot.version>
@@ -423,7 +424,7 @@
 			<plugin>
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-maven-plugin</artifactId>
-				<version>${kotlin.version}</version>
+				<version>${kotlin.compiler.version}</version>
 				<configuration>
 					<jvmTarget>${java.version}</jvmTarget>
 					<javaParameters>true</javaParameters>


### PR DESCRIPTION
This PR updates the kotlin compiler plugin to be compatible with JDK 25.

This harmonizes build infrastructures across branches and removes the need to switch back and forth between JDKs