### PR TITLE
Upgrade commons-lang3 to 3.18.0 to fix CVE (Uncontrolled Recursion)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1071,6 +1071,12 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Override commons-lang3 to fix CVE (Uncontrolled Recursion) in 3.17.0 -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.18.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
## Summary

This PR upgrades `commons-lang3` from 3.17.0 to 3.18.0 to fix a **High Severity** security vulnerability.

## Vulnerability Details

- **CVE**: [SNYK-JAVA-ORGAPACHECOMMONS-10734078](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-10734078)
- **Type**: Uncontrolled Recursion
- **Severity**: High
- **Fixed in**: commons-lang3 3.18.0

### Description

Uncontrolled recursion occurs when a function calls itself repeatedly without proper termination conditions, which can lead to:
- Stack overflow crashes
- Denial of Service (DoS) attacks

## Affected Dependency Paths

The vulnerability was introduced through multiple transitive dependency paths:

1. `org.apache.tika:tika-parsers-standard-package` → `tika-parser-code-module` → `commons-lang3@3.17.0`
2. `com.azure:azure-spring-data-cosmos` → `commons-lang3@3.17.0`
3. `io.rest-assured:json-path` → `rest-assured-common` → `commons-lang3@3.17.0`

## Affected Modules (24 modules with compile-scope dependency)

The following modules had `commons-lang3` as a compile dependency:

- `spring-ai-tika-document-reader`
- `spring-ai-azure-cosmos-db-store`
- `spring-ai-cassandra-store`
- `spring-ai-weaviate-store`
- `spring-ai-milvus-store`
- `spring-ai-anthropic`
- `spring-ai-elevenlabs`
- `spring-ai-model-chat-memory-repository-cosmos-db`
- `spring-ai-spring-boot-docker-compose`
- `spring-ai-spring-boot-testcontainers`
- `spring-ai-autoconfigure-vector-store-weaviate`
- `spring-ai-autoconfigure-vector-store-milvus`
- `spring-ai-autoconfigure-vector-store-cassandra`
- `spring-ai-autoconfigure-vector-store-azure-cosmos-db`
- `spring-ai-autoconfigure-model-anthropic`
- `spring-ai-autoconfigure-model-elevenlabs`
- `spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db`
- `spring-ai-starter-vector-store-azure-cosmos-db`
- `spring-ai-starter-vector-store-cassandra`
- `spring-ai-starter-vector-store-milvus`
- `spring-ai-starter-vector-store-weaviate`
- `spring-ai-starter-model-anthropic`
- `spring-ai-starter-model-elevenlabs`
- `spring-ai-starter-model-chat-memory-repository-cosmos-db`

Many additional modules had the dependency in test scope.

## Solution Approach

### Why Parent POM vs Per-Module?

The fix is applied in the **parent pom.xml** `dependencyManagement` section rather than in individual modules because:

1. **Single point of management** - Easier to update when newer versions are released
2. **Consistency** - Ensures all 24+ modules use the same fixed version
3. **Future-proofing** - Automatically covers any new modules that might transitively depend on commons-lang3
4. **Reduced maintenance** - Avoids duplicating the override in 24+ module pom.xml files
5. **Maven best practice** - Central dependency version management is the recommended approach for multi-module projects

## Verification

Snyk scan after the fix shows no `commons-lang3` vulnerabilities.
