### PR TITLE
Upgrade commons-compress to 1.28.0 to fix CVE (Infinite Loop, Resource Allocation)

### DIFF
--- a/models/spring-ai-transformers/pom.xml
+++ b/models/spring-ai-transformers/pom.xml
@@ -48,6 +48,12 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<!-- Override commons-compress to fix CVE (Infinite Loop, Resource Allocation) in 1.24.0 -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.28.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/vector-stores/spring-ai-azure-cosmos-db-store/pom.xml
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/pom.xml
@@ -41,6 +41,17 @@
         <maven.compiler.source>17</maven.compiler.source>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- Override commons-compress to fix CVE (Infinite Loop, Resource Allocation) in 1.24.0 -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.28.0</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.azure</groupId>


### PR DESCRIPTION
## Summary

This PR upgrades `commons-compress` from 1.24.0/1.27.1 to 1.28.0 to fix security vulnerabilities.

## Vulnerability Details

### High Severity
- **CVE**: [SNYK-JAVA-ORGAPACHECOMMONS-6254296](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254296)
- **Type**: Infinite Loop
- **Severity**: High

### Medium Severity
- **CVE**: [SNYK-JAVA-ORGAPACHECOMMONS-6254297](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-6254297)
- **Type**: Allocation of Resources Without Limits or Throttling
- **Severity**: Medium

## Affected Dependency Paths

The vulnerability was introduced through transitive dependencies:

1. `ai.djl:api` → `commons-compress@1.27.1` (in spring-ai-transformers)
2. `com.azure:azure-spring-data-cosmos` → `commons-compress@1.27.1` (in spring-ai-azure-cosmos-db-store)

## Affected Modules

Only 2 modules have `commons-compress` as a **compile** dependency (others have it in test scope via testcontainers):

- `spring-ai-transformers` (ONNX Transformers)
- `spring-ai-azure-cosmos-db-store`

Downstream modules (autoconfigure, starters) inherit the fix from these.

## Solution Approach

The fix is applied at the **module level** in the `dependencyManagement` section of each affected module, rather than in the parent POM, because:

1. Only 2 modules are affected at compile scope
2. Keeps the fix localized to where the vulnerability exists
3. More targeted approach for a transitive dependency

## Verification

```
mvn dependency:tree -Dincludes=org.apache.commons:commons-compress
```

Shows `commons-compress:1.28.0` in both affected modules after the fix.

Tests pass for both affected modules.
