### PR TITLE
fix: Add Usage with the ZhiPu model（#5024）

### DIFF
--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -418,7 +418,7 @@ public class ZhiPuAiChatModel implements ChatModel {
 	}
 
 	/**
-	 * Convert the ChatCompletionChunk into a ChatCompletion. The Usage is set to null.
+	 * Convert the ChatCompletionChunk into a ChatCompletion.
 	 * @param chunk the ChatCompletionChunk to convert
 	 * @return the ChatCompletion
 	 */
@@ -432,7 +432,7 @@ public class ZhiPuAiChatModel implements ChatModel {
 		}).toList();
 
 		return new ChatCompletion(chunk.id(), choices, chunk.created(), chunk.model(), chunk.systemFingerprint(),
-				"chat.completion", null);
+				"chat.completion", chunk.usage());
 	}
 
 	private List<ZhiPuAiApi.FunctionTool> getFunctionTools(List<ToolDefinition> toolDefinitions) {


### PR DESCRIPTION
Due to the fact that the usage field is not correctly populated when converting ChatCompletionChunk to ChatCompletion, users always receive EmptyUsage when attempting to retrieve usage information from the ChatResponse.