### PR TITLE
[java doc] outdated Milvus json fields documentation link

### DIFF
--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusFilterExpressionConverter.java
@@ -23,8 +23,9 @@ import org.springframework.ai.vectorstore.filter.Filter.Key;
 import org.springframework.ai.vectorstore.filter.converter.AbstractFilterExpressionConverter;
 
 /**
- * Converts {@link Expression} into Milvus metadata filter expression format.
- * (https://milvus.io/docs/json_data_type.md)
+ * Converts {@link Expression} into Milvus metadata filter expression format. See Milvus
+ * JSON‑field & filtering docs:
+ * <a href="https://milvus.io/docs/json-field-overview.md">json-field-overview</a>
  *
  * @author Christian Tzolov
  */


### PR DESCRIPTION
The previous Javadoc referenced https://milvus.io/docs/json_data_type.md, which is no longer available (404).
Updated the link to point to the current Milvus JSON field documentation: https://milvus.io/docs/use-json-fields.md.

No code logic changes; only Javadoc update.