### PR TITLE
fix: Add the reasoningContent field to the metadata（#5029）.

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -220,7 +220,8 @@ public class OpenAiChatModel implements ChatModel {
 							"index", choice.index() != null ? choice.index() : 0,
 							"finishReason", getFinishReasonJson(choice.finishReason()),
 							"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
-							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(Map.of()));
+							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(Map.of()),
+							"reasoningContent", choice.message().reasoningContent() != null ? choice.message().reasoningContent() : "");
 					return buildGeneration(choice, metadata, request);
 				}).toList();
 				// @formatter:on


### PR DESCRIPTION
fix: https://github.com/spring-projects/spring-ai/issues/5029

In the call method of OpenAIChatModel, add a reasoningContent field to the metadata, keeping it consistent with how metadata is handled in the stream method.