### PR TITLE
chore: make openai autoconfiguration classes consistent

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
@@ -24,7 +24,6 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.ai.openai.OpenAiImageModel;
 import org.springframework.ai.openai.OpenAiModerationModel;
-import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.ai.utils.SpringAiTestAutoConfigurations;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -46,7 +45,6 @@ public class OpenAiModelConfigurationTests {
 	void chatModelActivation() {
 		this.contextRunner.withConfiguration(SpringAiTestAutoConfigurations.of(OpenAiChatAutoConfiguration.class))
 			.run(context -> {
-				assertThat(context.getBeansOfType(OpenAiApi.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(OpenAiChatModel.class)).isNotEmpty();
 				assertThat(context.getBeansOfType(OpenAiEmbeddingModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(OpenAiImageModel.class)).isEmpty();
@@ -312,17 +310,6 @@ public class OpenAiModelConfigurationTests {
 				assertThat(context.getBeansOfType(OpenAiAudioSpeechModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(OpenAiAudioTranscriptionModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(OpenAiModerationModel.class)).isNotEmpty();
-			});
-	}
-
-	@Test
-	void openAiApiBean() {
-		// Test that OpenAiApi bean is registered and can be injected
-		this.contextRunner.withConfiguration(SpringAiTestAutoConfigurations.of(OpenAiChatAutoConfiguration.class))
-			.run(context -> {
-				assertThat(context.getBeansOfType(OpenAiApi.class)).hasSize(1);
-				OpenAiApi openAiApi = context.getBean(OpenAiApi.class);
-				assertThat(openAiApi).isNotNull();
 			});
 	}
 


### PR DESCRIPTION
OpenAIChatAutoConfiguration creates an additional bean that cannot be used in any of the other OpenAi*AutoConfig classes.

This PR makes the creation of OpenAiApi private in each autoconfiguration class (consistent across them all).