### PR TITLE
Remove duplicate azure-identity.version property to fix CVE SNYK-JAVA-COMNIMBUSDS-10691768 - Uncontrolled Recursion).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,6 @@
 		<fastjson2.version>2.0.46</fastjson2.version>
 		<azure-core.version>1.55.3</azure-core.version>
 		<azure-json.version>1.5.0</azure-json.version>
-		<azure-identity.version>1.15.4</azure-identity.version>
 		<azure-search.version>11.7.6</azure-search.version>
 		<azure-cosmos.version>5.22.0</azure-cosmos.version>
 		<elasticsearch-java.version>8.18.1</elasticsearch-java.version>


### PR DESCRIPTION
The pom.xml contained two azure-identity.version properties:
- Line 284: 1.18.1 (correct, used by production code)
- Line 322: 1.15.4 (duplicate, incorrectly overriding the correct version)

This duplicate caused azure-identity 1.15.4 to be used, which transitively brought in msal4j 1.17.2 with nimbus-jose-jwt 9.37.3 (vulnerable to CVE SNYK-JAVA-COMNIMBUSDS-10691768 - Uncontrolled Recursion).

With azure-identity 1.18.1, msal4j 1.23.1 is used which has nimbus-jose-jwt as a test-only dependency, resolving the security vulnerability.