### PR TITLE
Override protobuf-java version in milvus-store to fix CVE-2024-7254

### DIFF
--- a/vector-stores/spring-ai-milvus-store/pom.xml
+++ b/vector-stores/spring-ai-milvus-store/pom.xml
@@ -41,6 +41,17 @@
 		<maven.compiler.source>17</maven.compiler.source>
 	</properties>
 
+	<!-- Override transitive protobuf-java to fix CVE-2024-7254 (SNYK-JAVA-COMGOOGLEPROTOBUF-8055227) -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.google.protobuf</groupId>
+				<artifactId>protobuf-java</artifactId>
+				<version>${protobuf-java.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.ai</groupId>


### PR DESCRIPTION
The milvus-sdk-java 2.5.8 depends on protobuf-java 3.24.0 which is vulnerable to CVE-2024-7254 (SNYK-JAVA-COMGOOGLEPROTOBUF-8055227) Stack-based Buffer Overflow.

This fix adds a dependencyManagement section to override the transitive protobuf-java dependency to use version 3.25.8 (defined in parent pom as protobuf-java.version property) which contains the fix for this CVE.