### PR TITLE
GH-4933: Always using current model name when merging two OllamaApi.C…

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApiHelper.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApiHelper.java
@@ -63,7 +63,7 @@ public final class OllamaApiHelper {
 
 	public static ChatResponse merge(ChatResponse previous, ChatResponse current) {
 
-		String model = merge(previous.model(), current.model());
+		String model = (current.model() != null ? current.model() : previous.model());
 		Instant createdAt = merge(previous.createdAt(), current.createdAt());
 		OllamaApi.Message message = merge(previous.message(), current.message());
 		String doneReason = (current.doneReason() != null ? current.doneReason() : previous.doneReason());
@@ -113,16 +113,6 @@ public final class OllamaApiHelper {
 	}
 
 	private static Long merge(Long previous, Long current) {
-		if (previous == null) {
-			return current;
-		}
-		if (current == null) {
-			return previous;
-		}
-		return previous + current;
-	}
-
-	private static String merge(String previous, String current) {
 		if (previous == null) {
 			return current;
 		}

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiHelperTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaApiHelperTests.java
@@ -149,7 +149,7 @@ class OllamaApiHelperTests {
 
 		OllamaApi.ChatResponse result = OllamaApiHelper.merge(previous, current);
 
-		assertThat(result.model()).isEqualTo("previous-modelcurrent-model");
+		assertThat(result.model()).isEqualTo("current-model");
 		assertThat(result.createdAt()).isEqualTo(currentCreatedAt);
 		assertThat(result.message().content()).isEqualTo("Previous contentCurrent content");
 		assertThat(result.message().thinking()).isEqualTo("Previous thinkingCurrent thinking");
@@ -187,7 +187,6 @@ class OllamaApiHelperTests {
 
 		OllamaApi.ChatResponse result = OllamaApiHelper.merge(previous, current);
 
-		assertThat(result.model()).isEqualTo("model1model2");
 		assertThat(result.message().content()).isEqualTo("Hello World");
 		assertThat(result.message().thinking()).isEqualTo("Thinking");
 		assertThat(result.message().toolName()).isEqualTo("ToolBox");


### PR DESCRIPTION
…hatResponse.

Closes #4933

* Ollama always sends the same model name in every part of the response.
* Removes unused merge-method.