### PR TITLE
Add support for Ollama's OpenAI-compatible API reasoning field

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -1492,7 +1493,7 @@ public class OpenAiApi {
 			@JsonProperty("refusal") String refusal,
 			@JsonProperty("audio") AudioOutput audioOutput,
 			@JsonProperty("annotations") List<Annotation> annotations,
-			@JsonProperty("reasoning_content") String reasoningContent
+			@JsonProperty("reasoning_content") @JsonAlias("reasoning") String reasoningContent
 	) { // @formatter:on
 
 		/**


### PR DESCRIPTION
When using Ollama's OpenAI-compatible /api/chat endpoint with think: true and stream: true, some models (e.g., qwen3, deepseek-r1) emit reasoning tokens in the thinking field instead of the standard OpenAI reasoning_content field.

This causes the reasoning trace to be lost in the current implementation, as ChatCompletionMessage.reasoningContent only deserializes the standard field name.

### Example (Ollama 0.13.1, 0.12.11)

```bash
curl http://localhost:11434/api/chat -d '{
  "model": "qwen3",
  "messages": [{"role": "user", "content": "Summarize why HTTP/2 is faster."}],
  "think": true,
  "stream": true
}'
```

Streamed chunks contain:
```json
{"model":"qwen3","created_at":"2025-12-08T06:23:02.518809Z","message":{"role":"assistant","content":"","thinking":"Okay"},"done":false}
{"model":"qwen3","created_at":"2025-12-08T06:23:02.562574Z","message":{"role":"assistant","content":"","thinking":","},"done":false}
{"model":"qwen3","created_at":"2025-12-08T06:23:02.606487Z","message":{"role":"assistant","content":"","thinking":" so"},"done":false}
{"model":"qwen3","created_at":"2025-12-08T06:23:02.650708Z","message":{"role":"assistant","content":"","thinking":" I"},"done":false}
```

In this format, the reasoning trace is emitted in the thinking field, not reasoning_content, so ChatCompletionMessage currently does not capture it.

This PR adds @JsonAlias("reasoning") to the reasoningContent field in ChatCompletionMessage to ensure compatibility with both field names.