### PR TITLE
Fine tune the BuildCache config

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -9,6 +9,25 @@
 		</global>
 	</input>
 	<executionControl>
+		<runAlways>
+			<goalsLists>
+				<goalsList artifactId="maven-install-plugin">
+					<goals>
+						<goal>install</goal>
+					</goals>
+				</goalsList>
+				<goalsList artifactId="maven-deploy-plugin">
+					<goals>
+						<goal>deploy</goal>
+					</goals>
+				</goalsList>
+				<goalsList groupId="org.codehaus.mojo" artifactId="flatten-maven-plugin">
+					<goals>
+						<goal>flatten</goal>
+					</goals>
+				</goalsList>
+			</goalsLists>
+		</runAlways>
 		<reconcile>
 			<plugins>
 				<plugin artifactId="maven-surefire-plugin" goal="test">
@@ -26,7 +45,12 @@
 						<reconcile propertyName="skipTests" skipValue="true"/>
 					</reconciles>
 				</plugin>
-
+				<!-- workaround for https://issues.apache.org/jira/browse/MBUILDCACHE-56 -->
+				<plugin artifactId="maven-enforcer-plugin" goal="enforce">
+					<nologs>
+						<nolog propertyName="commandLineRules"/>
+					</nologs>
+				</plugin>
 			</plugins>
 		</reconcile>
 	</executionControl>


### PR DESCRIPTION
This makes sure that the following plugins always run (because we're interested in their side effects):
 * install
 * deploy
 * flatten

Also, silence a warning about an arg of the enforcer plugin. (harmless)
