### PR TITLE
Add doFinalizeLoop() hook to ToolCallAdvisor

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -150,6 +150,11 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 		}
 		while (isToolCall); // loop until no tool calls are present
 
+		return this.doFinalizeLoop(chatClientResponse, callAdvisorChain);
+	}
+
+	protected ChatClientResponse doFinalizeLoop(ChatClientResponse chatClientResponse,
+			CallAdvisorChain callAdvisorChain) {
 		return chatClientResponse;
 	}
 


### PR DESCRIPTION
Introduce doFinalizeLoop() method as a symmetric counterpart to doInitializeLoop(). This protected hook allows subclasses to perform cleanup or finalization logic after the tool calling loop completes.
