### PR TITLE
chore: Updated Google GenAI SDK to 1.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
 		<onnxruntime.version>1.19.2</onnxruntime.version>
 		<oci-sdk-version>3.63.1</oci-sdk-version>
 		<com.google.cloud.version>26.72.0</com.google.cloud.version>
-		<com.google.genai.version>1.28.0</com.google.genai.version>
+		<com.google.genai.version>1.30.0</com.google.genai.version>
 		<ibm.sdk.version>9.20.0</ibm.sdk.version>
 		<jsonschema.version>4.38.0</jsonschema.version>
 		<swagger-annotations.version>2.2.38</swagger-annotations.version>


### PR DESCRIPTION
These changes are required for Google GenAI SDK

Native Image support - mandatory upgrade to 1.30.0 to work 

Could this be merged into the 2.0.0 branch and backported to a 1.1.x fixes branch?