### PR TITLE
add framework name to mongodb driver metadata

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/main/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/main/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.vectorstore.mongodb.autoconfigure;
 
+import com.mongodb.MongoDriverInformation;
+import com.mongodb.client.MongoClient;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,6 +30,7 @@ import org.springframework.ai.vectorstore.SpringAIVectorStoreTypes;
 import org.springframework.ai.vectorstore.mongodb.atlas.MongoDBAtlasVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -65,11 +68,14 @@ public class MongoDBAtlasVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	MongoDBAtlasVectorStore vectorStore(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel,
+	MongoDBAtlasVectorStore vectorStore(@Autowired(required = false) MongoClient mongoClient, MongoTemplate mongoTemplate, EmbeddingModel embeddingModel,
 			MongoDBAtlasVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
-
+		if(mongoClient != null) {
+			// append framework name to the driver info
+			mongoClient.appendMetadata(MongoDriverInformation.builder().driverName("spring-ai").build());
+		}
 		MongoDBAtlasVectorStore.Builder builder = MongoDBAtlasVectorStore.builder(mongoTemplate, embeddingModel)
 			.initializeSchema(properties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/main/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/main/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfiguration.java
@@ -16,11 +16,11 @@
 
 package org.springframework.ai.vectorstore.mongodb.autoconfigure;
 
-import com.mongodb.MongoDriverInformation;
-import com.mongodb.client.MongoClient;
 import java.util.Arrays;
 import java.util.List;
 
+import com.mongodb.MongoDriverInformation;
+import com.mongodb.client.MongoClient;
 import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.embedding.BatchingStrategy;
@@ -30,7 +30,7 @@ import org.springframework.ai.vectorstore.SpringAIVectorStoreTypes;
 import org.springframework.ai.vectorstore.mongodb.atlas.MongoDBAtlasVectorStore;
 import org.springframework.ai.vectorstore.observation.VectorStoreObservationConvention;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -66,16 +66,28 @@ public class MongoDBAtlasVectorStoreAutoConfiguration {
 		return new TokenCountBatchingStrategy();
 	}
 
+	/**
+	 * Appends the {@code spring-ai} framework name to the {@link MongoClient} driver
+	 * metadata so that Spring AI traffic can be identified in MongoDB Atlas. This is done
+	 * in a {@link SmartInitializingSingleton} rather than in the {@code vectorStore} bean
+	 * method so that the metadata is still appended when the user provides a custom
+	 * {@link MongoDBAtlasVectorStore} bean (which would suppress the auto-configured
+	 * one).
+	 * @param mongoClientProvider provider for the optional {@link MongoClient} bean
+	 * @return the initializer that appends the driver metadata
+	 */
+	@Bean
+	SmartInitializingSingleton mongoDriverMetadataInitializer(ObjectProvider<MongoClient> mongoClientProvider) {
+		return () -> mongoClientProvider.ifAvailable(mongoClient -> mongoClient
+			.appendMetadata(MongoDriverInformation.builder().driverName("spring-ai").build()));
+	}
+
 	@Bean
 	@ConditionalOnMissingBean
-	MongoDBAtlasVectorStore vectorStore(@Autowired(required = false) MongoClient mongoClient, MongoTemplate mongoTemplate, EmbeddingModel embeddingModel,
+	MongoDBAtlasVectorStore vectorStore(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel,
 			MongoDBAtlasVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
-		if(mongoClient != null) {
-			// append framework name to the driver info
-			mongoClient.appendMetadata(MongoDriverInformation.builder().driverName("spring-ai").build());
-		}
 		MongoDBAtlasVectorStore.Builder builder = MongoDBAtlasVectorStore.builder(mongoTemplate, embeddingModel)
 			.initializeSchema(properties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/test/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/test/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfigurationIT.java
@@ -21,9 +21,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.mongodb.ConnectionString;
+import com.mongodb.MongoDriverInformation;
+import com.mongodb.client.MongoClient;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.ArgumentCaptor;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.mongodb.MongoDBAtlasLocalContainer;
@@ -49,6 +52,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Eddú Meléndez
@@ -189,6 +195,20 @@ class MongoDBAtlasVectorStoreAutoConfigurationIT {
 			assertThat(context.getBeansOfType(VectorStore.class)).isNotEmpty();
 			assertThat(context.getBean(VectorStore.class)).isInstanceOf(MongoDBAtlasVectorStore.class);
 		});
+	}
+
+	@Test
+	public void appendsFrameworkMetadataWhenMongoClientBeanIsPresent() {
+		MongoClient mongoClient = mock(MongoClient.class);
+		getContextRunner().withPropertyValues("spring.ai.vectorstore.mongodb.initialize-schema=false")
+			.withBean(MongoClient.class, () -> mongoClient)
+			.run(context -> {
+				assertThat(context).hasSingleBean(MongoDBAtlasVectorStore.class);
+
+				ArgumentCaptor<MongoDriverInformation> captor = ArgumentCaptor.forClass(MongoDriverInformation.class);
+				verify(mongoClient, times(1)).appendMetadata(captor.capture());
+				assertThat(captor.getValue().getDriverNames()).contains("spring-ai");
+			});
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Hello Spring Team
MongoDB java driver team introduced a new API to MongoClient that allows users to dynamically append metadata to the driver 
that later can be seen within atlas 
Right now we are trying to integrate this api into all popular java frameworks that use MongoDB
For example
1. spring boot already adds metadata [here](https://github.com/spring-projects/spring-boot/blob/c687998f56ff462e1bfb00bd905218a96a4e0315/module/spring-boot-mongodb/src/main/java/org/springframework/boot/mongodb/autoconfigure/MongoClientFactorySupport.java#L62) when it creates `MongoClient` as a bean
2.  we already added it to langchain4j [here ](https://github.com/langchain4j/langchain4j/blob/b09a00eb354e05d3027e73b73409befb23d3aa3e/langchain4j-mongodb-atlas/src/main/java/dev/langchain4j/store/embedding/mongodb/MongoDbEmbeddingStore.java#L440)

In this PR , `MongoClient` is injected into `MongoDBAtlasVectorStore` and metadata about framework name is appended dynamically 