### PR TITLE
docs: Remove redundant /v1 suffix from OpenAI base-url examples

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -784,7 +784,7 @@ Each property under `spring.ai.openai.chat.options.extra-body` becomes a top-lev
 
 [source,properties]
 ----
-spring.ai.openai.base-url=http://localhost:8000/v1
+spring.ai.openai.base-url=http://localhost:8000
 spring.ai.openai.chat.options.model=meta-llama/Llama-3-8B-Instruct
 spring.ai.openai.chat.options.temperature=0.7
 spring.ai.openai.chat.options.extra-body.top_k=50
@@ -831,7 +831,7 @@ When running vLLM with a Llama model, you might want to use sampling parameters 
 
 [source,properties]
 ----
-spring.ai.openai.base-url=http://localhost:8000/v1
+spring.ai.openai.base-url=http://localhost:8000
 spring.ai.openai.chat.options.model=meta-llama/Llama-3-70B-Instruct
 spring.ai.openai.chat.options.extra-body.top_k=40
 spring.ai.openai.chat.options.extra-body.top_p=0.95
@@ -998,7 +998,7 @@ vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
 
 [source,properties]
 ----
-spring.ai.openai.base-url=http://localhost:8000/v1
+spring.ai.openai.base-url=http://localhost:8000
 spring.ai.openai.chat.options.model=deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
 ----
 


### PR DESCRIPTION
Removed the '/v1' suffix from the `spring.ai.openai.base-url` examples in the OpenAI Chat documentation.

The `OpenAiApi` already includes `/v1` in the default `completionsPath` (`/v1/chat/completions`). Including it in the base-url causes a double `/v1/v1` path in the final request URL. This change aligns the documentation with the actual client behavior.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc