### PR TITLE
fix:Advisor parameters lost when mutate ChatClient

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -820,7 +820,11 @@ public class DefaultChatClient implements ChatClient {
 				.defaultToolNames(StringUtils.toStringArray(this.toolNames));
 
 			if (!CollectionUtils.isEmpty(this.advisors)) {
-				builder.defaultAdvisors(a -> a.advisors(this.advisors).params(this.advisorParams));
+				builder.defaultAdvisors(a -> a.advisors(this.advisors));
+			}
+
+			if (!CollectionUtils.isEmpty(this.advisorParams)) {
+				builder.defaultAdvisors(a -> a.params(this.advisorParams));
 			}
 
 			if (StringUtils.hasText(this.userText)) {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientTests.java
@@ -409,6 +409,20 @@ public class ChatClientTests {
 	}
 
 	@Test
+	void mutateAdvisorParams() {
+		ChatClient defaultChatClient = ChatClient.builder(this.chatModel)
+			.defaultAdvisors(AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT)
+			.build();
+
+		ChatClient mutatedChatClient = defaultChatClient.mutate().build();
+
+		ChatClient.ChatClientRequestSpec prompt = mutatedChatClient.prompt();
+
+		assertThat(((DefaultChatClient.DefaultChatClientRequestSpec) prompt).getAdvisorParams())
+			.containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
+	}
+
+	@Test
 	void mutatePrompt() {
 
 		ToolCallingChatOptions options = new DefaultToolCallingChatOptions();


### PR DESCRIPTION
- Fixed issue where advisor parameters were lost when advisors were not present during ChatClient mutation.
- Added test case mutateAdvisorParams to ensure correct parameter mutation handling.