### PR TITLE
[java doc] outdated the OpenTelemetry Semantic Conventions reference link in VectorStoreSimilarityMetric Javadoc

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/VectorStoreSimilarityMetric.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/VectorStoreSimilarityMetric.java
@@ -24,8 +24,8 @@ package org.springframework.ai.observation.conventions;
  * @author Thomas Vitale
  * @since 1.0.0
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/db">DB
- * Semantic Conventions</a>.
+ * "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/db">DB Semantic
+ * Conventions</a>.
  */
 public enum VectorStoreSimilarityMetric {
 


### PR DESCRIPTION
The previously referenced URL:

```
https://github.com/open-telemetry/semantic-conventions/tree/main/docs/database
```
now returns 404, as the OpenTelemetry project has renamed the directory from
docs/database to docs/db.
```
https://github.com/open-telemetry/semantic-conventions/tree/main/docs/db
```

No functional or behavioral changes to the code.