### PR TITLE
Allow for customization of JSON schema in BeanOutputConverter

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/converter/BeanOutputConverter.java
@@ -203,6 +203,7 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 		SchemaGeneratorConfig config = configBuilder.build();
 		SchemaGenerator generator = new SchemaGenerator(config);
 		JsonNode jsonNode = generator.generateSchema(this.type);
+		postProcessSchema(jsonNode);
 		ObjectWriter objectWriter = this.objectMapper.writer(new DefaultPrettyPrinter()
 			.withObjectIndenter(new DefaultIndenter().withLinefeed(System.lineSeparator())));
 		try {
@@ -212,6 +213,13 @@ public class BeanOutputConverter<T> implements StructuredOutputConverter<T> {
 			logger.error("Could not pretty print json schema for jsonNode: {}", jsonNode);
 			throw new RuntimeException("Could not pretty print json schema for " + this.type, e);
 		}
+	}
+
+	/**
+	 * Empty template method that allows for customization of the JSON schema in subclasses.
+	 * @param jsonNode the JSON schema, in the form of a JSON node
+	 */
+	protected void postProcessSchema(@NonNull JsonNode jsonNode) {
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces an empty template in the BeanOutputConverter that allows for customization of the JSON schema.