### PR TITLE
Make mongodb starter optional for Testcontainers and Docker Compose modules

### DIFF
--- a/spring-ai-spring-boot-docker-compose/pom.xml
+++ b/spring-ai-spring-boot-docker-compose/pom.xml
@@ -104,6 +104,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mongodb</artifactId>
+			<optional>true</optional>
 		</dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -124,6 +124,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+			<optional>true</optional>
 		</dependency>
 
 


### PR DESCRIPTION
Currently, `org.springframework.boot:spring-boot-starter-data-mongodb` and
`org.springframework.boot:spring-boot-starter-mongodb` are transitive dependencies.
This should not be the case for Testcontainers and Docker Compose modules.

Signed-off-by: Eddú Meléndez <eddu.melendez@gmail.com>
