### PR TITLE
Polish MistralAiOcrAutoConfiguration

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -47,6 +47,12 @@
       "type": "java.lang.String",
       "description": "The primary ModerationModel to autoconfigure. If not set, each ModerationModel auto-configuration is enabled by default.",
       "defaultValue": ""
+    },
+    {
+      "name": "spring.ai.model.ocr",
+      "type": "java.lang.String",
+      "description": "The primary OcrModel to autoconfigure. If not set, each OcrModel auto-configuration is enabled by default.",
+      "defaultValue": ""
     }
   ]
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/main/java/org/springframework/ai/model/mistralai/autoconfigure/MistralAiOcrAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.model.mistralai.autoconfigure;
 
 import org.springframework.ai.mistralai.ocr.MistralOcrApi;
+import org.springframework.ai.model.SpringAIModelProperties;
 import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.beans.factory.ObjectProvider;
@@ -39,7 +40,8 @@ import org.springframework.web.client.RestClient;
  */
 @AutoConfiguration
 @ConditionalOnClass(MistralOcrApi.class)
-@ConditionalOnProperty(name = "spring.ai.model.ocr", havingValue = SpringAIModels.MISTRAL, matchIfMissing = true)
+@ConditionalOnProperty(name = SpringAIModelProperties.OCR_MODEL, havingValue = SpringAIModels.MISTRAL,
+		matchIfMissing = true)
 @EnableConfigurationProperties({ MistralAiCommonProperties.class, MistralAiOcrProperties.class })
 public class MistralAiOcrAutoConfiguration {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/test/java/org/springframework/ai/model/mistralai/autoconfigure/MistralModelConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/src/test/java/org/springframework/ai/model/mistralai/autoconfigure/MistralModelConfigurationTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.mistralai.MistralAiChatModel;
 import org.springframework.ai.mistralai.MistralAiEmbeddingModel;
 import org.springframework.ai.mistralai.moderation.MistralAiModerationModel;
+import org.springframework.ai.mistralai.ocr.MistralOcrApi;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -36,25 +37,30 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Ilayaperumal Gopinathan
  * @author Ricken Bazolo
  * @author Issam El-atif
+ * @author Nicolas Krier
  */
-public class MistralModelConfigurationTests {
+class MistralModelConfigurationTests {
 
-	private final ApplicationContextRunner chatContextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.ai.mistralai.api-key=" + System.getenv("MISTRAL_AI_API_KEY"))
-		.withConfiguration(AutoConfigurations.of(MistralAiChatAutoConfiguration.class,
-				RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class,
-				ToolCallingAutoConfiguration.class, WebClientAutoConfiguration.class));
+	private final ApplicationContextRunner chatContextRunner = createApplicationContextRunner(
+			MistralAiChatAutoConfiguration.class, RestClientAutoConfiguration.class,
+			SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class, WebClientAutoConfiguration.class);
 
-	private final ApplicationContextRunner embeddingContextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.ai.mistralai.api-key=" + System.getenv("MISTRAL_AI_API_KEY"))
-		.withConfiguration(AutoConfigurations.of(MistralAiEmbeddingAutoConfiguration.class,
-				RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class));
+	private final ApplicationContextRunner embeddingContextRunner = createApplicationContextRunner(
+			MistralAiEmbeddingAutoConfiguration.class, RestClientAutoConfiguration.class,
+			SpringAiRetryAutoConfiguration.class);
 
-	private final ApplicationContextRunner moderationContextRunner = new ApplicationContextRunner()
-		.withPropertyValues("spring.ai.mistralai.api-key=" + System.getenv("MISTRAL_AI_API_KEY"))
-		.withConfiguration(
-				AutoConfigurations.of(MistralAiModerationAutoConfiguration.class, RestClientAutoConfiguration.class,
-						SpringAiRetryAutoConfiguration.class, WebClientAutoConfiguration.class));
+	private final ApplicationContextRunner moderationContextRunner = createApplicationContextRunner(
+			MistralAiModerationAutoConfiguration.class, RestClientAutoConfiguration.class,
+			SpringAiRetryAutoConfiguration.class);
+
+	private final ApplicationContextRunner ocrContextRunner = createApplicationContextRunner(
+			MistralAiOcrAutoConfiguration.class, RestClientAutoConfiguration.class,
+			SpringAiRetryAutoConfiguration.class);
+
+	private static ApplicationContextRunner createApplicationContextRunner(Class<?>... autoConfigurationClasses) {
+		return new ApplicationContextRunner().withPropertyValues("spring.ai.mistralai.apiKey=FAKED_API_KEY")
+			.withConfiguration(AutoConfigurations.of(autoConfigurationClasses));
+	}
 
 	@Test
 	void chatModelActivation() {
@@ -129,6 +135,24 @@ public class MistralModelConfigurationTests {
 				assertThat(context.getBeansOfType(MistralAiEmbeddingModel.class)).isEmpty();
 				assertThat(context.getBeansOfType(MistralAiChatModel.class)).isEmpty();
 			});
+	}
+
+	@Test
+	void ocrModelActivation() {
+		this.ocrContextRunner.run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).hasSingleBean(MistralOcrApi.class);
+		});
+
+		this.ocrContextRunner.withPropertyValues("spring.ai.model.ocr=mistral").run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).hasSingleBean(MistralOcrApi.class);
+		});
+
+		this.ocrContextRunner.withPropertyValues("spring.ai.model.ocr=none").run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).doesNotHaveBean(MistralOcrApi.class);
+		});
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModelProperties.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModelProperties.java
@@ -40,4 +40,6 @@ public final class SpringAIModelProperties {
 
 	public static final String MODERATION_MODEL = MODEL_PREFIX + ".moderation";
 
+	public static final String OCR_MODEL = MODEL_PREFIX + ".ocr";
+
 }


### PR DESCRIPTION
- Add OCR model constant in SpringAIModelProperties
- Use OCR model constant in MistralAiOcrAutoConfiguration
- Add spring.ai.model.ocr property in additional-spring-configuration-metadata.json file
- Add unit tests verifying OCR model activation feature
- Refactor existing unit tests