### PR TITLE
feat(google-genai): add Gemini Text-to-Speech (TTS) implementation

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsAutoConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.tts;
+
+import org.springframework.ai.google.genai.tts.GeminiTtsModel;
+import org.springframework.ai.google.genai.tts.api.GeminiTtsApi;
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Auto-configuration for Google GenAI Text-to-Speech.
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+@AutoConfiguration(after = SpringAiRetryAutoConfiguration.class)
+@ConditionalOnClass({ GeminiTtsApi.class, GeminiTtsModel.class })
+@ConditionalOnProperty(name = SpringAIModelProperties.AUDIO_SPEECH_MODEL, havingValue = SpringAIModels.GOOGLE_GEN_AI,
+		matchIfMissing = false)
+@EnableConfigurationProperties({ GoogleGenAiTtsProperties.class, GoogleGenAiTtsConnectionProperties.class })
+public class GoogleGenAiTtsAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public GeminiTtsApi geminiTtsApi(GoogleGenAiTtsConnectionProperties connectionProperties) {
+		Assert.hasText(connectionProperties.getApiKey(), "Google GenAI API key must be set!");
+
+		if (StringUtils.hasText(connectionProperties.getBaseUrl())) {
+			return new GeminiTtsApi(connectionProperties.getApiKey(), connectionProperties.getBaseUrl());
+		}
+
+		return new GeminiTtsApi(connectionProperties.getApiKey());
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public GeminiTtsModel geminiTtsModel(GeminiTtsApi geminiTtsApi, GoogleGenAiTtsProperties ttsProperties,
+			RetryTemplate retryTemplate) {
+
+		return GeminiTtsModel.builder()
+			.geminiTtsApi(geminiTtsApi)
+			.defaultOptions(ttsProperties.getOptions())
+			.retryTemplate(retryTemplate)
+			.build();
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsConnectionProperties.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.tts;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Connection properties for Google GenAI TTS.
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+@ConfigurationProperties(GoogleGenAiTtsConnectionProperties.CONFIG_PREFIX)
+public class GoogleGenAiTtsConnectionProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.google.genai";
+
+	/**
+	 * Google GenAI API Key for TTS.
+	 */
+	private String apiKey;
+
+	/**
+	 * Base URL for the Google GenAI TTS API.
+	 */
+	private String baseUrl = "https://generativelanguage.googleapis.com";
+
+	public String getApiKey() {
+		return this.apiKey;
+	}
+
+	public void setApiKey(String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public String getBaseUrl() {
+		return this.baseUrl;
+	}
+
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.tts;
+
+import org.springframework.ai.google.genai.tts.GeminiTtsOptions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for Google GenAI Text-to-Speech.
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+@ConfigurationProperties(GoogleGenAiTtsProperties.CONFIG_PREFIX)
+public class GoogleGenAiTtsProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.google.genai.tts";
+
+	public static final String DEFAULT_MODEL = "gemini-2.5-flash-preview-tts";
+
+	public static final String DEFAULT_VOICE = "Kore";
+
+	/**
+	 * Google GenAI TTS options.
+	 */
+	@NestedConfigurationProperty
+	private final GeminiTtsOptions options = GeminiTtsOptions.builder()
+		.model(DEFAULT_MODEL)
+		.voice(DEFAULT_VOICE)
+		.build();
+
+	public GeminiTtsOptions getOptions() {
+		return this.options;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -16,3 +16,4 @@
 org.springframework.ai.model.google.genai.autoconfigure.chat.GoogleGenAiChatAutoConfiguration
 org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiEmbeddingConnectionAutoConfiguration
 org.springframework.ai.model.google.genai.autoconfigure.embedding.GoogleGenAiTextEmbeddingAutoConfiguration
+org.springframework.ai.model.google.genai.autoconfigure.tts.GoogleGenAiTtsAutoConfiguration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsAutoConfigurationIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.tts;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.google.genai.tts.GeminiTtsModel;
+import org.springframework.ai.utils.SpringAiTestAutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the {@link GoogleGenAiTtsAutoConfiguration}.
+ *
+ * @author Alexandros Pappas
+ */
+@EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".*")
+public class GoogleGenAiTtsAutoConfigurationIT {
+
+	private static final org.apache.commons.logging.Log logger = org.apache.commons.logging.LogFactory
+		.getLog(GoogleGenAiTtsAutoConfigurationIT.class);
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.google.genai.api-key=" + System.getenv("GOOGLE_API_KEY"),
+				"spring.ai.model.audio.speech=google-genai")
+		.withConfiguration(SpringAiTestAutoConfigurations.of(GoogleGenAiTtsAutoConfiguration.class));
+
+	@Test
+	void ttsModelBeanCreation() {
+		this.contextRunner.run(context -> {
+			assertThat(context).hasSingleBean(GeminiTtsModel.class);
+			GeminiTtsModel ttsModel = context.getBean(GeminiTtsModel.class);
+			assertThat(ttsModel).isNotNull();
+		});
+	}
+
+	@Test
+	void ttsModelApiCall() {
+		this.contextRunner.run(context -> {
+			GeminiTtsModel ttsModel = context.getBean(GeminiTtsModel.class);
+			byte[] response = ttsModel.call("Hello");
+
+			assertThat(response).isNotNull();
+			assertThat(response).isNotEmpty();
+			// PCM audio should be substantial (24kHz * 2 bytes/sample * ~1 second)
+			assertThat(response.length).isGreaterThan(1000);
+
+			logger.debug("PCM audio response size: " + response.length + " bytes");
+		});
+	}
+
+	@Test
+	void ttsModelWithCustomVoice() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.google.genai.tts.options.voice=Puck",
+					"spring.ai.google.genai.tts.options.model=gemini-2.5-flash-preview-tts")
+			.run(context -> {
+				GeminiTtsModel ttsModel = context.getBean(GeminiTtsModel.class);
+				byte[] response = ttsModel.call("Testing custom voice");
+
+				assertThat(response).isNotNull();
+				assertThat(response).isNotEmpty();
+				assertThat(response.length).isGreaterThan(1000);
+			});
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/tts/GoogleGenAiTtsPropertiesTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.google.genai.autoconfigure.tts;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for Google GenAI TTS properties binding.
+ *
+ * @author Alexandros Pappas
+ */
+public class GoogleGenAiTtsPropertiesTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(PropertiesTestConfiguration.class);
+
+	@Test
+	void connectionPropertiesBinding() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.google.genai.api-key=test-tts-key",
+					"spring.ai.google.genai.base-url=https://test.api.google.com")
+			.run(context -> {
+				GoogleGenAiTtsConnectionProperties connectionProperties = context
+					.getBean(GoogleGenAiTtsConnectionProperties.class);
+				assertThat(connectionProperties.getApiKey()).isEqualTo("test-tts-key");
+				assertThat(connectionProperties.getBaseUrl()).isEqualTo("https://test.api.google.com");
+			});
+	}
+
+	@Test
+	void ttsPropertiesBinding() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.google.genai.tts.options.model=gemini-2.5-pro-preview-tts",
+					"spring.ai.google.genai.tts.options.voice=Puck", "spring.ai.google.genai.tts.options.speed=1.2")
+			.run(context -> {
+				GoogleGenAiTtsProperties ttsProperties = context.getBean(GoogleGenAiTtsProperties.class);
+				assertThat(ttsProperties.getOptions().getModel()).isEqualTo("gemini-2.5-pro-preview-tts");
+				assertThat(ttsProperties.getOptions().getVoice()).isEqualTo("Puck");
+				assertThat(ttsProperties.getOptions().getSpeed()).isEqualTo(1.2);
+			});
+	}
+
+	@Test
+	void ttsDefaultValuesBinding() {
+		// Test that defaults are applied when not specified
+		this.contextRunner.run(context -> {
+			GoogleGenAiTtsProperties ttsProperties = context.getBean(GoogleGenAiTtsProperties.class);
+			assertThat(ttsProperties.getOptions().getModel()).isEqualTo("gemini-2.5-flash-preview-tts");
+			assertThat(ttsProperties.getOptions().getVoice()).isEqualTo("Kore");
+			assertThat(ttsProperties.getOptions().getFormat()).isEqualTo("pcm");
+		});
+	}
+
+	@Test
+	void connectionDefaultBaseUrl() {
+		this.contextRunner.withPropertyValues("spring.ai.google.genai.api-key=test-key").run(context -> {
+			GoogleGenAiTtsConnectionProperties connectionProperties = context
+				.getBean(GoogleGenAiTtsConnectionProperties.class);
+			assertThat(connectionProperties.getBaseUrl()).isEqualTo("https://generativelanguage.googleapis.com");
+		});
+	}
+
+	@Configuration
+	@EnableConfigurationProperties({ GoogleGenAiTtsConnectionProperties.class, GoogleGenAiTtsProperties.class })
+	static class PropertiesTestConfiguration {
+
+	}
+
+}

--- a/models/spring-ai-google-genai/README.md
+++ b/models/spring-ai-google-genai/README.md
@@ -127,3 +127,156 @@ Usage usage = response.getMetadata().getUsage();
 Long promptTokens = usage.getPromptTokens();
 Long completionTokens = usage.getCompletionTokens();
 ```
+
+## Text-to-Speech (TTS)
+
+The Google GenAI module provides native text-to-speech capabilities through the `GeminiTtsModel` class, supporting both single-speaker and multi-speaker voice synthesis.
+
+### Features
+
+- **30+ Voices**: Wide selection of voices across 24+ languages
+- **Single-Speaker TTS**: Simple voice synthesis with style control
+- **Multi-Speaker TTS**: Conversational dialogue with multiple voices
+- **Prompt-Based Control**: Natural language directives for accent, pace, and style
+- **PCM Audio Output**: High-quality 24kHz, mono, s16le PCM audio
+
+### Basic Usage (Single-Speaker)
+
+```java
+@Component
+public class TextToSpeechExample {
+
+    private final GeminiTtsModel ttsModel;
+
+    public byte[] generateSpeech(String text) {
+        // Simple convenience method
+        byte[] audioData = ttsModel.call(text);
+        return audioData;
+    }
+
+    public byte[] generateWithPrompt() {
+        // Using TextToSpeechPrompt for more control
+        TextToSpeechPrompt prompt = new TextToSpeechPrompt(
+            "Say cheerfully: Have a wonderful day!"
+        );
+
+        TextToSpeechResponse response = ttsModel.call(prompt);
+        return response.getResult().getOutput();
+    }
+}
+```
+
+### Voice Selection
+
+Specify a voice using `GeminiTtsOptions`:
+
+```java
+GeminiTtsOptions options = GeminiTtsOptions.builder()
+    .model("gemini-2.5-flash-preview-tts")
+    .voice("Puck")  // Choose from 30+ available voices
+    .speed(1.1)     // Optional: Adjust speech speed
+    .build();
+
+TextToSpeechPrompt prompt = new TextToSpeechPrompt(
+    "Hello, this is using a specific voice.",
+    options
+);
+
+byte[] audioData = ttsModel.call(prompt).getResult().getOutput();
+```
+
+### Multi-Speaker Conversations
+
+For dialogue with multiple speakers, use speaker voice configurations:
+
+```java
+// Define speakers with their voice assignments
+GeminiTtsApi.SpeakerVoiceConfig joe = new GeminiTtsApi.SpeakerVoiceConfig("Joe",
+    new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Kore")));
+
+GeminiTtsApi.SpeakerVoiceConfig jane = new GeminiTtsApi.SpeakerVoiceConfig("Jane",
+    new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Puck")));
+
+// Configure multi-speaker options
+GeminiTtsOptions options = GeminiTtsOptions.builder()
+    .model("gemini-2.5-flash-preview-tts")
+    .speakerVoiceConfigs(List.of(joe, jane))
+    .build();
+
+// Provide dialogue text with speaker labels
+String conversation = """
+    TTS the following conversation between Joe and Jane:
+    Joe: How's it going today Jane?
+    Jane: Not too bad, how about you?
+    Joe: Pretty good, thanks for asking!
+    """;
+
+TextToSpeechPrompt prompt = new TextToSpeechPrompt(conversation, options);
+byte[] audioData = ttsModel.call(prompt).getResult().getOutput();
+```
+
+### Prompt-Based Style Control
+
+Use natural language directives in your text to control delivery:
+
+```java
+// Control accent, pace, and style through prompts
+String text = """
+    Say in a British accent with a slow, dramatic pace:
+    To be, or not to be, that is the question.
+    """;
+
+byte[] audioData = ttsModel.call(text);
+```
+
+### Configuration
+
+Create and configure the TTS model:
+
+```java
+@Configuration
+public class TtsConfiguration {
+
+    @Bean
+    public GeminiTtsModel geminiTtsModel(
+            @Value("${spring.ai.google-genai.api-key}") String apiKey) {
+
+        GeminiTtsApi api = new GeminiTtsApi(apiKey);
+
+        GeminiTtsOptions defaultOptions = GeminiTtsOptions.builder()
+            .model("gemini-2.5-flash-preview-tts")
+            .voice("Kore")
+            .build();
+
+        return new GeminiTtsModel(api, defaultOptions);
+    }
+}
+```
+
+### Available Voices
+
+The Gemini TTS API provides 30+ voices including:
+- **Kore**: Neutral, versatile voice
+- **Puck**: Warm, friendly voice
+- **Charon**: Deep, authoritative voice
+- **Zephyr**: Light, energetic voice
+- And many more across 24+ languages
+
+### Audio Format
+
+Gemini TTS returns PCM audio with the following specifications:
+- **Format**: PCM (s16le)
+- **Sample Rate**: 24kHz
+- **Channels**: Mono
+
+To convert to other formats (e.g., WAV, MP3), use audio processing libraries like FFmpeg:
+
+```bash
+# Convert PCM to WAV using FFmpeg
+ffmpeg -f s16le -ar 24000 -ac 1 -i output.pcm output.wav
+```
+
+### Additional Resources
+
+For more information about Gemini TTS, including rate limits and API options, see:
+- [Gemini Speech Generation Documentation](https://ai.google.dev/gemini-api/docs/speech-generation)

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/GeminiTtsModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/GeminiTtsModel.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.audio.tts.Speech;
+import org.springframework.ai.audio.tts.TextToSpeechModel;
+import org.springframework.ai.audio.tts.TextToSpeechPrompt;
+import org.springframework.ai.audio.tts.TextToSpeechResponse;
+import org.springframework.ai.google.genai.tts.api.GeminiTtsApi;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+
+/**
+ * Google Gemini Text-to-Speech model implementation.
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+public class GeminiTtsModel implements TextToSpeechModel {
+
+	private static final Logger logger = LoggerFactory.getLogger(GeminiTtsModel.class);
+
+	private final GeminiTtsApi geminiTtsApi;
+
+	private final GeminiTtsOptions defaultOptions;
+
+	private final RetryTemplate retryTemplate;
+
+	/**
+	 * Create a new GeminiTtsModel with default retry template.
+	 * @param geminiTtsApi The API client
+	 * @param defaultOptions Default options
+	 */
+	public GeminiTtsModel(GeminiTtsApi geminiTtsApi, GeminiTtsOptions defaultOptions) {
+		this(geminiTtsApi, defaultOptions, RetryUtils.DEFAULT_RETRY_TEMPLATE);
+	}
+
+	/**
+	 * Create a new GeminiTtsModel with custom retry template.
+	 * @param geminiTtsApi The API client
+	 * @param defaultOptions Default options
+	 * @param retryTemplate Retry template
+	 */
+	public GeminiTtsModel(GeminiTtsApi geminiTtsApi, GeminiTtsOptions defaultOptions, RetryTemplate retryTemplate) {
+		Assert.notNull(geminiTtsApi, "GeminiTtsApi must not be null");
+		Assert.notNull(defaultOptions, "GeminiTtsOptions must not be null");
+		Assert.notNull(retryTemplate, "RetryTemplate must not be null");
+
+		this.geminiTtsApi = geminiTtsApi;
+		this.defaultOptions = defaultOptions;
+		this.retryTemplate = retryTemplate;
+	}
+
+	/**
+	 * Create a new builder for GeminiTtsModel.
+	 * @return a new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public TextToSpeechResponse call(TextToSpeechPrompt prompt) {
+		Assert.notNull(prompt, "Prompt must not be null");
+
+		GeminiTtsOptions options = mergeOptions(prompt);
+		GeminiTtsApi.GenerateContentRequest request = createRequest(prompt, options);
+		String model = options.getModel();
+
+		ResponseEntity<GeminiTtsApi.GenerateContentResponse> responseEntity = RetryUtils.execute(this.retryTemplate,
+				() -> this.geminiTtsApi.generateContent(model, request));
+
+		GeminiTtsApi.GenerateContentResponse response = responseEntity.getBody();
+		if (response == null) {
+			logger.warn("No response returned for model: {}", model);
+			return new TextToSpeechResponse(List.of(new Speech(new byte[0])));
+		}
+
+		byte[] audioData = GeminiTtsApi.extractAudioData(response);
+		return new TextToSpeechResponse(List.of(new Speech(audioData)));
+	}
+
+	@Override
+	public Flux<TextToSpeechResponse> stream(TextToSpeechPrompt prompt) {
+		// Gemini TTS API doesn't support streaming, return single response
+		return Flux.just(call(prompt));
+	}
+
+	@Override
+	public GeminiTtsOptions getDefaultOptions() {
+		return this.defaultOptions;
+	}
+
+	private GeminiTtsOptions mergeOptions(TextToSpeechPrompt prompt) {
+		GeminiTtsOptions runtimeOptions = (prompt.getOptions() instanceof GeminiTtsOptions geminiOptions)
+				? geminiOptions : null;
+
+		if (runtimeOptions == null) {
+			return this.defaultOptions;
+		}
+
+		return GeminiTtsOptions.builder()
+			.model(getOrDefault(runtimeOptions.getModel(), this.defaultOptions.getModel()))
+			.voice(getOrDefault(runtimeOptions.getVoice(), this.defaultOptions.getVoice()))
+			.speakerVoiceConfigs(
+					getOrDefault(runtimeOptions.getSpeakerVoiceConfigs(), this.defaultOptions.getSpeakerVoiceConfigs()))
+			.speed(getOrDefault(runtimeOptions.getSpeed(), this.defaultOptions.getSpeed()))
+			.build();
+	}
+
+	private <T> T getOrDefault(T runtimeValue, T defaultValue) {
+		return runtimeValue != null ? runtimeValue : defaultValue;
+	}
+
+	private GeminiTtsApi.GenerateContentRequest createRequest(TextToSpeechPrompt prompt, GeminiTtsOptions options) {
+		String text = prompt.getInstructions().getText();
+		Assert.hasText(text, "Prompt text must not be empty");
+
+		// Create content part with text
+		GeminiTtsApi.Part part = new GeminiTtsApi.Part(text);
+		GeminiTtsApi.Content content = new GeminiTtsApi.Content(List.of(part));
+
+		// Create speech config (single-speaker or multi-speaker)
+		GeminiTtsApi.SpeechConfig speechConfig = createSpeechConfig(options);
+
+		// Create generation config
+		GeminiTtsApi.GenerationConfig generationConfig = new GeminiTtsApi.GenerationConfig(List.of("AUDIO"),
+				speechConfig);
+
+		return new GeminiTtsApi.GenerateContentRequest(List.of(content), generationConfig);
+	}
+
+	private GeminiTtsApi.SpeechConfig createSpeechConfig(GeminiTtsOptions options) {
+		// Multi-speaker configuration takes precedence
+		if (options.getSpeakerVoiceConfigs() != null && !options.getSpeakerVoiceConfigs().isEmpty()) {
+			GeminiTtsApi.MultiSpeakerVoiceConfig multiSpeakerConfig = new GeminiTtsApi.MultiSpeakerVoiceConfig(
+					options.getSpeakerVoiceConfigs());
+
+			return new GeminiTtsApi.SpeechConfig(null, multiSpeakerConfig);
+		}
+
+		// Single-speaker configuration
+		String voiceName = options.getVoice();
+		Assert.hasText(voiceName, "Voice name must be specified for single-speaker TTS");
+
+		GeminiTtsApi.VoiceConfig voiceConfig = new GeminiTtsApi.VoiceConfig(
+				new GeminiTtsApi.PrebuiltVoiceConfig(voiceName));
+
+		return new GeminiTtsApi.SpeechConfig(voiceConfig, null);
+	}
+
+	/**
+	 * Builder for creating GeminiTtsModel instances.
+	 */
+	public static final class Builder {
+
+		private GeminiTtsApi geminiTtsApi;
+
+		private RetryTemplate retryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+
+		private GeminiTtsOptions defaultOptions;
+
+		/**
+		 * Sets the Gemini TTS API client.
+		 * @param geminiTtsApi the API client to use
+		 * @return this builder
+		 */
+		public Builder geminiTtsApi(GeminiTtsApi geminiTtsApi) {
+			this.geminiTtsApi = geminiTtsApi;
+			return this;
+		}
+
+		/**
+		 * Sets the retry template for handling transient failures. If not specified, uses
+		 * {@link RetryUtils#DEFAULT_RETRY_TEMPLATE}.
+		 * @param retryTemplate the retry template to use
+		 * @return this builder
+		 */
+		public Builder retryTemplate(RetryTemplate retryTemplate) {
+			this.retryTemplate = retryTemplate;
+			return this;
+		}
+
+		/**
+		 * Sets the default options for text-to-speech generation. These options will be
+		 * used when no runtime options are specified in the prompt.
+		 * @param defaultOptions the default options to use
+		 * @return this builder
+		 */
+		public Builder defaultOptions(GeminiTtsOptions defaultOptions) {
+			this.defaultOptions = defaultOptions;
+			return this;
+		}
+
+		/**
+		 * Builds the GeminiTtsModel instance.
+		 * @return a new GeminiTtsModel instance
+		 * @throws IllegalArgumentException if geminiTtsApi or defaultOptions are null
+		 */
+		public GeminiTtsModel build() {
+			Assert.notNull(this.geminiTtsApi, "GeminiTtsApi must not be null");
+			Assert.notNull(this.defaultOptions, "GeminiTtsOptions must not be null");
+			return new GeminiTtsModel(this.geminiTtsApi, this.defaultOptions, this.retryTemplate);
+		}
+
+	}
+
+}

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/GeminiTtsOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/GeminiTtsOptions.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.springframework.ai.audio.tts.TextToSpeechOptions;
+import org.springframework.ai.google.genai.tts.api.GeminiTtsApi;
+
+/**
+ * Options for Google Gemini Text-to-Speech.
+ *
+ * Supports both single-speaker and multi-speaker configurations. For single-speaker, use
+ * {@link #getVoice()}. For multi-speaker, use {@link #getSpeakerVoiceConfigs()}.
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GeminiTtsOptions implements TextToSpeechOptions {
+
+	@JsonProperty("model")
+	private String model;
+
+	@JsonProperty("voice")
+	private String voice;
+
+	@JsonProperty("speaker_voice_configs")
+	private List<GeminiTtsApi.SpeakerVoiceConfig> speakerVoiceConfigs;
+
+	@JsonProperty("speed")
+	private Double speed;
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	@JsonIgnore
+	public String getModel() {
+		return this.model;
+	}
+
+	@JsonIgnore
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	@Override
+	@JsonIgnore
+	public String getVoice() {
+		return this.voice;
+	}
+
+	@JsonIgnore
+	public void setVoice(String voice) {
+		this.voice = voice;
+	}
+
+	/**
+	 * Get the multi-speaker voice configurations.
+	 * @return List of speaker voice configurations, or null for single-speaker
+	 */
+	public List<GeminiTtsApi.SpeakerVoiceConfig> getSpeakerVoiceConfigs() {
+		return this.speakerVoiceConfigs;
+	}
+
+	public void setSpeakerVoiceConfigs(List<GeminiTtsApi.SpeakerVoiceConfig> speakerVoiceConfigs) {
+		this.speakerVoiceConfigs = speakerVoiceConfigs;
+	}
+
+	@Override
+	@JsonIgnore
+	public String getFormat() {
+		// Gemini TTS always returns PCM audio
+		return "pcm";
+	}
+
+	@Override
+	@JsonIgnore
+	public Double getSpeed() {
+		return this.speed;
+	}
+
+	@JsonIgnore
+	public void setSpeed(Double speed) {
+		this.speed = speed;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public GeminiTtsOptions copy() {
+		return GeminiTtsOptions.builder()
+			.model(this.model)
+			.voice(this.voice)
+			.speakerVoiceConfigs(this.speakerVoiceConfigs != null ? List.copyOf(this.speakerVoiceConfigs) : null)
+			.speed(this.speed)
+			.build();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof GeminiTtsOptions that)) {
+			return false;
+		}
+		return Objects.equals(this.model, that.model) && Objects.equals(this.voice, that.voice)
+				&& Objects.equals(this.speakerVoiceConfigs, that.speakerVoiceConfigs)
+				&& Objects.equals(this.speed, that.speed);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.model, this.voice, this.speakerVoiceConfigs, this.speed);
+	}
+
+	@Override
+	public String toString() {
+		return "GeminiTtsOptions{" + "model='" + this.model + '\'' + ", voice='" + this.voice + '\''
+				+ ", speakerVoiceConfigs=" + this.speakerVoiceConfigs + ", speed=" + this.speed + '}';
+	}
+
+	public static final class Builder {
+
+		private final GeminiTtsOptions options = new GeminiTtsOptions();
+
+		/**
+		 * Sets the model name for text-to-speech generation.
+		 * @param model The model name (e.g., "gemini-2.5-flash-preview-tts",
+		 * "gemini-2.5-pro-preview-tts")
+		 * @return this builder
+		 */
+		public Builder model(String model) {
+			this.options.setModel(model);
+			return this;
+		}
+
+		/**
+		 * Sets the voice name for single-speaker text-to-speech. Mutually exclusive with
+		 * {@link #speakerVoiceConfigs(List)}.
+		 * @param voice The voice name (e.g., "Kore", "Puck", "Zephyr", "Charon")
+		 * @return this builder
+		 */
+		public Builder voice(String voice) {
+			this.options.setVoice(voice);
+			return this;
+		}
+
+		/**
+		 * Sets the speaker voice configurations for multi-speaker text-to-speech.
+		 * Mutually exclusive with {@link #voice(String)}. Supports up to 2 speakers.
+		 * @param speakerVoiceConfigs List of speaker voice configurations
+		 * @return this builder
+		 */
+		public Builder speakerVoiceConfigs(List<GeminiTtsApi.SpeakerVoiceConfig> speakerVoiceConfigs) {
+			this.options.setSpeakerVoiceConfigs(speakerVoiceConfigs);
+			return this;
+		}
+
+		/**
+		 * Sets the speech speed/rate. Note: Gemini TTS controls pace via text prompts
+		 * (e.g., "Speak at a faster pace"), not via this parameter. This field exists for
+		 * {@link TextToSpeechOptions} interface compatibility but is not sent to the API.
+		 * @param speed The speed value (currently not used by Gemini API)
+		 * @return this builder
+		 */
+		public Builder speed(Double speed) {
+			this.options.setSpeed(speed);
+			return this;
+		}
+
+		/**
+		 * Builds the GeminiTtsOptions instance.
+		 * @return the configured GeminiTtsOptions
+		 */
+		public GeminiTtsOptions build() {
+			return this.options;
+		}
+
+	}
+
+}

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/aot/GeminiTtsRuntimeHints.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/aot/GeminiTtsRuntimeHints.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts.aot;
+
+import org.springframework.ai.google.genai.tts.api.GeminiTtsApi;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import static org.springframework.ai.aot.AiRuntimeHints.findJsonAnnotatedClassesInPackage;
+
+/**
+ * The GeminiTtsRuntimeHints class is responsible for registering runtime hints for Gemini
+ * TTS API classes to support GraalVM native image compilation.
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+public class GeminiTtsRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(@NonNull RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		var mcs = MemberCategory.values();
+		for (var tr : findJsonAnnotatedClassesInPackage(GeminiTtsApi.class)) {
+			hints.reflection().registerType(tr, mcs);
+		}
+	}
+
+}

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/api/GeminiTtsApi.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/api/GeminiTtsApi.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts.api;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Client for Google Gemini Text-to-Speech (TTS) API.
+ *
+ * <p>
+ * This API provides text-to-speech capabilities using Gemini models. It supports both
+ * single-speaker and multi-speaker audio generation.
+ *
+ * <p>
+ * Example usage for single-speaker: <pre>{@code
+ * GeminiTtsApi api = new GeminiTtsApi("https://generativelanguage.googleapis.com/v1beta", apiKey);
+ *
+ * var voiceConfig = new VoiceConfig(new PrebuiltVoiceConfig("Kore"));
+ * var speechConfig = new SpeechConfig(voiceConfig, null);
+ * var generationConfig = new GenerationConfig(List.of("AUDIO"), speechConfig);
+ * var content = new Content(List.of(new Part("Say hello world!")));
+ * var request = new GenerateContentRequest(List.of(content), generationConfig);
+ *
+ * ResponseEntity<GenerateContentResponse> response = api.generateContent("gemini-2.5-flash-preview-tts", request);
+ * byte[] audioData = GeminiTtsApi.extractAudioData(response.getBody());
+ * }</pre>
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+public class GeminiTtsApi {
+
+	private static final String DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+
+	private final RestClient restClient;
+
+	/**
+	 * Create a new Gemini TTS API client with default base URL.
+	 * @param apiKey The API key for authentication
+	 */
+	public GeminiTtsApi(String apiKey) {
+		this(DEFAULT_BASE_URL, apiKey);
+	}
+
+	/**
+	 * Create a new Gemini TTS API client.
+	 * @param baseUrl The base URL for the API
+	 * @param apiKey The API key for authentication
+	 */
+	public GeminiTtsApi(String baseUrl, String apiKey) {
+		this(baseUrl, apiKey, RestClient.builder());
+	}
+
+	/**
+	 * Create a new Gemini TTS API client with custom RestClient builder.
+	 * @param baseUrl The base URL for the API
+	 * @param apiKey The API key for authentication
+	 * @param restClientBuilder RestClient builder for customization
+	 */
+	public GeminiTtsApi(String baseUrl, String apiKey, RestClient.Builder restClientBuilder) {
+		this(baseUrl, apiKey, restClientBuilder, HttpHeaders::new);
+	}
+
+	/**
+	 * Create a new Gemini TTS API client with custom headers.
+	 * @param baseUrl The base URL for the API
+	 * @param apiKey The API key for authentication
+	 * @param restClientBuilder RestClient builder for customization
+	 * @param defaultHeaders Consumer for adding default headers
+	 */
+	public GeminiTtsApi(String baseUrl, String apiKey, RestClient.Builder restClientBuilder,
+			Consumer<HttpHeaders> defaultHeaders) {
+
+		Assert.hasText(baseUrl, "Base URL must not be empty");
+		Assert.hasText(apiKey, "API key must not be empty");
+		Assert.notNull(restClientBuilder, "RestClient.Builder must not be null");
+
+		this.restClient = restClientBuilder.baseUrl(baseUrl)
+			.defaultHeaders(defaultHeaders)
+			.defaultHeader("x-goog-api-key", apiKey)
+			.build();
+	}
+
+	/**
+	 * Generate speech from text using the specified model.
+	 * @param model The model name (e.g., "gemini-2.5-flash-preview-tts")
+	 * @param request The generation request
+	 * @return Response containing base64-encoded audio data
+	 */
+	public ResponseEntity<GenerateContentResponse> generateContent(String model, GenerateContentRequest request) {
+		Assert.hasText(model, "Model must not be empty");
+		Assert.notNull(request, "Request must not be null");
+
+		return this.restClient.post()
+			.uri("/models/{model}:generateContent", model)
+			.body(request)
+			.retrieve()
+			.toEntity(GenerateContentResponse.class);
+	}
+
+	/**
+	 * Extract and decode the audio data from the response.
+	 * @param response The API response
+	 * @return Decoded PCM audio bytes
+	 */
+	public static byte[] extractAudioData(GenerateContentResponse response) {
+		if (response == null || response.candidates() == null || response.candidates().isEmpty()) {
+			return new byte[0];
+		}
+
+		var candidate = response.candidates().get(0);
+		if (candidate.content() == null || candidate.content().parts() == null
+				|| candidate.content().parts().isEmpty()) {
+			return new byte[0];
+		}
+
+		var part = candidate.content().parts().get(0);
+		if (part.inlineData() == null || part.inlineData().data() == null) {
+			return new byte[0];
+		}
+
+		return Base64.getDecoder().decode(part.inlineData().data());
+	}
+
+	// Request POJOs
+
+	/**
+	 * Request to generate content (audio from text).
+	 *
+	 * @param contents The input content containing text to convert to speech
+	 * @param generationConfig Configuration for the generation including speech settings
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record GenerateContentRequest(@JsonProperty("contents") List<Content> contents,
+			@JsonProperty("generationConfig") GenerationConfig generationConfig) {
+	}
+
+	/**
+	 * Content containing parts to be converted to speech.
+	 *
+	 * @param parts List of parts (typically one text part)
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Content(@JsonProperty("parts") List<Part> parts) {
+	}
+
+	/**
+	 * A part of the content (text to be spoken).
+	 *
+	 * @param text The text content to convert to speech
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Part(@JsonProperty("text") String text) {
+	}
+
+	/**
+	 * Generation configuration specifying output modality and speech settings.
+	 *
+	 * @param responseModalities List of response modalities (e.g., ["AUDIO"])
+	 * @param speechConfig Speech-specific configuration
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record GenerationConfig(@JsonProperty("responseModalities") List<String> responseModalities,
+			@JsonProperty("speechConfig") SpeechConfig speechConfig) {
+	}
+
+	/**
+	 * Speech configuration for single or multi-speaker audio generation.
+	 *
+	 * @param voiceConfig Configuration for single-speaker voice (mutually exclusive with
+	 * multiSpeakerVoiceConfig)
+	 * @param multiSpeakerVoiceConfig Configuration for multi-speaker voices (mutually
+	 * exclusive with voiceConfig)
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record SpeechConfig(@JsonProperty("voiceConfig") VoiceConfig voiceConfig,
+			@JsonProperty("multiSpeakerVoiceConfig") MultiSpeakerVoiceConfig multiSpeakerVoiceConfig) {
+	}
+
+	/**
+	 * Voice configuration for a speaker.
+	 *
+	 * @param prebuiltVoiceConfig The prebuilt voice to use
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record VoiceConfig(@JsonProperty("prebuiltVoiceConfig") PrebuiltVoiceConfig prebuiltVoiceConfig) {
+
+		/**
+		 * Convenience factory method to create a VoiceConfig from a voice name.
+		 * @param voiceName The name of the prebuilt voice (e.g., "Kore", "Puck")
+		 * @return A VoiceConfig instance
+		 */
+		public static VoiceConfig of(String voiceName) {
+			return new VoiceConfig(new PrebuiltVoiceConfig(voiceName));
+		}
+
+	}
+
+	/**
+	 * Prebuilt voice configuration specifying voice name.
+	 *
+	 * @param voiceName Name of the voice (e.g., "Kore", "Puck", "Zephyr")
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record PrebuiltVoiceConfig(@JsonProperty("voiceName") String voiceName) {
+	}
+
+	/**
+	 * Multi-speaker voice configuration.
+	 *
+	 * @param speakerVoiceConfigs List of speaker configurations (up to 2 speakers)
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record MultiSpeakerVoiceConfig(
+			@JsonProperty("speakerVoiceConfigs") List<SpeakerVoiceConfig> speakerVoiceConfigs) {
+	}
+
+	/**
+	 * Configuration for a single speaker in multi-speaker mode.
+	 *
+	 * @param speaker The speaker name (must match the name used in the text prompt)
+	 * @param voiceConfig The voice configuration for this speaker
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record SpeakerVoiceConfig(@JsonProperty("speaker") String speaker,
+			@JsonProperty("voiceConfig") VoiceConfig voiceConfig) {
+
+		/**
+		 * Convenience factory method to create a SpeakerVoiceConfig from speaker and
+		 * voice names.
+		 * @param speaker The speaker name (e.g., "Joe", "Jane")
+		 * @param voiceName The prebuilt voice name (e.g., "Kore", "Puck")
+		 * @return A SpeakerVoiceConfig instance
+		 */
+		public static SpeakerVoiceConfig of(String speaker, String voiceName) {
+			return new SpeakerVoiceConfig(speaker, VoiceConfig.of(voiceName));
+		}
+
+	}
+
+	// Response POJOs
+
+	/**
+	 * Response containing generated content (audio).
+	 *
+	 * @param candidates List of candidate responses (typically one)
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record GenerateContentResponse(@JsonProperty("candidates") List<Candidate> candidates) {
+	}
+
+	/**
+	 * A candidate response.
+	 *
+	 * @param content The content of the response
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Candidate(@JsonProperty("content") ContentResponse content) {
+	}
+
+	/**
+	 * Response content containing parts.
+	 *
+	 * @param parts List of response parts (typically one audio part)
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record ContentResponse(@JsonProperty("parts") List<PartResponse> parts) {
+	}
+
+	/**
+	 * A part of the response content.
+	 *
+	 * @param inlineData The inline data (audio) in the response
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record PartResponse(@JsonProperty("inlineData") InlineData inlineData) {
+	}
+
+	/**
+	 * Inline data in the response.
+	 *
+	 * @param mimeType The MIME type of the data (e.g., "audio/L16;codec=pcm;rate=24000")
+	 * @param data The base64-encoded audio data
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record InlineData(@JsonProperty("mimeType") String mimeType, @JsonProperty("data") String data) {
+	}
+
+}

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/api/package-info.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/tts/api/package-info.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Low-level API client and POJOs for Google Gemini Text-to-Speech.
+ *
+ * <p>
+ * This package contains the HTTP client implementation and request/response data
+ * structures for the Gemini TTS API.
+ *
+ * <h2>Key Classes</h2>
+ * <ul>
+ * <li>{@link org.springframework.ai.google.genai.tts.api.GeminiTtsApi} - RestClient-based
+ * HTTP client</li>
+ * <li>{@link org.springframework.ai.google.genai.tts.api.GeminiTtsApi.GenerateContentRequest}
+ * - API request</li>
+ * <li>{@link org.springframework.ai.google.genai.tts.api.GeminiTtsApi.GenerateContentResponse}
+ * - API response</li>
+ * <li>{@link org.springframework.ai.google.genai.tts.api.GeminiTtsApi.SpeakerVoiceConfig}
+ * - Multi-speaker configuration</li>
+ * </ul>
+ *
+ * <h2>API Endpoint</h2> <pre>
+ * POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+ * </pre>
+ *
+ * @author Alexandros Pappas
+ * @since 1.1.0
+ */
+@NonNullApi
+@NonNullFields
+package org.springframework.ai.google.genai.tts.api;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/models/spring-ai-google-genai/src/main/resources/META-INF/spring/aot.factories
+++ b/models/spring-ai-google-genai/src/main/resources/META-INF/spring/aot.factories
@@ -1,2 +1,3 @@
 org.springframework.aot.hint.RuntimeHintsRegistrar=\
-	org.springframework.ai.google.genai.aot.GoogleGenAiRuntimeHints
+	org.springframework.ai.google.genai.aot.GoogleGenAiRuntimeHints,\
+	org.springframework.ai.google.genai.tts.aot.GeminiTtsRuntimeHints

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/GeminiTtsModelIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/GeminiTtsModelIT.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.audio.tts.TextToSpeechPrompt;
+import org.springframework.ai.audio.tts.TextToSpeechResponse;
+import org.springframework.ai.google.genai.tts.api.GeminiTtsApi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for GeminiTtsModel.
+ *
+ * Requires GOOGLE_API_KEY environment variable.
+ */
+@EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".+")
+class GeminiTtsModelIT {
+
+	private GeminiTtsModel model;
+
+	@BeforeEach
+	void setUp() {
+		String apiKey = System.getenv("GOOGLE_API_KEY");
+		GeminiTtsApi api = new GeminiTtsApi(apiKey);
+		GeminiTtsOptions defaultOptions = GeminiTtsOptions.builder()
+			.model("gemini-2.5-flash-preview-tts")
+			.voice("Kore")
+			.build();
+		this.model = new GeminiTtsModel(api, defaultOptions);
+	}
+
+	@Test
+	void testSingleSpeakerGeneration() {
+		// Arrange
+		String text = "Say cheerfully: Have a wonderful day!";
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt(text);
+
+		// Act
+		TextToSpeechResponse response = this.model.call(prompt);
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(1);
+		byte[] audioData = response.getResult().getOutput();
+		assertThat(audioData).isNotEmpty();
+		assertThat(audioData.length).isGreaterThan(1000); // PCM audio should be
+															// substantial
+	}
+
+	@Test
+	void testMultiSpeakerGeneration() {
+		// Arrange
+		String text = """
+				TTS the following conversation between Joe and Jane:
+				Joe: How's it going today Jane?
+				Jane: Not too bad, how about you?
+				""";
+
+		GeminiTtsApi.SpeakerVoiceConfig joe = GeminiTtsApi.SpeakerVoiceConfig.of("Joe", "Kore");
+		GeminiTtsApi.SpeakerVoiceConfig jane = GeminiTtsApi.SpeakerVoiceConfig.of("Jane", "Puck");
+
+		GeminiTtsOptions options = GeminiTtsOptions.builder()
+			.model("gemini-2.5-flash-preview-tts")
+			.speakerVoiceConfigs(List.of(joe, jane))
+			.build();
+
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt(text, options);
+
+		// Act
+		TextToSpeechResponse response = this.model.call(prompt);
+
+		// Assert
+		assertThat(response).isNotNull();
+		byte[] audioData = response.getResult().getOutput();
+		assertThat(audioData).isNotEmpty();
+		assertThat(audioData.length).isGreaterThan(1000);
+	}
+
+	@Test
+	void testConvenienceMethod() {
+		// Act
+		byte[] audioData = this.model.call("Hello, this is a test.");
+
+		// Assert
+		assertThat(audioData).isNotEmpty();
+	}
+
+	@Test
+	void testDifferentVoices() {
+		// Test multiple voices to ensure voice selection works
+		String[] voices = { "Kore", "Puck", "Zephyr", "Charon" };
+
+		for (String voice : voices) {
+			GeminiTtsOptions options = GeminiTtsOptions.builder()
+				.model("gemini-2.5-flash-preview-tts")
+				.voice(voice)
+				.build();
+
+			TextToSpeechPrompt prompt = new TextToSpeechPrompt("Testing voice: " + voice, options);
+			TextToSpeechResponse response = this.model.call(prompt);
+
+			assertThat(response.getResult().getOutput()).as("Voice %s should produce audio", voice).isNotEmpty();
+		}
+	}
+
+	@Test
+	void testInvalidVoiceName() {
+		// Arrange - use a non-existent voice name
+		GeminiTtsOptions options = GeminiTtsOptions.builder()
+			.model("gemini-2.5-flash-preview-tts")
+			.voice("NonExistentVoiceName123")
+			.build();
+
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("This should fail with an invalid voice.", options);
+
+		// Act & Assert - expect an exception for invalid voice
+		assertThat(this.model.call(prompt).getResult().getOutput())
+			.as("API should handle invalid voice gracefully or return audio")
+			.isNotNull();
+	}
+
+	@Test
+	void testEmptyInputText() {
+		// Arrange
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("");
+
+		// Act
+		TextToSpeechResponse response = this.model.call(prompt);
+
+		// Assert - empty text should either fail or return minimal audio
+		assertThat(response).isNotNull();
+		// The API behavior may vary - it might return empty audio or a short silence
+	}
+
+	@Test
+	void testNullInputText() {
+		// Arrange & Act & Assert
+		assertThat(org.assertj.core.api.Assertions.catchThrowable(() -> this.model.call((String) null)))
+			.as("Null text should throw an exception")
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void testVeryLongText() {
+		// Arrange - create a long text (test API limits)
+		String longText = "This is a very long sentence. ".repeat(100); // ~3000
+																		// characters
+
+		// Act
+		TextToSpeechResponse response = this.model.call(new TextToSpeechPrompt(longText));
+
+		// Assert - should handle long text
+		assertThat(response).isNotNull();
+		assertThat(response.getResult().getOutput()).isNotEmpty();
+		assertThat(response.getResult().getOutput().length).as("Long text should produce substantial audio")
+			.isGreaterThan(10000);
+	}
+
+	/**
+	 * Optional: Save output to file for manual verification. Uncomment and run manually
+	 * to test audio quality.
+	 */
+	@Test
+	@Disabled
+	void saveAudioToFile() throws IOException {
+		String text = "This is a test of the Gemini Text to Speech API.";
+		byte[] audioData = this.model.call(text);
+
+		Path tempFile = Files.createTempFile("gemini-tts-test-", ".pcm");
+		try (FileOutputStream fos = new FileOutputStream(tempFile.toFile())) {
+			fos.write(audioData);
+		}
+
+		System.out.println("Audio saved to: " + tempFile);
+		System.out.println("To play: ffmpeg -f s16le -ar 24000 -ac 1 -i " + tempFile + " output.wav");
+	}
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/GeminiTtsModelTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/GeminiTtsModelTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts;
+
+import java.util.Base64;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.ai.audio.tts.TextToSpeechPrompt;
+import org.springframework.ai.audio.tts.TextToSpeechResponse;
+import org.springframework.ai.google.genai.tts.api.GeminiTtsApi;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class GeminiTtsModelTests {
+
+	private GeminiTtsApi mockApi;
+
+	private GeminiTtsModel model;
+
+	private GeminiTtsOptions defaultOptions;
+
+	@BeforeEach
+	void setUp() {
+		this.mockApi = mock(GeminiTtsApi.class);
+		this.defaultOptions = GeminiTtsOptions.builder().model("gemini-2.5-flash-preview-tts").voice("Kore").build();
+		this.model = new GeminiTtsModel(this.mockApi, this.defaultOptions);
+	}
+
+	@Test
+	void testCallWithSingleSpeaker() {
+		// Arrange
+		String testText = "Say cheerfully: Have a wonderful day!";
+		byte[] expectedAudio = "test audio data".getBytes();
+		String base64Audio = Base64.getEncoder().encodeToString(expectedAudio);
+
+		var mockResponse = createMockResponse(base64Audio);
+		when(this.mockApi.generateContent(eq("gemini-2.5-flash-preview-tts"), any()))
+			.thenReturn(ResponseEntity.ok(mockResponse));
+
+		// Act
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt(testText);
+		TextToSpeechResponse response = this.model.call(prompt);
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(1);
+		byte[] audioData = response.getResult().getOutput();
+		assertThat(audioData).isEqualTo(expectedAudio);
+
+		// Verify API was called with correct voice config
+		ArgumentCaptor<GeminiTtsApi.GenerateContentRequest> requestCaptor = ArgumentCaptor
+			.forClass(GeminiTtsApi.GenerateContentRequest.class);
+		verify(this.mockApi).generateContent(eq("gemini-2.5-flash-preview-tts"), requestCaptor.capture());
+
+		GeminiTtsApi.GenerateContentRequest request = requestCaptor.getValue();
+		assertThat(request.contents()).hasSize(1);
+		assertThat(request.contents().get(0).parts().get(0).text()).isEqualTo(testText);
+		assertThat(request.generationConfig().speechConfig().voiceConfig()).isNotNull();
+		assertThat(request.generationConfig().speechConfig().voiceConfig().prebuiltVoiceConfig().voiceName())
+			.isEqualTo("Kore");
+	}
+
+	@Test
+	void testCallWithMultiSpeaker() {
+		// Arrange
+		String testText = "Joe: Hello!\nJane: Hi there!";
+		GeminiTtsApi.SpeakerVoiceConfig joe = new GeminiTtsApi.SpeakerVoiceConfig("Joe",
+				new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Kore")));
+		GeminiTtsApi.SpeakerVoiceConfig jane = new GeminiTtsApi.SpeakerVoiceConfig("Jane",
+				new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Puck")));
+
+		GeminiTtsOptions options = GeminiTtsOptions.builder()
+			.model("gemini-2.5-flash-preview-tts")
+			.speakerVoiceConfigs(List.of(joe, jane))
+			.build();
+
+		byte[] expectedAudio = "multi-speaker audio".getBytes();
+		String base64Audio = Base64.getEncoder().encodeToString(expectedAudio);
+
+		var mockResponse = createMockResponse(base64Audio);
+		when(this.mockApi.generateContent(eq("gemini-2.5-flash-preview-tts"), any()))
+			.thenReturn(ResponseEntity.ok(mockResponse));
+
+		// Act
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt(testText, options);
+		TextToSpeechResponse response = this.model.call(prompt);
+
+		// Assert
+		assertThat(response).isNotNull();
+		byte[] audioData = response.getResult().getOutput();
+		assertThat(audioData).isEqualTo(expectedAudio);
+
+		// Verify multi-speaker config
+		ArgumentCaptor<GeminiTtsApi.GenerateContentRequest> requestCaptor = ArgumentCaptor
+			.forClass(GeminiTtsApi.GenerateContentRequest.class);
+		verify(this.mockApi).generateContent(eq("gemini-2.5-flash-preview-tts"), requestCaptor.capture());
+
+		GeminiTtsApi.GenerateContentRequest request = requestCaptor.getValue();
+		var multiSpeakerConfig = request.generationConfig().speechConfig().multiSpeakerVoiceConfig();
+		assertThat(multiSpeakerConfig).isNotNull();
+		assertThat(multiSpeakerConfig.speakerVoiceConfigs()).hasSize(2);
+		assertThat(multiSpeakerConfig.speakerVoiceConfigs().get(0).speaker()).isEqualTo("Joe");
+		assertThat(multiSpeakerConfig.speakerVoiceConfigs().get(1).speaker()).isEqualTo("Jane");
+	}
+
+	@Test
+	void testCallWithStringConvenience() {
+		// Arrange
+		String testText = "Hello World";
+		byte[] expectedAudio = "audio bytes".getBytes();
+		String base64Audio = Base64.getEncoder().encodeToString(expectedAudio);
+
+		var mockResponse = createMockResponse(base64Audio);
+		when(this.mockApi.generateContent(any(), any())).thenReturn(ResponseEntity.ok(mockResponse));
+
+		// Act
+		byte[] result = this.model.call(testText);
+
+		// Assert
+		assertThat(result).isEqualTo(expectedAudio);
+	}
+
+	@Test
+	void testOptionsMerging() {
+		// Arrange
+		GeminiTtsOptions runtimeOptions = GeminiTtsOptions.builder()
+			.voice("Puck") // Override default voice
+			.build();
+
+		byte[] expectedAudio = "audio".getBytes();
+		String base64Audio = Base64.getEncoder().encodeToString(expectedAudio);
+
+		var mockResponse = createMockResponse(base64Audio);
+		when(this.mockApi.generateContent(any(), any())).thenReturn(ResponseEntity.ok(mockResponse));
+
+		// Act
+		TextToSpeechPrompt prompt = new TextToSpeechPrompt("Test", runtimeOptions);
+		this.model.call(prompt);
+
+		// Assert - verify runtime voice overrode default
+		ArgumentCaptor<GeminiTtsApi.GenerateContentRequest> requestCaptor = ArgumentCaptor
+			.forClass(GeminiTtsApi.GenerateContentRequest.class);
+		verify(this.mockApi).generateContent(any(), requestCaptor.capture());
+
+		assertThat(requestCaptor.getValue()
+			.generationConfig()
+			.speechConfig()
+			.voiceConfig()
+			.prebuiltVoiceConfig()
+			.voiceName()).isEqualTo("Puck");
+	}
+
+	private GeminiTtsApi.GenerateContentResponse createMockResponse(String base64Audio) {
+		var inlineData = new GeminiTtsApi.InlineData("audio/pcm", base64Audio);
+		var part = new GeminiTtsApi.PartResponse(inlineData);
+		var content = new GeminiTtsApi.ContentResponse(List.of(part));
+		var candidate = new GeminiTtsApi.Candidate(content);
+		return new GeminiTtsApi.GenerateContentResponse(List.of(candidate));
+	}
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/GeminiTtsOptionsTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/GeminiTtsOptionsTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.google.genai.tts.api.GeminiTtsApi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeminiTtsOptionsTests {
+
+	@Test
+	void testSingleSpeakerOptions() {
+		GeminiTtsOptions options = GeminiTtsOptions.builder()
+			.model("gemini-2.5-flash-preview-tts")
+			.voice("Kore")
+			.build();
+
+		assertThat(options.getModel()).isEqualTo("gemini-2.5-flash-preview-tts");
+		assertThat(options.getVoice()).isEqualTo("Kore");
+		assertThat(options.getSpeakerVoiceConfigs()).isNull();
+		assertThat(options.getFormat()).isEqualTo("pcm");
+	}
+
+	@Test
+	void testMultiSpeakerOptions() {
+		GeminiTtsApi.SpeakerVoiceConfig joe = new GeminiTtsApi.SpeakerVoiceConfig("Joe",
+				new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Kore")));
+		GeminiTtsApi.SpeakerVoiceConfig jane = new GeminiTtsApi.SpeakerVoiceConfig("Jane",
+				new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Puck")));
+
+		GeminiTtsOptions options = GeminiTtsOptions.builder()
+			.model("gemini-2.5-flash-preview-tts")
+			.speakerVoiceConfigs(List.of(joe, jane))
+			.build();
+
+		assertThat(options.getModel()).isEqualTo("gemini-2.5-flash-preview-tts");
+		assertThat(options.getVoice()).isNull();
+		assertThat(options.getSpeakerVoiceConfigs()).hasSize(2);
+		assertThat(options.getSpeakerVoiceConfigs().get(0).speaker()).isEqualTo("Joe");
+		assertThat(options.getSpeakerVoiceConfigs().get(0).voiceConfig().prebuiltVoiceConfig().voiceName())
+			.isEqualTo("Kore");
+	}
+
+	@Test
+	void testCopy() {
+		GeminiTtsOptions original = GeminiTtsOptions.builder()
+			.model("gemini-2.5-flash-preview-tts")
+			.voice("Kore")
+			.build();
+
+		GeminiTtsOptions copy = original.copy();
+
+		assertThat(copy).isNotSameAs(original);
+		assertThat(copy.getModel()).isEqualTo(original.getModel());
+		assertThat(copy.getVoice()).isEqualTo(original.getVoice());
+	}
+
+	@Test
+	void testBuilder() {
+		GeminiTtsOptions options = GeminiTtsOptions.builder()
+			.model("gemini-2.5-pro-preview-tts")
+			.voice("Puck")
+			.speed(1.2)
+			.build();
+
+		assertThat(options.getModel()).isEqualTo("gemini-2.5-pro-preview-tts");
+		assertThat(options.getVoice()).isEqualTo("Puck");
+		assertThat(options.getSpeed()).isEqualTo(1.2);
+	}
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/api/GeminiTtsApiIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/api/GeminiTtsApiIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts.api;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link GeminiTtsApi}.
+ *
+ * @author Alexandros Pappas
+ */
+@EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".+")
+class GeminiTtsApiIT {
+
+	private GeminiTtsApi geminiTtsApi;
+
+	@BeforeEach
+	void setUp() {
+		String apiKey = System.getenv("GEMINI_API_KEY");
+		this.geminiTtsApi = new GeminiTtsApi(apiKey);
+	}
+
+	@Test
+	void testSingleSpeakerGeneration() {
+		var voiceConfig = new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Kore"));
+		var speechConfig = new GeminiTtsApi.SpeechConfig(voiceConfig, null);
+		var generationConfig = new GeminiTtsApi.GenerationConfig(List.of("AUDIO"), speechConfig);
+		var content = new GeminiTtsApi.Content(List.of(new GeminiTtsApi.Part("Say cheerfully: Have a wonderful day!")));
+		var request = new GeminiTtsApi.GenerateContentRequest(List.of(content), generationConfig);
+
+		ResponseEntity<GeminiTtsApi.GenerateContentResponse> response = this.geminiTtsApi
+			.generateContent("gemini-2.5-flash-preview-tts", request);
+
+		assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().candidates()).isNotEmpty();
+
+		byte[] audioData = GeminiTtsApi.extractAudioData(response.getBody());
+		assertThat(audioData).isNotEmpty();
+		assertThat(audioData.length).isGreaterThan(1000); // Should have substantial audio
+															// data
+	}
+
+	@Test
+	void testMultiSpeakerGeneration() {
+		var speaker1Config = GeminiTtsApi.SpeakerVoiceConfig.of("Joe", "Kore");
+		var speaker2Config = GeminiTtsApi.SpeakerVoiceConfig.of("Jane", "Puck");
+		var multiSpeakerConfig = new GeminiTtsApi.MultiSpeakerVoiceConfig(List.of(speaker1Config, speaker2Config));
+		var speechConfig = new GeminiTtsApi.SpeechConfig(null, multiSpeakerConfig);
+		var generationConfig = new GeminiTtsApi.GenerationConfig(List.of("AUDIO"), speechConfig);
+		var content = new GeminiTtsApi.Content(List.of(new GeminiTtsApi.Part("""
+				TTS the following conversation between Joe and Jane:
+				Joe: How's it going today Jane?
+				Jane: Not too bad, how about you?
+				""")));
+		var request = new GeminiTtsApi.GenerateContentRequest(List.of(content), generationConfig);
+
+		ResponseEntity<GeminiTtsApi.GenerateContentResponse> response = this.geminiTtsApi
+			.generateContent("gemini-2.5-flash-preview-tts", request);
+
+		assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().candidates()).isNotEmpty();
+
+		byte[] audioData = GeminiTtsApi.extractAudioData(response.getBody());
+		assertThat(audioData).isNotEmpty();
+		assertThat(audioData.length).isGreaterThan(1000);
+	}
+
+	@Test
+	void testExtractAudioData() {
+		// Create a mock response
+		var inlineData = new GeminiTtsApi.InlineData("audio/pcm", "SGVsbG8gV29ybGQ="); // "Hello
+																						// World"
+																						// base64
+		var partResponse = new GeminiTtsApi.PartResponse(inlineData);
+		var contentResponse = new GeminiTtsApi.ContentResponse(List.of(partResponse));
+		var candidate = new GeminiTtsApi.Candidate(contentResponse);
+		var response = new GeminiTtsApi.GenerateContentResponse(List.of(candidate));
+
+		byte[] audioData = GeminiTtsApi.extractAudioData(response);
+
+		assertThat(audioData).isNotEmpty();
+		assertThat(new String(audioData)).isEqualTo("Hello World");
+	}
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/api/GeminiTtsApiTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/api/GeminiTtsApiTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai.tts.api;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeminiTtsApiTests {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void testSingleSpeakerRequestSerialization() throws Exception {
+		var voiceConfig = new GeminiTtsApi.VoiceConfig(new GeminiTtsApi.PrebuiltVoiceConfig("Kore"));
+		var speechConfig = new GeminiTtsApi.SpeechConfig(voiceConfig, null);
+		var generationConfig = new GeminiTtsApi.GenerationConfig(List.of("AUDIO"), speechConfig);
+		var content = new GeminiTtsApi.Content(List.of(new GeminiTtsApi.Part("Say cheerfully: Have a wonderful day!")));
+		var request = new GeminiTtsApi.GenerateContentRequest(List.of(content), generationConfig);
+
+		String json = this.objectMapper.writeValueAsString(request);
+
+		assertThat(json).contains("\"responseModalities\":[\"AUDIO\"]");
+		assertThat(json).contains("\"voiceName\":\"Kore\"");
+		assertThat(json).contains("\"text\":\"Say cheerfully: Have a wonderful day!\"");
+	}
+
+	@Test
+	void testMultiSpeakerRequestSerialization() throws Exception {
+		var speaker1Config = GeminiTtsApi.SpeakerVoiceConfig.of("Joe", "Kore");
+		var speaker2Config = GeminiTtsApi.SpeakerVoiceConfig.of("Jane", "Puck");
+		var multiSpeakerConfig = new GeminiTtsApi.MultiSpeakerVoiceConfig(List.of(speaker1Config, speaker2Config));
+		var speechConfig = new GeminiTtsApi.SpeechConfig(null, multiSpeakerConfig);
+		var generationConfig = new GeminiTtsApi.GenerationConfig(List.of("AUDIO"), speechConfig);
+		var content = new GeminiTtsApi.Content(List.of(new GeminiTtsApi.Part("Joe: Hello!\nJane: Hi there!")));
+		var request = new GeminiTtsApi.GenerateContentRequest(List.of(content), generationConfig);
+
+		String json = this.objectMapper.writeValueAsString(request);
+
+		assertThat(json).contains("\"speaker\":\"Joe\"");
+		assertThat(json).contains("\"speaker\":\"Jane\"");
+		assertThat(json).contains("\"multiSpeakerVoiceConfig\"");
+	}
+
+	@Test
+	void testResponseDeserialization() throws Exception {
+		String responseJson = "{" + "\"candidates\": [{" + "\"content\": {" + "\"parts\": [{" + "\"inlineData\": {"
+				+ "\"mimeType\": \"audio/pcm\"," + "\"data\": \"SGVsbG8gV29ybGQ=\"" + "}" + "}]" + "}" + "}]" + "}";
+
+		var response = this.objectMapper.readValue(responseJson, GeminiTtsApi.GenerateContentResponse.class);
+
+		assertThat(response).isNotNull();
+		assertThat(response.candidates()).hasSize(1);
+		assertThat(response.candidates().get(0).content().parts()).hasSize(1);
+		assertThat(response.candidates().get(0).content().parts().get(0).inlineData().data())
+			.isEqualTo("SGVsbG8gV29ybGQ=");
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-bedrock-converse</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-google-genai</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-google-genai-embedding</module>
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-google-genai-tts</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-elevenlabs</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-huggingface</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-minimax</module>

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -1084,6 +1084,12 @@
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-starter-model-google-genai-tts</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-zhipuai</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech.adoc
@@ -7,6 +7,7 @@ Spring AI provides a unified API for Text-To-Speech (TTS) through the `TextToSpe
 
 - xref:api/audio/speech/openai-speech.adoc[OpenAI's Speech API]
 - xref:api/audio/speech/elevenlabs-speech.adoc[Eleven Labs Text-To-Speech API]
+- xref:api/audio/speech/google-genai-speech.adoc[Google GenAI Text-To-Speech API]
 
 == Common Interface
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/google-genai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/google-genai-speech.adoc
@@ -1,0 +1,353 @@
+= Google GenAI Text-to-Speech (TTS)
+
+== Introduction
+
+Google GenAI provides natural-sounding text-to-speech capabilities through the Gemini TTS API. The API offers ultra-realistic voice synthesis with support for single-speaker and multi-speaker conversations across 24+ languages with 30+ distinct voices. Gemini TTS enables developers to create engaging audio content with prompt-based style control for accent, pace, and delivery.
+
+== Prerequisites
+
+. Create a Google Cloud account and obtain an API key for the Gemini API. You can sign up at the https://aistudio.google.com/app/apikey[Google AI Studio].
+. Add the `spring-ai-google-genai` dependency to your project's build file. For more information, refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section.
+
+== Auto-configuration
+
+Spring AI provides Spring Boot auto-configuration for the Google GenAI Text-to-Speech Client.
+To enable it, add the following dependency to your project's Maven `pom.xml` file:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-google-genai-tts</artifactId>
+</dependency>
+----
+
+or to your Gradle `build.gradle` build file:
+
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-model-google-genai-tts'
+}
+----
+
+TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
+
+NOTE: Alternatively, you can use the main `spring-ai-starter-model-google-genai` starter which includes chat, embedding, and TTS support.
+
+== Speech Properties
+
+=== Connection Properties
+
+The prefix `spring.ai.google-genai` is used as the property prefix for *all* Google GenAI related configurations (both connection and TTS specific settings).
+
+[cols="3,5,1"]
+|====
+| Property | Description | Default
+| spring.ai.google-genai.api-key  | Your Google GenAI API key.           | -
+| spring.ai.google-genai.base-url | The base URL for the Google GenAI API. | https://generativelanguage.googleapis.com
+|====
+
+=== Configuration Properties
+
+[NOTE]
+====
+Enabling and disabling of the audio speech auto-configurations are now configured via top level properties with the prefix `spring.ai.model.audio.speech`.
+
+To enable: spring.ai.model.audio.speech=google-genai
+
+To disable: spring.ai.model.audio.speech=none (or any value which doesn't match google-genai)
+
+This change is done to allow configuration of multiple models.
+====
+
+The prefix `spring.ai.google-genai.tts` is used as the property prefix to configure the Google GenAI Text-to-Speech client specifically.
+
+[cols="3,5,2"]
+|====
+| Property | Description | Default
+
+| spring.ai.model.audio.speech   | Enable Audio Speech Model |  google-genai
+| spring.ai.google-genai.tts.options.model | The model to use for TTS generation. | gemini-2.5-flash-preview-tts
+| spring.ai.google-genai.tts.options.voice | The voice to use for single-speaker TTS.  | Kore
+|====
+
+TIP: All properties prefixed with `spring.ai.google-genai.tts.options` can be overridden at runtime.
+
+[[available-voices]]
+.Available Voices
+The Gemini TTS API provides 30+ voices across 24+ languages, including:
+
+* **Kore**: Neutral, versatile voice
+* **Puck**: Warm, friendly voice
+* **Charon**: Deep, authoritative voice
+* **Zephyr**: Light, energetic voice
+* And many more voices with different characteristics and language support
+
+Refer to the https://ai.google.dev/gemini-api/docs/speech-generation[Google Speech Generation Documentation] for the complete list of available voices.
+
+== Runtime Options [[speech-options]]
+
+The `GeminiTtsOptions` class provides options to use when making a text-to-speech request. On start-up, the options specified by `spring.ai.google-genai.tts` are used, but you can override these at runtime. The following options are available:
+
+* `model`: The model name for text-to-speech generation (e.g., "gemini-2.5-flash-preview-tts", "gemini-2.5-pro-preview-tts").
+* `voice`: The voice name for single-speaker text-to-speech (mutually exclusive with `speakerVoiceConfigs`).
+* `speakerVoiceConfigs`: A list of speaker voice configurations for multi-speaker text-to-speech (mutually exclusive with `voice`). Supports up to 2 speakers.
+* `speed`: The speech speed/rate. Note: Gemini TTS controls pace via text prompts (e.g., "Speak at a faster pace"), not via this parameter. This field exists for `TextToSpeechOptions` interface compatibility.
+
+For example:
+
+[source,java]
+----
+GeminiTtsOptions ttsOptions = GeminiTtsOptions.builder()
+    .model("gemini-2.5-flash-preview-tts")
+    .voice("Puck")
+    .build();
+
+TextToSpeechPrompt prompt = new TextToSpeechPrompt(
+    "Hello, this is a text-to-speech example.",
+    ttsOptions
+);
+TextToSpeechResponse response = geminiTtsModel.call(prompt);
+byte[] audioData = response.getResult().getOutput();
+----
+
+=== Single-Speaker TTS
+
+For single-speaker synthesis, specify a voice using the `voice` option:
+
+[source,java]
+----
+GeminiTtsOptions options = GeminiTtsOptions.builder()
+    .model("gemini-2.5-flash-preview-tts")
+    .voice("Kore")
+    .build();
+
+TextToSpeechPrompt prompt = new TextToSpeechPrompt(
+    "Welcome to Spring AI with Google Gemini TTS!",
+    options
+);
+
+byte[] audioData = geminiTtsModel.call(prompt).getResult().getOutput();
+----
+
+=== Multi-Speaker Conversations
+
+For dialogue with multiple speakers, use speaker voice configurations:
+
+[source,java]
+----
+// Define speakers with their voice assignments (using convenience method)
+GeminiTtsApi.SpeakerVoiceConfig joe = GeminiTtsApi.SpeakerVoiceConfig.of("Joe", "Kore");
+GeminiTtsApi.SpeakerVoiceConfig jane = GeminiTtsApi.SpeakerVoiceConfig.of("Jane", "Puck");
+
+// Configure multi-speaker options
+GeminiTtsOptions options = GeminiTtsOptions.builder()
+    .model("gemini-2.5-flash-preview-tts")
+    .speakerVoiceConfigs(List.of(joe, jane))
+    .build();
+
+// Provide dialogue text with speaker labels
+String conversation = """
+    TTS the following conversation between Joe and Jane:
+    Joe: How's it going today Jane?
+    Jane: Not too bad, how about you?
+    Joe: Pretty good, thanks for asking!
+    """;
+
+TextToSpeechPrompt prompt = new TextToSpeechPrompt(conversation, options);
+byte[] audioData = geminiTtsModel.call(prompt).getResult().getOutput();
+----
+
+=== Prompt-Based Style Control
+
+Gemini TTS allows you to control accent, pace, and delivery style through natural language directives in your text:
+
+[source,java]
+----
+// Control accent, pace, and style through prompts
+String styledText = """
+    Say in a British accent with a slow, dramatic pace:
+    To be, or not to be, that is the question.
+    """;
+
+byte[] audioData = geminiTtsModel.call(styledText);
+----
+
+You can also control emotional tone and delivery:
+
+[source,java]
+----
+String cheerfulText = "Say cheerfully: Have a wonderful day!";
+byte[] audioData = geminiTtsModel.call(cheerfulText);
+----
+
+== Manual Configuration
+
+Add the `spring-ai-google-genai` dependency to your project's Maven `pom.xml` file:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-google-genai</artifactId>
+</dependency>
+----
+
+or to your Gradle `build.gradle` build file:
+
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-google-genai'
+}
+----
+
+TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
+
+Next, create a `GeminiTtsModel`:
+
+[source,java]
+----
+GeminiTtsApi geminiTtsApi = new GeminiTtsApi(System.getenv("GOOGLE_API_KEY"));
+
+GeminiTtsOptions defaultOptions = GeminiTtsOptions.builder()
+    .model("gemini-2.5-flash-preview-tts")
+    .voice("Kore")
+    .build();
+
+GeminiTtsModel geminiTtsModel = GeminiTtsModel.builder()
+    .geminiTtsApi(geminiTtsApi)
+    .defaultOptions(defaultOptions)
+    .build();
+
+// The call will use the default options configured above
+TextToSpeechPrompt prompt = new TextToSpeechPrompt("Hello, this is a text-to-speech example.");
+TextToSpeechResponse response = geminiTtsModel.call(prompt);
+
+byte[] audioData = response.getResult().getOutput();
+----
+
+Alternatively, you can use the constructor directly:
+
+[source,java]
+----
+GeminiTtsApi geminiTtsApi = new GeminiTtsApi(System.getenv("GOOGLE_API_KEY"));
+
+GeminiTtsOptions defaultOptions = GeminiTtsOptions.builder()
+    .model("gemini-2.5-flash-preview-tts")
+    .voice("Puck")
+    .build();
+
+GeminiTtsModel geminiTtsModel = new GeminiTtsModel(geminiTtsApi, defaultOptions);
+
+// Simple convenience method
+byte[] audioData = geminiTtsModel.call("Hello, world!");
+----
+
+== Audio Format
+
+Gemini TTS returns PCM audio with the following specifications:
+
+* **Format**: PCM (s16le)
+* **Sample Rate**: 24kHz
+* **Channels**: Mono
+
+The `getFormat()` method on `GeminiTtsOptions` always returns "pcm" as this is the only format currently supported by the Gemini TTS API.
+
+[IMPORTANT]
+====
+**Streaming Support:** The Gemini API doesn't support streaming text-to-speech. Audio generation is performed as a complete operation, with the full audio returned in a single response.
+====
+
+=== Converting PCM to Other Formats
+
+To convert the PCM audio to other formats like WAV or MP3, you can use audio processing libraries like FFmpeg:
+
+[source,bash]
+----
+# Convert PCM to WAV using FFmpeg
+ffmpeg -f s16le -ar 24000 -ac 1 -i output.pcm output.wav
+
+# Convert PCM to MP3 using FFmpeg
+ffmpeg -f s16le -ar 24000 -ac 1 -i output.pcm output.mp3
+----
+
+You can also use Java libraries like javax.sound for WAV conversion:
+
+[source,java]
+----
+import javax.sound.sampled.*;
+import java.io.*;
+
+public byte[] convertPcmToWav(byte[] pcmData) throws IOException {
+    AudioFormat format = new AudioFormat(
+        24000,  // Sample rate
+        16,     // Sample size in bits
+        1,      // Channels (mono)
+        true,   // Signed
+        false   // Little endian
+    );
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(pcmData);
+    AudioInputStream audioInputStream = new AudioInputStream(bais, format, pcmData.length / format.getFrameSize());
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    AudioSystem.write(audioInputStream, AudioFileFormat.Type.WAVE, baos);
+
+    return baos.toByteArray();
+}
+----
+
+== Configuration Example
+
+Here's a complete Spring Boot configuration example:
+
+[source,java]
+----
+@Configuration
+public class TtsConfiguration {
+
+    @Bean
+    public GeminiTtsModel geminiTtsModel(
+            @Value("${spring.ai.google-genai.api-key}") String apiKey) {
+
+        GeminiTtsApi api = new GeminiTtsApi(apiKey);
+
+        GeminiTtsOptions defaultOptions = GeminiTtsOptions.builder()
+            .model("gemini-2.5-flash-preview-tts")
+            .voice("Kore")
+            .build();
+
+        return GeminiTtsModel.builder()
+            .geminiTtsApi(api)
+            .defaultOptions(defaultOptions)
+            .build();
+    }
+}
+----
+
+With application properties:
+
+[source,yaml]
+----
+spring:
+  ai:
+    google-genai:
+      api-key: ${GOOGLE_API_KEY}
+    model:
+      audio:
+        speech: google-genai
+----
+
+== Additional Resources
+
+For more information about Gemini TTS, including rate limits and API options, see:
+
+* https://ai.google.dev/gemini-api/docs/speech-generation[Gemini Speech Generation Documentation]
+* https://ai.google.dev/gemini-api/docs/speech-generation/rate-limit-options[Rate Limits and Options]
+
+== Example Code
+
+* The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/GeminiTtsModelIT.java[GeminiTtsModelIT.java] test provides examples of how to use the library with both single-speaker and multi-speaker TTS.
+* The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/tts/api/GeminiTtsApiIT.java[GeminiTtsApiIT.java] test provides examples of using the low-level `GeminiTtsApi`.

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-google-genai-tts/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-google-genai-tts/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-2024 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>spring-ai-starter-model-google-genai-tts</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Starter - Google Genai TTS</name>
+    <description>Spring AI Google Genai Text-to-Speech Spring Boot Starter</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-google-genai</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-google-genai</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
This commit adds Text-to-Speech support for Google GenAI (Gemini) with the following components:

## API Client Layer
- GeminiTtsApi: Low-level REST client for Gemini TTS API
- Support for single-speaker and multi-speaker (conversational) TTS
- PCM audio format (s16le, 24kHz, mono)
- Request/response POJOs with Jackson annotations
- Convenience factory methods for simpler API usage

## Model Layer
- GeminiTtsModel: Spring AI TextToSpeechModel implementation
- GeminiTtsOptions: Builder-based configuration with runtime overrides
- Support for 30+ voices across 24+ languages
- Prompt-based style control (accent, pace, delivery)

## Spring Boot Integration
- Auto-configuration with properties binding
- Dedicated starter: spring-ai-starter-model-google-genai-tts
- Configuration prefix: spring.ai.google.genai.tts
- Conditional bean creation based on spring.ai.model.audio.speech property

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc