### PR TITLE
Optionally expose feedback from RelevancyEvaluator 

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
@@ -162,7 +162,7 @@ public class RelevancyEvaluator implements Evaluator {
 	}
 
 	record Response(
-			@JsonPropertyDescription("Provides a short explanation how the query is or is not in line with the context information provided")
+			@JsonPropertyDescription("Provides a short explanation of how the response for the query is or is not in line with the context information provided")
 			String reasoning,
 			@JsonPropertyDescription("Indicates whether the response for the query is in line with the context information provided")
 			boolean isInLine) {

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java
@@ -19,6 +19,7 @@ package org.springframework.ai.chat.evaluation;
 import java.util.Collections;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -33,6 +34,7 @@ import org.springframework.util.Assert;
  */
 public class RelevancyEvaluator implements Evaluator {
 
+	private boolean reasoningEnabled = false;
 	private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = new PromptTemplate("""
 				Your task is to evaluate if the response for the query
 				is in line with the context information provided.
@@ -54,6 +56,21 @@ public class RelevancyEvaluator implements Evaluator {
 				Answer:
 			""");
 
+	private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE_FOR_REASONING = new PromptTemplate("""
+				Your task is to evaluate if the response for the query
+				is in line with the context information provided.
+
+				Query:
+				{query}
+
+				Response:
+				{response}
+
+				Context:
+				{context}
+
+			""");
+
 	private final ChatClient.Builder chatClientBuilder;
 
 	private final PromptTemplate promptTemplate;
@@ -63,29 +80,50 @@ public class RelevancyEvaluator implements Evaluator {
 	}
 
 	private RelevancyEvaluator(ChatClient.Builder chatClientBuilder, @Nullable PromptTemplate promptTemplate) {
+		this(chatClientBuilder, promptTemplate, false);
+	}
+
+	private RelevancyEvaluator(ChatClient.Builder chatClientBuilder, @Nullable PromptTemplate promptTemplate, boolean reasoningEnabled) {
 		Assert.notNull(chatClientBuilder, "chatClientBuilder cannot be null");
 		this.chatClientBuilder = chatClientBuilder;
-		this.promptTemplate = promptTemplate != null ? promptTemplate : DEFAULT_PROMPT_TEMPLATE;
+		this.promptTemplate = promptTemplate != null ? promptTemplate :
+				(reasoningEnabled ? DEFAULT_PROMPT_TEMPLATE_FOR_REASONING : DEFAULT_PROMPT_TEMPLATE);
+		this.reasoningEnabled = reasoningEnabled;
 	}
 
 	@Override
 	public EvaluationResponse evaluate(EvaluationRequest evaluationRequest) {
-		var response = evaluationRequest.getResponseContent();
-		var context = doGetSupportingData(evaluationRequest);
+		var inputResponse = evaluationRequest.getResponseContent();
+		var inputContext = doGetSupportingData(evaluationRequest);
 
 		var userMessage = this.promptTemplate
-			.render(Map.of("query", evaluationRequest.getUserText(), "response", response, "context", context));
+				.render(Map.of("query", evaluationRequest.getUserText(), "response", inputResponse, "context", inputContext));
 
-		String evaluationResponse = this.chatClientBuilder.build().prompt().user(userMessage).call().content();
+		Response evalResponse = evaluateUserMessage(userMessage);
 
-		boolean passing = false;
-		float score = 0;
-		if ("yes".equalsIgnoreCase(evaluationResponse)) {
-			passing = true;
-			score = 1;
+		return new EvaluationResponse(
+				evalResponse.isInLine(),
+				evalResponse.isInLine() ? 1 : 0,
+				evalResponse.reasoning(),
+				Collections.emptyMap()
+		);
+	}
+
+	private Response evaluateUserMessage(String userMessage) {
+		Response evalResponse;
+		if (reasoningEnabled) {
+			evalResponse = this.chatClientBuilder.build().prompt().user(userMessage).call().entity(Response.class);
+
+			if (evalResponse == null) {
+				evalResponse = new Response("Error: NULL response from the chatClient during relevancy evaluation", false);
+			}
+		} else {
+			String clientResponse = this.chatClientBuilder.build().prompt().user(userMessage).call().content();
+
+			boolean passing = "yes".equalsIgnoreCase(clientResponse);
+			evalResponse = new Response("", passing);
 		}
-
-		return new EvaluationResponse(passing, score, "", Collections.emptyMap());
+		return evalResponse;
 	}
 
 	public static Builder builder() {
@@ -94,6 +132,7 @@ public class RelevancyEvaluator implements Evaluator {
 
 	public static final class Builder {
 
+		private boolean feedbackEnabled = false;
 		private ChatClient.@Nullable Builder chatClientBuilder;
 
 		private @Nullable PromptTemplate promptTemplate;
@@ -111,11 +150,21 @@ public class RelevancyEvaluator implements Evaluator {
 			return this;
 		}
 
-		public RelevancyEvaluator build() {
-			Assert.state(this.chatClientBuilder != null, "chatClientBuilder cannot be null");
-			return new RelevancyEvaluator(this.chatClientBuilder, this.promptTemplate);
+		public Builder feedbackEnabled(boolean feedbackEnabled) {
+			this.feedbackEnabled = feedbackEnabled;
+			return this;
 		}
 
+		public RelevancyEvaluator build() {
+			Assert.state(this.chatClientBuilder != null, "chatClientBuilder cannot be null");
+			return new RelevancyEvaluator(this.chatClientBuilder, this.promptTemplate, feedbackEnabled);
+		}
 	}
 
+	record Response(
+			@JsonPropertyDescription("Provides a short explanation how the query is or is not in line with the context information provided")
+			String reasoning,
+			@JsonPropertyDescription("Indicates whether the response for the query is in line with the context information provided")
+			boolean isInLine) {
+	}
 }


### PR DESCRIPTION
**Problem:** 

The [RelevancyEvaluator](https://github.com/spring-projects/spring-ai/blob/83e35762228a899e5612ab20a6021e9032cfaaf6/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/RelevancyEvaluator.java#L88) is a black box at the moment, which evaluates the content without providing any explanation about why it came to such conclusion. Furthermore the code relies on dated method of forcing the LLM to respond in a structured manner without using the spring-ai's structured output option.

**Solution:**

Modify the RelevancyEvaluator in a backwards compatible way to offer a new `feedbackEnabled(boolean feedbackEnabled)` method in the `Builder`, which would enable the evaluator to use structured output with a response type that offer both the answer, and the accompanying reasoning behind it.

```
record Response(
			@JsonPropertyDescription("Provides a short explanation how the query is or is not in line with the context information provided")
			String reasoning,
			@JsonPropertyDescription("Indicates whether the response for the query is in line with the context information provided")
			boolean isInLine) {
	}
```

The reasoning is then mapped to `EvaluationResponse`'s existing `feedback` field, which was currently unused and always left as an empty String.

The existing solution is kept working by default so that the change would not break existing flows or change the nature of the LLM calls, potentially disrupting token usage and bias in the prompt.

**Additional notes**

[FactCheckingEvaluator](https://github.com/spring-projects/spring-ai/blob/83e35762228a899e5612ab20a6021e9032cfaaf6/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/evaluation/FactCheckingEvaluator.java) faces a similar problem, but I didn't want to change it unless the method is validated by the maintainers as useful and worth doing.


Example request body, when `feedbackEnabled` is set true.
```
	Your task is to evaluate if the response for the query
	is in line with the context information provided.

	Query:
	${query here}

	Response:
	${response here}

	Context:
	${context here}



Your response should be in JSON format.
Do not include any explanations, only provide a RFC8259 compliant JSON response following this format without deviation.
Do not include markdown code blocks in your response.
Remove the ```json markdown from the output.
Here is the JSON Schema instance your output must adhere to:
```{
  "$schema" : "https://json-schema.org/draft/2020-12/schema",
  "type" : "object",
  "properties" : {
    "isInLine" : {
      "type" : "boolean",
      "description" : "Indicates whether the response for the query is in line with the context information provided"
    },
    "reasoning" : {
      "type" : "string",
      "description" : "Provides a short explanation of how the response for the query is or is not in line with the context information provided"
    }
  },
  "additionalProperties" : false
}```
```