### PR TITLE
GH-1812: Fix broken xref links and add missing audio/moderation index pages

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -67,7 +67,7 @@
 **** xref:api/image/zhipuai-image.adoc[ZhiPuAI]
 **** xref:api/image/qianfan-image.adoc[QianFan]
 
-*** xref:api/audio[Audio Models]
+*** xref:api/audio.adoc[Audio Models]
 **** xref:api/audio/transcriptions.adoc[]
 ***** xref:api/audio/transcriptions/azure-openai-transcriptions.adoc[Azure OpenAI]
 ***** xref:api/audio/transcriptions/openai-transcriptions.adoc[OpenAI]
@@ -75,7 +75,7 @@
 ***** xref:api/audio/speech/openai-speech.adoc[OpenAI]
 ***** xref:api/audio/speech/elevenlabs-speech.adoc[ElevenLabs]
 
-*** xref:api/moderation[Moderation Models]
+*** xref:api/moderation.adoc[Moderation Models]
 **** xref:api/moderation/openai-moderation.adoc[OpenAI]
 **** xref:api/moderation/mistral-ai-moderation.adoc[Mistral AI]
 // ** xref:api/generic-model.adoc[]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio.adoc
@@ -1,0 +1,31 @@
+[[Audio]]
+= Audio Model API
+
+The Spring AI Audio API provides a unified interface for interacting with AI models specialized in audio processing, including Speech-to-Text (transcription) and Text-to-Speech (TTS) capabilities.
+
+== Transcription (Speech-to-Text)
+
+The Transcription API allows you to convert audio files into text. Spring AI provides a unified `TranscriptionModel` interface that works across different providers.
+
+=== Supported Providers
+
+* xref:api/audio/transcriptions/openai-transcriptions.adoc[OpenAI Whisper API]
+* xref:api/audio/transcriptions/azure-openai-transcriptions.adoc[Azure OpenAI Whisper API]
+
+For more details on the transcription API, see xref:api/audio/transcriptions.adoc[Transcription API].
+
+== Text-to-Speech (TTS)
+
+The Text-to-Speech API allows you to convert text into spoken audio. Spring AI provides unified `TextToSpeechModel` and `StreamingTextToSpeechModel` interfaces.
+
+=== Supported Providers
+
+* xref:api/audio/speech/openai-speech.adoc[OpenAI Speech API]
+* xref:api/audio/speech/elevenlabs-speech.adoc[ElevenLabs Text-to-Speech API]
+
+For more details on the Text-to-Speech API, see xref:api/audio/speech.adoc[Text-to-Speech (TTS) API].
+
+== Feedback and Contributions
+
+The project's https://github.com/spring-projects/spring-ai/discussions[GitHub discussions] is a great place to send feedback.
+

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation.adoc
@@ -1,0 +1,26 @@
+[[Moderation]]
+= Moderation Model API
+
+The Spring AI Moderation API provides a unified interface for interacting with AI models specialized in content moderation. These models can detect potentially harmful, unsafe, or sensitive content in text.
+
+== Overview
+
+Content moderation is essential for applications that handle user-generated content. Moderation models can identify various categories of potentially problematic content, including:
+
+* Hate speech
+* Violence
+* Sexual content
+* Self-harm
+* Harassment
+
+== Supported Providers
+
+Spring AI provides integrations with the following moderation model providers:
+
+* xref:api/moderation/openai-moderation.adoc[OpenAI Moderation] - Uses OpenAI's moderation endpoint to classify text
+* xref:api/moderation/mistral-ai-moderation.adoc[Mistral AI Moderation] - Uses Mistral AI's moderation capabilities
+
+== Feedback and Contributions
+
+The project's https://github.com/spring-projects/spring-ai/discussions[GitHub discussions] is a great place to send feedback.
+

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/index.adoc
@@ -24,7 +24,7 @@ Spring AI provides the following features:
 ** xref:api/imageclient.adoc[Text to Image]
 ** xref:api/audio/transcriptions.adoc[Audio Transcription]
 ** xref:api/audio/speech.adoc[Text to Speech]
-** xref:api/moderation[Moderation]
+** xref:api/moderation.adoc[Moderation]
 * xref:api/structured-output-converter.adoc[Structured Outputs] - Mapping of AI Model output to POJOs.
 * Support for all major xref:api/vectordbs.adoc[Vector Database providers] such as Apache Cassandra, Azure Cosmos DB, Azure Vector Search, Chroma, Elasticsearch, GemFire, MariaDB, Milvus, MongoDB Atlas, Neo4j, OpenSearch, Oracle, PostgreSQL/PGVector, Pinecone, Qdrant, Redis, SAP Hana, Typesense and Weaviate.
 * Portable API across Vector Store providers, including a novel SQL-like metadata filter API.


### PR DESCRIPTION
## Summary

This PR fixes broken xref links in the documentation by adding missing index pages and correcting xref syntax.

## Changes

### New Files
- api/audio.adoc - Index page for Audio Model API (transcription and speech)
- api/moderation.adoc - Index page for Moderation Model API

### Fixed Files
- nav.adoc - Fixed xref links to include .adoc extension for audio and moderation
- index.adoc - Fixed xref link to include .adoc extension for moderation

## Problem

The xref links for api/audio and api/moderation were pointing to directories instead of actual .adoc files, causing broken links in the generated Antora documentation.

Closes #1812