### PR TITLE
GH-3183: Add file-based ChatMemoryRepository implementation

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/FileChatMemoryRepository.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/FileChatMemoryRepository.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.util.Assert;
+
+/**
+ * A file-based implementation of {@link ChatMemoryRepository} that stores chat messages
+ * as JSON files on the local filesystem. Each conversation is stored in a separate file
+ * named {@code {conversationId}.json}.
+ *
+ * <p>
+ * This implementation is useful for local development, testing, and simple applications
+ * that require persistent chat memory without setting up a database.
+ *
+ * @author Ranjit Muniyappa
+ * @since 1.0.0
+ */
+public final class FileChatMemoryRepository implements ChatMemoryRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(FileChatMemoryRepository.class);
+
+	private static final String FILE_EXTENSION = ".json";
+
+	private static final Path DEFAULT_DIRECTORY = Path.of("chat-memory");
+
+	private final Path directory;
+
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * Creates a new {@link FileChatMemoryRepository} with the default directory
+	 * {@code chat-memory}.
+	 */
+	public FileChatMemoryRepository() {
+		this(DEFAULT_DIRECTORY);
+	}
+
+	/**
+	 * Creates a new {@link FileChatMemoryRepository} with the specified directory.
+	 * @param directory the directory where conversation files will be stored
+	 */
+	public FileChatMemoryRepository(Path directory) {
+		Assert.notNull(directory, "directory cannot be null");
+		this.directory = directory;
+		this.objectMapper = new ObjectMapper();
+		ensureDirectoryExists();
+	}
+
+	private void ensureDirectoryExists() {
+		try {
+			Files.createDirectories(this.directory);
+		}
+		catch (IOException ex) {
+			throw new RuntimeException("Failed to create chat memory directory: " + this.directory, ex);
+		}
+	}
+
+	@Override
+	public List<String> findConversationIds() {
+		try (Stream<Path> files = Files.list(this.directory)) {
+			return files.filter(path -> path.toString().endsWith(FILE_EXTENSION))
+				.map(path -> path.getFileName().toString().replace(FILE_EXTENSION, ""))
+				.toList();
+		}
+		catch (IOException ex) {
+			logger.warn("Failed to list conversation files in directory: {}", this.directory, ex);
+			return List.of();
+		}
+	}
+
+	@Override
+	public List<Message> findByConversationId(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		Path filePath = getFilePath(conversationId);
+		if (!Files.exists(filePath)) {
+			return List.of();
+		}
+		try {
+			String json = Files.readString(filePath);
+			List<StoredMessage> storedMessages = this.objectMapper.readValue(json,
+					new TypeReference<List<StoredMessage>>() {
+					});
+			return storedMessages.stream().map(this::toMessage).toList();
+		}
+		catch (IOException ex) {
+			logger.warn("Failed to read conversation file: {}", filePath, ex);
+			return List.of();
+		}
+	}
+
+	@Override
+	public void saveAll(String conversationId, List<Message> messages) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		Assert.notNull(messages, "messages cannot be null");
+		Assert.noNullElements(messages, "messages cannot contain null elements");
+		Path filePath = getFilePath(conversationId);
+		try {
+			List<StoredMessage> storedMessages = messages.stream().map(this::toStoredMessage).toList();
+			String json = this.objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(storedMessages);
+			Files.writeString(filePath, json);
+			logger.debug("Saved {} messages to conversation: {}", messages.size(), conversationId);
+		}
+		catch (IOException ex) {
+			throw new RuntimeException("Failed to save conversation: " + conversationId, ex);
+		}
+	}
+
+	private StoredMessage toStoredMessage(Message message) {
+		return new StoredMessage(message.getMessageType().name(), message.getText(), message.getMetadata());
+	}
+
+	private Message toMessage(StoredMessage stored) {
+		MessageType type = MessageType.valueOf(stored.type());
+		return switch (type) {
+			case USER -> UserMessage.builder().text(stored.content()).metadata(stored.metadata()).build();
+			case ASSISTANT ->
+				AssistantMessage.builder().content(stored.content()).properties(stored.metadata()).build();
+			case SYSTEM -> SystemMessage.builder().text(stored.content()).metadata(stored.metadata()).build();
+			case TOOL -> ToolResponseMessage.builder().build();
+		};
+	}
+
+	@Override
+	public void deleteByConversationId(String conversationId) {
+		Assert.hasText(conversationId, "conversationId cannot be null or empty");
+		Path filePath = getFilePath(conversationId);
+		try {
+			Files.deleteIfExists(filePath);
+			logger.debug("Deleted conversation: {}", conversationId);
+		}
+		catch (IOException ex) {
+			logger.warn("Failed to delete conversation file: {}", filePath, ex);
+		}
+	}
+
+	private Path getFilePath(String conversationId) {
+		return this.directory.resolve(conversationId + FILE_EXTENSION);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		private Path directory = DEFAULT_DIRECTORY;
+
+		private Builder() {
+		}
+
+		public Builder directory(Path directory) {
+			this.directory = directory;
+			return this;
+		}
+
+		public Builder directory(String directory) {
+			this.directory = Path.of(directory);
+			return this;
+		}
+
+		public FileChatMemoryRepository build() {
+			return new FileChatMemoryRepository(this.directory);
+		}
+
+	}
+
+	/**
+	 * Internal record for JSON serialization of messages.
+	 */
+	private record StoredMessage(String type, String content, Map<String, Object> metadata) {
+
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/FileChatMemoryRepositoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/FileChatMemoryRepositoryTests.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link FileChatMemoryRepository}.
+ *
+ * @author Ranjit Muniyappa
+ */
+class FileChatMemoryRepositoryTests {
+
+	@TempDir
+	Path tempDir;
+
+	private FileChatMemoryRepository chatMemoryRepository;
+
+	@BeforeEach
+	void setUp() {
+		this.chatMemoryRepository = FileChatMemoryRepository.builder().directory(this.tempDir).build();
+	}
+
+	@Test
+	void findConversationIds() {
+		String conversationId1 = UUID.randomUUID().toString();
+		String conversationId2 = UUID.randomUUID().toString();
+		List<Message> messages1 = List.of(new UserMessage("Hello"));
+		List<Message> messages2 = List.of(new AssistantMessage("Hi there"));
+
+		this.chatMemoryRepository.saveAll(conversationId1, messages1);
+		this.chatMemoryRepository.saveAll(conversationId2, messages2);
+
+		assertThat(this.chatMemoryRepository.findConversationIds()).containsExactlyInAnyOrder(conversationId1,
+				conversationId2);
+
+		this.chatMemoryRepository.deleteByConversationId(conversationId1);
+		assertThat(this.chatMemoryRepository.findConversationIds()).containsExactlyInAnyOrder(conversationId2);
+	}
+
+	@Test
+	void saveMessagesAndFindMultipleMessagesInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new AssistantMessage("I, Robot"), new UserMessage("Hello"));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		List<Message> retrieved = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(retrieved).hasSize(2);
+		assertThat(retrieved.get(0).getText()).isEqualTo("I, Robot");
+		assertThat(retrieved.get(1).getText()).isEqualTo("Hello");
+
+		this.chatMemoryRepository.deleteByConversationId(conversationId);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEmpty();
+	}
+
+	@Test
+	void saveMessagesAndFindSingleMessageInConversation() {
+		String conversationId = UUID.randomUUID().toString();
+		Message message = new UserMessage("Hello");
+		List<Message> messages = List.of(message);
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		List<Message> retrieved = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(retrieved).hasSize(1);
+		assertThat(retrieved.get(0).getText()).isEqualTo("Hello");
+
+		this.chatMemoryRepository.deleteByConversationId(conversationId);
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEmpty();
+	}
+
+	@Test
+	void findNonExistingConversation() {
+		String conversationId = UUID.randomUUID().toString();
+
+		assertThat(this.chatMemoryRepository.findByConversationId(conversationId)).isEmpty();
+	}
+
+	@Test
+	void subsequentSaveOverwritesPreviousVersion() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> firstMessages = List.of(new UserMessage("Hello"));
+		List<Message> secondMessages = List.of(new AssistantMessage("Hi there"));
+
+		this.chatMemoryRepository.saveAll(conversationId, firstMessages);
+		this.chatMemoryRepository.saveAll(conversationId, secondMessages);
+
+		List<Message> retrieved = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(retrieved).hasSize(1);
+		assertThat(retrieved.get(0).getText()).isEqualTo("Hi there");
+	}
+
+	@Test
+	void saveAllMessageTypes() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messages = List.of(new SystemMessage("You are a helpful assistant"),
+				new UserMessage("What is Java?"), new AssistantMessage("Java is a programming language"));
+
+		this.chatMemoryRepository.saveAll(conversationId, messages);
+
+		List<Message> retrieved = this.chatMemoryRepository.findByConversationId(conversationId);
+		assertThat(retrieved).hasSize(3);
+		assertThat(retrieved.get(0)).isInstanceOf(SystemMessage.class);
+		assertThat(retrieved.get(1)).isInstanceOf(UserMessage.class);
+		assertThat(retrieved.get(2)).isInstanceOf(AssistantMessage.class);
+	}
+
+	@Test
+	void nullConversationIdNotAllowed() {
+		assertThatThrownBy(() -> this.chatMemoryRepository.saveAll(null, List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> this.chatMemoryRepository.findByConversationId(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+
+		assertThatThrownBy(() -> this.chatMemoryRepository.deleteByConversationId(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void emptyConversationIdNotAllowed() {
+		assertThatThrownBy(() -> this.chatMemoryRepository.saveAll("", List.of(new UserMessage("Hello"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("conversationId cannot be null or empty");
+	}
+
+	@Test
+	void nullMessagesNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		assertThatThrownBy(() -> this.chatMemoryRepository.saveAll(conversationId, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot be null");
+	}
+
+	@Test
+	void messagesWithNullElementsNotAllowed() {
+		String conversationId = UUID.randomUUID().toString();
+		List<Message> messagesWithNull = new ArrayList<>();
+		messagesWithNull.add(null);
+
+		assertThatThrownBy(() -> this.chatMemoryRepository.saveAll(conversationId, messagesWithNull))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages cannot contain null elements");
+	}
+
+	@Test
+	void builderWithStringPath() {
+		Path customDir = this.tempDir.resolve("custom-memory");
+		FileChatMemoryRepository repo = FileChatMemoryRepository.builder().directory(customDir.toString()).build();
+
+		String conversationId = UUID.randomUUID().toString();
+		repo.saveAll(conversationId, List.of(new UserMessage("Test")));
+
+		assertThat(Files.exists(customDir.resolve(conversationId + ".json"))).isTrue();
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR adds `FileChatMemoryRepository`, a file-based implementation of `ChatMemoryRepository` that stores chat messages as JSON files on the local filesystem. Each conversation is stored in a separate file named `{conversationId}.json`.

## Motivation

As requested in #3183, there was a gap in the available ChatMemoryRepository implementations. While there are options for in-memory, JDBC, MongoDB, Redis, Neo4j, Cassandra, and CosmosDB, there was no simple file-based option for:
- **Local development** - Persist conversations across app restarts without database setup
- **Testing** - Pre-populate conversations from files
- **Simple applications** - Persist chat history without infrastructure dependencies

## Changes

### New Files
- `FileChatMemoryRepository.java` - Main implementation
- `FileChatMemoryRepositoryTests.java` - Unit tests (11 tests, all passing)

### Features
- Stores one JSON file per conversation
- Configurable storage directory via builder (default: `chat-memory/`)
- Uses Jackson for JSON serialization with a clean DTO approach
- Full support for `UserMessage`, `AssistantMessage`, `SystemMessage` types
- DEBUG logging for save/delete operations

## Testing

All 11 unit tests pass.

Closes #3183