### PR TITLE
add configuration properties processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,10 @@
 							<artifactId>nullaway</artifactId>
 							<version>${nullaway.version}</version>
 						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
 					</annotationProcessorPaths>
 				</configuration>
 				<executions>


### PR DESCRIPTION
adding configuration processor to address https://github.com/spring-projects/spring-ai/issues/5156

Build doesn't quite work with this change (yet), so this PR needs more work. Some modules seem to have duplicate config properties defined:

```
[ERROR] /Users/martinlippert/Engineering/projects/spring-ai/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBStoreIT.java:[437,45] Duplicate @ConfigurationProperties definition for prefix 'app.datasource'
[ERROR] /Users/martinlippert/Engineering/projects/spring-ai/vector-stores/spring-ai-mariadb-store/src/test/java/org/springframework/ai/vectorstore/mariadb/MariaDBStoreObservationIT.java:[195,45] Duplicate @ConfigurationProperties definition for prefix 'app.d
```

Happy to move this forward, but would love to hear your advice on this.