### PR TITLE
docs: fix duplicated step numbering in RetrievalAugmentationAdvisor

### DIFF
--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/advisor/RetrievalAugmentationAdvisor.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/advisor/RetrievalAugmentationAdvisor.java
@@ -142,10 +142,10 @@ public final class RetrievalAugmentationAdvisor implements BaseAdvisor {
 		}
 		context.put(DOCUMENT_CONTEXT, documents);
 
-		// 5. Augment user query with the document contextual data.
+		// 6. Augment user query with the document contextual data.
 		Query augmentedQuery = this.queryAugmenter.augment(originalQuery, documents);
 
-		// 6. Update ChatClientRequest with augmented prompt.
+		// 7. Update ChatClientRequest with augmented prompt.
 		return chatClientRequest.mutate()
 			.prompt(chatClientRequest.prompt().augmentUserMessage(augmentedQuery.text()))
 			.context(context)


### PR DESCRIPTION
### Description
This pull request fixes a minor documentation issue in the `RetrievalAugmentationAdvisor.java` file. 
Inside the `before` method, the step numbers in the comments were duplicated as `5, 5, 6`.

### Changes
- Updated the sequential numbering of steps in the `before` method from `5, 5, 6` to `5, 6, 7` to ensure correct logical ordering.
- No functional code changes were made.