### PR TITLE
Fix extraBody lost when toolDefinitions is present

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -651,9 +651,10 @@ public class OpenAiChatModel implements ChatModel {
 		// Add the tool definitions to the request's tools parameter.
 		List<ToolDefinition> toolDefinitions = this.toolCallingManager.resolveToolDefinitions(requestOptions);
 		if (!CollectionUtils.isEmpty(toolDefinitions)) {
-			request = ModelOptionsUtils.merge(
-					OpenAiChatOptions.builder().tools(this.getFunctionTools(toolDefinitions)).build(), request,
-					ChatCompletionRequest.class);
+			request = ModelOptionsUtils.merge(OpenAiChatOptions.builder()
+				.tools(this.getFunctionTools(toolDefinitions))
+				.extraBody(request.extraBody())
+				.build(), request, ChatCompletionRequest.class);
 		}
 
 		// Remove `streamOptions` from the request if it is not a streaming request


### PR DESCRIPTION
   When both `extraBody` and `toolCallbacks` are configured in `OpenAiChatOptions`, 
   the `extraBody` was being lost during the merge operation that adds tool 
   definitions to the `ChatCompletionRequest`.

   This fix preserves the `extraBody` by including it in the merge source when 
   adding tool definitions.

   Closes gh-5056
   Related: gh-5046