### PR TITLE
GH-1514: Add support for Anthropic Models on Vertex AI

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/pom.xml
@@ -42,6 +42,14 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Vertex AI Anthropic -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-vertex-ai-anthropic</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- Spring AI auto configurations -->
 
 		<dependency>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/StringToToolChoiceConverter.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/StringToToolChoiceConverter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.vertexai.autoconfigure.anthropic;
+
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.boot.context.properties.ConfigurationPropertiesBinding;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationPropertiesBinding
+public class StringToToolChoiceConverter implements Converter<String, AnthropicApi.ToolChoice> {
+
+	@Override
+	public AnthropicApi.ToolChoice convert(String source) {
+		return ModelOptionsUtils.jsonToObject(source, AnthropicApi.ToolChoice.class);
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicChatAutoConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.vertexai.autoconfigure.anthropic;
+
+import java.io.IOException;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.vertexai.api.PredictionServiceSettings;
+import io.micrometer.observation.ObservationRegistry;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.chat.observation.ChatModelObservationConvention;
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
+import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
+import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.ai.vertexai.anthropic.api.VertexAiAnthropicApi;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.restclient.autoconfigure.RestClientAutoConfiguration;
+import org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * AutoConfiguration for Anthropic chat models hosted on Google Cloud Vertex AI.
+ * <p>
+ * Requires the {@code spring.ai.vertex.ai.anthropic} configuration prefix for
+ * customization.
+ */
+@AutoConfiguration(after = { RestClientAutoConfiguration.class, WebClientAutoConfiguration.class,
+		ToolCallingAutoConfiguration.class, SpringAiRetryAutoConfiguration.class })
+@EnableConfigurationProperties({ VertexAiAnthropicChatProperties.class, VertexAiAnthropicConnectionProperties.class })
+@ConditionalOnClass(VertexAiAnthropicApi.class)
+@ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.ANTHROPIC,
+		matchIfMissing = true)
+@Import(StringToToolChoiceConverter.class)
+public class VertexAiAnthropicChatAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public VertexAiAnthropicApi vertexAiAnthropicApi(VertexAiAnthropicConnectionProperties connectionProperties,
+			VertexAiAnthropicChatProperties chatProperties,
+			ObjectProvider<RestClient.Builder> restClientBuilderProvider,
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ResponseErrorHandler responseErrorHandler)
+			throws IOException {
+
+		return VertexAiAnthropicApi.builderForVertexAi()
+			.projectId(connectionProperties.getProjectId())
+			.credentials(vertexAiCredential(connectionProperties))
+			.location(connectionProperties.getLocation())
+			.model(chatProperties.getOptions().getModel())
+			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
+			.webClientBuilder(webClientBuilderProvider.getIfAvailable(WebClient::builder))
+			.responseErrorHandler(responseErrorHandler)
+			.build();
+	}
+
+	public Credentials vertexAiCredential(VertexAiAnthropicConnectionProperties connectionProperties)
+			throws IOException {
+		if (connectionProperties.getCredentialsUri() != null) {
+			return GoogleCredentials.fromStream(connectionProperties.getCredentialsUri().getInputStream());
+		}
+		return PredictionServiceSettings.defaultCredentialsProviderBuilder().build().getCredentials();
+
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public AnthropicChatModel vertexAiAnthropicChatModel(VertexAiAnthropicApi anthropicApi,
+			VertexAiAnthropicConnectionProperties connectionProperties, VertexAiAnthropicChatProperties chatProperties,
+			RetryTemplate retryTemplate, ToolCallingManager toolCallingManager,
+			ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<ChatModelObservationConvention> observationConvention,
+			ObjectProvider<ToolExecutionEligibilityPredicate> anthropicToolExecutionEligibilityPredicate) {
+		var chatModel = AnthropicChatModel.builder()
+			.anthropicApi(anthropicApi)
+			.defaultOptions(chatProperties.getOptions())
+			.toolCallingManager(toolCallingManager)
+			.toolExecutionEligibilityPredicate(anthropicToolExecutionEligibilityPredicate
+				.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))
+			.retryTemplate(retryTemplate)
+			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+			.build();
+		observationConvention.ifAvailable(chatModel::setObservationConvention);
+		return chatModel;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicChatProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.vertexai.autoconfigure.anthropic;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.vertexai.anthropic.api.VertexAiAnthropicApi;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for Anthropic chat models on the Vertex AI platform.
+ * <p>
+ * Allows customization of chat model options such as model selection, max tokens, and
+ * other Anthropic-specific parameters via the {@code spring.ai.vertex.ai.anthropic.chat}
+ * prefix.
+ */
+@ConfigurationProperties(VertexAiAnthropicChatProperties.CONFIG_PREFIX)
+public class VertexAiAnthropicChatProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.vertex.ai.anthropic.chat";
+
+	@NestedConfigurationProperty
+	private final AnthropicChatOptions options = AnthropicChatOptions.builder()
+		.model(VertexAiAnthropicApi.ChatModel.CLAUDE_SONNET_4_5.getValue())
+		.maxTokens(AnthropicChatModel.DEFAULT_MAX_TOKENS)
+		.build();
+
+	public AnthropicChatOptions getOptions() {
+		return this.options;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicConnectionProperties.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.vertexai.autoconfigure.anthropic;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+
+/**
+ * Configuration properties for connecting to Anthropic models on Google Cloud Vertex AI.
+ */
+@ConfigurationProperties(VertexAiAnthropicConnectionProperties.CONFIG_PREFIX)
+public class VertexAiAnthropicConnectionProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.vertex.ai.anthropic";
+
+	/**
+	 * Google Cloud project ID for Vertex AI.
+	 */
+	public String getProjectId() {
+		return this.projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	private String projectId;
+
+	/**
+	 * Google Cloud region supporting Anthropic Claude models (e.g., "us-central1").
+	 */
+	public String getLocation() {
+		return this.location;
+	}
+
+	public void setLocation(String location) {
+		this.location = location;
+	}
+
+	private String location;
+
+	/**
+	 * URI to the Vertex AI credentials file (optional, uses default credentials if not
+	 * set).
+	 */
+	public Resource getCredentialsUri() {
+		return this.credentialsUri;
+	}
+
+	public void setCredentialsUri(Resource credentialsUri) {
+		this.credentialsUri = credentialsUri;
+	}
+
+	private Resource credentialsUri;
+
+	/**
+	 * Custom Vertex AI API endpoint URL (optional, uses default if not set).
+	 */
+	public String getApiEndpoint() {
+		return this.apiEndpoint;
+	}
+
+	public void setApiEndpoint(String apiEndpoint) {
+		this.apiEndpoint = apiEndpoint;
+	}
+
+	private String apiEndpoint;
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,5 @@
 #
-# Copyright 2025-2025 the original author or authors.
+# Copyright 2025-2026 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,3 +17,4 @@ org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiTextEmbedd
 org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiEmbeddingConnectionAutoConfiguration
 org.springframework.ai.model.vertexai.autoconfigure.embedding.VertexAiMultiModalEmbeddingAutoConfiguration
 org.springframework.ai.model.vertexai.autoconfigure.gemini.VertexAiGeminiChatAutoConfiguration
+org.springframework.ai.model.vertexai.autoconfigure.anthropic.VertexAiAnthropicChatAutoConfiguration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicAutoConfigurationIT.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.vertexai.autoconfigure.anthropic;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.utils.SpringAiTestAutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link VertexAiAnthropicChatAutoConfiguration}.
+ */
+@EnabledIfEnvironmentVariable(named = "VERTEX_AI_ANTHROPIC_PROJECT_ID", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "VERTEX_AI_ANTHROPIC_LOCATION", matches = ".*")
+@EnabledIfEnvironmentVariable(named = "VERTEX_AI_ANTHROPIC_CHAT_MODEL", matches = ".*")
+public class VertexAiAnthropicAutoConfigurationIT {
+
+	private static final Log LOG = LogFactory.getLog(VertexAiAnthropicAutoConfigurationIT.class);
+
+	ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues(
+				"spring.ai.vertex.ai.anthropic.project-id=%s"
+					.formatted(System.getenv("VERTEX_AI_ANTHROPIC_PROJECT_ID")),
+				"spring.ai.vertex.ai.anthropic.location=%s".formatted(System.getenv("VERTEX_AI_ANTHROPIC_LOCATION")),
+				"spring.ai.vertex.ai.anthropic.chat.options.model=%s"
+					.formatted(System.getenv("VERTEX_AI_ANTHROPIC_CHAT_MODEL")))
+		.withConfiguration(SpringAiTestAutoConfigurations.of(VertexAiAnthropicChatAutoConfiguration.class));
+
+	/**
+	 * Tests that the Anthropic chat model is properly configured and can generate
+	 * responses.
+	 */
+	@Test
+	void testChatModelConfiguration() {
+		this.contextRunner.run(context -> {
+			var chatModel = context.getBean(AnthropicChatModel.class);
+			String response = chatModel.call("hi!");
+			assertThat(response).isNotEmpty();
+			LOG.info("Response: %s".formatted(response));
+		});
+	}
+
+	/**
+	 * Tests chat model functionality with tool calling enabled.
+	 */
+	@Test
+	void testChatModelWithToolCalling() {
+		this.contextRunner.run(context -> {
+			var chatModel = context.getBean(AnthropicChatModel.class);
+			ToolCallback tool = new ToolCallback() {
+				@Override
+				public ToolDefinition getToolDefinition() {
+					return ToolDefinition.builder()
+						.name("get_weather")
+						.description("Get current weather for a location")
+						.inputSchema("{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\"}}}")
+						.build();
+				}
+
+				@Override
+				public String call(String toolInput) {
+					return "Sunny, 25°C";
+				}
+			};
+			var options = AnthropicChatOptions.builder().toolCallbacks(List.of(tool)).build();
+			var prompt = new Prompt("What's the weather in Paris?", options);
+			var response = chatModel.call(prompt);
+			assertThat(response).isNotNull();
+			assertThat(response.getResult().getOutput().getText()).contains("25");
+			LOG.info("Tool calling response: %s".formatted(response.getResult().getOutput().getText()));
+		});
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicAutoConfigurationTest.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/test/java/org/springframework/ai/model/vertexai/autoconfigure/anthropic/VertexAiAnthropicAutoConfigurationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.vertexai.autoconfigure.anthropic;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.utils.SpringAiTestAutoConfigurations;
+import org.springframework.ai.vertexai.anthropic.api.VertexAiAnthropicApi;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link VertexAiAnthropicChatAutoConfiguration}.
+ */
+public class VertexAiAnthropicAutoConfigurationTest {
+
+	ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.vertex.ai.anthropic.project-id=dummy_pj",
+				"spring.ai.vertex.ai.anthropic.location=asia-east1",
+				"spring.ai.vertex.ai.anthropic.chat.options.model=claude-sonnet-4@20250514")
+		.withConfiguration(SpringAiTestAutoConfigurations.of(VertexAiAnthropicChatAutoConfiguration.class));
+
+	/**
+	 * Tests that the Vertex AI Anthropic API and chat model beans are properly
+	 * configured.
+	 */
+	@Test
+	void testChatModelConfiguration() {
+		this.contextRunner.run(context -> {
+			var api = context.getBean(VertexAiAnthropicApi.class);
+			assertThat(api).isNotNull();
+
+			var chatModel = context.getBean(AnthropicChatModel.class);
+			assertThat(chatModel).isNotNull();
+		});
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -68,7 +68,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Austin Dase
  * @since 1.0.0
  */
-public final class AnthropicApi {
+public class AnthropicApi {
 
 	private static final Logger logger = LoggerFactory.getLogger(AnthropicApi.class);
 
@@ -127,13 +127,17 @@ public final class AnthropicApi {
 	 * @param responseErrorHandler Response error handler.
 	 * @param anthropicBetaFeatures Anthropic beta features.
 	 */
-	private AnthropicApi(String baseUrl, String completionsPath, ApiKey anthropicApiKey, String anthropicVersion,
+	protected AnthropicApi(String baseUrl, String completionsPath, ApiKey anthropicApiKey, String anthropicVersion,
 			RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder,
 			ResponseErrorHandler responseErrorHandler, String anthropicBetaFeatures) {
 
 		Consumer<HttpHeaders> jsonContentHeaders = headers -> {
-			headers.add(HEADER_ANTHROPIC_VERSION, anthropicVersion);
-			headers.add(HEADER_ANTHROPIC_BETA, anthropicBetaFeatures);
+			if (anthropicVersion != null) {
+				headers.add(HEADER_ANTHROPIC_VERSION, anthropicVersion);
+			}
+			if (anthropicBetaFeatures != null) {
+				headers.add(HEADER_ANTHROPIC_BETA, anthropicBetaFeatures);
+			}
 			headers.setContentType(MediaType.APPLICATION_JSON);
 		};
 
@@ -899,6 +903,8 @@ public final class AnthropicApi {
 	 * model can perform more in-depth reasoning before responding to a query.
 	 * @param outputFormat Output format configuration for structured outputs.
 	 * @param container Container for Claude Skills configuration.
+	 * @param anthropicVersion The Anthropic API version for this request. Required when
+	 * using platforms like Vertex AI or Bedrock.
 	 */
 	@JsonInclude(Include.NON_NULL)
 	public record ChatCompletionRequest(
@@ -917,19 +923,20 @@ public final class AnthropicApi {
 		@JsonProperty("tool_choice") ToolChoice toolChoice,
 		@JsonProperty("thinking") ThinkingConfig thinking,
 		@JsonProperty("output_format") OutputFormat outputFormat,
-		@JsonProperty("container") SkillContainer container) {
+		@JsonProperty("container") SkillContainer container,
+		@JsonProperty("anthropic_version") String anthropicVersion) {
 		// @formatter:on
 
 		public ChatCompletionRequest(String model, List<AnthropicMessage> messages, Object system, Integer maxTokens,
 				Double temperature, Boolean stream) {
 			this(model, messages, system, maxTokens, null, null, stream, temperature, null, null, null, null, null,
-					null, null);
+					null, null, null);
 		}
 
 		public ChatCompletionRequest(String model, List<AnthropicMessage> messages, Object system, Integer maxTokens,
 				List<String> stopSequences, Double temperature, Boolean stream) {
 			this(model, messages, system, maxTokens, null, stopSequences, stream, temperature, null, null, null, null,
-					null, null, null);
+					null, null, null, null);
 		}
 
 		public static ChatCompletionRequestBuilder builder() {
@@ -1020,6 +1027,8 @@ public final class AnthropicApi {
 
 		private SkillContainer container;
 
+		private String anthropicVersion;
+
 		private ChatCompletionRequestBuilder() {
 		}
 
@@ -1039,6 +1048,7 @@ public final class AnthropicApi {
 			this.thinking = request.thinking;
 			this.outputFormat = request.outputFormat;
 			this.container = request.container;
+			this.anthropicVersion = request.anthropicVersion;
 		}
 
 		public ChatCompletionRequestBuilder model(ChatModel model) {
@@ -1126,6 +1136,11 @@ public final class AnthropicApi {
 			return this;
 		}
 
+		public ChatCompletionRequestBuilder anthropicVersion(String anthropicVersion) {
+			this.anthropicVersion = anthropicVersion;
+			return this;
+		}
+
 		public ChatCompletionRequestBuilder skills(List<Skill> skills) {
 			if (skills != null && !skills.isEmpty()) {
 				this.container = new SkillContainer(skills);
@@ -1136,7 +1151,7 @@ public final class AnthropicApi {
 		public ChatCompletionRequest build() {
 			return new ChatCompletionRequest(this.model, this.messages, this.system, this.maxTokens, this.metadata,
 					this.stopSequences, this.stream, this.temperature, this.topP, this.topK, this.tools,
-					this.toolChoice, this.thinking, this.outputFormat, this.container);
+					this.toolChoice, this.thinking, this.outputFormat, this.container, this.anthropicVersion);
 		}
 
 	}

--- a/models/spring-ai-vertex-ai-anthropic/README.md
+++ b/models/spring-ai-vertex-ai-anthropic/README.md
@@ -1,0 +1,1 @@
+VertexAI Anthropic Chat

--- a/models/spring-ai-vertex-ai-anthropic/pom.xml
+++ b/models/spring-ai-vertex-ai-anthropic/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-vertex-ai-anthropic</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Model - Vertex AI Anthropic</name>
+	<description>Vertex AI Anthropic models support</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.google.cloud</groupId>
+				<artifactId>libraries-bom</artifactId>
+				<version>${com.google.cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>com.github.victools</groupId>
+			<artifactId>jsonschema-generator</artifactId>
+			<version>${jsonschema.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.victools</groupId>
+			<artifactId>jsonschema-module-jackson</artifactId>
+			<version>${jsonschema.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-vertexai</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-anthropic</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Spring Framework -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webclient</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/models/spring-ai-vertex-ai-anthropic/src/main/java/org/springframework/ai/vertexai/anthropic/api/VertexAiAnthropicApi.java
+++ b/models/spring-ai-vertex-ai-anthropic/src/main/java/org/springframework/ai/vertexai/anthropic/api/VertexAiAnthropicApi.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertexai.anthropic.api;
+
+import java.io.IOException;
+
+import com.google.auth.Credentials;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.model.ChatModelDescription;
+import org.springframework.ai.model.SimpleApiKey;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Client for Anthropic LLM models hosted on Google Cloud Vertex AI platform.
+ * <p>
+ * This class extends {@link AnthropicApi} to provide seamless integration with Google
+ * Cloud Vertex AI, handling authentication via Google Cloud credentials, Vertex
+ * AI-specific request formatting (including version headers), and routing to the
+ * appropriate Vertex AI endpoints.
+ */
+public class VertexAiAnthropicApi extends AnthropicApi {
+
+	private static final String VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16";
+
+	private static final String LOCATION_GLOBAL = "global";
+
+	private static final String DEFAULT_MODEL = ChatModel.CLAUDE_SONNET_4_5.getValue();
+
+	/**
+	 * Constructs a new VertexAiAnthropicApi instance with the specified configuration.
+	 * <p>
+	 * This constructor is primarily intended for internal use. For standard
+	 * instantiation, use {@link #builderForVertexAi()} instead.
+	 * @param baseUrl the base URL for the Vertex AI API endpoint
+	 * @param completionsPath the path for the chat completions endpoint
+	 * @param credentials the Google Cloud credentials for authentication
+	 * @param restClientBuilder the builder for creating the RestClient
+	 * @param webClientBuilder the builder for creating the WebClient
+	 * @param responseErrorHandler the error handler for HTTP responses
+	 */
+	protected VertexAiAnthropicApi(String baseUrl, String completionsPath, Credentials credentials,
+			RestClient.Builder restClientBuilder, WebClient.Builder webClientBuilder,
+			ResponseErrorHandler responseErrorHandler) {
+		super(baseUrl, completionsPath, new SimpleApiKey(""), null, restClientBuilder, webClientBuilder,
+				responseErrorHandler, null);
+		this.credentials = credentials;
+	}
+
+	private final Credentials credentials;
+
+	@Override
+	public ResponseEntity<ChatCompletionResponse> chatCompletionEntity(ChatCompletionRequest chatRequest,
+			HttpHeaders additionalHttpHeader) {
+		addAuthHeader(additionalHttpHeader);
+		return super.chatCompletionEntity(createVertexCompletionRequest(chatRequest), additionalHttpHeader);
+	}
+
+	@Override
+	public Flux<ChatCompletionResponse> chatCompletionStream(ChatCompletionRequest chatRequest,
+			HttpHeaders additionalHttpHeader) {
+		addAuthHeader(additionalHttpHeader);
+		return super.chatCompletionStream(createVertexCompletionRequest(chatRequest), additionalHttpHeader);
+	}
+
+	private void addAuthHeader(HttpHeaders headers) {
+		try {
+			headers.putAll(this.credentials.getRequestMetadata());
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private ChatCompletionRequest createVertexCompletionRequest(ChatCompletionRequest request) {
+		return ChatCompletionRequest.from(request)
+			.model((String) null)
+			.anthropicVersion(VERTEX_ANTHROPIC_VERSION)
+			.build();
+	}
+
+	/**
+	 * Returns a new builder for constructing {@link VertexAiAnthropicApi} instances.
+	 * @return a new {@link Builder} instance
+	 */
+	public static Builder builderForVertexAi() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link VertexAiAnthropicApi}.
+	 * <p>
+	 * Example usage: <pre>{@code
+	 * VertexAiAnthropicApi api = VertexAiAnthropicApi.builderForVertexAi()
+	 *     .credentials(credentials)
+	 *     .projectId("my-project")
+	 *     .model(ChatModel.CLAUDE_SONNET_4_5)
+	 *     .build();
+	 * }</pre>
+	 */
+	public static final class Builder {
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets the Google Cloud credentials for authentication with Vertex AI.
+		 * @param credentials the credentials to use for API requests
+		 * @return this builder instance for method chaining
+		 */
+		public Builder credentials(Credentials credentials) {
+			Assert.notNull(credentials, "credentials cannot be null");
+			this.credentials = credentials;
+			return this;
+		}
+
+		private Credentials credentials;
+
+		/**
+		 * Sets the Google Cloud project ID where the Vertex AI resources are located.
+		 * @param projectId the project ID
+		 * @return this builder instance for method chaining
+		 */
+		public Builder projectId(String projectId) {
+			Assert.notNull(projectId, "projectId cannot be null");
+			this.projectId = projectId;
+			return this;
+		}
+
+		private String projectId;
+
+		/**
+		 * Sets the Google Cloud region location for the Vertex AI endpoint (e.g.,
+		 * "us-central1"). Defaults to "global" if not specified.
+		 * @param location the location string
+		 * @return this builder instance for method chaining
+		 */
+		public Builder location(String location) {
+			Assert.notNull(location, "location cannot be null");
+			this.location = location;
+			return this;
+		}
+
+		private String location = LOCATION_GLOBAL;
+
+		/**
+		 * Sets the Anthropic model name to use for chat completions. See <a href=
+		 * "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/use-claude#model-list">available
+		 * models</a> for the list of supported models.
+		 * @param model the model name (e.g., "claude-haiku-4-5@20251001")
+		 * @return this builder instance for method chaining
+		 */
+		public Builder model(String model) {
+			Assert.notNull(model, "model cannot be null");
+			this.model = model;
+			return this;
+		}
+
+		/**
+		 * Sets the Anthropic model using a {@link ChatModel} enum value.
+		 * @param model the chat model enum
+		 * @return this builder instance for method chaining
+		 */
+		public Builder model(ChatModel model) {
+			Assert.notNull(model, "model cannot be null");
+			this.model = model.getValue();
+			return this;
+		}
+
+		private String model = DEFAULT_MODEL;
+
+		/**
+		 * Sets the custom RestClient.Builder for HTTP requests.
+		 * @param restClientBuilder the RestClient builder
+		 * @return this builder instance for method chaining
+		 */
+		public Builder restClientBuilder(RestClient.Builder restClientBuilder) {
+			Assert.notNull(restClientBuilder, "restClientBuilder cannot be null");
+			this.restClientBuilder = restClientBuilder;
+			return this;
+		}
+
+		private RestClient.Builder restClientBuilder = RestClient.builder();
+
+		/**
+		 * Sets the custom WebClient.Builder for reactive HTTP requests.
+		 * @param webClientBuilder the WebClient builder
+		 * @return this builder instance for method chaining
+		 */
+		public Builder webClientBuilder(WebClient.Builder webClientBuilder) {
+			Assert.notNull(webClientBuilder, "webClientBuilder cannot be null");
+			this.webClientBuilder = webClientBuilder;
+			return this;
+		}
+
+		private WebClient.Builder webClientBuilder = WebClient.builder();
+
+		/**
+		 * Sets the custom response error handler for HTTP responses.
+		 * @param responseErrorHandler the error handler
+		 * @return this builder instance for method chaining
+		 */
+		public Builder responseErrorHandler(ResponseErrorHandler responseErrorHandler) {
+			Assert.notNull(responseErrorHandler, "responseErrorHandler cannot be null");
+			this.responseErrorHandler = responseErrorHandler;
+			return this;
+		}
+
+		private ResponseErrorHandler responseErrorHandler = RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER;
+
+		/**
+		 * Builds and returns a new {@link VertexAiAnthropicApi} instance with the
+		 * configured parameters.
+		 * @return the constructed API client instance
+		 */
+		public VertexAiAnthropicApi build() {
+			Assert.notNull(this.credentials, "credentials cannot be null");
+			Assert.notNull(this.projectId, "projectId cannot be null");
+			String baseUrl = "https://%saiplatform.googleapis.com"
+				.formatted(this.location.equals(LOCATION_GLOBAL) ? "" : (this.location + "-"));
+			String completionPath = "/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict"
+				.formatted(this.projectId, this.location, this.model);
+			return new VertexAiAnthropicApi(baseUrl, completionPath, this.credentials, this.restClientBuilder,
+					this.webClientBuilder, this.responseErrorHandler);
+		}
+
+	}
+
+	/**
+	 * Claude models names. <a href=
+	 * "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/use-claude#model-list">link</a>
+	 */
+	public enum ChatModel implements ChatModelDescription {
+
+		/**
+		 * Claude Opus 4.5
+		 */
+		CLAUDE_OPUS_4_5("claude-opus-4-5@20251101"),
+
+		/**
+		 * Claude Opus 4.1
+		 */
+		CLAUDE_OPUS_4_1("claude-opus-4-1@20250805"),
+
+		/**
+		 * Claude Opus 4
+		 */
+		CLAUDE_OPUS_4("claude-opus-4@20250514"),
+
+		/**
+		 * Claude Sonnet 4.5
+		 */
+		CLAUDE_SONNET_4_5("claude-sonnet-4-5@20250929"),
+
+		/**
+		 * Claude Sonnet 4
+		 */
+		CLAUDE_SONNET_4("claude-sonnet-4@20250514"),
+
+		/**
+		 * Claude 3.7 Sonnet
+		 */
+		CLAUDE_3_7_SONNET("claude-3-7-sonnet@20250219"),
+
+		/**
+		 * Claude 3.5 Sonnet v2
+		 */
+		CLAUDE_3_5_SONNET_V2("claude-3-5-sonnet-v2@20241022"),
+
+		/**
+		 * Claude Haiku 4.5
+		 */
+		CLAUDE_4_5_HAIKU("claude-haiku-4-5@20251001"),
+
+		/**
+		 * Claude 3.5 Haiku
+		 */
+		CLAUDE_3_5_HAIKU("claude-3-5-haiku@20241022"),
+
+		/**
+		 * Claude 3.5 Sonnet
+		 */
+		CLAUDE_3_5_SONNET("claude-3-5-sonnet@20240620"),
+
+		/**
+		 * Claude 3 Opus
+		 */
+		CLAUDE_3_OPUS("claude-3-opus@20240229"),
+
+		/**
+		 * Claude 3 Haiku
+		 */
+		CLAUDE_3_HAIKU("claude-3-haiku@20240307");
+
+		public final String value;
+
+		ChatModel(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return this.value;
+		}
+
+		@Override
+		public String getName() {
+			return this.value;
+		}
+
+	}
+
+}

--- a/models/spring-ai-vertex-ai-anthropic/src/test/java/org/springframework/ai/vertexai/anthropic/api/VertexAiAnthropicApiTest.java
+++ b/models/spring-ai-vertex-ai-anthropic/src/test/java/org/springframework/ai/vertexai/anthropic/api/VertexAiAnthropicApiTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2023-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vertexai.anthropic.api;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.auth.Credentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Tests for {@link VertexAiAnthropicApi}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class VertexAiAnthropicApiTest {
+
+	@Mock
+	Credentials credentials;
+
+	MockRestServiceServer server;
+
+	RestClient.Builder restClientBuilder;
+
+	Map<String, List<String>> requestMetadata;
+
+	@BeforeEach
+	void beforeEach() throws Exception {
+		this.restClientBuilder = RestClient.builder();
+		this.server = MockRestServiceServer.bindTo(this.restClientBuilder).build();
+		this.requestMetadata = new HashMap<>();
+		this.requestMetadata.put("Authorization", List.of("Bearer DUMMY"));
+		doReturn(this.requestMetadata).when(this.credentials).getRequestMetadata();
+	}
+
+	/**
+	 * Tests chat completion with minimal options.
+	 */
+	@Test
+	void testChatCompletionWithMinimalOptions() {
+		var api = VertexAiAnthropicApi.builderForVertexAi()
+			.credentials(this.credentials)
+			.restClientBuilder(this.restClientBuilder)
+			.projectId("dummy_pj")
+			.build();
+		var request = AnthropicApi.ChatCompletionRequest.builder().build();
+		this.server.expect(requestTo(
+				"https://aiplatform.googleapis.com/v1/projects/dummy_pj/locations/global/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict"))
+			.andExpect(method(HttpMethod.POST))
+			.andExpect(header("Authorization", "Bearer DUMMY"))
+			.andExpect(jsonPath("anthropic_version").value("vertex-2023-10-16"))
+			.andExpect(jsonPath("model").doesNotExist())
+			.andExpect(jsonPath("messages").doesNotExist())
+			.andRespond(withSuccess());
+		api.chatCompletionEntity(request);
+		this.server.verify();
+	}
+
+	/**
+	 * Tests various Vertex AI endpoint configurations with different locations and
+	 * models.
+	 */
+	@ParameterizedTest
+	@CsvSource({
+	// @formatter:off
+			"        ,                           , https://aiplatform.googleapis.com/v1/projects/dummy_pj/locations/global/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict",
+			"global  , claude-sonnet-4-5@20250929, https://aiplatform.googleapis.com/v1/projects/dummy_pj/locations/global/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict",
+			"us-east5,                           , https://us-east5-aiplatform.googleapis.com/v1/projects/dummy_pj/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict",
+			"        , claude-haiku-4-5@20251001 , https://aiplatform.googleapis.com/v1/projects/dummy_pj/locations/global/publishers/anthropic/models/claude-haiku-4-5@20251001:streamRawPredict"
+			// @formatter:on
+	})
+	void testVertexEndpoint(String location, String model, String expected) {
+		var api = VertexAiAnthropicApi.builderForVertexAi()
+			.credentials(this.credentials)
+			.restClientBuilder(this.restClientBuilder)
+			.projectId("dummy_pj");
+		if (location != null) {
+			api.location(location);
+		}
+		if (model != null) {
+			api.model(model);
+		}
+		var request = AnthropicApi.ChatCompletionRequest.builder();
+		this.server.expect(requestTo(expected)).andRespond(withSuccess());
+		api.build().chatCompletionEntity(request.build());
+		this.server.verify();
+	}
+
+	/**
+	 * Tests that request body properties are correctly mapped to JSON paths.
+	 */
+	@ParameterizedTest
+	@CsvSource({
+	// @formatter:off
+			"role                , assistant, messages[0].role",
+			"content             , hi!!     , messages[0].content[0].text",
+			"maxTokens           , 2048     , max_tokens",
+			"thinkingBudgetTokens, 4096     , thinking.budget_tokens"
+			// @formatter:on
+	})
+	void testChatCompletion(String property, String value, String jsonPath) {
+		var api = VertexAiAnthropicApi.builderForVertexAi()
+			.credentials(this.credentials)
+			.restClientBuilder(this.restClientBuilder)
+			.projectId("dummy_pj");
+		var request = AnthropicApi.ChatCompletionRequest.builder();
+
+		var role = property.equals("role") ? value : "user";
+		var content = property.equals("content") ? value : "";
+		var messageContent = List.of(new AnthropicApi.ContentBlock(content));
+		var messageRole = AnthropicApi.Role.valueOf(role.toUpperCase());
+		request.messages(List.of(new AnthropicApi.AnthropicMessage(messageContent, messageRole)));
+
+		var maxTokens = property.equals("maxTokens") ? Integer.valueOf(value) : null;
+		if (maxTokens != null) {
+			request.maxTokens(maxTokens);
+		}
+		var thinkingBudgetTokens = property.equals("thinkingBudgetTokens") ? Integer.valueOf(value) : null;
+		if (thinkingBudgetTokens != null) {
+			request.thinking(AnthropicApi.ThinkingType.ENABLED, thinkingBudgetTokens);
+		}
+		this.server.expect(requestTo(
+				"https://aiplatform.googleapis.com/v1/projects/dummy_pj/locations/global/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict"))
+			.andExpect(jsonPath(jsonPath).value(value))
+			.andRespond(withSuccess());
+		api.build().chatCompletionEntity(request.build());
+		this.server.verify();
+	}
+
+	/**
+	 * Tests chat completion request with tool calling.
+	 */
+	@Test
+	void testChatCompletionWithToolCalling() {
+		var api = VertexAiAnthropicApi.builderForVertexAi()
+			.credentials(this.credentials)
+			.restClientBuilder(this.restClientBuilder)
+			.projectId("dummy_pj")
+			.build();
+		var tool = new AnthropicApi.Tool("get_weather", "Get current weather",
+				Map.of("type", "object", "properties", Map.of("location", Map.of("type", "string"))));
+		var request = AnthropicApi.ChatCompletionRequest.builder()
+			.messages(List.of(new AnthropicApi.AnthropicMessage(
+					List.of(new AnthropicApi.ContentBlock("What's the weather?")), AnthropicApi.Role.USER)))
+			.tools(List.of(tool))
+			.build();
+		this.server.expect(requestTo(
+				"https://aiplatform.googleapis.com/v1/projects/dummy_pj/locations/global/publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict"))
+			.andExpect(jsonPath("tools[0].name").value("get_weather"))
+			.andExpect(jsonPath("tools[0].description").value("Get current weather"))
+			.andExpect(jsonPath("messages[0].content[0].text").value("What's the weather?"))
+			.andRespond(withSuccess());
+		api.chatCompletionEntity(request);
+		this.server.verify();
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
 		<module>models/spring-ai-transformers</module>
 		<module>models/spring-ai-vertex-ai-embedding</module>
 		<module>models/spring-ai-vertex-ai-gemini</module>
+		<module>models/spring-ai-vertex-ai-anthropic</module>
 		<module>models/spring-ai-google-genai</module>
 		<module>models/spring-ai-google-genai-embedding</module>
 		<module>models/spring-ai-zhipuai</module>
@@ -213,6 +214,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-transformers</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-vertex-ai-embedding</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-vertex-ai-gemini</module>
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-vertex-ai-anthropic</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-zhipuai</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-deepseek</module>
 
@@ -876,6 +878,7 @@
 								<exclude>org.springframework.ai.transformers/**/*IT.java</exclude>
 								<exclude>org.springframework.ai.vertexai.embedding/**/*IT.java</exclude>
 								<exclude>org.springframework.ai.vertexai.gemini/**/*IT.java</exclude>
+								<exclude>org.springframework.ai.vertexai.anthropic/**/*IT.java</exclude>
 								<exclude>org.springframework.ai.zhipuai/**/*IT.java</exclude>
 
 								<!-- Vector Stores -->

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -341,6 +341,12 @@
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-vertex-ai-anthropic</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-zhipuai</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -1067,6 +1073,12 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-starter-model-vertex-ai-anthropic</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-vertex-ai-anthropic/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-vertex-ai-anthropic/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>spring-ai-starter-model-vertex-ai-anthropic</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Starter - VertexAI Anthropic</name>
+    <description>Spring AI Vertex Anthropic AI Spring Boot Starter</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-vertex-ai</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-vertex-ai-anthropic</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
This PR introduces comprehensive support for Anthropic Claude models hosted on Google Cloud Vertex AI. It adds a new module `spring-ai-vertex-ai-anthropic` with API integration, autoconfiguration, and configuration properties to enable seamless use of Anthropic models through Vertex AI.

**Key Changes:**
- **New Module:** Added `spring-ai-vertex-ai-anthropic` with core API classes for Vertex AI Anthropic integration.
- **Autoconfiguration:** Implemented `VertexAiAnthropicChatAutoConfiguration` for automatic bean setup, including API client and chat model.
- **Configuration Properties:** Added `VertexAiAnthropicConnectionProperties` and `VertexAiAnthropicChatProperties` for customizable settings (project ID, location, model, credentials).

**Requirements:**  
- Google Cloud credentials and project setup.  
- Configuration via `spring.ai.vertex.ai.anthropic.*` properties.

**Testing:**  
All tests pass, including integration tests with real Vertex AI calls (requires env vars).

Closes gh-1514.