### PR TITLE
GH-5191: Fix Neo4jVectorStore doAdd method ignoring sessionConfig

### DIFF
--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
@@ -209,7 +209,7 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 			.map(document -> documentToRecord(document, embeddings.get(documents.indexOf(document))))
 			.toList();
 
-		try (var session = this.driver.session()) {
+		try (var session = this.driver.session(this.sessionConfig)) {
 			var statement = """
 						UNWIND $rows AS row
 						MERGE (u:%s {%2$s: row.id})


### PR DESCRIPTION
Fixes GH-5191

### Description
This PR fixes a bug where the `doAdd` method in `Neo4jVectorStore` was ignoring the user-configured `sessionConfig`. 

Previously, `doAdd` initialized the session using `this.driver.session()`, which falls back to the default database configuration. This caused connection errors when a custom database name was specified in `Neo4jVectorStoreConfig`.

**Changes:**
- Updated `doAdd` to use `this.driver.session(this.sessionConfig)` to ensure the configured session settings (e.g., database name) are respected.

### Verification
- I have verified that the code compiles successfully.
- The fix aligns with how other methods (like `doDelete` or `doSearch`) initialize the session in this class.