### PR TITLE
Add `@McpClient` qualifier for selective client injection

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
@@ -31,12 +31,14 @@ import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpSync
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.customizer.McpClientCustomizer;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -97,6 +99,7 @@ import org.springframework.util.CollectionUtils;
  * @see StdioTransportAutoConfiguration
  */
 @AutoConfiguration
+@Import(McpConnectionBeanRegistrar.class)
 @EnableConfigurationProperties(McpClientCommonProperties.class)
 @ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 		matchIfMissing = true)
@@ -205,7 +208,7 @@ public class McpClientAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
-	public CloseableMcpSyncClients makeSyncClientsClosable(List<McpSyncClient> clients) {
+	public CloseableMcpSyncClients makeSyncClientsClosable(@Qualifier("mcpSyncClients") List<McpSyncClient> clients) {
 		return new CloseableMcpSyncClients(clients);
 	}
 
@@ -290,7 +293,8 @@ public class McpClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
-	public CloseableMcpAsyncClients makeAsyncClientsClosable(List<McpAsyncClient> clients) {
+	public CloseableMcpAsyncClients makeAsyncClientsClosable(
+			@Qualifier("mcpAsyncClients") List<McpAsyncClient> clients) {
 		return new CloseableMcpAsyncClients(clients);
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpConnectionBeanRegistrar.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpConnectionBeanRegistrar.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.ai.mcp.annotation.spring.McpClient;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStdioClientProperties;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AutowireCandidateQualifier;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.StringUtils;
+
+/**
+ * An {@link ImportBeanDefinitionRegistrar} that registers an individual MCP client bean
+ * for each connection name discoverable from MCP client configuration properties.
+ *
+ * <p>
+ * SSE, Streamable HTTP, and stdio connection names are registered with both the
+ * {@link McpClient @McpClient} qualifier and the standard {@link Qualifier @Qualifier}.
+ * The configured {@code spring.ai.mcp.client.type} determines whether each definition
+ * uses {@link NamedMcpSyncClientFactoryBean} or {@link NamedMcpAsyncClientFactoryBean}.
+ *
+ * <p>
+ * Sync beans use the name {@code mcpSyncClient_{connectionName}} and async beans use
+ * {@code mcpAsyncClient_{connectionName}}. For example, a connection named
+ * {@code filesystem} can be injected with {@code @McpClient("filesystem")}.
+ *
+ * @author Taewoong Kim
+ * @see NamedMcpSyncClientFactoryBean
+ * @see NamedMcpAsyncClientFactoryBean
+ * @since 2.0.1
+ */
+public class McpConnectionBeanRegistrar implements ImportBeanDefinitionRegistrar {
+
+	private static final Log logger = LogFactory.getLog(McpConnectionBeanRegistrar.class);
+
+	private static final String SYNC_BEAN_NAME_PREFIX = "mcpSyncClient_";
+
+	private static final String ASYNC_BEAN_NAME_PREFIX = "mcpAsyncClient_";
+
+	private static final String QUALIFIER_TYPE_ATTRIBUTE = McpConnectionBeanRegistrar.class.getName()
+			+ ".qualifierType";
+
+	private final Environment environment;
+
+	/**
+	 * Creates a registrar that discovers MCP connections from the environment.
+	 * @param environment the environment containing MCP client configuration
+	 */
+	public McpConnectionBeanRegistrar(Environment environment) {
+		this.environment = environment;
+	}
+
+	@Override
+	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+		boolean async = isAsyncClientType();
+		Set<String> connectionNames = new LinkedHashSet<>();
+
+		collectSseConnectionNames(connectionNames);
+		collectStreamableHttpConnectionNames(connectionNames);
+		collectStdioConnectionNames(connectionNames);
+		Set<String> registeredConnections = new LinkedHashSet<>();
+		for (String connectionName : connectionNames) {
+			if (registerNamedClientFactoryBean(registry, connectionName, async)) {
+				registeredConnections.add(connectionName);
+			}
+		}
+
+		if (!registeredConnections.isEmpty() && logger.isDebugEnabled()) {
+			String clientType = async ? "async" : "sync";
+			logger.debug("Registered " + registeredConnections.size() + " named MCP " + clientType + " client bean(s): "
+					+ registeredConnections);
+		}
+	}
+
+	@SuppressWarnings("removal")
+	private void collectSseConnectionNames(Set<String> connectionNames) {
+		Bindable<Map<String, McpSseClientProperties.SseParameters>> bindable = Bindable.mapOf(String.class,
+				McpSseClientProperties.SseParameters.class);
+
+		Binder.get(this.environment)
+			.bind(McpSseClientProperties.CONFIG_PREFIX + ".connections", bindable)
+			.ifBound(connections -> connections.keySet().forEach(name -> addConnectionName(connectionNames, name)));
+	}
+
+	private void collectStreamableHttpConnectionNames(Set<String> connectionNames) {
+		Bindable<Map<String, McpStreamableHttpClientProperties.ConnectionParameters>> bindable = Bindable
+			.mapOf(String.class, McpStreamableHttpClientProperties.ConnectionParameters.class);
+
+		Binder.get(this.environment)
+			.bind(McpStreamableHttpClientProperties.CONFIG_PREFIX + ".connections", bindable)
+			.ifBound(connections -> connections.keySet().forEach(name -> addConnectionName(connectionNames, name)));
+	}
+
+	private void collectStdioConnectionNames(Set<String> connectionNames) {
+		Bindable<McpStdioClientProperties> bindable = Bindable.of(McpStdioClientProperties.class);
+
+		Binder.get(this.environment)
+			.bind(McpStdioClientProperties.CONFIG_PREFIX, bindable)
+			.ifBound(properties -> properties.toServerParameters()
+				.keySet()
+				.forEach(name -> addConnectionName(connectionNames, name)));
+	}
+
+	private void addConnectionName(Set<String> connectionNames, String connectionName) {
+		if (!StringUtils.hasText(connectionName)) {
+			return;
+		}
+		connectionNames.add(connectionName);
+	}
+
+	private boolean isAsyncClientType() {
+		String type = this.environment.getProperty(McpClientCommonProperties.CONFIG_PREFIX + ".type", "SYNC");
+		return "ASYNC".equalsIgnoreCase(type);
+	}
+
+	private boolean registerNamedClientFactoryBean(BeanDefinitionRegistry registry, String connectionName,
+			boolean async) {
+		String beanName = getBeanName(connectionName, async);
+		if (registry.isBeanNameInUse(beanName)) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Bean name '" + beanName
+						+ "' is already in use. Skipping auto-registration for connection '" + connectionName + "'.");
+			}
+			return false;
+		}
+
+		GenericBeanDefinition definition = new GenericBeanDefinition();
+		definition.setBeanClass(async ? NamedMcpAsyncClientFactoryBean.class : NamedMcpSyncClientFactoryBean.class);
+		definition.getConstructorArgumentValues().addIndexedArgumentValue(0, connectionName);
+		definition.setScope(BeanDefinition.SCOPE_SINGLETON);
+		definition.addQualifier(createQualifier(McpClient.class, connectionName));
+		definition.addQualifier(createQualifier(Qualifier.class, connectionName));
+		definition.setDefaultCandidate(false);
+		definition.setLazyInit(true);
+		definition.setSynthetic(true);
+
+		registry.registerBeanDefinition(beanName, definition);
+		return true;
+	}
+
+	private static AutowireCandidateQualifier createQualifier(Class<?> qualifierType, String connectionName) {
+		AutowireCandidateQualifier qualifier = new AutowireCandidateQualifier(qualifierType, connectionName);
+		// Include the type in equality so equal-valued qualifiers both survive AOT code
+		// generation.
+		qualifier.setAttribute(QUALIFIER_TYPE_ATTRIBUTE, qualifierType.getName());
+		return qualifier;
+	}
+
+	private String getBeanName(String connectionName, boolean async) {
+		return async ? ASYNC_BEAN_NAME_PREFIX + connectionName : SYNC_BEAN_NAME_PREFIX + connectionName;
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/NamedMcpAsyncClientFactoryBean.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/NamedMcpAsyncClientFactoryBean.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import java.util.List;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * A {@link FactoryBean} that exposes the {@link McpAsyncClient} for a named MCP
+ * connection.
+ *
+ * <p>
+ * {@link McpConnectionBeanRegistrar} registers definitions for configured connections.
+ * The matching client is resolved from the existing aggregate client list, keeping
+ * aggregate access and selective injection on the same client instance.
+ *
+ * @author Taewoong Kim
+ * @see org.springframework.ai.mcp.annotation.spring.McpClient
+ * @since 2.0.1
+ */
+public class NamedMcpAsyncClientFactoryBean implements FactoryBean<McpAsyncClient> {
+
+	private final String connectionName;
+
+	private ObjectProvider<List<NamedClientMcpTransport>> transportsProvider;
+
+	private List<McpAsyncClient> mcpAsyncClients;
+
+	/**
+	 * Creates a factory bean for the specified connection.
+	 * @param connectionName the configured MCP connection name
+	 */
+	public NamedMcpAsyncClientFactoryBean(String connectionName) {
+		this.connectionName = connectionName;
+	}
+
+	@Autowired
+	void setTransportsProvider(ObjectProvider<List<NamedClientMcpTransport>> transportsProvider) {
+		this.transportsProvider = transportsProvider;
+	}
+
+	@Autowired
+	void setMcpAsyncClients(@Qualifier("mcpAsyncClients") List<McpAsyncClient> mcpAsyncClients) {
+		this.mcpAsyncClients = mcpAsyncClients;
+	}
+
+	@Override
+	public McpAsyncClient getObject() {
+		return findClient();
+	}
+
+	private McpAsyncClient findClient() {
+		List<NamedClientMcpTransport> namedTransports = this.transportsProvider.stream().flatMap(List::stream).toList();
+		if (namedTransports.size() != this.mcpAsyncClients.size()) {
+			throw new IllegalStateException("MCP transport and async client counts do not match");
+		}
+
+		int matchingIndex = -1;
+		for (int i = 0; i < namedTransports.size(); i++) {
+			if (this.connectionName.equals(namedTransports.get(i).name())) {
+				if (matchingIndex >= 0) {
+					throw new IllegalStateException(
+							"Multiple transports found for MCP connection '" + this.connectionName + "'");
+				}
+				matchingIndex = i;
+			}
+		}
+
+		if (matchingIndex < 0) {
+			throw new IllegalStateException("No transport found for MCP connection '" + this.connectionName + "'");
+		}
+
+		return this.mcpAsyncClients.get(matchingIndex);
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return McpAsyncClient.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/NamedMcpSyncClientFactoryBean.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/NamedMcpSyncClientFactoryBean.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import java.util.List;
+
+import io.modelcontextprotocol.client.McpSyncClient;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * A {@link FactoryBean} that exposes the {@link McpSyncClient} for a named MCP
+ * connection.
+ *
+ * <p>
+ * {@link McpConnectionBeanRegistrar} registers definitions for configured connections.
+ * The matching client is resolved from the existing aggregate client list, keeping
+ * aggregate access and selective injection on the same client instance.
+ *
+ * @author Taewoong Kim
+ * @see org.springframework.ai.mcp.annotation.spring.McpClient
+ * @since 2.0.1
+ */
+public class NamedMcpSyncClientFactoryBean implements FactoryBean<McpSyncClient> {
+
+	private final String connectionName;
+
+	private ObjectProvider<List<NamedClientMcpTransport>> transportsProvider;
+
+	private List<McpSyncClient> mcpSyncClients;
+
+	/**
+	 * Creates a factory bean for the specified connection.
+	 * @param connectionName the configured MCP connection name
+	 */
+	public NamedMcpSyncClientFactoryBean(String connectionName) {
+		this.connectionName = connectionName;
+	}
+
+	@Autowired
+	void setTransportsProvider(ObjectProvider<List<NamedClientMcpTransport>> transportsProvider) {
+		this.transportsProvider = transportsProvider;
+	}
+
+	@Autowired
+	void setMcpSyncClients(@Qualifier("mcpSyncClients") List<McpSyncClient> mcpSyncClients) {
+		this.mcpSyncClients = mcpSyncClients;
+	}
+
+	@Override
+	public McpSyncClient getObject() {
+		return findClient();
+	}
+
+	private McpSyncClient findClient() {
+		List<NamedClientMcpTransport> namedTransports = this.transportsProvider.stream().flatMap(List::stream).toList();
+		if (namedTransports.size() != this.mcpSyncClients.size()) {
+			throw new IllegalStateException("MCP transport and sync client counts do not match");
+		}
+
+		int matchingIndex = -1;
+		for (int i = 0; i < namedTransports.size(); i++) {
+			if (this.connectionName.equals(namedTransports.get(i).name())) {
+				if (matchingIndex >= 0) {
+					throw new IllegalStateException(
+							"Multiple transports found for MCP connection '" + this.connectionName + "'");
+				}
+				matchingIndex = i;
+			}
+		}
+
+		if (matchingIndex < 0) {
+			throw new IllegalStateException("No transport found for MCP connection '" + this.connectionName + "'");
+		}
+
+		return this.mcpSyncClients.get(matchingIndex);
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return McpSyncClient.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfigurationAotTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfigurationAotTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.generate.ClassNameGenerator;
+import org.springframework.aot.generate.DefaultGenerationContext;
+import org.springframework.aot.generate.GeneratedFiles;
+import org.springframework.aot.generate.InMemoryGeneratedFiles;
+import org.springframework.context.annotation.AnnotatedBeanDefinitionReader;
+import org.springframework.context.aot.ApplicationContextAotGenerator;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.javapoet.ClassName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AOT tests for {@link McpClientAutoConfiguration}.
+ *
+ * @author Taewoong Kim
+ */
+class McpClientAutoConfigurationAotTests {
+
+	@Test
+	void generatesRegistrationForNamedClientBean() throws IOException {
+		GenericApplicationContext applicationContext = new GenericApplicationContext();
+		applicationContext.getEnvironment()
+			.getPropertySources()
+			.addFirst(new MapPropertySource("test", Map.of("spring.ai.mcp.client.initialized", "false",
+					"spring.ai.mcp.client.streamable-http.connections.alpha.url", "http://localhost:8080")));
+		new AnnotatedBeanDefinitionReader(applicationContext).register(McpClientAutoConfiguration.class);
+
+		InMemoryGeneratedFiles generatedFiles = new InMemoryGeneratedFiles();
+		DefaultGenerationContext generationContext = new DefaultGenerationContext(
+				new ClassNameGenerator(ClassName.get(getClass())), generatedFiles);
+
+		try {
+			new ApplicationContextAotGenerator().processAheadOfTime(applicationContext, generationContext);
+			generationContext.writeGeneratedContent();
+
+			Set<String> generatedSourcePaths = generatedFiles.getGeneratedFiles(GeneratedFiles.Kind.SOURCE).keySet();
+			assertThat(generatedSourcePaths)
+				.anySatisfy(path -> assertThat(generatedFiles.getGeneratedFileContent(GeneratedFiles.Kind.SOURCE, path))
+					.contains("mcpSyncClient_alpha", "setDefaultCandidate(false)",
+							"org.springframework.ai.mcp.annotation.spring.McpClient",
+							"org.springframework.beans.factory.annotation.Qualifier"));
+			assertThat(generatedSourcePaths)
+				.allSatisfy(path -> assertThat(generatedFiles.getGeneratedFileContent(GeneratedFiles.Kind.SOURCE, path))
+					.doesNotContain("mcpConnectionBeanRegistrar"));
+		}
+		finally {
+			applicationContext.close();
+		}
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfigurationIT.java
@@ -18,10 +18,11 @@ package org.springframework.ai.mcp.client.common.autoconfigure;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 import io.modelcontextprotocol.client.McpAsyncClient;
-import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpClient.SyncSpec;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.spec.McpClientTransport;
@@ -30,17 +31,20 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 
+import org.springframework.ai.mcp.annotation.spring.McpClient;
 import org.springframework.ai.mcp.client.common.autoconfigure.annotations.McpClientAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.client.common.autoconfigure.configurer.McpSyncClientConfigurer;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.customizer.McpClientCustomizer;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Integration tests for MCP (Model Context Protocol) client auto-configuration.
@@ -137,12 +141,115 @@ public class McpClientAutoConfigurationIT {
 	}
 
 	@Test
+	void injectsNamedSyncClientsByMcpClientQualifier() {
+		this.contextRunner.withUserConfiguration(QualifiedSyncClientsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.initialized=false",
+					"spring.ai.mcp.client.streamable-http.connections.alpha.url=http://localhost:8080",
+					"spring.ai.mcp.client.streamable-http.connections.beta.url=http://localhost:8081")
+			.run(context -> {
+				QualifiedSyncClients qualifiedClients = context.getBean(QualifiedSyncClients.class);
+				List<McpSyncClient> clients = context.getBean("mcpSyncClients", List.class);
+				McpClientAutoConfiguration.CloseableMcpSyncClients closeableClients = context
+					.getBean(McpClientAutoConfiguration.CloseableMcpSyncClients.class);
+
+				assertThat(qualifiedClients.alpha())
+					.isSameAs(context.getBean("mcpSyncClient_alpha", McpSyncClient.class));
+				assertThat(qualifiedClients.beta())
+					.isSameAs(context.getBean("mcpSyncClient_beta", McpSyncClient.class));
+				assertThat(qualifiedClients.allClients()).isSameAs(clients);
+				assertThat(qualifiedClients.unqualifiedClient()).isEmpty();
+				assertThat(closeableClients.clients()).isSameAs(clients);
+				assertThat(clients).hasSize(3).contains(qualifiedClients.alpha(), qualifiedClients.beta());
+				assertThat(clients).extracting(client -> client.getClientInfo().title())
+					.containsExactlyInAnyOrder("alpha", "beta", "gamma");
+				assertThat(qualifiedClients.alpha().getClientInfo().title()).isEqualTo("alpha");
+				assertThat(qualifiedClients.beta().getClientInfo().title()).isEqualTo("beta");
+			});
+	}
+
+	@Test
+	void injectsNamedAsyncClientsByMcpClientQualifier() {
+		this.contextRunner.withUserConfiguration(QualifiedAsyncClientsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.type=ASYNC", "spring.ai.mcp.client.initialized=false",
+					"spring.ai.mcp.client.streamable-http.connections.alpha.url=http://localhost:8080",
+					"spring.ai.mcp.client.streamable-http.connections.beta.url=http://localhost:8081")
+			.run(context -> {
+				QualifiedAsyncClients qualifiedClients = context.getBean(QualifiedAsyncClients.class);
+				List<McpAsyncClient> clients = context.getBean("mcpAsyncClients", List.class);
+
+				assertThat(qualifiedClients.alpha())
+					.isSameAs(context.getBean("mcpAsyncClient_alpha", McpAsyncClient.class));
+				assertThat(qualifiedClients.beta())
+					.isSameAs(context.getBean("mcpAsyncClient_beta", McpAsyncClient.class));
+				assertThat(clients).containsExactlyInAnyOrder(qualifiedClients.alpha(), qualifiedClients.beta());
+				assertThat(qualifiedClients.alpha().getClientInfo().name()).endsWith(" - alpha");
+				assertThat(qualifiedClients.beta().getClientInfo().name()).endsWith(" - beta");
+			});
+	}
+
+	@Test
+	void injectsUserDefinedIndividualClientByMcpClientQualifier() {
+		this.contextRunner.withUserConfiguration(UserDefinedClientConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.initialized=false")
+			.run(context -> {
+				UserDefinedClientHolder holder = context.getBean(UserDefinedClientHolder.class);
+				assertThat(holder.client()).isSameAs(context.getBean("manualClient", McpSyncClient.class));
+			});
+	}
+
+	@Test
+	void userDefinedIndividualClientIsPreferredToGeneratedNonDefaultCandidate() {
+		this.contextRunner.withUserConfiguration(UserDefinedQualifiedClientConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.initialized=false",
+					"spring.ai.mcp.client.streamable-http.connections.alpha.url=http://localhost:8080")
+			.run(context -> {
+				UserDefinedClientHolder holder = context.getBean(UserDefinedClientHolder.class);
+				assertThat(holder.client()).isSameAs(context.getBean("userDefinedAlphaClient", McpSyncClient.class));
+				assertThat(holder.client()).isNotSameAs(context.getBean("mcpSyncClient_alpha", McpSyncClient.class));
+			});
+	}
+
+	@Test
+	void duplicateConnectionNameOnlyFailsWhenSelectiveClientIsRequested() {
+		this.contextRunner.withUserConfiguration(DuplicateNamedTransportsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.initialized=false",
+					"spring.ai.mcp.client.streamable-http.connections.alpha.url=http://localhost:8080")
+			.run(context -> {
+				List<McpSyncClient> clients = context.getBean("mcpSyncClients", List.class);
+				assertThat(clients).hasSize(2);
+				assertThatThrownBy(() -> context.getBean("mcpSyncClient_alpha", McpSyncClient.class))
+					.hasRootCauseInstanceOf(IllegalStateException.class)
+					.hasRootCauseMessage("Multiple transports found for MCP connection 'alpha'");
+			});
+	}
+
+	@Test
+	void configuredNameWithoutMatchingTransportOnlyFailsWhenSelectiveClientIsRequested() {
+		this.contextRunner.withUserConfiguration(TestTransportConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.initialized=false",
+					"spring.ai.mcp.client.streamable-http.connections.stale.url=http://localhost:8080")
+			.run(context -> {
+				List<McpSyncClient> clients = context.getBean("mcpSyncClients", List.class);
+				assertThat(clients).hasSize(1);
+				assertThat(clients.get(0).getClientInfo().title()).isEqualTo("test");
+				assertThat(context).doesNotHaveBean("mcpSyncClient_test");
+				assertThatThrownBy(() -> context.getBean("mcpSyncClient_stale", McpSyncClient.class))
+					.hasRootCauseInstanceOf(IllegalStateException.class)
+					.hasRootCauseMessage("No transport found for MCP connection 'stale'");
+			});
+	}
+
+	@Test
 	void disabledConfiguration() {
-		this.contextRunner.withPropertyValues("spring.ai.mcp.client.enabled=false").run(context -> {
-			assertThat(context).doesNotHaveBean(McpSyncClient.class);
-			assertThat(context).doesNotHaveBean(McpAsyncClient.class);
-			assertThat(context).doesNotHaveBean(ToolCallback.class);
-		});
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.enabled=false",
+					"spring.ai.mcp.client.streamable-http.connections.alpha.url=http://localhost:8080")
+			.run(context -> {
+				assertThat(context).doesNotHaveBean(McpSyncClient.class);
+				assertThat(context).doesNotHaveBean(McpAsyncClient.class);
+				assertThat(context).doesNotHaveBean(ToolCallback.class);
+				assertThat(context).doesNotHaveBean("mcpSyncClient_alpha");
+			});
 	}
 
 	/**
@@ -160,8 +267,11 @@ public class McpClientAutoConfigurationIT {
 			.withPropertyValues("spring.ai.mcp.client.initialized=false")
 			.run(context -> {
 				List<NamedClientMcpTransport> transports = context.getBean("customTransports", List.class);
+				List<McpSyncClient> clients = context.getBean("mcpSyncClients", List.class);
 				assertThat(transports).hasSize(1);
 				assertThat(transports.get(0).transport()).isInstanceOf(CustomClientTransport.class);
+				assertThat(clients).hasSize(1);
+				assertThat(context).doesNotHaveBean("mcpSyncClient_custom");
 			});
 	}
 
@@ -245,22 +355,104 @@ public class McpClientAutoConfigurationIT {
 				.hasSingleBean(McpClientAutoConfiguration.CloseableMcpSyncClients.class));
 	}
 
+	private static McpClientTransport mockTransport() {
+		McpClientTransport mockTransport = Mockito.mock(McpClientTransport.class);
+		Mockito.when(mockTransport.protocolVersions()).thenReturn(List.of("2024-11-05"));
+		Mockito.when(mockTransport.connect(Mockito.any())).thenReturn(Mono.never());
+		Mockito.when(mockTransport.sendMessage(Mockito.any())).thenReturn(Mono.never());
+		return mockTransport;
+	}
+
 	@Configuration
 	static class TestTransportConfiguration {
 
 		@Bean
 		List<NamedClientMcpTransport> testTransports() {
-			// Create a properly configured mock that handles default interface methods
-			McpClientTransport mockTransport = Mockito.mock(McpClientTransport.class);
-			// Configure the mock to return proper protocol versions for the default
-			// interface method
-			Mockito.when(mockTransport.protocolVersions()).thenReturn(List.of("2024-11-05"));
-			// Configure the mock to return a never-completing Mono to simulate pending
-			// connection
-			Mockito.when(mockTransport.connect(Mockito.any())).thenReturn(Mono.never());
-			// Configure the mock to return a never-completing Mono for sendMessage
-			Mockito.when(mockTransport.sendMessage(Mockito.any())).thenReturn(Mono.never());
-			return List.of(new NamedClientMcpTransport("test", mockTransport));
+			return List.of(new NamedClientMcpTransport("test", mockTransport()));
+		}
+
+	}
+
+	@Configuration
+	static class QualifiedSyncClientsConfiguration {
+
+		@Bean
+		List<NamedClientMcpTransport> qualifiedSyncTransports() {
+			return List.of(new NamedClientMcpTransport("alpha", mockTransport()),
+					new NamedClientMcpTransport("beta", mockTransport()),
+					new NamedClientMcpTransport("gamma", mockTransport()));
+		}
+
+		@Bean
+		QualifiedSyncClients qualifiedSyncClients(@McpClient("alpha") McpSyncClient alpha,
+				@Qualifier("beta") McpSyncClient beta, List<McpSyncClient> allClients,
+				Optional<McpSyncClient> unqualifiedClient) {
+			return new QualifiedSyncClients(alpha, beta, allClients, unqualifiedClient);
+		}
+
+	}
+
+	@Configuration
+	static class QualifiedAsyncClientsConfiguration {
+
+		@Bean
+		List<NamedClientMcpTransport> qualifiedAsyncTransports() {
+			return List.of(new NamedClientMcpTransport("alpha", mockTransport()),
+					new NamedClientMcpTransport("beta", mockTransport()));
+		}
+
+		@Bean
+		QualifiedAsyncClients qualifiedAsyncClients(@McpClient("alpha") McpAsyncClient alpha,
+				@McpClient("beta") McpAsyncClient beta) {
+			return new QualifiedAsyncClients(alpha, beta);
+		}
+
+	}
+
+	@Configuration
+	static class DuplicateNamedTransportsConfiguration {
+
+		@Bean
+		List<NamedClientMcpTransport> duplicateNamedTransports() {
+			return List.of(new NamedClientMcpTransport("alpha", mockTransport()),
+					new NamedClientMcpTransport("alpha", mockTransport()));
+		}
+
+	}
+
+	@Configuration
+	static class UserDefinedClientConfiguration {
+
+		@Bean
+		@McpClient("manual")
+		McpSyncClient manualClient() {
+			return Mockito.mock(McpSyncClient.class);
+		}
+
+		@Bean
+		UserDefinedClientHolder userDefinedClientHolder(@McpClient("manual") McpSyncClient client) {
+			return new UserDefinedClientHolder(client);
+		}
+
+	}
+
+	@Configuration
+	static class UserDefinedQualifiedClientConfiguration {
+
+		@Bean
+		List<NamedClientMcpTransport> alphaTransport() {
+			return List.of(new NamedClientMcpTransport("alpha", mockTransport()));
+		}
+
+		@Bean
+		@McpClient("alpha")
+		McpSyncClient userDefinedAlphaClient() {
+			return Mockito.mock(McpSyncClient.class);
+		}
+
+		@Bean
+		UserDefinedClientHolder userDefinedClientHolder(@McpClient("alpha") McpSyncClient client) {
+			return new UserDefinedClientHolder(client);
 		}
 
 	}
@@ -279,7 +471,7 @@ public class McpClientAutoConfigurationIT {
 	static class CustomizerConfiguration {
 
 		@Bean
-		McpClientCustomizer<McpClient.SyncSpec> testCustomizer() {
+		McpClientCustomizer<SyncSpec> testCustomizer() {
 			return (name, spec) -> {
 				/* no-op */ };
 		}
@@ -314,6 +506,16 @@ public class McpClientAutoConfigurationIT {
 			return Mono.empty(); // Test implementation
 		}
 
+	}
+
+	record QualifiedSyncClients(McpSyncClient alpha, McpSyncClient beta, List<McpSyncClient> allClients,
+			Optional<McpSyncClient> unqualifiedClient) {
+	}
+
+	record QualifiedAsyncClients(McpAsyncClient alpha, McpAsyncClient beta) {
+	}
+
+	record UserDefinedClientHolder(McpSyncClient client) {
 	}
 
 }

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpConnectionBeanRegistrarTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/test/java/org/springframework/ai/mcp/client/common/autoconfigure/McpConnectionBeanRegistrarTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.ai.mcp.annotation.spring.McpClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link McpConnectionBeanRegistrar}.
+ *
+ * @author Taewoong Kim
+ */
+class McpConnectionBeanRegistrarTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(TestConfiguration.class);
+
+	@Test
+	void registersNamedBeanForSseConnection() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.test_server.url=http://localhost:8080")
+			.run(context -> assertSyncBeanRegistered(
+					context.getBeanFactory().getBeanDefinition("mcpSyncClient_test_server"), "test_server"));
+	}
+
+	@Test
+	void registersNamedBeanForStreamableHttpConnection() {
+		this.contextRunner
+			.withPropertyValues(
+					"spring.ai.mcp.client.streamable-http.connections.http_server.url=http://localhost:9090")
+			.run(context -> assertSyncBeanRegistered(
+					context.getBeanFactory().getBeanDefinition("mcpSyncClient_http_server"), "http_server"));
+	}
+
+	@Test
+	void registersNamedBeanForStdioConnection() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.client.stdio.connections.stdio_server.command=echo")
+			.run(context -> assertSyncBeanRegistered(
+					context.getBeanFactory().getBeanDefinition("mcpSyncClient_stdio_server"), "stdio_server"));
+	}
+
+	@Test
+	void registersNamedBeanForStdioServersConfiguration(@TempDir Path tempDirectory) throws IOException {
+		Path serversConfiguration = Files.writeString(tempDirectory.resolve("mcp-servers.json"),
+				"{\"mcpServers\":{\"resource.server\":{\"command\":\"echo\"}}}");
+
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.stdio.servers-configuration=" + serversConfiguration.toUri())
+			.run(context -> assertSyncBeanRegistered(
+					context.getBeanFactory().getBeanDefinition("mcpSyncClient_resource.server"), "resource.server"));
+	}
+
+	@Test
+	void registersMultipleNamedBeans() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.server_a.url=http://localhost:8080",
+					"spring.ai.mcp.client.streamable-http.connections.server_b.url=http://localhost:8081",
+					"spring.ai.mcp.client.stdio.connections.server_c.command=echo")
+			.run(context -> {
+				assertThat(context.getBeanFactory().containsBeanDefinition("mcpSyncClient_server_a")).isTrue();
+				assertThat(context.getBeanFactory().containsBeanDefinition("mcpSyncClient_server_b")).isTrue();
+				assertThat(context.getBeanFactory().containsBeanDefinition("mcpSyncClient_server_c")).isTrue();
+			});
+	}
+
+	@Test
+	void registersOneSelectiveBeanWhenTransportConfigurationsReuseAConnectionName() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.shared.url=http://localhost:8080",
+					"spring.ai.mcp.client.streamable-http.connections.shared.url=http://localhost:8081")
+			.run(context -> assertThat(context.getBeanFactory().containsBeanDefinition("mcpSyncClient_shared"))
+				.isTrue());
+	}
+
+	@Test
+	void noBeanRegisteredWithoutConnections() {
+		this.contextRunner
+			.run(context -> assertThat(context.getBeanNamesForType(NamedMcpSyncClientFactoryBean.class)).isEmpty());
+	}
+
+	@Test
+	void backsOffWhenGeneratedBeanNameIsAlreadyDefined() {
+		this.contextRunner.withBean("mcpSyncClient_existing", String.class, () -> "user-defined")
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.existing.url=http://localhost:8080")
+			.run(context -> {
+				assertThat(context.getBean("mcpSyncClient_existing")).isEqualTo("user-defined");
+				assertThat(context.getBeanFactory().getBeanDefinition("mcpSyncClient_existing").getBeanClassName())
+					.isEqualTo(String.class.getName());
+			});
+	}
+
+	@Test
+	void backsOffWhenGeneratedBeanNameIsAlreadyAnAlias() {
+		this.contextRunner.withBean("existing", String.class, () -> "user-defined")
+			.withInitializer(context -> ((BeanDefinitionRegistry) context.getBeanFactory()).registerAlias("existing",
+					"mcpSyncClient_existing"))
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.existing.url=http://localhost:8080")
+			.run(context -> {
+				assertThat(context.getBean("mcpSyncClient_existing")).isEqualTo("user-defined");
+				assertThat(((BeanDefinitionRegistry) context.getBeanFactory()).isAlias("mcpSyncClient_existing"))
+					.isTrue();
+			});
+	}
+
+	@Test
+	void acceptsValidConnectionNames() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.my-server_123.url=http://localhost:8080")
+			.run(context -> assertThat(context.getBeanFactory().containsBeanDefinition("mcpSyncClient_my-server_123"))
+				.isTrue());
+	}
+
+	@Test
+	void registersAsyncNamedBeanWhenTypeIsAsync() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.type=ASYNC",
+					"spring.ai.mcp.client.sse.connections.async_server.url=http://localhost:8080")
+			.run(context -> {
+				assertThat(context.getBeanFactory().containsBeanDefinition("mcpAsyncClient_async_server")).isTrue();
+				assertThat(context.getBeanFactory().containsBeanDefinition("mcpSyncClient_async_server")).isFalse();
+				assertAsyncBeanRegistered(context.getBeanFactory().getBeanDefinition("mcpAsyncClient_async_server"),
+						"async_server");
+			});
+	}
+
+	@Test
+	void registersSyncBeansWhenTypeIsDefault() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.default_server.url=http://localhost:8080")
+			.run(context -> {
+				assertThat(context.getBeanFactory().containsBeanDefinition("mcpSyncClient_default_server")).isTrue();
+				assertThat(context.getBeanFactory().containsBeanDefinition("mcpAsyncClient_default_server")).isFalse();
+			});
+	}
+
+	private static void assertSyncBeanRegistered(BeanDefinition beanDefinition, String connectionName) {
+		assertFactoryBeanRegistered(beanDefinition, NamedMcpSyncClientFactoryBean.class, connectionName);
+	}
+
+	private static void assertAsyncBeanRegistered(BeanDefinition beanDefinition, String connectionName) {
+		assertFactoryBeanRegistered(beanDefinition, NamedMcpAsyncClientFactoryBean.class, connectionName);
+	}
+
+	private static void assertFactoryBeanRegistered(BeanDefinition beanDefinition, Class<?> factoryBeanClass,
+			String connectionName) {
+		assertThat(beanDefinition).isInstanceOf(AbstractBeanDefinition.class);
+		AbstractBeanDefinition abstractBeanDefinition = (AbstractBeanDefinition) beanDefinition;
+		assertThat(abstractBeanDefinition.getBeanClass()).isEqualTo(factoryBeanClass);
+		assertThat(abstractBeanDefinition.getQualifiers()).hasSize(2);
+		assertThat(abstractBeanDefinition.getQualifier(McpClient.class.getName()))
+			.extracting(qualifier -> qualifier.getAttribute("value"))
+			.isEqualTo(connectionName);
+		assertThat(abstractBeanDefinition.getQualifier(Qualifier.class.getName()))
+			.extracting(qualifier -> qualifier.getAttribute("value"))
+			.isEqualTo(connectionName);
+		assertThat(abstractBeanDefinition.isDefaultCandidate()).isFalse();
+		assertThat(abstractBeanDefinition.isLazyInit()).isTrue();
+		assertThat(abstractBeanDefinition.getDestroyMethodName()).isNull();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(McpConnectionBeanRegistrar.class)
+	static class TestConfiguration {
+
+	}
+
+}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/McpClient.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/McpClient.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.spring;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Qualifier annotation for injecting an individual MCP client by its connection name.
+ *
+ * <p>
+ * Spring AI auto-configuration exposes individual client beans for named connections
+ * declared through MCP client configuration properties. User-defined individual MCP
+ * client beans can also opt in by annotating their bean method or component class.
+ *
+ * <p>
+ * This annotation selects Spring bean candidates. It does not select objects that only
+ * exist as elements of an aggregate collection bean.
+ *
+ * <p>
+ * Example usage:
+ *
+ * <pre>
+ * {@code @Bean}
+ * public ChatClient fileAgent(ChatClient.Builder builder,
+ *         {@code @McpClient("filesystem")} McpSyncClient filesystemClient) {
+ *     return builder
+ *             .defaultTools(SyncMcpToolCallbackProvider.builder()
+ *                     .mcpClients(filesystemClient)
+ *                     .build())
+ *             .build();
+ * }
+ * </pre>
+ *
+ * @author Taewoong Kim
+ * @see io.modelcontextprotocol.client.McpSyncClient
+ * @see io.modelcontextprotocol.client.McpAsyncClient
+ * @since 2.0.1
+ */
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface McpClient {
+
+	/**
+	 * The logical MCP connection name.
+	 * @return the connection name
+	 */
+	String value();
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -918,6 +918,18 @@ private List<McpSyncClient> mcpSyncClients;  // For sync client
 private List<McpAsyncClient> mcpAsyncClients;  // For async client
 ----
 
+For applications with multiple connections, an individual client can be injected by connection name:
+
+[source,java]
+----
+@Autowired
+@McpClient("server3")
+private McpSyncClient server3Client;
+----
+
+The same mechanism applies to `McpAsyncClient` when the client type is `ASYNC`.
+The standard `@Qualifier("server3")` annotation can also be used.
+
 When tool callbacks are enabled (the default behavior), the registered MCP Tools with all MCP clients are provided as a `ToolCallbackProvider` instance:
 
 [source,java]


### PR DESCRIPTION
Fixes #5201

Expose each auto-configured MCP client as an individual Spring bean qualified by
its configured connection name. This allows applications with multiple MCP
connections to inject only the client they need.

```java
@Bean
ChatClient fileAgent(ChatClient.Builder builder,
        @McpClient("filesystem") McpSyncClient filesystemClient) {
    return builder
        .defaultTools(SyncMcpToolCallbackProvider.builder()
            .mcpClients(filesystemClient)
            .build())
        .build();
}
```

Clients can be selected with the MCP-specific `@McpClient("filesystem")`
qualifier or the standard `@Qualifier("filesystem")` annotation.

MCP client auto-configuration registers an individual sync or async client bean
for each SSE, Streamable HTTP, or stdio connection declared in the client
configuration.

The individual beans expose the same client instances held by the existing
aggregate `List<McpSyncClient>` and `List<McpAsyncClient>` beans. This avoids
creating additional connections and preserves existing aggregate injection and
shutdown handling.

Named client beans are registered for connections declared through Spring Boot
configuration.

Tests cover sync and async injection, both qualifier annotations, supported
transport types, aggregate client reuse, shutdown handling, bean-name
collisions, and AOT processing.

Tested locally with Spring AI and Node MCP servers over Streamable HTTP, SSE,
and stdio using `ping`, `listTools`, and `callTool`.
