### PR TITLE
Switch test to IT test, as it's what it is.

### DIFF
--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMetadataIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelMetadataIT.java
@@ -34,12 +34,12 @@ import org.springframework.context.annotation.Bean;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit Tests for {@link OllamaChatModel} asserting AI metadata.
+ * ITs for {@link OllamaChatModel} asserting AI metadata.
  *
  * @author Sun Yuhan
  */
-@SpringBootTest(classes = OllamaChatModelMetadataTests.Config.class)
-class OllamaChatModelMetadataTests extends BaseOllamaIT {
+@SpringBootTest(classes = OllamaChatModelMetadataIT.Config.class)
+class OllamaChatModelMetadataIT extends BaseOllamaIT {
 
 	private static final String MODEL = OllamaModel.QWEN_3_06B.getName();
 


### PR DESCRIPTION
That test class is slowing day to day development so much. It either:
- succeeds, but after having downloaded Ollama and its model, which is long (definitely puts it in the IT category..)
- fails because of what seems to be a race condition between the model DL and the test execution. I'll look into this asap.

In the meantime, let's make sure this test doesn't have to run on a day to day basis.