### PR TITLE
Add MustacheTemplateRenderer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<module>spring-ai-bom</module>
 		<module>spring-ai-commons</module>
 		<module>spring-ai-template-st</module>
+		<module>spring-ai-template-mustache</module>
 		<module>spring-ai-client-chat</module>
 		<module>spring-ai-model</module>
 		<module>spring-ai-test</module>
@@ -281,6 +282,7 @@
 		<!-- production dependencies -->
 		<spring-boot.version>4.0.0</spring-boot.version>
 		<ST4.version>4.3.4</ST4.version>
+		<mustache.java.version>0.9.14</mustache.java.version>
 		<azure-open-ai-client.version>1.0.0-beta.16</azure-open-ai-client.version>
 		<openai-sdk.version>4.13.0</openai-sdk.version>
 		<azure-identity.version>1.18.1</azure-identity.version>

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -93,6 +93,12 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-template-mustache</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
 			<!-- Spring AI model -->
 
 			<dependency>

--- a/spring-ai-template-mustache/pom.xml
+++ b/spring-ai-template-mustache/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>spring-ai-template-mustache</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Template Mustache</name>
+    <description>Mustache implementation for Spring AI templating</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <properties>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-commons</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <!-- Mustache.java compiler -->
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>${mustache.java.version}</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/spring-ai-template-mustache/src/main/java/org/springframework/ai/template/mustache/MustacheTemplateRenderer.java
+++ b/spring-ai-template-mustache/src/main/java/org/springframework/ai/template/mustache/MustacheTemplateRenderer.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.template.mustache;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.template.TemplateRenderer;
+import org.springframework.ai.template.ValidationMode;
+import org.springframework.util.Assert;
+
+/**
+ * Renders a template using the Mustache templating engine.
+ *
+ * <p>
+ * This renderer supports Mustache syntax including:
+ * <ul>
+ * <li>Variable interpolation: {@code {{variable}}}</li>
+ * <li>Sections (loops/conditionals): {@code {{#items}}...{{/items}}}</li>
+ * <li>Inverted sections: {@code {{^items}}...{{/items}}}</li>
+ * <li>Dot notation for nested properties: {@code {{object.property}}}</li>
+ * <li>Comments: {@code {{! comment }}}</li>
+ * </ul>
+ *
+ * <p>
+ * Use the {@link #builder()} to create and configure instances.
+ *
+ * <p>
+ * <b>Thread safety:</b> This class is safe for concurrent use. The underlying
+ * {@link MustacheFactory} is thread-safe, and each call to {@link #apply(String, Map)}
+ * compiles and executes a new Mustache template instance.
+ *
+ * @author Hyunjoon Park
+ * @since 2.0.0
+ * @see <a href="https://mustache.github.io/">Mustache Template Language</a>
+ * @see <a href="https://github.com/spullara/mustache.java">Mustache.java</a>
+ */
+public class MustacheTemplateRenderer implements TemplateRenderer {
+
+	private static final Logger logger = LoggerFactory.getLogger(MustacheTemplateRenderer.class);
+
+	private static final String VALIDATION_MESSAGE = "Not all variables were replaced in the template. Missing variable names are: %s.";
+
+	private static final ValidationMode DEFAULT_VALIDATION_MODE = ValidationMode.THROW;
+
+	/**
+	 * Pattern to extract section tags ({{#var}} or {{^var}}) from Mustache template.
+	 */
+	private static final Pattern SECTION_TAG_PATTERN = Pattern.compile("\\{\\{[#^]([a-zA-Z_][a-zA-Z0-9_]*)\\}\\}");
+
+	/**
+	 * Pattern to remove section blocks ({{#var}}...{{/var}} or {{^var}}...{{/var}}).
+	 */
+	private static final Pattern SECTION_BLOCK_PATTERN = Pattern
+		.compile("\\{\\{[#^]([a-zA-Z_][a-zA-Z0-9_]*)\\}\\}.*?\\{\\{/\\1\\}\\}", Pattern.DOTALL);
+
+	/**
+	 * Pattern to extract simple variable tags ({{var}} or {{var.prop}}).
+	 */
+	private static final Pattern VARIABLE_PATTERN = Pattern
+		.compile("\\{\\{([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*)\\}\\}");
+
+	private final MustacheFactory mustacheFactory;
+
+	private final ValidationMode validationMode;
+
+	/**
+	 * Constructs a new {@code MustacheTemplateRenderer} with the specified configuration.
+	 * @param mustacheFactory the factory to use for compiling templates
+	 * @param validationMode the mode to use for template variable validation
+	 */
+	MustacheTemplateRenderer(MustacheFactory mustacheFactory, ValidationMode validationMode) {
+		Assert.notNull(mustacheFactory, "mustacheFactory cannot be null");
+		Assert.notNull(validationMode, "validationMode cannot be null");
+		this.mustacheFactory = mustacheFactory;
+		this.validationMode = validationMode;
+	}
+
+	@Override
+	public String apply(String template, Map<String, ? extends @Nullable Object> variables) {
+		Assert.hasText(template, "template cannot be null or empty");
+		Assert.notNull(variables, "variables cannot be null");
+		Assert.noNullElements(variables.keySet(), "variables keys cannot be null");
+
+		if (this.validationMode != ValidationMode.NONE) {
+			validate(template, variables);
+		}
+
+		try {
+			Mustache mustache = this.mustacheFactory.compile(new StringReader(template), "template");
+			StringWriter writer = new StringWriter();
+			mustache.execute(writer, variables).flush();
+			return writer.toString();
+		}
+		catch (Exception ex) {
+			throw new IllegalArgumentException("Failed to render Mustache template.", ex);
+		}
+	}
+
+	/**
+	 * Validates that all required template variables are provided in the variables map.
+	 * @param template the template string
+	 * @param variables the provided variables
+	 * @return set of missing variable names, or empty set if none are missing
+	 */
+	private Set<String> validate(String template, Map<String, ? extends @Nullable Object> variables) {
+		Set<String> templateVariables = extractVariables(template);
+		Set<String> providedKeys = variables.keySet();
+		Set<String> missingVariables = new HashSet<>(templateVariables);
+		missingVariables.removeAll(providedKeys);
+
+		if (!missingVariables.isEmpty()) {
+			if (this.validationMode == ValidationMode.WARN) {
+				logger.warn(VALIDATION_MESSAGE.formatted(missingVariables));
+			}
+			else if (this.validationMode == ValidationMode.THROW) {
+				throw new IllegalStateException(VALIDATION_MESSAGE.formatted(missingVariables));
+			}
+		}
+		return missingVariables;
+	}
+
+	/**
+	 * Extracts top-level variable names from a Mustache template. For dot notation like
+	 * {{user.name}}, only the top-level variable (user) is extracted. Variables inside
+	 * section blocks are excluded as they reference properties of the section variable.
+	 * @param template the Mustache template string
+	 * @return set of top-level variable names
+	 */
+	private Set<String> extractVariables(String template) {
+		Set<String> variables = new HashSet<>();
+
+		// 1. Extract variables from section tags ({{#var}}, {{^var}})
+		Matcher sectionMatcher = SECTION_TAG_PATTERN.matcher(template);
+		while (sectionMatcher.find()) {
+			variables.add(sectionMatcher.group(1));
+		}
+
+		// 2. Remove section blocks to avoid extracting inner variables
+		String templateWithoutSections = removeSectionBlocks(template);
+
+		// 3. Extract remaining variables from outside sections
+		Matcher varMatcher = VARIABLE_PATTERN.matcher(templateWithoutSections);
+		while (varMatcher.find()) {
+			String fullPath = varMatcher.group(1);
+			// Extract only the top-level variable name (before the first dot)
+			String topLevelVariable = fullPath.contains(".") ? fullPath.substring(0, fullPath.indexOf('.')) : fullPath;
+			variables.add(topLevelVariable);
+		}
+
+		return variables;
+	}
+
+	/**
+	 * Removes section blocks from the template to avoid extracting inner variables.
+	 * Handles nested sections by repeatedly removing innermost sections first.
+	 * @param template the Mustache template string
+	 * @return template with all section blocks removed
+	 */
+	private String removeSectionBlocks(String template) {
+		String result = template;
+		String previous;
+		do {
+			previous = result;
+			result = SECTION_BLOCK_PATTERN.matcher(result).replaceAll("");
+		}
+		while (!result.equals(previous));
+		return result;
+	}
+
+	/**
+	 * Creates a new builder for {@link MustacheTemplateRenderer}.
+	 * @return a new builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for configuring and creating {@link MustacheTemplateRenderer} instances.
+	 */
+	public static final class Builder {
+
+		private MustacheFactory mustacheFactory = new DefaultMustacheFactory();
+
+		private ValidationMode validationMode = DEFAULT_VALIDATION_MODE;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets a custom {@link MustacheFactory} for template compilation.
+		 * <p>
+		 * By default, a {@link DefaultMustacheFactory} is used.
+		 * @param mustacheFactory the factory to use
+		 * @return this builder instance for chaining
+		 */
+		public Builder mustacheFactory(MustacheFactory mustacheFactory) {
+			Assert.notNull(mustacheFactory, "mustacheFactory cannot be null");
+			this.mustacheFactory = mustacheFactory;
+			return this;
+		}
+
+		/**
+		 * Sets the validation mode to control behavior when the provided variables do not
+		 * match the variables required by the template.
+		 * <p>
+		 * Default is {@link ValidationMode#THROW}.
+		 * @param validationMode the desired validation mode
+		 * @return this builder instance for chaining
+		 */
+		public Builder validationMode(ValidationMode validationMode) {
+			Assert.notNull(validationMode, "validationMode cannot be null");
+			this.validationMode = validationMode;
+			return this;
+		}
+
+		/**
+		 * Builds and returns a new {@link MustacheTemplateRenderer} instance with the
+		 * configured settings.
+		 * @return a configured {@link MustacheTemplateRenderer}
+		 */
+		public MustacheTemplateRenderer build() {
+			return new MustacheTemplateRenderer(this.mustacheFactory, this.validationMode);
+		}
+
+	}
+
+}

--- a/spring-ai-template-mustache/src/main/java/org/springframework/ai/template/mustache/MustacheTemplateRenderer.java
+++ b/spring-ai-template-mustache/src/main/java/org/springframework/ai/template/mustache/MustacheTemplateRenderer.java
@@ -56,7 +56,7 @@ import org.springframework.util.Assert;
  * {@link MustacheFactory} is thread-safe, and each call to {@link #apply(String, Map)}
  * compiles and executes a new Mustache template instance.
  *
- * @author Hyunjoon Park
+ * @author SangHo Park
  * @since 2.0.0
  * @see <a href="https://mustache.github.io/">Mustache Template Language</a>
  * @see <a href="https://github.com/spullara/mustache.java">Mustache.java</a>

--- a/spring-ai-template-mustache/src/main/java/org/springframework/ai/template/mustache/package-info.java
+++ b/spring-ai-template-mustache/src/main/java/org/springframework/ai/template/mustache/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mustache template rendering support for Spring AI.
+ */
+@NullMarked
+package org.springframework.ai.template.mustache;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-template-mustache/src/test/java/org/springframework/ai/template/mustache/MustacheTemplateRendererTests.java
+++ b/spring-ai-template-mustache/src/test/java/org/springframework/ai/template/mustache/MustacheTemplateRendererTests.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.template.mustache;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.template.ValidationMode;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link MustacheTemplateRenderer}.
+ *
+ * @author Hyunjoon Park
+ */
+class MustacheTemplateRendererTests {
+
+	// Builder tests
+
+	@Test
+	void shouldNotAcceptNullValidationMode() {
+		assertThatThrownBy(() -> MustacheTemplateRenderer.builder().validationMode(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("validationMode cannot be null");
+	}
+
+	@Test
+	void shouldNotAcceptNullMustacheFactory() {
+		assertThatThrownBy(() -> MustacheTemplateRenderer.builder().mustacheFactory(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("mustacheFactory cannot be null");
+	}
+
+	@Test
+	void shouldUseDefaultValuesWhenUsingBuilder() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		assertThat(ReflectionTestUtils.getField(renderer, "validationMode")).isEqualTo(ValidationMode.THROW);
+		assertThat(ReflectionTestUtils.getField(renderer, "mustacheFactory")).isNotNull();
+	}
+
+	// Basic rendering tests
+
+	@Test
+	void shouldRenderTemplateWithSingleVariable() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		String result = renderer.apply("Hello {{name}}!", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void shouldRenderTemplateWithMultipleVariables() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+		variables.put("name", "Spring AI");
+		variables.put("punctuation", "!");
+
+		String result = renderer.apply("{{greeting}} {{name}}{{punctuation}}", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void shouldRenderMultilineTemplate() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("title", "Welcome");
+		variables.put("content", "This is the content");
+
+		String template = """
+				Title: {{title}}
+				Content: {{content}}
+				""";
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualTo("""
+				Title: Welcome
+				Content: This is the content
+				""");
+	}
+
+	// Input validation tests
+
+	@Test
+	void shouldNotRenderEmptyTemplate() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+
+		assertThatThrownBy(() -> renderer.apply("", variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("template cannot be null or empty");
+	}
+
+	@Test
+	void shouldNotRenderNullTemplate() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+
+		assertThatThrownBy(() -> renderer.apply(null, variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("template cannot be null or empty");
+	}
+
+	@Test
+	void shouldNotAcceptNullVariables() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+
+		assertThatThrownBy(() -> renderer.apply("Hello!", null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("variables cannot be null");
+	}
+
+	@Test
+	void shouldNotAcceptNullVariableKeys() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put(null, "value");
+
+		assertThatThrownBy(() -> renderer.apply("Hello!", variables)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	// ValidationMode tests
+
+	@Test
+	void shouldThrowExceptionForMissingVariablesInThrowMode() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+
+		assertThatThrownBy(() -> renderer.apply("{{greeting}} {{name}}!", variables))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Not all variables were replaced in the template")
+			.hasMessageContaining("name");
+	}
+
+	@Test
+	void shouldContinueRenderingWithMissingVariablesInWarnMode() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder()
+			.validationMode(ValidationMode.WARN)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+
+		String result = renderer.apply("{{greeting}} {{name}}!", variables);
+
+		assertThat(result).isEqualTo("Hello !");
+	}
+
+	@Test
+	void shouldRenderWithoutValidationInNoneMode() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder()
+			.validationMode(ValidationMode.NONE)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+
+		String result = renderer.apply("{{greeting}} {{name}}!", variables);
+
+		assertThat(result).isEqualTo("Hello !");
+	}
+
+	// Mustache-specific feature tests
+
+	@Test
+	void shouldRenderSectionWithIterable() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder()
+			.validationMode(ValidationMode.NONE)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("items", List.of(Map.of("name", "Item 1", "price", 100), Map.of("name", "Item 2", "price", 200)));
+
+		String template = "{{#items}}- {{name}}: {{price}}\n{{/items}}";
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualTo("- Item 1: 100\n- Item 2: 200\n");
+	}
+
+	@Test
+	void shouldRenderNestedProperties() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("user", Map.of("profile", Map.of("name", "John")));
+
+		String result = renderer.apply("Hello {{user.profile.name}}!", variables);
+
+		assertThat(result).isEqualTo("Hello John!");
+	}
+
+	@Test
+	void shouldRenderInvertedSection() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder()
+			.validationMode(ValidationMode.NONE)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("items", List.of());
+
+		String template = "{{#items}}Has items{{/items}}{{^items}}No items{{/items}}";
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualTo("No items");
+	}
+
+	@Test
+	void shouldRenderSectionWithNonEmptyList() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder()
+			.validationMode(ValidationMode.NONE)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("items", List.of("a", "b", "c"));
+
+		String template = "{{#items}}Has items{{/items}}{{^items}}No items{{/items}}";
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualTo("Has itemsHas itemsHas items");
+	}
+
+	@Test
+	void shouldRenderBooleanSection() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("showGreeting", true);
+		variables.put("name", "World");
+
+		String template = "{{#showGreeting}}Hello {{name}}!{{/showGreeting}}";
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualTo("Hello World!");
+	}
+
+	@Test
+	void shouldNotRenderFalseBooleanSection() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("showGreeting", false);
+		variables.put("name", "World");
+
+		String template = "{{#showGreeting}}Hello {{name}}!{{/showGreeting}}Goodbye!";
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualTo("Goodbye!");
+	}
+
+	// Static text tests
+
+	@Test
+	void shouldRenderStaticTextTemplate() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+
+		String result = renderer.apply("Just static text.", variables);
+
+		assertThat(result).isEqualTo("Just static text.");
+	}
+
+	// Null value tests
+
+	@Test
+	void shouldRenderNullVariableValuesAsBlank() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder()
+			.validationMode(ValidationMode.NONE)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("foo", null);
+
+		String result = renderer.apply("Value: {{foo}}", variables);
+
+		assertThat(result).isEqualTo("Value: ");
+	}
+
+	// Complex template tests (from issue example)
+
+	@Test
+	void shouldRenderComplexTemplateFromIssueExample() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("query", "Find me the best deals");
+		variables.put("items", List.of(Map.of("name", "Product A", "pricing", Map.of("salePrice", "$99.99")),
+				Map.of("name", "Product B", "pricing", Map.of("salePrice", "$149.99"))));
+
+		String template = """
+				Query: {{query}}
+
+				{{#items}}
+				- {{name}} ({{pricing.salePrice}})
+				{{/items}}
+				""";
+
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualTo("""
+				Query: Find me the best deals
+
+				- Product A ($99.99)
+				- Product B ($149.99)
+				""");
+	}
+
+	// Unicode and special character tests
+
+	@Test
+	void shouldRenderUnicodeCharacters() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+		variables.put("emoji", "\uD83D\uDE00");
+
+		String result = renderer.apply("{{greeting}} {{emoji}}", variables);
+
+		assertThat(result).isEqualTo("Hello \uD83D\uDE00");
+	}
+
+	@Test
+	void shouldRenderAccentedCharacters() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("place", "Caf\u00e9");
+
+		String result = renderer.apply("Welcome to {{place}}", variables);
+
+		assertThat(result).isEqualTo("Welcome to Caf\u00e9");
+	}
+
+	// Number variable tests
+
+	@Test
+	void shouldRenderNumericVariables() {
+		MustacheTemplateRenderer renderer = MustacheTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("count", 42);
+		variables.put("price", 19.99);
+
+		String result = renderer.apply("Count: {{count}}, Price: {{price}}", variables);
+
+		assertThat(result).isEqualTo("Count: 42, Price: 19.99");
+	}
+
+}


### PR DESCRIPTION
Closes #4885

## Summary
- Add `spring-ai-template-mustache` module with Mustache templating support
- Implement `MustacheTemplateRenderer` following the same pattern as `StTemplateRenderer`
- Support Mustache syntax: variable interpolation, sections/loops, inverted sections, dot notation

## Changes
- `pom.xml` - Register new module
- `spring-ai-bom/pom.xml` - Add dependency management
- `spring-ai-template-mustache/pom.xml` - New module configuration
- `MustacheTemplateRenderer.java` - Core implementation with Builder pattern and ValidationMode
- `package-info.java` - JSpecify @NullMarked annotation
- `MustacheTemplateRendererTests.java` - 26 unit tests

## Test plan
- [x] All unit tests pass
- [x] Checkstyle pass