### PR TITLE
[Minor enhancement] Add Prompt#getSystemMessages() for convenience

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -140,6 +140,20 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	/**
+	 * Get all system messages in the prompt.
+	 * @return a list of all system messages in the prompt
+	 */
+	public List<SystemMessage> getSystemMessages() {
+		List<SystemMessage> systemMessages = new ArrayList<>();
+		for (Message message : this.messages) {
+			if (message instanceof SystemMessage systemMessage) {
+				systemMessages.add(systemMessage);
+			}
+		}
+		return systemMessages;
+	}
+
+	/**
 	 * Get all user messages in the prompt.
 	 * @return a list of all user messages in the prompt
 	 */


### PR DESCRIPTION
Small convenience enhancement for `org.springframework.ai.chat.prompt.Prompt`.

`Prompt` already provides:
- `getSystemMessage()` (returns the first system message, or an empty one)
- `getUserMessage()` (returns the last user message, or an empty one)
- `getUserMessages()` (returns all user messages)

But there is no accessor to retrieve **all** `SystemMessage`s when multiple are present.


## Proposed change
Add:

```java
public List<SystemMessage> getSystemMessages()
````

## Notes / Alternative
If you prefer a strict Harmony-style approach (single `SystemMessage` only), please comment. In that case, I will open a follow-up PR that adds logic to **enforce/normalize a single system message** upstream instead of introducing `getSystemMessages()`.
