### PR TITLE
GH-5218: Fix credentials-uri being ignored when using gRPC transport

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.model.vertexai.autoconfigure.gemini;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.vertexai.VertexAI;
@@ -51,6 +52,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
+ * @author yeonggyu park
  * @since 1.0.0
  */
 @AutoConfiguration(after = { SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class })
@@ -82,6 +84,15 @@ public class VertexAiGeminiChatAutoConfiguration {
 		if (connectionProperties.getCredentialsUri() != null) {
 			GoogleCredentials credentials = GoogleCredentials
 				.fromStream(connectionProperties.getCredentialsUri().getInputStream());
+
+			if (credentials.createScopedRequired()) {
+				List<String> scopes = connectionProperties.getScopes();
+				if (CollectionUtils.isEmpty(scopes)) {
+					scopes = List.of("https://www.googleapis.com/auth/cloud-platform");
+					vertexAIBuilder.setScopes(scopes);
+				}
+				credentials = credentials.createScoped(scopes);
+			}
 
 			vertexAIBuilder.setCredentials(credentials);
 		}


### PR DESCRIPTION
GH-5218: Fix credentials-uri being ignored when using gRPC transport

This PR fixes an authentication issue where service account credentials loaded via
`credentials-uri` could fail with `UNAUTHENTICATED` errors when using the gRPC transport.

When credentials are loaded directly from a service account JSON file, the resulting
`GoogleCredentials` instance may be unscoped. While REST-based transports may implicitly
apply default scopes or fall back to ADC, the gRPC transport requires explicitly scoped
credentials and fails otherwise.

This change ensures that credentials loaded via `credentials-uri` are properly scoped
when required:
- If explicit scopes are configured, they are applied to the credentials.
- If no scopes are configured, a safe default scope
  (`https://www.googleapis.com/auth/cloud-platform`) is applied.

With this change, authentication behavior is consistent across REST and gRPC transports,
and users are no longer required to manually configure scopes to avoid gRPC failures.

Verification
- `spring-ai-autoconfigure-model-vertex-ai` module builds and tests pass locally.

Fixes #5218 