### PR TITLE
GH-5204 fix: invalid Filter.Expression constructor usage in documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
@@ -816,17 +816,15 @@ Document documentV2 = new Document(
 // First, delete the old version using filter expression
 Filter.Expression deleteOldVersion = new Filter.Expression(
     Filter.ExpressionType.AND,
-    Arrays.asList(
-        new Filter.Expression(
-            Filter.ExpressionType.EQ,
-            new Filter.Key("docId"),
-            new Filter.Value("AIML-001")
-        ),
-        new Filter.Expression(
-            Filter.ExpressionType.EQ,
-            new Filter.Key("version"),
-            new Filter.Value("1.0")
-        )
+    new Filter.Expression(
+        Filter.ExpressionType.EQ,
+        new Filter.Key("docId"),
+        new Filter.Value("AIML-001")
+    ),
+    new Filter.Expression(
+        Filter.ExpressionType.EQ,
+        new Filter.Key("version"),
+        new Filter.Value("1.0")
     )
 );
 vectorStore.delete(deleteOldVersion);


### PR DESCRIPTION
## Description
This PR corrects the invalid `Filter.Expression` constructor usage in the documentation.

The documentation incorrectly illustrated wrapping child expressions in `Arrays.asList()`. However, the actual `Filter.Expression` record constructor accepts individual `Operand` arguments for `left` and `right` (binary structure), not a `List`.

## Changes
- Removed the `Arrays.asList()` wrapper from the `Filter.Expression` constructor example.
- Updated the example to use the correct positional arguments: `new Filter.Expression(type, left, right)`.