### PR TITLE
Fix MCP autoconfig non web apps

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpAsyncServerCustomizer.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpAsyncServerCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.customizer;
+
+import io.modelcontextprotocol.server.McpServer;
+
+/**
+ * Interface for customizing synchronous MCP server configurations.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @since 1.1.3
+ * @see McpServer.AsyncSpecification
+ */
+public interface McpAsyncServerCustomizer {
+
+	void customize(McpServer.AsyncSpecification<?> serverBuilder);
+
+}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpSyncServerCustomizer.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/customizer/McpSyncServerCustomizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.customizer;
+
+import io.modelcontextprotocol.server.McpServer;
+
+/**
+ * Interface for customizing synchronous MCP server configurations.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @since 1.1.3
+ * @see io.modelcontextprotocol.server.McpServer.SyncSpecification
+ */
+public interface McpSyncServerCustomizer {
+
+	void customize(McpServer.SyncSpecification<?> serverBuilder);
+
+}


### PR DESCRIPTION
When building STDIO-based MCP servers, `spring-web` is typically not included.

This breaks the `McpServerAutoConfiguration`, because it checks for the environment type using the `StandardServletEnvironment` class which is in `spring-web`, and you get the error message below.

This PR refactors the `McpAutoConfiguration` to use Spring Boot's `@ConditionalOnWebApplication` instead of a manual conditional check. In the process, it introduces an `McpSyncServerCustomizer`, and its async equivalent. Customizers are a typical Spring Boot pattern.


---


Appendix: error logs for STDIO servers without `spring-web`.


```
Exception in thread "main" org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'mcpSyncServer' defined in class path resource [org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.class]: Failed to instantiate [io.modelcontextprotocol.server.McpSyncServer]: Factory method 'mcpSyncServer' threw exception with message: org/springframework/web/context/support/StandardServletEnvironment
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:657)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:645)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1375)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1205)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:569)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:529)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:339)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:373)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:337)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.instantiateSingleton(DefaultListableBeanFactory.java:1228)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingleton(DefaultListableBeanFactory.java:1194)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:1130)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:990)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:627)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350)
	at be.devoxx.Application.main(Application.java:15)
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.modelcontextprotocol.server.McpSyncServer]: Factory method 'mcpSyncServer' threw exception with message: org/springframework/web/context/support/StandardServletEnvironment
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:200)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiateWithFactoryMethod(SimpleInstantiationStrategy.java:89)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:169)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:653)
	... 20 more
Caused by: java.lang.NoClassDefFoundError: org/springframework/web/context/support/StandardServletEnvironment
	at org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration.mcpSyncServer(McpServerAutoConfiguration.java:217)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:172)
	... 23 more
Caused by: java.lang.ClassNotFoundException: org.springframework.web.context.support.StandardServletEnvironment
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	... 27 more

```