### PR TITLE
GH-3797 change: make QdrantVectorStore contentFieldName configurable

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreAutoConfiguration.java
@@ -83,6 +83,7 @@ public class QdrantVectorStoreAutoConfiguration {
 			BatchingStrategy batchingStrategy) {
 		return QdrantVectorStore.builder(qdrantClient, embeddingModel)
 			.collectionName(properties.getCollectionName())
+			.contentFieldName(properties.getContentFieldName())
 			.initializeSchema(properties.isInitializeSchema())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.customObservationConvention(customObservationConvention.getIfAvailable(() -> null))

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreProperties.java
@@ -38,6 +38,11 @@ public class QdrantVectorStoreProperties extends CommonVectorStoreProperties {
 	private String collectionName = QdrantVectorStore.DEFAULT_COLLECTION_NAME;
 
 	/**
+	 * The name of the content field to use in Qdrant.
+	 */
+	private String contentFieldName = QdrantVectorStore.DEFAULT_CONTENT_FIELD_NAME;
+
+	/**
 	 * The host of the Qdrant server.
 	 */
 	private String host = "localhost";
@@ -63,6 +68,14 @@ public class QdrantVectorStoreProperties extends CommonVectorStoreProperties {
 
 	public void setCollectionName(String collectionName) {
 		this.collectionName = collectionName;
+	}
+
+	public String getContentFieldName() {
+		return this.contentFieldName;
+	}
+
+	public void setContentFieldName(String contentFieldName) {
+		this.contentFieldName = contentFieldName;
 	}
 
 	public String getHost() {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/test/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStorePropertiesTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/test/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStorePropertiesTests.java
@@ -33,6 +33,7 @@ public class QdrantVectorStorePropertiesTests {
 		var props = new QdrantVectorStoreProperties();
 
 		assertThat(props.getCollectionName()).isEqualTo(QdrantVectorStore.DEFAULT_COLLECTION_NAME);
+		assertThat(props.getContentFieldName()).isEqualTo(QdrantVectorStore.DEFAULT_CONTENT_FIELD_NAME);
 		assertThat(props.getHost()).isEqualTo("localhost");
 		assertThat(props.getPort()).isEqualTo(6334);
 		assertThat(props.isUseTls()).isFalse();
@@ -44,12 +45,14 @@ public class QdrantVectorStorePropertiesTests {
 		var props = new QdrantVectorStoreProperties();
 
 		props.setCollectionName("MY_COLLECTION");
+		props.setContentFieldName("MY_CONTENT_FIELD");
 		props.setHost("MY_HOST");
 		props.setPort(999);
 		props.setUseTls(true);
 		props.setApiKey("MY_API_KEY");
 
 		assertThat(props.getCollectionName()).isEqualTo("MY_COLLECTION");
+		assertThat(props.getContentFieldName()).isEqualTo("MY_CONTENT_FIELD");
 		assertThat(props.getHost()).isEqualTo("MY_HOST");
 		assertThat(props.getPort()).isEqualTo(999);
 		assertThat(props.isUseTls()).isTrue();

--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -129,11 +129,13 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 
 	public static final String DEFAULT_COLLECTION_NAME = "vector_store";
 
-	private static final String CONTENT_FIELD_NAME = "doc_content";
+	public static final String DEFAULT_CONTENT_FIELD_NAME = "doc_content";
 
 	private final QdrantClient qdrantClient;
 
 	private final String collectionName;
+
+	private final String contentFieldName;
 
 	private final QdrantFilterExpressionConverter filterExpressionConverter = new QdrantFilterExpressionConverter();
 
@@ -155,6 +157,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		this.qdrantClient = builder.qdrantClient;
 		this.collectionName = builder.collectionName;
 		this.initializeSchema = builder.initializeSchema;
+		this.contentFieldName = builder.contentFieldName;
 	}
 
 	/**
@@ -280,7 +283,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 			var metadata = QdrantObjectFactory.toObjectMap(point.getPayloadMap());
 			metadata.put(DocumentMetadata.DISTANCE.value(), 1 - point.getScore());
 
-			var content = (String) metadata.remove(CONTENT_FIELD_NAME);
+			var content = (String) metadata.remove(this.contentFieldName);
 
 			return Document.builder().id(id).text(content).metadata(metadata).score((double) point.getScore()).build();
 		}
@@ -297,7 +300,7 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 	private Map<String, Value> toPayload(Document document) {
 		try {
 			var payload = QdrantValueFactory.toValueMap(document.getMetadata());
-			payload.put(CONTENT_FIELD_NAME, io.qdrant.client.ValueFactory.value(document.getText()));
+			payload.put(this.contentFieldName, io.qdrant.client.ValueFactory.value(document.getText()));
 			return payload;
 		}
 		catch (Exception e) {
@@ -359,6 +362,8 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 
 		private String collectionName = DEFAULT_COLLECTION_NAME;
 
+		private String contentFieldName = DEFAULT_CONTENT_FIELD_NAME;
+
 		private boolean initializeSchema = false;
 
 		/**
@@ -383,6 +388,19 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 		public Builder collectionName(String collectionName) {
 			Assert.hasText(collectionName, "collectionName must not be empty");
 			this.collectionName = collectionName;
+			return this;
+		}
+
+		/**
+		 * Configures the Qdrant content field name.
+		 * @param contentFieldName the name of the content field to use (defaults to
+		 * {@value DEFAULT_CONTENT_FIELD_NAME})
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contentFieldName is null or empty
+		 */
+		public Builder contentFieldName(String contentFieldName) {
+			Assert.hasText(contentFieldName, "contentFieldName must not be empty");
+			this.contentFieldName = contentFieldName;
 			return this;
 		}
 

--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreBuilderTests.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreBuilderTests.java
@@ -50,6 +50,7 @@ class QdrantVectorStoreBuilderTests {
 
 		// Verify default values
 		assertThat(vectorStore).hasFieldOrPropertyWithValue("collectionName", "vector_store");
+		assertThat(vectorStore).hasFieldOrPropertyWithValue("contentFieldName", "doc_content");
 		assertThat(vectorStore).hasFieldOrPropertyWithValue("initializeSchema", false);
 		assertThat(vectorStore).hasFieldOrPropertyWithValue("batchingStrategy.class", TokenCountBatchingStrategy.class);
 	}
@@ -58,11 +59,13 @@ class QdrantVectorStoreBuilderTests {
 	void customConfiguration() {
 		QdrantVectorStore vectorStore = QdrantVectorStore.builder(this.qdrantClient, this.embeddingModel)
 			.collectionName("custom_collection")
+			.contentFieldName("custom_content_field")
 			.initializeSchema(true)
 			.batchingStrategy(new TokenCountBatchingStrategy())
 			.build();
 
 		assertThat(vectorStore).hasFieldOrPropertyWithValue("collectionName", "custom_collection");
+		assertThat(vectorStore).hasFieldOrPropertyWithValue("contentFieldName", "custom_content_field");
 		assertThat(vectorStore).hasFieldOrPropertyWithValue("initializeSchema", true);
 		assertThat(vectorStore).hasFieldOrPropertyWithValue("batchingStrategy.class", TokenCountBatchingStrategy.class);
 	}


### PR DESCRIPTION
## Description
This Pull Request changes the content field name of the Qdrant Vector Store to enable setting via auto configuration in hard-coded "doc_contents"
fix #3797 

## Changes
- Add contentFieldName in QdrantVecotrStoreProperties

## Usage
Add property spring.ai.vectorstore.qdrant.content-field-name to application.yml