### PR TITLE
GH-2722: Fix unescaped asterisk in HanaDB docs

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/hana.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/hana.adoc
@@ -22,7 +22,7 @@ Additionally, you will need a configured `EmbeddingModel` bean. Refer to the xre
 == HanaCloudVectorStore Properties
 
 You can use the following properties in your Spring Boot configuration to customize the SAP Hana vector store.
-It uses `spring.datasource.*` properties to configure the Hana datasource and the `spring.ai.vectorstore.hanadb.*` properties to configure the Hana vector store.
+It uses `spring.datasource.*` properties to configure the Hana datasource and the `spring.ai.vectorstore.hanadb.\*` properties to configure the Hana vector store.
 
 |===
 |Property| Description | Default value


### PR DESCRIPTION
This PR fixes a rendering issue in the HanaDB documentation where the asterisk in spring.ai.vectorstore.hanadb.* was being interpreted as AsciiDoc formatting (bolding) instead of a literal character.

Related Issue

Fixes #2722