### PR TITLE
fix: correct typo in MKV video MIME type

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/content/Media.java
@@ -382,9 +382,9 @@ public class Media {
 		// Video Formats
 		// -----------------
 		/**
-		 * Public constant mime type for {@code video/x-matros}.
+		 * Public constant mime type for {@code video/x-matroska}.
 		 */
-		public static final MimeType VIDEO_MKV = MimeType.valueOf("video/x-matros");
+		public static final MimeType VIDEO_MKV = MimeType.valueOf("video/x-matroska");
 
 		/**
 		 * Public constant mime type for {@code video/quicktime}.


### PR DESCRIPTION
## Summary
The `VIDEO_MKV` constant in `Media.java` contained a typo ("video/x-matros").
This commit fixes the value to "video/x-matroska" to ensure correct media type handling for Matroska video files.