### PR TITLE
fix: Correct max repeat attempts logic

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -178,7 +178,7 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 				}
 			}
 		}
-		while (!isValidationSuccess && repeatCounter <= this.maxRepeatAttempts);
+		while (!isValidationSuccess && repeatCounter < this.maxRepeatAttempts);
 
 		return chatClientResponse;
 	}


### PR DESCRIPTION
### Description
Fixed an off-by-one error in the `adviseCall` method of `StructuredOutputValidationAdvisor`.

In the `do-while` loop, the `repeatCounter` is incremented at the beginning of the iteration. Previously, the condition `repeatCounter <= this.maxRepeatAttempts` caused the loop to execute one more time than the configured limit.

For example, if `maxRepeatAttempts` was set to 1, the previous logic allowed 2 executions. Changing the condition to `<` ensures the number of attempts strictly adheres to the configuration.