### PR TITLE
GH-5220: Update ZhiPuAI default model to the latest available model

### DIFF
--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -69,7 +69,7 @@ public class ZhiPuAiApi {
 		return new Builder();
 	}
 
-	public static final String DEFAULT_CHAT_MODEL = ChatModel.GLM_4_Air.getValue();
+	public static final String DEFAULT_CHAT_MODEL = ChatModel.GLM_4_7.getValue();
 
 	public static final String DEFAULT_EMBEDDING_MODEL = EmbeddingModel.Embedding_2.getValue();
 
@@ -344,6 +344,8 @@ public class ZhiPuAiApi {
 	public enum ChatModel implements ChatModelDescription {
 
 		// @formatter:off
+		GLM_4_7("glm-4.7"),
+
 		GLM_4_6("glm-4.6"),
 
 		GLM_4_5("glm-4.5"),

--- a/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiApiIT.java
+++ b/models/spring-ai-zhipuai/src/test/java/org/springframework/ai/zhipuai/api/ZhiPuAiApiIT.java
@@ -44,10 +44,20 @@ public class ZhiPuAiApiIT {
 	ZhiPuAiApi zhiPuAiApi = ZhiPuAiApi.builder().apiKey(System.getenv("ZHIPU_AI_API_KEY")).build();
 
 	@Test
+	void chatCompletionEntityWithDefaultModel() {
+		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world", Role.USER);
+		ResponseEntity<ChatCompletion> response = this.zhiPuAiApi
+				.chatCompletionEntity(new ChatCompletionRequest(List.of(chatCompletionMessage), null, 0.7, false));
+
+		assertThat(response).isNotNull();
+		assertThat(response.getBody()).isNotNull();
+	}
+
+	@Test
 	void chatCompletionEntity() {
 		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world", Role.USER);
 		ResponseEntity<ChatCompletion> response = this.zhiPuAiApi
-			.chatCompletionEntity(new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-3-turbo", 0.7, false));
+			.chatCompletionEntity(new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-4.6", 0.7, false));
 
 		assertThat(response).isNotNull();
 		assertThat(response.getBody()).isNotNull();
@@ -57,7 +67,7 @@ public class ZhiPuAiApiIT {
 	void chatCompletionEntityWithMoreParams() {
 		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world", Role.USER);
 		ResponseEntity<ChatCompletion> response = this.zhiPuAiApi
-			.chatCompletionEntity(new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-4-flash", 1024, null,
+			.chatCompletionEntity(new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-4.7", 1024, null,
 					false, 0.95, 0.7, null, null, null, "test_request_id", false, null, null));
 
 		assertThat(response).isNotNull();
@@ -69,7 +79,7 @@ public class ZhiPuAiApiIT {
 	void chatCompletionStream() {
 		ChatCompletionMessage chatCompletionMessage = new ChatCompletionMessage("Hello world", Role.USER);
 		Flux<ChatCompletionChunk> response = this.zhiPuAiApi
-			.chatCompletionStream(new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-4-flash", 0.7, true));
+			.chatCompletionStream(new ChatCompletionRequest(List.of(chatCompletionMessage), "glm-4.7", 0.7, true));
 
 		assertThat(response).isNotNull();
 		List<ChatCompletionChunk> chunks = response.collectList().block();


### PR DESCRIPTION
Fixes [GH-5220](https://github.com/spring-projects/spring-ai/issues/5220)

## Description
This PR updates the default ZhiPuAI model to **glm-4.7**, which is the latest supported model, to ensure compatibility with the current ZhiPuAI API.

Several tests were previously failing due to references to deprecated or non-existent model identifiers. This change aligns the default configuration with supported models and stabilizes the test suite.

## Changes
- Update the default ZhiPuAI chat model to `glm-4.7`
- Fix failing tests caused by deprecated or unavailable model identifiers
- Add tests to verify behavior when using the default model configuration

## Verification
- All existing tests pass
- New tests validate chat completion behavior using the default model

## Question
1. There are several ZhiPuAI model identifiers referenced in the codebase that appear to be deprecated or no longer supported according to this issue(https://github.com/spring-projects/spring-ai/issues/5220)
   Would it be preferable to remove enums for models that are no longer available, or should we keep them for backward compatibility?

2. Although the official ZhiPuAI documentation indicates that Embedding Model 3 is supported, actual API calls fail with "model not found" errors.  
   This issue affects both `embedding-2` and `embedding-3`, and currently causes CI test failures.

   Would it be better to remove or temporarily disable embedding model tests until the API behavior is clarified?