### PR TITLE
Move ReReadingAdvisor to the chat advisor package

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ReReadingAdvisor;
 import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.converter.BeanOutputConverter;

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ReReadingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ReReadingAdvisor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.openai.chat.client;
+package org.springframework.ai.chat.client.advisor;
 
 import java.util.Map;
 


### PR DESCRIPTION
Move ReReadingAdvisor out of the OpenAI-specific package into the core chat advisor package.

ReReadingAdvisor implements a generic BaseAdvisor and applies a model-agnostic re-reading (RE2) strategy during prompt construction. It does not depend on any OpenAI-specific APIs or configuration.

Keeping this advisor under the OpenAI module is misleading and blurs the intended abstraction boundaries. Relocating it improves package alignment and makes the advisor discoverable and reusable across all supported chat models.

No functional changes are introduced.