### PR TITLE
Improve redis semantic cache module

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.util.StringUtils;
 
 import redis.clients.jedis.JedisPooled;
@@ -38,10 +39,12 @@ import redis.clients.jedis.JedisPooled;
  * Auto-configuration for Redis semantic cache.
  *
  * @author Brian Sam-Bodden
+ * @author Eddú Meléndez
  */
 @AutoConfiguration(after = DataRedisAutoConfiguration.class)
 @ConditionalOnClass({ DefaultSemanticCache.class, JedisPooled.class, CallAdvisor.class, StreamAdvisor.class,
 		TransformersEmbeddingModel.class })
+@ConditionalOnBean(JedisConnectionFactory.class)
 @EnableConfigurationProperties(RedisSemanticCacheProperties.class)
 @ConditionalOnProperty(name = "spring.ai.vectorstore.redis.semantic-cache.enabled", havingValue = "true",
 		matchIfMissing = true)
@@ -71,8 +74,8 @@ public class RedisSemanticCacheAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnBean(EmbeddingModel.class)
-	public JedisPooled jedisClient(RedisSemanticCacheProperties properties) {
-		return new JedisPooled(properties.getHost(), properties.getPort());
+	public JedisPooled jedisClient(JedisConnectionFactory jedisConnectionFactory) {
+		return new JedisPooled(jedisConnectionFactory.getHostName(), jedisConnectionFactory.getPort());
 	}
 
 	@Bean

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/main/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheProperties.java
@@ -21,6 +21,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for Redis semantic cache.
  *
  * @author Brian Sam-Bodden
+ * @author Eddú Meléndez
  */
 @ConfigurationProperties(prefix = "spring.ai.vectorstore.redis.semantic-cache")
 public class RedisSemanticCacheProperties {
@@ -29,16 +30,6 @@ public class RedisSemanticCacheProperties {
 	 * Enable the Redis semantic cache.
 	 */
 	private boolean enabled = true;
-
-	/**
-	 * Redis server host.
-	 */
-	private String host = "localhost";
-
-	/**
-	 * Redis server port.
-	 */
-	private int port = 6379;
 
 	/**
 	 * Similarity threshold for matching cached responses (0.0 to 1.0). Higher values mean
@@ -62,22 +53,6 @@ public class RedisSemanticCacheProperties {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
-	}
-
-	public String getHost() {
-		return host;
-	}
-
-	public void setHost(String host) {
-		this.host = host;
-	}
-
-	public int getPort() {
-		return port;
-	}
-
-	public void setPort(int port) {
-		this.port = port;
 	}
 
 	public double getSimilarityThreshold() {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/test/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/src/test/java/org/springframework/ai/vectorstore/redis/cache/semantic/autoconfigure/RedisSemanticCacheAutoConfigurationIT.java
@@ -63,14 +63,10 @@ class RedisSemanticCacheAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(
-				AutoConfigurations.of(RedisSemanticCacheAutoConfiguration.class, DataRedisAutoConfiguration.class))
+				AutoConfigurations.of(DataRedisAutoConfiguration.class, RedisSemanticCacheAutoConfiguration.class))
 		.withUserConfiguration(TestConfig.class)
 		.withPropertyValues("spring.data.redis.host=" + redisContainer.getHost(),
-				"spring.data.redis.port=" + redisContainer.getFirstMappedPort(),
-				// Pass the same Redis connection properties to our semantic cache
-				// properties
-				"spring.ai.vectorstore.redis.semantic-cache.host=" + redisContainer.getHost(),
-				"spring.ai.vectorstore.redis.semantic-cache.port=" + redisContainer.getFirstMappedPort());
+				"spring.data.redis.port=" + redisContainer.getFirstMappedPort(), "spring.data.redis.client-type=jedis");
 
 	@Test
 	void autoConfigurationRegistersExpectedBeans() {


### PR DESCRIPTION
Currently, autoconfiguration requires to specify host and port
for the redis instance. Given the autoconfiguration relies on
spring-boot's DataRedisAutoConfiguration, it can take advantage of
JedisConnectionFactory bean to fetch these properties. This will allow
to reuse existing infrastructure and features such as Docker Compose and
Testcontainers Service Connection.

Signed-off-by: Eddú Meléndez <eddu.melendez@gmail.com>
