### PR TITLE
Improve time complexity and reduce memory allocations

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
@@ -66,6 +66,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author chabinhwang
  * @since 0.8.0
  */
 public abstract class ModelOptionsUtils {

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  * Default implementation of {@link ToolCallingManager}.
  *
  * @author Thomas Vitale
+ * @author chabinhwang
  * @since 1.0.0
  */
 public final class DefaultToolCallingManager implements ToolCallingManager {


### PR DESCRIPTION
## Summary

### Improve time complexity

- 6d5850a85abc2ee9e6661f07fd4cbb09cd80e4d0:It originally had $O(N \times M)$ time complexity, but I reduced it to $O(N + M)$ by using a HashSet (existingToolNames).
- 22caee3d379782380c484163bcbb98c1981207e8: Optimized lookup performance ($O(N) \rightarrow O(1)$) by switching to HashSet.
- 3848a3bc19fcf14b5d0b235f7e70e006f65db441: Improve null-safety and reduce memory allocations by removing `substring` usage.

