### PR TITLE
GH-5293 Add Skill extension support for Spring AI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 		<module>spring-ai-test</module>
 		<module>spring-ai-vector-store</module>
 		<module>spring-ai-rag</module>
+		<module>spring-ai-skill</module>
 		<module>advisors/spring-ai-advisors-vector-store</module>
 
 		<module>memory/repository/spring-ai-model-chat-memory-repository-cassandra</module>

--- a/spring-ai-skill/pom.xml
+++ b/spring-ai-skill/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2026 Semir Group and the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>spring-ai-skill</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Skill</name>
+	<description>Skill management extension for Spring AI applications</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/adapter/SkillProxy.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/adapter/SkillProxy.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.adapter;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.skill.core.Skill;
+import org.springframework.ai.skill.core.SkillMetadata;
+import org.springframework.ai.skill.core.SkillRegistrar;
+import org.springframework.ai.skill.exception.SkillInvocationException;
+import org.springframework.ai.tool.ToolCallback;
+
+/**
+ * Proxy-based Skill implementation wrapping user POJOs annotated with {@code @Skill}.
+ *
+ * <p>
+ * This class acts as a dynamic proxy that delegates method calls to the underlying
+ * annotated POJO instance using reflection. It supports capability extension through JDK
+ * dynamic proxies.
+ *
+ * <p>
+ * INTERNAL USE ONLY: Framework internal class subject to change.
+ *
+ * @author LinPeng Zhang
+ * @see Skill
+ * @see SkillRegistrar
+ * @since 1.1.3
+ */
+public final class SkillProxy implements Skill {
+
+	private final SkillMetadata metadata;
+
+	private final Object delegate;
+
+	private final Map<String, Method> extensionMethods;
+
+	private final Map<Class<?>, Object> capabilityProxies = new ConcurrentHashMap<>();
+
+	/**
+	 * Constructor.
+	 * @param metadata skill metadata
+	 * @param delegate user POJO instance
+	 * @param extensionMethods extension method mappings
+	 */
+	public SkillProxy(SkillMetadata metadata, Object delegate, Map<String, Method> extensionMethods) {
+		this.metadata = Objects.requireNonNull(metadata, "metadata cannot be null");
+		this.delegate = Objects.requireNonNull(delegate, "delegate cannot be null");
+		this.extensionMethods = Objects.requireNonNull(extensionMethods, "extensionMethods cannot be null");
+	}
+
+	@Override
+	public SkillMetadata getMetadata() {
+		return this.metadata;
+	}
+
+	/**
+	 * Gets skill content.
+	 * @return skill content
+	 * @throws UnsupportedOperationException if no @SkillContent method found
+	 * @throws SkillInvocationException if invocation fails
+	 */
+	@Override
+	public String getContent() {
+		Method contentMethod = this.extensionMethods.get("content");
+		if (contentMethod == null) {
+			throw new UnsupportedOperationException(
+					"Skill '" + this.getName() + "' does not have @SkillContent annotated method");
+		}
+
+		try {
+			contentMethod.setAccessible(true);
+			Object result = contentMethod.invoke(this.delegate);
+
+			// Validate return type
+			if (result == null) {
+				throw new SkillInvocationException(this.getName(), contentMethod.getName(),
+						"@SkillContent method '" + contentMethod.getName() + "' returned null. "
+								+ "The method must return a non-null String value.",
+						null);
+			}
+
+			if (!(result instanceof String)) {
+				throw new SkillInvocationException(this.getName(), contentMethod.getName(),
+						"@SkillContent method '" + contentMethod.getName() + "' must return String, " + "but returned "
+								+ result.getClass().getName() + ". " + "Ensure the method signature is: public String "
+								+ contentMethod.getName() + "()",
+						null);
+			}
+
+			return (String) result;
+		}
+		catch (SkillInvocationException e) {
+			throw e; // Re-throw our custom exception
+		}
+		catch (Exception e) {
+			throw new SkillInvocationException(this.getName(), contentMethod.getName(),
+					"Failed to invoke @SkillContent method '" + contentMethod.getName() + "' on skill '"
+							+ this.getName() + "'. " + "Ensure the method is accessible and does not throw exceptions.",
+					e);
+		}
+	}
+
+	/**
+	 * Gets tool callbacks.
+	 * @return tool callbacks (empty if no @SkillTools method)
+	 * @throws SkillInvocationException if invocation fails
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<ToolCallback> getTools() {
+		Method toolsMethod = this.extensionMethods.get("tools");
+		if (toolsMethod == null) {
+			return Collections.emptyList(); // No @SkillTools method, return empty list
+		}
+
+		try {
+			toolsMethod.setAccessible(true);
+			Object result = toolsMethod.invoke(this.delegate);
+
+			// Validate return type
+			if (result == null) {
+				throw new SkillInvocationException(this.getName(), toolsMethod.getName(),
+						"@SkillTools method '" + toolsMethod.getName() + "' returned null. "
+								+ "The method must return a non-null List<ToolCallback>.",
+						null);
+			}
+
+			if (!(result instanceof List<?> list)) {
+				throw new SkillInvocationException(this.getName(), toolsMethod.getName(),
+						"@SkillTools method '" + toolsMethod.getName() + "' must return List<ToolCallback>, "
+								+ "but returned " + result.getClass().getName() + ". "
+								+ "Ensure the method signature is: public List<ToolCallback> " + toolsMethod.getName()
+								+ "()",
+						null);
+			}
+
+			// Check list contents ( the best effort - generics are erased at runtime)
+			if (!list.isEmpty()) {
+				Object firstElement = list.get(0);
+				if (firstElement != null && !(firstElement instanceof ToolCallback)) {
+					throw new SkillInvocationException(this.getName(), toolsMethod.getName(),
+							"@SkillTools method '" + toolsMethod.getName()
+									+ "' returned a list containing invalid elements. "
+									+ "Expected List<ToolCallback>, but found element of type "
+									+ firstElement.getClass().getName() + ". "
+									+ "Ensure all list elements are instances of ToolCallback.",
+							null);
+				}
+			}
+
+			return (List<ToolCallback>) result;
+		}
+		catch (SkillInvocationException e) {
+			throw e; // Re-throw our custom exception
+		}
+		catch (Exception e) {
+			throw new SkillInvocationException(this.getName(), toolsMethod.getName(),
+					"Failed to invoke @SkillTools method '" + toolsMethod.getName() + "' on skill '" + this.getName()
+							+ "'. " + "Ensure the method is accessible and does not throw exceptions.",
+					e);
+		}
+	}
+
+	@Override
+	public <T> boolean supports(Class<T> capabilityType) {
+		if (!capabilityType.isInterface()) {
+			return false;
+		}
+
+		String expectedKey = this.getCapabilityKey(capabilityType);
+		return expectedKey != null && this.extensionMethods.containsKey(expectedKey);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T as(Class<T> capabilityType) {
+		if (!capabilityType.isInterface()) {
+			throw new IllegalArgumentException("Capability must be an interface: " + capabilityType.getName());
+		}
+
+		if (!this.supports(capabilityType)) {
+			throw new UnsupportedOperationException(
+					"Skill '" + this.getName() + "' does not support capability: " + capabilityType.getName());
+		}
+
+		return (T) this.capabilityProxies.computeIfAbsent(capabilityType, this::createCapabilityProxy);
+	}
+
+	/**
+	 * Creates dynamic proxy for capability interface.
+	 * @param capability capability interface
+	 * @return proxy instance
+	 */
+	private Object createCapabilityProxy(Class<?> capability) {
+		return Proxy.newProxyInstance(capability.getClassLoader(), new Class<?>[] { capability },
+				(proxy, method, args) -> {
+					String key = this.methodToExtensionKey(method);
+					Method extensionMethod = this.extensionMethods.get(key);
+
+					if (extensionMethod == null) {
+						throw new UnsupportedOperationException("No implementation found for method '"
+								+ method.getName() + "' in capability interface '" + capability.getName() + "' "
+								+ "for skill '" + this.getName() + "'. " + "Expected an annotated method with key '"
+								+ key + "'.");
+					}
+
+					try {
+						extensionMethod.setAccessible(true);
+						return extensionMethod.invoke(this.delegate, args);
+					}
+					catch (Exception e) {
+						throw new SkillInvocationException(this.getName(), extensionMethod.getName(),
+								"Failed to invoke capability method '" + method.getName() + "' (mapped to '"
+										+ extensionMethod.getName() + "') " + "for capability '" + capability.getName()
+										+ "' " + "on skill '" + this.getName() + "'.",
+								e);
+					}
+				});
+	}
+
+	private @Nullable String getCapabilityKey(Class<?> capability) {
+		Method[] methods = capability.getDeclaredMethods();
+		if (methods.length == 0) {
+			return null;
+		}
+		return this.methodToExtensionKey(methods[0]);
+	}
+
+	private String methodToExtensionKey(Method method) {
+		String methodName = method.getName();
+		if (methodName.startsWith("get") && methodName.length() > 3) {
+			return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+		}
+		return methodName;
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/adapter/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/adapter/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter classes for skill proxy and dynamic invocation.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.adapter;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/Skill.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/Skill.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Class-level annotation for marking a class as a Skill.
+ *
+ * <p>
+ * Supports annotation mode (POJO) and interface mode (Skill implementation).
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Skill {
+
+	/**
+	 * Skill name (required).
+	 * @return skill name
+	 */
+	String name();
+
+	/**
+	 * Skill description (required).
+	 * @return skill description
+	 */
+	String description();
+
+	/**
+	 * Source identifier (optional, default "custom").
+	 * @return source identifier
+	 */
+	String source() default "custom";
+
+	/**
+	 * Extension properties (optional).
+	 *
+	 * <p>
+	 * Format: key=value
+	 * @return extension properties array
+	 */
+	String[] extensions() default {};
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillContent.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillContent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks method returning skill markdown content.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@SkillExtension(key = "content", returnType = String.class, required = true)
+public @interface SkillContent {
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillExtension.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillExtension.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta-annotation for custom skill extension methods.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SkillExtension {
+
+	/**
+	 * Extension key.
+	 * @return key value
+	 */
+	String key();
+
+	/**
+	 * Expected return type.
+	 * @return return type class
+	 */
+	Class<?> returnType() default Object.class;
+
+	/**
+	 * Whether extension is required.
+	 * @return true if required
+	 */
+	boolean required() default false;
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillInit.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillInit.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks skill initialization factory method.
+ *
+ * @author LinPeng Zhang
+ * @see Skill
+ * @see org.springframework.ai.skill.registration.ClassBasedSkillRegistrar
+ * @since 1.1.3
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SkillInit {
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillTools.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/SkillTools.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+/**
+ * Marks method returning skill tool list.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@SkillExtension(key = "tools", returnType = List.class, required = false)
+public @interface SkillTools {
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/annotation/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Annotations for declarative skill definition and configuration.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.annotation;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/capability/ReferencesLoader.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/capability/ReferencesLoader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.capability;
+
+import java.util.Map;
+
+/**
+ * Extension capability interface for providing reference resources.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public interface ReferencesLoader {
+
+	/**
+	 * Gets reference resources map.
+	 * @return reference resources (never null, may be empty)
+	 */
+	Map<String, String> getReferences();
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/capability/SkillReferences.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/capability/SkillReferences.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.capability;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+
+import org.springframework.ai.skill.annotation.SkillExtension;
+
+/**
+ * Marks method returning skill reference resources as Map<String, String>.
+ *
+ * @author LinPeng Zhang
+ * @see org.springframework.ai.skill.capability.ReferencesLoader
+ * @since 1.1.3
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@SkillExtension(key = "references", returnType = Map.class, required = false)
+public @interface SkillReferences {
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/capability/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/capability/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Capability interfaces for skill references and content loading.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.capability;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/common/LoadStrategy.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/common/LoadStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.common;
+
+/**
+ * Skill loading strategy.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public enum LoadStrategy {
+
+	/**
+	 * Lazy loading (default) - instance created on first use.
+	 */
+	LAZY,
+
+	/**
+	 * Eager loading - instance created immediately during registration.
+	 */
+	EAGER
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/common/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/common/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common types and enumerations shared across skill components.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.common;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/DefaultSkillKit.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/DefaultSkillKit.java
@@ -1,0 +1,471 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.skill.exception.SkillRegistrationException;
+import org.springframework.ai.skill.exception.SkillValidationException;
+import org.springframework.ai.skill.registration.ClassBasedSkillRegistrar;
+import org.springframework.ai.skill.registration.InstanceBasedSkillRegistrar;
+import org.springframework.ai.skill.support.DefaultSkillIdGenerator;
+import org.springframework.ai.skill.tool.SimpleSkillLoaderTools;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.ToolCallback;
+
+/**
+ * Default implementation of SkillKit coordinating SkillBox and SkillPoolManager.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class DefaultSkillKit implements SkillKit {
+
+	private final SkillBox skillBox;
+
+	private final SkillPoolManager poolManager;
+
+	private final SkillIdGenerator idGenerator;
+
+	private final SkillRegistrar<Class<?>> classRegistrar;
+
+	private final SkillRegistrar<Object> instanceRegistrar;
+
+	private final List<ToolCallback> skillLoaderTools;
+
+	private DefaultSkillKit(Builder builder) {
+		this.skillBox = Objects.requireNonNull(builder.skillBox, "skillBox cannot be null");
+		this.poolManager = Objects.requireNonNull(builder.poolManager, "poolManager cannot be null");
+		this.idGenerator = (builder.idGenerator != null) ? builder.idGenerator : new DefaultSkillIdGenerator();
+		this.classRegistrar = (builder.classRegistrar != null) ? builder.classRegistrar
+				: ClassBasedSkillRegistrar.builder().idGenerator(this.idGenerator).build();
+		this.instanceRegistrar = (builder.instanceRegistrar != null) ? builder.instanceRegistrar
+				: InstanceBasedSkillRegistrar.builder().idGenerator(this.idGenerator).build();
+		this.skillLoaderTools = (builder.tools != null) ? builder.tools
+				: List.of(ToolCallbacks.from(SimpleSkillLoaderTools.builder().skillKit(this).build()));
+	}
+
+	/**
+	 * Creates a new builder instance.
+	 * @return new builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public void register(SkillMetadata metadata, Supplier<Skill> loader) {
+		this.validateRegistrationParameters(metadata, loader);
+		String skillId = this.buildSkillId(metadata);
+
+		if (this.poolManager.hasDefinition(skillId)) {
+			throw new SkillRegistrationException(skillId, "Skill with ID '" + skillId + "' already registered. "
+					+ "Each combination of (name, source) must be unique.");
+		}
+
+		SkillDefinition definition = SkillDefinition.builder()
+			.skillId(skillId)
+			.source(metadata.getSource())
+			.loader(loader)
+			.metadata(metadata)
+			.build();
+
+		this.poolManager.registerDefinition(definition);
+		this.skillBox.addSkill(metadata.getName(), metadata);
+	}
+
+	// ==================== Skill Registration ====================
+
+	@Override
+	public void register(Object instance) {
+		SkillDefinition definition = this.instanceRegistrar.register(this.poolManager, instance);
+		this.skillBox.addSkill(definition.getMetadata().getName(), definition.getMetadata());
+	}
+
+	@Override
+	public void register(Class<?> skillClass) {
+		SkillDefinition definition = this.classRegistrar.register(this.poolManager, skillClass);
+		this.skillBox.addSkill(definition.getMetadata().getName(), definition.getMetadata());
+	}
+
+	protected String buildSkillId(SkillMetadata metadata) {
+		return this.idGenerator.generateId(metadata);
+	}
+
+	private void validateRegistrationParameters(SkillMetadata metadata, Supplier<Skill> loader) {
+		if (metadata == null) {
+			throw new SkillValidationException(null, "metadata cannot be null");
+		}
+
+		String name = metadata.getName();
+		if (name == null || name.trim().isEmpty()) {
+			throw new SkillValidationException(null, "metadata.name cannot be null or empty. "
+					+ "Example: SkillMetadata.builder(\"calculator\", \"Calculator skill\", \"spring\").build()");
+		}
+
+		String description = metadata.getDescription();
+		if (description == null || description.trim().isEmpty()) {
+			throw new SkillValidationException(null, "metadata.description cannot be null or empty. "
+					+ "Example: SkillMetadata.builder(\"calculator\", \"A skill for calculations\", \"spring\").build()");
+		}
+
+		String source = metadata.getSource();
+		if (source == null || source.trim().isEmpty()) {
+			throw new SkillValidationException(null,
+					"metadata.source cannot be null or empty. "
+							+ "Common sources: \"spring\", \"official\", \"filesystem\", \"database\". "
+							+ "Example: SkillMetadata.builder(\"calculator\", \"desc\", \"spring\").build()");
+		}
+
+		if (loader == null) {
+			throw new SkillValidationException(null,
+					"loader cannot be null. " + "Example: skillKit.registerSkill(metadata, () -> new MySkill())");
+		}
+	}
+
+	/**
+	 * Gets skill instance by skillId.
+	 * @param skillId unique skill ID (format: {name}_{source})
+	 * @return skill instance
+	 * @throws org.springframework.ai.skill.exception.SkillNotFoundException if skill not
+	 * found
+	 * @throws org.springframework.ai.skill.exception.SkillLoadException if loading fails
+	 */
+	@Override
+	public Skill getSkill(String skillId) {
+		return this.poolManager.load(skillId);
+	}
+
+	// ==================== Skill Access ====================
+
+	/**
+	 * Gets skill instance by name from SkillBox.
+	 * @param name skill name
+	 * @return skill instance, null if not found
+	 */
+	@Override
+	public @Nullable Skill getSkillByName(String name) {
+		SkillMetadata metadata = this.skillBox.getMetadata(name);
+		if (metadata == null) {
+			return null;
+		}
+		String skillId = this.buildSkillId(metadata);
+		return this.poolManager.load(skillId);
+	}
+
+	/**
+	 * Gets skill metadata by name from SkillBox without triggering skill loading.
+	 * @param name skill name
+	 * @return skill metadata, null if not found
+	 */
+	@Override
+	public @Nullable SkillMetadata getMetadata(String name) {
+		return this.skillBox.getMetadata(name);
+	}
+
+	/**
+	 * Checks if skill exists in SkillBox.
+	 * @param name skill name
+	 * @return true if exists
+	 */
+	@Override
+	public boolean exists(String name) {
+		return this.skillBox.exists(name);
+	}
+
+	/**
+	 * Adds skill metadata to SkillBox from PoolManager.
+	 * @param name skill name
+	 * @throws IllegalArgumentException if skill not found in PoolManager or already
+	 * exists in SkillBox
+	 */
+	public void addSkillToBox(String name) {
+		SkillDefinition definition = this.findDefinitionByName(name);
+		if (definition == null) {
+			throw new IllegalArgumentException("Skill not found in PoolManager: " + name + ". "
+					+ "Please register the skill first using registerSkill().");
+		}
+
+		this.skillBox.addSkill(name, definition.getMetadata());
+	}
+
+	// ==================== SkillBox Management ====================
+
+	/**
+	 * Finds skill definition by name, checking SkillBox sources in priority order.
+	 * @param name skill name
+	 * @return skill definition, null if not found
+	 */
+	protected @Nullable SkillDefinition findDefinitionByName(String name) {
+		SkillMetadata metadata = this.skillBox.getMetadata(name);
+		if (metadata != null) {
+			String metadataSource = metadata.getSource();
+			if (!this.skillBox.getSources().contains(metadataSource)) {
+				return null;
+			}
+
+			String skillId = this.buildSkillId(metadata);
+			return this.poolManager.getDefinition(skillId);
+		}
+
+		List<SkillDefinition> allDefinitions = this.poolManager.getDefinitions();
+
+		for (String source : this.skillBox.getSources()) {
+			for (SkillDefinition definition : allDefinitions) {
+				SkillMetadata defMetadata = definition.getMetadata();
+				if (name.equals(defMetadata.getName()) && source.equals(defMetadata.getSource())) {
+					String expectedSkillId = this.buildSkillId(defMetadata);
+					if (expectedSkillId.equals(definition.getSkillId())) {
+						return definition;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Activates skill by name.
+	 * @param name skill name
+	 * @throws IllegalArgumentException if skill not found in SkillBox
+	 */
+	@Override
+	public void activateSkill(String name) {
+		if (!this.skillBox.exists(name)) {
+			throw new IllegalArgumentException("Skill not found in SkillBox: " + name + ". "
+					+ "Please register the skill first using registerSkill().");
+		}
+
+		this.skillBox.activateSkill(name);
+	}
+
+	// ==================== Skill Activation ====================
+
+	/**
+	 * Deactivates skill by name.
+	 * @param name skill name
+	 * @throws IllegalArgumentException if skill not found in SkillBox
+	 */
+	@Override
+	public void deactivateSkill(String name) {
+		if (!this.skillBox.exists(name)) {
+			throw new IllegalArgumentException("Skill not found in SkillBox: " + name);
+		}
+
+		this.skillBox.deactivateSkill(name);
+	}
+
+	/**
+	 * Deactivates all skills.
+	 */
+	@Override
+	public void deactivateAllSkills() {
+		this.skillBox.deactivateAllSkills();
+	}
+
+	/**
+	 * Checks if skill is activated.
+	 * @param name skill name
+	 * @return true if activated
+	 */
+	@Override
+	public boolean isActivated(String name) {
+		return this.skillBox.isActivated(name);
+	}
+
+	/**
+	 * Gets all tool callbacks from activated skills.
+	 * @return list of tool callbacks from activated skills
+	 * @throws IllegalStateException if activated skill not found in PoolManager
+	 */
+	@Override
+	public List<ToolCallback> getAllActiveTools() {
+		List<ToolCallback> allTools = new ArrayList<>();
+
+		Set<String> activatedSkillNames = this.skillBox.getActivatedSkillNames();
+
+		for (String name : activatedSkillNames) {
+			SkillDefinition definition = this.findDefinitionByName(name);
+			if (definition == null) {
+				throw new IllegalStateException(
+						"Skill '" + name + "' is activated in SkillBox but not found in PoolManager. "
+								+ "This indicates a data inconsistency. "
+								+ "Please ensure the skill is properly registered in PoolManager.");
+			}
+
+			String skillId = definition.getSkillId();
+			Skill skill = this.poolManager.load(skillId);
+
+			List<ToolCallback> tools = skill.getTools();
+			if (tools != null && !tools.isEmpty()) {
+				allTools.addAll(tools);
+			}
+		}
+
+		return allTools;
+	}
+
+	/**
+	 * Gets system prompt describing all skills in SkillBox.
+	 * @return system prompt string, empty if no skills
+	 */
+	@Override
+	public String getSkillSystemPrompt() {
+		Map<String, SkillMetadata> allMetadata = this.skillBox.getAllMetadata();
+
+		if (allMetadata.isEmpty()) {
+			return "";
+		}
+
+		StringBuilder prompt = new StringBuilder();
+		prompt.append("You have access to the following skills:\n\n");
+
+		int index = 1;
+		for (SkillMetadata metadata : allMetadata.values()) {
+			prompt.append(String.format("%d. %s: %s\n", index++, metadata.getName(), metadata.getDescription()));
+		}
+
+		prompt.append("\n");
+		prompt.append("**How to Use Skills:**\n\n");
+		prompt.append(
+				"1. **loadSkillContent(skillName)**: Load the full content of a skill to understand what it does and what tools it provides.\n");
+		prompt.append("   - Use this when you need to know a skill's capabilities\n");
+		prompt.append("   - The content will describe available tools and how to use them\n\n");
+		prompt.append(
+				"2. **loadSkillReference(skillName, referenceKey)**: Load a specific reference material from a skill.\n");
+		prompt.append("   - ONLY use this when a skill's content EXPLICITLY mentions it has reference materials\n");
+		prompt.append("   - You must use the exact reference key mentioned in the skill's content\n");
+		prompt.append("   - For regular skill operations, use the skill's own tools instead\n");
+
+		return prompt.toString();
+	}
+
+	/**
+	 * Gets skill-related tool callbacks for progressive skill loading.
+	 * @return list of skill tool callbacks
+	 */
+	@Override
+	public List<ToolCallback> getSkillLoaderTools() {
+		return this.skillLoaderTools;
+	}
+
+	// ==================== Skill Tools ====================
+
+	/**
+	 * Builder for DefaultSkillKit.
+	 */
+	public static class Builder {
+
+		private @Nullable SkillBox skillBox;
+
+		private @Nullable SkillPoolManager poolManager;
+
+		private @Nullable List<ToolCallback> tools;
+
+		private @Nullable SkillIdGenerator idGenerator;
+
+		private @Nullable SkillRegistrar<Class<?>> classRegistrar;
+
+		private @Nullable SkillRegistrar<Object> instanceRegistrar;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets the skill box.
+		 * @param skillBox skill box instance
+		 * @return this builder
+		 */
+		public Builder skillBox(SkillBox skillBox) {
+			this.skillBox = skillBox;
+			return this;
+		}
+
+		/**
+		 * Sets the pool manager.
+		 * @param poolManager pool manager instance
+		 * @return this builder
+		 */
+		public Builder poolManager(SkillPoolManager poolManager) {
+			this.poolManager = poolManager;
+			return this;
+		}
+
+		/**
+		 * Sets custom tools.
+		 * @param tools tool callbacks list
+		 * @return this builder
+		 */
+		public Builder tools(List<ToolCallback> tools) {
+			this.tools = tools;
+			return this;
+		}
+
+		/**
+		 * Sets custom ID generator.
+		 * @param idGenerator ID generator instance
+		 * @return this builder
+		 */
+		public Builder idGenerator(SkillIdGenerator idGenerator) {
+			this.idGenerator = idGenerator;
+			return this;
+		}
+
+		/**
+		 * Sets custom class-based registrar.
+		 * @param classRegistrar class registrar instance
+		 * @return this builder
+		 */
+		public Builder classRegistrar(SkillRegistrar<Class<?>> classRegistrar) {
+			this.classRegistrar = classRegistrar;
+			return this;
+		}
+
+		/**
+		 * Sets custom instance-based registrar.
+		 * @param instanceRegistrar instance registrar instance
+		 * @return this builder
+		 */
+		public Builder instanceRegistrar(SkillRegistrar<Object> instanceRegistrar) {
+			this.instanceRegistrar = instanceRegistrar;
+			return this;
+		}
+
+		/**
+		 * Builds the DefaultSkillKit instance.
+		 * @return new DefaultSkillKit instance
+		 */
+		public DefaultSkillKit build() {
+			if (this.skillBox == null) {
+				throw new IllegalArgumentException("skillBox cannot be null");
+			}
+			if (this.poolManager == null) {
+				throw new IllegalArgumentException("poolManager cannot be null");
+			}
+			return new DefaultSkillKit(this);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/Skill.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/Skill.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.ai.tool.ToolCallback;
+
+/**
+ * Core Skill interface.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public interface Skill {
+
+	/**
+	 * Gets skill metadata.
+	 * @return skill metadata
+	 */
+	SkillMetadata getMetadata();
+
+	/**
+	 * Gets skill name.
+	 * @return skill name
+	 */
+	default String getName() {
+		return this.getMetadata().getName();
+	}
+
+	/**
+	 * Gets skill description.
+	 * @return skill description
+	 */
+	default String getDescription() {
+		return this.getMetadata().getDescription();
+	}
+
+	/**
+	 * Gets skill content in Markdown format.
+	 * @return skill content
+	 */
+	String getContent();
+
+	/**
+	 * Gets tool callbacks provided by this skill.
+	 * @return tool callback list (never null, defaults to empty)
+	 */
+	default List<ToolCallback> getTools() {
+		return Collections.emptyList();
+	}
+
+	/**
+	 * Checks if this skill supports the specified capability interface.
+	 * @param capabilityType capability interface class
+	 * @param <T> capability type
+	 * @return true if supported
+	 */
+	default <T> boolean supports(Class<T> capabilityType) {
+		return capabilityType.isInstance(this);
+	}
+
+	/**
+	 * Converts this skill to the specified capability interface.
+	 * @param capabilityType capability interface class
+	 * @param <T> capability type
+	 * @return capability instance
+	 * @throws ClassCastException if capability not supported
+	 */
+	default <T> T as(Class<T> capabilityType) {
+		if (!this.supports(capabilityType)) {
+			throw new ClassCastException(
+					"Skill '" + this.getName() + "' does not support capability: " + capabilityType.getName());
+		}
+		return capabilityType.cast(this);
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillBox.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillBox.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Tenant-level skill metadata container.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public interface SkillBox {
+
+	/**
+	 * Adds skill metadata.
+	 * @param name skill name
+	 * @param metadata skill metadata
+	 * @throws IllegalArgumentException if name already exists
+	 */
+	void addSkill(String name, SkillMetadata metadata);
+
+	/**
+	 * Gets skill metadata.
+	 * @param name skill name
+	 * @return skill metadata or null if not found
+	 */
+	@Nullable SkillMetadata getMetadata(String name);
+
+	/**
+	 * Gets all skill metadata.
+	 * @return unmodifiable map of name to metadata
+	 */
+	Map<String, SkillMetadata> getAllMetadata();
+
+	/**
+	 * Checks if skill exists.
+	 * @param name skill name
+	 * @return true if exists
+	 */
+	boolean exists(String name);
+
+	/**
+	 * Gets skill count.
+	 * @return skill count
+	 */
+	int getSkillCount();
+
+	/**
+	 * Activates skill.
+	 * @param name skill name
+	 * @throws IllegalArgumentException if skill not found
+	 */
+	void activateSkill(String name);
+
+	/**
+	 * Deactivates skill.
+	 * @param name skill name
+	 * @throws IllegalArgumentException if skill not found
+	 */
+	void deactivateSkill(String name);
+
+	/**
+	 * Deactivates all skills.
+	 */
+	void deactivateAllSkills();
+
+	/**
+	 * Checks if skill is activated.
+	 * @param name skill name
+	 * @return true if activated
+	 */
+	boolean isActivated(String name);
+
+	/**
+	 * Gets activated skill names.
+	 * @return set of activated skill names (never null)
+	 */
+	java.util.Set<String> getActivatedSkillNames();
+
+	/**
+	 * Gets supported skill sources in priority order.
+	 * @return source list (mutable, ordered by priority)
+	 */
+	List<String> getSources();
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillDefinition.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillDefinition.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.skill.common.LoadStrategy;
+
+/**
+ * Skill definition containing metadata and loading strategy.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillDefinition {
+
+	private final String skillId;
+
+	private final String source;
+
+	private final Supplier<Skill> loader;
+
+	private final LoadStrategy loadStrategy;
+
+	private final SkillMetadata metadata;
+
+	private SkillDefinition(Builder builder) {
+		this.skillId = Objects.requireNonNull(builder.skillId, "skillId cannot be null");
+		this.source = Objects.requireNonNull(builder.source, "source cannot be null");
+		this.loader = Objects.requireNonNull(builder.loader, "loader cannot be null");
+		this.loadStrategy = Objects.requireNonNull(builder.loadStrategy, "loadStrategy cannot be null");
+		this.metadata = Objects.requireNonNull(builder.metadata, "metadata cannot be null");
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public String getSkillId() {
+		return this.skillId;
+	}
+
+	public String getSource() {
+		return this.source;
+	}
+
+	public Supplier<Skill> getLoader() {
+		return this.loader;
+	}
+
+	public LoadStrategy getLoadStrategy() {
+		return this.loadStrategy;
+	}
+
+	public SkillMetadata getMetadata() {
+		return this.metadata;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || this.getClass() != o.getClass()) {
+			return false;
+		}
+		SkillDefinition that = (SkillDefinition) o;
+		return Objects.equals(this.skillId, that.skillId);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.skillId);
+	}
+
+	@Override
+	public String toString() {
+		return "SkillDefinition{" + "skillId='" + this.skillId + '\'' + ", source='" + this.source + '\''
+				+ ", loadStrategy=" + this.loadStrategy + ", metadata=" + this.metadata + '}';
+	}
+
+	/**
+	 * Builder for immutable SkillDefinition objects.
+	 */
+	public static class Builder {
+
+		private @Nullable String skillId;
+
+		private @Nullable String source;
+
+		private @Nullable Supplier<Skill> loader;
+
+		private LoadStrategy loadStrategy = LoadStrategy.LAZY;
+
+		private @Nullable SkillMetadata metadata;
+
+		private Builder() {
+		}
+
+		public Builder skillId(String skillId) {
+			this.skillId = skillId;
+			return this;
+		}
+
+		public Builder source(String source) {
+			this.source = source;
+			return this;
+		}
+
+		public Builder loader(Supplier<Skill> loader) {
+			this.loader = loader;
+			return this;
+		}
+
+		public Builder loadStrategy(LoadStrategy loadStrategy) {
+			this.loadStrategy = loadStrategy;
+			return this;
+		}
+
+		public Builder metadata(SkillMetadata metadata) {
+			this.metadata = metadata;
+			return this;
+		}
+
+		public SkillDefinition build() {
+			if (this.skillId == null) {
+				throw new IllegalArgumentException("skillId cannot be null");
+			}
+			if (this.source == null) {
+				throw new IllegalArgumentException("source cannot be null");
+			}
+			if (this.loader == null) {
+				throw new IllegalArgumentException("loader cannot be null");
+			}
+			if (this.loadStrategy == null) {
+				throw new IllegalArgumentException("loadStrategy cannot be null");
+			}
+			if (this.metadata == null) {
+				throw new IllegalArgumentException("metadata cannot be null");
+			}
+			return new SkillDefinition(this);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillIdGenerator.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillIdGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+/**
+ * Skill ID generator interface.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+@FunctionalInterface
+public interface SkillIdGenerator {
+
+	/**
+	 * Generates unique skill ID from metadata.
+	 * @param metadata skill metadata
+	 * @return generated skill ID
+	 * @throws IllegalArgumentException if metadata invalid
+	 */
+	String generateId(SkillMetadata metadata);
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillKit.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillKit.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.tool.ToolCallback;
+
+/**
+ * Unified coordination interface for skill management.
+ *
+ * @author LinPeng Zhang
+ * @see DefaultSkillKit
+ * @since 1.1.3
+ */
+public interface SkillKit {
+
+	// ==================== Skill Registration ====================
+
+	/**
+	 * Registers skill with metadata and lazy loader.
+	 * @param metadata skill metadata
+	 * @param loader skill instance loader
+	 * @throws org.springframework.ai.skill.exception.SkillValidationException if
+	 * validation fails
+	 * @throws org.springframework.ai.skill.exception.SkillRegistrationException if
+	 * registration fails
+	 */
+	void register(SkillMetadata metadata, Supplier<Skill> loader);
+
+	/**
+	 * Registers skill from instance.
+	 * @param instance skill instance with @Skill annotation
+	 * @throws IllegalArgumentException if instance class lacks @Skill annotation
+	 */
+	void register(Object instance);
+
+	/**
+	 * Registers skill from class with lazy loading.
+	 * @param skillClass skill class with @Skill annotation
+	 * @throws IllegalArgumentException if class lacks @Skill annotation
+	 */
+	void register(Class<?> skillClass);
+
+	// ==================== Skill Access ====================
+
+	/**
+	 * Checks if skill exists by name.
+	 * @param name skill name
+	 * @return true if exists
+	 */
+	boolean exists(String name);
+
+	/**
+	 * Gets skill instance by ID.
+	 * @param skillId skill ID
+	 * @return skill instance
+	 * @throws org.springframework.ai.skill.exception.SkillNotFoundException if not found
+	 * @throws org.springframework.ai.skill.exception.SkillLoadException if loading fails
+	 */
+	Skill getSkill(String skillId);
+
+	/**
+	 * Gets skill instance by name.
+	 * @param name skill name
+	 * @return skill instance or null if not found
+	 */
+	@Nullable Skill getSkillByName(String name);
+
+	/**
+	 * Gets skill metadata by name.
+	 * @param name skill name
+	 * @return skill metadata or null if not found
+	 */
+	@Nullable SkillMetadata getMetadata(String name);
+
+	// ==================== Skill Activation ====================
+
+	/**
+	 * Activates skill by name.
+	 * @param name skill name
+	 * @throws IllegalArgumentException if skill not found
+	 */
+	void activateSkill(String name);
+
+	/**
+	 * Deactivates skill by name.
+	 * @param name skill name
+	 * @throws IllegalArgumentException if skill not found
+	 */
+	void deactivateSkill(String name);
+
+	/**
+	 * Deactivates all skills.
+	 */
+	void deactivateAllSkills();
+
+	/**
+	 * Checks if skill is activated.
+	 * @param name skill name
+	 * @return true if activated
+	 */
+	boolean isActivated(String name);
+
+	// ==================== Tools ====================
+
+	/**
+	 * Gets framework skill tools for progressive loading.
+	 * @return skill tool list
+	 */
+	List<ToolCallback> getSkillLoaderTools();
+
+	/**
+	 * Gets all active skill tools.
+	 * @return active tool list (never null)
+	 * @throws IllegalStateException if data inconsistency detected
+	 */
+	List<ToolCallback> getAllActiveTools();
+
+	/**
+	 * Gets system prompt describing available skills.
+	 * @return system prompt (never null)
+	 */
+	String getSkillSystemPrompt();
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillMetadata.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillMetadata.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Skill metadata.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillMetadata {
+
+	private final String name;
+
+	private final String description;
+
+	private final String source;
+
+	private final Map<String, Object> extensions;
+
+	public SkillMetadata(String name, String description, String source) {
+		this(name, description, source, new HashMap<>());
+	}
+
+	public SkillMetadata(String name, String description, String source, Map<String, Object> extensions) {
+		if (name == null || name.isEmpty()) {
+			throw new IllegalArgumentException("name is required");
+		}
+		if (description == null || description.isEmpty()) {
+			throw new IllegalArgumentException("description is required");
+		}
+		if (source == null || source.isEmpty()) {
+			throw new IllegalArgumentException("source is required");
+		}
+
+		this.name = name;
+		this.description = description;
+		this.source = source;
+		this.extensions = new HashMap<>(extensions);
+	}
+
+	// Builder
+	public static Builder builder(String name, String description, String source) {
+		return new Builder(name, description, source);
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getDescription() {
+		return this.description;
+	}
+
+	public String getSource() {
+		return this.source;
+	}
+
+	public Map<String, Object> getExtensions() {
+		return Collections.unmodifiableMap(this.extensions);
+	}
+
+	public @Nullable Object getExtension(String key) {
+		return this.extensions.get(key);
+	}
+
+	public @Nullable <T> T getExtension(String key, Class<T> type) {
+		Object value = this.extensions.get(key);
+		if (value == null) {
+			return null;
+		}
+		if (!type.isInstance(value)) {
+			throw new ClassCastException("Extension '" + key + "' is not of type " + type.getName());
+		}
+		return type.cast(value);
+	}
+
+	public boolean hasExtension(String key) {
+		return this.extensions.containsKey(key);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || this.getClass() != o.getClass()) {
+			return false;
+		}
+		SkillMetadata that = (SkillMetadata) o;
+		return Objects.equals(this.name, that.name) && Objects.equals(this.description, that.description)
+				&& Objects.equals(this.source, that.source) && Objects.equals(this.extensions, that.extensions);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.name, this.description, this.source, this.extensions);
+	}
+
+	@Override
+	public String toString() {
+		return "SkillMetadata{" + "name='" + this.name + '\'' + ", description='" + this.description + '\''
+				+ ", source='" + this.source + '\'' + ", extensions=" + this.extensions + '}';
+	}
+
+	public static class Builder {
+
+		private final String name;
+
+		private final String description;
+
+		private final String source;
+
+		private final Map<String, Object> extensions = new HashMap<>();
+
+		private Builder(String name, String description, String source) {
+			if (name == null || name.isEmpty()) {
+				throw new IllegalArgumentException("name is required");
+			}
+			if (description == null || description.isEmpty()) {
+				throw new IllegalArgumentException("description is required");
+			}
+			if (source == null || source.isEmpty()) {
+				throw new IllegalArgumentException("source is required");
+			}
+			this.name = name;
+			this.description = description;
+			this.source = source;
+		}
+
+		public Builder extension(String key, Object value) {
+			this.extensions.put(key, value);
+			return this;
+		}
+
+		public Builder extensions(Map<String, Object> extensions) {
+			this.extensions.putAll(extensions);
+			return this;
+		}
+
+		public SkillMetadata build() {
+			return new SkillMetadata(this.name, this.description, this.source, this.extensions);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillPoolManager.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillPoolManager.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.skill.exception.SkillLoadException;
+import org.springframework.ai.skill.exception.SkillNotFoundException;
+
+/**
+ * Skill pool manager for definition storage and instance lifecycle management.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public interface SkillPoolManager {
+
+	/**
+	 * Registers skill definition.
+	 * @param definition skill definition
+	 * @throws IllegalArgumentException if skillId already exists
+	 */
+	void registerDefinition(SkillDefinition definition);
+
+	/**
+	 * Unregisters skill completely (definition and instance).
+	 * @param skillId skill ID
+	 */
+	void unregister(String skillId);
+
+	/**
+	 * Gets skill definition.
+	 * @param skillId skill ID
+	 * @return skill definition or null if not found
+	 */
+	@Nullable SkillDefinition getDefinition(String skillId);
+
+	/**
+	 * Checks if skill definition exists.
+	 * @param skillId skill ID
+	 * @return true if exists
+	 */
+	boolean hasDefinition(String skillId);
+
+	/**
+	 * Loads skill instance (singleton per skillId).
+	 * @param skillId skill ID
+	 * @return skill instance
+	 * @throws SkillNotFoundException if skill not found
+	 * @throws SkillLoadException if loading fails
+	 */
+	Skill load(String skillId);
+
+	/**
+	 * Gets all registered skill definitions.
+	 * @return skill definition list (never null)
+	 */
+	List<SkillDefinition> getDefinitions();
+
+	/**
+	 * Evicts skill instance but retains definition.
+	 * @param skillId skill ID
+	 */
+	void evict(String skillId);
+
+	/**
+	 * Evicts all skill instances but retains definitions.
+	 */
+	void evictAll();
+
+	/**
+	 * Clears all definitions and instances.
+	 */
+	void clear();
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillRegistrar.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/SkillRegistrar.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.core;
+
+/**
+ * Skill registrar interface for registering skills from various sources.
+ *
+ * @param <T> source type (Class, Object, String, Path, etc.)
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public interface SkillRegistrar<T> {
+
+	/**
+	 * Creates SkillDefinition from source and registers to SkillPoolManager.
+	 * @param poolManager skill pool manager
+	 * @param source registration source
+	 * @return created SkillDefinition
+	 * @throws IllegalArgumentException if source invalid
+	 * @throws org.springframework.ai.skill.exception.SkillRegistrationException if
+	 * registration fails
+	 */
+	SkillDefinition register(SkillPoolManager poolManager, T source);
+
+	/**
+	 * Checks if registrar supports given source.
+	 * @param source source object
+	 * @return true if supported
+	 */
+	boolean supports(Object source);
+
+	/**
+	 * Gets registrar name for logging.
+	 * @return registrar name
+	 */
+	default String getName() {
+		return this.getClass().getSimpleName();
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/core/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Core interfaces and implementations for skill management and lifecycle.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.core;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillException.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Base exception for skill framework.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillException extends RuntimeException {
+
+	public SkillException(String message) {
+		super(message);
+	}
+
+	public SkillException(String message, @Nullable Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillInvocationException.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillInvocationException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Thrown when skill method invocation fails.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillInvocationException extends SkillException {
+
+	private final String skillId;
+
+	private final String methodName;
+
+	public SkillInvocationException(String skillId, String methodName, String message, @Nullable Throwable cause) {
+		super("Failed to invoke method '" + methodName + "' on skill '" + skillId + "': " + message, cause);
+		this.skillId = skillId;
+		this.methodName = methodName;
+	}
+
+	public String getSkillId() {
+		return this.skillId;
+	}
+
+	public String getMethodName() {
+		return this.methodName;
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillLoadException.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillLoadException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.exception;
+
+/**
+ * Thrown when skill loading fails.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillLoadException extends SkillException {
+
+	private final String skillId;
+
+	public SkillLoadException(String skillId, String message, Throwable cause) {
+		super("Failed to load skill '" + skillId + "': " + message, cause);
+		this.skillId = skillId;
+	}
+
+	public String getSkillId() {
+		return this.skillId;
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillNotFoundException.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.exception;
+
+/**
+ * Thrown when requested skill not found.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillNotFoundException extends SkillException {
+
+	private final String skillId;
+
+	public SkillNotFoundException(String skillId) {
+		super("Skill not found: '" + skillId + "'");
+		this.skillId = skillId;
+	}
+
+	public String getSkillId() {
+		return this.skillId;
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillRegistrationException.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillRegistrationException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.exception;
+
+/**
+ * Thrown when skill registration fails.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillRegistrationException extends SkillException {
+
+	private final String skillId;
+
+	public SkillRegistrationException(String skillId, String message) {
+		super("Failed to register skill '" + skillId + "': " + message);
+		this.skillId = skillId;
+	}
+
+	public SkillRegistrationException(String skillId, String message, Throwable cause) {
+		super("Failed to register skill '" + skillId + "': " + message, cause);
+		this.skillId = skillId;
+	}
+
+	public String getSkillId() {
+		return this.skillId;
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillValidationException.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/SkillValidationException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Thrown when skill validation fails.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SkillValidationException extends SkillException {
+
+	private final @Nullable String skillClass;
+
+	public SkillValidationException(@Nullable String skillClass, String message) {
+		super("Validation failed" + (skillClass != null ? " for skill class '" + skillClass + "'" : "") + ": "
+				+ message);
+		this.skillClass = skillClass;
+	}
+
+	public @Nullable String getSkillClass() {
+		return this.skillClass;
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/exception/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Exception hierarchy for skill-related errors and failures.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.exception;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/package-info.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The {@code org.springframework.ai.skill} package provides classes and interfaces for
+ * managing and executing skills (modular AI capabilities) in Spring AI applications. It
+ * includes core components for skill registration, lifecycle management, and progressive
+ * loading.
+ *
+ * <p>
+ * Key classes and interfaces:
+ * </p>
+ * <ul>
+ * <li>{@link org.springframework.ai.skill.core.SkillKit} - Main entry point for skill
+ * management, coordinating {@link org.springframework.ai.skill.core.SkillBox} and
+ * {@link org.springframework.ai.skill.core.SkillPoolManager}.</li>
+ * <li>{@link org.springframework.ai.skill.core.DefaultSkillKit} - Default implementation
+ * of {@link org.springframework.ai.skill.core.SkillKit}.</li>
+ * <li>{@link org.springframework.ai.skill.core.SkillBox} - Container for managing skill
+ * metadata and activation state.</li>
+ * <li>{@link org.springframework.ai.skill.support.SimpleSkillBox} - Default
+ * implementation of {@link org.springframework.ai.skill.core.SkillBox}.</li>
+ * <li>{@link org.springframework.ai.skill.core.SkillPoolManager} - Manages skill
+ * instances, definitions, and caching strategies.</li>
+ * <li>{@link org.springframework.ai.skill.support.DefaultSkillPoolManager} - Default
+ * implementation of {@link org.springframework.ai.skill.core.SkillPoolManager}.</li>
+ * <li>{@link org.springframework.ai.skill.core.Skill} - Core interface representing an
+ * executable skill with metadata, content, and tools.</li>
+ * <li>{@link org.springframework.ai.skill.core.SkillMetadata} - Immutable metadata
+ * describing a skill's name, description, source, and extensions.</li>
+ * <li>{@link org.springframework.ai.skill.core.SkillDefinition} - Defines how a skill
+ * should be loaded and managed.</li>
+ * <li>{@link org.springframework.ai.skill.core.SkillRegistrar} - SPI for pluggable skill
+ * registration strategies.</li>
+ * <li>{@link org.springframework.ai.skill.registration.ClassBasedSkillRegistrar} -
+ * Registers skills from annotated classes with {@code @SkillInit} factory methods.</li>
+ * <li>{@link org.springframework.ai.skill.registration.InstanceBasedSkillRegistrar} -
+ * Registers skills from pre-created instances annotated with {@code @Skill}.</li>
+ * </ul>
+ *
+ * <p>
+ * Spring AI integration classes:
+ * </p>
+ * <ul>
+ * <li>{@link org.springframework.ai.skill.spi.SkillAwareAdvisor} - Chat advisor for
+ * injecting skill system prompts and managing skill lifecycle.</li>
+ * <li>{@link org.springframework.ai.skill.spi.SkillAwareToolCallbackResolver} - Resolves
+ * tool callbacks dynamically from active skills.</li>
+ * <li>{@link org.springframework.ai.skill.spi.SkillAwareToolCallingManager} - Manages
+ * tool calling with skill-aware tool resolution.</li>
+ * <li>{@link org.springframework.ai.skill.tool.SimpleSkillLoaderTools} - Provides
+ * {@code loadSkillContent} and {@code loadSkillReference} tools for progressive skill
+ * loading.</li>
+ * </ul>
+ *
+ * <p>
+ * Annotation-driven development:
+ * </p>
+ * <ul>
+ * <li>{@link org.springframework.ai.skill.annotation.Skill} - Marks a class as a skill
+ * with metadata.</li>
+ * <li>{@link org.springframework.ai.skill.annotation.SkillInit} - Marks a static factory
+ * method for lazy skill instantiation.</li>
+ * <li>{@link org.springframework.ai.skill.annotation.SkillContent} - Marks a method that
+ * provides skill documentation.</li>
+ * <li>{@link org.springframework.ai.skill.annotation.SkillTools} - Marks a method that
+ * provides skill tool callbacks.</li>
+ * </ul>
+ *
+ * <p>
+ * Exception hierarchy:
+ * </p>
+ * <ul>
+ * <li>{@link org.springframework.ai.skill.exception.SkillException} - Base exception for
+ * all skill-related errors.</li>
+ * <li>{@link org.springframework.ai.skill.exception.SkillNotFoundException} - Thrown when
+ * a requested skill cannot be found.</li>
+ * <li>{@link org.springframework.ai.skill.exception.SkillLoadException} - Thrown when a
+ * skill fails to load.</li>
+ * <li>{@link org.springframework.ai.skill.exception.SkillRegistrationException} - Thrown
+ * when skill registration fails.</li>
+ * <li>{@link org.springframework.ai.skill.exception.SkillValidationException} - Thrown
+ * when skill validation fails.</li>
+ * </ul>
+ */
+@NullMarked
+package org.springframework.ai.skill;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/registration/ClassBasedSkillRegistrar.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/registration/ClassBasedSkillRegistrar.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.registration;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.skill.adapter.SkillProxy;
+import org.springframework.ai.skill.annotation.SkillContent;
+import org.springframework.ai.skill.annotation.SkillInit;
+import org.springframework.ai.skill.annotation.SkillTools;
+import org.springframework.ai.skill.capability.SkillReferences;
+import org.springframework.ai.skill.common.LoadStrategy;
+import org.springframework.ai.skill.core.Skill;
+import org.springframework.ai.skill.core.SkillDefinition;
+import org.springframework.ai.skill.core.SkillIdGenerator;
+import org.springframework.ai.skill.core.SkillMetadata;
+import org.springframework.ai.skill.core.SkillPoolManager;
+import org.springframework.ai.skill.core.SkillRegistrar;
+import org.springframework.ai.skill.exception.SkillRegistrationException;
+import org.springframework.ai.skill.support.DefaultSkillIdGenerator;
+
+/**
+ * Class-based skill registrar for lazy-loaded POJO skills.
+ *
+ * <p>
+ * Requirements: Class must be annotated with @Skill and have a @SkillInit static factory
+ * method.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class ClassBasedSkillRegistrar implements SkillRegistrar<Class<?>> {
+
+	private final SkillIdGenerator idGenerator;
+
+	private ClassBasedSkillRegistrar(Builder builder) {
+		this.idGenerator = (builder.idGenerator != null) ? builder.idGenerator : new DefaultSkillIdGenerator();
+	}
+
+	/**
+	 * Creates a new builder instance.
+	 * @return new builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Finds and validates @SkillInit method.
+	 * @param skillClass skill class
+	 * @return validated @SkillInit method
+	 * @throws IllegalArgumentException if method not found or invalid
+	 */
+	private static Method findAndValidateSkillInitMethod(Class<?> skillClass) {
+		Method initMethod = null;
+
+		for (Method method : skillClass.getDeclaredMethods()) {
+			if (method.isAnnotationPresent(SkillInit.class)) {
+				if (initMethod != null) {
+					throw new IllegalArgumentException("Class " + skillClass.getName()
+							+ " must have exactly one @SkillInit method, but found multiple");
+				}
+				initMethod = method;
+			}
+		}
+
+		if (initMethod == null) {
+			throw new IllegalArgumentException(
+					"Class " + skillClass.getName() + " must have a @SkillInit annotated method. "
+							+ "Example: @SkillInit public static MySkill create() { return new MySkill(); }");
+		}
+
+		Method method = initMethod;
+
+		if (!Modifier.isStatic(method.getModifiers())) {
+			throw new IllegalArgumentException("@SkillInit method '" + method.getName() + "' in class "
+					+ skillClass.getName() + " must be static. Example: public static MySkill create() { ... }");
+		}
+
+		Class<?> returnType = method.getReturnType();
+		if (!returnType.isAssignableFrom(skillClass)) {
+			throw new IllegalArgumentException("@SkillInit method '" + method.getName() + "' in class "
+					+ skillClass.getName() + " must return type " + skillClass.getSimpleName()
+					+ " (or its superclass), but returns " + returnType.getSimpleName());
+		}
+
+		method.setAccessible(true);
+
+		return method;
+	}
+
+	/**
+	 * Builds Skill from instance.
+	 * @param instance skill instance
+	 * @param metadata skill metadata
+	 * @return Skill instance (either direct or wrapped)
+	 */
+	protected static Skill buildSkillFromInstance(Object instance, SkillMetadata metadata) {
+		if (instance instanceof Skill) {
+			return (Skill) instance;
+		}
+
+		Map<String, Method> extensionMethods = extractExtensionMethods(instance.getClass());
+		return new SkillProxy(metadata, instance, extensionMethods);
+	}
+
+	/**
+	 * Extracts annotated extension methods from class.
+	 * @param clazz class to scan
+	 * @return extension method map
+	 */
+	protected static Map<String, Method> extractExtensionMethods(Class<?> clazz) {
+		Map<String, Method> extensionMethods = new HashMap<>();
+
+		for (Method method : clazz.getDeclaredMethods()) {
+			if (method.isAnnotationPresent(SkillContent.class)) {
+				extensionMethods.put("content", method);
+			}
+			if (method.isAnnotationPresent(SkillTools.class)) {
+				extensionMethods.put("tools", method);
+			}
+			if (method.isAnnotationPresent(SkillReferences.class)) {
+				extensionMethods.put("references", method);
+			}
+		}
+
+		return extensionMethods;
+	}
+
+	/**
+	 * Extracts extension properties from @Skill annotation.
+	 * @param skillAnnotation @Skill annotation
+	 * @return extension properties map
+	 */
+	protected static Map<String, Object> extractExtensions(
+			org.springframework.ai.skill.annotation.Skill skillAnnotation) {
+		Map<String, Object> extensions = new HashMap<>();
+
+		for (String ext : skillAnnotation.extensions()) {
+			String[] parts = ext.split("=", 2);
+			if (parts.length == 2) {
+				extensions.put(parts[0].trim(), parts[1].trim());
+			}
+		}
+
+		return extensions;
+	}
+
+	/**
+	 * Checks if class has @SkillInit method.
+	 * @param clazz class to check
+	 * @return true if at least one @SkillInit method found
+	 */
+	private static boolean hasSkillInitMethod(Class<?> clazz) {
+		for (Method method : clazz.getDeclaredMethods()) {
+			if (method.isAnnotationPresent(SkillInit.class)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Registers skill from class definition.
+	 * @param poolManager skill pool manager
+	 * @param skillClass skill class annotated with @Skill and @SkillInit
+	 * @return created skill definition
+	 * @throws IllegalArgumentException if class missing required annotations
+	 * @throws SkillRegistrationException if registration fails
+	 */
+	@Override
+	public SkillDefinition register(SkillPoolManager poolManager, Class<?> skillClass) {
+		Objects.requireNonNull(poolManager, "poolManager cannot be null");
+		Objects.requireNonNull(skillClass, "skillClass cannot be null");
+
+		org.springframework.ai.skill.annotation.Skill skillAnnotation = skillClass
+			.getAnnotation(org.springframework.ai.skill.annotation.Skill.class);
+
+		if (skillAnnotation == null) {
+			throw new IllegalArgumentException("Class " + skillClass.getName() + " must be annotated with @Skill");
+		}
+
+		Method initMethod = findAndValidateSkillInitMethod(skillClass);
+
+		String source = skillAnnotation.source();
+
+		SkillMetadata metadata = SkillMetadata.builder(skillAnnotation.name(), skillAnnotation.description(), source)
+			.extensions(extractExtensions(skillAnnotation))
+			.build();
+
+		String skillId = this.idGenerator.generateId(metadata);
+
+		Supplier<Skill> loader = () -> {
+			try {
+				Object instance = initMethod.invoke(null);
+				return buildSkillFromInstance(instance, metadata);
+			}
+			catch (Exception e) {
+				throw new SkillRegistrationException(metadata.getName(),
+						"Failed to instantiate skill class via @SkillInit method: " + skillClass.getName(), e);
+			}
+		};
+
+		SkillDefinition definition = SkillDefinition.builder()
+			.skillId(skillId)
+			.source(source)
+			.loader(loader)
+			.metadata(metadata)
+			.loadStrategy(LoadStrategy.LAZY)
+			.build();
+
+		poolManager.registerDefinition(definition);
+
+		return definition;
+	}
+
+	// ==================== SkillRegistrar Interface ====================
+
+	/**
+	 * Checks if source is supported.
+	 * @param source source object to check
+	 * @return true if source is a Class with @Skill and @SkillInit
+	 */
+	@Override
+	public boolean supports(Object source) {
+		if (!(source instanceof Class<?> clazz)) {
+			return false;
+		}
+
+		if (!clazz.isAnnotationPresent(org.springframework.ai.skill.annotation.Skill.class)) {
+			return false;
+		}
+
+		return hasSkillInitMethod(clazz);
+	}
+
+	/**
+	 * Builder for ClassBasedSkillRegistrar.
+	 */
+	public static class Builder {
+
+		private @Nullable SkillIdGenerator idGenerator;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets custom ID generator.
+		 * @param idGenerator ID generator instance
+		 * @return this builder
+		 */
+		public Builder idGenerator(SkillIdGenerator idGenerator) {
+			this.idGenerator = idGenerator;
+			return this;
+		}
+
+		/**
+		 * Builds the ClassBasedSkillRegistrar instance.
+		 * @return new ClassBasedSkillRegistrar instance
+		 */
+		public ClassBasedSkillRegistrar build() {
+			return new ClassBasedSkillRegistrar(this);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/registration/InstanceBasedSkillRegistrar.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/registration/InstanceBasedSkillRegistrar.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.registration;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.skill.adapter.SkillProxy;
+import org.springframework.ai.skill.annotation.SkillContent;
+import org.springframework.ai.skill.annotation.SkillTools;
+import org.springframework.ai.skill.capability.SkillReferences;
+import org.springframework.ai.skill.common.LoadStrategy;
+import org.springframework.ai.skill.core.Skill;
+import org.springframework.ai.skill.core.SkillDefinition;
+import org.springframework.ai.skill.core.SkillIdGenerator;
+import org.springframework.ai.skill.core.SkillMetadata;
+import org.springframework.ai.skill.core.SkillPoolManager;
+import org.springframework.ai.skill.core.SkillRegistrar;
+import org.springframework.ai.skill.support.DefaultSkillIdGenerator;
+
+/**
+ * Instance-based skill registrar for pre-created POJO instances.
+ *
+ * <p>
+ * Supports both interface mode (Skill implementation) and annotation mode (@Skill POJO).
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class InstanceBasedSkillRegistrar implements SkillRegistrar<Object> {
+
+	private final SkillIdGenerator idGenerator;
+
+	private InstanceBasedSkillRegistrar(Builder builder) {
+		this.idGenerator = (builder.idGenerator != null) ? builder.idGenerator : new DefaultSkillIdGenerator();
+	}
+
+	/**
+	 * Creates a new builder instance.
+	 * @return new builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builds Skill from instance.
+	 * @param instance skill instance
+	 * @param metadata skill metadata
+	 * @return Skill instance (either direct or wrapped)
+	 */
+	protected static Skill buildSkillFromInstance(Object instance, SkillMetadata metadata) {
+		if (instance instanceof Skill) {
+			return (Skill) instance;
+		}
+
+		Map<String, Method> extensionMethods = extractExtensionMethods(instance.getClass());
+		return new SkillProxy(metadata, instance, extensionMethods);
+	}
+
+	/**
+	 * Extracts annotated extension methods from class.
+	 * @param clazz class to scan
+	 * @return extension method map
+	 */
+	protected static Map<String, Method> extractExtensionMethods(Class<?> clazz) {
+		Map<String, Method> extensionMethods = new HashMap<>();
+
+		for (Method method : clazz.getDeclaredMethods()) {
+			if (method.isAnnotationPresent(SkillContent.class)) {
+				extensionMethods.put("content", method);
+			}
+			if (method.isAnnotationPresent(SkillTools.class)) {
+				extensionMethods.put("tools", method);
+			}
+			if (method.isAnnotationPresent(SkillReferences.class)) {
+				extensionMethods.put("references", method);
+			}
+		}
+
+		return extensionMethods;
+	}
+
+	/**
+	 * Extracts extension properties from @Skill annotation.
+	 * @param skillAnnotation @Skill annotation
+	 * @return extension properties map
+	 */
+	protected static Map<String, Object> extractExtensions(
+			org.springframework.ai.skill.annotation.Skill skillAnnotation) {
+		Map<String, Object> extensions = new HashMap<>();
+
+		for (String ext : skillAnnotation.extensions()) {
+			String[] parts = ext.split("=", 2);
+			if (parts.length == 2) {
+				extensions.put(parts[0].trim(), parts[1].trim());
+			}
+		}
+
+		return extensions;
+	}
+
+	/**
+	 * Registers skill from instance.
+	 * @param poolManager skill pool manager
+	 * @param instance skill instance annotated with @Skill
+	 * @return created skill definition
+	 * @throws IllegalArgumentException if instance class missing @Skill annotation
+	 */
+	@Override
+	public SkillDefinition register(SkillPoolManager poolManager, Object instance) {
+		Objects.requireNonNull(poolManager, "poolManager cannot be null");
+		Objects.requireNonNull(instance, "instance cannot be null");
+
+		Class<?> skillClass = instance.getClass();
+		org.springframework.ai.skill.annotation.Skill skillAnnotation = skillClass
+			.getAnnotation(org.springframework.ai.skill.annotation.Skill.class);
+
+		if (skillAnnotation == null) {
+			throw new IllegalArgumentException(
+					"Instance class " + skillClass.getName() + " must be annotated with @Skill");
+		}
+
+		String source = skillAnnotation.source();
+
+		SkillMetadata metadata = SkillMetadata.builder(skillAnnotation.name(), skillAnnotation.description(), source)
+			.extensions(extractExtensions(skillAnnotation))
+			.build();
+
+		String skillId = this.idGenerator.generateId(metadata);
+
+		Supplier<Skill> loader = () -> buildSkillFromInstance(instance, metadata);
+
+		SkillDefinition definition = SkillDefinition.builder()
+			.skillId(skillId)
+			.source(source)
+			.loader(loader)
+			.metadata(metadata)
+			.loadStrategy(LoadStrategy.LAZY)
+			.build();
+
+		poolManager.registerDefinition(definition);
+
+		return definition;
+	}
+
+	/**
+	 * Checks if source is supported.
+	 * @param source source object to check
+	 * @return true if source is non-null object with @Skill annotation
+	 */
+	@Override
+	public boolean supports(Object source) {
+		return source != null
+				&& source.getClass().isAnnotationPresent(org.springframework.ai.skill.annotation.Skill.class);
+	}
+
+	// ==================== SkillRegistrar Interface ====================
+
+	/**
+	 * Builder for InstanceBasedSkillRegistrar.
+	 */
+	public static class Builder {
+
+		private @Nullable SkillIdGenerator idGenerator;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets custom ID generator.
+		 * @param idGenerator ID generator instance
+		 * @return this builder
+		 */
+		public Builder idGenerator(SkillIdGenerator idGenerator) {
+			this.idGenerator = idGenerator;
+			return this;
+		}
+
+		/**
+		 * Builds the InstanceBasedSkillRegistrar instance.
+		 * @return new InstanceBasedSkillRegistrar instance
+		 */
+		public InstanceBasedSkillRegistrar build() {
+			return new InstanceBasedSkillRegistrar(this);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/registration/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/registration/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Registration strategies for class-based and instance-based skill registration.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.registration;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/SkillAwareAdvisor.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/SkillAwareAdvisor.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClientMessageAggregator;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.skill.core.SkillKit;
+
+/**
+ * Skill Advisor - manages skill lifecycle and system prompt injection.
+ *
+ * <p>
+ * This advisor implements CallAdvisor and StreamAdvisor to:
+ *
+ * <ul>
+ * <li>Inject skill system prompt before conversation
+ * <li>Clean up skill state after conversation
+ * </ul>
+ *
+ * <p>
+ * <b>Tool Injection:</b>
+ * <ul>
+ * <li>Dynamic tool injection is handled by {@code SkillAwareToolCallingManager}
+ * <li>SkillAwareToolCallingManager.resolveToolDefinitions() provides tools to LLM
+ * <li>SkillAwareToolCallbackResolver.resolve() finds tools during execution
+ * <li>This advisor ONLY injects skill system prompt and manages skill lifecycle
+ * </ul>
+ *
+ * <p>
+ * <b>Usage with SkillAwareToolCallingManager (recommended):</b>
+ *
+ * <pre>{@code
+ * // 1. Create SkillKit and register skills
+ * SkillBox skillBox = new SimpleSkillBox();
+ * SkillPoolManager poolManager = new DefaultSkillPoolManager();
+ * SkillKit skillKit = new DefaultSkillKit(skillBox, poolManager);
+ * skillKit.registerSkill(metadata, loader);
+ *
+ * // 2. Create SkillAwareToolCallingManager for tool injection
+ * SkillAwareToolCallingManager toolManager =
+ *     SkillAwareToolCallingManager.builder()
+ *         .skillKit(skillKit)
+ *         .build();
+ *
+ * // 3. Create ChatModel with SkillAwareToolCallingManager
+ * OpenAiChatModel chatModel = OpenAiChatModel.builder()
+ *     .toolCallingManager(toolManager)  // Handles tool injection
+ *     .build();
+ *
+ * // 4. Create SkillAwareAdvisor for prompt injection
+ * SkillAwareAdvisor advisor = new SkillAwareAdvisor(skillKit);
+ *
+ * // Build ChatClient with ONLY the advisor (NO tools registered at build time!)
+ * ChatClient client = ChatClient.builder(chatModel)
+ *     .defaultSystem("Your base system prompt here")
+ *     .defaultAdvisors(advisor)
+ *     .build();
+ * }</pre>
+ *
+ * <p>
+ * <b>Alternative usage with static helpers (simpler):</b>
+ *
+ * <pre>{@code
+ * String systemPrompt = SkillAwareAdvisor.buildSystemPrompt(basePrompt, skillKit);
+ * ChatClient client = ChatClient.builder(chatModel)
+ *     .defaultSystem(systemPrompt)
+ *     .build();
+ * // Don't forget to cleanup after each turn:
+ * SkillAwareAdvisor.cleanupSkills(skillKit);
+ * }</pre>
+ */
+public class SkillAwareAdvisor implements CallAdvisor, StreamAdvisor {
+
+	private static final Logger logger = LoggerFactory.getLogger(SkillAwareAdvisor.class);
+
+	private final SkillKit skillKit;
+
+	private SkillAwareAdvisor(Builder builder) {
+		this.skillKit = Objects.requireNonNull(builder.skillKit, "skillKit cannot be null");
+	}
+
+	/**
+	 * Creates a new builder instance.
+	 * @return new builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Build system prompt with skill information (static utility method).
+	 *
+	 * <p>
+	 * This is a simplified helper method for cases where you don't want to use the full
+	 * Advisor pattern. Useful for simple use cases or when you need manual control.
+	 * @param basePrompt The base system prompt
+	 * @param skillKit The SkillKit containing skill management and prompt generation
+	 * @return Combined system prompt with skill information
+	 */
+	public static String buildSystemPrompt(String basePrompt, SkillKit skillKit) {
+		String skillPrompt = skillKit.getSkillSystemPrompt();
+
+		if (skillPrompt == null || skillPrompt.isEmpty()) {
+			return basePrompt;
+		}
+
+		if (basePrompt == null || basePrompt.isEmpty()) {
+			return skillPrompt;
+		}
+
+		return basePrompt + "\n\n" + skillPrompt;
+	}
+
+	/**
+	 * Cleanup skills after conversation (static utility method).
+	 *
+	 * <p>
+	 * This is a simplified helper method for cases where you don't want to use the full
+	 * Advisor pattern. When using the Advisor pattern, cleanup is automatic.
+	 * @param skillKit The SkillKit to clean up
+	 */
+	public static void cleanupSkills(SkillKit skillKit) {
+		skillKit.deactivateAllSkills();
+	}
+
+	@Override
+	public String getName() {
+		return "SpringAiSkillAdvisor";
+	}
+
+	@Override
+	public int getOrder() {
+		return 0; // Execute first to inject system prompt
+	}
+
+	@Override
+	public ChatClientResponse adviseCall(ChatClientRequest request, CallAdvisorChain chain) {
+		ChatClientRequest modifiedRequest = this.injectSkillSystemPrompt(request);
+
+		try {
+			ChatClientResponse response = chain.nextCall(modifiedRequest);
+			cleanupSkills(this.skillKit);
+			return response;
+		}
+		catch (Exception e) {
+			logger.error("Error in skill advisor", e);
+			cleanupSkills(this.skillKit);
+			throw e;
+		}
+	}
+
+	@Override
+	public Flux<ChatClientResponse> adviseStream(ChatClientRequest request, StreamAdvisorChain chain) {
+		ChatClientRequest modifiedRequest = this.injectSkillSystemPrompt(request);
+		Flux<ChatClientResponse> responses = chain.nextStream(modifiedRequest);
+		return new ChatClientMessageAggregator().aggregateChatClientResponse(responses,
+				response -> cleanupSkills(this.skillKit));
+	}
+
+	// ==================== Static Helper Methods (Extension API) ====================
+
+	/**
+	 * Inject skill system prompt into the request.
+	 *
+	 * <p>
+	 * This method:
+	 * <ul>
+	 * <li>Extracts base system prompt from request
+	 * <li>Combines it with skill system prompt using buildSystemPrompt()
+	 * <li>Returns modified request with updated system message
+	 * </ul>
+	 *
+	 * <p>
+	 * <b>Note:</b> Tool injection is handled by
+	 * {@code SkillAwareToolCallingManager.resolveToolDefinitions()}, not by this Advisor.
+	 * @param request The original request
+	 * @return Modified request with skill prompt
+	 */
+	private ChatClientRequest injectSkillSystemPrompt(ChatClientRequest request) {
+		// 1. Extract and combine system prompt
+		List<Message> messages = new ArrayList<>(request.prompt().getInstructions());
+
+		String basePrompt = "";
+		boolean hasSystemMessage = false;
+		int systemMessageIndex = -1;
+
+		for (int i = 0; i < messages.size(); i++) {
+			if (messages.get(i) instanceof SystemMessage systemMessage) {
+				String text = systemMessage.getText();
+				basePrompt = (text != null) ? text : "";
+				hasSystemMessage = true;
+				systemMessageIndex = i;
+				break;
+			}
+		}
+
+		// Build combined prompt with skill information
+		String combinedPrompt = buildSystemPrompt(basePrompt, this.skillKit);
+
+		// Replace existing system message or add new one
+		if (hasSystemMessage) {
+			messages.set(systemMessageIndex, new SystemMessage(combinedPrompt));
+		}
+		else {
+			messages.add(0, new SystemMessage(combinedPrompt));
+		}
+
+		// 2. Create modified request with updated prompt
+		// Note: Tools are NOT injected here - SkillAwareToolCallingManager handles that!
+		ChatOptions originalOptions = request.prompt().getOptions();
+		return request.mutate().prompt(new Prompt(messages, originalOptions)).build();
+	}
+
+	/**
+	 * Builder for SkillAwareAdvisor.
+	 */
+	public static class Builder {
+
+		private @Nullable SkillKit skillKit;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets the skill kit.
+		 * @param skillKit skill kit instance
+		 * @return this builder
+		 */
+		public Builder skillKit(SkillKit skillKit) {
+			this.skillKit = skillKit;
+			return this;
+		}
+
+		/**
+		 * Builds the SkillAwareAdvisor instance.
+		 * @return new SkillAwareAdvisor instance
+		 */
+		public SkillAwareAdvisor build() {
+			if (this.skillKit == null) {
+				throw new IllegalArgumentException("skillKit cannot be null");
+			}
+			return new SkillAwareAdvisor(this);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/SkillAwareToolCallbackResolver.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/SkillAwareToolCallbackResolver.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.spi;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.skill.core.SkillKit;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.resolution.ToolCallbackResolver;
+
+/**
+ * Skill-aware ToolCallbackResolver - dynamically resolves tools from SkillKit.
+ *
+ * <p>
+ * This resolver works with {@code SkillAwareToolCallingManager} to enable dynamic tool
+ * execution. When the LLM calls a tool, this resolver finds the tool callback from the
+ * SkillKit's active tools.
+ *
+ * @see ToolCallbackResolver
+ * @see SkillKit
+ */
+public class SkillAwareToolCallbackResolver implements ToolCallbackResolver {
+
+	private static final Logger logger = LoggerFactory.getLogger(SkillAwareToolCallbackResolver.class);
+
+	private final SkillKit skillKit;
+
+	private SkillAwareToolCallbackResolver(SkillKit skillKit) {
+		this.skillKit = skillKit;
+	}
+
+	/**
+	 * Creates a new builder instance.
+	 * @return new builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public @Nullable ToolCallback resolve(String toolName) {
+		if (this.skillKit == null) {
+			logger.warn("No SkillKit configured");
+			return null;
+		}
+
+		List<ToolCallback> activeSkillCallbacks = this.skillKit.getAllActiveTools();
+		for (ToolCallback callback : activeSkillCallbacks) {
+			if (callback != null && callback.getToolDefinition() != null
+					&& toolName.equals(callback.getToolDefinition().name())) {
+				return callback;
+			}
+		}
+
+		List<ToolCallback> defaultSkillTools = this.skillKit.getSkillLoaderTools();
+		for (ToolCallback callback : defaultSkillTools) {
+			if (callback != null && callback.getToolDefinition() != null
+					&& toolName.equals(callback.getToolDefinition().name())) {
+				return callback;
+			}
+		}
+
+		logger.warn("Tool '{}' not found", toolName);
+		return null;
+	}
+
+	/**
+	 * Builder for SkillAwareToolCallbackResolver.
+	 */
+	public static class Builder {
+
+		private @Nullable SkillKit skillKit;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets the skill kit.
+		 * @param skillKit skill kit instance
+		 * @return this builder
+		 */
+		public Builder skillKit(SkillKit skillKit) {
+			this.skillKit = skillKit;
+			return this;
+		}
+
+		/**
+		 * Builds the SkillAwareToolCallbackResolver instance.
+		 * @return new SkillAwareToolCallbackResolver instance
+		 */
+		public SkillAwareToolCallbackResolver build() {
+			if (this.skillKit == null) {
+				throw new IllegalArgumentException("skillKit cannot be null");
+			}
+			return new SkillAwareToolCallbackResolver(this.skillKit);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/SkillAwareToolCallingManager.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/SkillAwareToolCallingManager.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.spi;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
+import org.springframework.ai.skill.core.SkillKit;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.resolution.DelegatingToolCallbackResolver;
+
+/**
+ * Skill-aware ToolCallingManager that automatically merges skill tools with base tools.
+ *
+ * <p>
+ * <b>Why We Need This:</b>
+ *
+ * <p>
+ * We implement {@code ToolCallingManager} interface and delegate to the underlying
+ * {@code ToolCallingManager} implementation while adding skill tool merging logic.
+ *
+ * <p>
+ * <b>How It Works:</b>
+ *
+ * <p>
+ * This class works together with {@code SkillAwareToolCallbackResolver}:
+ *
+ * <pre>
+ * 1. resolveToolDefinitions() - Provides tool definitions to LLM:
+ *    - Delegate to underlying ToolCallingManager to resolve base tool definitions
+ *    - Get default skill tools from skillKit.getSkillTools()
+ *    - Get active skill tools from skillKit.getAllActiveTools()
+ *    - Merge with deduplication by tool name (priority: base > default > active)
+ *    - Return merged ToolDefinition list
+ *
+ * 2. executeToolCalls() - Executes tool calls from LLM:
+ *    - Delegates to the underlying ToolCallingManager
+ *    - The delegate uses SkillAwareToolCallbackResolver
+ *    - SkillAwareToolCallbackResolver finds tools in skillKit.getAllActiveTools()
+ * </pre>
+ *
+ * @see ToolCallingManager
+ * @see SkillKit
+ * @since 1.1.3
+ */
+public class SkillAwareToolCallingManager implements ToolCallingManager {
+
+	private static final Logger logger = LoggerFactory.getLogger(SkillAwareToolCallingManager.class);
+
+	private final SkillKit skillKit;
+
+	private final ToolCallingManager delegate;
+
+	/**
+	 * Create a SkillAwareToolCallingManager with custom delegate.
+	 * @param skillKit The SkillKit containing skill management and tools
+	 * @param delegate The underlying ToolCallingManager to delegate to
+	 */
+	public SkillAwareToolCallingManager(SkillKit skillKit, ToolCallingManager delegate) {
+		this.skillKit = skillKit;
+		this.delegate = delegate;
+	}
+
+	/**
+	 * Builder for SkillAwareToolCallingManager.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Resolve tool definitions by merging base tools with skill tools.
+	 *
+	 * <p>
+	 * This is the KEY method where we inject skill tools dynamically!
+	 * @param chatOptions The chat options containing base tools
+	 * @return Merged list of tool definitions (base + skill tools)
+	 */
+	@Override
+	public List<ToolDefinition> resolveToolDefinitions(ToolCallingChatOptions chatOptions) {
+		// Delegate to the underlying ToolCallingManager to resolve base definitions
+		List<ToolDefinition> baseDefinitions = this.delegate.resolveToolDefinitions(chatOptions);
+
+		if (this.skillKit == null) {
+			logger.warn("No SkillKit configured, returning base tools only");
+			return baseDefinitions != null ? baseDefinitions : List.of();
+		}
+
+		List<ToolCallback> defaultSkillToolCallbacks = this.skillKit.getSkillLoaderTools();
+		List<ToolDefinition> defaultSkillToolDefinitions = new ArrayList<>();
+		for (ToolCallback callback : defaultSkillToolCallbacks) {
+			if (callback != null && callback.getToolDefinition() != null) {
+				defaultSkillToolDefinitions.add(callback.getToolDefinition());
+			}
+		}
+
+		List<ToolCallback> activeSkillCallbacks = this.skillKit.getAllActiveTools();
+
+		List<ToolDefinition> skillDefinitions = new ArrayList<>();
+		for (ToolCallback callback : activeSkillCallbacks) {
+			if (callback != null && callback.getToolDefinition() != null) {
+				skillDefinitions.add(callback.getToolDefinition());
+			}
+		}
+
+		return this.mergeToolDefinitions(baseDefinitions, defaultSkillToolDefinitions, skillDefinitions);
+	}
+
+	/**
+	 * Merge tool definitions with deduplication by tool name.
+	 *
+	 * <p>
+	 * <b>Priority order</b>: base > default > skills
+	 * <ul>
+	 * <li>Base tools take the highest precedence (from chatOptions)</li>
+	 * <li>Default SkillTools added next (for progressive loading)</li>
+	 * <li>Skill tools added last (from activated skills)</li>
+	 * </ul>
+	 * @param baseDefinitions Base tool definitions from chatOptions
+	 * @param defaultSkillToolDefinitions Default SkillTools for progressive loading
+	 * @param skillDefinitions Skill tool definitions from activated skills
+	 * @return Merged list with no duplicates
+	 */
+	private List<ToolDefinition> mergeToolDefinitions(List<ToolDefinition> baseDefinitions,
+			List<ToolDefinition> defaultSkillToolDefinitions, List<ToolDefinition> skillDefinitions) {
+
+		List<ToolDefinition> merged = new ArrayList<>();
+		Set<String> toolNames = new HashSet<>();
+
+		for (ToolDefinition def : baseDefinitions) {
+			if (def != null && def.name() != null) {
+				merged.add(def);
+				toolNames.add(def.name());
+			}
+		}
+
+		for (ToolDefinition def : defaultSkillToolDefinitions) {
+			if (def != null && def.name() != null) {
+				if (!toolNames.contains(def.name())) {
+					merged.add(def);
+					toolNames.add(def.name());
+				}
+			}
+		}
+
+		for (ToolDefinition def : skillDefinitions) {
+			if (def != null && def.name() != null) {
+				if (!toolNames.contains(def.name())) {
+					merged.add(def);
+					toolNames.add(def.name());
+				}
+			}
+		}
+
+		return merged;
+	}
+
+	/**
+	 * Execute tool calls - delegate to the underlying ToolCallingManager.
+	 *
+	 * <p>
+	 * Tool execution logic is delegated to the underlying manager. The delegate uses
+	 * {@code
+	 * SkillAwareToolCallbackResolver} to find tool callbacks from both chatOptions and
+	 * skillBox.getAllActiveTools().
+	 * @param prompt The prompt
+	 * @param chatResponse The chat response containing tool calls
+	 * @return Tool execution result
+	 */
+	@Override
+	public ToolExecutionResult executeToolCalls(Prompt prompt, ChatResponse chatResponse) {
+		return this.delegate.executeToolCalls(prompt, chatResponse);
+	}
+
+	public static class Builder {
+
+		private @Nullable SkillKit skillKit;
+
+		private @Nullable ToolCallingManager delegate;
+
+		public Builder skillKit(SkillKit skillKit) {
+			this.skillKit = skillKit;
+			return this;
+		}
+
+		public Builder delegate(ToolCallingManager delegate) {
+			this.delegate = delegate;
+			return this;
+		}
+
+		public SkillAwareToolCallingManager build() {
+			if (this.skillKit == null) {
+				throw new IllegalArgumentException("skillKit cannot be null");
+			}
+			ToolCallingManager delegateManager = this.delegate;
+			if (delegateManager == null) {
+				// Create delegate with SkillAwareToolCallbackResolver
+				delegateManager = DefaultToolCallingManager.builder()
+					.toolCallbackResolver(new DelegatingToolCallbackResolver(
+							List.of(SkillAwareToolCallbackResolver.builder().skillKit(this.skillKit).build())))
+					.build();
+			}
+			return new SkillAwareToolCallingManager(this.skillKit, delegateManager);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/spi/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Service provider interfaces for Spring AI integration and extensibility.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.spi;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/DefaultSkillIdGenerator.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/DefaultSkillIdGenerator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.support;
+
+import java.util.Objects;
+
+import org.springframework.ai.skill.core.SkillIdGenerator;
+import org.springframework.ai.skill.core.SkillMetadata;
+
+/**
+ * Default skill ID generator using "{name}_{source}" format.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class DefaultSkillIdGenerator implements SkillIdGenerator {
+
+	/**
+	 * Generates skill ID in format: {name}_{source}.
+	 * @param metadata skill metadata
+	 * @return generated skill ID
+	 * @throws IllegalArgumentException if metadata invalid
+	 */
+	@Override
+	public String generateId(SkillMetadata metadata) {
+		Objects.requireNonNull(metadata, "metadata cannot be null");
+
+		String name = metadata.getName();
+		String source = metadata.getSource();
+
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("metadata.name cannot be null or empty");
+		}
+
+		if (source == null || source.trim().isEmpty()) {
+			throw new IllegalArgumentException("metadata.source cannot be null or empty");
+		}
+
+		return name + "_" + source;
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/DefaultSkillPoolManager.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/DefaultSkillPoolManager.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.support;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.skill.common.LoadStrategy;
+import org.springframework.ai.skill.core.Skill;
+import org.springframework.ai.skill.core.SkillDefinition;
+import org.springframework.ai.skill.core.SkillPoolManager;
+import org.springframework.ai.skill.exception.SkillLoadException;
+import org.springframework.ai.skill.exception.SkillNotFoundException;
+
+/**
+ * Default implementation of SkillPoolManager with thread-safe caching.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class DefaultSkillPoolManager implements SkillPoolManager {
+
+	private static final Logger logger = LoggerFactory.getLogger(DefaultSkillPoolManager.class);
+
+	private final ConcurrentHashMap<String, SkillDefinition> definitions = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, Skill> skillPool = new ConcurrentHashMap<>();
+
+	@Override
+	public void registerDefinition(SkillDefinition definition) {
+		Objects.requireNonNull(definition, "definition cannot be null");
+
+		String skillId = definition.getSkillId();
+
+		if (this.definitions.containsKey(skillId)) {
+			throw new IllegalArgumentException("Skill with ID '" + skillId + "' is already registered");
+		}
+
+		this.definitions.put(skillId, definition);
+
+		if (definition.getLoadStrategy() == LoadStrategy.EAGER) {
+			try {
+				Skill skill = this.createInstance(definition);
+				this.skillPool.put(skillId, skill);
+			}
+			catch (Exception e) {
+				this.definitions.remove(skillId);
+				throw new SkillLoadException(skillId, "EAGER loading failed during registration", e);
+			}
+		}
+	}
+
+	@Override
+	public @Nullable SkillDefinition getDefinition(String skillId) {
+		return this.definitions.get(skillId);
+	}
+
+	@Override
+	public boolean hasDefinition(String skillId) {
+		return this.definitions.containsKey(skillId);
+	}
+
+	@Override
+	public Skill load(String skillId) {
+		Objects.requireNonNull(skillId, "skillId cannot be null");
+
+		SkillDefinition definition = this.definitions.get(skillId);
+		if (definition == null) {
+			throw new SkillNotFoundException(skillId);
+		}
+
+		return this.doLoad(skillId, definition);
+	}
+
+	private Skill doLoad(String skillId, SkillDefinition definition) {
+		return this.skillPool.computeIfAbsent(skillId, id -> this.createInstance(definition));
+	}
+
+	private Skill createInstance(SkillDefinition definition) {
+		try {
+			Skill skill = definition.getLoader().get();
+			if (skill == null) {
+				throw new NullPointerException("Loader returned null");
+			}
+			return skill;
+		}
+		catch (Exception e) {
+			throw new SkillLoadException(definition.getSkillId(), "Loader threw exception", e);
+		}
+	}
+
+	@Override
+	public List<SkillDefinition> getDefinitions() {
+		return List.copyOf(this.definitions.values());
+	}
+
+	/**
+	 * Gets skill definitions by source.
+	 * @param source source identifier
+	 * @return list of skill definitions
+	 */
+	public List<SkillDefinition> getDefinitionsBySource(String source) {
+		Objects.requireNonNull(source, "source cannot be null");
+
+		return this.definitions.values()
+			.stream()
+			.filter(def -> source.equals(def.getSource()))
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Gets skill definitions by name.
+	 * @param name skill name
+	 * @return list of skill definitions
+	 */
+	public List<SkillDefinition> getDefinitionsByName(String name) {
+		Objects.requireNonNull(name, "name cannot be null");
+
+		return this.definitions.values()
+			.stream()
+			.filter(def -> name.equals(def.getMetadata().getName()))
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public void evict(String skillId) {
+		this.skillPool.remove(skillId);
+	}
+
+	@Override
+	public void evictAll() {
+		this.skillPool.clear();
+	}
+
+	@Override
+	public void unregister(String skillId) {
+		Objects.requireNonNull(skillId, "skillId cannot be null");
+
+		this.skillPool.remove(skillId);
+
+		SkillDefinition removedDefinition = this.definitions.remove(skillId);
+		if (removedDefinition == null) {
+			logger.warn("Attempted to unregister non-existent skill: {}", skillId);
+		}
+	}
+
+	@Override
+	public void clear() {
+		this.definitions.clear();
+		this.skillPool.clear();
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/SimpleSkillBox.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/SimpleSkillBox.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.support;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.skill.core.SkillBox;
+import org.springframework.ai.skill.core.SkillMetadata;
+
+/**
+ * Default implementation of SkillBox with thread-safe metadata storage.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SimpleSkillBox implements SkillBox {
+
+	private static final Logger logger = LoggerFactory.getLogger(SimpleSkillBox.class);
+
+	private final ConcurrentHashMap<String, SkillMetadata> skills = new ConcurrentHashMap<>();
+
+	private final ConcurrentHashMap<String, Boolean> activated = new ConcurrentHashMap<>();
+
+	private final List<String> sources = new ArrayList<>();
+
+	public SimpleSkillBox() {
+		this.sources.add("custom");
+	}
+
+	@Override
+	public void addSkill(String name, SkillMetadata metadata) {
+		Objects.requireNonNull(name, "name cannot be null");
+		Objects.requireNonNull(metadata, "metadata cannot be null");
+
+		if (this.skills.containsKey(name)) {
+			throw new IllegalArgumentException("Skill with name '" + name + "' already exists in this SkillBox");
+		}
+
+		this.skills.put(name, metadata);
+		this.addSource(metadata.getSource());
+		this.activated.putIfAbsent(name, false);
+	}
+
+	@Override
+	public @Nullable SkillMetadata getMetadata(String name) {
+		return this.skills.get(name);
+	}
+
+	@Override
+	public Map<String, SkillMetadata> getAllMetadata() {
+		return Collections.unmodifiableMap(this.skills);
+	}
+
+	@Override
+	public boolean exists(String name) {
+		return this.skills.containsKey(name);
+	}
+
+	@Override
+	public int getSkillCount() {
+		return this.skills.size();
+	}
+
+	@Override
+	public void activateSkill(String name) {
+		this.activated.put(name, true);
+	}
+
+	@Override
+	public void deactivateSkill(String name) {
+		this.activated.put(name, false);
+	}
+
+	@Override
+	public void deactivateAllSkills() {
+		this.activated.replaceAll((k, v) -> false);
+	}
+
+	@Override
+	public boolean isActivated(String name) {
+		return this.activated.getOrDefault(name, false);
+	}
+
+	@Override
+	public Set<String> getActivatedSkillNames() {
+		return this.activated.entrySet()
+			.stream()
+			.filter(Map.Entry::getValue)
+			.map(Map.Entry::getKey)
+			.collect(Collectors.toSet());
+	}
+
+	@Override
+	public List<String> getSources() {
+		return this.sources;
+	}
+
+	public void setSources(List<String> sourceList) {
+		this.sources.clear();
+		this.sources.addAll(sourceList);
+	}
+
+	public void addSource(String source) {
+		if (!this.sources.contains(source)) {
+			this.sources.add(source);
+		}
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/support/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support classes providing default implementations of core interfaces.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.support;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/tool/SimpleSkillLoaderTools.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/tool/SimpleSkillLoaderTools.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.tool;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.skill.capability.ReferencesLoader;
+import org.springframework.ai.skill.core.Skill;
+import org.springframework.ai.skill.core.SkillKit;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+/**
+ * Tool for progressive skill loading via Spring AI @Tool annotations.
+ *
+ * <p>
+ * Provides loadSkillContent and loadSkillReference methods for LLM to activate and access
+ * skills.
+ *
+ * @author LinPeng Zhang
+ * @since 1.1.3
+ */
+public class SimpleSkillLoaderTools {
+
+	private static final Logger logger = LoggerFactory.getLogger(SimpleSkillLoaderTools.class);
+
+	private final SkillKit skillKit;
+
+	private SimpleSkillLoaderTools(Builder builder) {
+		this.skillKit = Objects.requireNonNull(builder.skillKit, "skillKit cannot be null");
+	}
+
+	/**
+	 * Creates a new builder instance.
+	 * @return new builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Loads skill content by name, activates skill, and returns its documentation.
+	 * @param skillName skill name
+	 * @return skill content or error message
+	 */
+	@Tool(description = "Load the content of a skill by its name. "
+			+ "This activates the skill and returns its documentation. "
+			+ "Use this when you need to understand what a skill does and how to use it.")
+	public String loadSkillContent(@ToolParam(description = "The name of the skill to load") String skillName) {
+		try {
+			if (skillName == null || skillName.trim().isEmpty()) {
+				return "Error: Missing or empty skill name";
+			}
+
+			if (!this.skillKit.exists(skillName)) {
+				return "Error: Skill not found in SkillBox: " + skillName
+						+ ". Please use a skill that has been added to the SkillBox.";
+			}
+
+			this.skillKit.activateSkill(skillName);
+
+			Skill skill = this.skillKit.getSkillByName(skillName);
+			if (skill == null) {
+				return "Error: Skill not found: " + skillName;
+			}
+
+			return skill.getContent();
+
+		}
+		catch (Exception e) {
+			logger.error("Error loading skill: {}", skillName, e);
+			return "Error loading skill: " + e.getMessage();
+		}
+	}
+
+	/**
+	 * Loads specific reference from skill using reference key.
+	 * @param skillName skill name with references
+	 * @param referenceKey reference key from skill content
+	 * @return reference content (URL, file path, or text) or error message
+	 */
+	@Tool(description = "ONLY use this tool when a skill's content explicitly mentions it has reference materials. "
+			+ "Load a specific reference from a skill using the reference key mentioned in the skill's content. "
+			+ "Returns reference content (URL, file path, or text string). "
+			+ "Do NOT use this for regular skill operations - use skill's own tools instead.")
+	public String loadSkillReference(@ToolParam(description = "The skill name that has references") String skillName,
+			@ToolParam(description = "The exact reference key mentioned in the skill's content") String referenceKey) {
+		try {
+			if (skillName == null || skillName.trim().isEmpty()) {
+				return "Error: Missing or empty skill name";
+			}
+
+			if (referenceKey == null || referenceKey.trim().isEmpty()) {
+				return "Error: Missing or empty reference key";
+			}
+
+			if (!this.skillKit.exists(skillName)) {
+				return "Error: Skill not found in SkillBox: " + skillName
+						+ ". Please use a skill that has been added to the SkillBox.";
+			}
+
+			Skill skill = this.skillKit.getSkillByName(skillName);
+			if (skill == null) {
+				return "Error: Skill not found: " + skillName;
+			}
+
+			if (!skill.supports(ReferencesLoader.class)) {
+				return "Error: Skill '" + skillName + "' does not have references. ";
+			}
+
+			ReferencesLoader loader = skill.as(ReferencesLoader.class);
+			Map<String, String> references = loader.getReferences();
+
+			if (!references.containsKey(referenceKey)) {
+				return "Error: Reference key '" + referenceKey + "' not found in skill '" + skillName + "'. "
+						+ "Available keys: " + references.keySet();
+			}
+
+			return references.get(referenceKey);
+
+		}
+		catch (Exception e) {
+			logger.error("Error loading skill reference: skill={}, key={}", skillName, referenceKey, e);
+			return "Error loading skill reference: " + e.getMessage();
+		}
+	}
+
+	/**
+	 * Builder for SimpleSkillLoaderTool.
+	 */
+	public static class Builder {
+
+		private @Nullable SkillKit skillKit;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets the skill kit.
+		 * @param skillKit skill kit instance
+		 * @return this builder
+		 */
+		public Builder skillKit(SkillKit skillKit) {
+			this.skillKit = skillKit;
+			return this;
+		}
+
+		/**
+		 * Builds the SimpleSkillLoaderTool instance.
+		 * @return new SimpleSkillLoaderTool instance
+		 */
+		public SimpleSkillLoaderTools build() {
+			if (this.skillKit == null) {
+				throw new IllegalArgumentException("skillKit cannot be null");
+			}
+			return new SimpleSkillLoaderTools(this);
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/main/java/org/springframework/ai/skill/tool/package-info.java
+++ b/spring-ai-skill/src/main/java/org/springframework/ai/skill/tool/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tool implementations for progressive skill loading and management.
+ */
+
+@NullMarked
+package org.springframework.ai.skill.tool;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/ClassBasedSkillRegistrarTests.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/ClassBasedSkillRegistrarTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.skill.core.SkillDefinition;
+import org.springframework.ai.skill.core.SkillPoolManager;
+import org.springframework.ai.skill.fixtures.WeatherSkill;
+import org.springframework.ai.skill.registration.ClassBasedSkillRegistrar;
+import org.springframework.ai.skill.support.DefaultSkillPoolManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ClassBasedSkillRegistrar}.
+ *
+ * @author LinPeng Zhang
+ */
+class ClassBasedSkillRegistrarTests {
+
+	private ClassBasedSkillRegistrar registrar;
+
+	private SkillPoolManager poolManager;
+
+	@BeforeEach
+	void setUp() {
+		this.registrar = ClassBasedSkillRegistrar.builder().build();
+		this.poolManager = new DefaultSkillPoolManager();
+	}
+
+	@Test
+	void registerShouldRegisterValidSkillClass() {
+		SkillDefinition definition = this.registrar.register(this.poolManager, WeatherSkill.class);
+
+		assertThat(definition).isNotNull();
+		assertThat(definition.getMetadata().getName()).isEqualTo("weather");
+		assertThat(this.poolManager.hasDefinition(definition.getSkillId())).isTrue();
+	}
+
+	@Test
+	void registerShouldValidateInputs() {
+		assertThatThrownBy(() -> this.registrar.register(null, WeatherSkill.class))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> this.registrar.register(this.poolManager, null))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> this.registrar.register(this.poolManager, String.class))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("@Skill");
+	}
+
+	@Test
+	void supportsShouldIdentifyValidClasses() {
+		assertThat(this.registrar.supports(WeatherSkill.class)).isTrue();
+		assertThat(this.registrar.supports(String.class)).isFalse();
+		assertThat(this.registrar.supports("not a class")).isFalse();
+		assertThat(this.registrar.supports(null)).isFalse();
+	}
+
+}

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/DefaultSkillKitTests.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/DefaultSkillKitTests.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.skill.core.DefaultSkillKit;
+import org.springframework.ai.skill.core.Skill;
+import org.springframework.ai.skill.core.SkillBox;
+import org.springframework.ai.skill.core.SkillMetadata;
+import org.springframework.ai.skill.core.SkillPoolManager;
+import org.springframework.ai.skill.exception.SkillRegistrationException;
+import org.springframework.ai.skill.exception.SkillValidationException;
+import org.springframework.ai.skill.fixtures.CalculatorSkill;
+import org.springframework.ai.skill.fixtures.WeatherSkill;
+import org.springframework.ai.skill.support.DefaultSkillPoolManager;
+import org.springframework.ai.skill.support.SimpleSkillBox;
+import org.springframework.ai.tool.ToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link DefaultSkillKit}.
+ *
+ * @author LinPeng Zhang
+ */
+class DefaultSkillKitTests {
+
+	private DefaultSkillKit skillKit;
+
+	private SkillPoolManager poolManager;
+
+	private SkillBox skillBox;
+
+	@BeforeEach
+	void setUp() {
+		this.poolManager = new DefaultSkillPoolManager();
+		SimpleSkillBox simpleSkillBox = new SimpleSkillBox();
+		simpleSkillBox.setSources(List.of("custom", "example"));
+		this.skillBox = simpleSkillBox;
+		this.skillKit = DefaultSkillKit.builder().skillBox(this.skillBox).poolManager(this.poolManager).build();
+	}
+
+	@Test
+	void registerShouldValidateInputsAndRejectDuplicates() {
+		SkillMetadata metadata = SkillMetadata.builder("test", "description", "custom").build();
+
+		assertThatThrownBy(() -> this.skillKit.register(null, () -> new TestSkill(metadata)))
+			.isInstanceOf(SkillValidationException.class)
+			.hasMessageContaining("metadata cannot be null");
+		assertThatThrownBy(() -> this.skillKit.register(metadata, null)).isInstanceOf(SkillValidationException.class)
+			.hasMessageContaining("loader cannot be null");
+
+		this.skillKit.register(metadata, () -> new TestSkill(metadata));
+		assertThatThrownBy(() -> this.skillKit.register(metadata, () -> new TestSkill(metadata)))
+			.isInstanceOf(SkillRegistrationException.class)
+			.hasMessageContaining("already registered");
+	}
+
+	@Test
+	void registerFromInstanceShouldRegisterAnnotatedSkill() {
+		this.skillKit.register(new CalculatorSkill());
+
+		assertThat(this.skillKit.exists("calculator")).isTrue();
+		assertThat(this.skillKit.getMetadata("calculator")).isNotNull();
+	}
+
+	@Test
+	void registerFromClassShouldRegisterClass() {
+		this.skillKit.register(WeatherSkill.class);
+
+		assertThat(this.skillKit.exists("weather")).isTrue();
+		Skill skill = this.skillKit.getSkillByName("weather");
+		assertThat(skill).isNotNull();
+		assertThat(skill.getTools()).isNotEmpty();
+	}
+
+	@Test
+	void deactivateAllSkillsShouldClearAllActivation() {
+		this.skillKit.register(new CalculatorSkill());
+		this.skillKit.register(WeatherSkill.class);
+		this.skillKit.activateSkill("calculator");
+		this.skillKit.activateSkill("weather");
+
+		this.skillKit.deactivateAllSkills();
+
+		assertThat(this.skillKit.isActivated("calculator")).isFalse();
+		assertThat(this.skillKit.isActivated("weather")).isFalse();
+	}
+
+	@Test
+	void getSkillByNameShouldReturnSkillOrNull() {
+		this.skillKit.register(new CalculatorSkill());
+
+		Skill skill = this.skillKit.getSkillByName("calculator");
+		assertThat(skill).isNotNull();
+		assertThat(skill.getMetadata().getName()).isEqualTo("calculator");
+
+		Skill nonexistent = this.skillKit.getSkillByName("nonexistent");
+		assertThat(nonexistent).isNull();
+	}
+
+	@Test
+	void getAllActiveToolsShouldReturnToolsFromActivatedSkills() {
+		this.skillKit.register(WeatherSkill.class);
+		this.skillKit.activateSkill("weather");
+
+		List<ToolCallback> tools = this.skillKit.getAllActiveTools();
+
+		assertThat(tools).isNotEmpty();
+	}
+
+	@Test
+	void getSkillSystemPromptShouldGeneratePromptContent() {
+		String emptyPrompt = this.skillKit.getSkillSystemPrompt();
+		assertThat(emptyPrompt).isEmpty();
+
+		this.skillKit.register(new CalculatorSkill());
+		String prompt = this.skillKit.getSkillSystemPrompt();
+		assertThat(prompt).contains("calculator").contains("loadSkillContent");
+	}
+
+	@Test
+	void multiTenantShouldIsolateBoxButSharePoolManager() {
+		SkillBox tenant1Box = new SimpleSkillBox();
+		SkillBox tenant2Box = new SimpleSkillBox();
+		SkillPoolManager sharedPoolManager = new DefaultSkillPoolManager();
+
+		DefaultSkillKit tenant1Kit = DefaultSkillKit.builder()
+			.skillBox(tenant1Box)
+			.poolManager(sharedPoolManager)
+			.build();
+		DefaultSkillKit tenant2Kit = DefaultSkillKit.builder()
+			.skillBox(tenant2Box)
+			.poolManager(sharedPoolManager)
+			.build();
+
+		tenant1Kit.register(new CalculatorSkill());
+
+		assertThat(tenant1Kit.exists("calculator")).isTrue();
+		assertThat(tenant2Kit.exists("calculator")).isFalse();
+	}
+
+	@Test
+	void multiTenantShouldIsolateActivationState() {
+		SimpleSkillBox tenant1Box = new SimpleSkillBox();
+		tenant1Box.setSources(List.of("example"));
+		SimpleSkillBox tenant2Box = new SimpleSkillBox();
+		tenant2Box.setSources(List.of("example"));
+		SkillPoolManager sharedPoolManager = new DefaultSkillPoolManager();
+
+		DefaultSkillKit tenant1Kit = DefaultSkillKit.builder()
+			.skillBox(tenant1Box)
+			.poolManager(sharedPoolManager)
+			.build();
+		DefaultSkillKit tenant2Kit = DefaultSkillKit.builder()
+			.skillBox(tenant2Box)
+			.poolManager(sharedPoolManager)
+			.build();
+
+		tenant1Kit.register(new CalculatorSkill());
+		tenant1Kit.activateSkill("calculator");
+
+		tenant2Kit.addSkillToBox("calculator");
+
+		assertThat(tenant1Kit.isActivated("calculator")).isTrue();
+		assertThat(tenant2Kit.isActivated("calculator")).isFalse();
+	}
+
+	@Test
+	void multiTenantShouldShareSingletonInstances() {
+		SimpleSkillBox tenant1Box = new SimpleSkillBox();
+		tenant1Box.setSources(List.of("example"));
+		SimpleSkillBox tenant2Box = new SimpleSkillBox();
+		tenant2Box.setSources(List.of("example"));
+		SkillPoolManager sharedPoolManager = new DefaultSkillPoolManager();
+
+		DefaultSkillKit tenant1Kit = DefaultSkillKit.builder()
+			.skillBox(tenant1Box)
+			.poolManager(sharedPoolManager)
+			.build();
+		DefaultSkillKit tenant2Kit = DefaultSkillKit.builder()
+			.skillBox(tenant2Box)
+			.poolManager(sharedPoolManager)
+			.build();
+
+		tenant1Kit.register(new CalculatorSkill());
+		tenant2Kit.addSkillToBox("calculator");
+
+		Skill skill1 = tenant1Kit.getSkillByName("calculator");
+		Skill skill2 = tenant2Kit.getSkillByName("calculator");
+
+		assertThat(skill1).isSameAs(skill2);
+	}
+
+	private static class TestSkill implements Skill {
+
+		private final SkillMetadata metadata;
+
+		TestSkill(SkillMetadata metadata) {
+			this.metadata = metadata;
+		}
+
+		@Override
+		public SkillMetadata getMetadata() {
+			return this.metadata;
+		}
+
+		@Override
+		public String getContent() {
+			return "Test content";
+		}
+
+		@Override
+		public List<ToolCallback> getTools() {
+			return List.of();
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/DefaultSkillPoolManagerTests.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/DefaultSkillPoolManagerTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.skill.common.LoadStrategy;
+import org.springframework.ai.skill.core.Skill;
+import org.springframework.ai.skill.core.SkillDefinition;
+import org.springframework.ai.skill.core.SkillMetadata;
+import org.springframework.ai.skill.exception.SkillLoadException;
+import org.springframework.ai.skill.exception.SkillNotFoundException;
+import org.springframework.ai.skill.support.DefaultSkillPoolManager;
+import org.springframework.ai.tool.ToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link DefaultSkillPoolManager}.
+ *
+ * @author LinPeng Zhang
+ */
+class DefaultSkillPoolManagerTests {
+
+	private DefaultSkillPoolManager poolManager;
+
+	private SkillMetadata testMetadata;
+
+	@BeforeEach
+	void setUp() {
+		this.poolManager = new DefaultSkillPoolManager();
+		this.testMetadata = SkillMetadata.builder("test", "Test skill", "spring").build();
+	}
+
+	@Test
+	void registerDefinitionShouldStoreDefinitionAndRejectDuplicates() {
+		SkillDefinition definition = createDefinition("test_spring");
+
+		this.poolManager.registerDefinition(definition);
+
+		assertThat(this.poolManager.hasDefinition("test_spring")).isTrue();
+		assertThat(this.poolManager.getDefinition("test_spring")).isNotNull();
+
+		assertThatThrownBy(() -> this.poolManager.registerDefinition(definition))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void lazyLoadingShouldCacheInstancesOnFirstCall() {
+		SkillDefinition definition = createDefinition("test_spring", LoadStrategy.LAZY);
+		this.poolManager.registerDefinition(definition);
+
+		Skill skill1 = this.poolManager.load("test_spring");
+		Skill skill2 = this.poolManager.load("test_spring");
+
+		assertThat(skill1).isNotNull();
+		assertThat(skill1).isSameAs(skill2);
+	}
+
+	@Test
+	void eagerLoadingShouldCacheInstancesImmediately() {
+		SkillDefinition definition = createDefinition("test_spring", LoadStrategy.EAGER);
+
+		this.poolManager.registerDefinition(definition);
+
+		Skill skill1 = this.poolManager.load("test_spring");
+		Skill skill2 = this.poolManager.load("test_spring");
+		assertThat(skill1).isSameAs(skill2);
+	}
+
+	@Test
+	void loadShouldThrowExceptionForNonexistentSkill() {
+		assertThatThrownBy(() -> this.poolManager.load("nonexistent")).isInstanceOf(SkillNotFoundException.class);
+	}
+
+	@Test
+	void loadShouldWrapLoaderExceptions() {
+		SkillDefinition definition = SkillDefinition.builder()
+			.skillId("test_spring")
+			.source("spring")
+			.metadata(this.testMetadata)
+			.loader(() -> {
+				throw new RuntimeException("Loader failed");
+			})
+			.build();
+		this.poolManager.registerDefinition(definition);
+
+		assertThatThrownBy(() -> this.poolManager.load("test_spring")).isInstanceOf(SkillLoadException.class)
+			.hasMessageContaining("Failed to load skill");
+	}
+
+	@Test
+	void evictShouldRemoveInstancesButKeepDefinitions() {
+		this.poolManager.registerDefinition(createDefinition("test1_spring"));
+		this.poolManager.registerDefinition(createDefinition("test2_spring"));
+		Skill skill1 = this.poolManager.load("test1_spring");
+
+		this.poolManager.evict("test1_spring");
+		Skill skill1Reloaded = this.poolManager.load("test1_spring");
+		assertThat(skill1).isNotSameAs(skill1Reloaded);
+		assertThat(this.poolManager.hasDefinition("test1_spring")).isTrue();
+
+		this.poolManager.evictAll();
+		skill1Reloaded = this.poolManager.load("test1_spring");
+		assertThat(this.poolManager.hasDefinition("test1_spring")).isTrue();
+	}
+
+	@Test
+	void unregisterAndClearShouldRemoveDefinitions() {
+		this.poolManager.registerDefinition(createDefinition("test1_spring"));
+		this.poolManager.registerDefinition(createDefinition("test2_spring"));
+		this.poolManager.load("test1_spring");
+
+		this.poolManager.unregister("test1_spring");
+		assertThat(this.poolManager.hasDefinition("test1_spring")).isFalse();
+		assertThatThrownBy(() -> this.poolManager.load("test1_spring")).isInstanceOf(SkillNotFoundException.class);
+
+		this.poolManager.clear();
+		assertThat(this.poolManager.getDefinitions()).isEmpty();
+	}
+
+	@Test
+	void getDefinitionsBySourceShouldFilterBySource() {
+		this.poolManager.registerDefinition(createDefinition("test1_spring", "spring"));
+		this.poolManager.registerDefinition(createDefinition("test2_spring", "spring"));
+		this.poolManager.registerDefinition(createDefinition("test3_official", "official"));
+
+		List<SkillDefinition> springSkills = this.poolManager.getDefinitionsBySource("spring");
+		List<SkillDefinition> officialSkills = this.poolManager.getDefinitionsBySource("official");
+
+		assertThat(springSkills).hasSize(2);
+		assertThat(officialSkills).hasSize(1);
+	}
+
+	private SkillDefinition createDefinition(String skillId) {
+		return createDefinition(skillId, LoadStrategy.LAZY);
+	}
+
+	private SkillDefinition createDefinition(String skillId, LoadStrategy strategy) {
+		return createDefinition(skillId, "spring", strategy);
+	}
+
+	private SkillDefinition createDefinition(String skillId, String source) {
+		return createDefinition(skillId, source, LoadStrategy.LAZY);
+	}
+
+	private SkillDefinition createDefinition(String skillId, String source, LoadStrategy strategy) {
+		return SkillDefinition.builder()
+			.skillId(skillId)
+			.source(source)
+			.metadata(this.testMetadata)
+			.loader(() -> new TestSkill(this.testMetadata))
+			.loadStrategy(strategy)
+			.build();
+	}
+
+	private static class TestSkill implements Skill {
+
+		private final SkillMetadata metadata;
+
+		TestSkill(SkillMetadata metadata) {
+			this.metadata = metadata;
+		}
+
+		@Override
+		public SkillMetadata getMetadata() {
+			return this.metadata;
+		}
+
+		@Override
+		public String getContent() {
+			return "Test content";
+		}
+
+		@Override
+		public List<ToolCallback> getTools() {
+			return Collections.emptyList();
+		}
+
+	}
+
+}

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/InstanceBasedSkillRegistrarTests.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/InstanceBasedSkillRegistrarTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.skill.core.SkillDefinition;
+import org.springframework.ai.skill.core.SkillPoolManager;
+import org.springframework.ai.skill.fixtures.CalculatorSkill;
+import org.springframework.ai.skill.registration.InstanceBasedSkillRegistrar;
+import org.springframework.ai.skill.support.DefaultSkillPoolManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link InstanceBasedSkillRegistrar}.
+ *
+ * @author LinPeng Zhang
+ */
+class InstanceBasedSkillRegistrarTests {
+
+	private InstanceBasedSkillRegistrar registrar;
+
+	private SkillPoolManager poolManager;
+
+	@BeforeEach
+	void setUp() {
+		this.registrar = InstanceBasedSkillRegistrar.builder().build();
+		this.poolManager = new DefaultSkillPoolManager();
+	}
+
+	@Test
+	void registerShouldRegisterValidSkillInstance() {
+		CalculatorSkill skill = new CalculatorSkill();
+
+		SkillDefinition definition = this.registrar.register(this.poolManager, skill);
+
+		assertThat(definition).isNotNull();
+		assertThat(definition.getMetadata().getName()).isEqualTo("calculator");
+		assertThat(this.poolManager.hasDefinition(definition.getSkillId())).isTrue();
+	}
+
+	@Test
+	void registerShouldValidateInputs() {
+		assertThatThrownBy(() -> this.registrar.register(null, new CalculatorSkill()))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> this.registrar.register(this.poolManager, null))
+			.isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> this.registrar.register(this.poolManager, "not a skill"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("@Skill");
+	}
+
+	@Test
+	void supportsShouldIdentifyValidInstances() {
+		assertThat(this.registrar.supports(new CalculatorSkill())).isTrue();
+		assertThat(this.registrar.supports("not a skill")).isFalse();
+		assertThat(this.registrar.supports(null)).isFalse();
+	}
+
+}

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/SimpleSkillBoxTests.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/SimpleSkillBoxTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.skill.core.SkillMetadata;
+import org.springframework.ai.skill.support.SimpleSkillBox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SimpleSkillBox}.
+ *
+ * @author LinPeng Zhang
+ */
+class SimpleSkillBoxTests {
+
+	@Test
+	void addSkillShouldStoreSkillMetadata() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+		SkillMetadata metadata = SkillMetadata.builder("test", "description", "source").build();
+
+		skillBox.addSkill("test", metadata);
+
+		assertThat(skillBox.exists("test")).isTrue();
+		assertThat(skillBox.getMetadata("test")).isEqualTo(metadata);
+		assertThat(skillBox.getSkillCount()).isEqualTo(1);
+	}
+
+	@Test
+	void addSkillShouldValidateInputs() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+		SkillMetadata metadata = SkillMetadata.builder("test", "description", "source").build();
+
+		assertThatThrownBy(() -> skillBox.addSkill(null, metadata)).isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> skillBox.addSkill("test", null)).isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	void addSkillShouldRejectDuplicateName() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+		SkillMetadata metadata1 = SkillMetadata.builder("test", "description1", "source").build();
+		SkillMetadata metadata2 = SkillMetadata.builder("test", "description2", "source").build();
+
+		skillBox.addSkill("test", metadata1);
+
+		assertThatThrownBy(() -> skillBox.addSkill("test", metadata2)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("already exists");
+	}
+
+	@Test
+	void activationShouldToggleState() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+		SkillMetadata metadata = SkillMetadata.builder("test", "description", "source").build();
+		skillBox.addSkill("test", metadata);
+
+		skillBox.activateSkill("test");
+		assertThat(skillBox.isActivated("test")).isTrue();
+		assertThat(skillBox.getActivatedSkillNames()).containsExactly("test");
+
+		skillBox.deactivateSkill("test");
+		assertThat(skillBox.isActivated("test")).isFalse();
+		assertThat(skillBox.getActivatedSkillNames()).isEmpty();
+	}
+
+	@Test
+	void deactivateAllSkillsShouldClearAllActivation() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+		SkillMetadata metadata1 = SkillMetadata.builder("skill1", "description", "source").build();
+		SkillMetadata metadata2 = SkillMetadata.builder("skill2", "description", "source").build();
+		skillBox.addSkill("skill1", metadata1);
+		skillBox.addSkill("skill2", metadata2);
+		skillBox.activateSkill("skill1");
+		skillBox.activateSkill("skill2");
+
+		skillBox.deactivateAllSkills();
+
+		assertThat(skillBox.isActivated("skill1")).isFalse();
+		assertThat(skillBox.isActivated("skill2")).isFalse();
+		assertThat(skillBox.getActivatedSkillNames()).isEmpty();
+	}
+
+	@Test
+	void isActivatedShouldReturnFalseForNonexistentSkill() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+
+		assertThat(skillBox.isActivated("nonexistent")).isFalse();
+	}
+
+	@Test
+	void sourceManagementShouldWorkCorrectly() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+
+		assertThat(skillBox.getSources()).containsExactly("custom");
+
+		skillBox.setSources(List.of("source1", "source2"));
+		assertThat(skillBox.getSources()).containsExactly("source1", "source2");
+
+		skillBox.addSource("source3");
+		assertThat(skillBox.getSources()).contains("source1", "source2", "source3");
+	}
+
+	@Test
+	void getActivatedSkillNamesShouldReturnOnlyActiveSkills() {
+		SimpleSkillBox skillBox = new SimpleSkillBox();
+		SkillMetadata metadata1 = SkillMetadata.builder("skill1", "description", "source").build();
+		SkillMetadata metadata2 = SkillMetadata.builder("skill2", "description", "source").build();
+		SkillMetadata metadata3 = SkillMetadata.builder("skill3", "description", "source").build();
+		skillBox.addSkill("skill1", metadata1);
+		skillBox.addSkill("skill2", metadata2);
+		skillBox.addSkill("skill3", metadata3);
+		skillBox.activateSkill("skill1");
+		skillBox.activateSkill("skill3");
+
+		assertThat(skillBox.getActivatedSkillNames()).containsExactlyInAnyOrder("skill1", "skill3");
+	}
+
+}

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/SkillMetadataTests.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/SkillMetadataTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.skill.core.SkillMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SkillMetadata}.
+ *
+ * @author LinPeng Zhang
+ */
+class SkillMetadataTests {
+
+	@Test
+	void builderShouldCreateMetadataWithRequiredFields() {
+		SkillMetadata metadata = SkillMetadata.builder("test-skill", "Test description", "spring").build();
+
+		assertThat(metadata.getName()).isEqualTo("test-skill");
+		assertThat(metadata.getDescription()).isEqualTo("Test description");
+		assertThat(metadata.getSource()).isEqualTo("spring");
+		assertThat(metadata.getExtensions()).isEmpty();
+	}
+
+	@Test
+	void builderShouldStoreExtensions() {
+		SkillMetadata metadata = SkillMetadata.builder("skill", "description", "spring")
+			.extension("version", "1.0.0")
+			.extension("author", "test")
+			.build();
+
+		assertThat(metadata.getExtension("version")).isEqualTo("1.0.0");
+		assertThat(metadata.getExtension("author")).isEqualTo("test");
+		assertThat(metadata.getExtension("nonexistent")).isNull();
+	}
+
+	@Test
+	void builderShouldValidateRequiredFields() {
+		assertThatThrownBy(() -> SkillMetadata.builder(null, "description", "spring").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> SkillMetadata.builder("", "description", "spring").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> SkillMetadata.builder("name", null, "spring").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> SkillMetadata.builder("name", "", "spring").build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> SkillMetadata.builder("name", "description", null).build())
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> SkillMetadata.builder("name", "description", "").build())
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void equalsShouldWorkCorrectly() {
+		SkillMetadata metadata1 = SkillMetadata.builder("name", "description", "spring")
+			.extension("key", "value")
+			.build();
+		SkillMetadata metadata2 = SkillMetadata.builder("name", "description", "spring")
+			.extension("key", "value")
+			.build();
+		SkillMetadata metadata3 = SkillMetadata.builder("different", "description", "spring").build();
+
+		assertThat(metadata1).isEqualTo(metadata2).hasSameHashCodeAs(metadata2);
+		assertThat(metadata1).isNotEqualTo(metadata3);
+	}
+
+}

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/fixtures/CalculatorSkill.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/fixtures/CalculatorSkill.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.fixtures;
+
+import org.springframework.ai.skill.annotation.Skill;
+import org.springframework.ai.skill.annotation.SkillContent;
+
+/**
+ * Test Calculator Skill
+ *
+ * <p>
+ * Simple POJO Skill for testing framework functionality
+ *
+ * @author Semir
+ */
+@Skill(name = "calculator", description = "A simple calculator skill for basic arithmetic operations",
+		source = "example", extensions = { "version=1.0.0", "author=Semir" })
+public class CalculatorSkill {
+
+	public CalculatorSkill() {
+	}
+
+	@SkillContent
+	public String content() {
+		return """
+				# Calculator Skill
+
+				A simple calculator skill that provides basic arithmetic operations.
+
+				## Features
+
+				- Addition
+				- Subtraction
+				- Multiplication
+				- Division
+
+				## Usage
+
+				Use this skill to perform basic calculations.
+				""";
+	}
+
+}

--- a/spring-ai-skill/src/test/java/org/springframework/ai/skill/fixtures/WeatherSkill.java
+++ b/spring-ai-skill/src/test/java/org/springframework/ai/skill/fixtures/WeatherSkill.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.skill.fixtures;
+
+import java.util.List;
+
+import org.springframework.ai.skill.annotation.Skill;
+import org.springframework.ai.skill.annotation.SkillContent;
+import org.springframework.ai.skill.annotation.SkillInit;
+import org.springframework.ai.skill.annotation.SkillTools;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.Tool;
+
+/**
+ * Test Weather Skill POJO
+ *
+ * <p>
+ * Weather skill using fixed data for testing
+ *
+ * @author Semir
+ */
+@Skill(name = "weather", description = "Provides weather information for cities around the world", source = "example",
+		extensions = { "version=1.0.0", "author=Semir", "category=information" })
+public class WeatherSkill {
+
+	private WeatherSkill() {
+	}
+
+	@SkillInit
+	public static WeatherSkill create() {
+		return new WeatherSkill();
+	}
+
+	@SkillContent
+	public String content() {
+		return """
+				# Weather Skill
+
+				Provides weather information for cities around the world.
+
+				## Features
+
+				- Get current weather for any city
+				- Temperature in Celsius
+				- Weather conditions (Sunny, Rainy, Cloudy, etc.)
+
+				## Available Tools
+
+				- `getWeather(city)` - Get current weather for a specific city
+
+				## Usage
+
+				Ask me "What's the weather in Beijing?" or "Tell me the weather in New York".
+				""";
+	}
+
+	@SkillTools
+	public List<ToolCallback> tools() {
+		return List.of(ToolCallbacks.from(this));
+	}
+
+	/**
+	 * Get weather information for a specific city (uses fixed data for testing)
+	 * @param city city name
+	 * @return JSON string containing weather information
+	 */
+	@Tool(description = "Get current weather information for a specific city. Returns temperature in Celsius, weather condition, humidity percentage, and wind speed in km/h.")
+	public String getWeather(String city) {
+		if (city == null || city.trim().isEmpty()) {
+			return "{\"error\": \"City name is required\"}";
+		}
+
+		// Use fixed data for test verification
+		int temperature;
+		String condition;
+		int humidity;
+		int windSpeed;
+
+		switch (city.toLowerCase()) {
+			case "beijing":
+				temperature = 25;
+				condition = "Sunny";
+				humidity = 60;
+				windSpeed = 15;
+				break;
+			case "new york":
+				temperature = 20;
+				condition = "Cloudy";
+				humidity = 70;
+				windSpeed = 20;
+				break;
+			case "london":
+				temperature = 15;
+				condition = "Rainy";
+				humidity = 85;
+				windSpeed = 25;
+				break;
+			case "tokyo":
+				temperature = 22;
+				condition = "Partly Cloudy";
+				humidity = 65;
+				windSpeed = 10;
+				break;
+			case "paris":
+				temperature = 18;
+				condition = "Foggy";
+				humidity = 75;
+				windSpeed = 12;
+				break;
+			default:
+				temperature = 20;
+				condition = "Clear";
+				humidity = 50;
+				windSpeed = 10;
+				break;
+		}
+
+		return String.format(
+				"{\"city\": \"%s\", \"temperature\": %d, \"unit\": \"Celsius\", \"condition\": \"%s\", "
+						+ "\"humidity\": %d, \"windSpeed\": %d, \"windUnit\": \"km/h\", "
+						+ "\"description\": \"The weather in %s is %s with a temperature of %d°C, "
+						+ "humidity at %d%%, and wind speed of %d km/h.\"}",
+				city, temperature, condition, humidity, windSpeed, city, condition, temperature, humidity, windSpeed);
+	}
+
+}

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -97,5 +97,7 @@
 	<suppress files="spring-ai-spring-boot-starters" id="bannedNullabilityImports" />
 	<suppress files="spring-ai-spring-boot-testcontainers" id="bannedNullabilityImports" />
 
+	<suppress files="spring-ai-skill" checks="FinalClass" />
+
 	<suppress files="models|auto-configurations|spring-ai-integration-tests|spring-ai-spring-boot-docker-compose|spring-ai-spring-boot-starters|spring-ai-spring-boot-testcontainers" checks="JavadocPackage" />
 </suppressions>


### PR DESCRIPTION
Introduce a comprehensive skill extension that enables dynamic skill loading, activation, and progressive skill integration with LLM conversations.

Key Features:
- Progressive loading: LLM can discover and load skills on-demand
- Multi-tenant support: Isolated skill activation per conversation
- Flexible registration: Support class-based and instance-based skills, easily extensible for more types
- Customizable skill capabilities: Support flexible extension and customization of diverse skill functionalities

Components:
- Core:
  - SkillKit: Central coordination of skill lifecycle management
  - SkillBox: Skill metadata storage and activation state tracking
  - SkillPoolManager: Lazy/eager skill instance loading and caching
  - SkillRegistrar: Interface class providing diversified skill registration capabilities
- SPI:
  - SkillAwareAdvisor: Responsible for loading skills into LLM prompts and managing conversation-level skill activation/deactivation
  - SkillAwareToolCallingManager: Manages automatic injection and execution of skill-associated tools; delegates execution and parsing of non-skill tools to other components
  - SkillAwareToolCallbackResolver: Works with SkillAwareToolCallingManager to enable dynamic tool execution by resolving tool callbacks from SkillBox's active skills
- Annotations:
  - Skill, SkillInit, SkillExtension, SkillContent, SkillTools, SkillReferences
- Tools:
  - Progressive skill loader tools for LLM interaction

== Semir Group Contribution ==
Developed by Semir Lab Team
Part of Semir's open source technology initiative
Original implementation: https://github.com/semir-lab/spring-ai-skill-extension

Fixes: [#5293 ](https://github.com/spring-projects/spring-ai/issues/5293)

Thank you for taking time to contribute this pull request!
Signed-off-by: LinPeng Zhang <zhanglinpeng@semir.com>