### PR TITLE
Upgrade MCP SDK to 0.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.17.0</mcp.sdk.version>
+		<mcp.sdk.version>0.17.1</mcp.sdk.version>
 		<mcp-annotations.version>0.8.0</mcp-annotations.version>
 
 		<!-- plugin versions -->


### PR DESCRIPTION
Fixes elicitation capability deserialization failure where InitializeRequest containing form or url fields would throw UnrecognizedPropertyException. The SDK now supports form and url fields in Elicitation per MCP 2025-11-25 spec.

Closes #5133
