### PR TITLE
Fix ToolCallAdvisor to preserve system message when memory disabled

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/MessageChatMemoryAdvisor.java
@@ -33,6 +33,7 @@ import org.springframework.ai.chat.client.advisor.api.BaseChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.util.Assert;
 
 /**
@@ -84,6 +85,15 @@ public final class MessageChatMemoryAdvisor implements BaseChatMemoryAdvisor {
 		// 2. Advise the request messages list.
 		List<Message> processedMessages = new ArrayList<>(memoryMessages);
 		processedMessages.addAll(chatClientRequest.prompt().getInstructions());
+
+		// 2.1. Ensure system message, if present, appears first in the list.
+		for (int i = 0; i < processedMessages.size(); i++) {
+			if (processedMessages.get(i) instanceof SystemMessage) {
+				Message systemMessage = processedMessages.remove(i);
+				processedMessages.add(0, systemMessage);
+				break;
+			}
+		}
 
 		// 3. Create a new request with the advised messages.
 		ChatClientRequest processedChatClientRequest = chatClientRequest.mutate()

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -151,9 +151,8 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 						.build();
 
 					// Interrupt the tool calling loop and return the tool execution
-					// result
-					// directly to the client application instead of returning it to the
-					// LLM.
+					// result directly to the client application instead of returning
+					// it to the LLM.
 					break;
 				}
 
@@ -171,7 +170,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 			ChatClientResponse chatClientResponse, ToolExecutionResult toolExecutionResult) {
 
 		if (!this.conversationHistoryEnabled) {
-			return List.of(toolExecutionResult.conversationHistory()
+			return List.of(chatClientRequest.prompt().getSystemMessage(), toolExecutionResult.conversationHistory()
 				.get(toolExecutionResult.conversationHistory().size() - 1));
 		}
 
@@ -268,6 +267,16 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 		 */
 		public T conversationHistoryEnabled(boolean conversationHistoryEnabled) {
 			this.conversationHistoryEnabled = conversationHistoryEnabled;
+			return self();
+		}
+
+		/**
+		 * Disables internal conversation history. You need a ChatMemory Advisor
+		 * registered next in the chain.
+		 * @return this Builder instance for method chaining
+		 */
+		public T disableMemory() {
+			this.conversationHistoryEnabled = false;
 			return self();
 		}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -58,9 +58,10 @@ var chatClient = ChatClient.builder(chatModel)
 
 The `ToolCallAdvisor` includes a `conversationHistoryEnabled` configuration option that controls how conversation history is managed during tool calling iterations.
 
+
 By default (`conversationHistoryEnabled=true`), the advisor maintains the full conversation history internally during tool call iterations. This means each subsequent LLM call in the tool calling loop includes all previous messages (user message, assistant responses, tool responses).
 
-When set to `false`, only the last tool response message is passed to the next iteration. This is useful when:
+Use the `.disableMemory()` method to disable internal conversation history management. When disabled, only the last tool response message is passed to the next iteration. This is useful when:
 
 * You have a Chat Memory Advisor registered next in the chain that already manages conversation history
 * You want to reduce token usage by not duplicating history management
@@ -72,7 +73,7 @@ Example with conversation history disabled:
 ----
 var toolCallAdvisor = ToolCallAdvisor.builder()
     .toolCallingManager(toolCallingManager)
-    .conversationHistoryEnabled(false)  // Disable internal history - let ChatMemory handle it
+    .disableMemory()  // Disable internal history - let ChatMemory handle it
     .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 300)
     .build();
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1146,13 +1146,13 @@ The `ToolCallAdvisor.Builder` supports the following configuration options:
 
 By default (`conversationHistoryEnabled=true`), the `ToolCallAdvisor` maintains the full conversation history internally during tool call iterations. Each subsequent LLM call includes all previous messages.
 
-When set to `false`, only the last tool response message is passed to the next iteration. This is useful when integrating with a Chat Memory advisor that already manages conversation history:
+Use the `.disableMemory()` method to disable internal conversation history management. When disabled, only the last tool response message is passed to the next iteration. This is useful when integrating with a Chat Memory advisor that already manages conversation history:
 
 [source,java]
 ----
 var toolCallAdvisor = ToolCallAdvisor.builder()
     .toolCallingManager(toolCallingManager)
-    .conversationHistoryEnabled(false)  // Let ChatMemory handle history
+    .disableMemory()  // Let ChatMemory handle history
     .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 300)
     .build();
 


### PR DESCRIPTION
When conversation history is disabled in ToolCallAdvisor, the system message was being lost on subsequent tool call iterations, causing the LLM to lose its system instructions.

- Include system message in the messages sent to LLM when conversationHistoryEnabled is false
- Add disableMemory() builder method for clearer API. Shortcut for the conversationHistoryEnabled(false)
- Fix MessageChatMemoryAdvisor to ensure system message appears first after merging with memory messages
- Add tests for both fixes