### PR TITLE
fix: preserve link/image URLs and support GFM tables

### DIFF
--- a/document-readers/markdown-reader/pom.xml
+++ b/document-readers/markdown-reader/pom.xml
@@ -50,6 +50,12 @@
 			<version>${commonmark.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.commonmark</groupId>
+			<artifactId>commonmark-ext-gfm-tables</artifactId>
+			<version>${commonmark.version}</version>
+		</dependency>
+
 		<!-- TESTING -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
+++ b/document-readers/markdown-reader/src/test/java/org/springframework/ai/reader/markdown/MarkdownDocumentReaderTest.java
@@ -33,6 +33,7 @@ import static org.assertj.core.groups.Tuple.tuple;
  * @author Piotr Olaszewski
  * @author shown.Ji
  * @author Eric Bottard
+ * @author Songhee An
  */
 class MarkdownDocumentReaderTest {
 
@@ -281,6 +282,34 @@ class MarkdownDocumentReaderTest {
 		Document documentsFirst = documents.get(0);
 		assertThat(documentsFirst.getMetadata()).isEqualTo(Map.of("service", "some-service-name", "env", "prod"));
 		assertThat(documentsFirst.getText()).startsWith("Lorem ipsum dolor sit amet, consectetur adipiscing elit.");
+	}
+
+	@Test
+	void testLinksAndImagesPreserved() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/links.md");
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(1);
+
+		Document document = documents.get(0);
+		assertThat(document.getText()).contains("Example Java (docs/src/doc/docs/assets/img/example-java.png)")
+			.contains("Example (https://example.com/example-project)")
+			.contains("Alt text (https://example.com/image.png)")
+			.contains("Alt text for image (https://example.com/image2.png) (https://example.com/linked)")
+			.contains("https://example.com/self")
+			.doesNotContain("https://example.com/self (https://example.com/self)");
+	}
+
+	@Test
+	void testTableLinksAndImagesPreserved() {
+		MarkdownDocumentReader reader = new MarkdownDocumentReader("classpath:/table-links.md");
+		List<Document> documents = reader.get();
+
+		assertThat(documents).hasSize(1);
+
+		Document document = documents.get(0);
+		assertThat(document.getText()).contains("Table link (https://example.com/table-link)")
+			.contains("Table image (https://example.com/table-image.png)");
 	}
 
 }

--- a/document-readers/markdown-reader/src/test/resources/links.md
+++ b/document-readers/markdown-reader/src/test/resources/links.md
@@ -1,0 +1,12 @@
+1. Standard Image: ![Example Java](docs/src/doc/docs/assets/img/example-java.png)
+
+2. Standard Link: [Example](https://example.com/example-project)
+
+3. Mixed elements in a list:
+    * Standard link in list: [Example](https://example.com/example-project)
+    * Standard image in list: ![Alt text](https://example.com/image.png)
+
+4. Nested Image Link:
+   [![Alt text for image](https://example.com/image2.png)](https://example.com/linked)
+
+5. Self link: [https://example.com/self](https://example.com/self)

--- a/document-readers/markdown-reader/src/test/resources/table-links.md
+++ b/document-readers/markdown-reader/src/test/resources/table-links.md
@@ -1,0 +1,4 @@
+| Name | Link |
+| --- | --- |
+| Table link | [Table link](https://example.com/table-link) |
+| Table image | ![Table image](https://example.com/table-image.png) |


### PR DESCRIPTION
### Description
Fixed MarkdownDocumentReader to preserve link and image URLs that were lost during parsing. This ensures destination URLs are maintained in the output text, including those within GFM tables.

### Changes
- Overrode visit(Link) and visit(Image) to append destination URLs
- Skipped appending when link text matches destination (deduplication)
- Registered TablesExtension for GFM table support
- Added tests for nested links, self-links, and tables

Closes #5144