### PR TITLE
Unify VectorStore bean naming for type consistency

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/main/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/main/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStoreAutoConfiguration.java
@@ -82,7 +82,7 @@ public class AzureVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public AzureVectorStore vectorStore(SearchIndexClient searchIndexClient, EmbeddingModel embeddingModel,
+	public AzureVectorStore azureVectorStore(SearchIndexClient searchIndexClient, EmbeddingModel embeddingModel,
 			AzureVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-cassandra/src/main/java/org/springframework/ai/vectorstore/cassandra/autoconfigure/CassandraVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-cassandra/src/main/java/org/springframework/ai/vectorstore/cassandra/autoconfigure/CassandraVectorStoreAutoConfiguration.java
@@ -61,8 +61,9 @@ public class CassandraVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public CassandraVectorStore vectorStore(EmbeddingModel embeddingModel, CassandraVectorStoreProperties properties,
-			CqlSession cqlSession, ObjectProvider<ObservationRegistry> observationRegistry,
+	public CassandraVectorStore cassandraVectorStore(EmbeddingModel embeddingModel,
+			CassandraVectorStoreProperties properties, CqlSession cqlSession,
+			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
 

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/src/main/java/org/springframework/ai/vectorstore/chroma/autoconfigure/ChromaVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/src/main/java/org/springframework/ai/vectorstore/chroma/autoconfigure/ChromaVectorStoreAutoConfiguration.java
@@ -89,7 +89,7 @@ public class ChromaVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ChromaVectorStore vectorStore(EmbeddingModel embeddingModel, ChromaApi chromaApi,
+	public ChromaVectorStore chromaVectorStore(EmbeddingModel embeddingModel, ChromaApi chromaApi,
 			ChromaVectorStoreProperties storeProperties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy chromaBatchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-couchbase/src/main/java/org/springframework/ai/vectorstore/couchbase/autoconfigure/CouchbaseSearchVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-couchbase/src/main/java/org/springframework/ai/vectorstore/couchbase/autoconfigure/CouchbaseSearchVectorStoreAutoConfiguration.java
@@ -40,8 +40,8 @@ public class CouchbaseSearchVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public CouchbaseSearchVectorStore vectorStore(CouchbaseSearchVectorStoreProperties properties, Cluster cluster,
-			EmbeddingModel embeddingModel) {
+	public CouchbaseSearchVectorStore couchbaseSearchVectorStore(CouchbaseSearchVectorStoreProperties properties,
+			Cluster cluster, EmbeddingModel embeddingModel) {
 		var builder = CouchbaseSearchVectorStore.builder(cluster, embeddingModel);
 
 		PropertyMapper mapper = PropertyMapper.get();

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-elasticsearch/src/main/java/org/springframework/ai/vectorstore/elasticsearch/autoconfigure/ElasticsearchVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-elasticsearch/src/main/java/org/springframework/ai/vectorstore/elasticsearch/autoconfigure/ElasticsearchVectorStoreAutoConfiguration.java
@@ -63,8 +63,9 @@ public class ElasticsearchVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	ElasticsearchVectorStore vectorStore(ElasticsearchVectorStoreProperties properties, Rest5Client restClient,
-			EmbeddingModel embeddingModel, ObjectProvider<ObservationRegistry> observationRegistry,
+	ElasticsearchVectorStore elasticsearchVectorStore(ElasticsearchVectorStoreProperties properties,
+			Rest5Client restClient, EmbeddingModel embeddingModel,
+			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
 		ElasticsearchVectorStoreOptions elasticsearchVectorStoreOptions = new ElasticsearchVectorStoreOptions();

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mariadb/src/main/java/org/springframework/ai/vectorstore/mariadb/autoconfigure/MariaDbStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mariadb/src/main/java/org/springframework/ai/vectorstore/mariadb/autoconfigure/MariaDbStoreAutoConfiguration.java
@@ -55,7 +55,7 @@ public class MariaDbStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public MariaDBVectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
+	public MariaDBVectorStore mariaDbVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 			org.springframework.ai.vectorstore.mariadb.autoconfigure.MariaDbStoreProperties properties,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/main/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/src/main/java/org/springframework/ai/vectorstore/milvus/autoconfigure/MilvusVectorStoreAutoConfiguration.java
@@ -69,7 +69,7 @@ public class MilvusVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public MilvusVectorStore vectorStore(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel,
+	public MilvusVectorStore milvusVectorStore(MilvusServiceClient milvusClient, EmbeddingModel embeddingModel,
 			MilvusVectorStoreProperties properties, BatchingStrategy batchingStrategy,
 			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/main/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/src/main/java/org/springframework/ai/vectorstore/mongodb/autoconfigure/MongoDBAtlasVectorStoreAutoConfiguration.java
@@ -65,7 +65,7 @@ public class MongoDBAtlasVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	MongoDBAtlasVectorStore vectorStore(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel,
+	MongoDBAtlasVectorStore mongoDBAtlasVectorStore(MongoTemplate mongoTemplate, EmbeddingModel embeddingModel,
 			MongoDBAtlasVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-neo4j/src/main/java/org/springframework/ai/vectorstore/neo4j/autoconfigure/Neo4jVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-neo4j/src/main/java/org/springframework/ai/vectorstore/neo4j/autoconfigure/Neo4jVectorStoreAutoConfiguration.java
@@ -57,7 +57,7 @@ public class Neo4jVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Neo4jVectorStore vectorStore(Driver driver, EmbeddingModel embeddingModel,
+	public Neo4jVectorStore neo4jVectorStore(Driver driver, EmbeddingModel embeddingModel,
 			Neo4jVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/src/main/java/org/springframework/ai/vectorstore/opensearch/autoconfigure/OpenSearchVectorStoreAutoConfiguration.java
@@ -80,8 +80,9 @@ public class OpenSearchVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	OpenSearchVectorStore vectorStore(OpenSearchVectorStoreProperties properties, OpenSearchClient openSearchClient,
-			EmbeddingModel embeddingModel, ObjectProvider<ObservationRegistry> observationRegistry,
+	OpenSearchVectorStore openSearchVectorStore(OpenSearchVectorStoreProperties properties,
+			OpenSearchClient openSearchClient, EmbeddingModel embeddingModel,
+			ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
 		var indexName = Optional.ofNullable(properties.getIndexName()).orElse(OpenSearchVectorStore.DEFAULT_INDEX_NAME);

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-oracle/src/main/java/org/springframework/ai/vectorstore/oracle/autoconfigure/OracleVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-oracle/src/main/java/org/springframework/ai/vectorstore/oracle/autoconfigure/OracleVectorStoreAutoConfiguration.java
@@ -59,7 +59,7 @@ public class OracleVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public OracleVectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
+	public OracleVectorStore oracleVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 			OracleVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/src/main/java/org/springframework/ai/vectorstore/pgvector/autoconfigure/PgVectorStoreAutoConfiguration.java
@@ -59,7 +59,7 @@ public class PgVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public PgVectorStore vectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
+	public PgVectorStore pgVectorStore(JdbcTemplate jdbcTemplate, EmbeddingModel embeddingModel,
 			PgVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pinecone/src/main/java/org/springframework/ai/vectorstore/pinecone/autoconfigure/PineconeVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pinecone/src/main/java/org/springframework/ai/vectorstore/pinecone/autoconfigure/PineconeVectorStoreAutoConfiguration.java
@@ -53,8 +53,8 @@ public class PineconeVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public PineconeVectorStore vectorStore(EmbeddingModel embeddingModel, PineconeVectorStoreProperties properties,
-			ObjectProvider<ObservationRegistry> observationRegistry,
+	public PineconeVectorStore pineconeVectorStore(EmbeddingModel embeddingModel,
+			PineconeVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {
 

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreAutoConfiguration.java
@@ -77,7 +77,7 @@ public class QdrantVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public QdrantVectorStore vectorStore(EmbeddingModel embeddingModel, QdrantVectorStoreProperties properties,
+	public QdrantVectorStore qdrantVectorStore(EmbeddingModel embeddingModel, QdrantVectorStoreProperties properties,
 			QdrantClient qdrantClient, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/src/main/java/org/springframework/ai/vectorstore/redis/autoconfigure/RedisVectorStoreAutoConfiguration.java
@@ -78,7 +78,7 @@ public class RedisVectorStoreAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	public RedisVectorStore vectorStore(final EmbeddingModel embeddingModel,
+	public RedisVectorStore redisVectorStore(final EmbeddingModel embeddingModel,
 			final RedisVectorStoreProperties properties, final JedisConnectionFactory jedisConnectionFactory,
 			final ObjectProvider<ObservationRegistry> observationRegistry,
 			final ObjectProvider<VectorStoreObservationConvention> convention,

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-typesense/src/main/java/org/springframework/ai/vectorstore/typesense/autoconfigure/TypesenseVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-typesense/src/main/java/org/springframework/ai/vectorstore/typesense/autoconfigure/TypesenseVectorStoreAutoConfiguration.java
@@ -68,7 +68,7 @@ public class TypesenseVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public TypesenseVectorStore vectorStore(Client typesenseClient, EmbeddingModel embeddingModel,
+	public TypesenseVectorStore typesenseVectorStore(Client typesenseClient, EmbeddingModel embeddingModel,
 			TypesenseVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreAutoConfiguration.java
@@ -81,7 +81,7 @@ public class WeaviateVectorStoreAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public WeaviateVectorStore vectorStore(EmbeddingModel embeddingModel, WeaviateClient weaviateClient,
+	public WeaviateVectorStore weaviateVectorStore(EmbeddingModel embeddingModel, WeaviateClient weaviateClient,
 			WeaviateVectorStoreProperties properties, ObjectProvider<ObservationRegistry> observationRegistry,
 			ObjectProvider<VectorStoreObservationConvention> customObservationConvention,
 			BatchingStrategy batchingStrategy) {


### PR DESCRIPTION
## Summary

- Rename VectorStore bean methods from generic `vectorStore` to type-specific names
- Prevents bean name conflicts when multiple VectorStore implementations are used
- Maintains backward compatibility - all tests use type-based injection

## Changes

Modified 17 auto-configuration classes to use type-specific bean names following the pattern `<techName>VectorStore`:

| Configuration | Old Bean Name | New Bean Name |
|---------------|--------------|---------------|
| Azure | `vectorStore` | `azureVectorStore` |
| Chroma | `vectorStore` | `chromaVectorStore` |
| Cassandra | `vectorStore` | `cassandraVectorStore` |
| Elasticsearch | `vectorStore` | `elasticsearchVectorStore` |
| Milvus | `vectorStore` | `milvusVectorStore` |
| MongoDB Atlas | `vectorStore` | `mongoDBAtlasVectorStore` |
| OpenSearch | `vectorStore` | `openSearchVectorStore` |
| Pinecone | `vectorStore` | `pineconeVectorStore` |
| Typesense | `vectorStore` | `typesenseVectorStore` |
| Weaviate | `vectorStore` | `weaviateVectorStore` |
| Neo4j | `vectorStore` | `neo4jVectorStore` |
| Oracle | `vectorStore` | `oracleVectorStore` |
| PgVector | `vectorStore` | `pgVectorStore` |
| Couchbase | `vectorStore` | `couchbaseSearchVectorStore` |
| Redis | `vectorStore` | `redisVectorStore` |
| Qdrant | `vectorStore` | `qdrantVectorStore` |
| MariaDB | `vectorStore` | `mariaDbVectorStore` |

The following configurations already used type-specific naming and remain unchanged:
- Infinispan, GemFire, CosmosDB, S3, Bedrock Knowledge Base

## Motivation

Previously, all VectorStore auto-configurations used the same bean name `vectorStore`, which caused conflicts when applications needed to use multiple VectorStore implementations simultaneously. This change adopts a consistent naming convention across all VectorStore implementations.

## Backward Compatibility

✅ **No breaking changes**: All existing code remains unaffected because:
- Tests use `context.getBean(VectorStore.class)` (type-based)
- Documentation examples use `@Autowired VectorStore vectorStore` (type-based)
- No code was found that references beans by string name

## Benefits

1. **Prevents conflicts**: Multiple VectorStore implementations can coexist
2. **Better ergonomics**: Bean names clearly indicate their type
3. **Consistency**: All 22 VectorStore configurations follow the same naming pattern
4. **Spring Boot best practices**: Follows the convention of specific bean naming

## Test Plan

- [x] Code follows Spring Java format standards
- [x] All 17 modified configurations compile successfully
- [x] No changes required to existing tests (type-based injection)
- [x] No changes required to documentation (type-based injection)