### PR TITLE
GH-5297: Fix Elasticsearch IN/NIN expression grouping syntax

### DIFF
--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchAiSearchFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchAiSearchFilterExpressionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ public class ElasticsearchAiSearchFilterExpressionConverter extends AbstractFilt
 		if (expression.type() == Filter.ExpressionType.IN || expression.type() == Filter.ExpressionType.NIN) {
 			Assert.state(expression.right() != null, "expression.right() must not be null");
 			context.append(getOperationSymbol(expression));
-			context.append("(");
 			this.convertOperand(expression.left(), context);
+			context.append("(");
 			this.convertOperand(expression.right(), context);
 			context.append(")");
 		}
@@ -119,7 +119,7 @@ public class ElasticsearchAiSearchFilterExpressionConverter extends AbstractFilt
 		if (filterValue.value() instanceof List list) {
 			int c = 0;
 			for (Object v : list) {
-				context.append(v);
+				this.doSingleValue(v, context);
 				if (c++ < list.size() - 1) {
 					this.doAddValueRangeSpitter(filterValue, context);
 				}
@@ -146,7 +146,7 @@ public class ElasticsearchAiSearchFilterExpressionConverter extends AbstractFilt
 				}
 			}
 			else {
-				context.append(text);
+				context.append("\"").append(text).append("\"");
 			}
 		}
 		else {

--- a/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchAiSearchFilterExpressionConverterTest.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/test/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchAiSearchFilterExpressionConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ class ElasticsearchAiSearchFilterExpressionConverterTest {
 	public void testEQ() {
 		String vectorExpr = this.converter
 			.convertExpression(new Filter.Expression(EQ, new Filter.Key("country"), new Filter.Value("BG")));
-		assertThat(vectorExpr).isEqualTo("metadata.country:BG");
+		assertThat(vectorExpr).isEqualTo("metadata.country:\"BG\"");
 	}
 
 	@Test
@@ -74,14 +74,14 @@ class ElasticsearchAiSearchFilterExpressionConverterTest {
 		String vectorExpr = this.converter.convertExpression(new Filter.Expression(AND,
 				new Filter.Expression(EQ, new Filter.Key("genre"), new Filter.Value("drama")),
 				new Filter.Expression(GTE, new Filter.Key("year"), new Filter.Value(2020))));
-		assertThat(vectorExpr).isEqualTo("metadata.genre:drama AND metadata.year:>=2020");
+		assertThat(vectorExpr).isEqualTo("metadata.genre:\"drama\" AND metadata.year:>=2020");
 	}
 
 	@Test
 	public void tesIn() {
 		String vectorExpr = this.converter.convertExpression(new Filter.Expression(IN, new Filter.Key("genre"),
 				new Filter.Value(List.of("comedy", "documentary", "drama"))));
-		assertThat(vectorExpr).isEqualTo("(metadata.genre:comedy OR documentary OR drama)");
+		assertThat(vectorExpr).isEqualTo("metadata.genre:(\"comedy\" OR \"documentary\" OR \"drama\")");
 	}
 
 	@Test
@@ -91,7 +91,8 @@ class ElasticsearchAiSearchFilterExpressionConverterTest {
 						new Filter.Expression(AND,
 								new Filter.Expression(EQ, new Filter.Key("country"), new Filter.Value("BG")),
 								new Filter.Expression(NE, new Filter.Key("city"), new Filter.Value("Sofia")))));
-		assertThat(vectorExpr).isEqualTo("metadata.year:>=2020 OR metadata.country:BG AND metadata.city: NOT Sofia");
+		assertThat(vectorExpr)
+			.isEqualTo("metadata.year:>=2020 OR metadata.country:\"BG\" AND metadata.city: NOT \"Sofia\"");
 	}
 
 	@Test
@@ -101,8 +102,8 @@ class ElasticsearchAiSearchFilterExpressionConverterTest {
 						new Filter.Expression(GTE, new Filter.Key("year"), new Filter.Value(2020)),
 						new Filter.Expression(EQ, new Filter.Key("country"), new Filter.Value("BG")))),
 				new Filter.Expression(NIN, new Filter.Key("city"), new Filter.Value(List.of("Sofia", "Plovdiv")))));
-		assertThat(vectorExpr)
-			.isEqualTo("(metadata.year:>=2020 OR metadata.country:BG) AND NOT (metadata.city:Sofia OR Plovdiv)");
+		assertThat(vectorExpr).isEqualTo(
+				"(metadata.year:>=2020 OR metadata.country:\"BG\") AND NOT metadata.city:(\"Sofia\" OR \"Plovdiv\")");
 	}
 
 	@Test
@@ -112,8 +113,8 @@ class ElasticsearchAiSearchFilterExpressionConverterTest {
 						new Filter.Expression(GTE, new Filter.Key("year"), new Filter.Value(2020))),
 				new Filter.Expression(IN, new Filter.Key("country"), new Filter.Value(List.of("BG", "NL", "US")))));
 
-		assertThat(vectorExpr)
-			.isEqualTo("metadata.isOpen:true AND metadata.year:>=2020 AND (metadata.country:BG OR NL OR US)");
+		assertThat(vectorExpr).isEqualTo(
+				"metadata.isOpen:true AND metadata.year:>=2020 AND metadata.country:(\"BG\" OR \"NL\" OR \"US\")");
 	}
 
 	@Test
@@ -129,11 +130,10 @@ class ElasticsearchAiSearchFilterExpressionConverterTest {
 	public void testComplexIdentifiers() {
 		String vectorExpr = this.converter
 			.convertExpression(new Filter.Expression(EQ, new Filter.Key("\"country 1 2 3\""), new Filter.Value("BG")));
-		assertThat(vectorExpr).isEqualTo("metadata.country 1 2 3:BG");
-
+		assertThat(vectorExpr).isEqualTo("metadata.country 1 2 3:\"BG\"");
 		vectorExpr = this.converter
 			.convertExpression(new Filter.Expression(EQ, new Filter.Key("'country 1 2 3'"), new Filter.Value("BG")));
-		assertThat(vectorExpr).isEqualTo("metadata.country 1 2 3:BG");
+		assertThat(vectorExpr).isEqualTo("metadata.country 1 2 3:\"BG\"");
 	}
 
 }


### PR DESCRIPTION
Fixes GH-5297 (https://github.com/spring-projects/spring-ai/issues/5297)

### Description
The current `IN` operator in Elasticsearch produces `(field:val1 OR val2)`, which is incorrect for Lucene grouping. 
This PR changes it to `field:(val1 OR val2)` to ensure the values are correctly grouped for the specific field.

### Changes
- Updated `ElasticsearchAiSearchFilterExpressionConverter` to wrap `IN` and `NIN` values in parentheses after the field name.
- Added a new test case `testIn()` in `ElasticsearchAiSearchFilterExpressionConverterTest`.