### PR TITLE
GH-5263: Remove deprecated constants of mistral model enums

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -269,24 +269,7 @@ public class MistralAiApi {
 		MISTRAL_SMALL("mistral-small-latest"),
 		PIXTRAL_12B("pixtral-12b-latest"),
 		// Free Models - Research
-		OPEN_MISTRAL_NEMO("open-mistral-nemo"),
-
-		// Deprecated - use the new names above
-		/** @deprecated Use {@link #MISTRAL_LARGE} instead */
-		@Deprecated(forRemoval = true, since = "1.1.0")
-		LARGE("mistral-large-latest"),
-		/** @deprecated Use {@link #MISTRAL_SMALL} instead */
-		@Deprecated(forRemoval = true, since = "1.1.0")
-		SMALL("mistral-small-latest"),
-		/** @deprecated Use {@link #MINISTRAL_3B} instead */
-		@Deprecated(forRemoval = true, since = "1.1.0")
-		MINISTRAL_3B_LATEST("ministral-3b-latest"),
-		/** @deprecated Use {@link #MINISTRAL_8B} instead */
-		@Deprecated(forRemoval = true, since = "1.1.0")
-		MINISTRAL_8B_LATEST("ministral-8b-latest"),
-		/** @deprecated Use {@link #PIXTRAL_12B} instead */
-		@Deprecated(forRemoval = true, since = "1.1.0")
-		PIXTRAL("pixtral-12b-2409");
+		OPEN_MISTRAL_NEMO("open-mistral-nemo");
 		// @formatter:on
 
 		private final String value;

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
@@ -433,7 +433,7 @@ class MistralAiChatModelIT {
 		// Test using ResponseFormat.jsonSchema(Class<?>) for structured output
 
 		var promptOptions = MistralAiChatOptions.builder()
-			.model(MistralAiApi.ChatModel.SMALL.getValue())
+			.model(MistralAiApi.ChatModel.MISTRAL_SMALL.getValue())
 			.responseFormat(ResponseFormat.jsonSchema(MovieRecommendation.class))
 			.build();
 
@@ -474,7 +474,7 @@ class MistralAiChatModelIT {
 				"required", List.of("city", "country", "population", "famousFor"), "additionalProperties", false);
 
 		var promptOptions = MistralAiChatOptions.builder()
-			.model(MistralAiApi.ChatModel.SMALL.getValue())
+			.model(MistralAiApi.ChatModel.MISTRAL_SMALL.getValue())
 			.responseFormat(ResponseFormat.jsonSchema(schema))
 			.build();
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -172,7 +172,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         MistralAiChatOptions.builder()
-            .model(MistralAiApi.ChatModel.LARGE.getValue())
+            .model(MistralAiApi.ChatModel.MISTRAL_LARGE.getValue())
             .temperature(0.5)
         .build()
     ));
@@ -220,7 +220,7 @@ For more control, you can use the `ResponseFormat` class with `MistralAiChatOpti
 record MovieRecommendation(String title, String director, int year, String plotSummary) {}
 
 var options = MistralAiChatOptions.builder()
-    .model(MistralAiApi.ChatModel.SMALL.getValue())
+    .model(MistralAiApi.ChatModel.MISTRAL_SMALL.getValue())
     .responseFormat(ResponseFormat.jsonSchema(MovieRecommendation.class))
     .build();
 
@@ -396,7 +396,7 @@ Next, create a `MistralAiChatModel` and use it for text generations:
 var mistralAiApi = new MistralAiApi(System.getenv("MISTRAL_AI_API_KEY"));
 
 var chatModel = new MistralAiChatModel(this.mistralAiApi, MistralAiChatOptions.builder()
-                .model(MistralAiApi.ChatModel.LARGE.getValue())
+                .model(MistralAiApi.ChatModel.MISTRAL_LARGE.getValue())
                 .temperature(0.4)
                 .maxTokens(200)
                 .build());
@@ -427,11 +427,11 @@ ChatCompletionMessage chatCompletionMessage =
 
 // Sync request
 ResponseEntity<ChatCompletion> response = this.mistralAiApi.chatCompletionEntity(
-    new ChatCompletionRequest(List.of(this.chatCompletionMessage), MistralAiApi.ChatModel.LARGE.getValue(), 0.8, false));
+    new ChatCompletionRequest(List.of(this.chatCompletionMessage), MistralAiApi.ChatModel.MISTRAL_LARGE.getValue(), 0.8, false));
 
 // Streaming request
 Flux<ChatCompletionChunk> streamResponse = this.mistralAiApi.chatCompletionStream(
-        new ChatCompletionRequest(List.of(this.chatCompletionMessage), MistralAiApi.ChatModel.LARGE.getValue(), 0.8, true));
+        new ChatCompletionRequest(List.of(this.chatCompletionMessage), MistralAiApi.ChatModel.MISTRAL_LARGE.getValue(), 0.8, true));
 ----
 
 Follow the https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java[MistralAiApi.java]'s JavaDoc for further information.


### PR DESCRIPTION
# GH-5263: Remove deprecated constants of mistral model enums

Fixes https://github.com/spring-projects/spring-ai/issues/5263

## Summary
Cleanup for 2.0.0.RC1: Remove deprecated `MistralAiApi.ChatModel` enum constants that were kept for 1.1.x compatibility.

## Changes
- **MistralAiApi.java**: Remove deprecated enum constants:
  - `LARGE` (use `MISTRAL_LARGE`)
  - `SMALL` (use `MISTRAL_SMALL`)
  - `MINISTRAL_3B_LATEST` (use `MINISTRAL_3B`)
  - `MINISTRAL_8B_LATEST` (use `MINISTRAL_8B`)
  - `PIXTRAL` (use `PIXTRAL_12B`)
- **MistralAiChatModelIT.java**: Update tests to use `MISTRAL_SMALL` instead of `SMALL`
- **mistralai-chat.adoc**: Update docs to use `MISTRAL_SMALL` / `MISTRAL_LARGE` instead of `SMALL` / `LARGE`

## Checklist
- [x] Signed-off-by in commit message (DCO)
- [x] Topic branch `GH-5263` used
- [x] Tests pass (`mvn test -pl models/spring-ai-mistral-ai`)
- [x] Link to issue #5263 in PR description
