### PR TITLE
Prevent extra_body parameter from being serialized in OpenAI requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,7 @@ package.json
 shell.log
 
 .profiler
-/spring-ai-spring-boot-autoconfigure/nbproject/
-/vector-stores/spring-ai-cassandra-store/nbproject/
+nbproject/
 
 CLAUDE.md
 **/.claude/settings.local.json

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiApi.java
@@ -1160,7 +1160,7 @@ public class OpenAiApi {
 			@JsonProperty("verbosity") String verbosity,
 			@JsonProperty("prompt_cache_key") String promptCacheKey,
 			@JsonProperty("safety_identifier") String safetyIdentifier,
-			@JsonProperty("extra_body") Map<String, Object> extraBody) {
+			@JsonProperty(value = "extra_body", access = JsonProperty.Access.WRITE_ONLY) Map<String, Object> extraBody) {
 
 		/**
 		 * Compact constructor that ensures extraBody is initialized as a mutable HashMap


### PR DESCRIPTION
## Problem

When calling OpenAI APIs, Spring AI was serializing the `extra_body` field into the JSON request payload.
OpenAI rejects any unknown request parameters, causing requests to fail with a `400` error:
```
org.springframework.ai.retry.NonTransientAiException: HTTP 400 - {
  "error": {
    "message": "Unrecognized request argument supplied: extra_body",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
}
```

This occurs even when `extraBody` is `null` or empty, as it was still being serialized into the request.

## Root Cause

The `extraBody` field was annotated with `@JsonProperty`, causing it to be included during serialization (despite the presence of `@JsonAnyGetter`).
Since `extra_body` is not a recognized OpenAI request parameter, OpenAI rejects the request.

## Behavior Change
## Before
```
extraBody = null            -> {"extra_body": {}}
extraBody = Map.of()        -> {"extra_body": {}}
extraBody = Map.of("a","b") -> {"a": "b", "extra_body": {"a": "b"}}
```

## After
```
extraBody = null            -> {}
extraBody = Map.of()        -> {}
extraBody = Map.of("a","b") -> {"a": "b"}
```

## Impact
- Prevents invalid OpenAI request payloads
- Restores compatibility with OpenAI’s strict request validation
- No behavioral impact on consumers using extraBody internally

Closes #5196