### PR TITLE
docs: Fix comment typos in commons

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/VectorStoreObservationAttributes.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/VectorStoreObservationAttributes.java
@@ -72,7 +72,7 @@ public enum VectorStoreObservationAttributes {
 	DB_VECTOR_DIMENSION_COUNT("db.vector.dimension_count"),
 
 	/**
-	 * The name field as of the vector (e.g. a field name).
+	 * The name field of the vector (e.g. a field name).
 	 */
 	DB_VECTOR_FIELD_NAME("db.vector.field_name"),
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/VectorStoreProvider.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/VectorStoreProvider.java
@@ -52,7 +52,7 @@ public enum VectorStoreProvider {
 	 */
 	COSMOSDB("cosmosdb"),
 	/**
-	 * Vector store provided by CosmosDB.
+	 * Vector store provided by Couchbase.
 	 */
 	COUCHBASE("couchbase"),
 	/**

--- a/spring-ai-commons/src/main/java/org/springframework/ai/reader/TextReader.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/reader/TextReader.java
@@ -52,7 +52,7 @@ public class TextReader implements DocumentReader {
 	private final Map<String, Object> customMetadata = new HashMap<>();
 
 	/**
-	 * Character set to be used when loading data from the
+	 * Character set to be used when loading data from the input resource.
 	 */
 	private Charset charset = StandardCharsets.UTF_8;
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/util/JacksonUtils.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/util/JacksonUtils.java
@@ -34,8 +34,9 @@ public abstract class JacksonUtils {
 	/**
 	 * Instantiate well-known Jackson modules available in the classpath.
 	 * <p>
-	 * Supports the follow-modules: <code>Jdk8Module</code>, <code>JavaTimeModule</code>,
-	 * <code>ParameterNamesModule</code> and <code>KotlinModule</code>.
+	 * Supports the following modules: <code>Jdk8Module</code>,
+	 * <code>JavaTimeModule</code>, <code>ParameterNamesModule</code> and
+	 * <code>KotlinModule</code>.
 	 * @return The list of instantiated modules.
 	 */
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- Fix inaccurate or incomplete Javadoc text in observation/provider enums.
- Correct grammar/typos in commons reader and utility Javadocs.