### PR TITLE
Allow TokenTextSplitter to accept EncodingType

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Raphael Yu
  * @author Christian Tzolov
  * @author Ricken Bazolo
+ * @author Jemin Huh
  */
 public class TokenTextSplitter extends TextSplitter {
 
@@ -48,9 +49,11 @@ public class TokenTextSplitter extends TextSplitter {
 
 	private static final List<Character> DEFAULT_PUNCTUATION_MARKS = List.of('.', '?', '!', '\n');
 
+	private static final EncodingType DEFAULT_ENCODING_TYPE = EncodingType.CL100K_BASE;
+
 	private final EncodingRegistry registry = Encodings.newLazyEncodingRegistry();
 
-	private final Encoding encoding = this.registry.getEncoding(EncodingType.CL100K_BASE);
+	private final Encoding encoding;
 
 	// The target size of each text chunk in tokens
 	private final int chunkSize;
@@ -78,8 +81,25 @@ public class TokenTextSplitter extends TextSplitter {
 				DEFAULT_PUNCTUATION_MARKS);
 	}
 
+	public TokenTextSplitter(EncodingType encodingType) {
+		this(encodingType, DEFAULT_CHUNK_SIZE, MIN_CHUNK_SIZE_CHARS, MIN_CHUNK_LENGTH_TO_EMBED, MAX_NUM_CHUNKS,
+				KEEP_SEPARATOR, DEFAULT_PUNCTUATION_MARKS);
+	}
+
+	public TokenTextSplitter(EncodingType encodingType, boolean keepSeparator) {
+		this(encodingType, DEFAULT_CHUNK_SIZE, MIN_CHUNK_SIZE_CHARS, MIN_CHUNK_LENGTH_TO_EMBED, MAX_NUM_CHUNKS,
+				keepSeparator, DEFAULT_PUNCTUATION_MARKS);
+	}
+
 	public TokenTextSplitter(int chunkSize, int minChunkSizeChars, int minChunkLengthToEmbed, int maxNumChunks,
 			boolean keepSeparator, List<Character> punctuationMarks) {
+		this(DEFAULT_ENCODING_TYPE, DEFAULT_CHUNK_SIZE, MIN_CHUNK_SIZE_CHARS, MIN_CHUNK_LENGTH_TO_EMBED, MAX_NUM_CHUNKS,
+				keepSeparator, DEFAULT_PUNCTUATION_MARKS);
+	}
+
+	public TokenTextSplitter(EncodingType encodingType, int chunkSize, int minChunkSizeChars, int minChunkLengthToEmbed,
+			int maxNumChunks, boolean keepSeparator, List<Character> punctuationMarks) {
+		this.encoding = this.registry.getEncoding(encodingType);
 		this.chunkSize = chunkSize;
 		this.minChunkSizeChars = minChunkSizeChars;
 		this.minChunkLengthToEmbed = minChunkLengthToEmbed;
@@ -187,6 +207,8 @@ public class TokenTextSplitter extends TextSplitter {
 
 	public static final class Builder {
 
+		private EncodingType encodingType = DEFAULT_ENCODING_TYPE;
+
 		private int chunkSize = DEFAULT_CHUNK_SIZE;
 
 		private int minChunkSizeChars = MIN_CHUNK_SIZE_CHARS;
@@ -200,6 +222,11 @@ public class TokenTextSplitter extends TextSplitter {
 		private List<Character> punctuationMarks = DEFAULT_PUNCTUATION_MARKS;
 
 		private Builder() {
+		}
+
+		public Builder withEncodingType(EncodingType encodingType) {
+			this.encodingType = encodingType;
+			return this;
 		}
 
 		public Builder withChunkSize(int chunkSize) {
@@ -233,8 +260,8 @@ public class TokenTextSplitter extends TextSplitter {
 		}
 
 		public TokenTextSplitter build() {
-			return new TokenTextSplitter(this.chunkSize, this.minChunkSizeChars, this.minChunkLengthToEmbed,
-					this.maxNumChunks, this.keepSeparator, this.punctuationMarks);
+			return new TokenTextSplitter(this.encodingType, this.chunkSize, this.minChunkSizeChars,
+					this.minChunkLengthToEmbed, this.maxNumChunks, this.keepSeparator, this.punctuationMarks);
 		}
 
 	}


### PR DESCRIPTION
Replace the hardcoded CL100K_BASE encoding type with a configurable EncodingType.

This allows TokenTextSplitter to support different encoding types (e.g. CL100K_BASE, P50K_BASE, O200K_BASE).
