### PR TITLE
Refactor: Improve robustness in CosmosDBFilterExpressionConverter

### DIFF
--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverter.java
@@ -42,7 +42,10 @@ class CosmosDBFilterExpressionConverter extends AbstractFilterExpressionConverte
 	private Map<String, String> metadataFields;
 
 	CosmosDBFilterExpressionConverter(Collection<String> columns) {
-		this.metadataFields = columns.stream().collect(Collectors.toMap(Function.identity(), Function.identity()));
+		Assert.notNull(columns, "Columns must not be null");
+		this.metadataFields = columns.stream()
+				.distinct()
+				.collect(Collectors.toMap(Function.identity(), Function.identity()));
 	}
 
 	/**
@@ -58,13 +61,12 @@ class CosmosDBFilterExpressionConverter extends AbstractFilterExpressionConverte
 	@Override
 	protected void doKey(Key key, StringBuilder context) {
 		String keyName = key.key();
-		Optional<String> metadataField = getMetadataField(keyName);
-		if (metadataField.isPresent()) {
-			context.append("c.metadata." + metadataField.get());
-		}
-		else {
-			throw new IllegalArgumentException(String.format("No metadata field %s has been configured", keyName));
-		}
+
+		String field = getMetadataField(keyName)
+				.orElseThrow(() -> new IllegalArgumentException(
+						String.format("No metadata field %s has been configured", keyName)));
+
+		context.append("c.metadata.").append(field);
 	}
 
 	@Override

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverterTests.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverterTests.java
@@ -1,0 +1,76 @@
+package org.springframework.ai.vectorstore.cosmosdb;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.vectorstore.filter.Filter;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for CosmosDBFilterExpressionConverter.
+ * Verifies constructor robustness and doKey logic refactoring without Azure connection.
+ */
+class CosmosDBFilterExpressionConverterTests {
+
+	@Test
+	@DisplayName("Constructor should handle duplicate columns without exception using distinct()")
+	void constructor_ShouldHandleDuplicateColumns() {
+		// given
+		List<String> duplicateColumns = List.of("country", "year", "country"); // Duplicate 'country'
+
+		// when & then
+		assertThatCode(() -> new CosmosDBFilterExpressionConverter(duplicateColumns))
+				.doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("Constructor should throw exception when input columns are null")
+	void constructor_ShouldThrowExceptionOnNullInput() {
+		assertThatThrownBy(() -> new CosmosDBFilterExpressionConverter(null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Columns must not be null");
+	}
+
+	@Test
+	@DisplayName("doKey should correctly convert valid metadata fields")
+	void doKey_ShouldConvertValidMetadataField() {
+		// given
+		var converter = new CosmosDBFilterExpressionConverter(List.of("country"));
+		// Use public API convertExpression to invoke protected doKey
+		Filter.Expression expression = new Filter.Expression(
+				Filter.ExpressionType.EQ,
+				new Filter.Key("country"),
+				new Filter.Value("Korea")
+		);
+
+		// when
+		String result = converter.convertExpression(expression);
+
+		// then
+		// Verify "c.metadata.country" is generated
+		assertThat(result).contains("c.metadata.country");
+	}
+
+	@Test
+	@DisplayName("doKey should throw clear exception for unknown keys")
+	void doKey_ShouldThrowExceptionForUnknownKey() {
+		// given
+		var converter = new CosmosDBFilterExpressionConverter(List.of("country"));
+
+		// "city" is not configured in metadata fields
+		Filter.Expression expression = new Filter.Expression(
+				Filter.ExpressionType.EQ,
+				new Filter.Key("city"),
+				new Filter.Value("Seoul")
+		);
+
+		// when & then
+		assertThatThrownBy(() -> converter.convertExpression(expression))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("No metadata field city has been configured");
+	}
+}


### PR DESCRIPTION
Resolves #5337
This PR improves the robustness and readability of CosmosDBFilterExpressionConverter.

The changes are intentionally small and focused, addressing edge cases in the constructor and simplifying the doKey method to use more idiomatic Optional patterns.

All changes were made following a TDD-based approach, ensuring existing behavior is preserved while improving code quality.

1. Improve Constructor Robustness

before 
<img width="908" height="155" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/b73725f9-de13-4db1-b09a-e5314cfb994a" />

The constructor previously collected the provided columns directly into a Map using Collectors.toMap.

Problems addressed:
Duplicate column names would cause IllegalStateException
No explicit validation for null input

Improvements:
<img width="675" height="223" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/9c18c59b-fc18-42a9-bbfd-80ae1a07aa0d" />
Added Assert.notNull(columns, ...) to fail fast
Applied distinct() to safely handle duplicate column names

2. Simplify and Clarify doKey Method

<img width="910" height="248" alt="Pasted Graphic 13" src="https://github.com/user-attachments/assets/c7266326-2e0f-4d20-a333-ba1e8a2e93a0" />


The previous implementation relied on Optional.isPresent() followed by Optional.get(), which is verbose and less expressive.

Using Optional.get() without proper guarding can result in a NoSuchElementException and offers little advantage over traditional null checks. In such cases, it effectively behaves the same as accessing a potentially null value directly.

Improvement:
<img width="713" height="202" alt="image" src="https://github.com/user-attachments/assets/c4e2cd56-f544-42d9-a5d1-b288d9e4af56" />
Replaced with orElseThrow to clearly express that missing metadata configuration is an exceptional case
Improved readability and control flow

Testing (TDD)
The changes were implemented following a Test-Driven Development (TDD) approach.

Initially, I verified that an exception was thrown due to duplicate columns.
<img width="847" height="272" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/4f77571d-5fd8-41bb-b040-37fc6e611919" />


<img width="1073" height="310" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/1469276b-75d4-4b39-965e-2bf08e29b950" />

Verified that the constructor throws an IllegalArgumentException when the input is null

<img width="713" height="191" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/70f0d405-e929-45ff-bca7-ace6ec80cb4a" />

<img width="1071" height="212" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/22470672-c61b-4270-8575-c3bd90fb21a2" />


After modifying the application, I verified via unit tests that duplicate columns are handled safely without throwing exceptions

<img width="856" height="241" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/928b5cb6-d45c-42fb-8a8b-8010f4f23c10" />

<img width="694" height="95" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/eaab9dea-6f20-4a29-b199-fe37196273d2" />

Verified that null input is explicitly rejected with an IllegalArgumentException

<img width="657" height="202" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/191c26b8-85de-4e89-9f1d-b1092b899d26" />

<img width="711" height="188" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/0ec4c10f-8628-48ed-93f2-bc3709048556" />

This test ensures the robustness of the doKey method. It initializes the converter with a specific field (e.g., "country") and attempts to create a filter expression using an unconfigured field (e.g., "city"). The test asserts that this invalid operation triggers an IllegalArgumentException with the message "No metadata field city has been configured", confirming that the orElseThrow logic works as expected.

<img width="744" height="428" alt="Pasted Graphic 10" src="https://github.com/user-attachments/assets/85682d38-6c26-42ad-b892-9ff2dfc87464" />

<img width="749" height="123" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/28378007-3ef0-460c-8c89-0a0f75a0a6ed" />



I executed the full unit test suite to verify test isolation.
<img width="596" height="190" alt="✓ doKey should throw clear exception for unknown keys" src="https://github.com/user-attachments/assets/f87f8141-f885-47a2-9780-78b443a58769" />


