### PR TITLE
Fix locale-sensitive uppercasing in JSON schema type normalization

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -258,29 +259,33 @@ public final class JsonSchemaGenerator {
 
 	// Based on the method in ModelOptionsUtils.
 	public static void convertTypeValuesToUpperCase(ObjectNode node) {
+		convertTypeValuesToUpperCase(node, Locale.ROOT);
+	}
+	
+	public static void convertTypeValuesToUpperCase(ObjectNode node, Locale locale) {
 		if (node.isObject()) {
 			node.fields().forEachRemaining(entry -> {
 				JsonNode value = entry.getValue();
 				if (value.isObject()) {
-					convertTypeValuesToUpperCase((ObjectNode) value);
+					convertTypeValuesToUpperCase((ObjectNode) value, locale);
 				}
 				else if (value.isArray()) {
 					value.elements().forEachRemaining(element -> {
 						if (element.isObject() || element.isArray()) {
-							convertTypeValuesToUpperCase((ObjectNode) element);
+							convertTypeValuesToUpperCase((ObjectNode) element, locale);
 						}
 					});
 				}
 				else if (value.isTextual() && entry.getKey().equals("type")) {
 					String oldValue = node.get("type").asText();
-					node.put("type", oldValue.toUpperCase());
+					node.put("type", oldValue.toUpperCase(locale));
 				}
 			});
 		}
 		else if (node.isArray()) {
 			node.elements().forEachRemaining(element -> {
 				if (element.isObject() || element.isArray()) {
-					convertTypeValuesToUpperCase((ObjectNode) element);
+					convertTypeValuesToUpperCase((ObjectNode) element, locale);
 				}
 			});
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.Locale;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,7 @@ import org.springframework.lang.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests for {@link JsonSchemaGenerator}.
@@ -699,6 +702,23 @@ class JsonSchemaGeneratorTests {
 	void throwExceptionWhenTypeIsNull() {
 		assertThatThrownBy(() -> JsonSchemaGenerator.generateForType(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("type cannot be null");
+	}
+	
+	@Test
+	void shouldUppercaseTypesIndependentlyOfLocale() throws JsonProcessingException {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(new Locale("tr", "TR"));
+
+			ObjectNode objectNode = JsonParser.getObjectMapper().createObjectNode();
+			objectNode.put("type", "integer");
+
+			JsonSchemaGenerator.convertTypeValuesToUpperCase(objectNode);
+
+			assertEquals("INTEGER", objectNode.get("type").asText());
+		} finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 	static class TestMethods {


### PR DESCRIPTION
### Summary
Fixes locale-sensitive uppercasing when normalizing JSON schema type values.
On Turkish locales (tr_TR), `String.toUpperCase()` produces invalid values
(e.g. `İNTEGER`, `STRİNG`), which breaks Gemini tool calling.

### Changes
- Overloaded JsonSchemaGenerator.convertTypeValuesToUpperCase to accept Locale
- Defaulted normalization to `Locale.ROOT`
- Added regression test for Turkish locale

Fixes #5340 