### PR TITLE
GH-5345: Add rate limit metadata extraction for Anthropic API responses

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -46,6 +46,7 @@ import org.springframework.ai.anthropic.api.AnthropicCacheOptions;
 import org.springframework.ai.anthropic.api.AnthropicCacheTtl;
 import org.springframework.ai.anthropic.api.CitationDocument;
 import org.springframework.ai.anthropic.api.utils.CacheEligibilityResolver;
+import org.springframework.ai.anthropic.metadata.support.AnthropicResponseHeaderExtractor;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
@@ -55,6 +56,7 @@ import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.EmptyUsage;
+import org.springframework.ai.chat.metadata.RateLimit;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -79,6 +81,7 @@ import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.json.JsonParser;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -97,6 +100,7 @@ import org.springframework.util.StringUtils;
  * @author Jonghoon Park
  * @author Soby Chacko
  * @author Austin Dase
+ * @author Jake Son
  * @since 1.0.0
  */
 public class AnthropicChatModel implements ChatModel {
@@ -204,7 +208,9 @@ public class AnthropicChatModel implements ChatModel {
 				Usage accumulatedUsage = UsageCalculator.getCumulativeUsage(currentChatResponseUsage,
 						previousChatResponse);
 
-				ChatResponse chatResponse = toChatResponse(completionEntity.getBody(), accumulatedUsage);
+				RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(completionEntity);
+
+				ChatResponse chatResponse = toChatResponse(completionEntity.getBody(), accumulatedUsage, rateLimit);
 				observationContext.setResponse(chatResponse);
 
 				return chatResponse;
@@ -266,7 +272,7 @@ public class AnthropicChatModel implements ChatModel {
 				AnthropicApi.Usage usage = chatCompletionResponse.usage();
 				Usage currentChatResponseUsage = usage != null ? this.getDefaultUsage(chatCompletionResponse.usage()) : new EmptyUsage();
 				Usage accumulatedUsage = UsageCalculator.getCumulativeUsage(currentChatResponseUsage, previousChatResponse);
-				ChatResponse chatResponse = toChatResponse(chatCompletionResponse, accumulatedUsage);
+				ChatResponse chatResponse = toChatResponse(chatCompletionResponse, accumulatedUsage, null);
 
 				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), chatResponse)) {
 
@@ -314,7 +320,8 @@ public class AnthropicChatModel implements ChatModel {
 		});
 	}
 
-	private ChatResponse toChatResponse(ChatCompletionResponse chatCompletion, Usage usage) {
+	private ChatResponse toChatResponse(ChatCompletionResponse chatCompletion, Usage usage,
+			@Nullable RateLimit rateLimit) {
 
 		if (chatCompletion == null) {
 			logger.warn("Null chat completion returned");
@@ -383,6 +390,10 @@ public class AnthropicChatModel implements ChatModel {
 			.keyValue("stop-sequence", chatCompletion.stopSequence())
 			.keyValue("type", chatCompletion.type())
 			.keyValue("anthropic-response", chatCompletion);
+
+		if (rateLimit != null) {
+			metadataBuilder.rateLimit(rateLimit);
+		}
 
 		// Add citation metadata if citations were found
 		if (citationContext.hasCitations()) {

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/AnthropicRateLimit.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/AnthropicRateLimit.java
@@ -19,31 +19,55 @@ package org.springframework.ai.anthropic.metadata;
 import java.time.Duration;
 
 import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.lang.Nullable;
 
 /**
- * {@link RateLimit} implementation for {@literal OpenAI}.
+ * {@link RateLimit} implementation for {@literal Anthropic}.
+ * <p>
+ * Anthropic provides rate limit information for requests, tokens, input tokens, and
+ * output tokens. The base {@link RateLimit} interface provides access to request and
+ * token limits. This class extends those with additional Anthropic-specific methods for
+ * input and output token limits.
  *
  * @author Christian Tzolov
+ * @author Jake Son
  * @since 1.0.0
  */
 public class AnthropicRateLimit implements RateLimit {
 
-	private static final String RATE_LIMIT_STRING = "{ @type: %1$s, requestsLimit: %2$s, requestsRemaining: %3$s, requestsReset: %4$s, tokensLimit: %5$s; tokensRemaining: %6$s; tokensReset: %7$s }";
+	private static final String RATE_LIMIT_STRING = "{ @type: %1$s, requestsLimit: %2$s, requestsRemaining: %3$s, "
+			+ "requestsReset: %4$s, tokensLimit: %5$s, tokensRemaining: %6$s, tokensReset: %7$s, "
+			+ "inputTokensLimit: %8$s, inputTokensRemaining: %9$s, inputTokensReset: %10$s, "
+			+ "outputTokensLimit: %11$s, outputTokensRemaining: %12$s, outputTokensReset: %13$s }";
 
 	private final Long requestsLimit;
 
 	private final Long requestsRemaining;
 
+	private final Duration requestsReset;
+
 	private final Long tokensLimit;
 
 	private final Long tokensRemaining;
 
-	private final Duration requestsReset;
-
 	private final Duration tokensReset;
 
+	private final Long inputTokensLimit;
+
+	private final Long inputTokensRemaining;
+
+	private final Duration inputTokensReset;
+
+	private final Long outputTokensLimit;
+
+	private final Long outputTokensRemaining;
+
+	private final Duration outputTokensReset;
+
 	public AnthropicRateLimit(Long requestsLimit, Long requestsRemaining, Duration requestsReset, Long tokensLimit,
-			Long tokensRemaining, Duration tokensReset) {
+			Long tokensRemaining, Duration tokensReset, @Nullable Long inputTokensLimit,
+			@Nullable Long inputTokensRemaining, @Nullable Duration inputTokensReset, @Nullable Long outputTokensLimit,
+			@Nullable Long outputTokensRemaining, @Nullable Duration outputTokensReset) {
 
 		this.requestsLimit = requestsLimit;
 		this.requestsRemaining = requestsRemaining;
@@ -51,6 +75,12 @@ public class AnthropicRateLimit implements RateLimit {
 		this.tokensLimit = tokensLimit;
 		this.tokensRemaining = tokensRemaining;
 		this.tokensReset = tokensReset;
+		this.inputTokensLimit = inputTokensLimit;
+		this.inputTokensRemaining = inputTokensRemaining;
+		this.inputTokensReset = inputTokensReset;
+		this.outputTokensLimit = outputTokensLimit;
+		this.outputTokensRemaining = outputTokensRemaining;
+		this.outputTokensReset = outputTokensReset;
 	}
 
 	@Override
@@ -59,18 +89,8 @@ public class AnthropicRateLimit implements RateLimit {
 	}
 
 	@Override
-	public Long getTokensLimit() {
-		return this.tokensLimit;
-	}
-
-	@Override
 	public Long getRequestsRemaining() {
 		return this.requestsRemaining;
-	}
-
-	@Override
-	public Long getTokensRemaining() {
-		return this.tokensRemaining;
 	}
 
 	@Override
@@ -79,14 +99,74 @@ public class AnthropicRateLimit implements RateLimit {
 	}
 
 	@Override
+	public Long getTokensLimit() {
+		return this.tokensLimit;
+	}
+
+	@Override
+	public Long getTokensRemaining() {
+		return this.tokensRemaining;
+	}
+
+	@Override
 	public Duration getTokensReset() {
 		return this.tokensReset;
+	}
+
+	/**
+	 * Returns the maximum number of input tokens allowed within the rate limit window.
+	 * @return the input tokens limit, or null if not provided
+	 */
+	public @Nullable Long getInputTokensLimit() {
+		return this.inputTokensLimit;
+	}
+
+	/**
+	 * Returns the number of input tokens remaining within the current rate limit window.
+	 * @return the remaining input tokens, or null if not provided
+	 */
+	public @Nullable Long getInputTokensRemaining() {
+		return this.inputTokensRemaining;
+	}
+
+	/**
+	 * Returns the duration until the input token rate limit window resets.
+	 * @return the duration until reset, or null if not provided
+	 */
+	public @Nullable Duration getInputTokensReset() {
+		return this.inputTokensReset;
+	}
+
+	/**
+	 * Returns the maximum number of output tokens allowed within the rate limit window.
+	 * @return the output tokens limit, or null if not provided
+	 */
+	public @Nullable Long getOutputTokensLimit() {
+		return this.outputTokensLimit;
+	}
+
+	/**
+	 * Returns the number of output tokens remaining within the current rate limit window.
+	 * @return the remaining output tokens, or null if not provided
+	 */
+	public @Nullable Long getOutputTokensRemaining() {
+		return this.outputTokensRemaining;
+	}
+
+	/**
+	 * Returns the duration until the output token rate limit window resets.
+	 * @return the duration until reset, or null if not provided
+	 */
+	public @Nullable Duration getOutputTokensReset() {
+		return this.outputTokensReset;
 	}
 
 	@Override
 	public String toString() {
 		return RATE_LIMIT_STRING.formatted(getClass().getName(), getRequestsLimit(), getRequestsRemaining(),
-				getRequestsReset(), getTokensLimit(), getTokensRemaining(), getTokensReset());
+				getRequestsReset(), getTokensLimit(), getTokensRemaining(), getTokensReset(), getInputTokensLimit(),
+				getInputTokensRemaining(), getInputTokensReset(), getOutputTokensLimit(), getOutputTokensRemaining(),
+				getOutputTokensReset());
 	}
 
 }

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/support/AnthropicApiResponseHeaders.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/support/AnthropicApiResponseHeaders.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.metadata.support;
+
+/**
+ * Enumeration of HTTP response headers for the {@literal Anthropic} API rate limiting.
+ *
+ * @author Jake Son
+ * @see <a href="https://docs.anthropic.com/en/api/rate-limits#response-headers">Anthropic
+ * Rate Limits</a>
+ */
+public enum AnthropicApiResponseHeaders {
+
+	// Request rate limit headers
+	REQUESTS_LIMIT_HEADER("anthropic-ratelimit-requests-limit"),
+	REQUESTS_REMAINING_HEADER("anthropic-ratelimit-requests-remaining"),
+	REQUESTS_RESET_HEADER("anthropic-ratelimit-requests-reset"),
+
+	// Token rate limit headers
+	TOKENS_LIMIT_HEADER("anthropic-ratelimit-tokens-limit"),
+	TOKENS_REMAINING_HEADER("anthropic-ratelimit-tokens-remaining"),
+	TOKENS_RESET_HEADER("anthropic-ratelimit-tokens-reset"),
+
+	// Input token rate limit headers
+	INPUT_TOKENS_LIMIT_HEADER("anthropic-ratelimit-input-tokens-limit"),
+	INPUT_TOKENS_REMAINING_HEADER("anthropic-ratelimit-input-tokens-remaining"),
+	INPUT_TOKENS_RESET_HEADER("anthropic-ratelimit-input-tokens-reset"),
+
+	// Output token rate limit headers
+	OUTPUT_TOKENS_LIMIT_HEADER("anthropic-ratelimit-output-tokens-limit"),
+	OUTPUT_TOKENS_REMAINING_HEADER("anthropic-ratelimit-output-tokens-remaining"),
+	OUTPUT_TOKENS_RESET_HEADER("anthropic-ratelimit-output-tokens-reset");
+
+	private final String name;
+
+	AnthropicApiResponseHeaders(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/support/AnthropicResponseHeaderExtractor.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/support/AnthropicResponseHeaderExtractor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.metadata.support;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.anthropic.metadata.AnthropicRateLimit;
+import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility used to extract known HTTP response headers for the {@literal Anthropic} API.
+ *
+ * @author Jake Son
+ */
+public final class AnthropicResponseHeaderExtractor {
+
+	private static final Logger logger = LoggerFactory.getLogger(AnthropicResponseHeaderExtractor.class);
+
+	private AnthropicResponseHeaderExtractor() {
+	}
+
+	public static RateLimit extractAiResponseHeaders(ResponseEntity<?> response) {
+
+		Instant now = Instant.now();
+
+		Long requestsLimit = getHeaderAsLongOrDefault(response,
+				AnthropicApiResponseHeaders.REQUESTS_LIMIT_HEADER.getName());
+		Long requestsRemaining = getHeaderAsLongOrDefault(response,
+				AnthropicApiResponseHeaders.REQUESTS_REMAINING_HEADER.getName());
+		Duration requestsReset = getHeaderAsDurationOrDefault(response,
+				AnthropicApiResponseHeaders.REQUESTS_RESET_HEADER.getName(), now);
+
+		Long tokensLimit = getHeaderAsLongOrDefault(response,
+				AnthropicApiResponseHeaders.TOKENS_LIMIT_HEADER.getName());
+		Long tokensRemaining = getHeaderAsLongOrDefault(response,
+				AnthropicApiResponseHeaders.TOKENS_REMAINING_HEADER.getName());
+		Duration tokensReset = getHeaderAsDurationOrDefault(response,
+				AnthropicApiResponseHeaders.TOKENS_RESET_HEADER.getName(), now);
+
+		Long inputTokensLimit = getHeaderAsLong(response,
+				AnthropicApiResponseHeaders.INPUT_TOKENS_LIMIT_HEADER.getName());
+		Long inputTokensRemaining = getHeaderAsLong(response,
+				AnthropicApiResponseHeaders.INPUT_TOKENS_REMAINING_HEADER.getName());
+		Duration inputTokensReset = getHeaderAsDuration(response,
+				AnthropicApiResponseHeaders.INPUT_TOKENS_RESET_HEADER.getName(), now);
+
+		Long outputTokensLimit = getHeaderAsLong(response,
+				AnthropicApiResponseHeaders.OUTPUT_TOKENS_LIMIT_HEADER.getName());
+		Long outputTokensRemaining = getHeaderAsLong(response,
+				AnthropicApiResponseHeaders.OUTPUT_TOKENS_REMAINING_HEADER.getName());
+		Duration outputTokensReset = getHeaderAsDuration(response,
+				AnthropicApiResponseHeaders.OUTPUT_TOKENS_RESET_HEADER.getName(), now);
+
+		return new AnthropicRateLimit(requestsLimit, requestsRemaining, requestsReset, tokensLimit, tokensRemaining,
+				tokensReset, inputTokensLimit, inputTokensRemaining, inputTokensReset, outputTokensLimit,
+				outputTokensRemaining, outputTokensReset);
+	}
+
+	private static Duration getHeaderAsDurationOrDefault(ResponseEntity<?> response, String headerName, Instant now) {
+		Duration duration = getHeaderAsDuration(response, headerName, now);
+		return duration != null ? duration : Duration.ZERO;
+	}
+
+	private static Duration getHeaderAsDuration(ResponseEntity<?> response, String headerName, Instant now) {
+		var headers = response.getHeaders();
+		var values = headers.get(headerName);
+		if (!CollectionUtils.isEmpty(values)) {
+			return parseRfc3339ToDuration(headerName, values.get(0), now);
+		}
+		return null;
+	}
+
+	private static Long getHeaderAsLongOrDefault(ResponseEntity<?> response, String headerName) {
+		Long value = getHeaderAsLong(response, headerName);
+		return value != null ? value : 0L;
+	}
+
+	private static Long getHeaderAsLong(ResponseEntity<?> response, String headerName) {
+		var headers = response.getHeaders();
+		var values = headers.get(headerName);
+		if (!CollectionUtils.isEmpty(values)) {
+			return parseLong(headerName, values.get(0));
+		}
+		return null;
+	}
+
+	private static Duration parseRfc3339ToDuration(String headerName, String headerValue, Instant now) {
+
+		if (StringUtils.hasText(headerValue)) {
+			try {
+				Instant resetTime = Instant.parse(headerValue.trim());
+				Duration duration = Duration.between(now, resetTime);
+				return duration.isNegative() ? Duration.ZERO : duration;
+			}
+			catch (Exception e) {
+				logger.warn("Value [{}] for HTTP header [{}] is not a valid RFC 3339 timestamp: {}", headerValue,
+						headerName, e.getMessage());
+			}
+		}
+
+		return null;
+	}
+
+	private static Long parseLong(String headerName, String headerValue) {
+
+		if (StringUtils.hasText(headerValue)) {
+			try {
+				return Long.parseLong(headerValue.trim());
+			}
+			catch (NumberFormatException e) {
+				logger.warn("Value [{}] for HTTP header [{}] is not valid: {}", headerValue, headerName,
+						e.getMessage());
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/metadata/support/AnthropicResponseHeaderExtractorTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/metadata/support/AnthropicResponseHeaderExtractorTests.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.metadata.support;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.anthropic.metadata.AnthropicRateLimit;
+import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AnthropicResponseHeaderExtractor}.
+ *
+ * @author Jake Son
+ */
+class AnthropicResponseHeaderExtractorTests {
+
+	@Test
+	void extractAllHeaders() {
+		Instant futureTime = Instant.now().plus(60, ChronoUnit.SECONDS);
+		String resetTime = futureTime.toString();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-limit", "1000");
+		headers.add("anthropic-ratelimit-requests-remaining", "999");
+		headers.add("anthropic-ratelimit-requests-reset", resetTime);
+		headers.add("anthropic-ratelimit-tokens-limit", "100000");
+		headers.add("anthropic-ratelimit-tokens-remaining", "99000");
+		headers.add("anthropic-ratelimit-tokens-reset", resetTime);
+		headers.add("anthropic-ratelimit-input-tokens-limit", "50000");
+		headers.add("anthropic-ratelimit-input-tokens-remaining", "49500");
+		headers.add("anthropic-ratelimit-input-tokens-reset", resetTime);
+		headers.add("anthropic-ratelimit-output-tokens-limit", "50000");
+		headers.add("anthropic-ratelimit-output-tokens-remaining", "49500");
+		headers.add("anthropic-ratelimit-output-tokens-reset", resetTime);
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit).isInstanceOf(AnthropicRateLimit.class);
+		assertThat(rateLimit.getRequestsLimit()).isEqualTo(1000L);
+		assertThat(rateLimit.getRequestsRemaining()).isEqualTo(999L);
+		assertThat(rateLimit.getRequestsReset()).isNotNull();
+		assertThat(rateLimit.getTokensLimit()).isEqualTo(100000L);
+		assertThat(rateLimit.getTokensRemaining()).isEqualTo(99000L);
+		assertThat(rateLimit.getTokensReset()).isNotNull();
+
+		AnthropicRateLimit anthropicRateLimit = (AnthropicRateLimit) rateLimit;
+		assertThat(anthropicRateLimit.getInputTokensLimit()).isEqualTo(50000L);
+		assertThat(anthropicRateLimit.getInputTokensRemaining()).isEqualTo(49500L);
+		assertThat(anthropicRateLimit.getInputTokensReset()).isNotNull();
+		assertThat(anthropicRateLimit.getOutputTokensLimit()).isEqualTo(50000L);
+		assertThat(anthropicRateLimit.getOutputTokensRemaining()).isEqualTo(49500L);
+		assertThat(anthropicRateLimit.getOutputTokensReset()).isNotNull();
+	}
+
+	@Test
+	void extractPartialHeaders() {
+		Instant futureTime = Instant.now().plus(60, ChronoUnit.SECONDS);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-limit", "1000");
+		headers.add("anthropic-ratelimit-requests-remaining", "999");
+		headers.add("anthropic-ratelimit-requests-reset", futureTime.toString());
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsLimit()).isEqualTo(1000L);
+		assertThat(rateLimit.getRequestsRemaining()).isEqualTo(999L);
+		assertThat(rateLimit.getRequestsReset()).isNotNull();
+
+		assertThat(rateLimit.getTokensLimit()).isEqualTo(0L);
+		assertThat(rateLimit.getTokensRemaining()).isEqualTo(0L);
+		assertThat(rateLimit.getTokensReset()).isEqualTo(Duration.ZERO);
+
+		AnthropicRateLimit anthropicRateLimit = (AnthropicRateLimit) rateLimit;
+		assertThat(anthropicRateLimit.getInputTokensLimit()).isNull();
+		assertThat(anthropicRateLimit.getOutputTokensLimit()).isNull();
+	}
+
+	@Test
+	void extractNoHeaders() {
+		HttpHeaders headers = new HttpHeaders();
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsLimit()).isEqualTo(0L);
+		assertThat(rateLimit.getRequestsRemaining()).isEqualTo(0L);
+		assertThat(rateLimit.getRequestsReset()).isEqualTo(Duration.ZERO);
+		assertThat(rateLimit.getTokensLimit()).isEqualTo(0L);
+		assertThat(rateLimit.getTokensRemaining()).isEqualTo(0L);
+		assertThat(rateLimit.getTokensReset()).isEqualTo(Duration.ZERO);
+
+		AnthropicRateLimit anthropicRateLimit = (AnthropicRateLimit) rateLimit;
+		assertThat(anthropicRateLimit.getInputTokensLimit()).isNull();
+		assertThat(anthropicRateLimit.getInputTokensRemaining()).isNull();
+		assertThat(anthropicRateLimit.getInputTokensReset()).isNull();
+		assertThat(anthropicRateLimit.getOutputTokensLimit()).isNull();
+		assertThat(anthropicRateLimit.getOutputTokensRemaining()).isNull();
+		assertThat(anthropicRateLimit.getOutputTokensReset()).isNull();
+	}
+
+	@Test
+	void parseRfc3339Timestamp() {
+		// Future time: should return positive duration
+		Instant futureTime = Instant.now().plus(120, ChronoUnit.SECONDS);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-reset", futureTime.toString());
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsReset()).isNotNull();
+		assertThat(rateLimit.getRequestsReset().getSeconds()).isGreaterThan(0);
+		assertThat(rateLimit.getRequestsReset().getSeconds()).isLessThanOrEqualTo(120);
+	}
+
+	@Test
+	void parseRfc3339TimestampPastReturnsZero() {
+		// Past time: should return zero duration
+		Instant pastTime = Instant.now().minus(60, ChronoUnit.SECONDS);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-reset", pastTime.toString());
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsReset()).isEqualTo(Duration.ZERO);
+	}
+
+	@Test
+	void handleInvalidTimestamp() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-reset", "not-a-valid-timestamp");
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsReset()).isEqualTo(Duration.ZERO);
+	}
+
+	@Test
+	void handleInvalidLongValue() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-limit", "not-a-number");
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsLimit()).isEqualTo(0L);
+	}
+
+	@Test
+	void handleEmptyHeaderValue() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-limit", "");
+		headers.add("anthropic-ratelimit-requests-reset", "");
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsLimit()).isEqualTo(0L);
+		assertThat(rateLimit.getRequestsReset()).isEqualTo(Duration.ZERO);
+	}
+
+	@Test
+	void handleWhitespaceInValues() {
+		Instant futureTime = Instant.now().plus(60, ChronoUnit.SECONDS);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("anthropic-ratelimit-requests-limit", "  1000  ");
+		headers.add("anthropic-ratelimit-requests-reset", "  " + futureTime.toString() + "  ");
+
+		ResponseEntity<String> response = ResponseEntity.ok().headers(headers).body("test");
+
+		RateLimit rateLimit = AnthropicResponseHeaderExtractor.extractAiResponseHeaders(response);
+
+		assertThat(rateLimit.getRequestsLimit()).isEqualTo(1000L);
+		assertThat(rateLimit.getRequestsReset()).isNotNull();
+	}
+
+}


### PR DESCRIPTION
resolves #5345 

Extract rate limit information from Anthropic API response headers and expose it through ChatResponseMetadata. This includes request limits, token limits, and Anthropic-specific input/output token limits.

- Add AnthropicApiResponseHeaders enum for rate limit header names
- Add AnthropicResponseHeaderExtractor utility to parse response headers
- Extend AnthropicRateLimit with input/output token limit fields
- Update AnthropicChatModel to include rate limit in response metadata
- Add unit tests for header extraction and integration test validation