### PR TITLE
minor(mcp): Make default title of mcp clients info consistent

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java
@@ -258,7 +258,7 @@ public class McpClientAutoConfiguration {
 
 				McpSchema.Implementation clientInfo = new McpSchema.Implementation(
 						this.connectedClientName(commonProperties.getName(), namedTransport.name()),
-						commonProperties.getVersion());
+						namedTransport.name(), commonProperties.getVersion());
 				McpClient.AsyncSpec spec = McpClient.async(namedTransport.transport())
 					.clientInfo(clientInfo)
 					.requestTimeout(commonProperties.getRequestTimeout());


### PR DESCRIPTION
We should keep the clientInfo title consistent for mcp syncClients and asyncClients. Currently, we use `namedTransport.name()` as the syncClient info title, and this PR will also use `namedTransport.name()` as the `asyncClient` info title.

https://github.com/spring-projects/spring-ai/blob/ea7c7367687d9ef9f5f8255a49f10b1e2d0d3279/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpClientAutoConfiguration.java#L169-L172