### PR TITLE
Add ToolChoice support to Bedrock Converse (BedrockProxyChatModel)

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
+import software.amazon.awssdk.services.bedrockruntime.model.ToolChoice;
 
 import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
 import org.springframework.ai.chat.prompt.ChatOptions;
@@ -90,6 +91,8 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 	@JsonIgnore
 	private String outputSchema;
 
+	private ToolChoice toolChoice;
+
 	// TODO: left here for ModelOptionUtils.merge*()
 	public BedrockChatOptions() {
 	}
@@ -98,7 +101,7 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 			Map<String, String> requestParameters, List<String> stopSequences, Double temperature, Integer topK,
 			Double topP, Boolean internalToolExecutionEnabled, @Nullable List<ToolCallback> toolCallbacks,
 			@Nullable Set<String> toolNames, @Nullable Map<String, Object> toolContext,
-			BedrockCacheOptions cacheOptions, String outputSchema) {
+			BedrockCacheOptions cacheOptions, String outputSchema, ToolChoice toolChoice) {
 		this.model = model;
 		this.frequencyPenalty = frequencyPenalty;
 		this.maxTokens = maxTokens;
@@ -114,6 +117,7 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		this.toolContext = toolContext == null ? new HashMap<>() : new HashMap<>(toolContext);
 		this.cacheOptions = cacheOptions;
 		this.outputSchema = outputSchema;
+		this.toolChoice = toolChoice;
 	}
 
 	public static Builder builder() {
@@ -266,6 +270,16 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		this.cacheOptions = cacheOptions;
 	}
 
+	@JsonIgnore
+	public ToolChoice getToolChoice() {
+		return this.toolChoice;
+	}
+
+	@JsonIgnore
+	public void setToolChoice(ToolChoice toolChoice) {
+		this.toolChoice = toolChoice;
+	}
+
 	@Override
 	public @Nullable String getOutputSchema() {
 		return this.outputSchema;
@@ -301,7 +315,8 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 			// Bedrock Specific
 			.requestParameters(this.requestParameters)
 			.cacheOptions(this.cacheOptions)
-			.outputSchema(this.outputSchema);
+			.outputSchema(this.outputSchema)
+			.toolChoice(this.toolChoice);
 	}
 
 	@Override
@@ -322,14 +337,16 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 				&& Objects.equals(this.toolNames, that.toolNames) && Objects.equals(this.toolContext, that.toolContext)
 				&& Objects.equals(this.internalToolExecutionEnabled, that.internalToolExecutionEnabled)
 				&& Objects.equals(this.cacheOptions, that.cacheOptions)
-				&& Objects.equals(this.outputSchema, that.outputSchema);
+				&& Objects.equals(this.outputSchema, that.outputSchema)
+				&& Objects.equals(this.toolChoice, that.toolChoice);
 	}
 
 	@Override
 	public int hashCode() {
 		return Objects.hash(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
 				this.requestParameters, this.stopSequences, this.temperature, this.topK, this.topP, this.toolCallbacks,
-				this.toolNames, this.toolContext, this.internalToolExecutionEnabled, this.cacheOptions);
+				this.toolNames, this.toolContext, this.internalToolExecutionEnabled, this.cacheOptions,
+				this.toolChoice);
 	}
 
 	// public Builder class exposed to users. Avoids having to deal with noisy generic
@@ -346,6 +363,8 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		protected @Nullable BedrockCacheOptions cacheOptions;
 
 		private @Nullable String outputSchema;
+
+		private @Nullable ToolChoice toolChoice;
 
 		public B requestParameters(Map<String, String> requestParameters) {
 			this.requestParameters = requestParameters;
@@ -376,12 +395,17 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 			return self();
 		}
 
+		public B toolChoice(@Nullable ToolChoice toolChoice) {
+			this.toolChoice = toolChoice;
+			return self();
+		}
+
 		@Override
 		public BedrockChatOptions build() {
 			return new BedrockChatOptions(this.model, this.frequencyPenalty, this.maxTokens, this.presencePenalty,
 					this.requestParameters, this.stopSequences, this.temperature, this.topK, this.topP,
 					this.internalToolExecutionEnabled, this.toolCallbacks, this.toolNames, this.toolContext,
-					this.cacheOptions, this.outputSchema);
+					this.cacheOptions, this.outputSchema, this.toolChoice);
 		}
 
 	}

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -339,6 +339,8 @@ public class BedrockProxyChatModel implements ChatModel {
 						: this.defaultOptions.getCacheOptions())
 				.outputSchema(runtimeOptions.getOutputSchema() != null ? runtimeOptions.getOutputSchema()
 						: this.defaultOptions.getOutputSchema())
+				.toolChoice(runtimeOptions.getToolChoice() != null ? runtimeOptions.getToolChoice()
+						: this.defaultOptions.getToolChoice())
 				.build();
 		}
 
@@ -527,7 +529,14 @@ public class BedrockProxyChatModel implements ChatModel {
 				}
 			}
 
-			toolConfiguration = ToolConfiguration.builder().tools(bedrockTools).build();
+			ToolConfiguration.Builder toolConfigBuilder = ToolConfiguration.builder().tools(bedrockTools);
+
+			// Add toolChoice if specified in options
+			if (updatedRuntimeOptions.getToolChoice() != null) {
+				toolConfigBuilder.toolChoice(updatedRuntimeOptions.getToolChoice());
+			}
+
+			toolConfiguration = toolConfigBuilder.build();
 		}
 
 		InferenceConfiguration inferenceConfiguration = InferenceConfiguration.builder()

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.bedrockruntime.model.ToolChoice;
 
 import org.springframework.ai.bedrock.converse.BedrockChatOptions.Builder;
 import org.springframework.ai.model.tool.StructuredOutputChatOptions;
@@ -143,6 +144,58 @@ class BedrockChatOptionsTests extends AbstractChatOptionsTests<BedrockChatOption
 		options.setOutputSchema("{\"type\":\"array\"}");
 
 		assertThat(options.getOutputSchema()).isEqualTo("{\"type\":\"array\"}");
+	}
+
+	@Test
+	void testToolChoiceBuilder() {
+		ToolChoice toolChoice = ToolChoice.builder().auto(builder -> builder.build()).build();
+		BedrockChatOptions options = BedrockChatOptions.builder().toolChoice(toolChoice).build();
+
+		assertThat(options.getToolChoice()).isEqualTo(toolChoice);
+	}
+
+	@Test
+	void testToolChoiceDefaultIsNull() {
+		BedrockChatOptions options = new BedrockChatOptions();
+		assertThat(options.getToolChoice()).isNull();
+	}
+
+	@Test
+	void testToolChoiceSetter() {
+		ToolChoice toolChoice = ToolChoice.builder().any(builder -> builder.build()).build();
+		BedrockChatOptions options = new BedrockChatOptions();
+		options.setToolChoice(toolChoice);
+
+		assertThat(options.getToolChoice()).isEqualTo(toolChoice);
+	}
+
+	@Test
+	void testToolChoiceCopied() {
+		ToolChoice toolChoice = ToolChoice.builder().auto(builder -> builder.build()).build();
+		BedrockChatOptions original = BedrockChatOptions.builder().model("test-model").toolChoice(toolChoice).build();
+
+		BedrockChatOptions copied = original.copy();
+
+		assertThat(copied).isNotSameAs(original).isEqualTo(original);
+		assertThat(copied.getToolChoice()).isEqualTo(toolChoice);
+	}
+
+	@Test
+	void testToolChoiceIncludedInEquality() {
+		ToolChoice toolChoice = ToolChoice.builder().auto(builder -> builder.build()).build();
+		BedrockChatOptions with = BedrockChatOptions.builder().model("m").toolChoice(toolChoice).build();
+		BedrockChatOptions without = BedrockChatOptions.builder().model("m").build();
+
+		assertThat(with).isNotEqualTo(without);
+	}
+
+	@Test
+	void testToolChoiceIncludedInHashCode() {
+		ToolChoice toolChoice = ToolChoice.builder().auto(builder -> builder.build()).build();
+		BedrockChatOptions with = BedrockChatOptions.builder().toolChoice(toolChoice).build();
+		BedrockChatOptions without = BedrockChatOptions.builder().build();
+
+		assertThat(with.hashCode()).isNotEqualTo(without.hashCode());
 	}
 
 }


### PR DESCRIPTION
## Summary
Add support for AWS Bedrock ToolChoice configuration to allow users to specify tool choice strategies (e.g., SpecificToolChoice) for forcing the LLM to respond with specific tool calls.

## Changes
- Add `toolChoice` field to `BedrockChatOptions` with getter/setter methods
- Update `BedrockChatOptions.Builder` to support `toolChoice` configuration
- Modify `BedrockProxyChatModel` to apply `toolChoice` when building `ToolConfiguration`
- Update `equals()` and `hashCode()` methods to include `toolChoice` field
- Merge `toolChoice` during options merge in `buildRequestPrompt()`

## Benefits
- Reduces token usage by forcing specific tool execution
- Reduces latency by avoiding unnecessary LLM responses
- Provides fine-grained control over tool calling behavior

## Testing
- All existing unit tests pass (17/17)
- Compilation successful

Fixes #2752