### PR TITLE
Fix Bedrock cache metrics not reported in Usage native object

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -24,7 +24,6 @@ import java.net.URLConnection;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,6 +61,7 @@ import software.amazon.awssdk.services.bedrockruntime.model.Message;
 import software.amazon.awssdk.services.bedrockruntime.model.S3Location;
 import software.amazon.awssdk.services.bedrockruntime.model.StopReason;
 import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
 import software.amazon.awssdk.services.bedrockruntime.model.Tool;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolConfiguration;
 import software.amazon.awssdk.services.bedrockruntime.model.ToolInputSchema;
@@ -716,6 +716,8 @@ public class BedrockProxyChatModel implements ChatModel {
 		Integer promptTokens = response.usage().inputTokens();
 		Integer generationTokens = response.usage().outputTokens();
 		int totalTokens = response.usage().totalTokens();
+		Integer cacheReadInputTokens = response.usage().cacheReadInputTokens();
+		Integer cacheWriteInputTokens = response.usage().cacheWriteInputTokens();
 
 		if (perviousChatResponse != null && perviousChatResponse.getMetadata() != null
 				&& perviousChatResponse.getMetadata().getUsage() != null) {
@@ -723,9 +725,37 @@ public class BedrockProxyChatModel implements ChatModel {
 			promptTokens += perviousChatResponse.getMetadata().getUsage().getPromptTokens();
 			generationTokens += perviousChatResponse.getMetadata().getUsage().getCompletionTokens();
 			totalTokens += perviousChatResponse.getMetadata().getUsage().getTotalTokens();
+
+			// Merge cache metrics from previous response if available
+			if (perviousChatResponse.getMetadata().getUsage().getNativeUsage() instanceof TokenUsage) {
+				TokenUsage previousTokenUsage = (TokenUsage) perviousChatResponse.getMetadata()
+					.getUsage()
+					.getNativeUsage();
+				if (cacheReadInputTokens == null) {
+					cacheReadInputTokens = previousTokenUsage.cacheReadInputTokens();
+				}
+				else if (previousTokenUsage.cacheReadInputTokens() != null) {
+					cacheReadInputTokens += previousTokenUsage.cacheReadInputTokens();
+				}
+				if (cacheWriteInputTokens == null) {
+					cacheWriteInputTokens = previousTokenUsage.cacheWriteInputTokens();
+				}
+				else if (previousTokenUsage.cacheWriteInputTokens() != null) {
+					cacheWriteInputTokens += previousTokenUsage.cacheWriteInputTokens();
+				}
+			}
 		}
 
-		DefaultUsage usage = new DefaultUsage(promptTokens, generationTokens, totalTokens);
+		// Create native TokenUsage with cache metrics
+		TokenUsage nativeTokenUsage = TokenUsage.builder()
+			.inputTokens(promptTokens)
+			.outputTokens(generationTokens)
+			.totalTokens(totalTokens)
+			.cacheReadInputTokens(cacheReadInputTokens)
+			.cacheWriteInputTokens(cacheWriteInputTokens)
+			.build();
+
+		DefaultUsage usage = new DefaultUsage(promptTokens, generationTokens, totalTokens, nativeTokenUsage);
 
 		Document modelResponseFields = response.additionalModelResponseFields();
 
@@ -734,18 +764,6 @@ public class BedrockProxyChatModel implements ChatModel {
 		var metadataBuilder = ChatResponseMetadata.builder()
 			.id(response.responseMetadata() != null ? response.responseMetadata().requestId() : "Unknown")
 			.usage(usage);
-
-		// Add cache metrics if available
-		Map<String, Object> additionalMetadata = new HashMap<>();
-		if (response.usage().cacheReadInputTokens() != null) {
-			additionalMetadata.put("cacheReadInputTokens", response.usage().cacheReadInputTokens());
-		}
-		if (response.usage().cacheWriteInputTokens() != null) {
-			additionalMetadata.put("cacheWriteInputTokens", response.usage().cacheWriteInputTokens());
-		}
-		if (!additionalMetadata.isEmpty()) {
-			metadataBuilder.metadata(additionalMetadata);
-		}
 
 		return new ChatResponse(allGenerations, metadataBuilder.build());
 	}


### PR DESCRIPTION
## Summary
Fixes the issue where Bedrock prompt cache metrics (`cacheReadInputTokens` and `cacheWriteInputTokens`) were not being properly exposed in the `Usage` object's native usage field, making them unavailable for observability handlers and metrics collection.

## Problem
As reported in #4930, the cache token metrics were being added to metadata as a separate map, but not included in the native `TokenUsage` object within the `Usage`. This caused metrics handlers to miss these important cache statistics.

## Solution
- Include cache metrics in the native `TokenUsage` object when creating `DefaultUsage`
- Properly merge cache metrics when aggregating usage across multiple tool-call responses
- Remove the redundant metadata map approach that was previously used

## Changes
- Add `TokenUsage` to imports in `BedrockProxyChatModel`
- Create native `TokenUsage` with cache metrics fields populated
- Merge cache metrics from previous responses during tool execution aggregation
- Remove the workaround code that added cache metrics to metadata

## Testing
- All existing unit tests pass (17/17)
- Verified compilation succeeds
- Cache metrics are now properly accessible via `usage.getNativeUsage()`

Fixes #4930