### PR TITLE
Fix NoSuchMethodError for requestMetadata with older AWS SDK versions

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -526,15 +526,59 @@ public class BedrockProxyChatModel implements ChatModel {
 		Map<String, String> requestMetadata = ConverseApiUtils
 			.getRequestMetadata(prompt.getUserMessage().getMetadata());
 
-		return ConverseRequest.builder()
+		ConverseRequest.Builder requestBuilder = ConverseRequest.builder()
 			.modelId(updatedRuntimeOptions.getModel())
 			.inferenceConfig(inferenceConfiguration)
 			.messages(instructionMessages)
 			.system(systemMessages)
 			.additionalModelRequestFields(additionalModelRequestFields)
-			.toolConfig(toolConfiguration)
-			.requestMetadata(requestMetadata)
-			.build();
+			.toolConfig(toolConfiguration);
+
+		// Apply requestMetadata if the SDK supports it (AWS SDK >= 2.32.x)
+		applyRequestMetadataIfSupported(requestBuilder, requestMetadata);
+
+		return requestBuilder.build();
+	}
+
+	/**
+	 * Applies requestMetadata to the ConverseRequest.Builder if the AWS SDK version
+	 * supports it. The requestMetadata method was added in AWS SDK 2.32.x. For older SDK
+	 * versions, this method will log a debug message and skip setting the metadata.
+	 * @param builder the ConverseRequest.Builder to apply metadata to
+	 * @param requestMetadata the metadata map to apply
+	 */
+	private void applyRequestMetadataIfSupported(ConverseRequest.Builder builder, Map<String, String> requestMetadata) {
+		if (requestMetadata == null || requestMetadata.isEmpty()) {
+			return;
+		}
+		try {
+			builder.requestMetadata(requestMetadata);
+		}
+		catch (NoSuchMethodError e) {
+			logger.debug("requestMetadata is not supported by the current AWS SDK version. "
+					+ "Upgrade to AWS SDK 2.32.x or later to use this feature. Metadata will be ignored.");
+		}
+	}
+
+	/**
+	 * Applies requestMetadata to the ConverseStreamRequest.Builder if the AWS SDK version
+	 * supports it. The requestMetadata method was added in AWS SDK 2.32.x. For older SDK
+	 * versions, this method will log a debug message and skip setting the metadata.
+	 * @param builder the ConverseStreamRequest.Builder to apply metadata to
+	 * @param requestMetadata the metadata map to apply
+	 */
+	private void applyRequestMetadataIfSupported(ConverseStreamRequest.Builder builder,
+			Map<String, String> requestMetadata) {
+		if (requestMetadata == null || requestMetadata.isEmpty()) {
+			return;
+		}
+		try {
+			builder.requestMetadata(requestMetadata);
+		}
+		catch (NoSuchMethodError e) {
+			logger.debug("requestMetadata is not supported by the current AWS SDK version. "
+					+ "Upgrade to AWS SDK 2.32.x or later to use this feature. Metadata will be ignored.");
+		}
 	}
 
 	private ContentBlock mapMediaToContentBlock(Media media) {
@@ -782,15 +826,18 @@ public class BedrockProxyChatModel implements ChatModel {
 
 			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
 
-			ConverseStreamRequest converseStreamRequest = ConverseStreamRequest.builder()
+			ConverseStreamRequest.Builder streamRequestBuilder = ConverseStreamRequest.builder()
 				.modelId(converseRequest.modelId())
 				.inferenceConfig(converseRequest.inferenceConfig())
 				.messages(converseRequest.messages())
 				.system(converseRequest.system())
 				.additionalModelRequestFields(converseRequest.additionalModelRequestFields())
-				.toolConfig(converseRequest.toolConfig())
-				.requestMetadata(converseRequest.requestMetadata())
-				.build();
+				.toolConfig(converseRequest.toolConfig());
+
+			// Apply requestMetadata if the SDK supports it (AWS SDK >= 2.32.x)
+			applyRequestMetadataIfSupported(streamRequestBuilder, converseRequest.requestMetadata());
+
+			ConverseStreamRequest converseStreamRequest = streamRequestBuilder.build();
 
 			Usage accumulatedUsage = null;
 			if (perviousChatResponse != null && perviousChatResponse.getMetadata() != null) {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -29,6 +29,21 @@ Refer to https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.ht
 
 * Enable the Models to use: Go to link:https://us-east-1.console.aws.amazon.com/bedrock/home[Amazon Bedrock] and from the link:https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess[Model Access] menu on the left, configure access to the models you are going to use.
 
+=== AWS SDK Version Requirements
+
+[IMPORTANT]
+====
+If your project manages its own AWS SDK dependencies (e.g., via AWS BOM or explicit version overrides), ensure you are using **AWS SDK for Java version 2.32.x or later** for full feature support.
+
+Some features like `requestMetadata` (used for filtering invocation logs) require AWS SDK 2.32.x+.
+If you are using an older SDK version, these features will be gracefully disabled with a debug log message, but your application will continue to work.
+
+If you encounter a `NoSuchMethodError` related to `requestMetadata`, check your dependency tree for conflicting AWS SDK versions:
+[source,bash]
+----
+mvn dependency:tree -Dincludes=software.amazon.awssdk
+----
+====
 
 == Auto-configuration
 


### PR DESCRIPTION
- Add graceful fallback when requestMetadata() method is not available
- Catch NoSuchMethodError and log debug message instead of crashing
- Support both ConverseRequest and ConverseStreamRequest builders
- Add documentation about AWS SDK version requirements (2.32.x+)

Fixes #5063