### PR TITLE
Fix: Map Long metadata to Qdrant int64 to support numeric range filtering

### DIFF
--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantValueFactory.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantValueFactory.java
@@ -74,9 +74,7 @@ final class QdrantValueFactory {
 		return switch (value.getClass().getSimpleName()) {
 			case "String" -> ValueFactory.value((String) value);
 			case "Integer" -> ValueFactory.value((Integer) value);
-			case "Long" ->
-				// use String representation
-				ValueFactory.value(String.valueOf(value));
+			case "Long" -> ValueFactory.value((Long) value);
 			case "Double" -> ValueFactory.value((Double) value);
 			case "Float" -> ValueFactory.value((Float) value);
 			case "Boolean" -> ValueFactory.value((Boolean) value);


### PR DESCRIPTION
### Description
This PR fixes an issue where `Long` type metadata was forcibly converted to `String` when stored in Qdrant.

### Problem
Currently, `Long` values are converted to `String` via `String.valueOf(value)`.
This causes **numeric range filters (e.g., `lte`, `gte`) to fail** or behave unexpectedly because Qdrant performs lexicographical comparison on strings (e.g., "10" < "2").

It seems the original intention was to handle JavaScript Safe Integer limits ($2^{53}-1$). However, enforcing this at the Vector Store layer limits the database's native querying capabilities.

### Solution
- Map Java `Long` directly to Qdrant's `integer_value` (int64).
- This enables proper numeric filtering for Long values.

### Rationale
- **Database Responsibility:** The Vector Store should persist data types as accurately as possible to support query operations like range filtering.
- **Serialization Responsibility:** Concerns about JavaScript integer precision (Safe Integer) should be handled at the serialization/presentation layer (e.g., Jackson configuration) rather than distorting the data at the storage layer.