### PR TITLE
Improve Mistal AI API Javadoc

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -1094,8 +1094,9 @@ public class MistralAiApi {
 	/**
 	 * Message comprising the conversation.
 	 *
-	 * @param rawContent The contents of the message. Can be either a {@link MediaContent}
-	 * or a {@link String}. The response message content is always a {@link String}.
+	 * @param rawContent The content of the message. For request, message content can be
+	 * either a list of {@link MediaContent} or a {@link String}. For response, only
+	 * {@link String} is supported as message content for now.
 	 * @param role The role of the messages author. Could be one of the {@link Role}
 	 * types.
 	 * @param name The name of the author of the message.


### PR DESCRIPTION
## Description

- Clarify supported content types for request (string or list of media content),
- Clarify supported content types for response (string only).

## Explanations

Spring AI supports different content types for requests and for responses. It is a limitation on Spring AI side and it should be well documented in the Javadoc.
Here are interesting highlights of the different types used:
- [Request writing](https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java#L460-L468),
- [Response reading](https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java#L1144-L1152). 

## Targeted versions

1.1.x and 2.0.x.

## Related work

Spring AI doesn't support Magistral 1.2 models family and the restricted content type for the response is expected to be removed for this feature. More details can be found in #5020.