### PR TITLE
Use `spring-io/backport-bot` GHA directly

### DIFF
--- a/.github/workflows/backport-issue.yml
+++ b/.github/workflows/backport-issue.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   backport-issue:
-    uses: spring-io/spring-github-workflows/.github/workflows/spring-backport-issue.yml@main
-    secrets:
-      GH_ACTIONS_REPO_TOKEN: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
+    if: contains(github.event.head_commit.message, 'Fixes:') || contains(github.event.head_commit.message, 'Closes:')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: spring-io/backport-bot@v0.0.1
+        with:
+          token: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}


### PR DESCRIPTION
The `spring-io/spring-github-workflows/.github/workflows/spring-backport-issue` now just delegates directly to the `spring-io/backport-bot`. Therefore, there is no reason in extra reusable workflow layer on the matter.

* Fix `backport-issue.yml` to use `spring-io/backport-bot` directly

**Auto-cherry-pick to `1.1.x` & `1.0.x`**