### PR TITLE
GH-5256: Add system prompt isolation to semantic cache

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/redis.adoc
@@ -600,6 +600,74 @@ SemanticCacheAdvisor user1Advisor = SemanticCacheAdvisor.builder()
     .build();
 ----
 
+=== System Prompt Isolation
+
+The `SemanticCacheAdvisor` automatically isolates cached responses based on the system prompt.
+This ensures that the same user query with different system prompts returns different cached responses, which is essential for applications with multiple AI personas or context-dependent behavior.
+
+[source,java]
+----
+SemanticCacheAdvisor cacheAdvisor = SemanticCacheAdvisor.builder()
+    .cache(semanticCache)
+    .build();
+
+// Query with technical support persona
+ChatResponse technicalResponse = ChatClient.builder(chatModel)
+    .build()
+    .prompt()
+    .system("You are a technical support specialist. Provide detailed technical answers.")
+    .user("How do I reset my password?")
+    .advisors(cacheAdvisor)
+    .call()
+    .chatResponse();
+
+// Same query with customer service persona - cache MISS (different context)
+ChatResponse serviceResponse = ChatClient.builder(chatModel)
+    .build()
+    .prompt()
+    .system("You are a friendly customer service agent. Keep responses brief and helpful.")
+    .user("How do I reset my password?")
+    .advisors(cacheAdvisor)
+    .call()
+    .chatResponse();
+
+// Same query with technical support persona again - cache HIT
+ChatResponse technicalAgain = ChatClient.builder(chatModel)
+    .build()
+    .prompt()
+    .system("You are a technical support specialist. Provide detailed technical answers.")
+    .user("How do I reset my password?")
+    .advisors(cacheAdvisor)
+    .call()
+    .chatResponse();
+// Returns the cached technical response
+----
+
+**How it works:**
+
+The advisor computes a deterministic hash of the system prompt and uses it as a metadata filter when storing and retrieving cached responses:
+
+* Same user question + same system prompt → cache hit
+* Same user question + different system prompt → cache miss (separate cache entry)
+* Queries without a system prompt share a common cache space
+
+=== Context-Aware Cache API
+
+For advanced use cases, you can use the context-aware cache methods directly:
+
+[source,java]
+----
+// Store with explicit context hash
+String contextHash = "technical-support-context";
+semanticCache.set("How do I reset my password?", response, contextHash);
+
+// Retrieve with context filtering
+Optional<ChatResponse> cached = semanticCache.get("How do I reset my password?", contextHash);
+
+// Different context hash returns empty (no match)
+Optional<ChatResponse> otherContext = semanticCache.get("How do I reset my password?", "billing-context");
+----
+
 === Tuning the Similarity Threshold
 
 The similarity threshold determines how closely a query must match a cached entry to be considered a hit.

--- a/vector-stores/spring-ai-redis-semantic-cache/src/test/java/org/springframework/ai/chat/cache/semantic/SemanticCacheAdvisorTests.java
+++ b/vector-stores/spring-ai-redis-semantic-cache/src/test/java/org/springframework/ai/chat/cache/semantic/SemanticCacheAdvisorTests.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.cache.semantic;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SemanticCacheAdvisor}.
+ *
+ * @author Soby Chacko
+ */
+@ExtendWith(MockitoExtension.class)
+class SemanticCacheAdvisorTests {
+
+	@Mock
+	private SemanticCache mockCache;
+
+	@Mock
+	private CallAdvisorChain mockChain;
+
+	private SemanticCacheAdvisor advisor;
+
+	@BeforeEach
+	void setUp() {
+		this.advisor = SemanticCacheAdvisor.builder().cache(this.mockCache).build();
+	}
+
+	@Test
+	void adviseCallWithSystemPromptUsesContextHash() {
+		String systemPromptText = "You are a helpful assistant.";
+		String userText = "What is AI?";
+
+		Prompt prompt = new Prompt(List.of(new SystemMessage(systemPromptText), new UserMessage(userText)));
+
+		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+
+		ChatResponse chatResponse = createMockChatResponse("AI is artificial intelligence.");
+		ChatClientResponse clientResponse = ChatClientResponse.builder().chatResponse(chatResponse).build();
+
+		// Cache miss
+		when(this.mockCache.get(eq(userText), any(String.class))).thenReturn(Optional.empty());
+		when(this.mockChain.nextCall(request)).thenReturn(clientResponse);
+
+		this.advisor.adviseCall(request, this.mockChain);
+
+		// Assert - verify cache.get was called with user text and a non-null context hash
+		ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> hashCaptor = ArgumentCaptor.forClass(String.class);
+		verify(this.mockCache).get(queryCaptor.capture(), hashCaptor.capture());
+
+		assertThat(queryCaptor.getValue()).isEqualTo(userText);
+		assertThat(hashCaptor.getValue()).isNotNull().hasSize(8); // 8 hex chars
+
+		// Assert - verify cache.set was called with same parameters
+		verify(this.mockCache).set(eq(userText), eq(chatResponse), hashCaptor.capture());
+		assertThat(hashCaptor.getValue()).isNotNull().hasSize(8);
+	}
+
+	@Test
+	void adviseCallWithoutSystemPromptUsesNullContextHash() {
+		String userText = "What is AI?";
+
+		Prompt prompt = new Prompt(List.of(new UserMessage(userText)));
+
+		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+
+		ChatResponse chatResponse = createMockChatResponse("AI is artificial intelligence.");
+		ChatClientResponse clientResponse = ChatClientResponse.builder().chatResponse(chatResponse).build();
+
+		// Cache miss
+		when(this.mockCache.get(eq(userText), isNull())).thenReturn(Optional.empty());
+		when(this.mockChain.nextCall(request)).thenReturn(clientResponse);
+
+		this.advisor.adviseCall(request, this.mockChain);
+
+		// Assert - verify cache.get was called with null context hash
+		verify(this.mockCache).get(userText, null);
+
+		// Assert - verify cache.set was called with null context hash
+		verify(this.mockCache).set(eq(userText), eq(chatResponse), (String) isNull());
+	}
+
+	@Test
+	void adviseCallReturnsCachedResponseOnHit() {
+		String userText = "What is AI?";
+
+		Prompt prompt = new Prompt(List.of(new UserMessage(userText)));
+
+		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+
+		ChatResponse cachedResponse = createMockChatResponse("Cached response about AI.");
+
+		// Cache hit
+		when(this.mockCache.get(userText, null)).thenReturn(Optional.of(cachedResponse));
+
+		ChatClientResponse result = this.advisor.adviseCall(request, this.mockChain);
+
+		// Assert - should return cached response without calling the chain
+		assertThat(result.chatResponse()).isEqualTo(cachedResponse);
+		verify(this.mockChain, never()).nextCall(any());
+		verify(this.mockCache, never()).set(any(String.class), any(ChatResponse.class), any(String.class));
+	}
+
+	@Test
+	void sameSystemPromptProducesSameContextHash() {
+		String systemPromptText = "You are a pirate.";
+		String userText1 = "Hello";
+		String userText2 = "Goodbye";
+
+		Prompt prompt1 = new Prompt(List.of(new SystemMessage(systemPromptText), new UserMessage(userText1)));
+
+		Prompt prompt2 = new Prompt(List.of(new SystemMessage(systemPromptText), new UserMessage(userText2)));
+
+		ChatClientRequest request1 = ChatClientRequest.builder().prompt(prompt1).build();
+
+		ChatClientRequest request2 = ChatClientRequest.builder().prompt(prompt2).build();
+
+		ChatResponse chatResponse = createMockChatResponse("Response");
+		ChatClientResponse clientResponse = ChatClientResponse.builder().chatResponse(chatResponse).build();
+
+		when(this.mockCache.get(any(), any())).thenReturn(Optional.empty());
+		when(this.mockChain.nextCall(any())).thenReturn(clientResponse);
+
+		this.advisor.adviseCall(request1, this.mockChain);
+		this.advisor.adviseCall(request2, this.mockChain);
+
+		// Assert - capture both context hashes and verify they're the same
+		ArgumentCaptor<String> hashCaptor = ArgumentCaptor.forClass(String.class);
+		verify(this.mockCache).get(eq(userText1), hashCaptor.capture());
+		String hash1 = hashCaptor.getValue();
+
+		verify(this.mockCache).get(eq(userText2), hashCaptor.capture());
+		String hash2 = hashCaptor.getValue();
+
+		assertThat(hash1).isEqualTo(hash2);
+	}
+
+	@Test
+	void differentSystemPromptsProduceDifferentContextHashes() {
+		String userText = "Hello";
+
+		Prompt prompt1 = new Prompt(List.of(new SystemMessage("You are a pirate."), new UserMessage(userText)));
+
+		Prompt prompt2 = new Prompt(List.of(new SystemMessage("You are a teacher."), new UserMessage(userText)));
+
+		ChatClientRequest request1 = ChatClientRequest.builder().prompt(prompt1).build();
+
+		ChatClientRequest request2 = ChatClientRequest.builder().prompt(prompt2).build();
+
+		ChatResponse chatResponse = createMockChatResponse("Response");
+		ChatClientResponse clientResponse = ChatClientResponse.builder().chatResponse(chatResponse).build();
+
+		when(this.mockCache.get(any(), any(String.class))).thenReturn(Optional.empty());
+		when(this.mockChain.nextCall(any())).thenReturn(clientResponse);
+
+		this.advisor.adviseCall(request1, this.mockChain);
+		this.advisor.adviseCall(request2, this.mockChain);
+
+		// Assert - capture both context hashes and verify they're different
+		ArgumentCaptor<String> hashCaptor = ArgumentCaptor.forClass(String.class);
+		verify(this.mockCache, org.mockito.Mockito.times(2)).set(eq(userText), any(ChatResponse.class),
+				hashCaptor.capture());
+
+		List<String> capturedHashes = hashCaptor.getAllValues();
+		assertThat(capturedHashes).hasSize(2);
+		assertThat(capturedHashes.get(0)).isNotEqualTo(capturedHashes.get(1));
+	}
+
+	@Test
+	void emptySystemPromptTreatedAsNoSystemPrompt() {
+		String userText = "What is AI?";
+
+		Prompt prompt = new Prompt(List.of(new SystemMessage(""), new UserMessage(userText)));
+
+		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+
+		ChatResponse chatResponse = createMockChatResponse("AI is artificial intelligence.");
+		ChatClientResponse clientResponse = ChatClientResponse.builder().chatResponse(chatResponse).build();
+
+		// Cache miss
+		when(this.mockCache.get(eq(userText), isNull())).thenReturn(Optional.empty());
+		when(this.mockChain.nextCall(request)).thenReturn(clientResponse);
+
+		this.advisor.adviseCall(request, this.mockChain);
+
+		// Assert - empty system prompt should result in null context hash
+		verify(this.mockCache).get(eq(userText), (String) isNull());
+		verify(this.mockCache).set(eq(userText), eq(chatResponse), (String) isNull());
+	}
+
+	private ChatResponse createMockChatResponse(String text) {
+		return ChatResponse.builder().generations(List.of(new Generation(new AssistantMessage(text)))).build();
+	}
+
+}


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-ai/issues/5256

Previously, the semantic cache only used the user message text as the cache key, ignoring the system prompt. This caused incorrect cache hits when the same user question was asked with different system prompts (e.g., different AI personas or contexts).

This change introduces context-aware caching that isolates cached responses based on the system prompt:

- Add context-aware methods to SemanticCache interface:
  - set(query, response, contextHash)
  - get(query, contextHash)

- Implement metadata-based filtering in DefaultSemanticCache:
  - Store context_hash as a TAG field in document metadata
  - Filter by exact hash match during retrieval

- Update SemanticCacheAdvisor to compute deterministic SHA-256 hash of system prompt and pass it to cache operations

 - Add comprehensive tests:
  - Unit tests for hash computation and context isolation
  - Integration tests for system prompt isolation scenarios

- Update reference documentation with new sections:
  - System Prompt Isolation
  - Context-Aware Cache API