### PR TITLE
Add Builder pattern to OpenAiSdkChatModel

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai-sdk/src/main/java/org/springframework/ai/model/openaisdk/autoconfigure/OpenAiSdkChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai-sdk/src/main/java/org/springframework/ai/model/openaisdk/autoconfigure/OpenAiSdkChatAutoConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.context.annotation.Bean;
  * Chat {@link AutoConfiguration Auto-configuration} for OpenAI SDK.
  *
  * @author Christian Tzolov
+ * @author Soby Chacko
  */
 @AutoConfiguration(after = { ToolCallingAutoConfiguration.class })
 @EnableConfigurationProperties({ OpenAiSdkConnectionProperties.class, OpenAiSdkChatProperties.class })
@@ -63,9 +64,15 @@ public class OpenAiSdkChatAutoConfiguration {
 
 		OpenAIClientAsync openAIClientAsync = this.openAiClientAsync(resolvedConnectionProperties);
 
-		var chatModel = new OpenAiSdkChatModel(openAIClient, openAIClientAsync, chatProperties.getOptions(),
-				toolCallingManager, observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
-				openAiToolExecutionEligibilityPredicate.getIfUnique(DefaultToolExecutionEligibilityPredicate::new));
+		var chatModel = OpenAiSdkChatModel.builder()
+			.openAiClient(openAIClient)
+			.openAiClientAsync(openAIClientAsync)
+			.options(chatProperties.getOptions())
+			.toolCallingManager(toolCallingManager)
+			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+			.toolExecutionEligibilityPredicate(
+					openAiToolExecutionEligibilityPredicate.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))
+			.build();
 
 		observationConvention.ifAvailable(chatModel::setObservationConvention);
 

--- a/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkChatModel.java
+++ b/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkChatModel.java
@@ -106,6 +106,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Julien Dubois
  * @author Christian Tzolov
+ * @author Soby Chacko
  */
 public class OpenAiSdkChatModel implements ChatModel {
 
@@ -132,8 +133,18 @@ public class OpenAiSdkChatModel implements ChatModel {
 	private ChatModelObservationConvention observationConvention = DEFAULT_OBSERVATION_CONVENTION;
 
 	/**
-	 * Creates a new OpenAiSdkChatModel with default options.
+	 * Creates a new builder for {@link OpenAiSdkChatModel}.
+	 * @return a new builder instance
 	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Creates a new OpenAiSdkChatModel with default options.
+	 * @deprecated Use {@link #builder()} instead
+	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel() {
 		this(null, null, null, null, null, null);
 	}
@@ -141,7 +152,9 @@ public class OpenAiSdkChatModel implements ChatModel {
 	/**
 	 * Creates a new OpenAiSdkChatModel with the given options.
 	 * @param options the chat options
+	 * @deprecated Use {@link #builder()} instead
 	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel(OpenAiSdkChatOptions options) {
 		this(null, null, options, null, null, null);
 	}
@@ -150,7 +163,9 @@ public class OpenAiSdkChatModel implements ChatModel {
 	 * Creates a new OpenAiSdkChatModel with the given options and observation registry.
 	 * @param options the chat options
 	 * @param observationRegistry the observation registry
+	 * @deprecated Use {@link #builder()} instead
 	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel(OpenAiSdkChatOptions options, ObservationRegistry observationRegistry) {
 		this(null, null, options, null, observationRegistry, null);
 	}
@@ -161,7 +176,9 @@ public class OpenAiSdkChatModel implements ChatModel {
 	 * @param options the chat options
 	 * @param toolCallingManager the tool calling manager
 	 * @param observationRegistry the observation registry
+	 * @deprecated Use {@link #builder()} instead
 	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel(OpenAiSdkChatOptions options, ToolCallingManager toolCallingManager,
 			ObservationRegistry observationRegistry) {
 		this(null, null, options, toolCallingManager, observationRegistry, null);
@@ -171,7 +188,9 @@ public class OpenAiSdkChatModel implements ChatModel {
 	 * Creates a new OpenAiSdkChatModel with the given OpenAI clients.
 	 * @param openAIClient the synchronous OpenAI client
 	 * @param openAiClientAsync the asynchronous OpenAI client
+	 * @deprecated Use {@link #builder()} instead
 	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel(OpenAIClient openAIClient, OpenAIClientAsync openAiClientAsync) {
 		this(openAIClient, openAiClientAsync, null, null, null, null);
 	}
@@ -181,7 +200,9 @@ public class OpenAiSdkChatModel implements ChatModel {
 	 * @param openAIClient the synchronous OpenAI client
 	 * @param openAiClientAsync the asynchronous OpenAI client
 	 * @param options the chat options
+	 * @deprecated Use {@link #builder()} instead
 	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel(OpenAIClient openAIClient, OpenAIClientAsync openAiClientAsync,
 			OpenAiSdkChatOptions options) {
 		this(openAIClient, openAiClientAsync, options, null, null, null);
@@ -194,7 +215,9 @@ public class OpenAiSdkChatModel implements ChatModel {
 	 * @param openAiClientAsync the asynchronous OpenAI client
 	 * @param options the chat options
 	 * @param observationRegistry the observation registry
+	 * @deprecated Use {@link #builder()} instead
 	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel(OpenAIClient openAIClient, OpenAIClientAsync openAiClientAsync,
 			OpenAiSdkChatOptions options, ObservationRegistry observationRegistry) {
 		this(openAIClient, openAiClientAsync, options, null, observationRegistry, null);
@@ -209,7 +232,9 @@ public class OpenAiSdkChatModel implements ChatModel {
 	 * @param observationRegistry the observation registry
 	 * @param toolExecutionEligibilityPredicate the predicate to determine tool execution
 	 * eligibility
+	 * @deprecated Use {@link #builder()} instead
 	 */
+	@Deprecated(forRemoval = true, since = "2.0.0-M3")
 	public OpenAiSdkChatModel(OpenAIClient openAiClient, OpenAIClientAsync openAiClientAsync,
 			OpenAiSdkChatOptions options, ToolCallingManager toolCallingManager,
 			ObservationRegistry observationRegistry,
@@ -1314,6 +1339,99 @@ public class OpenAiSdkChatModel implements ChatModel {
 
 		AssistantMessage.ToolCall build() {
 			return new AssistantMessage.ToolCall(this.id, this.type, this.name, this.arguments.toString());
+		}
+
+	}
+
+	/**
+	 * Builder for creating {@link OpenAiSdkChatModel} instances.
+	 */
+	public static final class Builder {
+
+		private OpenAIClient openAiClient;
+
+		private OpenAIClientAsync openAiClientAsync;
+
+		private OpenAiSdkChatOptions options;
+
+		private ToolCallingManager toolCallingManager;
+
+		private ObservationRegistry observationRegistry;
+
+		private ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate;
+
+		private Builder() {
+		}
+
+		/**
+		 * Sets the synchronous OpenAI client.
+		 * @param openAiClient the synchronous client
+		 * @return this builder
+		 */
+		public Builder openAiClient(OpenAIClient openAiClient) {
+			this.openAiClient = openAiClient;
+			return this;
+		}
+
+		/**
+		 * Sets the asynchronous OpenAI client.
+		 * @param openAiClientAsync the asynchronous client
+		 * @return this builder
+		 */
+		public Builder openAiClientAsync(OpenAIClientAsync openAiClientAsync) {
+			this.openAiClientAsync = openAiClientAsync;
+			return this;
+		}
+
+		/**
+		 * Sets the chat options.
+		 * @param options the chat options
+		 * @return this builder
+		 */
+		public Builder options(OpenAiSdkChatOptions options) {
+			this.options = options;
+			return this;
+		}
+
+		/**
+		 * Sets the tool calling manager.
+		 * @param toolCallingManager the tool calling manager
+		 * @return this builder
+		 */
+		public Builder toolCallingManager(ToolCallingManager toolCallingManager) {
+			this.toolCallingManager = toolCallingManager;
+			return this;
+		}
+
+		/**
+		 * Sets the observation registry for metrics and tracing.
+		 * @param observationRegistry the observation registry
+		 * @return this builder
+		 */
+		public Builder observationRegistry(ObservationRegistry observationRegistry) {
+			this.observationRegistry = observationRegistry;
+			return this;
+		}
+
+		/**
+		 * Sets the predicate to determine tool execution eligibility.
+		 * @param toolExecutionEligibilityPredicate the predicate
+		 * @return this builder
+		 */
+		public Builder toolExecutionEligibilityPredicate(
+				ToolExecutionEligibilityPredicate toolExecutionEligibilityPredicate) {
+			this.toolExecutionEligibilityPredicate = toolExecutionEligibilityPredicate;
+			return this;
+		}
+
+		/**
+		 * Builds a new {@link OpenAiSdkChatModel} instance.
+		 * @return the configured chat model
+		 */
+		@SuppressWarnings("deprecation")
+		public OpenAiSdkChatModel build() {
+			return new OpenAiSdkChatModel(this.openAiClient, this.openAiClientAsync, this.options,
+					this.toolCallingManager, this.observationRegistry, this.toolExecutionEligibilityPredicate);
 		}
 
 	}

--- a/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/OpenAiSdkTestConfiguration.java
+++ b/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/OpenAiSdkTestConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Bean;
  * Context configuration for OpenAI Java SDK tests.
  *
  * @author Julien Dubois
+ * @author Soby Chacko
  */
 @SpringBootConfiguration
 public class OpenAiSdkTestConfiguration {
@@ -39,7 +40,7 @@ public class OpenAiSdkTestConfiguration {
 
 	@Bean
 	public OpenAiSdkChatModel openAiChatModel() {
-		return new OpenAiSdkChatModel();
+		return OpenAiSdkChatModel.builder().build();
 	}
 
 }

--- a/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/chat/OpenAiSdkChatModelObservationIT.java
+++ b/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/chat/OpenAiSdkChatModelObservationIT.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for observation instrumentation in {@link OpenAiSdkChatModel}.
  *
  * @author Julien Dubois
+ * @author Soby Chacko
  */
 @SpringBootTest
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -144,9 +145,10 @@ public class OpenAiSdkChatModelObservationIT {
 
 		@Bean
 		public OpenAiSdkChatModel openAiChatModel(TestObservationRegistry observationRegistry) {
-			return new OpenAiSdkChatModel(
-					OpenAiSdkChatOptions.builder().model(OpenAiSdkChatOptions.DEFAULT_CHAT_MODEL).build(),
-					observationRegistry);
+			return OpenAiSdkChatModel.builder()
+				.options(OpenAiSdkChatOptions.builder().model(OpenAiSdkChatOptions.DEFAULT_CHAT_MODEL).build())
+				.observationRegistry(observationRegistry)
+				.build();
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-sdk-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-sdk-chat.adoc
@@ -572,7 +572,9 @@ var chatOptions = OpenAiSdkChatOptions.builder()
     .apiKey(System.getenv("OPENAI_API_KEY"))
     .build();
 
-var chatModel = new OpenAiSdkChatModel(chatOptions);
+var chatModel = OpenAiSdkChatModel.builder()
+    .options(chatOptions)
+    .build();
 
 ChatResponse response = chatModel.call(
     new Prompt("Generate the names of 5 famous pirates."));
@@ -596,7 +598,9 @@ var chatOptions = OpenAiSdkChatOptions.builder()
     .azure(true)  // Enables Microsoft Foundry mode
     .build();
 
-var chatModel = new OpenAiSdkChatModel(chatOptions);
+var chatModel = OpenAiSdkChatModel.builder()
+    .options(chatOptions)
+    .build();
 ----
 
 TIP: Microsoft Foundry supports passwordless authentication. Add the `com.azure:azure-identity` dependency to your project. If you don't provide an API key, the implementation will automatically attempt to use Azure credentials from your environment.
@@ -614,7 +618,9 @@ var chatOptions = OpenAiSdkChatOptions.builder()
     .githubModels(true)
     .build();
 
-var chatModel = new OpenAiSdkChatModel(chatOptions);
+var chatModel = OpenAiSdkChatModel.builder()
+    .options(chatOptions)
+    .build();
 ----
 
 == Key Differences from Spring AI OpenAI


### PR DESCRIPTION
- Add static builder() factory method and nested Builder class
- Deprecate all public constructors (since 2.0.0-M3, for removal in 2.1.x)
- Update auto-configuration to use builder pattern
- Update tests to use builder pattern
- Update documentation examples to use builder pattern
