### PR TITLE
Make `ModelRequest#getOptions` non-null

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -210,7 +210,6 @@ public class AnthropicChatModel implements ChatModel {
 				return chatResponse;
 			});
 
-		Assert.state(prompt.getOptions() != null, "prompt.getOptions() must not be null");
 		if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
 			var toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
 			if (toolExecutionResult.returnDirect()) {
@@ -269,9 +268,7 @@ public class AnthropicChatModel implements ChatModel {
 				Usage accumulatedUsage = UsageCalculator.getCumulativeUsage(currentChatResponseUsage, previousChatResponse);
 				ChatResponse chatResponse = toChatResponse(chatCompletionResponse, accumulatedUsage);
 
-				ChatOptions options = prompt.getOptions();
-				Assert.notNull(options, "prompt.getOptions() must not be null");
-				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(options, chatResponse)) {
+				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), chatResponse)) {
 
 					if (chatResponse.hasFinishReasons(Set.of("tool_use"))) {
 						// FIXME: bounded elastic needs to be used since tool calling
@@ -572,7 +569,7 @@ public class AnthropicChatModel implements ChatModel {
 	private HttpHeaders getAdditionalHttpHeaders(Prompt prompt) {
 
 		Map<String, String> headers = new HashMap<>(this.defaultOptions.getHttpHeaders());
-		if (prompt.getOptions() != null && prompt.getOptions() instanceof AnthropicChatOptions chatOptions) {
+		if (prompt.getOptions() instanceof AnthropicChatOptions chatOptions) {
 			headers.putAll(chatOptions.getHttpHeaders());
 		}
 		HttpHeaders httpHeaders = new HttpHeaders();
@@ -583,15 +580,13 @@ public class AnthropicChatModel implements ChatModel {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		AnthropicChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						AnthropicChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						AnthropicChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					AnthropicChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					AnthropicChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options
@@ -664,8 +659,8 @@ public class AnthropicChatModel implements ChatModel {
 
 		// Get caching strategy and options from the request
 		AnthropicChatOptions requestOptions = null;
-		if (prompt.getOptions() instanceof AnthropicChatOptions) {
-			requestOptions = (AnthropicChatOptions) prompt.getOptions();
+		if (prompt.getOptions() instanceof AnthropicChatOptions anthropicOptions) {
+			requestOptions = anthropicOptions;
 		}
 
 		AnthropicCacheOptions cacheOptions = requestOptions != null ? requestOptions.getCacheOptions()

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -520,20 +520,18 @@ public class AzureOpenAiChatModel implements ChatModel {
 
 		AzureOpenAiChatOptions updatedRuntimeOptions;
 
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions,
-						ToolCallingChatOptions.class, AzureOpenAiChatOptions.class);
-			}
-			else {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						AzureOpenAiChatOptions.class);
-			}
-			options = this.merge(updatedRuntimeOptions, options);
-
-			// Add the tool definitions to the request's tools parameter.
-			functionsForThisRequest.addAll(this.toolCallingManager.resolveToolDefinitions(updatedRuntimeOptions));
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					AzureOpenAiChatOptions.class);
 		}
+		else {
+			updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					AzureOpenAiChatOptions.class);
+		}
+		options = this.merge(updatedRuntimeOptions, options);
+
+		// Add the tool definitions to the request's tools parameter.
+		functionsForThisRequest.addAll(this.toolCallingManager.resolveToolDefinitions(updatedRuntimeOptions));
 
 		// Add the enabled functions definitions to the request's tools parameter.
 		if (!CollectionUtils.isEmpty(functionsForThisRequest)) {
@@ -655,15 +653,13 @@ public class AzureOpenAiChatModel implements ChatModel {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		AzureOpenAiChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						AzureOpenAiChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						AzureOpenAiChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					AzureOpenAiChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					AzureOpenAiChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
@@ -108,7 +108,7 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 		logger.debug("Retrieving embeddings");
 
 		EmbeddingResponse response = this
-			.call(new EmbeddingRequest(List.of(document.getFormattedContent(this.metadataMode)), null));
+			.call(new EmbeddingRequest(List.of(document.getFormattedContent(this.metadataMode))));
 		logger.debug("Embeddings retrieved");
 
 		if (CollectionUtils.isEmpty(response.getResults())) {

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -272,17 +272,15 @@ public class BedrockProxyChatModel implements ChatModel {
 
 	Prompt buildRequestPrompt(Prompt prompt) {
 		BedrockChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof BedrockChatOptions bedrockChatOptions) {
-				runtimeOptions = bedrockChatOptions.copy();
-			}
-			else if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						BedrockChatOptions.class);
-			}
-			else {
-				runtimeOptions = from(prompt.getOptions());
-			}
+		if (prompt.getOptions() instanceof BedrockChatOptions bedrockChatOptions) {
+			runtimeOptions = bedrockChatOptions.copy();
+		}
+		else if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					BedrockChatOptions.class);
+		}
+		else {
+			runtimeOptions = from(prompt.getOptions());
 		}
 
 		// Merge runtime options with the default options

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -392,15 +392,13 @@ public class DeepSeekChatModel implements ChatModel {
 
 	Prompt buildRequestPrompt(Prompt prompt) {
 		DeepSeekChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						DeepSeekChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						DeepSeekChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					DeepSeekChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					DeepSeekChatOptions.class);
 		}
 
 		DeepSeekChatOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,

--- a/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
+++ b/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
@@ -228,10 +228,8 @@ public class GoogleGenAiTextEmbeddingModel extends AbstractEmbeddingModel {
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
 		GoogleGenAiTextEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					GoogleGenAiTextEmbeddingOptions.class);
-		}
+		runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
+				GoogleGenAiTextEmbeddingOptions.class);
 
 		// Define request options by merging runtime options and default options
 		GoogleGenAiTextEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -485,15 +485,13 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		GoogleGenAiChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						GoogleGenAiChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						GoogleGenAiChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					GoogleGenAiChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					GoogleGenAiChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -467,15 +467,13 @@ public class MiniMaxChatModel implements ChatModel {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		MiniMaxChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						MiniMaxChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						MiniMaxChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					MiniMaxChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					MiniMaxChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options
@@ -559,20 +557,17 @@ public class MiniMaxChatModel implements ChatModel {
 					ChatCompletionRequest.class);
 		}
 
-		if (prompt.getOptions() != null) {
-			MiniMaxChatOptions updatedRuntimeOptions;
-
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions,
-						ToolCallingChatOptions.class, MiniMaxChatOptions.class);
-			}
-			else {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						MiniMaxChatOptions.class);
-			}
-
-			request = ModelOptionsUtils.merge(updatedRuntimeOptions, request, ChatCompletionRequest.class);
+		MiniMaxChatOptions updatedRuntimeOptions;
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					MiniMaxChatOptions.class);
 		}
+		else {
+			updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					MiniMaxChatOptions.class);
+		}
+
+		request = ModelOptionsUtils.merge(updatedRuntimeOptions, request, ChatCompletionRequest.class);
 
 		request = ModelOptionsUtils.merge(request, this.defaultOptions, ChatCompletionRequest.class);
 

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
@@ -192,11 +192,8 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
-		MiniMaxEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					MiniMaxEmbeddingOptions.class);
-		}
+		MiniMaxEmbeddingOptions runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(),
+				EmbeddingOptions.class, MiniMaxEmbeddingOptions.class);
 
 		// Define request options by merging runtime options and default options
 		MiniMaxEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -228,8 +228,7 @@ public class MistralAiChatModel implements ChatModel {
 				return chatResponse;
 			});
 
-		ChatOptions options = Objects.requireNonNull(prompt.getOptions());
-		if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(options, response)) {
+		if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
 			var toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
 			if (toolExecutionResult.returnDirect()) {
 				// Return tool execution result directly to the client.
@@ -317,8 +316,7 @@ public class MistralAiChatModel implements ChatModel {
 
 			// @formatter:off
 			Flux<ChatResponse> chatResponseFlux = chatResponse.flatMap(response -> {
-				ChatOptions options = Objects.requireNonNull(prompt.getOptions());
-				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(options, response)) {
+				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(prompt.getOptions(), response)) {
 					// FIXME: bounded elastic needs to be used since tool calling
 					//  is currently only synchronous
 					return Flux.deferContextual(ctx -> {
@@ -390,15 +388,13 @@ public class MistralAiChatModel implements ChatModel {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		MistralAiChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						MistralAiChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						MistralAiChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					MistralAiChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					MistralAiChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
@@ -145,11 +145,8 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
-		MistralAiEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					MistralAiEmbeddingOptions.class);
-		}
+		MistralAiEmbeddingOptions runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(),
+				EmbeddingOptions.class, MistralAiEmbeddingOptions.class);
 
 		// Define request options by merging runtime options and default options
 		MistralAiEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
@@ -74,19 +74,8 @@ public class MistralAiModerationModel implements ModerationModel {
 
 			var instructions = moderationPrompt.getInstructions().getText();
 
-			var moderationRequest = new MistralAiModerationRequest(instructions);
-
-			if (this.defaultOptions != null) {
-				moderationRequest = ModelOptionsUtils.merge(this.defaultOptions, moderationRequest,
-						MistralAiModerationRequest.class);
-			}
-			else {
-				// moderationPrompt.getOptions() never null but model can be empty,
-				// cause
-				// by ModerationPrompt constructor
-				moderationRequest = ModelOptionsUtils.merge(toMistralAiModerationOptions(moderationPrompt.getOptions()),
-						moderationRequest, MistralAiModerationRequest.class);
-			}
+			var moderationRequest = ModelOptionsUtils.merge(this.defaultOptions,
+					new MistralAiModerationRequest(instructions), MistralAiModerationRequest.class);
 
 			var moderationResponseEntity = this.mistralAiModerationApi.moderate(moderationRequest);
 

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingModel.java
@@ -163,11 +163,8 @@ public class OCIEmbeddingModel extends AbstractEmbeddingModel {
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
-		OCIEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					OCIEmbeddingOptions.class);
-		}
+		OCIEmbeddingOptions runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(),
+				EmbeddingOptions.class, OCIEmbeddingOptions.class);
 
 		// Define request options by merging runtime options and default options
 		OCIEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.options,

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
@@ -119,11 +119,8 @@ public class OCICohereChatModel implements ChatModel {
 
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
-		OCICohereChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-					OCICohereChatOptions.class);
-		}
+		OCICohereChatOptions runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+				OCICohereChatOptions.class);
 
 		// Define request options by merging runtime options and default options
 		OCICohereChatOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
@@ -149,10 +149,8 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
 		OllamaEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					OllamaEmbeddingOptions.class);
-		}
+		runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
+				OllamaEmbeddingOptions.class);
 
 		// Define request options by merging runtime options and default options
 		OllamaEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,
@@ -171,7 +169,6 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 	 */
 	OllamaApi.EmbeddingsRequest ollamaEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		OllamaEmbeddingOptions requestOptions = (OllamaEmbeddingOptions) embeddingRequest.getOptions();
-		Assert.state(requestOptions != null, "requestOptions must not be null");
 		String model = requestOptions.getModel();
 		Assert.state(model != null, "model must not be null");
 

--- a/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkChatModel.java
+++ b/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkChatModel.java
@@ -714,15 +714,13 @@ public class OpenAiSdkChatModel implements ChatModel {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		OpenAiSdkChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						OpenAiSdkChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						OpenAiSdkChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					OpenAiSdkChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					OpenAiSdkChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options

--- a/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkEmbeddingModel.java
+++ b/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkEmbeddingModel.java
@@ -173,7 +173,7 @@ public class OpenAiSdkEmbeddingModel extends AbstractEmbeddingModel {
 	@Override
 	public float[] embed(Document document) {
 		EmbeddingResponse response = this
-			.call(new EmbeddingRequest(List.of(document.getFormattedContent(this.metadataMode)), null));
+			.call(new EmbeddingRequest(List.of(document.getFormattedContent(this.metadataMode))));
 
 		if (CollectionUtils.isEmpty(response.getResults())) {
 			return new float[0];

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiAudioTranscriptionModel.java
@@ -169,14 +169,8 @@ public class OpenAiAudioTranscriptionModel implements TranscriptionModel {
 
 		OpenAiAudioTranscriptionOptions options = this.defaultOptions;
 
-		if (transcriptionPrompt.getOptions() != null) {
-			if (transcriptionPrompt.getOptions() instanceof OpenAiAudioTranscriptionOptions runtimeOptions) {
-				options = this.merge(runtimeOptions, options);
-			}
-			else {
-				throw new IllegalArgumentException("Prompt options are not of type TranscriptionOptions: "
-						+ transcriptionPrompt.getOptions().getClass().getSimpleName());
-			}
+		if (transcriptionPrompt.getOptions() instanceof OpenAiAudioTranscriptionOptions runtimeOptions) {
+			options = this.merge(runtimeOptions, options);
 		}
 
 		Resource instructions = transcriptionPrompt.getInstructions();

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -405,7 +405,7 @@ public class OpenAiChatModel implements ChatModel {
 	private HttpHeaders getAdditionalHttpHeaders(Prompt prompt) {
 
 		Map<String, String> headers = new HashMap<>(this.defaultOptions.getHttpHeaders());
-		if (prompt.getOptions() != null && prompt.getOptions() instanceof OpenAiChatOptions chatOptions) {
+		if (prompt.getOptions() instanceof OpenAiChatOptions chatOptions) {
 			headers.putAll(chatOptions.getHttpHeaders());
 		}
 		HttpHeaders httpHeaders = new HttpHeaders();
@@ -515,15 +515,13 @@ public class OpenAiChatModel implements ChatModel {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		OpenAiChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						OpenAiChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						OpenAiChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					OpenAiChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					OpenAiChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -201,11 +201,8 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
-		OpenAiEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					OpenAiEmbeddingOptions.class);
-		}
+		OpenAiEmbeddingOptions runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(),
+				EmbeddingOptions.class, OpenAiEmbeddingOptions.class);
 
 		OpenAiEmbeddingOptions requestOptions = runtimeOptions == null ? this.defaultOptions : OpenAiEmbeddingOptions
 			.builder()

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
@@ -182,11 +182,8 @@ public class OpenAiImageModel implements ImageModel {
 
 	private ImagePrompt buildRequestImagePrompt(ImagePrompt imagePrompt) {
 		// Process runtime options
-		OpenAiImageOptions runtimeOptions = null;
-		if (imagePrompt.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(imagePrompt.getOptions(), ImageOptions.class,
-					OpenAiImageOptions.class);
-		}
+		OpenAiImageOptions runtimeOptions = ModelOptionsUtils.copyToTarget(imagePrompt.getOptions(), ImageOptions.class,
+				OpenAiImageOptions.class);
 
 		OpenAiImageOptions requestOptions = runtimeOptions == null ? this.defaultOptions : OpenAiImageOptions.builder()
 			// Handle portable image options

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiModerationModel.java
@@ -64,6 +64,7 @@ public class OpenAiModerationModel implements ModerationModel {
 		Assert.notNull(retryTemplate, "retryTemplate must not be null");
 		this.openAiModerationApi = openAiModerationApi;
 		this.retryTemplate = retryTemplate;
+		this.defaultOptions = OpenAiModerationOptions.builder().build();
 	}
 
 	public OpenAiModerationOptions getDefaultOptions() {
@@ -83,16 +84,10 @@ public class OpenAiModerationModel implements ModerationModel {
 
 			OpenAiModerationApi.OpenAiModerationRequest moderationRequest = new OpenAiModerationApi.OpenAiModerationRequest(
 					instructions);
-
-			if (this.defaultOptions != null) {
-				moderationRequest = ModelOptionsUtils.merge(this.defaultOptions, moderationRequest,
-						OpenAiModerationApi.OpenAiModerationRequest.class);
-			}
-
-			if (moderationPrompt.getOptions() != null) {
-				moderationRequest = ModelOptionsUtils.merge(toOpenAiModerationOptions(moderationPrompt.getOptions()),
-						moderationRequest, OpenAiModerationApi.OpenAiModerationRequest.class);
-			}
+			moderationRequest = ModelOptionsUtils.merge(this.defaultOptions, moderationRequest,
+					OpenAiModerationApi.OpenAiModerationRequest.class);
+			moderationRequest = ModelOptionsUtils.merge(toOpenAiModerationOptions(moderationPrompt.getOptions()),
+					moderationRequest, OpenAiModerationApi.OpenAiModerationRequest.class);
 
 			ResponseEntity<OpenAiModerationApi.OpenAiModerationResponse> moderationResponseEntity = this.openAiModerationApi
 				.createModeration(moderationRequest);

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
@@ -100,11 +100,9 @@ public class VertexAiMultimodalEmbeddingModel implements DocumentEmbeddingModel 
 		// merge the runtime and default vertex ai options.
 		VertexAiMultimodalEmbeddingOptions mergedOptions = this.defaultOptions;
 
-		if (request.getOptions() != null) {
-			var defaultOptionsCopy = VertexAiMultimodalEmbeddingOptions.builder().from(this.defaultOptions).build();
-			mergedOptions = ModelOptionsUtils.merge(request.getOptions(), defaultOptionsCopy,
-					VertexAiMultimodalEmbeddingOptions.class);
-		}
+		var defaultOptionsCopy = VertexAiMultimodalEmbeddingOptions.builder().from(this.defaultOptions).build();
+		mergedOptions = ModelOptionsUtils.merge(request.getOptions(), defaultOptionsCopy,
+				VertexAiMultimodalEmbeddingOptions.class);
 
 		// Create the Vertex AI Prediction Service client.
 		try (PredictionServiceClient client = PredictionServiceClient

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
@@ -168,11 +168,8 @@ public class VertexAiTextEmbeddingModel extends AbstractEmbeddingModel {
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
-		VertexAiTextEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					VertexAiTextEmbeddingOptions.class);
-		}
+		VertexAiTextEmbeddingOptions runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(),
+				EmbeddingOptions.class, VertexAiTextEmbeddingOptions.class);
 
 		// Define request options by merging runtime options and default options
 		VertexAiTextEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -436,15 +436,13 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		VertexAiGeminiChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						VertexAiGeminiChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						VertexAiGeminiChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					VertexAiGeminiChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					VertexAiGeminiChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options
@@ -679,12 +677,8 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 	}
 
 	private VertexAiGeminiChatOptions vertexAiGeminiChatOptions(Prompt prompt) {
-		VertexAiGeminiChatOptions updatedRuntimeOptions = VertexAiGeminiChatOptions.builder().build();
-		if (prompt.getOptions() != null) {
-			updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-					VertexAiGeminiChatOptions.class);
-
-		}
+		VertexAiGeminiChatOptions updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(),
+				ChatOptions.class, VertexAiGeminiChatOptions.class);
 
 		updatedRuntimeOptions = ModelOptionsUtils.merge(updatedRuntimeOptions, this.defaultOptions,
 				VertexAiGeminiChatOptions.class);
@@ -798,7 +792,9 @@ public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 		if (options.getLogprobs() != null) {
 			generationConfigBuilder.setLogprobs(options.getLogprobs());
 		}
-		generationConfigBuilder.setResponseLogprobs(options.getResponseLogprobs());
+		if (options.getResponseLogprobs() != null) {
+			generationConfigBuilder.setResponseLogprobs(options.getResponseLogprobs());
+		}
 
 		return generationConfigBuilder.build();
 	}

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -80,7 +80,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions, Struct
 	 * Optional. If true, returns the log probabilities of the tokens that were chosen by the model at each step.
 	 * By default, this parameter is set to false.
 	 */
-	private @JsonProperty("responseLogprobs") boolean responseLogprobs;
+	private @JsonProperty("responseLogprobs") Boolean responseLogprobs;
 
 	/**
 	 * Optional. If specified, nucleus sampling will be used.
@@ -217,7 +217,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions, Struct
 		this.temperature = temperature;
 	}
 
-	public void setResponseLogprobs(boolean responseLogprobs) {
+	public void setResponseLogprobs(Boolean responseLogprobs) {
 		this.responseLogprobs = responseLogprobs;
 	}
 
@@ -388,7 +388,7 @@ public class VertexAiGeminiChatOptions implements ToolCallingChatOptions, Struct
 		this.logprobs = logprobs;
 	}
 
-	public boolean getResponseLogprobs() {
+	public Boolean getResponseLogprobs() {
 		return this.responseLogprobs;
 	}
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -446,15 +446,13 @@ public class ZhiPuAiChatModel implements ChatModel {
 	Prompt buildRequestPrompt(Prompt prompt) {
 		// Process runtime options
 		ZhiPuAiChatOptions runtimeOptions = null;
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
-						ZhiPuAiChatOptions.class);
-			}
-			else {
-				runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						ZhiPuAiChatOptions.class);
-			}
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					ZhiPuAiChatOptions.class);
+		}
+		else {
+			runtimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					ZhiPuAiChatOptions.class);
 		}
 
 		// Define request options by merging runtime options and default options
@@ -542,19 +540,17 @@ public class ZhiPuAiChatModel implements ChatModel {
 
 		ChatCompletionRequest request = new ChatCompletionRequest(chatCompletionMessages, stream);
 
-		if (prompt.getOptions() != null) {
-			ZhiPuAiChatOptions updatedRuntimeOptions;
-			if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions,
-						ToolCallingChatOptions.class, ZhiPuAiChatOptions.class);
-			}
-			else {
-				updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
-						ZhiPuAiChatOptions.class);
-			}
-
-			request = ModelOptionsUtils.merge(updatedRuntimeOptions, request, ChatCompletionRequest.class);
+		ZhiPuAiChatOptions updatedRuntimeOptions;
+		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(toolCallingChatOptions, ToolCallingChatOptions.class,
+					ZhiPuAiChatOptions.class);
 		}
+		else {
+			updatedRuntimeOptions = ModelOptionsUtils.copyToTarget(prompt.getOptions(), ChatOptions.class,
+					ZhiPuAiChatOptions.class);
+		}
+
+		request = ModelOptionsUtils.merge(updatedRuntimeOptions, request, ChatCompletionRequest.class);
 
 		request = ModelOptionsUtils.merge(request, this.defaultOptions, ChatCompletionRequest.class);
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
@@ -203,11 +203,8 @@ public class ZhiPuAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
 		// Process runtime options
-		ZhiPuAiEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					ZhiPuAiEmbeddingOptions.class);
-		}
+		ZhiPuAiEmbeddingOptions runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(),
+				EmbeddingOptions.class, ZhiPuAiEmbeddingOptions.class);
 
 		// Define request options by merging runtime options and default options
 		ZhiPuAiEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageModel.java
@@ -78,16 +78,10 @@ public class ZhiPuAiImageModel implements ImageModel {
 
 			ZhiPuAiImageApi.ZhiPuAiImageRequest imageRequest = new ZhiPuAiImageApi.ZhiPuAiImageRequest(instructions,
 					ZhiPuAiImageApi.DEFAULT_IMAGE_MODEL);
-
-			if (this.defaultOptions != null) {
-				imageRequest = ModelOptionsUtils.merge(this.defaultOptions, imageRequest,
-						ZhiPuAiImageApi.ZhiPuAiImageRequest.class);
-			}
-
-			if (imagePrompt.getOptions() != null) {
-				imageRequest = ModelOptionsUtils.merge(toZhiPuAiImageOptions(imagePrompt.getOptions()), imageRequest,
-						ZhiPuAiImageApi.ZhiPuAiImageRequest.class);
-			}
+			imageRequest = ModelOptionsUtils.merge(this.defaultOptions, imageRequest,
+					ZhiPuAiImageApi.ZhiPuAiImageRequest.class);
+			imageRequest = ModelOptionsUtils.merge(toZhiPuAiImageOptions(imagePrompt.getOptions()), imageRequest,
+					ZhiPuAiImageApi.ZhiPuAiImageRequest.class);
 
 			// Make the request
 			ResponseEntity<ZhiPuAiImageApi.ZhiPuAiImageResponse> imageResponseEntity = this.zhiPuAiImageApi

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -112,16 +112,8 @@ public class DefaultChatClient implements ChatClient {
 		Assert.notNull(prompt, "prompt cannot be null");
 
 		DefaultChatClientRequestSpec spec = new DefaultChatClientRequestSpec(this.defaultChatClientRequest);
-
-		// Options
-		if (prompt.getOptions() != null) {
-			spec.options(prompt.getOptions());
-		}
-
-		// Messages
-		if (prompt.getInstructions() != null) {
-			spec.messages(prompt.getInstructions());
-		}
+		spec.options(prompt.getOptions());
+		spec.messages(prompt.getInstructions());
 
 		return spec;
 	}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -92,8 +92,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 		Assert.notNull(callAdvisorChain, "callAdvisorChain must not be null");
 		Assert.notNull(chatClientRequest, "chatClientRequest must not be null");
 
-		if (chatClientRequest.prompt().getOptions() == null
-				|| !(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions)) {
+		if (!(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions)) {
 			throw new IllegalArgumentException(
 					"ToolCall Advisor requires ToolCallingChatOptions to be set in the ChatClientRequest options.");
 		}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConvention.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/observation/DefaultChatClientObservationConvention.java
@@ -121,9 +121,6 @@ public class DefaultChatClientObservationConvention implements ChatClientObserva
 	}
 
 	protected KeyValues tools(KeyValues keyValues, ChatClientObservationContext context) {
-		if (context.getRequest().prompt().getOptions() == null) {
-			return keyValues;
-		}
 		if (!(context.getRequest().prompt().getOptions() instanceof ToolCallingChatOptions options)) {
 			return keyValues;
 		}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientNativeStructuredResponseTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientNativeStructuredResponseTests.java
@@ -67,6 +67,7 @@ public class ChatClientNativeStructuredResponseTests {
 				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
+		given(this.structuredOutputChatOptions.copy()).willReturn(this.structuredOutputChatOptions);
 
 		var textCallAdvisor = new ContextCatcherCallAdvisor();
 		ResponseEntity<ChatResponse, UserEntity> responseEntity = ChatClient.builder(this.chatModel)

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -120,7 +120,7 @@ class DefaultChatClientTests {
 		assertThat(spec.getMessages()).hasSize(2);
 		assertThat(spec.getMessages().get(0).getText()).isEqualTo("instructions");
 		assertThat(spec.getMessages().get(1).getText()).isEqualTo("my question");
-		assertThat(spec.getChatOptions()).isNull();
+		assertThat(spec.getChatOptions()).isNotNull();
 	}
 
 	@Test

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionOptions.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.audio.transcription;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.model.ModelOptions;
 
 /**
@@ -25,6 +27,6 @@ import org.springframework.ai.model.ModelOptions;
  */
 public interface AudioTranscriptionOptions extends ModelOptions {
 
-	String getModel();
+	@Nullable String getModel();
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionPrompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/AudioTranscriptionPrompt.java
@@ -34,7 +34,7 @@ public class AudioTranscriptionPrompt implements ModelRequest<Resource> {
 
 	private final Resource audioResource;
 
-	private @Nullable AudioTranscriptionOptions modelOptions;
+	private final AudioTranscriptionOptions modelOptions;
 
 	/**
 	 * Construct a new AudioTranscriptionPrompt given the resource representing the audio
@@ -43,7 +43,7 @@ public class AudioTranscriptionPrompt implements ModelRequest<Resource> {
 	 * @param audioResource resource of the audio file.
 	 */
 	public AudioTranscriptionPrompt(Resource audioResource) {
-		this.audioResource = audioResource;
+		this(audioResource, new EmptyAudioTranscriptionOptions());
 	}
 
 	/**
@@ -53,7 +53,7 @@ public class AudioTranscriptionPrompt implements ModelRequest<Resource> {
 	 * @param audioResource resource of the audio file.
 	 * @param modelOptions
 	 */
-	public AudioTranscriptionPrompt(Resource audioResource, @Nullable AudioTranscriptionOptions modelOptions) {
+	public AudioTranscriptionPrompt(Resource audioResource, AudioTranscriptionOptions modelOptions) {
 		this.audioResource = audioResource;
 		this.modelOptions = modelOptions;
 	}
@@ -64,8 +64,17 @@ public class AudioTranscriptionPrompt implements ModelRequest<Resource> {
 	}
 
 	@Override
-	public @Nullable AudioTranscriptionOptions getOptions() {
+	public AudioTranscriptionOptions getOptions() {
 		return this.modelOptions;
+	}
+
+	private static class EmptyAudioTranscriptionOptions implements AudioTranscriptionOptions {
+
+		@Override
+		public @Nullable String getModel() {
+			return null;
+		}
+
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/TranscriptionModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/audio/transcription/TranscriptionModel.java
@@ -53,7 +53,8 @@ public interface TranscriptionModel extends Model<AudioTranscriptionPrompt, Audi
 	 * @return The transcribed text.
 	 */
 	default String transcribe(Resource resource, @Nullable AudioTranscriptionOptions options) {
-		AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(resource, options);
+		AudioTranscriptionPrompt prompt = (options != null ? new AudioTranscriptionPrompt(resource, options)
+				: new AudioTranscriptionPrompt(resource));
 		AudioTranscription result = this.call(prompt).getResult();
 		return result != null ? result.getOutput() : "";
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
@@ -53,7 +53,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 	@Override
 	public String getContextualName(ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && StringUtils.hasText(options.getModel())) {
+		if (StringUtils.hasText(options.getModel())) {
 			return "%s %s".formatted(context.getOperationMetadata().operationType(), options.getModel());
 		}
 		return context.getOperationMetadata().operationType();
@@ -77,7 +77,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValue requestModel(ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && StringUtils.hasText(options.getModel())) {
+		if (StringUtils.hasText(options.getModel())) {
 			return KeyValue.of(ChatModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL,
 					options.getModel());
 		}
@@ -118,7 +118,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValues requestFrequencyPenalty(KeyValues keyValues, ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && options.getFrequencyPenalty() != null) {
+		if (options.getFrequencyPenalty() != null) {
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString(),
 					String.valueOf(options.getFrequencyPenalty()));
@@ -128,7 +128,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValues requestMaxTokens(KeyValues keyValues, ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && options.getMaxTokens() != null) {
+		if (options.getMaxTokens() != null) {
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString(),
 					String.valueOf(options.getMaxTokens()));
@@ -138,7 +138,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValues requestPresencePenalty(KeyValues keyValues, ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && options.getPresencePenalty() != null) {
+		if (options.getPresencePenalty() != null) {
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString(),
 					String.valueOf(options.getPresencePenalty()));
@@ -148,7 +148,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValues requestStopSequences(KeyValues keyValues, ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && !CollectionUtils.isEmpty(options.getStopSequences())) {
+		if (!CollectionUtils.isEmpty(options.getStopSequences())) {
 			StringJoiner stopSequencesJoiner = new StringJoiner(", ", "[", "]");
 			options.getStopSequences().forEach(value -> stopSequencesJoiner.add("\"" + value + "\""));
 			return keyValues.and(
@@ -160,7 +160,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValues requestTemperature(KeyValues keyValues, ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && options.getTemperature() != null) {
+		if (options.getTemperature() != null) {
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TEMPERATURE.asString(),
 					String.valueOf(options.getTemperature()));
@@ -188,7 +188,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValues requestTopK(KeyValues keyValues, ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && options.getTopK() != null) {
+		if (options.getTopK() != null) {
 			return keyValues.and(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_K.asString(),
 					String.valueOf(options.getTopK()));
 		}
@@ -197,7 +197,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 
 	protected KeyValues requestTopP(KeyValues keyValues, ChatModelObservationContext context) {
 		ChatOptions options = context.getRequest().getOptions();
-		if (options != null && options.getTopP() != null) {
+		if (options.getTopP() != null) {
 			return keyValues.and(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_TOP_P.asString(),
 					String.valueOf(options.getTopP()));
 		}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/Prompt.java
@@ -46,7 +46,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 
 	private final List<Message> messages;
 
-	private @Nullable ChatOptions chatOptions;
+	private final ChatOptions chatOptions;
 
 	public Prompt(String contents) {
 		this(new UserMessage(contents));
@@ -57,24 +57,25 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	public Prompt(List<Message> messages) {
-		this(messages, null);
+		this(messages, ChatOptions.builder().build());
 	}
 
 	public Prompt(Message... messages) {
-		this(Arrays.asList(messages), null);
+		this(Arrays.asList(messages), ChatOptions.builder().build());
 	}
 
-	public Prompt(String contents, @Nullable ChatOptions chatOptions) {
+	public Prompt(String contents, ChatOptions chatOptions) {
 		this(new UserMessage(contents), chatOptions);
 	}
 
-	public Prompt(Message message, @Nullable ChatOptions chatOptions) {
+	public Prompt(Message message, ChatOptions chatOptions) {
 		this(Collections.singletonList(message), chatOptions);
 	}
 
-	public Prompt(List<Message> messages, @Nullable ChatOptions chatOptions) {
+	public Prompt(List<Message> messages, ChatOptions chatOptions) {
 		Assert.notNull(messages, "messages cannot be null");
 		Assert.noNullElements(messages, "messages cannot contain null elements");
+		Assert.notNull(chatOptions, "chatOptions cannot be null");
 		this.messages = messages;
 		this.chatOptions = chatOptions;
 	}
@@ -88,7 +89,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	@Override
-	public @Nullable ChatOptions getOptions() {
+	public ChatOptions getOptions() {
 		return this.chatOptions;
 	}
 
@@ -189,7 +190,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 	}
 
 	public Prompt copy() {
-		return new Prompt(instructionsCopy(), null == this.chatOptions ? null : this.chatOptions.copy());
+		return new Prompt(instructionsCopy(), this.chatOptions.copy());
 	}
 
 	private List<Message> instructionsCopy() {
@@ -243,7 +244,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 			// and add it as the first item in the list.
 			messagesCopy.add(0, systemMessageAugmenter.apply(new SystemMessage("")));
 		}
-		return new Prompt(messagesCopy, null == this.chatOptions ? null : this.chatOptions.copy());
+		return new Prompt(messagesCopy, this.chatOptions.copy());
 	}
 
 	/**
@@ -273,7 +274,7 @@ public class Prompt implements ModelRequest<List<Message>> {
 			}
 		}
 
-		return new Prompt(messagesCopy, null == this.chatOptions ? null : this.chatOptions.copy());
+		return new Prompt(messagesCopy, this.chatOptions.copy());
 	}
 
 	/**
@@ -327,7 +328,8 @@ public class Prompt implements ModelRequest<List<Message>> {
 
 		public Prompt build() {
 			Assert.state(this.messages != null, "either messages or content needs to be set");
-			return new Prompt(this.messages, this.chatOptions);
+			return new Prompt(this.messages,
+					(this.chatOptions != null ? this.chatOptions : ChatOptions.builder().build()));
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/embedding/EmbeddingModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/embedding/EmbeddingModel.java
@@ -19,8 +19,6 @@ package org.springframework.ai.embedding;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.ai.document.Document;
 import org.springframework.ai.model.Model;
 import org.springframework.util.Assert;
@@ -83,8 +81,7 @@ public interface EmbeddingModel extends Model<EmbeddingRequest, EmbeddingRespons
 	 * {@link Document}s. The returned list is expected to be in the same order of the
 	 * {@link Document} list.
 	 */
-	default List<float[]> embed(List<Document> documents, @Nullable EmbeddingOptions options,
-			BatchingStrategy batchingStrategy) {
+	default List<float[]> embed(List<Document> documents, EmbeddingOptions options, BatchingStrategy batchingStrategy) {
 		Assert.notNull(documents, "Documents must not be null");
 		List<float[]> embeddings = new ArrayList<>(documents.size());
 		List<List<Document>> batch = batchingStrategy.batch(documents);

--- a/spring-ai-model/src/main/java/org/springframework/ai/embedding/EmbeddingRequest.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/embedding/EmbeddingRequest.java
@@ -18,8 +18,6 @@ package org.springframework.ai.embedding;
 
 import java.util.List;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.ai.model.ModelRequest;
 
 /**
@@ -31,9 +29,13 @@ public class EmbeddingRequest implements ModelRequest<List<String>> {
 
 	private final List<String> inputs;
 
-	private final @Nullable EmbeddingOptions options;
+	private final EmbeddingOptions options;
 
-	public EmbeddingRequest(List<String> inputs, @Nullable EmbeddingOptions options) {
+	public EmbeddingRequest(List<String> inputs) {
+		this(inputs, EmbeddingOptions.builder().build());
+	}
+
+	public EmbeddingRequest(List<String> inputs, EmbeddingOptions options) {
 		this.inputs = inputs;
 		this.options = options;
 	}
@@ -44,7 +46,7 @@ public class EmbeddingRequest implements ModelRequest<List<String>> {
 	}
 
 	@Override
-	public @Nullable EmbeddingOptions getOptions() {
+	public EmbeddingOptions getOptions() {
 		return this.options;
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/embedding/observation/DefaultEmbeddingModelObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/embedding/observation/DefaultEmbeddingModelObservationConvention.java
@@ -52,7 +52,7 @@ public class DefaultEmbeddingModelObservationConvention implements EmbeddingMode
 
 	@Override
 	public String getContextualName(EmbeddingModelObservationContext context) {
-		return Optional.ofNullable(context.getRequest().getOptions())
+		return Optional.of(context.getRequest().getOptions())
 			.map(EmbeddingOptions::getModel)
 			.filter(StringUtils::hasText)
 			.map(model -> "%s %s".formatted(context.getOperationMetadata().operationType(), model))
@@ -76,7 +76,7 @@ public class DefaultEmbeddingModelObservationConvention implements EmbeddingMode
 	}
 
 	protected KeyValue requestModel(EmbeddingModelObservationContext context) {
-		return Optional.ofNullable(context.getRequest().getOptions())
+		return Optional.of(context.getRequest().getOptions())
 			.map(EmbeddingOptions::getModel)
 			.filter(StringUtils::hasText)
 			.map(model -> KeyValue.of(EmbeddingModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL,
@@ -108,7 +108,7 @@ public class DefaultEmbeddingModelObservationConvention implements EmbeddingMode
 	// Request
 
 	protected KeyValues requestEmbeddingDimension(KeyValues keyValues, EmbeddingModelObservationContext context) {
-		return Optional.ofNullable(context.getRequest().getOptions())
+		return Optional.of(context.getRequest().getOptions())
 			.map(EmbeddingOptions::getDimensions)
 			.map(dimensions -> keyValues
 				.and(EmbeddingModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_EMBEDDING_DIMENSIONS

--- a/spring-ai-model/src/main/java/org/springframework/ai/image/ImagePrompt.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/image/ImagePrompt.java
@@ -20,18 +20,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.ai.model.ModelRequest;
 
 public class ImagePrompt implements ModelRequest<List<ImageMessage>> {
 
 	private final List<ImageMessage> messages;
 
-	private @Nullable ImageOptions imageModelOptions;
+	private final ImageOptions imageModelOptions;
 
 	public ImagePrompt(List<ImageMessage> messages) {
-		this.messages = messages;
+		this(messages, ImageOptionsBuilder.builder().build());
 	}
 
 	public ImagePrompt(List<ImageMessage> messages, ImageOptions imageModelOptions) {
@@ -57,7 +55,7 @@ public class ImagePrompt implements ModelRequest<List<ImageMessage>> {
 	}
 
 	@Override
-	public @Nullable ImageOptions getOptions() {
+	public ImageOptions getOptions() {
 		return this.imageModelOptions;
 	}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelRequest.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelRequest.java
@@ -16,8 +16,6 @@
 
 package org.springframework.ai.model;
 
-import org.jspecify.annotations.Nullable;
-
 /**
  * Interface representing a request to an AI model. This interface encapsulates the
  * necessary information required to interact with an AI model, including instructions or
@@ -41,6 +39,6 @@ public interface ModelRequest<T> {
 	 * Retrieves the customizable options for AI model interactions.
 	 * @return the customizable options for AI model interactions
 	 */
-	@Nullable ModelOptions getOptions();
+	ModelOptions getOptions();
 
 }


### PR DESCRIPTION
Before this commit, `ModelRequest#getOptions` was nullable but almost all usages were expecting mandatory options.

So this commit turns it to non-null and adapt usages accordingly, using default/empty options where relevant.