### PR TITLE
Fix MCP Gateway tool response double-wrapping

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -25,8 +25,6 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.common.util.StringUtils;
 import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpSyncClient;
@@ -41,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import tools.jackson.databind.JsonNode;
 
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.model.ModelOptionsUtils;
@@ -75,8 +74,6 @@ import org.springframework.util.MimeType;
 public final class McpToolUtils {
 
 	private static final Logger logger = LoggerFactory.getLogger(McpToolUtils.class);
-
-	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	/**
 	 * The name of tool context key used to store the MCP exchange object.
@@ -294,13 +291,13 @@ public final class McpToolUtils {
 	 */
 	static List<McpSchema.Content> parseContentList(String callResult) {
 		try {
-			JsonNode jsonNode = OBJECT_MAPPER.readTree(callResult);
+			JsonNode jsonNode = ModelOptionsUtils.JSON_MAPPER.readTree(callResult);
 			if (jsonNode.isArray() && !jsonNode.isEmpty()) {
 				List<McpSchema.Content> contents = new ArrayList<>();
 				for (JsonNode node : jsonNode) {
 					if (node.isObject() && node.has("data") && node.has("mimeType")) {
-						String mimeType = node.get("mimeType").asText();
-						String data = node.get("data").asText();
+						String mimeType = node.get("mimeType").textValue();
+						String data = node.get("data").textValue();
 						if (mimeType.startsWith("audio")) {
 							contents.add(new McpSchema.AudioContent(null, data, mimeType));
 						}
@@ -309,7 +306,7 @@ public final class McpToolUtils {
 						}
 					}
 					else if (node.isObject() && node.has("text")) {
-						contents.add(new McpSchema.TextContent(node.get("text").asText()));
+						contents.add(new McpSchema.TextContent(node.get("text").textValue()));
 					}
 					else if (node.isObject() && node.has("resource")) {
 						// EmbeddedResource contains a sealed ResourceContents type that
@@ -319,11 +316,11 @@ public final class McpToolUtils {
 					}
 					else if (node.isObject() && node.has("uri")) {
 						contents.add(McpSchema.ResourceLink.builder()
-							.uri(node.get("uri").asText())
-							.name(node.has("name") ? node.get("name").asText() : null)
-							.title(node.has("title") ? node.get("title").asText() : null)
-							.description(node.has("description") ? node.get("description").asText() : null)
-							.mimeType(node.has("mimeType") ? node.get("mimeType").asText() : null)
+							.uri(node.get("uri").textValue())
+							.name(node.has("name") ? node.get("name").textValue() : null)
+							.title(node.has("title") ? node.get("title").textValue() : null)
+							.description(node.has("description") ? node.get("description").textValue() : null)
+							.mimeType(node.has("mimeType") ? node.get("mimeType").textValue() : null)
 							.size(node.has("size") ? node.get("size").asLong() : null)
 							.build());
 					}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mcp;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,6 +25,8 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.common.util.StringUtils;
 import io.modelcontextprotocol.client.McpAsyncClient;
 import io.modelcontextprotocol.client.McpSyncClient;
@@ -34,6 +37,8 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.Role;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -68,6 +73,10 @@ import org.springframework.util.MimeType;
  * @author Ilayaperumal Gopinathan
  */
 public final class McpToolUtils {
+
+	private static final Logger logger = LoggerFactory.getLogger(McpToolUtils.class);
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	/**
 	 * The name of tool context key used to store the MCP exchange object.
@@ -264,10 +273,7 @@ public final class McpToolUtils {
 						.isError(false)
 						.build();
 				}
-				return McpSchema.CallToolResult.builder()
-					.content(List.of(new McpSchema.TextContent(callResult)))
-					.isError(false)
-					.build();
+				return McpSchema.CallToolResult.builder().content(parseContentList(callResult)).isError(false).build();
 			}
 			catch (Exception e) {
 				return McpSchema.CallToolResult.builder()
@@ -276,6 +282,65 @@ public final class McpToolUtils {
 					.build();
 			}
 		});
+	}
+
+	/**
+	 * Attempts to parse a string as a list of MCP Content objects. If the string is a
+	 * valid JSON array of Content objects (e.g., from a proxied MCP tool call), it
+	 * returns the deserialized list. Otherwise, it wraps the string in a single
+	 * TextContent.
+	 * @param callResult the string to parse
+	 * @return a list of Content objects
+	 */
+	static List<McpSchema.Content> parseContentList(String callResult) {
+		try {
+			JsonNode jsonNode = OBJECT_MAPPER.readTree(callResult);
+			if (jsonNode.isArray() && !jsonNode.isEmpty()) {
+				List<McpSchema.Content> contents = new ArrayList<>();
+				for (JsonNode node : jsonNode) {
+					if (node.isObject() && node.has("data") && node.has("mimeType")) {
+						String mimeType = node.get("mimeType").asText();
+						String data = node.get("data").asText();
+						if (mimeType.startsWith("audio")) {
+							contents.add(new McpSchema.AudioContent(null, data, mimeType));
+						}
+						else {
+							contents.add(new McpSchema.ImageContent(null, data, mimeType));
+						}
+					}
+					else if (node.isObject() && node.has("text")) {
+						contents.add(new McpSchema.TextContent(node.get("text").asText()));
+					}
+					else if (node.isObject() && node.has("resource")) {
+						// EmbeddedResource contains a sealed ResourceContents type that
+						// requires the MCP SDK ObjectMapper configuration to deserialize.
+						// Preserve the raw JSON as TextContent to avoid data loss.
+						contents.add(new McpSchema.TextContent(node.get("resource").toString()));
+					}
+					else if (node.isObject() && node.has("uri")) {
+						contents.add(McpSchema.ResourceLink.builder()
+							.uri(node.get("uri").asText())
+							.name(node.has("name") ? node.get("name").asText() : null)
+							.title(node.has("title") ? node.get("title").asText() : null)
+							.description(node.has("description") ? node.get("description").asText() : null)
+							.mimeType(node.has("mimeType") ? node.get("mimeType").asText() : null)
+							.size(node.has("size") ? node.get("size").asLong() : null)
+							.build());
+					}
+					else {
+						logger.warn(
+								"Unrecognized MCP content type in proxied tool result, falling back to TextContent: {}",
+								node);
+						contents.add(new McpSchema.TextContent(node.toString()));
+					}
+				}
+				return contents;
+			}
+		}
+		catch (Exception e) {
+			logger.debug("Failed to parse call result as MCP content list, falling back to plain text wrapping", e);
+		}
+		return List.of(new McpSchema.TextContent(callResult));
 	}
 
 	/**

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ParseContentListTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ParseContentListTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.util.List;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParseContentListTests {
+
+	@Test
+	void shouldParseTextContentWithoutTypeField() {
+		String json = "[{\"text\":\"Hello from proxied tool\"}]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(json);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((McpSchema.TextContent) result.get(0)).text()).isEqualTo("Hello from proxied tool");
+	}
+
+	@Test
+	void shouldParseMultipleTextContents() {
+		String json = "[{\"text\":\"First\"},{\"text\":\"Second\"}]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(json);
+
+		assertThat(result).hasSize(2);
+		assertThat(((McpSchema.TextContent) result.get(0)).text()).isEqualTo("First");
+		assertThat(((McpSchema.TextContent) result.get(1)).text()).isEqualTo("Second");
+	}
+
+	@Test
+	void shouldParseImageContent() {
+		String json = "[{\"data\":\"base64data\",\"mimeType\":\"image/png\"}]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(json);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.ImageContent.class);
+		McpSchema.ImageContent img = (McpSchema.ImageContent) result.get(0);
+		assertThat(img.data()).isEqualTo("base64data");
+		assertThat(img.mimeType()).isEqualTo("image/png");
+	}
+
+	@Test
+	void shouldParseAudioContent() {
+		String json = "[{\"data\":\"audiodata\",\"mimeType\":\"audio/mp3\"}]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(json);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.AudioContent.class);
+		McpSchema.AudioContent audio = (McpSchema.AudioContent) result.get(0);
+		assertThat(audio.data()).isEqualTo("audiodata");
+		assertThat(audio.mimeType()).isEqualTo("audio/mp3");
+	}
+
+	@Test
+	void shouldParseMixedContent() {
+		String json = "[{\"text\":\"hello\"},{\"data\":\"img\",\"mimeType\":\"image/jpeg\"}]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(json);
+
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(result.get(1)).isInstanceOf(McpSchema.ImageContent.class);
+	}
+
+	@Test
+	void shouldParseResourceLinkContent() {
+		String json = "[{\"uri\":\"file:///data/report.pdf\",\"name\":\"report\",\"mimeType\":\"application/pdf\"}]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(json);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.ResourceLink.class);
+		McpSchema.ResourceLink link = (McpSchema.ResourceLink) result.get(0);
+		assertThat(link.uri()).isEqualTo("file:///data/report.pdf");
+		assertThat(link.name()).isEqualTo("report");
+	}
+
+	@Test
+	void shouldPreserveEmbeddedResourceContentAsText() {
+		// EmbeddedResource contains a sealed ResourceContents type that requires the MCP
+		// SDK ObjectMapper to deserialize. The resource payload is preserved as
+		// TextContent.
+		String json = "[{\"resource\":{\"uri\":\"file:///data/report.pdf\",\"text\":\"report content\"}}]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(json);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((McpSchema.TextContent) result.get(0)).text()).contains("file:///data/report.pdf",
+				"report content");
+	}
+
+	@Test
+	void shouldWrapPlainStringAsTextContent() {
+		String plainText = "just a plain string";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(plainText);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((McpSchema.TextContent) result.get(0)).text()).isEqualTo("just a plain string");
+	}
+
+	@Test
+	void shouldWrapJsonObjectAsTextContent() {
+		String jsonObject = "{\"key\":\"value\"}";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(jsonObject);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((McpSchema.TextContent) result.get(0)).text()).isEqualTo(jsonObject);
+	}
+
+	@Test
+	void shouldHandleEmptyArray() {
+		String emptyArray = "[]";
+		List<McpSchema.Content> result = McpToolUtils.parseContentList(emptyArray);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0)).isInstanceOf(McpSchema.TextContent.class);
+		assertThat(((McpSchema.TextContent) result.get(0)).text()).isEqualTo("[]");
+	}
+
+}

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ParseContentListTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ParseContentListTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -340,6 +340,64 @@ class ToolUtilsTests {
 	}
 
 	@Test
+	void toSyncToolSpecificationShouldHandleProxiedTextContent() {
+		// Simulates SyncMcpToolCallback.call() returning serialized List<Content>
+		// without the 'type' discriminator field
+		String proxiedResult = "[{\"text\":\"Hello from proxied tool\"}]";
+		ToolCallback callback = createMockToolCallback("proxy-test", proxiedResult);
+
+		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
+
+		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
+		TextContent content = (TextContent) result.content().get(0);
+		assertThat(content.text()).isEqualTo("Hello from proxied tool");
+		assertThat(result.isError()).isFalse();
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldHandleProxiedMultipleTextContent() {
+		String proxiedResult = "[{\"text\":\"First\"},{\"text\":\"Second\"}]";
+		ToolCallback callback = createMockToolCallback("proxy-test", proxiedResult);
+
+		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
+
+		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		assertThat(result.content()).hasSize(2);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("First");
+		assertThat(((TextContent) result.content().get(1)).text()).isEqualTo("Second");
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldHandleProxiedImageContent() {
+		String proxiedResult = "[{\"data\":\"base64data\",\"mimeType\":\"image/png\"}]";
+		ToolCallback callback = createMockToolCallback("proxy-test", proxiedResult);
+
+		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
+
+		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(McpSchema.ImageContent.class);
+		McpSchema.ImageContent imageContent = (McpSchema.ImageContent) result.content().get(0);
+		assertThat(imageContent.data()).isEqualTo("base64data");
+		assertThat(imageContent.mimeType()).isEqualTo("image/png");
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldHandlePlainStringResult() {
+		// Non-JSON string should be wrapped in TextContent as-is
+		ToolCallback callback = createMockToolCallback("test", "plain text result");
+
+		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
+
+		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		assertThat(result.content()).hasSize(1);
+		TextContent content = (TextContent) result.content().get(0);
+		assertThat(content.text()).isEqualTo("plain text result");
+	}
+
+	@Test
 	void getToolCallbacksFromSyncClientsWithEmptyListShouldReturnEmptyList() {
 		List<ToolCallback> result = McpToolUtils.getToolCallbacksFromSyncClients(List.of());
 		assertThat(result).isEmpty();

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -348,7 +348,8 @@ class ToolUtilsTests {
 
 		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
 
-		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new McpSchema.CallToolRequest("proxy-test", Map.of()));
 		assertThat(result.content()).hasSize(1);
 		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
 		TextContent content = (TextContent) result.content().get(0);
@@ -363,7 +364,8 @@ class ToolUtilsTests {
 
 		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
 
-		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new McpSchema.CallToolRequest("proxy-test", Map.of()));
 		assertThat(result.content()).hasSize(2);
 		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("First");
 		assertThat(((TextContent) result.content().get(1)).text()).isEqualTo("Second");
@@ -376,7 +378,8 @@ class ToolUtilsTests {
 
 		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
 
-		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new McpSchema.CallToolRequest("proxy-test", Map.of()));
 		assertThat(result.content()).hasSize(1);
 		assertThat(result.content().get(0)).isInstanceOf(McpSchema.ImageContent.class);
 		McpSchema.ImageContent imageContent = (McpSchema.ImageContent) result.content().get(0);
@@ -391,7 +394,8 @@ class ToolUtilsTests {
 
 		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
 
-		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new McpSchema.CallToolRequest("test", Map.of()));
 		assertThat(result.content()).hasSize(1);
 		TextContent content = (TextContent) result.content().get(0);
 		assertThat(content.text()).isEqualTo("plain text result");


### PR DESCRIPTION
When proxying tool calls through an MCP Gateway, the tool response was being double-wrapped in `TextContent`. The gateway client serializes `CallToolResult.content()` to JSON via `ModelOptionsUtils.toJsonString()`, and then `McpToolUtils.toSharedSyncToolSpecification()` wraps that entire JSON string into a new `TextContent`, losing the original response structure.

**Before (through gateway):**
```json
[{"type":"text","text":"[{\"type\":\"text\",\"text\":\"{\\\"flights\\\":[...]}\"}]"}]
```

**After (through gateway):**
```json
[{"type":"text","text":"{\"flights\":[...]}"}]
```

The fix adds `parseContentList()` which attempts to deserialize the call result as a `List<Content>` before falling back to `TextContent` wrapping. This preserves the original response structure in gateway/proxy scenarios while maintaining backward compatibility for non-MCP tool callbacks.

Fixes #5382