### PR TITLE
Return correct output schema for OpenAi(Sdk)ChatOptions

### DIFF
--- a/models/spring-ai-anthropic/pom.xml
+++ b/models/spring-ai-anthropic/pom.xml
@@ -106,6 +106,13 @@
 		<artifactId>jackson-dataformat-xml</artifactId>
 		<scope>test</scope>
 	</dependency>
+
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<version>${json-unit-assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatOptionsTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatOptionsTests.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -126,6 +127,7 @@ class MistralAiChatOptionsTests {
 		assertThat(options.getRandomSeed()).isNull();
 		assertThat(options.getStopSequences()).isNull();
 		assertThat(options.getResponseFormat()).isNull();
+		assertThat(options.getOutputSchema()).isNull();
 	}
 
 	@Test
@@ -448,6 +450,13 @@ class MistralAiChatOptionsTests {
 
 		assertThat(options.getResponseFormat()).isNotNull();
 		assertThat(options.getResponseFormat().getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
+		ResponseFormat.JsonSchema jsonSchema = options.getResponseFormat().getJsonSchema();
+		assertThat(jsonSchema).isNotNull();
+		assertThat(jsonSchema.getName()).isEqualTo("custom_schema");
+		assertThat(jsonSchema.getStrict()).isTrue();
+		assertThat(jsonSchema.getSchema()).containsOnly(Assertions.entry("type", "object"),
+				Assertions.entry("properties", Map.of()));
+		assertThat(options.getOutputSchema()).isEqualTo(schema);
 	}
 
 	@Test

--- a/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/chat/OpenAiSdkChatOptionsTests.java
+++ b/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/chat/OpenAiSdkChatOptionsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.openaisdk.OpenAiSdkChatModel.ResponseFormat;
 import org.springframework.ai.openaisdk.OpenAiSdkChatOptions;
 import org.springframework.ai.openaisdk.OpenAiSdkChatOptions.StreamOptions;
 import org.springframework.ai.tool.ToolCallback;
@@ -249,6 +250,7 @@ public class OpenAiSdkChatOptionsTests {
 		assertThat(options.getInternalToolExecutionEnabled()).isNull();
 		assertThat(options.getCustomHeaders()).isNotNull().isEmpty();
 		assertThat(options.getToolContext()).isNotNull().isEmpty();
+		assertThat(options.getOutputSchema()).isNull();
 	}
 
 	@Test
@@ -674,6 +676,29 @@ public class OpenAiSdkChatOptionsTests {
 		OpenAiSdkChatOptions options = new OpenAiSdkChatOptions();
 		// TopK is not supported by OpenAI, should always return null
 		assertThat(options.getTopK()).isNull();
+	}
+
+	@Test
+	void testSetOutputSchema() {
+		OpenAiSdkChatOptions options = new OpenAiSdkChatOptions();
+		// language=JSON
+		String schema = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						}
+					}
+				}
+				""";
+
+		options.setOutputSchema(schema);
+
+		assertThat(options.getResponseFormat()).isNotNull();
+		assertThat(options.getResponseFormat().getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
+		assertThat(options.getResponseFormat().getJsonSchema()).isEqualTo(schema);
+		assertThat(options.getOutputSchema()).isEqualTo(schema);
 	}
 
 }

--- a/models/spring-ai-openai/pom.xml
+++ b/models/spring-ai-openai/pom.xml
@@ -135,6 +135,11 @@
 			<artifactId>rest-assured</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<version>${json-unit-assertj.version}</version>
+		</dependency>
 
 	</dependencies>
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -680,7 +680,16 @@ public class OpenAiChatOptions implements ToolCallingChatOptions, StructuredOutp
 	@Override
 	@JsonIgnore
 	public String getOutputSchema() {
-		return this.getResponseFormat().getSchema();
+		ResponseFormat responseFormat = this.getResponseFormat();
+		if (responseFormat == null) {
+			return null;
+		}
+		String schema = responseFormat.getSchema();
+		if (schema != null) {
+			return schema;
+		}
+		ResponseFormat.JsonSchema jsonSchema = responseFormat.getJsonSchema();
+		return jsonSchema != null ? ModelOptionsUtils.toJsonString(jsonSchema.getSchema()) : null;
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/ResponseFormat.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/ResponseFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,13 +97,15 @@ public class ResponseFormat {
 		}
 	}
 
-	private ResponseFormat(Type type, JsonSchema jsonSchema) {
+	private ResponseFormat(Type type, JsonSchema jsonSchema, String schema) {
 		this.type = type;
 		this.jsonSchema = jsonSchema;
+		this.schema = schema;
 	}
 
 	public ResponseFormat(Type type, String schema) {
-		this(type, StringUtils.hasText(schema) ? JsonSchema.builder().schema(schema).strict(true).build() : null);
+		this(type, StringUtils.hasText(schema) ? JsonSchema.builder().schema(schema).strict(true).build() : null,
+				schema);
 	}
 
 	public static Builder builder() {
@@ -136,6 +138,8 @@ public class ResponseFormat {
 
 		private Type type;
 
+		private String schema;
+
 		private JsonSchema jsonSchema;
 
 		private Builder() {
@@ -153,11 +157,12 @@ public class ResponseFormat {
 
 		public Builder jsonSchema(String jsonSchema) {
 			this.jsonSchema = JsonSchema.builder().schema(jsonSchema).build();
+			this.schema = jsonSchema;
 			return this;
 		}
 
 		public ResponseFormat build() {
-			return new ResponseFormat(this.type, this.jsonSchema);
+			return new ResponseFormat(this.type, this.jsonSchema, this.schema);
 		}
 
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/ResponseFormatTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/ResponseFormatTests.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.api;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ResponseFormat}.
+ *
+ * @author Filip Hrisafov
+ */
+class ResponseFormatTests {
+
+	@Test
+	void testDefaultConstructor() {
+		ResponseFormat format = new ResponseFormat();
+
+		assertThat(format.getType()).isNull();
+		assertThat(format.getJsonSchema()).isNull();
+		assertThat(format.getSchema()).isNull();
+	}
+
+	@Test
+	void testConstructorWithTypeAndSchema() {
+		// language=JSON
+		String schema = """
+				{
+					"type": "object",
+					"properties": {
+						"name": {"type": "string"}
+					}
+				}
+				""";
+
+		ResponseFormat format = new ResponseFormat(ResponseFormat.Type.JSON_SCHEMA, schema);
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
+		assertThat(format.getSchema()).isEqualTo(schema);
+		assertThat(format.getJsonSchema()).isNotNull();
+		assertThat(format.getJsonSchema().getSchema()).containsKeys("type", "properties");
+		assertThat(format.getJsonSchema().getStrict()).isTrue();
+		assertThat(format.getJsonSchema().getName()).isEqualTo("custom_schema");
+	}
+
+	@Test
+	void testConstructorWithTypeAndNullSchema() {
+		ResponseFormat format = new ResponseFormat(ResponseFormat.Type.TEXT, null);
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.TEXT);
+		assertThat(format.getSchema()).isNull();
+		assertThat(format.getJsonSchema()).isNull();
+	}
+
+	@Test
+	void testConstructorWithTypeAndEmptySchema() {
+		ResponseFormat format = new ResponseFormat(ResponseFormat.Type.JSON_OBJECT, "");
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.JSON_OBJECT);
+		assertThat(format.getSchema()).isEmpty();
+		assertThat(format.getJsonSchema()).isNull();
+	}
+
+	@Test
+	void testSettersAndGetters() {
+		ResponseFormat format = new ResponseFormat();
+
+		format.setType(ResponseFormat.Type.JSON_OBJECT);
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.JSON_OBJECT);
+
+		ResponseFormat.JsonSchema jsonSchema = ResponseFormat.JsonSchema.builder()
+			.name("test_schema")
+			.schema(Map.of("type", "object"))
+			.strict(false)
+			.build();
+
+		format.setJsonSchema(jsonSchema);
+		assertThat(format.getJsonSchema()).isEqualTo(jsonSchema);
+		assertThat(format.getSchema()).isNull();
+	}
+
+	@Test
+	void testSetSchema() {
+		ResponseFormat format = new ResponseFormat();
+		// language=JSON
+		String schema = """
+				{
+					"type": "array",
+					"items": { "type": "string" }
+				}
+				""";
+
+		format.setSchema(schema);
+
+		assertThat(format.getSchema()).isEqualTo(schema);
+		assertThat(format.getJsonSchema()).isNotNull();
+		assertThat(format.getJsonSchema().getSchema()).containsKeys("type", "items");
+		assertThat(format.getJsonSchema().getStrict()).isTrue();
+		assertThat(format.getJsonSchema().getName()).isEqualTo("custom_schema");
+	}
+
+	@Test
+	void testSetSchemaNullResetsJsonSchema() {
+		ResponseFormat format = new ResponseFormat();
+		// language=JSON
+		String schema = """
+				{ "type": "object" }
+				""";
+
+		format.setSchema(schema);
+		assertThat(format.getJsonSchema()).isNotNull();
+
+		format.setSchema(null);
+		assertThat(format.getSchema()).isNull();
+		// Note: The setter doesn't reset jsonSchema to null when schema is null
+		// This is the current behavior based on the implementation
+	}
+
+	@Test
+	void testBuilderWithType() {
+		ResponseFormat format = ResponseFormat.builder().type(ResponseFormat.Type.TEXT).build();
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.TEXT);
+		assertThat(format.getJsonSchema()).isNull();
+		assertThat(format.getSchema()).isNull();
+	}
+
+	@Test
+	void testBuilderWithJsonSchemaObject() {
+		ResponseFormat.JsonSchema jsonSchema = ResponseFormat.JsonSchema.builder()
+			.name("my_schema")
+			.schema(Map.of("type", "string"))
+			.strict(false)
+			.build();
+
+		ResponseFormat format = ResponseFormat.builder()
+			.type(ResponseFormat.Type.JSON_SCHEMA)
+			.jsonSchema(jsonSchema)
+			.build();
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
+		assertThat(format.getJsonSchema()).isEqualTo(jsonSchema);
+		assertThat(format.getSchema()).isNull();
+	}
+
+	@Test
+	void testBuilderWithJsonSchemaString() {
+		// language=JSON
+		String schema = """
+				{
+					"type": "object",
+					"properties": {
+						"age": {"type": "number"}
+					}
+				}
+				""";
+
+		ResponseFormat format = ResponseFormat.builder()
+			.type(ResponseFormat.Type.JSON_SCHEMA)
+			.jsonSchema(schema)
+			.build();
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
+		assertThat(format.getJsonSchema()).isNotNull();
+		assertThat(format.getJsonSchema().getSchema()).containsKeys("type", "properties");
+		assertThat(format.getSchema()).isEqualTo(schema);
+	}
+
+	@Test
+	void testEqualsAndHashCode() {
+		ResponseFormat format1 = ResponseFormat.builder()
+			.type(ResponseFormat.Type.JSON_OBJECT)
+			.jsonSchema(ResponseFormat.JsonSchema.builder().schema(Map.of("type", "object")).build())
+			.build();
+
+		ResponseFormat format2 = ResponseFormat.builder()
+			.type(ResponseFormat.Type.JSON_OBJECT)
+			.jsonSchema(ResponseFormat.JsonSchema.builder().schema(Map.of("type", "object")).build())
+			.build();
+
+		ResponseFormat format3 = ResponseFormat.builder().type(ResponseFormat.Type.TEXT).build();
+
+		assertThat(format1).isEqualTo(format2);
+		assertThat(format1).isNotEqualTo(format3);
+		assertThat(format1).isNotEqualTo(null);
+		assertThat(format1).isEqualTo(format1);
+
+		assertThat(format1.hashCode()).isEqualTo(format2.hashCode());
+		assertThat(format1.hashCode()).isNotEqualTo(format3.hashCode());
+	}
+
+	@Test
+	void testToString() {
+		ResponseFormat format = ResponseFormat.builder()
+			.type(ResponseFormat.Type.JSON_SCHEMA)
+			.jsonSchema(ResponseFormat.JsonSchema.builder().name("test").schema(Map.of("type", "object")).build())
+			.build();
+
+		String result = format.toString();
+
+		assertThat(result).contains("ResponseFormat");
+		assertThat(result).contains("type=JSON_SCHEMA");
+		assertThat(result).contains("jsonSchema=");
+	}
+
+	@Test
+	void testJsonSerializationWithType() {
+		ResponseFormat format = ResponseFormat.builder().type(ResponseFormat.Type.TEXT).build();
+
+		String json = JsonMapper.shared().writeValueAsString(format);
+
+		assertThat(json).contains("\"type\":\"text\"");
+		assertThat(json).doesNotContain("json_schema");
+	}
+
+	@Test
+	void testJsonSerializationWithJsonSchema() {
+		ResponseFormat format = ResponseFormat.builder()
+			.type(ResponseFormat.Type.JSON_SCHEMA)
+			.jsonSchema(ResponseFormat.JsonSchema.builder()
+				.name("person_schema")
+				.schema(Map.of("type", "object", "properties", Map.of("name", Map.of("type", "string"))))
+				.strict(true)
+				.build())
+			.build();
+
+		String json = JsonMapper.shared().writeValueAsString(format);
+
+		assertThat(json).contains("\"type\":\"json_schema\"");
+		assertThat(json).contains("\"json_schema\"");
+		assertThat(json).contains("\"name\":\"person_schema\"");
+		assertThat(json).contains("\"strict\":true");
+	}
+
+	@Test
+	void testJsonDeserializationWithType() {
+		String json = "{\"type\":\"json_object\"}";
+
+		ResponseFormat format = JsonMapper.shared().readValue(json, ResponseFormat.class);
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.JSON_OBJECT);
+		assertThat(format.getJsonSchema()).isNull();
+	}
+
+	@Test
+	void testJsonDeserializationWithJsonSchema() {
+		String json = """
+				{
+					"type": "json_schema",
+					"json_schema": {
+						"name": "test_schema",
+						"schema": {"type": "object"},
+						"strict": false
+					}
+				}
+				""";
+
+		ResponseFormat format = JsonMapper.shared().readValue(json, ResponseFormat.class);
+
+		assertThat(format.getType()).isEqualTo(ResponseFormat.Type.JSON_SCHEMA);
+		assertThat(format.getJsonSchema()).isNotNull();
+		assertThat(format.getJsonSchema().getName()).isEqualTo("test_schema");
+		assertThat(format.getJsonSchema().getSchema()).containsEntry("type", "object");
+		assertThat(format.getJsonSchema().getStrict()).isFalse();
+	}
+
+	@Test
+	void testJsonSchemaDefaultConstructor() {
+		ResponseFormat.JsonSchema jsonSchema = new ResponseFormat.JsonSchema();
+
+		assertThat(jsonSchema.getName()).isNull();
+		assertThat(jsonSchema.getSchema()).isNull();
+		assertThat(jsonSchema.getStrict()).isNull();
+	}
+
+	@Test
+	void testJsonSchemaBuilder() {
+		ResponseFormat.JsonSchema jsonSchema = ResponseFormat.JsonSchema.builder()
+			.name("my_schema")
+			.schema(Map.of("type", "string"))
+			.strict(false)
+			.build();
+
+		assertThat(jsonSchema.getName()).isEqualTo("my_schema");
+		assertThat(jsonSchema.getSchema()).containsEntry("type", "string");
+		assertThat(jsonSchema.getStrict()).isFalse();
+	}
+
+	@Test
+	void testJsonSchemaBuilderWithStringSchema() {
+		// language=JSON
+		String schema = """
+				{
+					"type": "object",
+					"properties": {
+						"id": { "type": "integer" }
+					}
+				}
+				""";
+
+		ResponseFormat.JsonSchema jsonSchema = ResponseFormat.JsonSchema.builder().schema(schema).build();
+
+		assertThat(jsonSchema.getSchema()).containsKeys("type", "properties");
+		assertThat(jsonSchema.getSchema()).containsEntry("type", "object");
+	}
+
+	@Test
+	void testJsonSchemaBuilderDefaults() {
+		ResponseFormat.JsonSchema jsonSchema = ResponseFormat.JsonSchema.builder()
+			.schema(Map.of("type", "object"))
+			.build();
+
+		assertThat(jsonSchema.getName()).isEqualTo("custom_schema");
+		assertThat(jsonSchema.getStrict()).isTrue();
+	}
+
+	@Test
+	void testJsonSchemaBuilderCanOverrideDefaults() {
+		ResponseFormat.JsonSchema jsonSchema = ResponseFormat.JsonSchema.builder()
+			.name("override_name")
+			.schema(Map.of("type", "array"))
+			.strict(false)
+			.build();
+
+		assertThat(jsonSchema.getName()).isEqualTo("override_name");
+		assertThat(jsonSchema.getStrict()).isFalse();
+	}
+
+	@Test
+	void testJsonSchemaEqualsAndHashCode() {
+		ResponseFormat.JsonSchema schema1 = ResponseFormat.JsonSchema.builder()
+			.name("schema1")
+			.schema(Map.of("type", "object"))
+			.strict(true)
+			.build();
+
+		ResponseFormat.JsonSchema schema2 = ResponseFormat.JsonSchema.builder()
+			.name("schema1")
+			.schema(Map.of("type", "object"))
+			.strict(true)
+			.build();
+
+		ResponseFormat.JsonSchema schema3 = ResponseFormat.JsonSchema.builder()
+			.name("schema2")
+			.schema(Map.of("type", "object"))
+			.strict(true)
+			.build();
+
+		assertThat(schema1).isEqualTo(schema2);
+		assertThat(schema1).isNotEqualTo(schema3);
+		assertThat(schema1).isNotEqualTo(null);
+		assertThat(schema1).isEqualTo(schema1);
+
+		assertThat(schema1.hashCode()).isEqualTo(schema2.hashCode());
+		assertThat(schema1.hashCode()).isNotEqualTo(schema3.hashCode());
+	}
+
+	@Test
+	void testTypeEnumJsonSerialization() {
+		ResponseFormat.Type type = ResponseFormat.Type.JSON_SCHEMA;
+
+		String json = JsonMapper.shared().writeValueAsString(type);
+
+		assertThat(json).isEqualTo("\"json_schema\"");
+	}
+
+	@Test
+	void testTypeEnumJsonDeserialization() {
+		String json = "\"json_object\"";
+
+		ResponseFormat.Type type = JsonMapper.shared().readValue(json, ResponseFormat.Type.class);
+
+		assertThat(type).isEqualTo(ResponseFormat.Type.JSON_OBJECT);
+	}
+
+}


### PR DESCRIPTION
- Fix NPE in OpenAi(Sdk)ChatOptions and return correct schema
- Add output schema test cases across for different models

