### PR TITLE
Migrate MCP Spring transports from Java SDK to Spring AI

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/StdioTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/StdioTransportAutoConfiguration.java
@@ -20,10 +20,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
@@ -78,8 +77,7 @@ public class StdioTransportAutoConfiguration {
 		List<NamedClientMcpTransport> stdioTransports = new ArrayList<>();
 
 		for (Map.Entry<String, ServerParameters> serverParameters : stdioProperties.toServerParameters().entrySet()) {
-			var transport = new StdioClientTransport(serverParameters.getValue(),
-					new JacksonMcpJsonMapper(new ObjectMapper()));
+			var transport = new StdioClientTransport(serverParameters.getValue(), McpJsonMapper.getDefault());
 			stdioTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -21,12 +21,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.McpSseClientConnectionDetails;
@@ -100,11 +99,8 @@ public class SseHttpClientTransportAutoConfiguration {
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> sseHttpClientTransports(McpSseClientConnectionDetails connectionDetails,
-			ObjectProvider<ObjectMapper> objectMapperProvider,
 			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
 			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
-
-		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
 		List<NamedClientMcpTransport> sseTransports = new ArrayList<>();
 
@@ -123,7 +119,7 @@ public class SseHttpClientTransportAutoConfiguration {
 				var transportBuilder = HttpClientSseClientTransport.builder(baseUrl)
 					.sseEndpoint(sseEndpoint)
 					.clientBuilder(HttpClient.newBuilder())
-					.jsonMapper(new JacksonMcpJsonMapper(objectMapper));
+					.jsonMapper(McpJsonMapper.getDefault());
 
 				asyncHttpRequestCustomizer.ifUnique(transportBuilder::asyncHttpRequestCustomizer);
 				syncHttpRequestCustomizer.ifUnique(transportBuilder::httpRequestCustomizer);

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
@@ -21,12 +21,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
@@ -95,11 +94,9 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> streamableHttpHttpClientTransports(
-			McpStreamableHttpClientProperties streamableProperties, ObjectProvider<ObjectMapper> objectMapperProvider,
+			McpStreamableHttpClientProperties streamableProperties,
 			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
 			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
-
-		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
 		List<NamedClientMcpTransport> streamableHttpTransports = new ArrayList<>();
 
@@ -114,7 +111,7 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 				.builder(baseUrl)
 				.endpoint(streamableHttpEndpoint)
 				.clientBuilder(HttpClient.newBuilder())
-				.jsonMapper(new JacksonMcpJsonMapper(objectMapper));
+				.jsonMapper(McpJsonMapper.getDefault());
 
 			asyncHttpRequestCustomizer.ifUnique(transportBuilder::asyncHttpRequestCustomizer);
 			syncHttpRequestCustomizer.ifUnique(transportBuilder::httpRequestCustomizer);

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/pom.xml
@@ -49,8 +49,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
+			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
@@ -21,9 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.McpSseClientConnectionDetails;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
@@ -31,6 +29,7 @@ import org.springframework.ai.mcp.client.common.autoconfigure.PropertiesMcpSseCl
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties.SseParameters;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -90,13 +89,11 @@ public class SseWebFluxTransportAutoConfiguration {
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> sseWebFluxClientTransports(McpSseClientConnectionDetails connectionDetails,
-			ObjectProvider<WebClient.Builder> webClientBuilderProvider,
-			ObjectProvider<ObjectMapper> objectMapperProvider) {
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider) {
 
 		List<NamedClientMcpTransport> sseTransports = new ArrayList<>();
 
 		var webClientBuilderTemplate = webClientBuilderProvider.getIfAvailable(WebClient::builder);
-		var objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
 		for (Map.Entry<String, SseParameters> serverParameters : connectionDetails.getConnections().entrySet()) {
 			String url = Objects.requireNonNull(serverParameters.getValue().url(),
@@ -105,7 +102,7 @@ public class SseWebFluxTransportAutoConfiguration {
 			String sseEndpoint = Objects.requireNonNullElse(serverParameters.getValue().sseEndpoint(), "/sse");
 			var transport = WebFluxSseClientTransport.builder(webClientBuilder)
 				.sseEndpoint(sseEndpoint)
-				.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+				.jsonMapper(McpJsonMapper.getDefault())
 				.build();
 			sseTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
 		}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
@@ -21,14 +21,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -86,13 +85,11 @@ public class StreamableHttpWebFluxTransportAutoConfiguration {
 	@Bean
 	public List<NamedClientMcpTransport> streamableHttpWebFluxClientTransports(
 			McpStreamableHttpClientProperties streamableProperties,
-			ObjectProvider<WebClient.Builder> webClientBuilderProvider,
-			ObjectProvider<ObjectMapper> objectMapperProvider) {
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider) {
 
 		List<NamedClientMcpTransport> streamableHttpTransports = new ArrayList<>();
 
 		var webClientBuilderTemplate = webClientBuilderProvider.getIfAvailable(WebClient::builder);
-		var objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
 
 		for (Map.Entry<String, ConnectionParameters> serverParameters : streamableProperties.getConnections()
 			.entrySet()) {
@@ -103,7 +100,7 @@ public class StreamableHttpWebFluxTransportAutoConfiguration {
 
 			var transport = WebClientStreamableHttpTransport.builder(webClientBuilder)
 				.endpoint(streamableHttpEndpoint)
-				.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+				.jsonMapper(McpJsonMapper.getDefault())
 				.build();
 
 			streamableHttpTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfigurationTests.java
@@ -20,10 +20,10 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -52,8 +52,8 @@ public class SseWebFluxTransportAutoConfigurationTests {
 	@Test
 	void webFluxClientTransportsNotPresentIfMissingWebFluxSseClientTransportNotPresent() {
 		this.applicationContext
-			.withClassLoader(
-					new FilteredClassLoader("io.modelcontextprotocol.client.transport.WebFluxSseClientTransport"))
+			.withClassLoader(new FilteredClassLoader(
+					"org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport"))
 			.run(context -> assertThat(context.containsBean("sseWebFluxClientTransports")).isFalse());
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
@@ -20,10 +20,10 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
@@ -22,8 +22,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServer;
@@ -54,7 +53,6 @@ import org.springframework.ai.mcp.customizer.McpSyncServerCustomizer;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerChangeNotificationProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
@@ -96,9 +94,8 @@ public class McpServerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public McpServerTransportProviderBase stdioServerTransport(
-			@Qualifier("mcpServerObjectMapper") ObjectMapper mcpServerObjectMapper) {
-		return new StdioServerTransportProvider(new JacksonMcpJsonMapper(mcpServerObjectMapper));
+	public McpServerTransportProviderBase stdioServerTransport() {
+		return new StdioServerTransportProvider(McpJsonMapper.getDefault());
 	}
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/pom.xml
@@ -49,8 +49,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
+			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStatelessWebFluxAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStatelessWebFluxAutoConfiguration.java
@@ -16,15 +16,13 @@
 
 package org.springframework.ai.mcp.server.webflux.autoconfigure;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -47,11 +45,10 @@ public class McpServerStatelessWebFluxAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public WebFluxStatelessServerTransport webFluxStatelessServerTransport(
-			@Qualifier("mcpServerObjectMapper") ObjectMapper objectMapper,
 			McpServerStreamableHttpProperties serverProperties) {
 
 		return WebFluxStatelessServerTransport.builder()
-			.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+			.jsonMapper(McpJsonMapper.getDefault())
 			.messageEndpoint(serverProperties.getMcpEndpoint())
 			.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStreamableHttpWebFluxAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStreamableHttpWebFluxAutoConfiguration.java
@@ -16,16 +16,14 @@
 
 package org.springframework.ai.mcp.server.webflux.autoconfigure;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -48,15 +46,16 @@ public class McpServerStreamableHttpWebFluxAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public WebFluxStreamableServerTransportProvider webFluxStreamableServerTransportProvider(
-			@Qualifier("mcpServerObjectMapper") ObjectMapper objectMapper,
 			McpServerStreamableHttpProperties serverProperties) {
 
-		return WebFluxStreamableServerTransportProvider.builder()
-			.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+		var builder = WebFluxStreamableServerTransportProvider.builder()
+			.jsonMapper(McpJsonMapper.getDefault())
 			.messageEndpoint(serverProperties.getMcpEndpoint())
-			.keepAliveInterval(serverProperties.getKeepAliveInterval())
-			.disallowDelete(serverProperties.isDisallowDelete())
-			.build();
+			.disallowDelete(serverProperties.isDisallowDelete());
+		if (serverProperties.getKeepAliveInterval() != null) {
+			builder.keepAliveInterval(serverProperties.getKeepAliveInterval());
+		}
+		return builder.build();
 	}
 
 	// Router function for streamable http transport used by Spring WebFlux to start an

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerSseWebFluxAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerSseWebFluxAutoConfigurationIT.java
@@ -18,12 +18,12 @@ package org.springframework.ai.mcp.server.webflux.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerSseProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.web.reactive.function.server.RouterFunction;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerSseWebFluxAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerSseWebFluxAutoConfigurationTests.java
@@ -17,11 +17,11 @@
 package org.springframework.ai.mcp.server.webflux.autoconfigure;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStatelessWebFluxAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStatelessWebFluxAutoConfigurationIT.java
@@ -18,10 +18,10 @@ package org.springframework.ai.mcp.server.webflux.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStreamableHttpWebFluxAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerStreamableHttpWebFluxAutoConfigurationIT.java
@@ -18,10 +18,10 @@ package org.springframework.ai.mcp.server.webflux.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.web.reactive.function.server.RouterFunction;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpToolCallProviderCachingIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpToolCallProviderCachingIT.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springaicommunity.mcp.annotation.McpTool;
@@ -41,6 +40,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMap
 import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration;
 import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpToolCallbackParameterlessToolIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpToolCallbackParameterlessToolIT.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
 import reactor.netty.DisposableServer;
@@ -42,6 +41,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMap
 import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/SseWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/SseWebClientWebFluxServerIT.java
@@ -30,7 +30,6 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -69,6 +68,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfi
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
@@ -25,7 +25,6 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.server.McpStatelessSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -57,6 +56,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStateless
 import org.springframework.ai.mcp.server.common.autoconfigure.StatelessToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotations2IT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotations2IT.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -80,6 +79,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpSer
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsIT.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -81,6 +80,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpSer
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsManualIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsManualIT.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -83,6 +82,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpSer
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration;
 import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsWithLLMIT.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
 import org.junit.jupiter.api.Test;
@@ -58,6 +57,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServ
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
 import org.springframework.ai.mcp.server.webflux.autoconfigure.capabilities.McpHandlerConfiguration;
 import org.springframework.ai.mcp.server.webflux.autoconfigure.capabilities.McpHandlerService;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration;
 import org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableWebClientWebFluxServerIT.java
@@ -31,7 +31,6 @@ import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -71,6 +70,7 @@ import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMap
 import org.springframework.ai.mcp.server.common.autoconfigure.ToolCallbackConverterAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/pom.xml
@@ -49,8 +49,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>mcp-spring-webmvc</artifactId>
+			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerSseWebMvcAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerSseWebMvcAutoConfiguration.java
@@ -16,15 +16,13 @@
 
 package org.springframework.ai.mcp.server.webmvc.autoconfigure;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerSseProperties;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -75,16 +73,17 @@ public class McpServerSseWebMvcAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider(
-			@Qualifier("mcpServerObjectMapper") ObjectMapper objectMapper, McpServerSseProperties serverProperties) {
+	public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider(McpServerSseProperties serverProperties) {
 
-		return WebMvcSseServerTransportProvider.builder()
-			.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+		var builder = WebMvcSseServerTransportProvider.builder()
+			.jsonMapper(McpJsonMapper.getDefault())
 			.baseUrl(serverProperties.getBaseUrl())
 			.sseEndpoint(serverProperties.getSseEndpoint())
-			.messageEndpoint(serverProperties.getSseMessageEndpoint())
-			.keepAliveInterval(serverProperties.getKeepAliveInterval())
-			.build();
+			.messageEndpoint(serverProperties.getSseMessageEndpoint());
+		if (serverProperties.getKeepAliveInterval() != null) {
+			builder.keepAliveInterval(serverProperties.getKeepAliveInterval());
+		}
+		return builder.build();
 	}
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStatelessWebMvcAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStatelessWebMvcAutoConfiguration.java
@@ -16,15 +16,13 @@
 
 package org.springframework.ai.mcp.server.webmvc.autoconfigure;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebMvcStatelessServerTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -48,11 +46,10 @@ public class McpServerStatelessWebMvcAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public WebMvcStatelessServerTransport webMvcStatelessServerTransport(
-			@Qualifier("mcpServerObjectMapper") ObjectMapper objectMapper,
 			McpServerStreamableHttpProperties serverProperties) {
 
 		return WebMvcStatelessServerTransport.builder()
-			.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+			.jsonMapper(McpJsonMapper.getDefault())
 			.messageEndpoint(serverProperties.getMcpEndpoint())
 			.build();
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStreamableHttpWebMvcAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStreamableHttpWebMvcAutoConfiguration.java
@@ -16,16 +16,14 @@
 
 package org.springframework.ai.mcp.server.webmvc.autoconfigure;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebMvcStreamableServerTransportProvider;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerStreamableHttpProperties;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -49,15 +47,16 @@ public class McpServerStreamableHttpWebMvcAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public WebMvcStreamableServerTransportProvider webMvcStreamableServerTransportProvider(
-			@Qualifier("mcpServerObjectMapper") ObjectMapper objectMapper,
 			McpServerStreamableHttpProperties serverProperties) {
 
-		return WebMvcStreamableServerTransportProvider.builder()
-			.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+		var builder = WebMvcStreamableServerTransportProvider.builder()
+			.jsonMapper(McpJsonMapper.getDefault())
 			.mcpEndpoint(serverProperties.getMcpEndpoint())
-			.keepAliveInterval(serverProperties.getKeepAliveInterval())
-			.disallowDelete(serverProperties.isDisallowDelete())
-			.build();
+			.disallowDelete(serverProperties.isDisallowDelete());
+		if (serverProperties.getKeepAliveInterval() != null) {
+			builder.keepAliveInterval(serverProperties.getKeepAliveInterval());
+		}
+		return builder.build();
 	}
 
 	// Router function for streamable http transport used by Spring WebFlux to start an

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerSseWebMvcAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerSseWebMvcAutoConfigurationIT.java
@@ -18,12 +18,12 @@ package org.springframework.ai.mcp.server.webmvc.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerSseProperties;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStatelessWebMvcAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStatelessWebMvcAutoConfigurationIT.java
@@ -18,10 +18,10 @@ package org.springframework.ai.mcp.server.webmvc.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebMvcStatelessServerTransport;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.web.servlet.function.RouterFunction;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStreamableHttpWebMvcAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerStreamableHttpWebMvcAutoConfigurationIT.java
@@ -18,10 +18,10 @@ package org.springframework.ai.mcp.server.webmvc.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.server.transport.WebMvcStreamableServerTransportProvider;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerObjectMapperAutoConfiguration;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.web.servlet.function.RouterFunction;

--- a/mcp/common/pom.xml
+++ b/mcp/common/pom.xml
@@ -53,14 +53,16 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
+			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
 
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>mcp-spring-webmvc</artifactId>
+			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/mcp/transport/mcp-spring-webflux/pom.xml
+++ b/mcp/transport/mcp-spring-webflux/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>mcp-spring-webflux</artifactId>
+	<packaging>jar</packaging>
+	<name>WebFlux transports</name>
+	<description>WebFlux implementation for the SSE and Streamable Http Client and Server transports</description>
+	<url>https://github.com/modelcontextprotocol/java-sdk</url>
+
+	<scm>
+		<url>https://github.com/modelcontextprotocol/java-sdk</url>
+		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
+	</scm>
+
+	<properties>
+		<testcontainers.version>1.21.4</testcontainers.version>
+		<toxiproxy.version>1.21.0</toxiproxy.version>
+		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-core</artifactId>
+			<version>${mcp.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-test</artifactId>
+			<version>${mcp.sdk.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webflux</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-json-jackson2</artifactId>
+			<version>${mcp.sdk.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty-http</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- The Spring Context is required due to the reactor-netty connector being dependant on
+		the Spring Lifecycle, as discussed here:
+		https://github.com/spring-projects/spring-framework/issues/31180 -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>toxiproxy</artifactId>
+			<version>${toxiproxy.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<version>${json-unit-assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+
+</project>

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
@@ -1,0 +1,643 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.ClosedMcpTransportSession;
+import io.modelcontextprotocol.spec.DefaultMcpTransportSession;
+import io.modelcontextprotocol.spec.DefaultMcpTransportStream;
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpTransportException;
+import io.modelcontextprotocol.spec.McpTransportSession;
+import io.modelcontextprotocol.spec.McpTransportSessionNotFoundException;
+import io.modelcontextprotocol.spec.McpTransportStream;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.Utils;
+import org.jspecify.annotations.Nullable;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * An implementation of the Streamable HTTP protocol as defined by the
+ * <code>2025-03-26</code> version of the MCP specification.
+ *
+ * <p>
+ * The transport is capable of resumability and reconnects. It reacts to transport-level
+ * session invalidation and will propagate {@link McpTransportSessionNotFoundException
+ * appropriate exceptions} to the higher level abstraction layer when needed in order to
+ * allow proper state management. The implementation handles servers that are stateful and
+ * provide session meta information, but can also communicate with stateless servers that
+ * do not provide a session identifier and do not support SSE streams.
+ * </p>
+ * <p>
+ * This implementation does not handle backwards compatibility with the <a href=
+ * "https://modelcontextprotocol.io/specification/2024-11-05/basic/transports#http-with-sse">"HTTP
+ * with SSE" transport</a>. In order to communicate over the phased-out
+ * <code>2024-11-05</code> protocol, use {@link HttpClientSseClientTransport} or
+ * {@link WebFluxSseClientTransport}.
+ * </p>
+ *
+ * @author Dariusz Jędrzejczyk
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http">Streamable
+ * HTTP transport specification</a>
+ */
+public final class WebClientStreamableHttpTransport implements McpClientTransport {
+
+	private static final String MISSING_SESSION_ID = "[missing_session_id]";
+
+	private static final Logger logger = LoggerFactory.getLogger(WebClientStreamableHttpTransport.class);
+
+	private static final String DEFAULT_ENDPOINT = "/mcp";
+
+	/**
+	 * Event type for JSON-RPC messages received through the SSE connection. The server
+	 * sends messages with this event type to transmit JSON-RPC protocol data.
+	 */
+	private static final String MESSAGE_EVENT_TYPE = "message";
+
+	private static final ParameterizedTypeReference<ServerSentEvent<String>> PARAMETERIZED_TYPE_REF = new ParameterizedTypeReference<>() {
+	};
+
+	private final McpJsonMapper jsonMapper;
+
+	private final WebClient webClient;
+
+	private final String endpoint;
+
+	private final boolean openConnectionOnStartup;
+
+	private final boolean resumableStreams;
+
+	private final AtomicReference<McpTransportSession<Disposable>> activeSession = new AtomicReference<>();
+
+	private final AtomicReference<Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>>> handler = new AtomicReference<>();
+
+	private final AtomicReference<@Nullable Consumer<Throwable>> exceptionHandler = new AtomicReference<>();
+
+	private final List<String> supportedProtocolVersions;
+
+	private final String latestSupportedProtocolVersion;
+
+	private WebClientStreamableHttpTransport(McpJsonMapper jsonMapper, WebClient.Builder webClientBuilder,
+			String endpoint, boolean resumableStreams, boolean openConnectionOnStartup,
+			List<String> supportedProtocolVersions) {
+		this.jsonMapper = jsonMapper;
+		this.webClient = webClientBuilder.build();
+		this.endpoint = endpoint;
+		this.resumableStreams = resumableStreams;
+		this.openConnectionOnStartup = openConnectionOnStartup;
+		this.activeSession.set(createTransportSession());
+		this.supportedProtocolVersions = List.copyOf(supportedProtocolVersions);
+		this.latestSupportedProtocolVersion = this.supportedProtocolVersions.stream()
+			.sorted(Comparator.reverseOrder())
+			.findFirst()
+			.get();
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return this.supportedProtocolVersions;
+	}
+
+	/**
+	 * Create a stateful builder for creating {@link WebClientStreamableHttpTransport}
+	 * instances.
+	 * @param webClientBuilder the {@link WebClient.Builder} to use
+	 * @return a builder which will create an instance of
+	 * {@link WebClientStreamableHttpTransport} once {@link Builder#build()} is called
+	 */
+	public static Builder builder(WebClient.Builder webClientBuilder) {
+		return new Builder(webClientBuilder);
+	}
+
+	@Override
+	public Mono<Void> connect(Function<Mono<McpSchema.JSONRPCMessage>, Mono<McpSchema.JSONRPCMessage>> handler) {
+		return Mono.deferContextual(ctx -> {
+			this.handler.set(handler);
+			if (this.openConnectionOnStartup) {
+				logger.debug("Eagerly opening connection on startup");
+				return this.reconnect(null).then();
+			}
+			return Mono.empty();
+		});
+	}
+
+	private McpTransportSession<Disposable> createTransportSession() {
+		Function<String, Publisher<Void>> onClose = sessionId -> sessionId == null ? Mono.empty()
+				: this.webClient.delete()
+					.uri(this.endpoint)
+					.header(HttpHeaders.MCP_SESSION_ID, sessionId)
+					.header(HttpHeaders.PROTOCOL_VERSION, this.latestSupportedProtocolVersion)
+					.retrieve()
+					.toBodilessEntity()
+					.onErrorComplete(e -> {
+						logger.warn("Got error when closing transport", e);
+						return true;
+					})
+					.then();
+		return new DefaultMcpTransportSession(onClose);
+	}
+
+	private McpTransportSession<Disposable> createClosedSession(McpTransportSession<Disposable> existingSession) {
+		var existingSessionId = Optional.ofNullable(existingSession)
+			.filter(session -> !(session instanceof ClosedMcpTransportSession<Disposable>))
+			.flatMap(McpTransportSession::sessionId)
+			.orElse(null);
+		return new ClosedMcpTransportSession<>(existingSessionId);
+	}
+
+	@Override
+	public void setExceptionHandler(Consumer<Throwable> handler) {
+		logger.debug("Exception handler registered");
+		this.exceptionHandler.set(handler);
+	}
+
+	private void handleException(Throwable t) {
+		logger.debug("Handling exception for session {}", sessionIdOrPlaceholder(this.activeSession.get()), t);
+		if (t instanceof McpTransportSessionNotFoundException) {
+			McpTransportSession<?> invalidSession = this.activeSession.getAndSet(createTransportSession());
+			logger.warn("Server does not recognize session {}. Invalidating.", invalidSession.sessionId());
+			invalidSession.close();
+		}
+		Consumer<Throwable> handler = this.exceptionHandler.get();
+		if (handler != null) {
+			handler.accept(t);
+		}
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Mono.defer(() -> {
+			logger.debug("Graceful close triggered");
+			McpTransportSession<Disposable> currentSession = this.activeSession.getAndUpdate(this::createClosedSession);
+			if (currentSession != null) {
+				return Mono.from(currentSession.closeGracefully());
+			}
+			return Mono.empty();
+		});
+	}
+
+	private Mono<Disposable> reconnect(@Nullable McpTransportStream<Disposable> stream) {
+		return Mono.deferContextual(ctx -> {
+			if (stream != null) {
+				logger.debug("Reconnecting stream {} with lastId {}", stream.streamId(), stream.lastId());
+			}
+			else {
+				logger.debug("Reconnecting with no prior stream");
+			}
+			// Here we attempt to initialize the client. In case the server supports SSE,
+			// we will establish a long-running
+			// session here and listen for messages. If it doesn't, that's ok, the server
+			// is a simple, stateless one.
+			final AtomicReference<@Nullable Disposable> disposableRef = new AtomicReference<>();
+			final McpTransportSession<Disposable> transportSession = this.activeSession.get();
+
+			Disposable connection = this.webClient.get()
+				.uri(this.endpoint)
+				.accept(MediaType.TEXT_EVENT_STREAM)
+				.header(HttpHeaders.PROTOCOL_VERSION,
+						Objects.requireNonNullElse(ctx.getOrDefault(McpAsyncClient.NEGOTIATED_PROTOCOL_VERSION,
+								this.latestSupportedProtocolVersion), this.latestSupportedProtocolVersion))
+				.headers(httpHeaders -> {
+					transportSession.sessionId().ifPresent(id -> httpHeaders.add(HttpHeaders.MCP_SESSION_ID, id));
+					if (stream != null) {
+						stream.lastId().ifPresent(id -> httpHeaders.add(HttpHeaders.LAST_EVENT_ID, id));
+					}
+				})
+				.exchangeToFlux(response -> {
+					if (isEventStream(response)) {
+						logger.debug("Established SSE stream via GET");
+						return eventStream(stream, response);
+					}
+					else if (isNotAllowed(response)) {
+						logger.debug("The server does not support SSE streams, using request-response mode.");
+						return Flux.empty();
+					}
+					else if (isNotFound(response)) {
+						if (transportSession.sessionId().isPresent()) {
+							String sessionIdRepresentation = sessionIdOrPlaceholder(transportSession);
+							return mcpSessionNotFoundError(sessionIdRepresentation);
+						}
+						else {
+							return this.extractError(response, MISSING_SESSION_ID);
+						}
+					}
+					else {
+						return response.<McpSchema.JSONRPCMessage>createError()
+							.doOnError(e -> logger.info("Opening an SSE stream failed. This can be safely ignored.", e))
+							.flux();
+					}
+				})
+				.flatMap(jsonrpcMessage -> this.handler.get().apply(Mono.just(jsonrpcMessage)))
+				.onErrorComplete(t -> {
+					this.handleException(t);
+					return true;
+				})
+				.doFinally(s -> {
+					Disposable ref = disposableRef.getAndSet(null);
+					if (ref != null) {
+						transportSession.removeConnection(ref);
+					}
+				})
+				.contextWrite(ctx)
+				.subscribe();
+
+			disposableRef.set(connection);
+			transportSession.addConnection(connection);
+			return Mono.just(connection);
+		});
+	}
+
+	@Override
+	public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+		String jsonText;
+		try {
+			jsonText = this.jsonMapper.writeValueAsString(message);
+		}
+		catch (IOException e) {
+			return Mono.error(new RuntimeException("Failed to serialize message", e));
+		}
+		return Mono.create(sink -> {
+			logger.debug("Sending message {}", message);
+			// Here we attempt to initialize the client.
+			// In case the server supports SSE, we will establish a long-running session
+			// here and
+			// listen for messages.
+			// If it doesn't, nothing actually happens here, that's just the way it is...
+			final AtomicReference<@Nullable Disposable> disposableRef = new AtomicReference<>();
+			final McpTransportSession<Disposable> transportSession = this.activeSession.get();
+
+			Disposable connection = Flux.deferContextual(ctx -> this.webClient.post()
+				.uri(this.endpoint)
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.header(HttpHeaders.PROTOCOL_VERSION,
+						Objects.requireNonNullElse(ctx.getOrDefault(McpAsyncClient.NEGOTIATED_PROTOCOL_VERSION,
+								this.latestSupportedProtocolVersion), this.latestSupportedProtocolVersion))
+				.headers(httpHeaders -> transportSession.sessionId()
+					.ifPresent(id -> httpHeaders.add(HttpHeaders.MCP_SESSION_ID, id)))
+				.bodyValue(jsonText)
+				.exchangeToFlux(response -> {
+					if (transportSession
+						.markInitialized(response.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID))) {
+						// Once we have a session, we try to open an async stream for
+						// the server to send notifications and requests out-of-band.
+						reconnect(null).contextWrite(sink.contextView()).subscribe();
+					}
+
+					String sessionRepresentation = sessionIdOrPlaceholder(transportSession);
+
+					// The spec mentions only ACCEPTED, but the existing SDKs can return
+					// 200 OK for notifications
+					if (response.statusCode().is2xxSuccessful()) {
+						Optional<MediaType> contentType = response.headers().contentType();
+						long contentLength = response.headers().contentLength().orElse(-1);
+						// Existing SDKs consume notifications with no response body nor
+						// content type
+						if (contentType.isEmpty() || contentLength == 0
+								|| response.statusCode().equals(HttpStatus.ACCEPTED)) {
+							logger.trace("Message was successfully sent via POST for session {}",
+									sessionRepresentation);
+							// signal the caller that the message was successfully
+							// delivered
+							sink.success();
+							// communicate to downstream there is no streamed data coming
+							return Flux.empty();
+						}
+						else {
+							MediaType mediaType = contentType.get();
+							if (mediaType.isCompatibleWith(MediaType.TEXT_EVENT_STREAM)) {
+								logger.debug("Established SSE stream via POST");
+								// communicate to caller that the message was delivered
+								sink.success();
+								// starting a stream
+								return newEventStream(response, sessionRepresentation);
+							}
+							else if (mediaType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+								logger.trace("Received response to POST for session {}", sessionRepresentation);
+								// communicate to caller the message was delivered
+								sink.success();
+								return directResponseFlux(message, response);
+							}
+							else {
+								logger.warn("Unknown media type {} returned for POST in session {}", contentType,
+										sessionRepresentation);
+								return Flux.error(new RuntimeException("Unknown media type returned: " + contentType));
+							}
+						}
+					}
+					else {
+						if (isNotFound(response) && !sessionRepresentation.equals(MISSING_SESSION_ID)) {
+							return mcpSessionNotFoundError(sessionRepresentation);
+						}
+						return this.extractError(response, sessionRepresentation);
+					}
+				}))
+				.flatMap(jsonRpcMessage -> this.handler.get().apply(Mono.just(jsonRpcMessage)))
+				.onErrorComplete(t -> {
+					// handle the error first
+					this.handleException(t);
+					// inform the caller of sendMessage
+					sink.error(t);
+					return true;
+				})
+				.doFinally(s -> {
+					Disposable ref = disposableRef.getAndSet(null);
+					if (ref != null) {
+						transportSession.removeConnection(ref);
+					}
+				})
+				.contextWrite(sink.contextView())
+				.subscribe();
+			disposableRef.set(connection);
+			transportSession.addConnection(connection);
+		});
+	}
+
+	private static Flux<McpSchema.JSONRPCMessage> mcpSessionNotFoundError(String sessionRepresentation) {
+		logger.warn("Session {} was not found on the MCP server", sessionRepresentation);
+		// inform the stream/connection subscriber
+		return Flux.error(new McpTransportSessionNotFoundException(sessionRepresentation));
+	}
+
+	private Flux<McpSchema.JSONRPCMessage> extractError(ClientResponse response, String sessionRepresentation) {
+		return response.<McpSchema.JSONRPCMessage>createError().onErrorResume(e -> {
+			WebClientResponseException responseException = (WebClientResponseException) e;
+			byte[] body = responseException.getResponseBodyAsByteArray();
+			McpSchema.JSONRPCResponse.JSONRPCError jsonRpcError = null;
+			Exception toPropagate;
+			try {
+				McpSchema.JSONRPCResponse jsonRpcResponse = this.jsonMapper.readValue(body,
+						McpSchema.JSONRPCResponse.class);
+				jsonRpcError = jsonRpcResponse.error();
+				toPropagate = jsonRpcError != null ? new McpError(jsonRpcError)
+						: new McpTransportException("Can't parse the jsonResponse " + jsonRpcResponse);
+			}
+			catch (IOException ex) {
+				toPropagate = new McpTransportException("Sending request failed, " + e.getMessage(), e);
+				logger.debug("Received content together with {} HTTP code response: {}", response.statusCode(), body);
+			}
+
+			// Some implementations can return 400 when presented with a
+			// session id that it doesn't know about, so we will
+			// invalidate the session
+			// https://github.com/modelcontextprotocol/typescript-sdk/issues/389
+			if (responseException.getStatusCode().isSameCodeAs(HttpStatus.BAD_REQUEST)) {
+				if (!sessionRepresentation.equals(MISSING_SESSION_ID)) {
+					return Mono.error(new McpTransportSessionNotFoundException(sessionRepresentation, toPropagate));
+				}
+				return Mono.error(new McpTransportException("Received 400 BAD REQUEST for session "
+						+ sessionRepresentation + ". " + toPropagate.getMessage(), toPropagate));
+			}
+			return Mono.error(toPropagate);
+		}).flux();
+	}
+
+	private Flux<McpSchema.JSONRPCMessage> eventStream(@Nullable McpTransportStream<Disposable> stream,
+			ClientResponse response) {
+		McpTransportStream<Disposable> sessionStream = stream != null ? stream
+				: new DefaultMcpTransportStream<>(this.resumableStreams, this::reconnect);
+		logger.debug("Connected stream {}", sessionStream.streamId());
+
+		var idWithMessages = response.bodyToFlux(PARAMETERIZED_TYPE_REF).map(this::parse);
+		return Flux.from(sessionStream.consumeSseStream(idWithMessages));
+	}
+
+	private static boolean isNotFound(ClientResponse response) {
+		return response.statusCode().isSameCodeAs(HttpStatus.NOT_FOUND);
+	}
+
+	private static boolean isNotAllowed(ClientResponse response) {
+		return response.statusCode().isSameCodeAs(HttpStatus.METHOD_NOT_ALLOWED);
+	}
+
+	private static boolean isEventStream(ClientResponse response) {
+		return response.statusCode().is2xxSuccessful() && response.headers().contentType().isPresent()
+				&& response.headers().contentType().get().isCompatibleWith(MediaType.TEXT_EVENT_STREAM);
+	}
+
+	private static String sessionIdOrPlaceholder(McpTransportSession<?> transportSession) {
+		return transportSession.sessionId().orElse(MISSING_SESSION_ID);
+	}
+
+	private Flux<McpSchema.JSONRPCMessage> directResponseFlux(McpSchema.JSONRPCMessage sentMessage,
+			ClientResponse response) {
+		return response.bodyToMono(String.class).<Iterable<McpSchema.JSONRPCMessage>>handle((responseMessage, s) -> {
+			try {
+				if (sentMessage instanceof McpSchema.JSONRPCNotification) {
+					logger.warn("Notification: {} received non-compliant response: {}", sentMessage,
+							Utils.hasText(responseMessage) ? responseMessage : "[empty]");
+					s.complete();
+				}
+				else {
+					McpSchema.JSONRPCMessage jsonRpcResponse = McpSchema.deserializeJsonRpcMessage(this.jsonMapper,
+							responseMessage);
+					s.next(List.of(jsonRpcResponse));
+				}
+			}
+			catch (IOException e) {
+				s.error(new McpTransportException(e));
+			}
+		}).flatMapIterable(Function.identity());
+	}
+
+	private Flux<McpSchema.JSONRPCMessage> newEventStream(ClientResponse response, String sessionRepresentation) {
+		McpTransportStream<Disposable> sessionStream = new DefaultMcpTransportStream<>(this.resumableStreams,
+				this::reconnect);
+		logger.trace("Sent POST and opened a stream ({}) for session {}", sessionStream.streamId(),
+				sessionRepresentation);
+		return eventStream(sessionStream, response);
+	}
+
+	@Override
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return this.jsonMapper.convertValue(data, typeRef);
+	}
+
+	private Tuple2<Optional<String>, Iterable<McpSchema.JSONRPCMessage>> parse(ServerSentEvent<String> event) {
+		if (MESSAGE_EVENT_TYPE.equals(event.event())) {
+			try {
+				// We don't support batching ATM and probably won't since the next version
+				// considers removing it.
+				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, event.data());
+				String eventId = event.id();
+				Optional<String> id = eventId != null ? Optional.of(eventId) : Optional.empty();
+				return Tuples.of(id, List.of(message));
+			}
+			catch (IOException ioException) {
+				throw new McpTransportException("Error parsing JSON-RPC message: " + event.data(), ioException);
+			}
+		}
+		else {
+			logger.debug("Received SSE event with type: {}", event);
+			return Tuples.of(Optional.empty(), List.of());
+		}
+	}
+
+	/**
+	 * Builder for {@link WebClientStreamableHttpTransport}.
+	 */
+	public static final class Builder {
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		private WebClient.Builder webClientBuilder;
+
+		private String endpoint = DEFAULT_ENDPOINT;
+
+		private boolean resumableStreams = true;
+
+		private boolean openConnectionOnStartup = false;
+
+		private List<String> supportedProtocolVersions = List.of(ProtocolVersions.MCP_2024_11_05,
+				ProtocolVersions.MCP_2025_03_26, ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
+
+		private Builder(WebClient.Builder webClientBuilder) {
+			Assert.notNull(webClientBuilder, "WebClient.Builder must not be null");
+			this.webClientBuilder = webClientBuilder;
+		}
+
+		/**
+		 * Configure the {@link McpJsonMapper} to use.
+		 * @param jsonMapper instance to use
+		 * @return the builder instance
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "JsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Configure the {@link WebClient.Builder} to construct the {@link WebClient}.
+		 * @param webClientBuilder instance to use
+		 * @return the builder instance
+		 */
+		public Builder webClientBuilder(WebClient.Builder webClientBuilder) {
+			Assert.notNull(webClientBuilder, "WebClient.Builder must not be null");
+			this.webClientBuilder = webClientBuilder;
+			return this;
+		}
+
+		/**
+		 * Configure the endpoint to make HTTP requests against.
+		 * @param endpoint endpoint to use
+		 * @return the builder instance
+		 */
+		public Builder endpoint(String endpoint) {
+			Assert.hasText(endpoint, "endpoint must be a non-empty String");
+			this.endpoint = endpoint;
+			return this;
+		}
+
+		/**
+		 * Configure whether to use the stream resumability feature by keeping track of
+		 * SSE event ids.
+		 * @param resumableStreams if {@code true} event ids will be tracked and upon
+		 * disconnection, the last seen id will be used upon reconnection as a header to
+		 * resume consuming messages.
+		 * @return the builder instance
+		 */
+		public Builder resumableStreams(boolean resumableStreams) {
+			this.resumableStreams = resumableStreams;
+			return this;
+		}
+
+		/**
+		 * Configure whether the client should open an SSE connection upon startup. Not
+		 * all servers support this (although it is in theory possible with the current
+		 * specification), so use with caution. By default, this value is {@code false}.
+		 * @param openConnectionOnStartup if {@code true} the {@link #connect(Function)}
+		 * method call will try to open an SSE connection before sending any JSON-RPC
+		 * request
+		 * @return the builder instance
+		 */
+		public Builder openConnectionOnStartup(boolean openConnectionOnStartup) {
+			this.openConnectionOnStartup = openConnectionOnStartup;
+			return this;
+		}
+
+		/**
+		 * Sets the list of supported protocol versions used in version negotiation. By
+		 * default, the client will send the latest of those versions in the
+		 * {@code MCP-Protocol-Version} header.
+		 * <p>
+		 * Setting this value only updates the values used in version negotiation, and
+		 * does NOT impact the actual capabilities of the transport. It should only be
+		 * used for compatibility with servers having strict requirements around the
+		 * {@code MCP-Protocol-Version} header.
+		 * @param supportedProtocolVersions protocol versions supported by this transport
+		 * @return this builder
+		 * @see <a href=
+		 * "https://modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle#version-negotiation">version
+		 * negotiation specification</a>
+		 * @see <a href=
+		 * "https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header">Protocol
+		 * Version Header</a>
+		 */
+		public Builder supportedProtocolVersions(List<String> supportedProtocolVersions) {
+			Assert.notEmpty(supportedProtocolVersions, "supportedProtocolVersions must not be empty");
+			this.supportedProtocolVersions = Collections.unmodifiableList(supportedProtocolVersions);
+			return this;
+		}
+
+		/**
+		 * Construct a fresh instance of {@link WebClientStreamableHttpTransport} using
+		 * the current builder configuration.
+		 * @return a new instance of {@link WebClientStreamableHttpTransport}
+		 */
+		public WebClientStreamableHttpTransport build() {
+			return new WebClientStreamableHttpTransport(
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.webClientBuilder,
+					this.endpoint, this.resumableStreams, this.openConnectionOnStartup, this.supportedProtocolVersions);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransport.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.publisher.SynchronousSink;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+import reactor.util.retry.Retry.RetrySignal;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Server-Sent Events (SSE) implementation of the
+ * {@link io.modelcontextprotocol.spec.McpTransport} that follows the MCP HTTP with SSE
+ * transport specification.
+ *
+ * <p>
+ * This transport establishes a bidirectional communication channel where:
+ * <ul>
+ * <li>Inbound messages are received through an SSE connection from the server</li>
+ * <li>Outbound messages are sent via HTTP POST requests to a server-provided
+ * endpoint</li>
+ * </ul>
+ *
+ * <p>
+ * The message flow follows these steps:
+ * <ol>
+ * <li>The client establishes an SSE connection to the server's /sse endpoint</li>
+ * <li>The server sends an 'endpoint' event containing the URI for sending messages</li>
+ * </ol>
+ *
+ * This implementation uses {@link WebClient} for HTTP communications and supports JSON
+ * serialization/deserialization of messages.
+ *
+ * @author Christian Tzolov
+ * @see <a href=
+ * "https://spec.modelcontextprotocol.io/specification/basic/transports/#http-with-sse">MCP
+ * HTTP with SSE Transport Specification</a>
+ */
+public class WebFluxSseClientTransport implements McpClientTransport {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebFluxSseClientTransport.class);
+
+	private static final String MCP_PROTOCOL_VERSION = ProtocolVersions.MCP_2024_11_05;
+
+	/**
+	 * Event type for JSON-RPC messages received through the SSE connection. The server
+	 * sends messages with this event type to transmit JSON-RPC protocol data.
+	 */
+	private static final String MESSAGE_EVENT_TYPE = "message";
+
+	/**
+	 * Event type for receiving the message endpoint URI from the server. The server MUST
+	 * send this event when a client connects, providing the URI where the client should
+	 * send its messages via HTTP POST.
+	 */
+	private static final String ENDPOINT_EVENT_TYPE = "endpoint";
+
+	/**
+	 * Default SSE endpoint path as specified by the MCP transport specification. This
+	 * endpoint is used to establish the SSE connection with the server.
+	 */
+	private static final String DEFAULT_SSE_ENDPOINT = "/sse";
+
+	/**
+	 * Type reference for parsing SSE events containing string data.
+	 */
+	private static final ParameterizedTypeReference<ServerSentEvent<String>> SSE_TYPE = new ParameterizedTypeReference<>() {
+	};
+
+	/**
+	 * WebClient instance for handling both SSE connections and HTTP POST requests. Used
+	 * for establishing the SSE connection and sending outbound messages.
+	 */
+	private final WebClient webClient;
+
+	/**
+	 * JSON mapper for serializing outbound messages and deserializing inbound messages.
+	 * Handles conversion between JSON-RPC messages and their string representation.
+	 */
+	protected McpJsonMapper jsonMapper;
+
+	/**
+	 * Subscription for the SSE connection handling inbound messages. Used for cleanup
+	 * during transport shutdown.
+	 */
+	@Nullable private Disposable inboundSubscription;
+
+	/**
+	 * Flag indicating if the transport is in the process of shutting down. Used to
+	 * prevent new operations during shutdown and handle cleanup gracefully.
+	 */
+	private volatile boolean isClosing = false;
+
+	/**
+	 * Sink for managing the message endpoint URI provided by the server. Stores the most
+	 * recent endpoint URI and makes it available for outbound message processing.
+	 */
+	protected final Sinks.One<String> messageEndpointSink = Sinks.one();
+
+	/**
+	 * The SSE endpoint URI provided by the server. Used for sending outbound messages via
+	 * HTTP POST requests.
+	 */
+	private String sseEndpoint;
+
+	/**
+	 * Constructs a new SseClientTransport with the specified WebClient builder and
+	 * ObjectMapper. Initializes both inbound and outbound message processing pipelines.
+	 * @param webClientBuilder the WebClient.Builder to use for creating the WebClient
+	 * instance
+	 * @param jsonMapper the ObjectMapper to use for JSON processing
+	 * @throws IllegalArgumentException if either parameter is null
+	 */
+	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, McpJsonMapper jsonMapper) {
+		this(webClientBuilder, jsonMapper, DEFAULT_SSE_ENDPOINT);
+	}
+
+	/**
+	 * Constructs a new SseClientTransport with the specified WebClient builder and
+	 * ObjectMapper. Initializes both inbound and outbound message processing pipelines.
+	 * @param webClientBuilder the WebClient.Builder to use for creating the WebClient
+	 * instance
+	 * @param jsonMapper the ObjectMapper to use for JSON processing
+	 * @param sseEndpoint the SSE endpoint URI to use for establishing the connection
+	 * @throws IllegalArgumentException if either parameter is null
+	 */
+	public WebFluxSseClientTransport(WebClient.Builder webClientBuilder, McpJsonMapper jsonMapper, String sseEndpoint) {
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
+		Assert.notNull(webClientBuilder, "WebClient.Builder must not be null");
+		Assert.hasText(sseEndpoint, "SSE endpoint must not be null or empty");
+
+		this.jsonMapper = jsonMapper;
+		this.webClient = webClientBuilder.build();
+		this.sseEndpoint = sseEndpoint;
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return List.of(MCP_PROTOCOL_VERSION);
+	}
+
+	/**
+	 * Establishes a connection to the MCP server using Server-Sent Events (SSE). This
+	 * method initiates the SSE connection and sets up the message processing pipeline.
+	 *
+	 * <p>
+	 * The connection process follows these steps:
+	 * <ol>
+	 * <li>Establishes an SSE connection to the server's /sse endpoint</li>
+	 * <li>Waits for the server to send an 'endpoint' event with the message posting
+	 * URI</li>
+	 * <li>Sets up message handling for incoming JSON-RPC messages</li>
+	 * </ol>
+	 *
+	 * <p>
+	 * The connection is considered established only after receiving the endpoint event
+	 * from the server.
+	 * @param handler a function that processes incoming JSON-RPC messages and returns
+	 * responses
+	 * @return a Mono that completes when the connection is fully established
+	 */
+	@Override
+	public Mono<Void> connect(Function<Mono<JSONRPCMessage>, Mono<JSONRPCMessage>> handler) {
+		// TODO: Avoid eager connection opening and enable resilience
+		// -> upon disconnects, re-establish connection
+		// -> allow optimizing for eager connection start using a constructor flag
+		Flux<ServerSentEvent<String>> events = eventStream();
+		this.inboundSubscription = events.concatMap(event -> Mono.just(event).<JSONRPCMessage>handle((e, s) -> {
+			if (ENDPOINT_EVENT_TYPE.equals(event.event())) {
+				String messageEndpointUri = event.data();
+				if (this.messageEndpointSink.tryEmitValue(messageEndpointUri).isSuccess()) {
+					s.complete();
+				}
+				else {
+					// TODO: clarify with the spec if multiple events can be
+					// received
+					s.error(new RuntimeException("Failed to handle SSE endpoint event"));
+				}
+			}
+			else if (MESSAGE_EVENT_TYPE.equals(event.event())) {
+				try {
+					JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, event.data());
+					s.next(message);
+				}
+				catch (IOException ioException) {
+					s.error(ioException);
+				}
+			}
+			else {
+				logger.debug("Received unrecognized SSE event type: {}", event);
+				s.complete();
+			}
+		}).transform(handler)).subscribe();
+
+		// The connection is established once the server sends the endpoint event
+		return this.messageEndpointSink.asMono().then();
+	}
+
+	/**
+	 * Sends a JSON-RPC message to the server using the endpoint provided during
+	 * connection.
+	 *
+	 * <p>
+	 * Messages are sent via HTTP POST requests to the server-provided endpoint URI. The
+	 * message is serialized to JSON before transmission. If the transport is in the
+	 * process of closing, the message send operation is skipped gracefully.
+	 * @param message the JSON-RPC message to send
+	 * @return a Mono that completes when the message has been sent successfully
+	 * @throws RuntimeException if message serialization fails
+	 */
+	@Override
+	public Mono<Void> sendMessage(JSONRPCMessage message) {
+		// The messageEndpoint is the endpoint URI to send the messages
+		// It is provided by the server as part of the endpoint event
+		return this.messageEndpointSink.asMono().flatMap(messageEndpointUri -> {
+			if (this.isClosing) {
+				return Mono.empty();
+			}
+			try {
+				String jsonText = this.jsonMapper.writeValueAsString(message);
+				return this.webClient.post()
+					.uri(messageEndpointUri)
+					.contentType(MediaType.APPLICATION_JSON)
+					.header(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
+					.bodyValue(jsonText)
+					.retrieve()
+					.toBodilessEntity()
+					.doOnSuccess(response -> logger.debug("Message sent successfully"))
+					.doOnError(error -> {
+						if (!this.isClosing) {
+							logger.error("Error sending message: {}", error.getMessage());
+						}
+					});
+			}
+			catch (IOException e) {
+				if (!this.isClosing) {
+					return Mono.error(new RuntimeException("Failed to serialize message", e));
+				}
+				return Mono.empty();
+			}
+		}).then(); // TODO: Consider non-200-ok response
+	}
+
+	/**
+	 * Initializes and starts the inbound SSE event processing. Establishes the SSE
+	 * connection and sets up event handling for both message and endpoint events.
+	 * Includes automatic retry logic for handling transient connection failures.
+	 */
+	// visible for tests
+	protected Flux<ServerSentEvent<String>> eventStream() { // @formatter:off
+		return this.webClient
+			.get()
+			.uri(this.sseEndpoint)
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.header(HttpHeaders.PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
+			.retrieve()
+			.bodyToFlux(SSE_TYPE)
+			.retryWhen(Retry.from(retrySignal -> retrySignal.handle(this.inboundRetryHandler)));
+	} // @formatter:on
+
+	/**
+	 * Retry handler for the inbound SSE stream. Implements the retry logic for handling
+	 * connection failures and other errors.
+	 */
+	private BiConsumer<RetrySignal, SynchronousSink<Object>> inboundRetryHandler = (retrySpec, sink) -> {
+		if (this.isClosing) {
+			logger.debug("SSE connection closed during shutdown");
+			sink.error(retrySpec.failure());
+			return;
+		}
+		if (retrySpec.failure() instanceof IOException) {
+			logger.debug("Retrying SSE connection after IO error");
+			sink.next(retrySpec);
+			return;
+		}
+		logger.error("Fatal SSE error, not retrying: {}", retrySpec.failure().getMessage());
+		sink.error(retrySpec.failure());
+	};
+
+	/**
+	 * Implements graceful shutdown of the transport. Cleans up all resources including
+	 * subscriptions and schedulers. Ensures orderly shutdown of both inbound and outbound
+	 * message processing.
+	 * @return a Mono that completes when shutdown is finished
+	 */
+	@Override
+	public Mono<Void> closeGracefully() { // @formatter:off
+		return Mono.fromRunnable(() -> {
+			this.isClosing = true;
+
+			// Dispose of subscriptions
+			if (this.inboundSubscription != null) {
+				this.inboundSubscription.dispose();
+			}
+		})
+		.then()
+		.subscribeOn(Schedulers.boundedElastic());
+	} // @formatter:on
+
+	/**
+	 * Unmarshalls data from a generic Object into the specified type using the configured
+	 * ObjectMapper.
+	 *
+	 * <p>
+	 * This method is particularly useful when working with JSON-RPC parameters or result
+	 * objects that need to be converted to specific Java types. It leverages Jackson's
+	 * type conversion capabilities to handle complex object structures.
+	 * @param <T> the target type to convert the data into
+	 * @param data the source object to convert
+	 * @param typeRef the TypeRef describing the target type
+	 * @return the unmarshalled object of type T
+	 * @throws IllegalArgumentException if the conversion cannot be performed
+	 */
+	@Override
+	public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+		return this.jsonMapper.convertValue(data, typeRef);
+	}
+
+	/**
+	 * Creates a new builder for {@link WebFluxSseClientTransport}.
+	 * @param webClientBuilder the WebClient.Builder to use for creating the WebClient
+	 * instance
+	 * @return a new builder instance
+	 */
+	public static Builder builder(WebClient.Builder webClientBuilder) {
+		return new Builder(webClientBuilder);
+	}
+
+	/**
+	 * Builder for {@link WebFluxSseClientTransport}.
+	 */
+	public static class Builder {
+
+		private final WebClient.Builder webClientBuilder;
+
+		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		/**
+		 * Creates a new builder with the specified WebClient.Builder.
+		 * @param webClientBuilder the WebClient.Builder to use
+		 */
+		public Builder(WebClient.Builder webClientBuilder) {
+			Assert.notNull(webClientBuilder, "WebClient.Builder must not be null");
+			this.webClientBuilder = webClientBuilder;
+		}
+
+		/**
+		 * Sets the SSE endpoint path.
+		 * @param sseEndpoint the SSE endpoint path
+		 * @return this builder
+		 */
+		public Builder sseEndpoint(String sseEndpoint) {
+			Assert.hasText(sseEndpoint, "sseEndpoint must not be empty");
+			this.sseEndpoint = sseEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the JSON mapper for serialization/deserialization.
+		 * @param jsonMapper the JsonMapper to use
+		 * @return this builder
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "jsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Builds a new {@link WebFluxSseClientTransport} instance.
+		 * @return a new transport instance
+		 */
+		public WebFluxSseClientTransport build() {
+			return new WebFluxSseClientTransport(this.webClientBuilder,
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.sseEndpoint);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/package-info.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WebFlux-based client transport implementations for the Model Context Protocol (MCP).
+ * <p>
+ * This package provides client-side transport implementations using Spring WebFlux,
+ * including SSE and Streamable HTTP transports.
+ *
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+@NullMarked
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import org.jspecify.annotations.NullMarked;

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
@@ -1,0 +1,594 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.KeepAliveScheduler;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Server-side implementation of the MCP (Model Context Protocol) HTTP transport using
+ * Server-Sent Events (SSE). This implementation provides a bidirectional communication
+ * channel between MCP clients and servers using HTTP POST for client-to-server messages
+ * and SSE for server-to-client messages.
+ *
+ * <p>
+ * Key features:
+ * <ul>
+ * <li>Implements the {@link McpServerTransportProvider} interface that allows managing
+ * {@link McpServerSession} instances and enabling their communication with the
+ * {@link McpServerTransport} abstraction.</li>
+ * <li>Uses WebFlux for non-blocking request handling and SSE support</li>
+ * <li>Maintains client sessions for reliable message delivery</li>
+ * <li>Supports graceful shutdown with session cleanup</li>
+ * <li>Thread-safe message broadcasting to multiple clients</li>
+ * </ul>
+ *
+ * <p>
+ * The transport sets up two main endpoints:
+ * <ul>
+ * <li>SSE endpoint (/sse) - For establishing SSE connections with clients</li>
+ * <li>Message endpoint (configurable) - For receiving JSON-RPC messages from clients</li>
+ * </ul>
+ *
+ * <p>
+ * This implementation is thread-safe and can handle multiple concurrent client
+ * connections. It uses {@link ConcurrentHashMap} for session management and Project
+ * Reactor's non-blocking APIs for message processing and delivery.
+ *
+ * @author Christian Tzolov
+ * @author Alexandros Pappas
+ * @author Dariusz Jędrzejczyk
+ * @see McpServerTransport
+ * @see ServerSentEvent
+ */
+public final class WebFluxSseServerTransportProvider implements McpServerTransportProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebFluxSseServerTransportProvider.class);
+
+	/**
+	 * Event type for JSON-RPC messages sent through the SSE connection.
+	 */
+	public static final String MESSAGE_EVENT_TYPE = "message";
+
+	/**
+	 * Event type for sending the message endpoint URI to clients.
+	 */
+	public static final String ENDPOINT_EVENT_TYPE = "endpoint";
+
+	private static final String MCP_PROTOCOL_VERSION = "2025-06-18";
+
+	/**
+	 * Default SSE endpoint path as specified by the MCP transport specification.
+	 */
+	public static final String DEFAULT_SSE_ENDPOINT = "/sse";
+
+	public static final String SESSION_ID = "sessionId";
+
+	public static final String DEFAULT_BASE_URL = "";
+
+	private final McpJsonMapper jsonMapper;
+
+	/**
+	 * Base URL for the message endpoint. This is used to construct the full URL for
+	 * clients to send their JSON-RPC messages.
+	 */
+	private final String baseUrl;
+
+	private final String messageEndpoint;
+
+	private final String sseEndpoint;
+
+	private final RouterFunction<?> routerFunction;
+
+	private McpServerSession.@Nullable Factory sessionFactory;
+
+	/**
+	 * Map of active client sessions, keyed by session ID.
+	 */
+	private final ConcurrentHashMap<String, McpServerSession> sessions = new ConcurrentHashMap<>();
+
+	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+
+	/**
+	 * Flag indicating if the transport is shutting down.
+	 */
+	private volatile boolean isClosing = false;
+
+	/**
+	 * Keep-alive scheduler for managing session pings. Activated if keepAliveInterval is
+	 * set. Disabled by default.
+	 */
+	@Nullable private KeepAliveScheduler keepAliveScheduler;
+
+	/**
+	 * Security validator for validating HTTP requests.
+	 */
+	private final ServerTransportSecurityValidator securityValidator;
+
+	/**
+	 * Constructs a new WebFlux SSE server transport provider instance.
+	 * @param jsonMapper The ObjectMapper to use for JSON serialization/deserialization of
+	 * MCP messages. Must not be null.
+	 * @param baseUrl webflux message base path
+	 * @param messageEndpoint The endpoint URI where clients should send their JSON-RPC
+	 * messages. This endpoint will be communicated to clients during SSE connection
+	 * setup. Must not be null.
+	 * @param sseEndpoint The SSE endpoint path. Must not be null.
+	 * @param keepAliveInterval The interval for sending keep-alive pings to clients.
+	 * @param contextExtractor The context extractor to use for extracting MCP transport
+	 * context from HTTP requests. Must not be null.
+	 * @param securityValidator The security validator for validating HTTP requests.
+	 * @throws IllegalArgumentException if either parameter is null
+	 */
+	private WebFluxSseServerTransportProvider(McpJsonMapper jsonMapper, String baseUrl, String messageEndpoint,
+			String sseEndpoint, @Nullable Duration keepAliveInterval,
+			McpTransportContextExtractor<ServerRequest> contextExtractor,
+			ServerTransportSecurityValidator securityValidator) {
+		Assert.notNull(jsonMapper, "ObjectMapper must not be null");
+		Assert.notNull(baseUrl, "Message base path must not be null");
+		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+		Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
+		Assert.notNull(contextExtractor, "Context extractor must not be null");
+		Assert.notNull(securityValidator, "Security validator must not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.baseUrl = baseUrl;
+		this.messageEndpoint = messageEndpoint;
+		this.sseEndpoint = sseEndpoint;
+		this.contextExtractor = contextExtractor;
+		this.securityValidator = securityValidator;
+		this.routerFunction = RouterFunctions.route()
+			.GET(this.sseEndpoint, this::handleSseConnection)
+			.POST(this.messageEndpoint, this::handleMessage)
+			.build();
+
+		if (keepAliveInterval != null) {
+
+			this.keepAliveScheduler = KeepAliveScheduler
+				.builder(() -> (this.isClosing) ? Flux.empty() : Flux.fromIterable(this.sessions.values()))
+				.initialDelay(keepAliveInterval)
+				.interval(keepAliveInterval)
+				.build();
+
+			this.keepAliveScheduler.start();
+		}
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return List.of(ProtocolVersions.MCP_2024_11_05);
+	}
+
+	@Override
+	public void setSessionFactory(McpServerSession.Factory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	/**
+	 * Broadcasts a JSON-RPC message to all connected clients through their SSE
+	 * connections. The message is serialized to JSON and sent as a server-sent event to
+	 * each active session.
+	 *
+	 * <p>
+	 * The method:
+	 * <ul>
+	 * <li>Serializes the message to JSON</li>
+	 * <li>Creates a server-sent event with the message data</li>
+	 * <li>Attempts to send the event to all active sessions</li>
+	 * <li>Tracks and reports any delivery failures</li>
+	 * </ul>
+	 * @param method The JSON-RPC method to send to clients
+	 * @param params The method parameters to send to clients
+	 * @return A Mono that completes when the message has been sent to all sessions, or
+	 * errors if any session fails to receive the message
+	 */
+	@Override
+	public Mono<Void> notifyClients(String method, Object params) {
+		if (this.sessions.isEmpty()) {
+			logger.debug("No active sessions to broadcast message to");
+			return Mono.empty();
+		}
+
+		logger.debug("Attempting to broadcast message to {} active sessions", this.sessions.size());
+
+		return Flux.fromIterable(this.sessions.values())
+			.flatMap(session -> session.sendNotification(method, params)
+				.doOnError(
+						e -> logger.error("Failed to send message to session {}: {}", session.getId(), e.getMessage()))
+				.onErrorComplete())
+			.then();
+	}
+
+	// FIXME: This javadoc makes claims about using isClosing flag but it's not
+	// actually
+	// doing that.
+
+	/**
+	 * Initiates a graceful shutdown of all the sessions. This method ensures all active
+	 * sessions are properly closed and cleaned up.
+	 * @return A Mono that completes when all sessions have been closed
+	 */
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Flux.fromIterable(this.sessions.values())
+			.doFirst(() -> logger.debug("Initiating graceful shutdown with {} active sessions", this.sessions.size()))
+			.flatMap(McpServerSession::closeGracefully)
+			.then()
+			.doOnSuccess(v -> {
+				logger.debug("Graceful shutdown completed");
+				this.sessions.clear();
+				if (this.keepAliveScheduler != null) {
+					this.keepAliveScheduler.shutdown();
+				}
+			});
+	}
+
+	/**
+	 * Returns the WebFlux router function that defines the transport's HTTP endpoints.
+	 * This router function should be integrated into the application's web configuration.
+	 *
+	 * <p>
+	 * The router function defines two endpoints:
+	 * <ul>
+	 * <li>GET {sseEndpoint} - For establishing SSE connections</li>
+	 * <li>POST {messageEndpoint} - For receiving client messages</li>
+	 * </ul>
+	 * @return The configured {@link RouterFunction} for handling HTTP requests
+	 */
+	public RouterFunction<?> getRouterFunction() {
+		return this.routerFunction;
+	}
+
+	/**
+	 * Handles new SSE connection requests from clients. Creates a new session for each
+	 * connection and sets up the SSE event stream.
+	 * @param request The incoming server request
+	 * @return A Mono which emits a response with the SSE event stream
+	 */
+	private Mono<ServerResponse> handleSseConnection(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.bodyValue(Objects.requireNonNullElse(e.getMessage(), "Security validation failed"));
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		McpServerSession.Factory factory = this.sessionFactory;
+		if (factory == null) {
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).bodyValue("Session factory not initialized");
+		}
+
+		return ServerResponse.ok()
+			.contentType(MediaType.TEXT_EVENT_STREAM)
+			.body(Flux.<ServerSentEvent<?>>create(sink -> {
+				WebFluxMcpSessionTransport sessionTransport = new WebFluxMcpSessionTransport(sink);
+
+				McpServerSession session = factory.create(sessionTransport);
+				String sessionId = session.getId();
+
+				logger.debug("Created new SSE connection for session: {}", sessionId);
+				this.sessions.put(sessionId, session);
+
+				// Send initial endpoint event
+				logger.debug("Sending initial endpoint event to session: {}", sessionId);
+				sink.next(
+						ServerSentEvent.builder().event(ENDPOINT_EVENT_TYPE).data(buildEndpointUrl(sessionId)).build());
+				sink.onCancel(() -> {
+					logger.debug("Session {} cancelled", sessionId);
+					this.sessions.remove(sessionId);
+				});
+			}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)), ServerSentEvent.class);
+	}
+
+	/**
+	 * Constructs the full message endpoint URL by combining the base URL, message path,
+	 * and the required session_id query parameter.
+	 * @param sessionId the unique session identifier
+	 * @return the fully qualified endpoint URL as a string
+	 */
+	private String buildEndpointUrl(String sessionId) {
+		// for WebMVC compatibility
+		return UriComponentsBuilder.fromUriString(this.baseUrl)
+			.path(this.messageEndpoint)
+			.queryParam(SESSION_ID, sessionId)
+			.build()
+			.toUriString();
+	}
+
+	/**
+	 * Handles incoming JSON-RPC messages from clients. Deserializes the message and
+	 * processes it through the configured message handler.
+	 *
+	 * <p>
+	 * The handler:
+	 * <ul>
+	 * <li>Deserializes the incoming JSON-RPC message</li>
+	 * <li>Passes it through the message handler chain</li>
+	 * <li>Returns appropriate HTTP responses based on processing results</li>
+	 * <li>Handles various error conditions with appropriate error responses</li>
+	 * </ul>
+	 * @param request The incoming server request containing the JSON-RPC message
+	 * @return A Mono emitting the response indicating the message processing result
+	 */
+	private Mono<ServerResponse> handleMessage(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.bodyValue(Objects.requireNonNullElse(e.getMessage(), "Security validation failed"));
+		}
+
+		if (request.queryParam("sessionId").isEmpty()) {
+			return ServerResponse.badRequest().bodyValue(new McpError("Session ID missing in message endpoint"));
+		}
+
+		McpServerSession session = this.sessions.get(request.queryParam("sessionId").get());
+
+		if (session == null) {
+			return ServerResponse.status(HttpStatus.NOT_FOUND)
+				.bodyValue(new McpError("Session not found: " + request.queryParam("sessionId").get()));
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		return request.bodyToMono(String.class).flatMap(body -> {
+			try {
+				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+				return session.handle(message).flatMap(response -> ServerResponse.ok().build()).onErrorResume(error -> {
+					logger.error("Error processing  message: {}", error.getMessage());
+					// TODO: instead of signalling the error, just respond with 200 OK
+					// - the error is signalled on the SSE connection
+					// return ServerResponse.ok().build();
+					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+						.bodyValue(new McpError(error.getMessage()));
+				});
+			}
+			catch (IllegalArgumentException | IOException e) {
+				logger.error("Failed to deserialize message: {}", e.getMessage());
+				return ServerResponse.badRequest().bodyValue(new McpError("Invalid message format"));
+			}
+		}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private class WebFluxMcpSessionTransport implements McpServerTransport {
+
+		private final FluxSink<ServerSentEvent<?>> sink;
+
+		WebFluxMcpSessionTransport(FluxSink<ServerSentEvent<?>> sink) {
+			this.sink = sink;
+		}
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+			return Mono.fromSupplier(() -> {
+				try {
+					return jsonMapper.writeValueAsString(message);
+				}
+				catch (IOException e) {
+					throw Exceptions.propagate(e);
+				}
+			}).doOnNext(jsonText -> {
+				ServerSentEvent<Object> event = ServerSentEvent.builder()
+					.event(MESSAGE_EVENT_TYPE)
+					.data(jsonText)
+					.build();
+				this.sink.next(event);
+			}).doOnError(e -> {
+				// TODO log with sessionid
+				Throwable exception = Exceptions.unwrap(e);
+				this.sink.error(exception);
+			}).then();
+		}
+
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return jsonMapper.convertValue(data, typeRef);
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.fromRunnable(this.sink::complete);
+		}
+
+		@Override
+		public void close() {
+			this.sink.complete();
+		}
+
+	}
+
+	/**
+	 * Builder for creating instances of {@link WebFluxSseServerTransportProvider}.
+	 * <p>
+	 * This builder provides a fluent API for configuring and creating instances of
+	 * WebFluxSseServerTransportProvider with custom settings.
+	 */
+	public static class Builder {
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		private String baseUrl = DEFAULT_BASE_URL;
+
+		@Nullable private String messageEndpoint;
+
+		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
+
+		@Nullable private Duration keepAliveInterval;
+
+		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
+
+		private ServerTransportSecurityValidator securityValidator = ServerTransportSecurityValidator.NOOP;
+
+		/**
+		 * Sets the McpJsonMapper to use for JSON serialization/deserialization of MCP
+		 * messages.
+		 * @param jsonMapper The McpJsonMapper instance. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if jsonMapper is null
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "JsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Sets the project basePath as endpoint prefix where clients should send their
+		 * JSON-RPC messages
+		 * @param baseUrl the message basePath . Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if basePath is null
+		 */
+		public Builder basePath(String baseUrl) {
+			Assert.notNull(baseUrl, "basePath must not be null");
+			this.baseUrl = baseUrl;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint URI where clients should send their JSON-RPC messages.
+		 * @param messageEndpoint The message endpoint URI. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if messageEndpoint is null
+		 */
+		public Builder messageEndpoint(String messageEndpoint) {
+			Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+			this.messageEndpoint = messageEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the SSE endpoint path.
+		 * @param sseEndpoint The SSE endpoint path. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if sseEndpoint is null
+		 */
+		public Builder sseEndpoint(String sseEndpoint) {
+			Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
+			this.sseEndpoint = sseEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the interval for sending keep-alive pings to clients.
+		 * @param keepAliveInterval The keep-alive interval duration. If null, keep-alive
+		 * is disabled.
+		 * @return this builder instance
+		 */
+		public Builder keepAliveInterval(Duration keepAliveInterval) {
+			this.keepAliveInterval = keepAliveInterval;
+			return this;
+		}
+
+		/**
+		 * Sets the context extractor that allows providing the MCP feature
+		 * implementations to inspect HTTP transport level metadata that was present at
+		 * HTTP request processing time. This allows to extract custom headers and other
+		 * useful data for use during execution later on in the process.
+		 * @param contextExtractor The contextExtractor to fill in a
+		 * {@link McpTransportContext}.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public Builder contextExtractor(McpTransportContextExtractor<ServerRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "contextExtractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
+		 * Sets the security validator for validating HTTP requests.
+		 * @param securityValidator The security validator to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if securityValidator is null
+		 */
+		public Builder securityValidator(ServerTransportSecurityValidator securityValidator) {
+			Assert.notNull(securityValidator, "Security validator must not be null");
+			this.securityValidator = securityValidator;
+			return this;
+		}
+
+		/**
+		 * Builds a new instance of {@link WebFluxSseServerTransportProvider} with the
+		 * configured settings.
+		 * @return A new WebFluxSseServerTransportProvider instance
+		 * @throws IllegalStateException if required parameters are not set
+		 */
+		public WebFluxSseServerTransportProvider build() {
+			String messageEndpoint = Objects.requireNonNull(this.messageEndpoint, "Message endpoint must be set");
+			return new WebFluxSseServerTransportProvider(
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.baseUrl,
+					messageEndpoint, this.sseEndpoint, this.keepAliveInterval, this.contextExtractor,
+					this.securityValidator);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import io.modelcontextprotocol.util.Assert;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+/**
+ * Implementation of a WebFlux based {@link McpStatelessServerTransport}.
+ *
+ * @author Dariusz Jędrzejczyk
+ */
+public final class WebFluxStatelessServerTransport implements McpStatelessServerTransport {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebFluxStatelessServerTransport.class);
+
+	private final McpJsonMapper jsonMapper;
+
+	private final String mcpEndpoint;
+
+	private final RouterFunction<?> routerFunction;
+
+	@Nullable private McpStatelessServerHandler mcpHandler;
+
+	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+
+	private volatile boolean isClosing = false;
+
+	/**
+	 * Security validator for validating HTTP requests.
+	 */
+	private final ServerTransportSecurityValidator securityValidator;
+
+	private WebFluxStatelessServerTransport(McpJsonMapper jsonMapper, String mcpEndpoint,
+			McpTransportContextExtractor<ServerRequest> contextExtractor,
+			ServerTransportSecurityValidator securityValidator) {
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
+		Assert.notNull(mcpEndpoint, "mcpEndpoint must not be null");
+		Assert.notNull(contextExtractor, "contextExtractor must not be null");
+		Assert.notNull(securityValidator, "Security validator must not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.mcpEndpoint = mcpEndpoint;
+		this.contextExtractor = contextExtractor;
+		this.securityValidator = securityValidator;
+		this.routerFunction = RouterFunctions.route()
+			.GET(this.mcpEndpoint, this::handleGet)
+			.POST(this.mcpEndpoint, this::handlePost)
+			.build();
+	}
+
+	@Override
+	public void setMcpHandler(McpStatelessServerHandler mcpHandler) {
+		this.mcpHandler = mcpHandler;
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Mono.fromRunnable(() -> this.isClosing = true);
+	}
+
+	/**
+	 * Returns the WebFlux router function that defines the transport's HTTP endpoints.
+	 * This router function should be integrated into the application's web configuration.
+	 *
+	 * <p>
+	 * The router function defines one endpoint handling two HTTP methods:
+	 * <ul>
+	 * <li>GET {messageEndpoint} - Unsupported, returns 405 METHOD NOT ALLOWED</li>
+	 * <li>POST {messageEndpoint} - For handling client requests and notifications</li>
+	 * </ul>
+	 * @return The configured {@link RouterFunction} for handling HTTP requests
+	 */
+	public RouterFunction<?> getRouterFunction() {
+		return this.routerFunction;
+	}
+
+	private Mono<ServerResponse> handleGet(ServerRequest request) {
+		return ServerResponse.status(HttpStatus.METHOD_NOT_ALLOWED).build();
+	}
+
+	private Mono<ServerResponse> handlePost(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.bodyValue(Objects.requireNonNullElse(e.getMessage(), "Security validation failed"));
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		McpStatelessServerHandler handler = this.mcpHandler;
+		if (handler == null) {
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).bodyValue("MCP handler not initialized");
+		}
+
+		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
+		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
+				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
+			return ServerResponse.badRequest().build();
+		}
+
+		return request.bodyToMono(String.class).<ServerResponse>flatMap(body -> {
+			try {
+				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+
+				if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest) {
+					return handler.handleRequest(transportContext, jsonrpcRequest).flatMap(jsonrpcResponse -> {
+						try {
+							String json = this.jsonMapper.writeValueAsString(jsonrpcResponse);
+							return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).bodyValue(json);
+						}
+						catch (IOException e) {
+							logger.error("Failed to serialize response: {}", e.getMessage());
+							return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+								.bodyValue(new McpError("Failed to serialize response"));
+						}
+					});
+				}
+				else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
+					return handler.handleNotification(transportContext, jsonrpcNotification)
+						.then(ServerResponse.accepted().build());
+				}
+				else {
+					return ServerResponse.badRequest()
+						.bodyValue(new McpError("The server accepts either requests or notifications"));
+				}
+			}
+			catch (IllegalArgumentException | IOException e) {
+				logger.error("Failed to deserialize message: {}", e.getMessage());
+				return ServerResponse.badRequest().bodyValue(new McpError("Invalid message format"));
+			}
+		}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
+	}
+
+	/**
+	 * Create a builder for the server.
+	 * @return a fresh {@link Builder} instance.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for creating instances of {@link WebFluxStatelessServerTransport}.
+	 * <p>
+	 * This builder provides a fluent API for configuring and creating instances of
+	 * WebFluxSseServerTransportProvider with custom settings.
+	 */
+	public static final class Builder {
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		private String mcpEndpoint = "/mcp";
+
+		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
+
+		private ServerTransportSecurityValidator securityValidator = ServerTransportSecurityValidator.NOOP;
+
+		private Builder() {
+			// used by a static method
+		}
+
+		/**
+		 * Sets the JsonMapper to use for JSON serialization/deserialization of MCP
+		 * messages.
+		 * @param jsonMapper The JsonMapper instance. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if jsonMapper is null
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "JsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint URI where clients should send their JSON-RPC messages.
+		 * @param messageEndpoint The message endpoint URI. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if messageEndpoint is null
+		 */
+		public Builder messageEndpoint(String messageEndpoint) {
+			Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+			this.mcpEndpoint = messageEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the context extractor that allows providing the MCP feature
+		 * implementations to inspect HTTP transport level metadata that was present at
+		 * HTTP request processing time. This allows to extract custom headers and other
+		 * useful data for use during execution later on in the process.
+		 * @param contextExtractor The contextExtractor to fill in a
+		 * {@link McpTransportContext}.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public Builder contextExtractor(McpTransportContextExtractor<ServerRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "Context extractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
+		 * Sets the security validator for validating HTTP requests.
+		 * @param securityValidator The security validator to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if securityValidator is null
+		 */
+		public Builder securityValidator(ServerTransportSecurityValidator securityValidator) {
+			Assert.notNull(securityValidator, "Security validator must not be null");
+			this.securityValidator = securityValidator;
+			return this;
+		}
+
+		/**
+		 * Builds a new instance of {@link WebFluxStatelessServerTransport} with the
+		 * configured settings.
+		 * @return A new WebFluxStatelessServerTransport instance
+		 * @throws IllegalStateException if required parameters are not set
+		 */
+		public WebFluxStatelessServerTransport build() {
+			Assert.notNull(this.mcpEndpoint, "Message endpoint must be set");
+			return new WebFluxStatelessServerTransport(
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.mcpEndpoint,
+					this.contextExtractor, this.securityValidator);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStreamableServerSession;
+import io.modelcontextprotocol.spec.McpStreamableServerTransport;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.KeepAliveScheduler;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+/**
+ * Implementation of a WebFlux based {@link McpStreamableServerTransportProvider}.
+ *
+ * @author Dariusz Jędrzejczyk
+ */
+public final class WebFluxStreamableServerTransportProvider implements McpStreamableServerTransportProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebFluxStreamableServerTransportProvider.class);
+
+	public static final String MESSAGE_EVENT_TYPE = "message";
+
+	private final McpJsonMapper jsonMapper;
+
+	private final String mcpEndpoint;
+
+	private final boolean disallowDelete;
+
+	private final RouterFunction<?> routerFunction;
+
+	private McpStreamableServerSession.@Nullable Factory sessionFactory;
+
+	private final ConcurrentHashMap<String, McpStreamableServerSession> sessions = new ConcurrentHashMap<>();
+
+	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+
+	private volatile boolean isClosing = false;
+
+	@Nullable private KeepAliveScheduler keepAliveScheduler;
+
+	/**
+	 * Security validator for validating HTTP requests.
+	 */
+	private final ServerTransportSecurityValidator securityValidator;
+
+	private WebFluxStreamableServerTransportProvider(McpJsonMapper jsonMapper, String mcpEndpoint,
+			McpTransportContextExtractor<ServerRequest> contextExtractor, boolean disallowDelete,
+			@Nullable Duration keepAliveInterval, ServerTransportSecurityValidator securityValidator) {
+		Assert.notNull(jsonMapper, "JsonMapper must not be null");
+		Assert.notNull(mcpEndpoint, "Message endpoint must not be null");
+		Assert.notNull(contextExtractor, "Context extractor must not be null");
+		Assert.notNull(securityValidator, "Security validator must not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.mcpEndpoint = mcpEndpoint;
+		this.contextExtractor = contextExtractor;
+		this.disallowDelete = disallowDelete;
+		this.securityValidator = securityValidator;
+		this.routerFunction = RouterFunctions.route()
+			.GET(this.mcpEndpoint, this::handleGet)
+			.POST(this.mcpEndpoint, this::handlePost)
+			.DELETE(this.mcpEndpoint, this::handleDelete)
+			.build();
+
+		if (keepAliveInterval != null) {
+			this.keepAliveScheduler = KeepAliveScheduler
+				.builder(() -> (this.isClosing) ? Flux.empty() : Flux.fromIterable(this.sessions.values()))
+				.initialDelay(keepAliveInterval)
+				.interval(keepAliveInterval)
+				.build();
+
+			this.keepAliveScheduler.start();
+		}
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return List.of(ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
+				ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
+	}
+
+	@Override
+	public void setSessionFactory(McpStreamableServerSession.Factory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	@Override
+	public Mono<Void> notifyClients(String method, Object params) {
+		if (this.sessions.isEmpty()) {
+			logger.debug("No active sessions to broadcast message to");
+			return Mono.empty();
+		}
+
+		logger.debug("Attempting to broadcast message to {} active sessions", this.sessions.size());
+
+		return Flux.fromIterable(this.sessions.values())
+			.flatMap(session -> session.sendNotification(method, params)
+				.doOnError(
+						e -> logger.error("Failed to send message to session {}: {}", session.getId(), e.getMessage()))
+				.onErrorComplete())
+			.then();
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Mono.defer(() -> {
+			this.isClosing = true;
+			return Flux.fromIterable(this.sessions.values())
+				.doFirst(() -> logger.debug("Initiating graceful shutdown with {} active sessions",
+						this.sessions.size()))
+				.flatMap(McpStreamableServerSession::closeGracefully)
+				.then();
+		}).then().doOnSuccess(v -> {
+			this.sessions.clear();
+			if (this.keepAliveScheduler != null) {
+				this.keepAliveScheduler.shutdown();
+			}
+		});
+	}
+
+	/**
+	 * Returns the WebFlux router function that defines the transport's HTTP endpoints.
+	 * This router function should be integrated into the application's web configuration.
+	 *
+	 * <p>
+	 * The router function defines one endpoint with three methods:
+	 * <ul>
+	 * <li>GET {messageEndpoint} - For the client listening SSE stream</li>
+	 * <li>POST {messageEndpoint} - For receiving client messages</li>
+	 * <li>DELETE {messageEndpoint} - For removing sessions</li>
+	 * </ul>
+	 * @return The configured {@link RouterFunction} for handling HTTP requests
+	 */
+	public RouterFunction<?> getRouterFunction() {
+		return this.routerFunction;
+	}
+
+	/**
+	 * Opens the listening SSE streams for clients.
+	 * @param request The incoming server request
+	 * @return A Mono which emits a response with the SSE event stream
+	 */
+	private Mono<ServerResponse> handleGet(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.bodyValue(Objects.requireNonNullElse(e.getMessage(), "Security validation failed"));
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		return Mono.defer(() -> {
+			List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
+			if (!acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM)) {
+				return ServerResponse.badRequest().build();
+			}
+
+			if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
+				return ServerResponse.badRequest().build(); // TODO: say we need a session
+															// id
+			}
+
+			String sessionId = request.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+
+			McpStreamableServerSession session = this.sessions.get(sessionId);
+
+			if (session == null) {
+				return ServerResponse.notFound().build();
+			}
+
+			if (!request.headers().header(HttpHeaders.LAST_EVENT_ID).isEmpty()) {
+				String lastId = request.headers().asHttpHeaders().getFirst(HttpHeaders.LAST_EVENT_ID);
+				return ServerResponse.ok()
+					.contentType(MediaType.TEXT_EVENT_STREAM)
+					.body(session.replay(lastId)
+						.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)),
+							ServerSentEvent.class);
+			}
+
+			return ServerResponse.ok()
+				.contentType(MediaType.TEXT_EVENT_STREAM)
+				.body(Flux.<ServerSentEvent<?>>create(sink -> {
+					WebFluxStreamableMcpSessionTransport sessionTransport = new WebFluxStreamableMcpSessionTransport(
+							sink);
+					McpStreamableServerSession.McpStreamableServerSessionStream listeningStream = session
+						.listeningStream(sessionTransport);
+					sink.onDispose(listeningStream::close);
+					// TODO Clarify why the outer context is not present in the
+					// Flux.create sink?
+				}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)), ServerSentEvent.class);
+
+		}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
+	}
+
+	/**
+	 * Handles incoming JSON-RPC messages from clients.
+	 * @param request The incoming server request containing the JSON-RPC message
+	 * @return A Mono with the response appropriate to a particular Streamable HTTP flow.
+	 */
+	private Mono<ServerResponse> handlePost(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.bodyValue(Objects.requireNonNullElse(e.getMessage(), "Security validation failed"));
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
+		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
+				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
+			return ServerResponse.badRequest().build();
+		}
+
+		return request.bodyToMono(String.class).<ServerResponse>flatMap(body -> {
+			try {
+				McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+				if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest
+						&& jsonrpcRequest.method().equals(McpSchema.METHOD_INITIALIZE)) {
+					var typeReference = new TypeRef<McpSchema.InitializeRequest>() {
+					};
+					McpSchema.InitializeRequest initializeRequest = this.jsonMapper
+						.convertValue(jsonrpcRequest.params(), typeReference);
+					McpStreamableServerSession.Factory factory = this.sessionFactory;
+					if (factory == null) {
+						return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+							.bodyValue("Session factory not initialized");
+					}
+					McpStreamableServerSession.McpStreamableServerSessionInit init = factory
+						.startSession(initializeRequest);
+					this.sessions.put(init.session().getId(), init.session());
+					return init.initResult().map(initializeResult -> {
+						McpSchema.JSONRPCResponse jsonrpcResponse = new McpSchema.JSONRPCResponse(
+								McpSchema.JSONRPC_VERSION, jsonrpcRequest.id(), initializeResult, null);
+						try {
+							return this.jsonMapper.writeValueAsString(jsonrpcResponse);
+						}
+						catch (IOException e) {
+							logger.warn("Failed to serialize initResponse", e);
+							throw Exceptions.propagate(e);
+						}
+					})
+						.flatMap(initResult -> ServerResponse.ok()
+							.contentType(MediaType.APPLICATION_JSON)
+							.header(HttpHeaders.MCP_SESSION_ID, init.session().getId())
+							.bodyValue(initResult));
+				}
+
+				if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
+					return ServerResponse.badRequest().bodyValue(new McpError("Session ID missing"));
+				}
+
+				String sessionId = request.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+				McpStreamableServerSession session = this.sessions.get(sessionId);
+
+				if (session == null) {
+					return ServerResponse.status(HttpStatus.NOT_FOUND)
+						.bodyValue(new McpError("Session not found: " + sessionId));
+				}
+
+				if (message instanceof McpSchema.JSONRPCResponse jsonrpcResponse) {
+					return session.accept(jsonrpcResponse).then(ServerResponse.accepted().build());
+				}
+				else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
+					return session.accept(jsonrpcNotification).then(ServerResponse.accepted().build());
+				}
+				else if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest) {
+					return ServerResponse.ok()
+						.contentType(MediaType.TEXT_EVENT_STREAM)
+						.body(Flux.<ServerSentEvent<?>>create(sink -> {
+							WebFluxStreamableMcpSessionTransport st = new WebFluxStreamableMcpSessionTransport(sink);
+							Mono<Void> stream = session.responseStream(jsonrpcRequest, st);
+							Disposable streamSubscription = stream.onErrorComplete(err -> {
+								sink.error(err);
+								return true;
+							}).contextWrite(sink.contextView()).subscribe();
+							sink.onCancel(streamSubscription);
+							// TODO Clarify why the outer context is not present in the
+							// Flux.create sink?
+						}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)),
+								ServerSentEvent.class);
+				}
+				else {
+					return ServerResponse.badRequest().bodyValue(new McpError("Unknown message type"));
+				}
+			}
+			catch (IllegalArgumentException | IOException e) {
+				logger.error("Failed to deserialize message: {}", e.getMessage());
+				return ServerResponse.badRequest().bodyValue(new McpError("Invalid message format"));
+			}
+		})
+			.switchIfEmpty(ServerResponse.badRequest().build())
+			.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
+	}
+
+	private Mono<ServerResponse> handleDelete(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.bodyValue(Objects.requireNonNullElse(e.getMessage(), "Security validation failed"));
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		return Mono.defer(() -> {
+			if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
+				return ServerResponse.badRequest().build(); // TODO: say we need a session
+															// id
+			}
+
+			if (this.disallowDelete) {
+				return ServerResponse.status(HttpStatus.METHOD_NOT_ALLOWED).build();
+			}
+
+			String sessionId = request.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+
+			McpStreamableServerSession session = this.sessions.get(sessionId);
+
+			if (session == null) {
+				return ServerResponse.notFound().build();
+			}
+
+			return session.delete().then(ServerResponse.ok().build());
+		}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private class WebFluxStreamableMcpSessionTransport implements McpStreamableServerTransport {
+
+		private final FluxSink<ServerSentEvent<?>> sink;
+
+		WebFluxStreamableMcpSessionTransport(FluxSink<ServerSentEvent<?>> sink) {
+			this.sink = sink;
+		}
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+			return this.sendMessage(message, null);
+		}
+
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message, @Nullable String messageId) {
+			return Mono.fromSupplier(() -> {
+				try {
+					return jsonMapper.writeValueAsString(message);
+				}
+				catch (IOException e) {
+					throw Exceptions.propagate(e);
+				}
+			}).doOnNext(jsonText -> {
+				ServerSentEvent.Builder<Object> eventBuilder = ServerSentEvent.builder()
+					.event(MESSAGE_EVENT_TYPE)
+					.data(jsonText);
+				if (messageId != null) {
+					eventBuilder.id(messageId);
+				}
+				this.sink.next(eventBuilder.build());
+			}).doOnError(e -> {
+				// TODO log with sessionid
+				Throwable exception = Exceptions.unwrap(e);
+				this.sink.error(exception);
+			}).then();
+		}
+
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return jsonMapper.convertValue(data, typeRef);
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.fromRunnable(this.sink::complete);
+		}
+
+		@Override
+		public void close() {
+			this.sink.complete();
+		}
+
+	}
+
+	/**
+	 * Builder for creating instances of {@link WebFluxStreamableServerTransportProvider}.
+	 * <p>
+	 * This builder provides a fluent API for configuring and creating instances of
+	 * WebFluxStreamableServerTransportProvider with custom settings.
+	 */
+	public static final class Builder {
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		private String mcpEndpoint = "/mcp";
+
+		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
+
+		private boolean disallowDelete;
+
+		@Nullable private Duration keepAliveInterval;
+
+		private ServerTransportSecurityValidator securityValidator = ServerTransportSecurityValidator.NOOP;
+
+		private Builder() {
+			// used by a static method
+		}
+
+		/**
+		 * Sets the {@link McpJsonMapper} to use for JSON serialization/deserialization of
+		 * MCP messages.
+		 * @param jsonMapper The {@link McpJsonMapper} instance. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if jsonMapper is null
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "McpJsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint URI where clients should send their JSON-RPC messages.
+		 * @param messageEndpoint The message endpoint URI. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if messageEndpoint is null
+		 */
+		public Builder messageEndpoint(String messageEndpoint) {
+			Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+			this.mcpEndpoint = messageEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the context extractor that allows providing the MCP feature
+		 * implementations to inspect HTTP transport level metadata that was present at
+		 * HTTP request processing time. This allows to extract custom headers and other
+		 * useful data for use during execution later on in the process.
+		 * @param contextExtractor The contextExtractor to fill in a
+		 * {@link McpTransportContext}.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public Builder contextExtractor(McpTransportContextExtractor<ServerRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "contextExtractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
+		 * Sets whether the session removal capability is disabled.
+		 * @param disallowDelete if {@code true}, the DELETE endpoint will not be
+		 * supported and sessions won't be deleted.
+		 * @return this builder instance
+		 */
+		public Builder disallowDelete(boolean disallowDelete) {
+			this.disallowDelete = disallowDelete;
+			return this;
+		}
+
+		/**
+		 * Sets the keep-alive interval for the server transport.
+		 * @param keepAliveInterval The interval for sending keep-alive messages. If null,
+		 * no keep-alive will be scheduled.
+		 * @return this builder instance
+		 */
+		public Builder keepAliveInterval(Duration keepAliveInterval) {
+			this.keepAliveInterval = keepAliveInterval;
+			return this;
+		}
+
+		/**
+		 * Sets the security validator for validating HTTP requests.
+		 * @param securityValidator The security validator to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if securityValidator is null
+		 */
+		public Builder securityValidator(ServerTransportSecurityValidator securityValidator) {
+			Assert.notNull(securityValidator, "Security validator must not be null");
+			this.securityValidator = securityValidator;
+			return this;
+		}
+
+		/**
+		 * Builds a new instance of {@link WebFluxStreamableServerTransportProvider} with
+		 * the configured settings.
+		 * @return A new WebFluxStreamableServerTransportProvider instance
+		 * @throws IllegalStateException if required parameters are not set
+		 */
+		public WebFluxStreamableServerTransportProvider build() {
+			Assert.notNull(this.mcpEndpoint, "Message endpoint must be set");
+			return new WebFluxStreamableServerTransportProvider(
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.mcpEndpoint,
+					this.contextExtractor, this.disallowDelete, this.keepAliveInterval, this.securityValidator);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/package-info.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WebFlux-based server transport implementations for the Model Context Protocol (MCP).
+ * <p>
+ * This package provides server-side transport providers using Spring WebFlux, including
+ * SSE, Streamable HTTP, and stateless transport implementations.
+ *
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+@NullMarked
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import org.jspecify.annotations.NullMarked;

--- a/mcp/transport/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpAsyncClientResiliencyTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/io/modelcontextprotocol/client/WebClientStreamableHttpAsyncClientResiliencyTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.modelcontextprotocol.client;
+
+import io.modelcontextprotocol.spec.McpClientTransport;
+import org.junit.jupiter.api.Timeout;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Timeout(15)
+public class WebClientStreamableHttpAsyncClientResiliencyTests extends AbstractMcpAsyncClientResiliencyTests {
+
+	@Override
+	protected McpClientTransport createMcpTransport() {
+		return WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(host)).build();
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxSseIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxSseIntegrationTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.AbstractMcpClientServerIntegrationTests;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.SingleSessionSyncSpecification;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.TestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.Arguments;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+@Timeout(15)
+class WebFluxSseIntegrationTests extends AbstractMcpClientServerIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String CUSTOM_SSE_ENDPOINT = "/somePath/sse";
+
+	private static final String CUSTOM_MESSAGE_ENDPOINT = "/otherPath/mcp/message";
+
+	private DisposableServer httpServer;
+
+	private WebFluxSseServerTransportProvider mcpServerTransportProvider;
+
+	static McpTransportContextExtractor<ServerRequest> TEST_CONTEXT_EXTRACTOR = r -> McpTransportContext
+		.create(Map.of("important", "value"));
+
+	static Stream<Arguments> clientsForTesting() {
+		return Stream.of(Arguments.of("httpclient"), Arguments.of("webflux"));
+	}
+
+	@Override
+	protected void prepareClients(int port, String mcpEndpoint) {
+
+		clientBuilders
+			.put("httpclient",
+					McpClient.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+						.sseEndpoint(CUSTOM_SSE_ENDPOINT)
+						.build()).requestTimeout(Duration.ofHours(10)));
+
+		clientBuilders.put("webflux",
+				McpClient
+					.sync(WebFluxSseClientTransport.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+						.sseEndpoint(CUSTOM_SSE_ENDPOINT)
+						.build())
+					.requestTimeout(Duration.ofHours(10)));
+
+	}
+
+	@Override
+	protected AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(this.mcpServerTransportProvider);
+	}
+
+	@Override
+	protected SingleSessionSyncSpecification prepareSyncServerBuilder() {
+		return McpServer.sync(this.mcpServerTransportProvider);
+	}
+
+	@BeforeEach
+	public void before() {
+
+		this.mcpServerTransportProvider = new WebFluxSseServerTransportProvider.Builder()
+			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
+			.sseEndpoint(CUSTOM_SSE_ENDPOINT)
+			.contextExtractor(TEST_CONTEXT_EXTRACTOR)
+			.build();
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(this.mcpServerTransportProvider.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+
+		prepareClients(PORT, null);
+	}
+
+	@AfterEach
+	public void after() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStatelessIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStatelessIntegrationTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.AbstractStatelessIntegrationTests;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification;
+import io.modelcontextprotocol.server.TestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.Arguments;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+@Timeout(15)
+class WebFluxStatelessIntegrationTests extends AbstractStatelessIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String CUSTOM_MESSAGE_ENDPOINT = "/otherPath/mcp/message";
+
+	private DisposableServer httpServer;
+
+	private WebFluxStatelessServerTransport mcpStreamableServerTransport;
+
+	static Stream<Arguments> clientsForTesting() {
+		return Stream.of(Arguments.of("httpclient"), Arguments.of("webflux"));
+	}
+
+	@Override
+	protected void prepareClients(int port, String mcpEndpoint) {
+		clientBuilders
+			.put("httpclient",
+					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+						.endpoint(CUSTOM_MESSAGE_ENDPOINT)
+						.build()).initializationTimeout(Duration.ofHours(10)).requestTimeout(Duration.ofHours(10)));
+		clientBuilders
+			.put("webflux", McpClient
+				.sync(WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+					.endpoint(CUSTOM_MESSAGE_ENDPOINT)
+					.build())
+				.initializationTimeout(Duration.ofHours(10))
+				.requestTimeout(Duration.ofHours(10)));
+	}
+
+	@Override
+	protected StatelessAsyncSpecification prepareAsyncServerBuilder() {
+		return McpServer.async(this.mcpStreamableServerTransport);
+	}
+
+	@Override
+	protected StatelessSyncSpecification prepareSyncServerBuilder() {
+		return McpServer.sync(this.mcpStreamableServerTransport);
+	}
+
+	@BeforeEach
+	public void before() {
+		this.mcpStreamableServerTransport = WebFluxStatelessServerTransport.builder()
+			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
+			.build();
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(this.mcpStreamableServerTransport.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+
+		prepareClients(PORT, null);
+	}
+
+	@AfterEach
+	public void after() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIntegrationTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
+import org.springframework.ai.mcp.utils.McpTestRequestRecordingExchangeFilterFunction;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebFluxStreamableHttpVersionNegotiationIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private DisposableServer httpServer;
+
+	private final McpTestRequestRecordingExchangeFilterFunction recordingFilterFunction = new McpTestRequestRecordingExchangeFilterFunction();
+
+	private final McpSchema.Tool toolSpec = McpSchema.Tool.builder()
+		.name("test-tool")
+		.description("return the protocol version used")
+		.build();
+
+	private final BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult> toolHandler = (
+			exchange, request) -> new McpSchema.CallToolResult(
+					exchange.transportContext().get("protocol-version").toString(), null);
+
+	private final WebFluxStreamableServerTransportProvider mcpStreamableServerTransportProvider = WebFluxStreamableServerTransportProvider
+		.builder()
+		.contextExtractor(req -> McpTransportContext
+			.create(Map.of("protocol-version", req.headers().firstHeader("MCP-protocol-version"))))
+		.build();
+
+	private final McpSyncServer mcpServer = McpServer.sync(this.mcpStreamableServerTransportProvider)
+		.capabilities(McpSchema.ServerCapabilities.builder().tools(false).build())
+		.tools(new McpServerFeatures.SyncToolSpecification(this.toolSpec, null, this.toolHandler))
+		.build();
+
+	@BeforeEach
+	void setUp() {
+		RouterFunction<ServerResponse> filteredRouter = this.mcpStreamableServerTransportProvider.getRouterFunction()
+			.filter(this.recordingFilterFunction);
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(filteredRouter);
+
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+	}
+
+	@AfterEach
+	public void after() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+		if (this.mcpServer != null) {
+			this.mcpServer.close();
+		}
+	}
+
+	@Test
+	void usesLatestVersion() {
+		var client = McpClient
+			.sync(WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+				.build())
+			.requestTimeout(Duration.ofHours(10))
+			.build();
+
+		client.initialize();
+
+		McpSchema.CallToolResult response = client.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		var calls = this.recordingFilterFunction.getCalls();
+		assertThat(calls).filteredOn(c -> !c.body().contains("\"method\":\"initialize\""))
+			// GET /mcp ; POST notification/initialized ; POST tools/call
+			.hasSize(3)
+			.map(McpTestRequestRecordingExchangeFilterFunction.Call::headers)
+			.allSatisfy(headers -> assertThat(headers).containsEntry("mcp-protocol-version",
+					ProtocolVersions.MCP_2025_11_25));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo(ProtocolVersions.MCP_2025_11_25);
+		this.mcpServer.close();
+	}
+
+	@Test
+	void usesServerSupportedVersion() {
+		var transport = WebClientStreamableHttpTransport
+			.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+			.supportedProtocolVersions(List.of(ProtocolVersions.MCP_2025_11_25, "2263-03-18"))
+			.build();
+		var client = McpClient.sync(transport).requestTimeout(Duration.ofHours(10)).build();
+
+		client.initialize();
+
+		McpSchema.CallToolResult response = client.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		var calls = this.recordingFilterFunction.getCalls();
+		// Initialize tells the server the Client's latest supported version
+		// FIXME: Set the correct protocol version on GET /mcp
+		assertThat(calls)
+			.filteredOn(c -> !c.body().contains("\"method\":\"initialize\"") && c.method().equals(HttpMethod.POST))
+			// POST notification/initialized ; POST tools/call
+			.hasSize(2)
+			.map(McpTestRequestRecordingExchangeFilterFunction.Call::headers)
+			.allSatisfy(headers -> assertThat(headers).containsEntry("mcp-protocol-version",
+					ProtocolVersions.MCP_2025_11_25));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo(ProtocolVersions.MCP_2025_11_25);
+		this.mcpServer.close();
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableIntegrationTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.AbstractMcpClientServerIntegrationTests;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.SyncSpecification;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.TestUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.Arguments;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+@Timeout(15)
+class WebFluxStreamableIntegrationTests extends AbstractMcpClientServerIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String CUSTOM_MESSAGE_ENDPOINT = "/otherPath/mcp/message";
+
+	private DisposableServer httpServer;
+
+	private WebFluxStreamableServerTransportProvider mcpStreamableServerTransportProvider;
+
+	static McpTransportContextExtractor<ServerRequest> TEST_CONTEXT_EXTRACTOR = r -> McpTransportContext
+		.create(Map.of("important", "value"));
+
+	static Stream<Arguments> clientsForTesting() {
+		return Stream.of(Arguments.of("httpclient"), Arguments.of("webflux"));
+	}
+
+	@Override
+	protected void prepareClients(int port, String mcpEndpoint) {
+
+		clientBuilders
+			.put("httpclient",
+					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+						.endpoint(CUSTOM_MESSAGE_ENDPOINT)
+						.build()).requestTimeout(Duration.ofHours(10)));
+		clientBuilders.put("webflux",
+				McpClient
+					.sync(WebClientStreamableHttpTransport
+						.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+						.endpoint(CUSTOM_MESSAGE_ENDPOINT)
+						.build())
+					.requestTimeout(Duration.ofHours(10)));
+	}
+
+	@Override
+	protected AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(this.mcpStreamableServerTransportProvider);
+	}
+
+	@Override
+	protected SyncSpecification<?> prepareSyncServerBuilder() {
+		return McpServer.sync(this.mcpStreamableServerTransportProvider);
+	}
+
+	@BeforeEach
+	public void before() {
+
+		this.mcpStreamableServerTransportProvider = WebFluxStreamableServerTransportProvider.builder()
+			.messageEndpoint(CUSTOM_MESSAGE_ENDPOINT)
+			.contextExtractor(TEST_CONTEXT_EXTRACTOR)
+			.build();
+
+		HttpHandler httpHandler = RouterFunctions
+			.toHttpHandler(this.mcpStreamableServerTransportProvider.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+
+		prepareClients(PORT, null);
+	}
+
+	@AfterEach
+	public void after() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebClientStreamableHttpAsyncClientTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebClientStreamableHttpAsyncClientTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client;
+
+import io.modelcontextprotocol.client.AbstractMcpAsyncClientTests;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Timeout(15)
+public class WebClientStreamableHttpAsyncClientTests extends AbstractMcpAsyncClientTests {
+
+	static String host = "http://localhost:3001";
+
+	@SuppressWarnings("resource")
+	static GenericContainer<?> container = new GenericContainer<>("docker.io/node:lts-alpine3.23")
+		.withCommand("npx -y @modelcontextprotocol/server-everything@2025.12.18 streamableHttp")
+		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
+		.withExposedPorts(3001)
+		.waitingFor(Wait.forHttp("/").forStatusCode(404));
+
+	@Override
+	protected McpClientTransport createMcpTransport() {
+		return WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(host)).build();
+	}
+
+	@BeforeAll
+	static void startContainer() {
+		container.start();
+		int port = container.getMappedPort(3001);
+		host = "http://" + container.getHost() + ":" + port;
+	}
+
+	@AfterAll
+	static void stopContainer() {
+		container.stop();
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebClientStreamableHttpSyncClientTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebClientStreamableHttpSyncClientTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client;
+
+import io.modelcontextprotocol.client.AbstractMcpSyncClientTests;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Timeout(15)
+public class WebClientStreamableHttpSyncClientTests extends AbstractMcpSyncClientTests {
+
+	static String host = "http://localhost:3001";
+
+	@SuppressWarnings("resource")
+	static GenericContainer<?> container = new GenericContainer<>("docker.io/node:lts-alpine3.23")
+		.withCommand("npx -y @modelcontextprotocol/server-everything@2025.12.18 streamableHttp")
+		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
+		.withExposedPorts(3001)
+		.waitingFor(Wait.forHttp("/").forStatusCode(404));
+
+	@Override
+	protected McpClientTransport createMcpTransport() {
+		return WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(host)).build();
+	}
+
+	@BeforeAll
+	static void startContainer() {
+		container.start();
+		int port = container.getMappedPort(3001);
+		host = "http://" + container.getHost() + ":" + port;
+	}
+
+	@AfterAll
+	static void stopContainer() {
+		container.stop();
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebFluxSseMcpAsyncClientTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebFluxSseMcpAsyncClientTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client;
+
+import java.time.Duration;
+
+import io.modelcontextprotocol.client.AbstractMcpAsyncClientTests;
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Tests for the {@link McpAsyncClient} with {@link WebFluxSseClientTransport}.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebFluxSseMcpAsyncClientTests extends AbstractMcpAsyncClientTests {
+
+	static String host = "http://localhost:3001";
+
+	@SuppressWarnings("resource")
+	static GenericContainer<?> container = new GenericContainer<>("docker.io/node:lts-alpine3.23")
+		.withCommand("npx -y @modelcontextprotocol/server-everything@2025.12.18 sse")
+		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
+		.withExposedPorts(3001)
+		.waitingFor(Wait.forHttp("/").forStatusCode(404).forPort(3001));
+
+	@Override
+	protected McpClientTransport createMcpTransport() {
+		return WebFluxSseClientTransport.builder(WebClient.builder().baseUrl(host)).build();
+	}
+
+	@BeforeAll
+	static void startContainer() {
+		container.start();
+		int port = container.getMappedPort(3001);
+		host = "http://" + container.getHost() + ":" + port;
+	}
+
+	@AfterAll
+	static void stopContainer() {
+		container.stop();
+	}
+
+	protected Duration getInitializationTimeout() {
+		return Duration.ofSeconds(1);
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebFluxSseMcpSyncClientTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/WebFluxSseMcpSyncClientTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client;
+
+import java.time.Duration;
+
+import io.modelcontextprotocol.client.AbstractMcpSyncClientTests;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Tests for the {@link McpSyncClient} with {@link WebFluxSseClientTransport}.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebFluxSseMcpSyncClientTests extends AbstractMcpSyncClientTests {
+
+	static String host = "http://localhost:3001";
+
+	@SuppressWarnings("resource")
+	static GenericContainer<?> container = new GenericContainer<>("docker.io/node:lts-alpine3.23")
+		.withCommand("npx -y @modelcontextprotocol/server-everything@2025.12.18 sse")
+		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
+		.withExposedPorts(3001)
+		.waitingFor(Wait.forHttp("/").forStatusCode(404));
+
+	@Override
+	protected McpClientTransport createMcpTransport() {
+		return WebFluxSseClientTransport.builder(WebClient.builder().baseUrl(host)).build();
+	}
+
+	@BeforeAll
+	static void startContainer() {
+		container.start();
+		int port = container.getMappedPort(3001);
+		host = "http://" + container.getHost() + ":" + port;
+	}
+
+	@AfterAll
+	static void stopContainer() {
+		container.stop();
+	}
+
+	protected Duration getInitializationTimeout() {
+		return Duration.ofSeconds(1);
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportErrorHandlingTest.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportErrorHandlingTest.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import com.sun.net.httpserver.HttpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpTransportException;
+import io.modelcontextprotocol.spec.McpTransportSessionNotFoundException;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for error handling in WebClientStreamableHttpTransport. Addresses concurrency
+ * issues with proper Reactor patterns.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15)
+public class WebClientStreamableHttpTransportErrorHandlingTest {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String HOST = "http://localhost:" + PORT;
+
+	private HttpServer server;
+
+	private AtomicReference<Integer> serverResponseStatus = new AtomicReference<>(200);
+
+	private AtomicReference<String> currentServerSessionId = new AtomicReference<>(null);
+
+	private AtomicReference<String> lastReceivedSessionId = new AtomicReference<>(null);
+
+	private McpClientTransport transport;
+
+	// Initialize latches for proper request synchronization
+	private CountDownLatch firstRequestLatch;
+
+	private CountDownLatch secondRequestLatch;
+
+	private CountDownLatch getRequestLatch;
+
+	@BeforeEach
+	void startServer() throws IOException {
+
+		// Initialize latches for proper synchronization
+		this.firstRequestLatch = new CountDownLatch(1);
+		this.secondRequestLatch = new CountDownLatch(1);
+		this.getRequestLatch = new CountDownLatch(1);
+
+		this.server = HttpServer.create(new InetSocketAddress(PORT), 0);
+
+		// Configure the /mcp endpoint with dynamic response
+		this.server.createContext("/mcp", exchange -> {
+			String method = exchange.getRequestMethod();
+
+			if ("GET".equals(method)) {
+				// This is the SSE connection attempt after session establishment
+				this.getRequestLatch.countDown();
+				// Return 405 Method Not Allowed to indicate SSE not supported
+				exchange.sendResponseHeaders(405, 0);
+				exchange.close();
+				return;
+			}
+
+			String requestSessionId = exchange.getRequestHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+			this.lastReceivedSessionId.set(requestSessionId);
+
+			int status = this.serverResponseStatus.get();
+
+			// Track which request this is
+			if (this.firstRequestLatch.getCount() > 0) {
+				// // First request - should have no session ID
+				this.firstRequestLatch.countDown();
+			}
+			else if (this.secondRequestLatch.getCount() > 0) {
+				// Second request - should have session ID
+				this.secondRequestLatch.countDown();
+			}
+
+			exchange.getResponseHeaders().set("Content-Type", "application/json");
+
+			// Don't include session ID in 404 and 400 responses - the implementation
+			// checks if the transport has a session stored locally
+			String responseSessionId = this.currentServerSessionId.get();
+			if (responseSessionId != null && status == 200) {
+				exchange.getResponseHeaders().set(HttpHeaders.MCP_SESSION_ID, responseSessionId);
+			}
+			if (status == 200) {
+				String response = "{\"jsonrpc\":\"2.0\",\"result\":{},\"id\":\"test-id\"}";
+				exchange.sendResponseHeaders(200, response.length());
+				exchange.getResponseBody().write(response.getBytes());
+			}
+			else {
+				exchange.sendResponseHeaders(status, 0);
+			}
+			exchange.close();
+		});
+
+		this.server.setExecutor(null);
+		this.server.start();
+
+		this.transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(HOST)).build();
+	}
+
+	@AfterEach
+	void stopServer() {
+		if (this.server != null) {
+			this.server.stop(0);
+		}
+		StepVerifier.create(this.transport.closeGracefully()).verifyComplete();
+	}
+
+	/**
+	 * Test that 404 response WITHOUT session ID throws McpTransportException (not
+	 * SessionNotFoundException)
+	 */
+	@Test
+	void test404WithoutSessionId() {
+		this.serverResponseStatus.set(404);
+		this.currentServerSessionId.set(null); // No session ID in response
+
+		var testMessage = createTestMessage();
+
+		StepVerifier.create(this.transport.sendMessage(testMessage))
+			.expectErrorMatches(throwable -> throwable instanceof McpTransportException
+					&& throwable.getMessage().contains("Not Found") && throwable.getMessage().contains("404")
+					&& !(throwable instanceof McpTransportSessionNotFoundException))
+			.verify(Duration.ofSeconds(5));
+	}
+
+	/**
+	 * Test that 404 response WITH session ID throws McpTransportSessionNotFoundException
+	 * Fixed version using proper async coordination
+	 */
+	@Test
+	void test404WithSessionId() throws InterruptedException {
+		// First establish a session
+		this.serverResponseStatus.set(200);
+		this.currentServerSessionId.set("test-session-123");
+
+		// Set up exception handler to verify session invalidation
+		@SuppressWarnings("unchecked")
+		Consumer<Throwable> exceptionHandler = mock(Consumer.class);
+		this.transport.setExceptionHandler(exceptionHandler);
+
+		// Connect with handler
+		StepVerifier.create(this.transport.connect(msg -> msg)).verifyComplete();
+
+		// Send initial message to establish session
+		var testMessage = createTestMessage();
+
+		// Send first message to establish session
+		StepVerifier.create(this.transport.sendMessage(testMessage)).verifyComplete();
+
+		// Wait for first request to complete
+		assertThat(this.firstRequestLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+		// Wait for the GET request (SSE connection attempt) to complete
+		assertThat(this.getRequestLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+		// Now return 404 for next request
+		this.serverResponseStatus.set(404);
+
+		// Use delaySubscription to ensure session is fully processed before next
+		// request
+		StepVerifier.create(Mono.delay(Duration.ofMillis(200)).then(this.transport.sendMessage(testMessage)))
+			.expectError(McpTransportSessionNotFoundException.class)
+			.verify(Duration.ofSeconds(5));
+
+		// Wait for second request to be made
+		assertThat(this.secondRequestLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+		// Verify the second request included the session ID
+		assertThat(this.lastReceivedSessionId.get()).isEqualTo("test-session-123");
+
+		// Verify exception handler was called with SessionNotFoundException using
+		// timeout
+		verify(exceptionHandler, timeout(5000)).accept(any(McpTransportSessionNotFoundException.class));
+	}
+
+	/**
+	 * Test that 400 response WITHOUT session ID throws McpTransportException (not
+	 * SessionNotFoundException)
+	 */
+	@Test
+	void test400WithoutSessionId() {
+		this.serverResponseStatus.set(400);
+		this.currentServerSessionId.set(null); // No session ID
+
+		var testMessage = createTestMessage();
+
+		StepVerifier.create(this.transport.sendMessage(testMessage))
+			.expectErrorMatches(throwable -> throwable instanceof McpTransportException
+					&& throwable.getMessage().contains("Bad Request") && throwable.getMessage().contains("400")
+					&& !(throwable instanceof McpTransportSessionNotFoundException))
+			.verify(Duration.ofSeconds(5));
+	}
+
+	/**
+	 * Test that 400 response WITH session ID throws McpTransportSessionNotFoundException
+	 * Fixed version using proper async coordination
+	 */
+	@Test
+	void test400WithSessionId() throws InterruptedException {
+
+		// First establish a session
+		this.serverResponseStatus.set(200);
+		this.currentServerSessionId.set("test-session-456");
+
+		// Set up exception handler
+		@SuppressWarnings("unchecked")
+		Consumer<Throwable> exceptionHandler = mock(Consumer.class);
+		this.transport.setExceptionHandler(exceptionHandler);
+
+		// Connect with handler
+		StepVerifier.create(this.transport.connect(msg -> msg)).verifyComplete();
+
+		// Send initial message to establish session
+		var testMessage = createTestMessage();
+
+		// Send first message to establish session
+		StepVerifier.create(this.transport.sendMessage(testMessage)).verifyComplete();
+
+		// Wait for first request to complete
+		boolean firstCompleted = this.firstRequestLatch.await(5, TimeUnit.SECONDS);
+		assertThat(firstCompleted).isTrue();
+
+		// Wait for the GET request (SSE connection attempt) to complete
+		boolean getCompleted = this.getRequestLatch.await(5, TimeUnit.SECONDS);
+		assertThat(getCompleted).isTrue();
+
+		// Now return 400 for next request (simulating unknown session ID)
+		this.serverResponseStatus.set(400);
+
+		// Use delaySubscription to ensure session is fully processed before next
+		// request
+		StepVerifier.create(Mono.delay(Duration.ofMillis(200)).then(this.transport.sendMessage(testMessage)))
+			.expectError(McpTransportSessionNotFoundException.class)
+			.verify(Duration.ofSeconds(5));
+
+		// Wait for second request to be made
+		boolean secondCompleted = this.secondRequestLatch.await(5, TimeUnit.SECONDS);
+		assertThat(secondCompleted).isTrue();
+
+		// Verify the second request included the session ID
+		assertThat(this.lastReceivedSessionId.get()).isEqualTo("test-session-456");
+
+		// Verify exception handler was called with timeout
+		verify(exceptionHandler, timeout(5000)).accept(any(McpTransportSessionNotFoundException.class));
+	}
+
+	/**
+	 * Test session recovery after SessionNotFoundException Fixed version using reactive
+	 * patterns and proper synchronization
+	 */
+	@Test
+	void testSessionRecoveryAfter404() {
+		// First establish a session
+		this.serverResponseStatus.set(200);
+		this.currentServerSessionId.set("session-1");
+
+		// Send initial message to establish session
+		var testMessage = createTestMessage();
+
+		// Use Mono.defer to ensure proper sequencing
+		Mono<Void> establishSession = this.transport.sendMessage(testMessage).then(Mono.defer(() -> {
+			// Simulate session loss - return 404
+			this.serverResponseStatus.set(404);
+			return this.transport.sendMessage(testMessage)
+				.onErrorResume(McpTransportSessionNotFoundException.class, e ->
+			// Expected error, continue with recovery
+			Mono.empty());
+		})).then(Mono.defer(() -> {
+			// Now server is back with new session
+			this.serverResponseStatus.set(200);
+			this.currentServerSessionId.set("session-2");
+			this.lastReceivedSessionId.set(null); // Reset to verify new session
+
+			// Should be able to establish new session
+			return this.transport.sendMessage(testMessage);
+		})).then(Mono.defer(() -> {
+			// Verify no session ID was sent (since old session was invalidated)
+			assertThat(this.lastReceivedSessionId.get()).isNull();
+
+			// Next request should use the new session ID
+			return this.transport.sendMessage(testMessage);
+		})).doOnSuccess(v ->
+		// Session ID should now be sent with requests
+		assertThat(this.lastReceivedSessionId.get()).isEqualTo("session-2"));
+
+		StepVerifier.create(establishSession).verifyComplete();
+	}
+
+	/**
+	 * Test that reconnect (GET request) also properly handles 404/400 errors Fixed
+	 * version with proper async handling
+	 */
+	@Test
+	void testReconnectErrorHandling() throws InterruptedException {
+		// Initialize latch for SSE connection
+		CountDownLatch sseConnectionLatch = new CountDownLatch(1);
+
+		// Set up SSE endpoint for GET requests
+		this.server.createContext("/mcp-sse", exchange -> {
+			String method = exchange.getRequestMethod();
+			String requestSessionId = exchange.getRequestHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+
+			if ("GET".equals(method)) {
+				sseConnectionLatch.countDown();
+				int status = this.serverResponseStatus.get();
+
+				if (status == 404 && requestSessionId != null) {
+					// 404 with session ID - should trigger SessionNotFoundException
+					exchange.sendResponseHeaders(404, 0);
+				}
+				else if (status == 404) {
+					// 404 without session ID - should trigger McpTransportException
+					exchange.sendResponseHeaders(404, 0);
+				}
+				else {
+					// Normal SSE response
+					exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+					exchange.sendResponseHeaders(200, 0);
+					// Send a test SSE event
+					String sseData = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{}}\n\n";
+					exchange.getResponseBody().write(sseData.getBytes());
+				}
+			}
+			else {
+				// POST request handling
+				exchange.getResponseHeaders().set("Content-Type", "application/json");
+				String responseSessionId = this.currentServerSessionId.get();
+				if (responseSessionId != null) {
+					exchange.getResponseHeaders().set(HttpHeaders.MCP_SESSION_ID, responseSessionId);
+				}
+				String response = "{\"jsonrpc\":\"2.0\",\"result\":{},\"id\":\"test-id\"}";
+				exchange.sendResponseHeaders(200, response.length());
+				exchange.getResponseBody().write(response.getBytes());
+			}
+			exchange.close();
+		});
+
+		// Test with session ID - should get SessionNotFoundException
+		this.serverResponseStatus.set(200);
+		this.currentServerSessionId.set("sse-session-1");
+
+		var transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(HOST))
+			.endpoint("/mcp-sse")
+			.openConnectionOnStartup(true) // This will trigger GET request on connect
+			.build();
+
+		// First connect successfully
+		StepVerifier.create(transport.connect(msg -> msg)).verifyComplete();
+
+		// Wait for SSE connection to be established
+		boolean connected = sseConnectionLatch.await(5, TimeUnit.SECONDS);
+		assertThat(connected).isTrue();
+
+		// Send message to establish session
+		var testMessage = createTestMessage();
+		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
+
+		// Clean up
+		StepVerifier.create(transport.closeGracefully()).verifyComplete();
+	}
+
+	private McpSchema.JSONRPCRequest createTestMessage() {
+		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_03_26,
+				McpSchema.ClientCapabilities.builder().roots(true).build(),
+				new McpSchema.Implementation("Test Client", "1.0.0"));
+		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE, "test-id",
+				initializeRequest);
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportTest.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import reactor.test.StepVerifier;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+class WebClientStreamableHttpTransportTest {
+
+	static String host = "http://localhost:3001";
+
+	static WebClient.Builder builder;
+
+	@SuppressWarnings("resource")
+	static GenericContainer<?> container = new GenericContainer<>("docker.io/node:lts-alpine3.23")
+		.withCommand("npx -y @modelcontextprotocol/server-everything@2025.12.18 streamableHttp")
+		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
+		.withExposedPorts(3001)
+		.waitingFor(Wait.forHttp("/").forStatusCode(404));
+
+	@BeforeAll
+	static void startContainer() {
+		container.start();
+		int port = container.getMappedPort(3001);
+		host = "http://" + container.getHost() + ":" + port;
+		builder = WebClient.builder().baseUrl(host);
+	}
+
+	@AfterAll
+	static void stopContainer() {
+		container.stop();
+	}
+
+	@Test
+	void testCloseUninitialized() {
+		var transport = WebClientStreamableHttpTransport.builder(builder).build();
+
+		StepVerifier.create(transport.closeGracefully()).verifyComplete();
+
+		var initializeRequest = new McpSchema.InitializeRequest(McpSchema.LATEST_PROTOCOL_VERSION,
+				McpSchema.ClientCapabilities.builder().roots(true).build(),
+				new McpSchema.Implementation("MCP Client", "0.3.1"));
+		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
+				"test-id", initializeRequest);
+
+		StepVerifier.create(transport.sendMessage(testMessage))
+			.expectErrorMessage("MCP session has been closed")
+			.verify();
+	}
+
+	@Test
+	void testCloseInitialized() {
+		var transport = WebClientStreamableHttpTransport.builder(builder).build();
+
+		var initializeRequest = new McpSchema.InitializeRequest(McpSchema.LATEST_PROTOCOL_VERSION,
+				McpSchema.ClientCapabilities.builder().roots(true).build(),
+				new McpSchema.Implementation("MCP Client", "0.3.1"));
+		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
+				"test-id", initializeRequest);
+
+		StepVerifier.create(transport.sendMessage(testMessage)).verifyComplete();
+		StepVerifier.create(transport.closeGracefully()).verifyComplete();
+
+		StepVerifier.create(transport.sendMessage(testMessage))
+			.expectErrorMatches(err -> err.getMessage().matches("MCP session with ID [a-zA-Z0-9-]* has been closed"))
+			.verify();
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransportTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransportTests.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.webflux.transport;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
+import io.modelcontextprotocol.util.McpJsonMapperUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the {@link WebFluxSseClientTransport} class.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15)
+class WebFluxSseClientTransportTests {
+
+	static String host = "http://localhost:3001";
+
+	@SuppressWarnings("resource")
+	static GenericContainer<?> container = new GenericContainer<>("docker.io/node:lts-alpine3.23")
+		.withCommand("npx -y @modelcontextprotocol/server-everything@2025.12.18 sse")
+		.withLogConsumer(outputFrame -> System.out.println(outputFrame.getUtf8String()))
+		.withExposedPorts(3001)
+		.waitingFor(Wait.forHttp("/").forStatusCode(404));
+
+	private TestSseClientTransport transport;
+
+	private WebClient.Builder webClientBuilder;
+
+	@BeforeAll
+	static void startContainer() {
+		container.start();
+		int port = container.getMappedPort(3001);
+		host = "http://" + container.getHost() + ":" + port;
+	}
+
+	@AfterAll
+	static void cleanup() {
+		container.stop();
+	}
+
+	@BeforeEach
+	void setUp() {
+		this.webClientBuilder = WebClient.builder().baseUrl(host);
+		this.transport = new TestSseClientTransport(this.webClientBuilder, McpJsonMapperUtils.JSON_MAPPER);
+		this.transport.connect(Function.identity()).block();
+	}
+
+	@AfterEach
+	void afterEach() {
+		if (this.transport != null) {
+			assertThatCode(() -> this.transport.closeGracefully().block(Duration.ofSeconds(10)))
+				.doesNotThrowAnyException();
+		}
+	}
+
+	@Test
+	void testEndpointEventHandling() {
+		assertThat(this.transport.getLastEndpoint()).startsWith("/message?");
+	}
+
+	@Test
+	void constructorValidation() {
+		assertThatThrownBy(() -> new WebFluxSseClientTransport(null, McpJsonMapperUtils.JSON_MAPPER))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("WebClient.Builder must not be null");
+
+		assertThatThrownBy(() -> new WebFluxSseClientTransport(this.webClientBuilder, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("jsonMapper must not be null");
+	}
+
+	@Test
+	void testBuilderPattern() {
+		// Test default builder
+		WebFluxSseClientTransport transport1 = WebFluxSseClientTransport.builder(this.webClientBuilder).build();
+		assertThatCode(() -> transport1.closeGracefully().block()).doesNotThrowAnyException();
+
+		// Test builder with custom ObjectMapper
+		JsonMapper customMapper = JsonMapper.builder().build();
+		WebFluxSseClientTransport transport2 = WebFluxSseClientTransport.builder(this.webClientBuilder)
+			.jsonMapper(new JacksonMcpJsonMapper(customMapper))
+			.build();
+		assertThatCode(() -> transport2.closeGracefully().block()).doesNotThrowAnyException();
+
+		// Test builder with custom SSE endpoint
+		WebFluxSseClientTransport transport3 = WebFluxSseClientTransport.builder(this.webClientBuilder)
+			.sseEndpoint("/custom-sse")
+			.build();
+		assertThatCode(() -> transport3.closeGracefully().block()).doesNotThrowAnyException();
+
+		// Test builder with all custom parameters
+		WebFluxSseClientTransport transport4 = WebFluxSseClientTransport.builder(this.webClientBuilder)
+			.sseEndpoint("/custom-sse")
+			.build();
+		assertThatCode(() -> transport4.closeGracefully().block()).doesNotThrowAnyException();
+	}
+
+	@Test
+	void testCommentSseMessage() {
+		// If the line starts with a character (:) are comment lins and should be ingored
+		// https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+
+		CopyOnWriteArrayList<Throwable> droppedErrors = new CopyOnWriteArrayList<>();
+		reactor.core.publisher.Hooks.onErrorDropped(droppedErrors::add);
+
+		try {
+			// Simulate receiving the SSE comment line
+			this.transport.simulateSseComment("sse comment");
+
+			StepVerifier.create(this.transport.closeGracefully()).verifyComplete();
+
+			assertThat(droppedErrors).hasSize(0);
+		}
+		finally {
+			reactor.core.publisher.Hooks.resetOnErrorDropped();
+		}
+	}
+
+	@Test
+	void testMessageProcessing() {
+		// Create a test message
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
+				Map.of("key", "value"));
+
+		// Simulate receiving the message
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"method": "test-method",
+					"id": "test-id",
+					"params": {"key": "value"}
+				}
+				""");
+
+		// Subscribe to messages and verify
+		StepVerifier.create(this.transport.sendMessage(testMessage)).verifyComplete();
+
+		assertThat(this.transport.getInboundMessageCount()).isEqualTo(1);
+	}
+
+	@Test
+	void testResponseMessageProcessing() {
+		// Simulate receiving a response message
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"id": "test-id",
+					"result": {"status": "success"}
+				}
+				""");
+
+		// Create and send a request message
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
+				Map.of("key", "value"));
+
+		// Verify message handling
+		StepVerifier.create(this.transport.sendMessage(testMessage)).verifyComplete();
+
+		assertThat(this.transport.getInboundMessageCount()).isEqualTo(1);
+	}
+
+	@Test
+	void testErrorMessageProcessing() {
+		// Simulate receiving an error message
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"id": "test-id",
+					"error": {
+						"code": -32600,
+						"message": "Invalid Request"
+					}
+				}
+				""");
+
+		// Create and send a request message
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
+				Map.of("key", "value"));
+
+		// Verify message handling
+		StepVerifier.create(this.transport.sendMessage(testMessage)).verifyComplete();
+
+		assertThat(this.transport.getInboundMessageCount()).isEqualTo(1);
+	}
+
+	@Test
+	void testNotificationMessageProcessing() {
+		// Simulate receiving a notification message (no id)
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"method": "update",
+					"params": {"status": "processing"}
+				}
+				""");
+
+		// Verify the notification was processed
+		assertThat(this.transport.getInboundMessageCount()).isEqualTo(1);
+	}
+
+	@Test
+	void testGracefulShutdown() {
+		// Test graceful shutdown
+		StepVerifier.create(this.transport.closeGracefully()).verifyComplete();
+
+		// Create a test message
+		JSONRPCRequest testMessage = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "test-method", "test-id",
+				Map.of("key", "value"));
+
+		// Verify message is not processed after shutdown
+		StepVerifier.create(this.transport.sendMessage(testMessage)).verifyComplete();
+
+		// Message count should remain 0 after shutdown
+		assertThat(this.transport.getInboundMessageCount()).isEqualTo(0);
+	}
+
+	@Test
+	void testRetryBehavior() {
+		// Create a WebClient that simulates connection failures
+		WebClient.Builder failingWebClientBuilder = WebClient.builder().baseUrl("http://non-existent-host");
+
+		WebFluxSseClientTransport failingTransport = WebFluxSseClientTransport.builder(failingWebClientBuilder).build();
+
+		// Verify that the transport attempts to reconnect
+		StepVerifier.create(Mono.delay(Duration.ofSeconds(2))).expectNextCount(1).verifyComplete();
+
+		// Clean up
+		failingTransport.closeGracefully().block();
+	}
+
+	@Test
+	void testMultipleMessageProcessing() {
+		// Simulate receiving multiple messages in sequence
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"method": "method1",
+					"id": "id1",
+					"params": {"key": "value1"}
+				}
+				""");
+
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"method": "method2",
+					"id": "id2",
+					"params": {"key": "value2"}
+				}
+				""");
+
+		// Create and send corresponding messages
+		JSONRPCRequest message1 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method1", "id1",
+				Map.of("key", "value1"));
+
+		JSONRPCRequest message2 = new JSONRPCRequest(McpSchema.JSONRPC_VERSION, "method2", "id2",
+				Map.of("key", "value2"));
+
+		// Verify both messages are processed
+		StepVerifier.create(this.transport.sendMessage(message1).then(this.transport.sendMessage(message2)))
+			.verifyComplete();
+
+		// Verify message count
+		assertThat(this.transport.getInboundMessageCount()).isEqualTo(2);
+	}
+
+	@Test
+	void testMessageOrderPreservation() {
+		// Simulate receiving messages in a specific order
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"method": "first",
+					"id": "1",
+					"params": {"sequence": 1}
+				}
+				""");
+
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"method": "second",
+					"id": "2",
+					"params": {"sequence": 2}
+				}
+				""");
+
+		this.transport.simulateMessageEvent("""
+				{
+					"jsonrpc": "2.0",
+					"method": "third",
+					"id": "3",
+					"params": {"sequence": 3}
+				}
+				""");
+
+		// Verify message count and order
+		assertThat(this.transport.getInboundMessageCount()).isEqualTo(3);
+	}
+
+	// Test class to access protected methods
+	static class TestSseClientTransport extends WebFluxSseClientTransport {
+
+		private final AtomicInteger inboundMessageCount = new AtomicInteger(0);
+
+		private Sinks.Many<ServerSentEvent<String>> events = Sinks.many().unicast().onBackpressureBuffer();
+
+		TestSseClientTransport(WebClient.Builder webClientBuilder, McpJsonMapper jsonMapper) {
+			super(webClientBuilder, jsonMapper);
+		}
+
+		@Override
+		protected Flux<ServerSentEvent<String>> eventStream() {
+			return super.eventStream().mergeWith(this.events.asFlux());
+		}
+
+		String getLastEndpoint() {
+			return this.messageEndpointSink.asMono().block();
+		}
+
+		int getInboundMessageCount() {
+			return this.inboundMessageCount.get();
+		}
+
+		void simulateSseComment(String comment) {
+			this.events.tryEmitNext(ServerSentEvent.<String>builder().comment(comment).build());
+			this.inboundMessageCount.incrementAndGet();
+		}
+
+		void simulateEndpointEvent(String jsonMessage) {
+			this.events.tryEmitNext(ServerSentEvent.<String>builder().event("endpoint").data(jsonMessage).build());
+			this.inboundMessageCount.incrementAndGet();
+		}
+
+		void simulateMessageEvent(String jsonMessage) {
+			this.events.tryEmitNext(ServerSentEvent.<String>builder().event("message").data(jsonMessage).build());
+			this.inboundMessageCount.incrementAndGet();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/AsyncServerMcpTransportContextIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/AsyncServerMcpTransportContextIntegrationTests.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.common;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import io.modelcontextprotocol.client.McpAsyncClient;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpAsyncServerExchange;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+import reactor.test.StepVerifier;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link McpTransportContext} propagation between MCP clients and
+ * async servers using Spring WebFlux infrastructure.
+ *
+ * <p>
+ * This test class validates the end-to-end flow of transport context propagation in MCP
+ * communication for asynchronous client and server implementations. It tests various
+ * combinations of client types and server transport mechanisms (stateless, streamable,
+ * SSE) to ensure proper context handling across different configurations.
+ *
+ * <h2>Context Propagation Flow</h2>
+ * <ol>
+ * <li>Client sets a value in its transport context via thread-local Reactor context</li>
+ * <li>Client-side context provider extracts the value and adds it as an HTTP header to
+ * the request</li>
+ * <li>Server-side context extractor reads the header from the incoming request</li>
+ * <li>Server handler receives the extracted context and returns the value as the tool
+ * call result</li>
+ * <li>Test verifies the round-trip context propagation was successful</li>
+ * </ol>
+ *
+ * @author Daniel Garnier-Moiroux
+ * @author Christian Tzolov
+ */
+@Timeout(15)
+class AsyncServerMcpTransportContextIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String HEADER_NAME = "x-test";
+
+	// Async client context provider
+	ExchangeFilterFunction asyncClientContextProvider = (request, next) -> Mono.deferContextual(ctx -> {
+		var transportContext = ctx.getOrDefault(McpTransportContext.KEY, McpTransportContext.EMPTY);
+		// // do stuff with the context
+		var headerValue = transportContext.get("client-side-header-value");
+		if (headerValue == null) {
+			return next.exchange(request);
+		}
+		var reqWithHeader = ClientRequest.from(request).header(HEADER_NAME, headerValue.toString()).build();
+		return next.exchange(reqWithHeader);
+	});
+
+	// Tools
+	private final McpSchema.Tool tool = McpSchema.Tool.builder()
+		.name("test-tool")
+		.description("return the value of the x-test header from call tool request")
+		.build();
+
+	private final BiFunction<McpTransportContext, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> asyncStatelessHandler = (
+			transportContext, request) -> Mono
+				.just(new McpSchema.CallToolResult(transportContext.get("server-side-header-value").toString(), null));
+
+	private final BiFunction<McpAsyncServerExchange, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> asyncStatefulHandler = (
+			exchange, request) -> this.asyncStatelessHandler.apply(exchange.transportContext(), request);
+
+	// Server context extractor
+	private final McpTransportContextExtractor<ServerRequest> serverContextExtractor = r -> {
+		var headerValue = r.headers().firstHeader(HEADER_NAME);
+		return headerValue != null ? McpTransportContext.create(Map.of("server-side-header-value", headerValue))
+				: McpTransportContext.EMPTY;
+	};
+
+	// Server transports
+	private final WebFluxStatelessServerTransport statelessServerTransport = WebFluxStatelessServerTransport.builder()
+		.contextExtractor(this.serverContextExtractor)
+		.build();
+
+	private final WebFluxStreamableServerTransportProvider streamableServerTransport = WebFluxStreamableServerTransportProvider
+		.builder()
+		.contextExtractor(this.serverContextExtractor)
+		.build();
+
+	private final WebFluxSseServerTransportProvider sseServerTransport = WebFluxSseServerTransportProvider.builder()
+		.contextExtractor(this.serverContextExtractor)
+		.messageEndpoint("/mcp/message")
+		.build();
+
+	// Async clients
+	private final McpAsyncClient asyncStreamableClient = McpClient
+		.async(WebClientStreamableHttpTransport
+			.builder(WebClient.builder().baseUrl("http://localhost:" + PORT).filter(this.asyncClientContextProvider))
+			.build())
+		.build();
+
+	private final McpAsyncClient asyncSseClient = McpClient
+		.async(WebFluxSseClientTransport
+			.builder(WebClient.builder().baseUrl("http://localhost:" + PORT).filter(this.asyncClientContextProvider))
+			.build())
+		.build();
+
+	private DisposableServer httpServer;
+
+	@AfterEach
+	void after() {
+		if (this.statelessServerTransport != null) {
+			this.statelessServerTransport.closeGracefully().block();
+		}
+		if (this.streamableServerTransport != null) {
+			this.streamableServerTransport.closeGracefully().block();
+		}
+		if (this.sseServerTransport != null) {
+			this.sseServerTransport.closeGracefully().block();
+		}
+		if (this.asyncStreamableClient != null) {
+			this.asyncStreamableClient.closeGracefully().block();
+		}
+		if (this.asyncSseClient != null) {
+			this.asyncSseClient.closeGracefully().block();
+		}
+		stopHttpServer();
+	}
+
+	@Test
+	void asyncClientStatelessServer() {
+
+		startHttpServer(this.statelessServerTransport.getRouterFunction());
+
+		var mcpServer = McpServer.async(this.statelessServerTransport)
+			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+			.tools(new McpStatelessServerFeatures.AsyncToolSpecification(this.tool, this.asyncStatelessHandler))
+			.build();
+
+		StepVerifier.create(this.asyncStreamableClient.initialize())
+			.assertNext(initResult -> assertThat(initResult).isNotNull())
+			.verifyComplete();
+
+		// Test tool call with context
+		StepVerifier
+			.create(this.asyncStreamableClient.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()))
+				.contextWrite(ctx -> ctx.put(McpTransportContext.KEY,
+						McpTransportContext.create(Map.of("client-side-header-value", "some important value")))))
+			.assertNext(response -> {
+				assertThat(response).isNotNull();
+				assertThat(response.content()).hasSize(1)
+					.first()
+					.extracting(McpSchema.TextContent.class::cast)
+					.extracting(McpSchema.TextContent::text)
+					.isEqualTo("some important value");
+			})
+			.verifyComplete();
+
+		mcpServer.close();
+	}
+
+	@Test
+	void asyncClientStreamableServer() {
+
+		startHttpServer(this.streamableServerTransport.getRouterFunction());
+
+		var mcpServer = McpServer.async(this.streamableServerTransport)
+			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+			.tools(new McpServerFeatures.AsyncToolSpecification(this.tool, null, this.asyncStatefulHandler))
+			.build();
+
+		StepVerifier.create(this.asyncStreamableClient.initialize())
+			.assertNext(initResult -> assertThat(initResult).isNotNull())
+			.verifyComplete();
+
+		// Test tool call with context
+		StepVerifier
+			.create(this.asyncStreamableClient.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()))
+				.contextWrite(ctx -> ctx.put(McpTransportContext.KEY,
+						McpTransportContext.create(Map.of("client-side-header-value", "some important value")))))
+			.assertNext(response -> {
+				assertThat(response).isNotNull();
+				assertThat(response.content()).hasSize(1)
+					.first()
+					.extracting(McpSchema.TextContent.class::cast)
+					.extracting(McpSchema.TextContent::text)
+					.isEqualTo("some important value");
+			})
+			.verifyComplete();
+
+		mcpServer.close();
+	}
+
+	@Test
+	void asyncClientSseServer() {
+
+		startHttpServer(this.sseServerTransport.getRouterFunction());
+
+		var mcpServer = McpServer.async(this.sseServerTransport)
+			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+			.tools(new McpServerFeatures.AsyncToolSpecification(this.tool, null, this.asyncStatefulHandler))
+			.build();
+
+		StepVerifier.create(this.asyncSseClient.initialize())
+			.assertNext(initResult -> assertThat(initResult).isNotNull())
+			.verifyComplete();
+
+		// Test tool call with context
+		StepVerifier
+			.create(this.asyncSseClient.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()))
+				.contextWrite(ctx -> ctx.put(McpTransportContext.KEY,
+						McpTransportContext.create(Map.of("client-side-header-value", "some important value")))))
+			.assertNext(response -> {
+				assertThat(response).isNotNull();
+				assertThat(response.content()).hasSize(1)
+					.first()
+					.extracting(McpSchema.TextContent.class::cast)
+					.extracting(McpSchema.TextContent::text)
+					.isEqualTo("some important value");
+			})
+			.verifyComplete();
+
+		mcpServer.close();
+	}
+
+	private void startHttpServer(RouterFunction<?> routerFunction) {
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(routerFunction);
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+	}
+
+	private void stopHttpServer() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/SyncServerMcpTransportContextIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/SyncServerMcpTransportContextIntegrationTests.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.common;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link McpTransportContext} propagation between MCP client and
+ * server using synchronous operations in a Spring WebFlux environment.
+ * <p>
+ * This test class validates the end-to-end flow of transport context propagation across
+ * different WebFlux-based MCP transport implementations
+ *
+ * <p>
+ * The test scenario follows these steps:
+ * <ol>
+ * <li>The client stores a value in a thread-local variable</li>
+ * <li>The client's transport context provider reads this value and includes it in the MCP
+ * context</li>
+ * <li>A WebClient filter extracts the context value and adds it as an HTTP header
+ * (x-test)</li>
+ * <li>The server's {@link McpTransportContextExtractor} reads the header from the
+ * request</li>
+ * <li>The server returns the header value as the tool call result, validating the
+ * round-trip</li>
+ * </ol>
+ *
+ * <p>
+ * This test demonstrates how custom context can be propagated through HTTP headers in a
+ * reactive WebFlux environment, enabling features like authentication tokens, correlation
+ * IDs, or other metadata to flow between MCP client and server.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @author Christian Tzolov
+ * @since 1.0.0
+ * @see McpTransportContext
+ * @see McpTransportContextExtractor
+ * @see WebFluxStatelessServerTransport
+ * @see WebFluxStreamableServerTransportProvider
+ * @see WebFluxSseServerTransportProvider
+ */
+@Timeout(15)
+public class SyncServerMcpTransportContextIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final ThreadLocal<String> CLIENT_SIDE_HEADER_VALUE_HOLDER = new ThreadLocal<>();
+
+	private static final String HEADER_NAME = "x-test";
+
+	private final Supplier<McpTransportContext> clientContextProvider = () -> {
+		var headerValue = CLIENT_SIDE_HEADER_VALUE_HOLDER.get();
+		return headerValue != null ? McpTransportContext.create(Map.of("client-side-header-value", headerValue))
+				: McpTransportContext.EMPTY;
+	};
+
+	private final BiFunction<McpTransportContext, McpSchema.CallToolRequest, McpSchema.CallToolResult> statelessHandler = (
+			transportContext,
+			request) -> new McpSchema.CallToolResult(transportContext.get("server-side-header-value").toString(), null);
+
+	private final BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult> statefulHandler = (
+			exchange, request) -> this.statelessHandler.apply(exchange.transportContext(), request);
+
+	private final McpTransportContextExtractor<ServerRequest> serverContextExtractor = (ServerRequest r) -> {
+		var headerValue = r.headers().firstHeader(HEADER_NAME);
+		return headerValue != null ? McpTransportContext.create(Map.of("server-side-header-value", headerValue))
+				: McpTransportContext.EMPTY;
+	};
+
+	private final WebFluxStatelessServerTransport statelessServerTransport = WebFluxStatelessServerTransport.builder()
+		.contextExtractor(this.serverContextExtractor)
+		.build();
+
+	private final WebFluxStreamableServerTransportProvider streamableServerTransport = WebFluxStreamableServerTransportProvider
+		.builder()
+		.contextExtractor(this.serverContextExtractor)
+		.build();
+
+	private final WebFluxSseServerTransportProvider sseServerTransport = WebFluxSseServerTransportProvider.builder()
+		.contextExtractor(this.serverContextExtractor)
+		.messageEndpoint("/mcp/message")
+		.build();
+
+	private final McpSyncClient streamableClient = McpClient
+		.sync(WebClientStreamableHttpTransport.builder(WebClient.builder()
+			.baseUrl("http://localhost:" + PORT)
+			.filter((request, next) -> Mono.deferContextual(ctx -> {
+				var context = ctx.getOrDefault(McpTransportContext.KEY, McpTransportContext.EMPTY);
+				// // do stuff with the context
+				var headerValue = context.get("client-side-header-value");
+				if (headerValue == null) {
+					return next.exchange(request);
+				}
+				var reqWithHeader = ClientRequest.from(request).header(HEADER_NAME, headerValue.toString()).build();
+				return next.exchange(reqWithHeader);
+			}))).build())
+		.transportContextProvider(this.clientContextProvider)
+		.build();
+
+	private final McpSyncClient sseClient = McpClient.sync(WebFluxSseClientTransport.builder(WebClient.builder()
+		.baseUrl("http://localhost:" + PORT)
+		.filter((request, next) -> Mono.deferContextual(ctx -> {
+			var context = ctx.getOrDefault(McpTransportContext.KEY, McpTransportContext.EMPTY);
+			// // do stuff with the context
+			var headerValue = context.get("client-side-header-value");
+			if (headerValue == null) {
+				return next.exchange(request);
+			}
+			var reqWithHeader = ClientRequest.from(request).header(HEADER_NAME, headerValue.toString()).build();
+			return next.exchange(reqWithHeader);
+		}))).build()).transportContextProvider(this.clientContextProvider).build();
+
+	private final McpSchema.Tool tool = McpSchema.Tool.builder()
+		.name("test-tool")
+		.description("return the value of the x-test header from call tool request")
+		.build();
+
+	private DisposableServer httpServer;
+
+	@AfterEach
+	public void after() {
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.remove();
+		if (this.statelessServerTransport != null) {
+			this.statelessServerTransport.closeGracefully().block();
+		}
+		if (this.streamableServerTransport != null) {
+			this.streamableServerTransport.closeGracefully().block();
+		}
+		if (this.sseServerTransport != null) {
+			this.sseServerTransport.closeGracefully().block();
+		}
+		if (this.streamableClient != null) {
+			this.streamableClient.closeGracefully();
+		}
+		if (this.sseClient != null) {
+			this.sseClient.closeGracefully();
+		}
+		stopHttpServer();
+	}
+
+	@Test
+	void statelessServer() {
+
+		startHttpServer(this.statelessServerTransport.getRouterFunction());
+
+		var mcpServer = McpServer.sync(this.statelessServerTransport)
+			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+			.tools(new McpStatelessServerFeatures.SyncToolSpecification(this.tool, this.statelessHandler))
+			.build();
+
+		McpSchema.InitializeResult initResult = this.streamableClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
+		McpSchema.CallToolResult response = this.streamableClient
+			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo("some important value");
+
+		mcpServer.close();
+	}
+
+	@Test
+	void streamableServer() {
+
+		startHttpServer(this.streamableServerTransport.getRouterFunction());
+
+		var mcpServer = McpServer.sync(this.streamableServerTransport)
+			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+			.tools(new McpServerFeatures.SyncToolSpecification(this.tool, null, this.statefulHandler))
+			.build();
+
+		McpSchema.InitializeResult initResult = this.streamableClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
+		McpSchema.CallToolResult response = this.streamableClient
+			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo("some important value");
+
+		mcpServer.close();
+	}
+
+	@Test
+	void sseServer() {
+		startHttpServer(this.sseServerTransport.getRouterFunction());
+
+		var mcpServer = McpServer.sync(this.sseServerTransport)
+			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+			.tools(new McpServerFeatures.SyncToolSpecification(this.tool, null, this.statefulHandler))
+			.build();
+
+		McpSchema.InitializeResult initResult = this.sseClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
+		McpSchema.CallToolResult response = this.sseClient
+			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo("some important value");
+
+		mcpServer.close();
+	}
+
+	private void startHttpServer(RouterFunction<?> routerFunction) {
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(routerFunction);
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+	}
+
+	private void stopHttpServer() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/security/WebFluxServerTransportSecurityIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/security/WebFluxServerTransportSecurityIntegrationTests.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.security;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.server.transport.DefaultServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.BeforeParameterizedClassInvocation;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test the header security validation for all transport types.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+@ParameterizedClass
+@MethodSource("transports")
+class WebFluxServerTransportSecurityIntegrationTests {
+
+	private static final String DISALLOWED_ORIGIN = "https://malicious.example.com";
+
+	@Parameter
+	private static Transport transport;
+
+	private static DisposableServer httpServer;
+
+	private static String baseUrl;
+
+	@BeforeParameterizedClassInvocation
+	static void createTransportAndStartServer(Transport transport) {
+		var port = TestUtil.findAvailablePort();
+		baseUrl = "http://localhost:" + port;
+		startServer(transport.routerFunction(), port);
+	}
+
+	@AfterAll
+	static void afterAll() {
+		stopServer();
+	}
+
+	private McpSyncClient mcpClient;
+
+	private final TestOriginHeaderExchangeFilterFunction exchangeFilterFunction = new TestOriginHeaderExchangeFilterFunction();
+
+	@BeforeEach
+	void setUp() {
+		this.mcpClient = transport.createMcpClient(baseUrl, this.exchangeFilterFunction);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.mcpClient.close();
+	}
+
+	@Test
+	void originAllowed() {
+		this.exchangeFilterFunction.setOriginHeader(baseUrl);
+		var result = this.mcpClient.initialize();
+		var tools = this.mcpClient.listTools();
+
+		assertThat(result.protocolVersion()).isNotEmpty();
+		assertThat(tools.tools()).isEmpty();
+	}
+
+	@Test
+	void noOrigin() {
+		this.exchangeFilterFunction.setOriginHeader(null);
+		var result = this.mcpClient.initialize();
+		var tools = this.mcpClient.listTools();
+
+		assertThat(result.protocolVersion()).isNotEmpty();
+		assertThat(tools.tools()).isEmpty();
+	}
+
+	@Test
+	void connectOriginNotAllowed() {
+		this.exchangeFilterFunction.setOriginHeader(DISALLOWED_ORIGIN);
+		assertThatThrownBy(() -> this.mcpClient.initialize());
+	}
+
+	@Test
+	void messageOriginNotAllowed() {
+		this.exchangeFilterFunction.setOriginHeader(baseUrl);
+		this.mcpClient.initialize();
+		this.exchangeFilterFunction.setOriginHeader(DISALLOWED_ORIGIN);
+		assertThatThrownBy(() -> this.mcpClient.listTools());
+	}
+
+	// ----------------------------------------------------
+	// Server management
+	// ----------------------------------------------------
+
+	private static void startServer(RouterFunction<?> routerFunction, int port) {
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(routerFunction);
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		httpServer = HttpServer.create().port(port).handle(adapter).bindNow();
+	}
+
+	private static void stopServer() {
+		if (httpServer != null) {
+			httpServer.disposeNow();
+		}
+	}
+
+	// ----------------------------------------------------
+	// Transport servers to test
+	// ----------------------------------------------------
+
+	/**
+	 * All transport types we want to test. We use a {@link MethodSource} rather than a
+	 * {@link org.junit.jupiter.params.provider.ValueSource} to provide a readable name.
+	 */
+	static Stream<Arguments> transports() {
+		//@formatter:off
+		return Stream.of(
+				Arguments.arguments(Named.named("SSE", new Sse())),
+				Arguments.arguments(Named.named("Streamable HTTP", new StreamableHttp())),
+				Arguments.arguments(Named.named("Stateless", new Stateless()))
+		);
+		//@formatter:on
+	}
+
+	/**
+	 * Represents a server transport we want to test, and how to create a client for the
+	 * resulting MCP Server.
+	 */
+	interface Transport {
+
+		McpSyncClient createMcpClient(String baseUrl, TestOriginHeaderExchangeFilterFunction customizer);
+
+		RouterFunction<?> routerFunction();
+
+	}
+
+	/**
+	 * SSE-based transport.
+	 */
+	static class Sse implements Transport {
+
+		private final WebFluxSseServerTransportProvider transportProvider;
+
+		Sse() {
+			this.transportProvider = WebFluxSseServerTransportProvider.builder()
+				.messageEndpoint("/mcp/message")
+				.securityValidator(
+						DefaultServerTransportSecurityValidator.builder().allowedOrigin("http://localhost:*").build())
+				.build();
+			McpServer.sync(this.transportProvider)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.build();
+		}
+
+		@Override
+		public McpSyncClient createMcpClient(String baseUrl,
+				TestOriginHeaderExchangeFilterFunction exchangeFilterFunction) {
+			var transport = WebFluxSseClientTransport
+				.builder(WebClient.builder().baseUrl(baseUrl).filter(exchangeFilterFunction))
+				.jsonMapper(McpJsonMapper.getDefault())
+				.build();
+			return McpClient.sync(transport).initializationTimeout(Duration.ofMillis(500)).build();
+		}
+
+		@Override
+		public RouterFunction<?> routerFunction() {
+			return this.transportProvider.getRouterFunction();
+		}
+
+	}
+
+	static class StreamableHttp implements Transport {
+
+		private final WebFluxStreamableServerTransportProvider transportProvider;
+
+		StreamableHttp() {
+			this.transportProvider = WebFluxStreamableServerTransportProvider.builder()
+				.securityValidator(
+						DefaultServerTransportSecurityValidator.builder().allowedOrigin("http://localhost:*").build())
+				.build();
+			McpServer.sync(this.transportProvider)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.build();
+		}
+
+		@Override
+		public McpSyncClient createMcpClient(String baseUrl,
+				TestOriginHeaderExchangeFilterFunction exchangeFilterFunction) {
+			var transport = WebClientStreamableHttpTransport
+				.builder(WebClient.builder().baseUrl(baseUrl).filter(exchangeFilterFunction))
+				.jsonMapper(McpJsonMapper.getDefault())
+				.openConnectionOnStartup(true)
+				.build();
+			return McpClient.sync(transport).initializationTimeout(Duration.ofMillis(500)).build();
+		}
+
+		@Override
+		public RouterFunction<?> routerFunction() {
+			return this.transportProvider.getRouterFunction();
+		}
+
+	}
+
+	static class Stateless implements Transport {
+
+		private final WebFluxStatelessServerTransport transportProvider;
+
+		Stateless() {
+			this.transportProvider = WebFluxStatelessServerTransport.builder()
+				.securityValidator(
+						DefaultServerTransportSecurityValidator.builder().allowedOrigin("http://localhost:*").build())
+				.build();
+			McpServer.sync(this.transportProvider)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.build();
+		}
+
+		@Override
+		public McpSyncClient createMcpClient(String baseUrl,
+				TestOriginHeaderExchangeFilterFunction exchangeFilterFunction) {
+			var transport = WebClientStreamableHttpTransport
+				.builder(WebClient.builder().baseUrl(baseUrl).filter(exchangeFilterFunction))
+				.jsonMapper(McpJsonMapper.getDefault())
+				.openConnectionOnStartup(true)
+				.build();
+			return McpClient.sync(transport).initializationTimeout(Duration.ofMillis(500)).build();
+		}
+
+		@Override
+		public RouterFunction<?> routerFunction() {
+			return this.transportProvider.getRouterFunction();
+		}
+
+	}
+
+	static class TestOriginHeaderExchangeFilterFunction implements ExchangeFilterFunction {
+
+		private String origin = null;
+
+		void setOriginHeader(String origin) {
+			this.origin = origin;
+		}
+
+		@Override
+		public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
+			var updatedRequest = ClientRequest.from(request).header("origin", this.origin).build();
+			return next.exchange(updatedRequest);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/BlockingInputStream.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/BlockingInputStream.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class BlockingInputStream extends InputStream {
+
+	private final BlockingQueue<Integer> queue = new LinkedBlockingQueue<>();
+
+	private volatile boolean completed = false;
+
+	private volatile boolean closed = false;
+
+	@Override
+	public int read() throws IOException {
+		if (this.closed) {
+			throw new IOException("Stream is closed");
+		}
+
+		try {
+			Integer value = this.queue.poll();
+			if (value == null) {
+				if (this.completed) {
+					return -1;
+				}
+				value = this.queue.take(); // Blocks until data is available
+				if (value == null && this.completed) {
+					return -1;
+				}
+			}
+			return value;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IOException("Read interrupted", e);
+		}
+	}
+
+	public void write(int b) {
+		if (!this.closed && !this.completed) {
+			this.queue.offer(b);
+		}
+	}
+
+	public void write(byte[] data) {
+		if (!this.closed && !this.completed) {
+			for (byte b : data) {
+				this.queue.offer((int) b & 0xFF);
+			}
+		}
+	}
+
+	public void complete() {
+		this.completed = true;
+	}
+
+	@Override
+	public void close() {
+		this.closed = true;
+		this.completed = true;
+		this.queue.clear();
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpAsyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpAsyncServerTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import org.junit.jupiter.api.Timeout;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+/**
+ * Tests for {@link McpAsyncServer} using {@link WebFluxSseServerTransportProvider}.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebFluxSseMcpAsyncServerTests extends AbstractMcpAsyncServerTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private DisposableServer httpServer;
+
+	private McpServerTransportProvider createMcpTransportProvider() {
+		var transportProvider = new WebFluxSseServerTransportProvider.Builder().messageEndpoint(MESSAGE_ENDPOINT)
+			.build();
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(transportProvider.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		return transportProvider;
+	}
+
+	@Override
+	protected McpServer.AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(createMcpTransportProvider());
+	}
+
+	@Override
+	protected void onStart() {
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpSyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpSyncServerTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import org.junit.jupiter.api.Timeout;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+/**
+ * Tests for {@link McpSyncServer} using {@link WebFluxSseServerTransportProvider}.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebFluxSseMcpSyncServerTests extends AbstractMcpSyncServerTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private DisposableServer httpServer;
+
+	private WebFluxSseServerTransportProvider transportProvider;
+
+	@Override
+	protected McpServer.SyncSpecification<?> prepareSyncServerBuilder() {
+		return McpServer.sync(createMcpTransportProvider());
+	}
+
+	private McpServerTransportProvider createMcpTransportProvider() {
+		this.transportProvider = new WebFluxSseServerTransportProvider.Builder().messageEndpoint(MESSAGE_ENDPOINT)
+			.build();
+		return this.transportProvider;
+	}
+
+	@Override
+	protected void onStart() {
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(this.transportProvider.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpAsyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpAsyncServerTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+import org.junit.jupiter.api.Timeout;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+/**
+ * Tests for {@link McpAsyncServer} using
+ * {@link WebFluxStreamableServerTransportProvider}.
+ *
+ * @author Christian Tzolov
+ * @author Dariusz Jędrzejczyk
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebFluxStreamableMcpAsyncServerTests extends AbstractMcpAsyncServerTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private DisposableServer httpServer;
+
+	private McpStreamableServerTransportProvider createMcpTransportProvider() {
+		var transportProvider = WebFluxStreamableServerTransportProvider.builder()
+			.messageEndpoint(MESSAGE_ENDPOINT)
+			.build();
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(transportProvider.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		return transportProvider;
+	}
+
+	@Override
+	protected McpServer.AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(createMcpTransportProvider());
+	}
+
+	@Override
+	protected void onStart() {
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpSyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpSyncServerTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webflux.transport;
+
+import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+import org.junit.jupiter.api.Timeout;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.server.HttpServer;
+
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+
+/**
+ * Tests for {@link McpAsyncServer} using
+ * {@link WebFluxStreamableServerTransportProvider}.
+ *
+ * @author Christian Tzolov
+ * @author Dariusz Jędrzejczyk
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebFluxStreamableMcpSyncServerTests extends AbstractMcpSyncServerTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private DisposableServer httpServer;
+
+	private McpStreamableServerTransportProvider createMcpTransportProvider() {
+		var transportProvider = WebFluxStreamableServerTransportProvider.builder()
+			.messageEndpoint(MESSAGE_ENDPOINT)
+			.build();
+
+		HttpHandler httpHandler = RouterFunctions.toHttpHandler(transportProvider.getRouterFunction());
+		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
+		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		return transportProvider;
+	}
+
+	@Override
+	protected McpServer.SyncSpecification<?> prepareSyncServerBuilder() {
+		return McpServer.sync(createMcpTransportProvider());
+	}
+
+	@Override
+	protected void onStart() {
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpJsonMapperUtils.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpJsonMapperUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.utils;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+
+public final class McpJsonMapperUtils {
+
+	private McpJsonMapperUtils() {
+	}
+
+	public static final McpJsonMapper JSON_MAPPER = McpJsonMapper.createDefault();
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpTestRequestRecordingExchangeFilterFunction.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/utils/McpTestRequestRecordingExchangeFilterFunction.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.server.HandlerFilterFunction;
+import org.springframework.web.reactive.function.server.HandlerFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+/**
+ * Simple {@link HandlerFilterFunction} which records calls made to an MCP server.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+public class McpTestRequestRecordingExchangeFilterFunction implements HandlerFilterFunction {
+
+	private final List<Call> calls = new ArrayList<>();
+
+	@Override
+	public Mono<ServerResponse> filter(ServerRequest request, HandlerFunction next) {
+		Map<String, String> headers = request.headers()
+			.asHttpHeaders()
+			.asMultiValueMap()
+			.keySet()
+			.stream()
+			.collect(Collectors.toMap(String::toLowerCase, k -> String.join(",", request.headers().header(k))));
+
+		var cr = request.bodyToMono(String.class).defaultIfEmpty("").map(body -> {
+			this.calls.add(new Call(request.method(), headers, body));
+			return ServerRequest.from(request).body(body).build();
+		});
+
+		return cr.flatMap(next::handle);
+
+	}
+
+	public List<Call> getCalls() {
+		return List.copyOf(this.calls);
+	}
+
+	public record Call(HttpMethod method, Map<String, String> headers, String body) {
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webflux/src/test/resources/logback.xml
+++ b/mcp/transport/mcp-spring-webflux/src/test/resources/logback.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Main MCP package -->
+    <logger name="io.modelcontextprotocol" level="INFO"/>
+
+    <!-- Client packages -->
+    <logger name="io.modelcontextprotocol.client" level="INFO"/>
+
+    <!-- Spec package -->
+    <logger name="io.modelcontextprotocol.spec" level="INFO"/>
+
+
+    <!-- Root logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/mcp/transport/mcp-spring-webmvc/pom.xml
+++ b/mcp/transport/mcp-spring-webmvc/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>mcp-spring-webmvc</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring Web MVC transports</name>
+	<description>Web MVC implementation for the SSE and Streamable Http Server transports</description>
+	<url>https://github.com/modelcontextprotocol/java-sdk</url>
+
+	<scm>
+		<url>https://github.com/modelcontextprotocol/java-sdk</url>
+		<connection>git://github.com/modelcontextprotocol/java-sdk.git</connection>
+		<developerConnection>git@github.com/modelcontextprotocol/java-sdk.git</developerConnection>
+	</scm>
+
+	<properties>
+		<testcontainers.version>1.21.4</testcontainers.version>
+		<toxiproxy.version>1.21.0</toxiproxy.version>
+		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
+	</properties>
+	
+	<dependencies>
+
+        <dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-core</artifactId>
+			<version>${mcp.sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-test</artifactId>
+			<version>${mcp.sdk.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>mcp-spring-webflux</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.modelcontextprotocol.sdk</groupId>
+			<artifactId>mcp-json-jackson2</artifactId>
+			<version>${mcp.sdk.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+
+		<!-- The Spring Context is required due to the reactor-netty connector being dependant on
+		the Spring Lifecycle, as discussed here:
+		https://github.com/spring-projects/spring-framework/issues/31180 -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty-http</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<version>${json-unit-assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+
+</project>

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
@@ -1,0 +1,631 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.KeepAliveScheduler;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Server-side implementation of the Model Context Protocol (MCP) transport layer using
+ * HTTP with Server-Sent Events (SSE) through Spring WebMVC. This implementation provides
+ * a bridge between synchronous WebMVC operations and reactive programming patterns to
+ * maintain compatibility with the reactive transport interface.
+ *
+ * <p>
+ * Key features:
+ * <ul>
+ * <li>Implements bidirectional communication using HTTP POST for client-to-server
+ * messages and SSE for server-to-client messages</li>
+ * <li>Manages client sessions with unique IDs for reliable message delivery</li>
+ * <li>Supports graceful shutdown with proper session cleanup</li>
+ * <li>Provides JSON-RPC message handling through configured endpoints</li>
+ * <li>Includes built-in error handling and logging</li>
+ * </ul>
+ *
+ * <p>
+ * The transport operates on two main endpoints:
+ * <ul>
+ * <li>{@code /sse} - The SSE endpoint where clients establish their event stream
+ * connection</li>
+ * <li>A configurable message endpoint where clients send their JSON-RPC messages via HTTP
+ * POST</li>
+ * </ul>
+ *
+ * <p>
+ * This implementation uses {@link ConcurrentHashMap} to safely manage multiple client
+ * sessions in a thread-safe manner. Each client session is assigned a unique ID and
+ * maintains its own SSE connection.
+ *
+ * @author Christian Tzolov
+ * @author Alexandros Pappas
+ * @see McpServerTransportProvider
+ * @see RouterFunction
+ */
+public final class WebMvcSseServerTransportProvider implements McpServerTransportProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebMvcSseServerTransportProvider.class);
+
+	/**
+	 * Event type for JSON-RPC messages sent through the SSE connection.
+	 */
+	public static final String MESSAGE_EVENT_TYPE = "message";
+
+	/**
+	 * Event type for sending the message endpoint URI to clients.
+	 */
+	public static final String ENDPOINT_EVENT_TYPE = "endpoint";
+
+	public static final String SESSION_ID = "sessionId";
+
+	/**
+	 * Default SSE endpoint path as specified by the MCP transport specification.
+	 */
+	public static final String DEFAULT_SSE_ENDPOINT = "/sse";
+
+	private final McpJsonMapper jsonMapper;
+
+	private final String messageEndpoint;
+
+	private final String sseEndpoint;
+
+	private final String baseUrl;
+
+	private final RouterFunction<ServerResponse> routerFunction;
+
+	private McpServerSession.@Nullable Factory sessionFactory;
+
+	/**
+	 * Map of active client sessions, keyed by session ID.
+	 */
+	private final ConcurrentHashMap<String, McpServerSession> sessions = new ConcurrentHashMap<>();
+
+	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+
+	/**
+	 * Flag indicating if the transport is shutting down.
+	 */
+	private volatile boolean isClosing = false;
+
+	@Nullable private KeepAliveScheduler keepAliveScheduler;
+
+	/**
+	 * Security validator for validating HTTP requests.
+	 */
+	private final ServerTransportSecurityValidator securityValidator;
+
+	/**
+	 * Constructs a new WebMvcSseServerTransportProvider instance.
+	 * @param jsonMapper The McpJsonMapper to use for JSON serialization/deserialization
+	 * of messages.
+	 * @param baseUrl The base URL for the message endpoint, used to construct the full
+	 * endpoint URL for clients.
+	 * @param messageEndpoint The endpoint URI where clients should send their JSON-RPC
+	 * messages via HTTP POST. This endpoint will be communicated to clients through the
+	 * SSE connection's initial endpoint event.
+	 * @param sseEndpoint The endpoint URI where clients establish their SSE connections.
+	 * @param keepAliveInterval The interval for sending keep-alive messages to clients.
+	 * @param contextExtractor The contextExtractor to fill in a
+	 * {@link McpTransportContext}.
+	 * @param securityValidator The security validator for validating HTTP requests.
+	 * @throws IllegalArgumentException if any parameter is null
+	 */
+	private WebMvcSseServerTransportProvider(McpJsonMapper jsonMapper, String baseUrl, String messageEndpoint,
+			String sseEndpoint, @Nullable Duration keepAliveInterval,
+			McpTransportContextExtractor<ServerRequest> contextExtractor,
+			ServerTransportSecurityValidator securityValidator) {
+		Assert.notNull(jsonMapper, "McpJsonMapper must not be null");
+		Assert.notNull(baseUrl, "Message base URL must not be null");
+		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+		Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
+		Assert.notNull(contextExtractor, "Context extractor must not be null");
+		Assert.notNull(securityValidator, "Security validator must not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.baseUrl = baseUrl;
+		this.messageEndpoint = messageEndpoint;
+		this.sseEndpoint = sseEndpoint;
+		this.contextExtractor = contextExtractor;
+		this.securityValidator = securityValidator;
+		this.routerFunction = RouterFunctions.route()
+			.GET(this.sseEndpoint, this::handleSseConnection)
+			.POST(this.messageEndpoint, this::handleMessage)
+			.build();
+
+		if (keepAliveInterval != null) {
+
+			this.keepAliveScheduler = KeepAliveScheduler
+				.builder(() -> (this.isClosing) ? Flux.empty() : Flux.fromIterable(this.sessions.values()))
+				.initialDelay(keepAliveInterval)
+				.interval(keepAliveInterval)
+				.build();
+
+			this.keepAliveScheduler.start();
+		}
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return List.of(ProtocolVersions.MCP_2024_11_05);
+	}
+
+	@Override
+	public void setSessionFactory(McpServerSession.Factory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	/**
+	 * Broadcasts a notification to all connected clients through their SSE connections.
+	 * The message is serialized to JSON and sent as an SSE event with type "message". If
+	 * any errors occur during sending to a particular client, they are logged but don't
+	 * prevent sending to other clients.
+	 * @param method The method name for the notification
+	 * @param params The parameters for the notification
+	 * @return A Mono that completes when the broadcast attempt is finished
+	 */
+	@Override
+	public Mono<Void> notifyClients(String method, Object params) {
+		if (this.sessions.isEmpty()) {
+			logger.debug("No active sessions to broadcast message to");
+			return Mono.empty();
+		}
+
+		logger.debug("Attempting to broadcast message to {} active sessions", this.sessions.size());
+
+		return Flux.fromIterable(this.sessions.values())
+			.flatMap(session -> session.sendNotification(method, params)
+				.doOnError(
+						e -> logger.error("Failed to send message to session {}: {}", session.getId(), e.getMessage()))
+				.onErrorComplete())
+			.then();
+	}
+
+	/**
+	 * Initiates a graceful shutdown of the transport. This method:
+	 * <ul>
+	 * <li>Sets the closing flag to prevent new connections</li>
+	 * <li>Closes all active SSE connections</li>
+	 * <li>Removes all session records</li>
+	 * </ul>
+	 * @return A Mono that completes when all cleanup operations are finished
+	 */
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Flux.fromIterable(this.sessions.values()).doFirst(() -> {
+			this.isClosing = true;
+			logger.debug("Initiating graceful shutdown with {} active sessions", this.sessions.size());
+		}).flatMap(McpServerSession::closeGracefully).then().doOnSuccess(v -> {
+			logger.debug("Graceful shutdown completed");
+			this.sessions.clear();
+			if (this.keepAliveScheduler != null) {
+				this.keepAliveScheduler.shutdown();
+			}
+		});
+	}
+
+	/**
+	 * Returns the RouterFunction that defines the HTTP endpoints for this transport. The
+	 * router function handles two endpoints:
+	 * <ul>
+	 * <li>GET /sse - For establishing SSE connections</li>
+	 * <li>POST [messageEndpoint] - For receiving JSON-RPC messages from clients</li>
+	 * </ul>
+	 * @return The configured RouterFunction for handling HTTP requests
+	 */
+	public RouterFunction<ServerResponse> getRouterFunction() {
+		return this.routerFunction;
+	}
+
+	/**
+	 * Handles new SSE connection requests from clients by creating a new session and
+	 * establishing an SSE connection. This method:
+	 * <ul>
+	 * <li>Generates a unique session ID</li>
+	 * <li>Creates a new session with a WebMvcMcpSessionTransport</li>
+	 * <li>Sends an initial endpoint event to inform the client where to send
+	 * messages</li>
+	 * <li>Maintains the session in the sessions map</li>
+	 * </ul>
+	 * @param request The incoming server request
+	 * @return A ServerResponse configured for SSE communication, or an error response if
+	 * the server is shutting down or the connection fails
+	 */
+	private ServerResponse handleSseConnection(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.body(e.getMessage() != null ? e.getMessage() : "Security validation failed");
+		}
+
+		McpServerSession.Factory factory = this.sessionFactory;
+		if (factory == null) {
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Session factory not initialized");
+		}
+
+		// Send initial endpoint event
+		return ServerResponse.sse(sseBuilder -> {
+			WebMvcMcpSessionTransport sessionTransport = new WebMvcMcpSessionTransport(sseBuilder);
+			McpServerSession session = factory.create(sessionTransport);
+			String sessionId = session.getId();
+			logger.debug("Creating new SSE connection for session: {}", sessionId);
+			sseBuilder.onComplete(() -> {
+				logger.debug("SSE connection completed for session: {}", sessionId);
+				this.sessions.remove(sessionId);
+			});
+			sseBuilder.onTimeout(() -> {
+				logger.debug("SSE connection timed out for session: {}", sessionId);
+				this.sessions.remove(sessionId);
+			});
+			this.sessions.put(sessionId, session);
+
+			try {
+				sseBuilder.event(ENDPOINT_EVENT_TYPE).data(buildEndpointUrl(sessionId));
+			}
+			catch (Exception e) {
+				logger.error("Failed to send initial endpoint event: {}", e.getMessage());
+				this.sessions.remove(sessionId);
+				sseBuilder.error(e);
+			}
+		}, Duration.ZERO);
+	}
+
+	/**
+	 * Constructs the full message endpoint URL by combining the base URL, message path,
+	 * and the required session_id query parameter.
+	 * @param sessionId the unique session identifier
+	 * @return the fully qualified endpoint URL as a string
+	 */
+	private String buildEndpointUrl(String sessionId) {
+		// for WebMVC compatibility
+		return UriComponentsBuilder.fromUriString(this.baseUrl)
+			.path(this.messageEndpoint)
+			.queryParam(SESSION_ID, sessionId)
+			.build()
+			.toUriString();
+	}
+
+	/**
+	 * Handles incoming JSON-RPC messages from clients. This method:
+	 * <ul>
+	 * <li>Deserializes the request body into a JSON-RPC message</li>
+	 * <li>Processes the message through the session's handle method</li>
+	 * <li>Returns appropriate HTTP responses based on the processing result</li>
+	 * </ul>
+	 * @param request The incoming server request containing the JSON-RPC message
+	 * @return A ServerResponse indicating success (200 OK) or appropriate error status
+	 * with error details in case of failures
+	 */
+	private ServerResponse handleMessage(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.body(e.getMessage() != null ? e.getMessage() : "Security validation failed");
+		}
+
+		if (request.param(SESSION_ID).isEmpty()) {
+			return ServerResponse.badRequest().body(new McpError("Session ID missing in message endpoint"));
+		}
+
+		String sessionId = request.param(SESSION_ID).get();
+		McpServerSession session = this.sessions.get(sessionId);
+
+		if (session == null) {
+			return ServerResponse.status(HttpStatus.NOT_FOUND).body(new McpError("Session not found: " + sessionId));
+		}
+
+		try {
+			final McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+			String body = request.body(String.class);
+			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+
+			// Process the message through the session's handle method
+			session.handle(message).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)).block(); // Block
+			// for
+			// WebMVC
+			// compatibility
+
+			return ServerResponse.ok().build();
+		}
+		catch (IllegalArgumentException | IOException e) {
+			logger.error("Failed to deserialize message: {}", e.getMessage());
+			return ServerResponse.badRequest().body(new McpError("Invalid message format"));
+		}
+		catch (Exception e) {
+			logger.error("Error handling message: {}", e.getMessage());
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new McpError(e.getMessage()));
+		}
+	}
+
+	/**
+	 * Creates a new Builder instance for configuring and creating instances of
+	 * WebMvcSseServerTransportProvider.
+	 * @return A new Builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Implementation of McpServerTransport for WebMVC SSE sessions. This class handles
+	 * the transport-level communication for a specific client session.
+	 */
+	private class WebMvcMcpSessionTransport implements McpServerTransport {
+
+		private final SseBuilder sseBuilder;
+
+		/**
+		 * Lock to ensure thread-safe access to the SSE builder when sending messages.
+		 * This prevents concurrent modifications that could lead to corrupted SSE events.
+		 */
+		private final ReentrantLock sseBuilderLock = new ReentrantLock();
+
+		/**
+		 * Creates a new session transport with the specified SSE builder.
+		 * @param sseBuilder The SSE builder for sending server events to the client
+		 */
+		WebMvcMcpSessionTransport(SseBuilder sseBuilder) {
+			this.sseBuilder = sseBuilder;
+		}
+
+		/**
+		 * Sends a JSON-RPC message to the client through the SSE connection.
+		 * @param message The JSON-RPC message to send
+		 * @return A Mono that completes when the message has been sent
+		 */
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+			return Mono.fromRunnable(() -> {
+				this.sseBuilderLock.lock();
+				try {
+					String jsonText = jsonMapper.writeValueAsString(message);
+					this.sseBuilder.event(MESSAGE_EVENT_TYPE).data(jsonText);
+				}
+				catch (Exception e) {
+					logger.error("Failed to send message: {}", e.getMessage());
+					this.sseBuilder.error(e);
+				}
+				finally {
+					this.sseBuilderLock.unlock();
+				}
+			});
+		}
+
+		/**
+		 * Converts data from one type to another using the configured McpJsonMapper.
+		 * @param data The source data object to convert
+		 * @param typeRef The target type reference
+		 * @param <T> The target type
+		 * @return The converted object of type T
+		 */
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return jsonMapper.convertValue(data, typeRef);
+		}
+
+		/**
+		 * Initiates a graceful shutdown of the transport.
+		 * @return A Mono that completes when the shutdown is complete
+		 */
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.fromRunnable(() -> {
+				this.sseBuilderLock.lock();
+				try {
+					this.sseBuilder.complete();
+				}
+				catch (Exception e) {
+					logger.warn("Failed to complete SSE builder: {}", e.getMessage());
+				}
+				finally {
+					this.sseBuilderLock.unlock();
+				}
+			});
+		}
+
+		/**
+		 * Closes the transport immediately.
+		 */
+		@Override
+		public void close() {
+			this.sseBuilderLock.lock();
+			try {
+				this.sseBuilder.complete();
+			}
+			catch (Exception e) {
+				logger.warn("Failed to complete SSE builder: {}", e.getMessage());
+			}
+			finally {
+				this.sseBuilderLock.unlock();
+			}
+		}
+
+	}
+
+	/**
+	 * Builder for creating instances of WebMvcSseServerTransportProvider.
+	 * <p>
+	 * This builder provides a fluent API for configuring and creating instances of
+	 * WebMvcSseServerTransportProvider with custom settings.
+	 */
+	public static class Builder {
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		private String baseUrl = "";
+
+		@Nullable private String messageEndpoint;
+
+		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
+
+		@Nullable private Duration keepAliveInterval;
+
+		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
+
+		private ServerTransportSecurityValidator securityValidator = ServerTransportSecurityValidator.NOOP;
+
+		/**
+		 * Sets the JSON object mapper to use for message serialization/deserialization.
+		 * @param jsonMapper The object mapper to use
+		 * @return This builder instance for method chaining
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "McpJsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Sets the base URL for the server transport.
+		 * @param baseUrl The base URL to use
+		 * @return This builder instance for method chaining
+		 */
+		public Builder baseUrl(String baseUrl) {
+			Assert.notNull(baseUrl, "Base URL must not be null");
+			this.baseUrl = baseUrl;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint path where clients will send their messages.
+		 * @param messageEndpoint The message endpoint path
+		 * @return This builder instance for method chaining
+		 */
+		public Builder messageEndpoint(String messageEndpoint) {
+			Assert.hasText(messageEndpoint, "Message endpoint must not be empty");
+			this.messageEndpoint = messageEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint path where clients will establish SSE connections.
+		 * <p>
+		 * If not specified, the default value of {@link #DEFAULT_SSE_ENDPOINT} will be
+		 * used.
+		 * @param sseEndpoint The SSE endpoint path
+		 * @return This builder instance for method chaining
+		 */
+		public Builder sseEndpoint(String sseEndpoint) {
+			Assert.hasText(sseEndpoint, "SSE endpoint must not be empty");
+			this.sseEndpoint = sseEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the interval for keep-alive pings.
+		 * <p>
+		 * If not specified, keep-alive pings will be disabled.
+		 * @param keepAliveInterval The interval duration for keep-alive pings
+		 * @return This builder instance for method chaining
+		 */
+		public Builder keepAliveInterval(Duration keepAliveInterval) {
+			this.keepAliveInterval = keepAliveInterval;
+			return this;
+		}
+
+		/**
+		 * Sets the context extractor that allows providing the MCP feature
+		 * implementations to inspect HTTP transport level metadata that was present at
+		 * HTTP request processing time. This allows to extract custom headers and other
+		 * useful data for use during execution later on in the process.
+		 * @param contextExtractor The contextExtractor to fill in a
+		 * {@link McpTransportContext}.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public Builder contextExtractor(McpTransportContextExtractor<ServerRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "contextExtractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
+		 * Sets the security validator for validating HTTP requests.
+		 * @param securityValidator The security validator to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if securityValidator is null
+		 */
+		public Builder securityValidator(ServerTransportSecurityValidator securityValidator) {
+			Assert.notNull(securityValidator, "Security validator must not be null");
+			this.securityValidator = securityValidator;
+			return this;
+		}
+
+		/**
+		 * Builds a new instance of WebMvcSseServerTransportProvider with the configured
+		 * settings.
+		 * @return A new WebMvcSseServerTransportProvider instance
+		 * @throws IllegalStateException if jsonMapper or messageEndpoint is not set
+		 */
+		public WebMvcSseServerTransportProvider build() {
+			if (this.messageEndpoint == null) {
+				throw new IllegalStateException("MessageEndpoint must be set");
+			}
+			return new WebMvcSseServerTransportProvider(
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.baseUrl,
+					this.messageEndpoint, this.sseEndpoint, this.keepAliveInterval, this.contextExtractor,
+					this.securityValidator);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import io.modelcontextprotocol.util.Assert;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Implementation of a WebMVC based {@link McpStatelessServerTransport}.
+ *
+ * <p>
+ * This is the non-reactive version of
+ * {@link io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport}
+ *
+ * @author Christian Tzolov
+ */
+public final class WebMvcStatelessServerTransport implements McpStatelessServerTransport {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebMvcStatelessServerTransport.class);
+
+	private final McpJsonMapper jsonMapper;
+
+	private final String mcpEndpoint;
+
+	private final RouterFunction<ServerResponse> routerFunction;
+
+	@Nullable private McpStatelessServerHandler mcpHandler;
+
+	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+
+	private volatile boolean isClosing = false;
+
+	/**
+	 * Security validator for validating HTTP requests.
+	 */
+	private final ServerTransportSecurityValidator securityValidator;
+
+	private WebMvcStatelessServerTransport(McpJsonMapper jsonMapper, String mcpEndpoint,
+			McpTransportContextExtractor<ServerRequest> contextExtractor,
+			ServerTransportSecurityValidator securityValidator) {
+		Assert.notNull(jsonMapper, "jsonMapper must not be null");
+		Assert.notNull(mcpEndpoint, "mcpEndpoint must not be null");
+		Assert.notNull(contextExtractor, "contextExtractor must not be null");
+		Assert.notNull(securityValidator, "Security validator must not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.mcpEndpoint = mcpEndpoint;
+		this.contextExtractor = contextExtractor;
+		this.securityValidator = securityValidator;
+		this.routerFunction = RouterFunctions.route()
+			.GET(this.mcpEndpoint, this::handleGet)
+			.POST(this.mcpEndpoint, this::handlePost)
+			.build();
+	}
+
+	@Override
+	public void setMcpHandler(McpStatelessServerHandler mcpHandler) {
+		this.mcpHandler = mcpHandler;
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Mono.fromRunnable(() -> this.isClosing = true);
+	}
+
+	/**
+	 * Returns the WebMVC router function that defines the transport's HTTP endpoints.
+	 * This router function should be integrated into the application's web configuration.
+	 *
+	 * <p>
+	 * The router function defines one endpoint handling two HTTP methods:
+	 * <ul>
+	 * <li>GET {messageEndpoint} - Unsupported, returns 405 METHOD NOT ALLOWED</li>
+	 * <li>POST {messageEndpoint} - For handling client requests and notifications</li>
+	 * </ul>
+	 * @return The configured {@link RouterFunction} for handling HTTP requests
+	 */
+	public RouterFunction<ServerResponse> getRouterFunction() {
+		return this.routerFunction;
+	}
+
+	private ServerResponse handleGet(ServerRequest request) {
+		return ServerResponse.status(HttpStatus.METHOD_NOT_ALLOWED).build();
+	}
+
+	private ServerResponse handlePost(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.body(e.getMessage() != null ? e.getMessage() : "Security validation failed");
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		McpStatelessServerHandler handler = this.mcpHandler;
+		if (handler == null) {
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body("MCP handler not initialized");
+		}
+
+		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
+		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
+				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
+			return ServerResponse.badRequest().build();
+		}
+
+		try {
+			String body = request.body(String.class);
+			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+
+			if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest) {
+				try {
+					McpSchema.JSONRPCResponse jsonrpcResponse = handler.handleRequest(transportContext, jsonrpcRequest)
+						.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+						.block();
+					String json = this.jsonMapper.writeValueAsString(jsonrpcResponse);
+					return ServerResponse.ok().contentType(MediaType.APPLICATION_JSON).body(json);
+				}
+				catch (Exception e) {
+					logger.error("Failed to handle request: {}", e.getMessage());
+					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+						.body(new McpError("Failed to handle request: " + e.getMessage()));
+				}
+			}
+			else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
+				try {
+					handler.handleNotification(transportContext, jsonrpcNotification)
+						.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+						.block();
+					return ServerResponse.accepted().build();
+				}
+				catch (Exception e) {
+					logger.error("Failed to handle notification: {}", e.getMessage());
+					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+						.body(new McpError("Failed to handle notification: " + e.getMessage()));
+				}
+			}
+			else {
+				return ServerResponse.badRequest()
+					.body(new McpError("The server accepts either requests or notifications"));
+			}
+		}
+		catch (IllegalArgumentException | IOException e) {
+			logger.error("Failed to deserialize message: {}", e.getMessage());
+			return ServerResponse.badRequest().body(new McpError("Invalid message format"));
+		}
+		catch (Exception e) {
+			logger.error("Unexpected error handling message: {}", e.getMessage());
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(new McpError("Unexpected error: " + e.getMessage()));
+		}
+	}
+
+	/**
+	 * Create a builder for the server.
+	 * @return a fresh {@link Builder} instance.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for creating instances of {@link WebMvcStatelessServerTransport}.
+	 * <p>
+	 * This builder provides a fluent API for configuring and creating instances of
+	 * WebMvcStatelessServerTransport with custom settings.
+	 */
+	public final static class Builder {
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		private String mcpEndpoint = "/mcp";
+
+		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
+
+		private ServerTransportSecurityValidator securityValidator = ServerTransportSecurityValidator.NOOP;
+
+		private Builder() {
+			// used by a static method
+		}
+
+		/**
+		 * Sets the ObjectMapper to use for JSON serialization/deserialization of MCP
+		 * messages.
+		 * @param jsonMapper The ObjectMapper instance. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if jsonMapper is null
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "ObjectMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint URI where clients should send their JSON-RPC messages.
+		 * @param messageEndpoint The message endpoint URI. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if messageEndpoint is null
+		 */
+		public Builder messageEndpoint(String messageEndpoint) {
+			Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+			this.mcpEndpoint = messageEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the context extractor that allows providing the MCP feature
+		 * implementations to inspect HTTP transport level metadata that was present at
+		 * HTTP request processing time. This allows to extract custom headers and other
+		 * useful data for use during execution later on in the process.
+		 * @param contextExtractor The contextExtractor to fill in a
+		 * {@link McpTransportContext}.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public Builder contextExtractor(McpTransportContextExtractor<ServerRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "Context extractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
+		 * Sets the security validator for validating HTTP requests.
+		 * @param securityValidator The security validator to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if securityValidator is null
+		 */
+		public Builder securityValidator(ServerTransportSecurityValidator securityValidator) {
+			Assert.notNull(securityValidator, "Security validator must not be null");
+			this.securityValidator = securityValidator;
+			return this;
+		}
+
+		/**
+		 * Builds a new instance of {@link WebMvcStatelessServerTransport} with the
+		 * configured settings.
+		 * @return A new WebMvcStatelessServerTransport instance
+		 * @throws IllegalStateException if required parameters are not set
+		 */
+		public WebMvcStatelessServerTransport build() {
+			Assert.notNull(this.mcpEndpoint, "Message endpoint must be set");
+			return new WebMvcStatelessServerTransport(
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.mcpEndpoint,
+					this.contextExtractor, this.securityValidator);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -1,0 +1,769 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityException;
+import io.modelcontextprotocol.server.transport.ServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStreamableServerSession;
+import io.modelcontextprotocol.spec.McpStreamableServerTransport;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import io.modelcontextprotocol.util.KeepAliveScheduler;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
+
+/**
+ * Server-side implementation of the Model Context Protocol (MCP) streamable transport
+ * layer using HTTP with Server-Sent Events (SSE) through Spring WebMVC. This
+ * implementation provides a bridge between synchronous WebMVC operations and reactive
+ * programming patterns to maintain compatibility with the reactive transport interface.
+ *
+ * <p>
+ * This is the non-reactive version of
+ * {@link io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider}
+ *
+ * @author Christian Tzolov
+ * @author Dariusz Jędrzejczyk
+ * @see McpStreamableServerTransportProvider
+ * @see RouterFunction
+ */
+public final class WebMvcStreamableServerTransportProvider implements McpStreamableServerTransportProvider {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebMvcStreamableServerTransportProvider.class);
+
+	/**
+	 * Event type for JSON-RPC messages sent through the SSE connection.
+	 */
+	public static final String MESSAGE_EVENT_TYPE = "message";
+
+	/**
+	 * Event type for sending the message endpoint URI to clients.
+	 */
+	public static final String ENDPOINT_EVENT_TYPE = "endpoint";
+
+	/**
+	 * Default base URL for the message endpoint.
+	 */
+	public static final String DEFAULT_BASE_URL = "";
+
+	/**
+	 * The endpoint URI where clients should send their JSON-RPC messages. Defaults to
+	 * "/mcp".
+	 */
+	private final String mcpEndpoint;
+
+	/**
+	 * Flag indicating whether DELETE requests are disallowed on the endpoint.
+	 */
+	private final boolean disallowDelete;
+
+	private final McpJsonMapper jsonMapper;
+
+	private final RouterFunction<ServerResponse> routerFunction;
+
+	private McpStreamableServerSession.@Nullable Factory sessionFactory;
+
+	/**
+	 * Map of active client sessions, keyed by mcp-session-id.
+	 */
+	private final ConcurrentHashMap<String, McpStreamableServerSession> sessions = new ConcurrentHashMap<>();
+
+	private McpTransportContextExtractor<ServerRequest> contextExtractor;
+
+	/**
+	 * Flag indicating if the transport is shutting down.
+	 */
+	private volatile boolean isClosing = false;
+
+	@Nullable private KeepAliveScheduler keepAliveScheduler;
+
+	/**
+	 * Security validator for validating HTTP requests.
+	 */
+	private final ServerTransportSecurityValidator securityValidator;
+
+	/**
+	 * Constructs a new WebMvcStreamableServerTransportProvider instance.
+	 * @param jsonMapper The McpJsonMapper to use for JSON serialization/deserialization
+	 * of messages.
+	 * @param baseUrl The base URL for the message endpoint, used to construct the full
+	 * endpoint URL for clients.
+	 * @param mcpEndpoint The endpoint URI where clients should send their JSON-RPC
+	 * messages via HTTP. This endpoint will handle GET, POST, and DELETE requests.
+	 * @param disallowDelete Whether to disallow DELETE requests on the endpoint.
+	 * @param contextExtractor The context extractor for transport context from the
+	 * request.
+	 * @param keepAliveInterval The interval for keep-alive pings. If null, no keep-alive
+	 * will be scheduled.
+	 * @param securityValidator The security validator for validating HTTP requests.
+	 * @throws IllegalArgumentException if any parameter is null
+	 */
+	private WebMvcStreamableServerTransportProvider(McpJsonMapper jsonMapper, String mcpEndpoint,
+			boolean disallowDelete, McpTransportContextExtractor<ServerRequest> contextExtractor,
+			@Nullable Duration keepAliveInterval, ServerTransportSecurityValidator securityValidator) {
+		Assert.notNull(jsonMapper, "McpJsonMapper must not be null");
+		Assert.notNull(mcpEndpoint, "MCP endpoint must not be null");
+		Assert.notNull(contextExtractor, "McpTransportContextExtractor must not be null");
+		Assert.notNull(securityValidator, "Security validator must not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.mcpEndpoint = mcpEndpoint;
+		this.disallowDelete = disallowDelete;
+		this.contextExtractor = contextExtractor;
+		this.securityValidator = securityValidator;
+		this.routerFunction = RouterFunctions.route()
+			.GET(this.mcpEndpoint, this::handleGet)
+			.POST(this.mcpEndpoint, this::handlePost)
+			.DELETE(this.mcpEndpoint, this::handleDelete)
+			.build();
+
+		if (keepAliveInterval != null) {
+			this.keepAliveScheduler = KeepAliveScheduler
+				.builder(() -> (this.isClosing) ? Flux.empty() : Flux.fromIterable(this.sessions.values()))
+				.initialDelay(keepAliveInterval)
+				.interval(keepAliveInterval)
+				.build();
+
+			this.keepAliveScheduler.start();
+		}
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return List.of(ProtocolVersions.MCP_2024_11_05, ProtocolVersions.MCP_2025_03_26,
+				ProtocolVersions.MCP_2025_06_18, ProtocolVersions.MCP_2025_11_25);
+	}
+
+	@Override
+	public void setSessionFactory(McpStreamableServerSession.Factory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	/**
+	 * Broadcasts a notification to all connected clients through their SSE connections.
+	 * If any errors occur during sending to a particular client, they are logged but
+	 * don't prevent sending to other clients.
+	 * @param method The method name for the notification
+	 * @param params The parameters for the notification
+	 * @return A Mono that completes when the broadcast attempt is finished
+	 */
+	@Override
+	public Mono<Void> notifyClients(String method, Object params) {
+		if (this.sessions.isEmpty()) {
+			logger.debug("No active sessions to broadcast message to");
+			return Mono.empty();
+		}
+
+		logger.debug("Attempting to broadcast message to {} active sessions", this.sessions.size());
+
+		return Mono.fromRunnable(() -> {
+			this.sessions.values().parallelStream().forEach(session -> {
+				try {
+					session.sendNotification(method, params).block();
+				}
+				catch (Exception e) {
+					logger.error("Failed to send message to session {}: {}", session.getId(), e.getMessage());
+				}
+			});
+		});
+	}
+
+	/**
+	 * Initiates a graceful shutdown of the transport.
+	 * @return A Mono that completes when all cleanup operations are finished
+	 */
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Mono.fromRunnable(() -> {
+			this.isClosing = true;
+			logger.debug("Initiating graceful shutdown with {} active sessions", this.sessions.size());
+
+			this.sessions.values().parallelStream().forEach(session -> {
+				try {
+					session.closeGracefully().block();
+				}
+				catch (Exception e) {
+					logger.error("Failed to close session {}: {}", session.getId(), e.getMessage());
+				}
+			});
+
+			this.sessions.clear();
+			logger.debug("Graceful shutdown completed");
+		}).then().doOnSuccess(v -> {
+			if (this.keepAliveScheduler != null) {
+				this.keepAliveScheduler.shutdown();
+			}
+		});
+	}
+
+	/**
+	 * Returns the RouterFunction that defines the HTTP endpoints for this transport. The
+	 * router function handles three endpoints:
+	 * <ul>
+	 * <li>GET [mcpEndpoint] - For establishing SSE connections and message replay</li>
+	 * <li>POST [mcpEndpoint] - For receiving JSON-RPC messages from clients</li>
+	 * <li>DELETE [mcpEndpoint] - For session deletion (if enabled)</li>
+	 * </ul>
+	 * @return The configured RouterFunction for handling HTTP requests
+	 */
+	public RouterFunction<ServerResponse> getRouterFunction() {
+		return this.routerFunction;
+	}
+
+	/**
+	 * Setup the listening SSE connections and message replay.
+	 * @param request The incoming server request
+	 * @return A ServerResponse configured for SSE communication, or an error response
+	 */
+	private ServerResponse handleGet(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.body(e.getMessage() != null ? e.getMessage() : "Security validation failed");
+		}
+
+		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
+		if (!acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM)) {
+			return ServerResponse.badRequest().body("Invalid Accept header. Expected TEXT_EVENT_STREAM");
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
+			return ServerResponse.badRequest().body("Session ID required in mcp-session-id header");
+		}
+
+		String sessionId = request.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+		if (sessionId == null) {
+			return ServerResponse.badRequest().body("Session ID required in mcp-session-id header");
+		}
+		McpStreamableServerSession session = this.sessions.get(sessionId);
+
+		if (session == null) {
+			return ServerResponse.notFound().build();
+		}
+
+		logger.debug("Handling GET request for session: {}", sessionId);
+
+		try {
+			return ServerResponse.sse(sseBuilder -> {
+				sseBuilder.onTimeout(() -> logger.debug("SSE connection timed out for session: {}", sessionId));
+
+				WebMvcStreamableMcpSessionTransport sessionTransport = new WebMvcStreamableMcpSessionTransport(
+						sessionId, sseBuilder);
+
+				// Check if this is a replay request
+				if (!request.headers().header(HttpHeaders.LAST_EVENT_ID).isEmpty()) {
+					String lastId = request.headers().asHttpHeaders().getFirst(HttpHeaders.LAST_EVENT_ID);
+
+					try {
+						session.replay(lastId)
+							.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+							.toIterable()
+							.forEach(message -> {
+								try {
+									sessionTransport.sendMessage(message)
+										.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+										.block();
+								}
+								catch (Exception e) {
+									logger.error("Failed to replay message: {}", e.getMessage());
+									sseBuilder.error(e);
+								}
+							});
+					}
+					catch (Exception e) {
+						logger.error("Failed to replay messages: {}", e.getMessage());
+						sseBuilder.error(e);
+					}
+				}
+				else {
+					// Establish new listening stream
+					McpStreamableServerSession.McpStreamableServerSessionStream listeningStream = session
+						.listeningStream(sessionTransport);
+
+					sseBuilder.onComplete(() -> {
+						logger.debug("SSE connection completed for session: {}", sessionId);
+						listeningStream.close();
+					});
+				}
+			}, Duration.ZERO);
+		}
+		catch (Exception e) {
+			logger.error("Failed to handle GET request for session {}: {}", sessionId, e.getMessage());
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+		}
+	}
+
+	/**
+	 * Handles POST requests for incoming JSON-RPC messages from clients.
+	 * @param request The incoming server request containing the JSON-RPC message
+	 * @return A ServerResponse indicating success or appropriate error status
+	 */
+	private ServerResponse handlePost(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.body(e.getMessage() != null ? e.getMessage() : "Security validation failed");
+		}
+
+		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
+		if (!acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM)
+				|| !acceptHeaders.contains(MediaType.APPLICATION_JSON)) {
+			return ServerResponse.badRequest()
+				.body(new McpError("Invalid Accept headers. Expected TEXT_EVENT_STREAM and APPLICATION_JSON"));
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		McpStreamableServerSession.Factory factory = this.sessionFactory;
+
+		try {
+			String body = request.body(String.class);
+			McpSchema.JSONRPCMessage message = McpSchema.deserializeJsonRpcMessage(this.jsonMapper, body);
+
+			// Handle initialization request
+			if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest
+					&& jsonrpcRequest.method().equals(McpSchema.METHOD_INITIALIZE)) {
+				if (factory == null) {
+					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+						.body(new McpError("Session factory not initialized"));
+				}
+				McpSchema.InitializeRequest initializeRequest = this.jsonMapper.convertValue(jsonrpcRequest.params(),
+						new TypeRef<McpSchema.InitializeRequest>() {
+						});
+				McpStreamableServerSession.McpStreamableServerSessionInit init = factory
+					.startSession(initializeRequest);
+				this.sessions.put(init.session().getId(), init.session());
+
+				try {
+					McpSchema.InitializeResult initResult = init.initResult().block();
+
+					return ServerResponse.ok()
+						.contentType(MediaType.APPLICATION_JSON)
+						.header(HttpHeaders.MCP_SESSION_ID, init.session().getId())
+						.body(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, jsonrpcRequest.id(), initResult,
+								null));
+				}
+				catch (Exception e) {
+					logger.error("Failed to initialize session: {}", e.getMessage());
+					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new McpError(e.getMessage()));
+				}
+			}
+
+			// Handle other messages that require a session
+			if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
+				return ServerResponse.badRequest().body(new McpError("Session ID missing"));
+			}
+
+			String sessionId = request.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+			if (sessionId == null) {
+				return ServerResponse.badRequest().body(new McpError("Session ID missing"));
+			}
+			McpStreamableServerSession session = this.sessions.get(sessionId);
+
+			if (session == null) {
+				return ServerResponse.status(HttpStatus.NOT_FOUND)
+					.body(new McpError("Session not found: " + sessionId));
+			}
+
+			if (message instanceof McpSchema.JSONRPCResponse jsonrpcResponse) {
+				session.accept(jsonrpcResponse)
+					.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+					.block();
+				return ServerResponse.accepted().build();
+			}
+			else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
+				session.accept(jsonrpcNotification)
+					.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+					.block();
+				return ServerResponse.accepted().build();
+			}
+			else if (message instanceof McpSchema.JSONRPCRequest jsonrpcRequest) {
+				// For streaming responses, we need to return SSE
+				return ServerResponse.sse(sseBuilder -> {
+					sseBuilder
+						.onComplete(() -> logger.debug("Request response stream completed for session: {}", sessionId));
+					sseBuilder
+						.onTimeout(() -> logger.debug("Request response stream timed out for session: {}", sessionId));
+
+					WebMvcStreamableMcpSessionTransport sessionTransport = new WebMvcStreamableMcpSessionTransport(
+							sessionId, sseBuilder);
+
+					try {
+						session.responseStream(jsonrpcRequest, sessionTransport)
+							.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+							.block();
+					}
+					catch (Exception e) {
+						logger.error("Failed to handle request stream: {}", e.getMessage());
+						sseBuilder.error(e);
+					}
+				}, Duration.ZERO);
+			}
+			else {
+				return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+					.body(new McpError("Unknown message type"));
+			}
+		}
+		catch (IllegalArgumentException |
+
+				IOException e) {
+			logger.error("Failed to deserialize message: {}", e.getMessage());
+			return ServerResponse.badRequest().body(new McpError("Invalid message format"));
+
+		}
+		catch (Exception e) {
+			logger.error("Error handling message: {}", e.getMessage());
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new McpError(e.getMessage()));
+		}
+	}
+
+	/**
+	 * Handles DELETE requests for session deletion.
+	 * @param request The incoming server request
+	 * @return A ServerResponse indicating success or appropriate error status
+	 */
+	private ServerResponse handleDelete(ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		try {
+			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			this.securityValidator.validateHeaders(headers);
+		}
+		catch (ServerTransportSecurityException e) {
+			return ServerResponse.status(e.getStatusCode())
+				.body(e.getMessage() != null ? e.getMessage() : "Security validation failed");
+		}
+
+		if (this.disallowDelete) {
+			return ServerResponse.status(HttpStatus.METHOD_NOT_ALLOWED).build();
+		}
+
+		McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+		if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
+			return ServerResponse.badRequest().body("Session ID required in mcp-session-id header");
+		}
+
+		String sessionId = request.headers().asHttpHeaders().getFirst(HttpHeaders.MCP_SESSION_ID);
+		if (sessionId == null) {
+			return ServerResponse.badRequest().body("Session ID required in mcp-session-id header");
+		}
+		McpStreamableServerSession session = this.sessions.get(sessionId);
+
+		if (session == null) {
+			return ServerResponse.notFound().build();
+		}
+
+		try {
+			session.delete().contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext)).block();
+			this.sessions.remove(sessionId);
+			return ServerResponse.ok().build();
+		}
+		catch (Exception e) {
+			logger.error("Failed to delete session {}: {}", sessionId, e.getMessage());
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new McpError(e.getMessage()));
+		}
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Implementation of McpStreamableServerTransport for WebMVC SSE sessions. This class
+	 * handles the transport-level communication for a specific client session.
+	 *
+	 * <p>
+	 * This class is thread-safe and uses a ReentrantLock to synchronize access to the
+	 * underlying SSE builder to prevent race conditions when multiple threads attempt to
+	 * send messages concurrently.
+	 */
+	private class WebMvcStreamableMcpSessionTransport implements McpStreamableServerTransport {
+
+		private final String sessionId;
+
+		private final SseBuilder sseBuilder;
+
+		private final ReentrantLock lock = new ReentrantLock();
+
+		private volatile boolean closed = false;
+
+		/**
+		 * Creates a new session transport with the specified ID and SSE builder.
+		 * @param sessionId The unique identifier for this session
+		 * @param sseBuilder The SSE builder for sending server events to the client
+		 */
+		WebMvcStreamableMcpSessionTransport(String sessionId, SseBuilder sseBuilder) {
+			this.sessionId = sessionId;
+			this.sseBuilder = sseBuilder;
+			logger.debug("Streamable session transport {} initialized with SSE builder", sessionId);
+		}
+
+		/**
+		 * Sends a JSON-RPC message to the client through the SSE connection.
+		 * @param message The JSON-RPC message to send
+		 * @return A Mono that completes when the message has been sent
+		 */
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
+			return sendMessage(message, null);
+		}
+
+		/**
+		 * Sends a JSON-RPC message to the client through the SSE connection with a
+		 * specific message ID.
+		 * @param message The JSON-RPC message to send
+		 * @param messageId The message ID for SSE event identification
+		 * @return A Mono that completes when the message has been sent
+		 */
+		@Override
+		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message, @Nullable String messageId) {
+			return Mono.fromRunnable(() -> {
+				if (this.closed) {
+					logger.debug("Attempted to send message to closed session: {}", this.sessionId);
+					return;
+				}
+
+				this.lock.lock();
+				try {
+					if (this.closed) {
+						logger.debug("Session {} was closed during message send attempt", this.sessionId);
+						return;
+					}
+
+					String jsonText = jsonMapper.writeValueAsString(message);
+					this.sseBuilder.id(messageId != null ? messageId : this.sessionId)
+						.event(MESSAGE_EVENT_TYPE)
+						.data(jsonText);
+					logger.debug("Message sent to session {} with ID {}", this.sessionId, messageId);
+				}
+				catch (Exception e) {
+					logger.error("Failed to send message to session {}: {}", this.sessionId, e.getMessage());
+					try {
+						this.sseBuilder.error(e);
+					}
+					catch (Exception errorException) {
+						logger.error("Failed to send error to SSE builder for session {}: {}", this.sessionId,
+								errorException.getMessage());
+					}
+				}
+				finally {
+					this.lock.unlock();
+				}
+			});
+		}
+
+		/**
+		 * Converts data from one type to another using the configured McpJsonMapper.
+		 * @param data The source data object to convert
+		 * @param typeRef The target type reference
+		 * @return The converted object of type T
+		 * @param <T> The target type
+		 */
+		@Override
+		public <T> T unmarshalFrom(Object data, TypeRef<T> typeRef) {
+			return jsonMapper.convertValue(data, typeRef);
+		}
+
+		/**
+		 * Initiates a graceful shutdown of the transport.
+		 * @return A Mono that completes when the shutdown is complete
+		 */
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.fromRunnable(() -> WebMvcStreamableMcpSessionTransport.this.close());
+		}
+
+		/**
+		 * Closes the transport immediately.
+		 */
+		@Override
+		public void close() {
+			this.lock.lock();
+			try {
+				if (this.closed) {
+					logger.debug("Session transport {} already closed", this.sessionId);
+					return;
+				}
+
+				this.closed = true;
+
+				this.sseBuilder.complete();
+				logger.debug("Successfully completed SSE builder for session {}", this.sessionId);
+			}
+			catch (Exception e) {
+				logger.warn("Failed to complete SSE builder for session {}: {}", this.sessionId, e.getMessage());
+			}
+			finally {
+				this.lock.unlock();
+			}
+		}
+
+	}
+
+	/**
+	 * Builder for creating instances of {@link WebMvcStreamableServerTransportProvider}.
+	 */
+	public static class Builder {
+
+		@Nullable private McpJsonMapper jsonMapper;
+
+		private String mcpEndpoint = "/mcp";
+
+		private boolean disallowDelete = false;
+
+		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
+
+		@Nullable private Duration keepAliveInterval;
+
+		private ServerTransportSecurityValidator securityValidator = ServerTransportSecurityValidator.NOOP;
+
+		/**
+		 * Sets the McpJsonMapper to use for JSON serialization/deserialization of MCP
+		 * messages.
+		 * @param jsonMapper The McpJsonMapper instance. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if jsonMapper is null
+		 */
+		public Builder jsonMapper(McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "McpJsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint URI where clients should send their JSON-RPC messages.
+		 * @param mcpEndpoint The MCP endpoint URI. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if mcpEndpoint is null
+		 */
+		public Builder mcpEndpoint(String mcpEndpoint) {
+			Assert.notNull(mcpEndpoint, "MCP endpoint must not be null");
+			this.mcpEndpoint = mcpEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets whether to disallow DELETE requests on the endpoint.
+		 * @param disallowDelete true to disallow DELETE requests, false otherwise
+		 * @return this builder instance
+		 */
+		public Builder disallowDelete(boolean disallowDelete) {
+			this.disallowDelete = disallowDelete;
+			return this;
+		}
+
+		/**
+		 * Sets the context extractor that allows providing the MCP feature
+		 * implementations to inspect HTTP transport level metadata that was present at
+		 * HTTP request processing time. This allows to extract custom headers and other
+		 * useful data for use during execution later on in the process.
+		 * @param contextExtractor The contextExtractor to fill in a
+		 * {@link McpTransportContext}.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if contextExtractor is null
+		 */
+		public Builder contextExtractor(McpTransportContextExtractor<ServerRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "contextExtractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
+		 * Sets the keep-alive interval for the transport. If set, a keep-alive scheduler
+		 * will be created to periodically check and send keep-alive messages to clients.
+		 * @param keepAliveInterval The interval duration for keep-alive messages, or null
+		 * to disable keep-alive
+		 * @return this builder instance
+		 */
+		public Builder keepAliveInterval(Duration keepAliveInterval) {
+			this.keepAliveInterval = keepAliveInterval;
+			return this;
+		}
+
+		/**
+		 * Sets the security validator for validating HTTP requests.
+		 * @param securityValidator The security validator to use. Must not be null.
+		 * @return this builder instance
+		 * @throws IllegalArgumentException if securityValidator is null
+		 */
+		public Builder securityValidator(ServerTransportSecurityValidator securityValidator) {
+			Assert.notNull(securityValidator, "Security validator must not be null");
+			this.securityValidator = securityValidator;
+			return this;
+		}
+
+		/**
+		 * Builds a new instance of {@link WebMvcStreamableServerTransportProvider} with
+		 * the configured settings.
+		 * @return A new WebMvcStreamableServerTransportProvider instance
+		 * @throws IllegalStateException if required parameters are not set
+		 */
+		public WebMvcStreamableServerTransportProvider build() {
+			Assert.notNull(this.mcpEndpoint, "MCP endpoint must be set");
+			return new WebMvcStreamableServerTransportProvider(
+					this.jsonMapper == null ? McpJsonMapper.getDefault() : this.jsonMapper, this.mcpEndpoint,
+					this.disallowDelete, this.contextExtractor, this.keepAliveInterval, this.securityValidator);
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/package-info.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WebFlux-based client transport implementations for the Model Context Protocol (MCP).
+ * <p>
+ * This package provides client-side transport implementations using Spring WebFlux,
+ * including SSE and Streamable HTTP transports.
+ *
+ * @author Christian Tzolov
+ * @since 1.0.0
+ */
+@NullMarked
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import org.jspecify.annotations.NullMarked;

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/common/McpTransportContextIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/common/McpTransportContextIntegrationTests.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.common;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import org.springframework.ai.mcp.server.webmvc.TomcatTestUtil;
+import org.springframework.ai.mcp.server.webmvc.TomcatTestUtil.TomcatServer;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link McpTransportContext} propagation between MCP clients and
+ * servers using Spring WebMVC transport implementations.
+ *
+ * <p>
+ * This test class validates the end-to-end flow of transport context propagation across
+ * different MCP transport mechanisms in a Spring WebMVC environment. It demonstrates how
+ * contextual information can be passed from client to server through HTTP headers and
+ * properly extracted and utilized on the server side.
+ *
+ * <h2>Transport Types Tested</h2>
+ * <ul>
+ * <li><b>Stateless</b>: Tests context propagation with
+ * {@link WebMvcStatelessServerTransport} where each request is independent</li>
+ * <li><b>Streamable HTTP</b>: Tests context propagation with
+ * {@link WebMvcStreamableServerTransportProvider} supporting stateful server
+ * sessions</li>
+ * <li><b>Server-Sent Events (SSE)</b>: Tests context propagation with
+ * {@link WebMvcSseServerTransportProvider} for long-lived connections</li>
+ * </ul>
+ *
+ * @author Daniel Garnier-Moiroux
+ * @author Christian Tzolov
+ */
+@Timeout(15)
+public class McpTransportContextIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private TomcatServer tomcatServer;
+
+	private static final ThreadLocal<String> CLIENT_SIDE_HEADER_VALUE_HOLDER = new ThreadLocal<>();
+
+	private static final String HEADER_NAME = "x-test";
+
+	private final Supplier<McpTransportContext> clientContextProvider = () -> {
+		var headerValue = CLIENT_SIDE_HEADER_VALUE_HOLDER.get();
+		return headerValue != null ? McpTransportContext.create(Map.of("client-side-header-value", headerValue))
+				: McpTransportContext.EMPTY;
+	};
+
+	private final McpSyncHttpClientRequestCustomizer clientRequestCustomizer = (builder, method, endpoint, body,
+			context) -> {
+		var headerValue = context.get("client-side-header-value");
+		if (headerValue != null) {
+			builder.header(HEADER_NAME, headerValue.toString());
+		}
+	};
+
+	private static final BiFunction<McpTransportContext, McpSchema.CallToolRequest, McpSchema.CallToolResult> statelessHandler = (
+			transportContext,
+			request) -> new McpSchema.CallToolResult(transportContext.get("server-side-header-value").toString(), null);
+
+	private static final BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult> statefulHandler = (
+			exchange, request) -> statelessHandler.apply(exchange.transportContext(), request);
+
+	private static McpTransportContextExtractor<ServerRequest> serverContextExtractor = (ServerRequest r) -> {
+		String headerValue = r.servletRequest().getHeader(HEADER_NAME);
+		return headerValue != null ? McpTransportContext.create(Map.of("server-side-header-value", headerValue))
+				: McpTransportContext.EMPTY;
+	};
+
+	private final McpSyncClient streamableClient = McpClient
+		.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+			.httpRequestCustomizer(this.clientRequestCustomizer)
+			.build())
+		.transportContextProvider(this.clientContextProvider)
+		.build();
+
+	private final McpSyncClient sseClient = McpClient
+		.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+			.httpRequestCustomizer(this.clientRequestCustomizer)
+			.build())
+		.transportContextProvider(this.clientContextProvider)
+		.build();
+
+	private static final McpSchema.Tool tool = McpSchema.Tool.builder()
+		.name("test-tool")
+		.description("return the value of the x-test header from call tool request")
+		.build();
+
+	@AfterEach
+	public void after() {
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.remove();
+		if (this.streamableClient != null) {
+			this.streamableClient.closeGracefully();
+		}
+		if (this.sseClient != null) {
+			this.sseClient.closeGracefully();
+		}
+		stopTomcat();
+	}
+
+	@Test
+	void statelessServer() {
+		startTomcat(TestStatelessConfig.class);
+
+		McpSchema.InitializeResult initResult = this.streamableClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
+		McpSchema.CallToolResult response = this.streamableClient
+			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo("some important value");
+	}
+
+	@Test
+	void streamableServer() {
+
+		startTomcat(TestStreamableHttpConfig.class);
+
+		McpSchema.InitializeResult initResult = this.streamableClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
+		McpSchema.CallToolResult response = this.streamableClient
+			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo("some important value");
+	}
+
+	@Test
+	void sseServer() {
+		startTomcat(TestSseConfig.class);
+
+		McpSchema.InitializeResult initResult = this.sseClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		CLIENT_SIDE_HEADER_VALUE_HOLDER.set("some important value");
+		McpSchema.CallToolResult response = this.sseClient
+			.callTool(new McpSchema.CallToolRequest("test-tool", Map.of()));
+
+		assertThat(response).isNotNull();
+		assertThat(response.content()).hasSize(1)
+			.first()
+			.extracting(McpSchema.TextContent.class::cast)
+			.extracting(McpSchema.TextContent::text)
+			.isEqualTo("some important value");
+	}
+
+	private void startTomcat(Class<?> componentClass) {
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", PORT, componentClass);
+		try {
+			this.tomcatServer.tomcat().start();
+			assertThat(this.tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+	}
+
+	private void stopTomcat() {
+		if (this.tomcatServer != null && this.tomcatServer.tomcat() != null) {
+			try {
+				this.tomcatServer.tomcat().stop();
+				this.tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestStatelessConfig {
+
+		@Bean
+		public WebMvcStatelessServerTransport webMvcStatelessServerTransport() {
+
+			return WebMvcStatelessServerTransport.builder().contextExtractor(serverContextExtractor).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcStatelessServerTransport transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+		@Bean
+		public McpStatelessSyncServer mcpStatelessServer(WebMvcStatelessServerTransport transportProvider) {
+			return McpServer.sync(transportProvider)
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.tools(new McpStatelessServerFeatures.SyncToolSpecification(tool, statelessHandler))
+				.build();
+		}
+
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestStreamableHttpConfig {
+
+		@Bean
+		public WebMvcStreamableServerTransportProvider webMvcStreamableServerTransport() {
+
+			return WebMvcStreamableServerTransportProvider.builder().contextExtractor(serverContextExtractor).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(
+				WebMvcStreamableServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+		@Bean
+		public McpSyncServer mcpStreamableServer(WebMvcStreamableServerTransportProvider transportProvider) {
+			return McpServer.sync(transportProvider)
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.tools(new McpServerFeatures.SyncToolSpecification(tool, null, statefulHandler))
+				.build();
+		}
+
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestSseConfig {
+
+		@Bean
+		public WebMvcSseServerTransportProvider webMvcSseServerTransport() {
+
+			return WebMvcSseServerTransportProvider.builder()
+				.contextExtractor(serverContextExtractor)
+				.messageEndpoint("/mcp/message")
+				.build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+		@Bean
+		public McpSyncServer mcpSseServer(WebMvcSseServerTransportProvider transportProvider) {
+			return McpServer.sync(transportProvider)
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.tools(new McpServerFeatures.SyncToolSpecification(tool, null, statefulHandler))
+				.build();
+
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/security/ServerTransportSecurityIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/security/ServerTransportSecurityIntegrationTests.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.security;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.server.transport.DefaultServerTransportSecurityValidator;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.BeforeParameterizedClassInvocation;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.ai.mcp.server.webmvc.TomcatTestUtil;
+import org.springframework.ai.mcp.server.webmvc.TomcatTestUtil.TomcatServer;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test the header security validation for all transport types.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+@ParameterizedClass
+@MethodSource("transports")
+public class ServerTransportSecurityIntegrationTests {
+
+	private static final String DISALLOWED_ORIGIN = "https://malicious.example.com";
+
+	@Parameter
+	private static Class<?> configClass;
+
+	private static TomcatServer tomcatServer;
+
+	private static String baseUrl;
+
+	@BeforeParameterizedClassInvocation
+	static void createTransportAndStartTomcat(Class<?> configClass) {
+		var port = TestUtil.findAvailablePort();
+		baseUrl = "http://localhost:" + port;
+		startTomcat(configClass, port);
+	}
+
+	@AfterAll
+	static void afterAll() {
+		stopTomcat();
+	}
+
+	private McpSyncClient mcpClient;
+
+	private TestRequestCustomizer requestCustomizer;
+
+	@BeforeEach
+	void setUp() {
+		this.mcpClient = tomcatServer.appContext().getBean(McpSyncClient.class);
+		this.requestCustomizer = tomcatServer.appContext().getBean(TestRequestCustomizer.class);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.mcpClient.close();
+	}
+
+	@Test
+	void originAllowed() {
+		this.requestCustomizer.setOriginHeader(baseUrl);
+		var result = this.mcpClient.initialize();
+		var tools = this.mcpClient.listTools();
+
+		assertThat(result.protocolVersion()).isNotEmpty();
+		assertThat(tools.tools()).isEmpty();
+	}
+
+	@Test
+	void noOrigin() {
+		this.requestCustomizer.setOriginHeader(null);
+		var result = this.mcpClient.initialize();
+		var tools = this.mcpClient.listTools();
+
+		assertThat(result.protocolVersion()).isNotEmpty();
+		assertThat(tools.tools()).isEmpty();
+	}
+
+	@Test
+	void connectOriginNotAllowed() {
+		this.requestCustomizer.setOriginHeader(DISALLOWED_ORIGIN);
+		assertThatThrownBy(() -> this.mcpClient.initialize());
+	}
+
+	@Test
+	void messageOriginNotAllowed() {
+		this.requestCustomizer.setOriginHeader(baseUrl);
+		this.mcpClient.initialize();
+		this.requestCustomizer.setOriginHeader(DISALLOWED_ORIGIN);
+		assertThatThrownBy(() -> this.mcpClient.listTools());
+	}
+
+	// ----------------------------------------------------
+	// Tomcat management
+	// ----------------------------------------------------
+
+	private static void startTomcat(Class<?> componentClass, int port) {
+		tomcatServer = TomcatTestUtil.createTomcatServer("", port, componentClass);
+		try {
+			tomcatServer.tomcat().start();
+			assertThat(tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+	}
+
+	private static void stopTomcat() {
+		if (tomcatServer != null) {
+			if (tomcatServer.appContext() != null) {
+				tomcatServer.appContext().close();
+			}
+			if (tomcatServer.tomcat() != null) {
+				try {
+					tomcatServer.tomcat().stop();
+					tomcatServer.tomcat().destroy();
+				}
+				catch (LifecycleException e) {
+					throw new RuntimeException("Failed to stop Tomcat", e);
+				}
+			}
+		}
+	}
+
+	// ----------------------------------------------------
+	// Transport servers to test
+	// ----------------------------------------------------
+
+	/**
+	 * All transport types we want to test. We use a {@link MethodSource} rather than a
+	 * {@link org.junit.jupiter.params.provider.ValueSource} to provide a readable name.
+	 */
+	static Stream<Arguments> transports() {
+		//@formatter:off
+		return Stream.of(
+				Arguments.arguments(Named.named("SSE", SseConfig.class)),
+				Arguments.arguments(Named.named("Streamable HTTP", StreamableHttpConfig.class)),
+				Arguments.arguments(Named.named("Stateless", StatelessConfig.class))
+		);
+		//@formatter:on
+	}
+
+	// ----------------------------------------------------
+	// Spring Configuration classes
+	// ----------------------------------------------------
+
+	@Configuration
+	static class CommonConfig {
+
+		@Bean
+		TestRequestCustomizer requestCustomizer() {
+			return new TestRequestCustomizer();
+		}
+
+		@Bean
+		DefaultServerTransportSecurityValidator validator() {
+			return DefaultServerTransportSecurityValidator.builder().allowedOrigin("http://localhost:*").build();
+		}
+
+	}
+
+	@Configuration
+	@EnableWebMvc
+	@Import(CommonConfig.class)
+	static class SseConfig {
+
+		@Bean
+		@Scope("prototype")
+		McpSyncClient createMcpClient(McpSyncHttpClientRequestCustomizer requestCustomizer) {
+			var transport = HttpClientSseClientTransport.builder(baseUrl)
+				.httpRequestCustomizer(requestCustomizer)
+				.jsonMapper(McpJsonMapper.getDefault())
+				.build();
+			return McpClient.sync(transport).initializationTimeout(Duration.ofMillis(500)).build();
+		}
+
+		@Bean
+		public WebMvcSseServerTransportProvider webMvcSseServerTransport(
+				DefaultServerTransportSecurityValidator validator) {
+			return WebMvcSseServerTransportProvider.builder()
+				.messageEndpoint("/mcp/message")
+				.securityValidator(validator)
+				.build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+		@Bean
+		public McpSyncServer mcpServer(WebMvcSseServerTransportProvider transportProvider) {
+			return McpServer.sync(transportProvider)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.build();
+		}
+
+	}
+
+	@Configuration
+	@EnableWebMvc
+	@Import(CommonConfig.class)
+	static class StreamableHttpConfig {
+
+		@Bean
+		@Scope("prototype")
+		McpSyncClient createMcpClient(McpSyncHttpClientRequestCustomizer requestCustomizer) {
+			var transport = HttpClientStreamableHttpTransport.builder(baseUrl)
+				.httpRequestCustomizer(requestCustomizer)
+				.jsonMapper(McpJsonMapper.getDefault())
+				.openConnectionOnStartup(true)
+				.build();
+			return McpClient.sync(transport).initializationTimeout(Duration.ofMillis(500)).build();
+		}
+
+		@Bean
+		public WebMvcStreamableServerTransportProvider webMvcStreamableServerTransport(
+				DefaultServerTransportSecurityValidator validator) {
+			return WebMvcStreamableServerTransportProvider.builder().securityValidator(validator).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(
+				WebMvcStreamableServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+		@Bean
+		public McpSyncServer mcpServer(WebMvcStreamableServerTransportProvider transportProvider) {
+			return McpServer.sync(transportProvider)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.build();
+		}
+
+	}
+
+	@Configuration
+	@EnableWebMvc
+	@Import(CommonConfig.class)
+	static class StatelessConfig {
+
+		@Bean
+		@Scope("prototype")
+		McpSyncClient createMcpClient(McpSyncHttpClientRequestCustomizer requestCustomizer) {
+			var transport = HttpClientStreamableHttpTransport.builder(baseUrl)
+				.httpRequestCustomizer(requestCustomizer)
+				.jsonMapper(McpJsonMapper.getDefault())
+				.openConnectionOnStartup(true)
+				.build();
+			return McpClient.sync(transport).initializationTimeout(Duration.ofMillis(500)).build();
+		}
+
+		@Bean
+		public WebMvcStatelessServerTransport webMvcStatelessServerTransport(
+				DefaultServerTransportSecurityValidator validator) {
+			return WebMvcStatelessServerTransport.builder().securityValidator(validator).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcStatelessServerTransport transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+		@Bean
+		public McpStatelessSyncServer mcpStatelessServer(WebMvcStatelessServerTransport transportProvider) {
+			return McpServer.sync(transportProvider)
+				.serverInfo("test-server", "1.0.0")
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
+				.build();
+		}
+
+	}
+
+	static class TestRequestCustomizer implements McpSyncHttpClientRequestCustomizer {
+
+		private String originHeader = null;
+
+		@Override
+		public void customize(HttpRequest.Builder builder, String method, URI endpoint, String body,
+				McpTransportContext context) {
+			if (this.originHeader != null) {
+				builder.header("Origin", this.originHeader);
+			}
+		}
+
+		public void setOriginHeader(String originHeader) {
+			this.originHeader = originHeader;
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/TomcatTestUtil.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/TomcatTestUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+/**
+ * @author Christian Tzolov
+ */
+public final class TomcatTestUtil {
+
+	private TomcatTestUtil() {
+		// Prevent instantiation
+	}
+
+	public static TomcatServer createTomcatServer(String contextPath, int port, Class<?> componentClass) {
+
+		// Set up Tomcat first
+		var tomcat = new Tomcat();
+		tomcat.setPort(port);
+
+		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
+		String baseDir = System.getProperty("java.io.tmpdir");
+		tomcat.setBaseDir(baseDir);
+
+		// Use the same directory for document base
+		Context context = tomcat.addContext(contextPath, baseDir);
+
+		// Create and configure Spring WebMvc context
+		var appContext = new AnnotationConfigWebApplicationContext();
+		appContext.register(componentClass);
+		appContext.setServletContext(context.getServletContext());
+		appContext.refresh();
+
+		// Create DispatcherServlet with our Spring context
+		DispatcherServlet dispatcherServlet = new DispatcherServlet(appContext);
+
+		// Add servlet to Tomcat and get the wrapper
+		var wrapper = Tomcat.addServlet(context, "dispatcherServlet", dispatcherServlet);
+		wrapper.setLoadOnStartup(1);
+		wrapper.setAsyncSupported(true);
+		context.addServletMappingDecoded("/*", "dispatcherServlet");
+
+		try {
+			// Configure and start the connector with async support
+			var connector = tomcat.getConnector();
+			connector.setAsyncTimeout(3000); // 3 seconds timeout for async requests
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		return new TomcatServer(tomcat, appContext);
+	}
+
+	public record TomcatServer(Tomcat tomcat, AnnotationConfigWebApplicationContext appContext) {
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMcpStreamableAsyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMcpStreamableAsyncServerTransportTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.Timeout;
+import reactor.netty.DisposableServer;
+
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Tests for {@link McpAsyncServer} using {@link WebMvcSseServerTransportProvider}.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebMcpStreamableAsyncServerTransportTests extends AbstractMcpAsyncServerTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MCP_ENDPOINT = "/mcp";
+
+	private DisposableServer httpServer;
+
+	private AnnotationConfigWebApplicationContext appContext;
+
+	private Tomcat tomcat;
+
+	private McpStreamableServerTransportProvider transportProvider;
+
+	private McpStreamableServerTransportProvider createMcpTransportProvider() {
+		// Set up Tomcat first
+		this.tomcat = new Tomcat();
+		this.tomcat.setPort(PORT);
+
+		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
+		String baseDir = System.getProperty("java.io.tmpdir");
+		this.tomcat.setBaseDir(baseDir);
+
+		// Use the same directory for document base
+		Context context = this.tomcat.addContext("", baseDir);
+
+		// Create and configure Spring WebMvc context
+		this.appContext = new AnnotationConfigWebApplicationContext();
+		this.appContext.register(TestConfig.class);
+		this.appContext.setServletContext(context.getServletContext());
+		this.appContext.refresh();
+
+		// Get the transport from Spring context
+		this.transportProvider = this.appContext.getBean(McpStreamableServerTransportProvider.class);
+
+		// Create DispatcherServlet with our Spring context
+		DispatcherServlet dispatcherServlet = new DispatcherServlet(this.appContext);
+
+		// Add servlet to Tomcat and get the wrapper
+		var wrapper = Tomcat.addServlet(context, "dispatcherServlet", dispatcherServlet);
+		wrapper.setLoadOnStartup(1);
+		context.addServletMappingDecoded("/*", "dispatcherServlet");
+
+		try {
+			this.tomcat.start();
+			this.tomcat.getConnector(); // Create and start the connector
+		}
+		catch (LifecycleException e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		return this.transportProvider;
+	}
+
+	@Override
+	protected McpServer.AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(createMcpTransportProvider());
+	}
+
+	@Override
+	protected void onStart() {
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcStreamableServerTransportProvider webMvcSseServerTransportProvider() {
+			return WebMvcStreamableServerTransportProvider.builder().mcpEndpoint(MCP_ENDPOINT).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(
+				WebMvcStreamableServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMcpStreamableSyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMcpStreamableSyncServerTransportTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.Timeout;
+import reactor.netty.DisposableServer;
+
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Tests for {@link McpAsyncServer} using {@link WebMvcSseServerTransportProvider}.
+ *
+ * @author Christian Tzolov
+ */
+@Timeout(15) // Giving extra time beyond the client timeout
+class WebMcpStreamableSyncServerTransportTests extends AbstractMcpSyncServerTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MCP_ENDPOINT = "/mcp";
+
+	private DisposableServer httpServer;
+
+	private AnnotationConfigWebApplicationContext appContext;
+
+	private Tomcat tomcat;
+
+	private McpStreamableServerTransportProvider transportProvider;
+
+	private McpStreamableServerTransportProvider createMcpTransportProvider() {
+		// Set up Tomcat first
+		this.tomcat = new Tomcat();
+		this.tomcat.setPort(PORT);
+
+		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
+		String baseDir = System.getProperty("java.io.tmpdir");
+		this.tomcat.setBaseDir(baseDir);
+
+		// Use the same directory for document base
+		Context context = this.tomcat.addContext("", baseDir);
+
+		// Create and configure Spring WebMvc context
+		this.appContext = new AnnotationConfigWebApplicationContext();
+		this.appContext.register(TestConfig.class);
+		this.appContext.setServletContext(context.getServletContext());
+		this.appContext.refresh();
+
+		// Get the transport from Spring context
+		this.transportProvider = this.appContext.getBean(McpStreamableServerTransportProvider.class);
+
+		// Create DispatcherServlet with our Spring context
+		DispatcherServlet dispatcherServlet = new DispatcherServlet(this.appContext);
+
+		// Add servlet to Tomcat and get the wrapper
+		var wrapper = Tomcat.addServlet(context, "dispatcherServlet", dispatcherServlet);
+		wrapper.setLoadOnStartup(1);
+		context.addServletMappingDecoded("/*", "dispatcherServlet");
+
+		try {
+			this.tomcat.start();
+			this.tomcat.getConnector(); // Create and start the connector
+		}
+		catch (LifecycleException e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		return this.transportProvider;
+	}
+
+	@Override
+	protected McpServer.SyncSpecification<?> prepareSyncServerBuilder() {
+		return McpServer.sync(createMcpTransportProvider());
+	}
+
+	@Override
+	protected void onStart() {
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.httpServer != null) {
+			this.httpServer.disposeNow();
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcStreamableServerTransportProvider webMvcStreamableServerTransportProvider() {
+			return WebMvcStreamableServerTransportProvider.builder().mcpEndpoint(MCP_ENDPOINT).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(
+				WebMvcStreamableServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseAsyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseAsyncServerTransportTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.Timeout;
+
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+@Timeout(15)
+class WebMvcSseAsyncServerTransportTests extends AbstractMcpAsyncServerTests {
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private Tomcat tomcat;
+
+	private McpServerTransportProvider transportProvider;
+
+	private AnnotationConfigWebApplicationContext appContext;
+
+	private McpServerTransportProvider createMcpTransportProvider() {
+		// Set up Tomcat first
+		this.tomcat = new Tomcat();
+		this.tomcat.setPort(PORT);
+
+		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
+		String baseDir = System.getProperty("java.io.tmpdir");
+		this.tomcat.setBaseDir(baseDir);
+
+		// Use the same directory for document base
+		Context context = this.tomcat.addContext("", baseDir);
+
+		// Create and configure Spring WebMvc context
+		this.appContext = new AnnotationConfigWebApplicationContext();
+		this.appContext.register(TestConfig.class);
+		this.appContext.setServletContext(context.getServletContext());
+		this.appContext.refresh();
+
+		// Get the transport from Spring context
+		this.transportProvider = this.appContext.getBean(WebMvcSseServerTransportProvider.class);
+
+		// Create DispatcherServlet with our Spring context
+		DispatcherServlet dispatcherServlet = new DispatcherServlet(this.appContext);
+
+		// Add servlet to Tomcat and get the wrapper
+		var wrapper = Tomcat.addServlet(context, "dispatcherServlet", dispatcherServlet);
+		wrapper.setLoadOnStartup(1);
+		context.addServletMappingDecoded("/*", "dispatcherServlet");
+
+		try {
+			this.tomcat.start();
+			this.tomcat.getConnector(); // Create and start the connector
+		}
+		catch (LifecycleException e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		return this.transportProvider;
+	}
+
+	@Override
+	protected McpServer.AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(createMcpTransportProvider());
+	}
+
+	@Override
+	protected void onStart() {
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.transportProvider != null) {
+			this.transportProvider.closeGracefully().block();
+		}
+		if (this.appContext != null) {
+			this.appContext.close();
+		}
+		if (this.tomcat != null) {
+			try {
+				this.tomcat.stop();
+				this.tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider() {
+			return WebMvcSseServerTransportProvider.builder()
+				.messageEndpoint(MESSAGE_ENDPOINT)
+				.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
+				.build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseCustomContextPathTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseCustomContextPathTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebMvcSseCustomContextPathTests {
+
+	private static final String CUSTOM_CONTEXT_PATH = "/app/1";
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private WebMvcSseServerTransportProvider mcpServerTransportProvider;
+
+	McpClient.SyncSpec clientBuilder;
+
+	private TomcatTestUtil.TomcatServer tomcatServer;
+
+	@BeforeEach
+	public void before() {
+
+		this.tomcatServer = TomcatTestUtil.createTomcatServer(CUSTOM_CONTEXT_PATH, PORT, TestConfig.class);
+
+		try {
+			this.tomcatServer.tomcat().start();
+			assertThat(this.tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		var clientTransport = HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+			.sseEndpoint(CUSTOM_CONTEXT_PATH + WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
+			.build();
+
+		this.clientBuilder = McpClient.sync(clientTransport);
+
+		this.mcpServerTransportProvider = this.tomcatServer.appContext()
+			.getBean(WebMvcSseServerTransportProvider.class);
+	}
+
+	@AfterEach
+	public void after() {
+		if (this.mcpServerTransportProvider != null) {
+			this.mcpServerTransportProvider.closeGracefully().block();
+		}
+		if (this.tomcatServer.appContext() != null) {
+			this.tomcatServer.appContext().close();
+		}
+		if (this.tomcatServer.tomcat() != null) {
+			try {
+				this.tomcatServer.tomcat().stop();
+				this.tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Test
+	void testCustomContextPath() {
+		McpServer.async(this.mcpServerTransportProvider).serverInfo("test-server", "1.0.0").build();
+		var client = this.clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0")).build();
+		assertThat(client.initialize()).isNotNull();
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider() {
+
+			return WebMvcSseServerTransportProvider.builder()
+				.baseUrl(CUSTOM_CONTEXT_PATH)
+				.messageEndpoint(MESSAGE_ENDPOINT)
+				.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
+				.build();
+			// return new WebMvcSseServerTransportProvider(new ObjectMapper(),
+			// CUSTOM_CONTEXT_PATH, MESSAGE_ENDPOINT,
+			// WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT);
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseIntegrationTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.AbstractMcpClientServerIntegrationTests;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.SingleSessionSyncSpecification;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.TestUtil;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.Arguments;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(15)
+class WebMvcSseIntegrationTests extends AbstractMcpClientServerIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private WebMvcSseServerTransportProvider mcpServerTransportProvider;
+
+	static McpTransportContextExtractor<ServerRequest> TEST_CONTEXT_EXTRACTOR = r -> McpTransportContext
+		.create(Map.of("important", "value"));
+
+	static Stream<Arguments> clientsForTesting() {
+		return Stream.of(Arguments.of("httpclient"), Arguments.of("webflux"));
+	}
+
+	@Override
+	protected void prepareClients(int port, String mcpEndpoint) {
+
+		clientBuilders.put("httpclient",
+				McpClient.sync(HttpClientSseClientTransport.builder("http://localhost:" + port).build())
+					.requestTimeout(Duration.ofHours(10)));
+
+		clientBuilders.put("webflux", McpClient
+			.sync(WebFluxSseClientTransport.builder(WebClient.builder().baseUrl("http://localhost:" + port)).build())
+			.requestTimeout(Duration.ofHours(10)));
+	}
+
+	private TomcatTestUtil.TomcatServer tomcatServer;
+
+	@BeforeEach
+	public void before() {
+
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", PORT, TestConfig.class);
+
+		try {
+			this.tomcatServer.tomcat().start();
+			assertThat(this.tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		prepareClients(PORT, MESSAGE_ENDPOINT);
+
+		// Get the transport from Spring context
+		this.mcpServerTransportProvider = this.tomcatServer.appContext()
+			.getBean(WebMvcSseServerTransportProvider.class);
+
+	}
+
+	@AfterEach
+	public void after() {
+		reactor.netty.http.HttpResources.disposeLoopsAndConnections();
+		if (this.mcpServerTransportProvider != null) {
+			this.mcpServerTransportProvider.closeGracefully().block();
+		}
+		Schedulers.shutdownNow();
+		if (this.tomcatServer.appContext() != null) {
+			this.tomcatServer.appContext().close();
+		}
+		if (this.tomcatServer.tomcat() != null) {
+			try {
+				this.tomcatServer.tomcat().stop();
+				this.tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Override
+	protected AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(this.mcpServerTransportProvider);
+	}
+
+	@Override
+	protected SingleSessionSyncSpecification prepareSyncServerBuilder() {
+		return McpServer.sync(this.mcpServerTransportProvider);
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider() {
+			return WebMvcSseServerTransportProvider.builder()
+				.messageEndpoint(MESSAGE_ENDPOINT)
+				.contextExtractor(TEST_CONTEXT_EXTRACTOR)
+				.build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseSyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcSseSyncServerTransportTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.Timeout;
+
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+@Timeout(15)
+class WebMvcSseSyncServerTransportTests extends AbstractMcpSyncServerTests {
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private Tomcat tomcat;
+
+	private WebMvcSseServerTransportProvider transportProvider;
+
+	private AnnotationConfigWebApplicationContext appContext;
+
+	@Override
+	protected McpServer.SyncSpecification<?> prepareSyncServerBuilder() {
+		return McpServer.sync(createMcpTransportProvider());
+	}
+
+	private WebMvcSseServerTransportProvider createMcpTransportProvider() {
+		// Set up Tomcat first
+		this.tomcat = new Tomcat();
+		this.tomcat.setPort(PORT);
+
+		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
+		String baseDir = System.getProperty("java.io.tmpdir");
+		this.tomcat.setBaseDir(baseDir);
+
+		// Use the same directory for document base
+		Context context = this.tomcat.addContext("", baseDir);
+
+		// Create and configure Spring WebMvc context
+		this.appContext = new AnnotationConfigWebApplicationContext();
+		this.appContext.register(TestConfig.class);
+		this.appContext.setServletContext(context.getServletContext());
+		this.appContext.refresh();
+
+		// Get the transport from Spring context
+		this.transportProvider = this.appContext.getBean(WebMvcSseServerTransportProvider.class);
+
+		// Create DispatcherServlet with our Spring context
+		DispatcherServlet dispatcherServlet = new DispatcherServlet(this.appContext);
+
+		// Add servlet to Tomcat and get the wrapper
+		var wrapper = Tomcat.addServlet(context, "dispatcherServlet", dispatcherServlet);
+		wrapper.setLoadOnStartup(1);
+		context.addServletMappingDecoded("/*", "dispatcherServlet");
+
+		try {
+			this.tomcat.start();
+			this.tomcat.getConnector(); // Create and start the connector
+		}
+		catch (LifecycleException e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		return this.transportProvider;
+	}
+
+	@Override
+	protected void onStart() {
+	}
+
+	@Override
+	protected void onClose() {
+		if (this.transportProvider != null) {
+			this.transportProvider.closeGracefully().block();
+		}
+		if (this.appContext != null) {
+			this.appContext.close();
+		}
+		if (this.tomcat != null) {
+			try {
+				this.tomcat.stop();
+				this.tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider() {
+			return WebMvcSseServerTransportProvider.builder().messageEndpoint(MESSAGE_ENDPOINT).build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcStatelessIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcStatelessIntegrationTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.AbstractStatelessIntegrationTests;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification;
+import io.modelcontextprotocol.server.TestUtil;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.Arguments;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(15)
+class WebMvcStatelessIntegrationTests extends AbstractStatelessIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private WebMvcStatelessServerTransport mcpServerTransport;
+
+	static Stream<Arguments> clientsForTesting() {
+		return Stream.of(Arguments.of("httpclient"), Arguments.of("webflux"));
+	}
+
+	private TomcatTestUtil.TomcatServer tomcatServer;
+
+	@Override
+	protected StatelessAsyncSpecification prepareAsyncServerBuilder() {
+		return McpServer.async(this.mcpServerTransport);
+	}
+
+	@Override
+	protected StatelessSyncSpecification prepareSyncServerBuilder() {
+		return McpServer.sync(this.mcpServerTransport);
+	}
+
+	@Override
+	protected void prepareClients(int port, String mcpEndpoint) {
+
+		clientBuilders.put("httpclient", McpClient
+			.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + port).endpoint(mcpEndpoint).build())
+			.requestTimeout(Duration.ofHours(10)));
+
+		clientBuilders.put("webflux",
+				McpClient
+					.sync(WebClientStreamableHttpTransport
+						.builder(WebClient.builder().baseUrl("http://localhost:" + port))
+						.endpoint(mcpEndpoint)
+						.build())
+					.requestTimeout(Duration.ofHours(10)));
+	}
+
+	@BeforeEach
+	public void before() {
+
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", PORT, TestConfig.class);
+
+		try {
+			this.tomcatServer.tomcat().start();
+			assertThat(this.tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		prepareClients(PORT, MESSAGE_ENDPOINT);
+
+		// Get the transport from Spring context
+		this.mcpServerTransport = this.tomcatServer.appContext().getBean(WebMvcStatelessServerTransport.class);
+
+	}
+
+	@AfterEach
+	public void after() {
+		reactor.netty.http.HttpResources.disposeLoopsAndConnections();
+		if (this.mcpServerTransport != null) {
+			this.mcpServerTransport.closeGracefully().block();
+		}
+		Schedulers.shutdownNow();
+		if (this.tomcatServer.appContext() != null) {
+			this.tomcatServer.appContext().close();
+		}
+		if (this.tomcatServer.tomcat() != null) {
+			try {
+				this.tomcatServer.tomcat().stop();
+				this.tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcStatelessServerTransport webMvcStatelessServerTransport() {
+
+			return WebMvcStatelessServerTransport.builder().messageEndpoint(MESSAGE_ENDPOINT).build();
+
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcStatelessServerTransport statelessServerTransport) {
+			return statelessServerTransport.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcStreamableIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/WebMvcStreamableIntegrationTests.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.modelcontextprotocol.AbstractMcpClientServerIntegrationTests;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
+import io.modelcontextprotocol.server.McpServer.SyncSpecification;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.server.TestUtil;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.Arguments;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Timeout(15)
+class WebMvcStreamableIntegrationTests extends AbstractMcpClientServerIntegrationTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private WebMvcStreamableServerTransportProvider mcpServerTransportProvider;
+
+	static McpTransportContextExtractor<ServerRequest> TEST_CONTEXT_EXTRACTOR = r -> McpTransportContext
+		.create(Map.of("important", "value"));
+
+	static Stream<Arguments> clientsForTesting() {
+		return Stream.of(Arguments.of("httpclient"), Arguments.of("webflux"));
+	}
+
+	private TomcatTestUtil.TomcatServer tomcatServer;
+
+	@BeforeEach
+	public void before() {
+
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", PORT, TestConfig.class);
+
+		try {
+			this.tomcatServer.tomcat().start();
+			assertThat(this.tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		clientBuilders
+			.put("httpclient",
+					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+						.endpoint(MESSAGE_ENDPOINT)
+						.build()).initializationTimeout(Duration.ofHours(10)).requestTimeout(Duration.ofHours(10)));
+
+		clientBuilders.put("webflux",
+				McpClient.sync(WebClientStreamableHttpTransport
+					.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+					.endpoint(MESSAGE_ENDPOINT)
+					.build()));
+
+		// Get the transport from Spring context
+		this.mcpServerTransportProvider = this.tomcatServer.appContext()
+			.getBean(WebMvcStreamableServerTransportProvider.class);
+
+	}
+
+	@Override
+	protected AsyncSpecification<?> prepareAsyncServerBuilder() {
+		return McpServer.async(this.mcpServerTransportProvider);
+	}
+
+	@Override
+	protected SyncSpecification<?> prepareSyncServerBuilder() {
+		return McpServer.sync(this.mcpServerTransportProvider);
+	}
+
+	@AfterEach
+	public void after() {
+		reactor.netty.http.HttpResources.disposeLoopsAndConnections();
+		if (this.mcpServerTransportProvider != null) {
+			this.mcpServerTransportProvider.closeGracefully().block();
+		}
+		Schedulers.shutdownNow();
+		if (this.tomcatServer.appContext() != null) {
+			this.tomcatServer.appContext().close();
+		}
+		if (this.tomcatServer.tomcat() != null) {
+			try {
+				this.tomcatServer.tomcat().stop();
+				this.tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Override
+	protected void prepareClients(int port, String mcpEndpoint) {
+
+		clientBuilders.put("httpclient", McpClient
+			.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + port).endpoint(mcpEndpoint).build())
+			.requestTimeout(Duration.ofHours(10)));
+
+		clientBuilders.put("webflux",
+				McpClient
+					.sync(WebClientStreamableHttpTransport
+						.builder(WebClient.builder().baseUrl("http://localhost:" + port))
+						.endpoint(mcpEndpoint)
+						.build())
+					.requestTimeout(Duration.ofHours(10)));
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcStreamableServerTransportProvider webMvcStreamableServerTransportProvider() {
+			return WebMvcStreamableServerTransportProvider.builder()
+				.contextExtractor(TEST_CONTEXT_EXTRACTOR)
+				.mcpEndpoint(MESSAGE_ENDPOINT)
+				.build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(
+				WebMvcStreamableServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProviderTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProviderTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.TestUtil;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.server.webmvc.TomcatTestUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for WebMvcSseServerTransportProvider
+ *
+ * @author lance
+ */
+class WebMvcSseServerTransportProviderTests {
+
+	private static final int PORT = TestUtil.findAvailablePort();
+
+	private static final String CUSTOM_CONTEXT_PATH = "";
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private WebMvcSseServerTransportProvider mcpServerTransportProvider;
+
+	McpClient.SyncSpec clientBuilder;
+
+	private TomcatTestUtil.TomcatServer tomcatServer;
+
+	@BeforeEach
+	public void before() {
+		this.tomcatServer = TomcatTestUtil.createTomcatServer(CUSTOM_CONTEXT_PATH, PORT, TestConfig.class);
+
+		try {
+			this.tomcatServer.tomcat().start();
+			assertThat(this.tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		HttpClientSseClientTransport transport = HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+			.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
+			.build();
+
+		this.clientBuilder = McpClient.sync(transport);
+		this.mcpServerTransportProvider = this.tomcatServer.appContext()
+			.getBean(WebMvcSseServerTransportProvider.class);
+	}
+
+	@Test
+	void validBaseUrl() {
+		McpServer.async(this.mcpServerTransportProvider).serverInfo("test-server", "1.0.0").build();
+		try (var client = this.clientBuilder.clientInfo(new McpSchema.Implementation("Sample " + "client", "0.0.0"))
+			.build()) {
+			assertThat(client.initialize()).isNotNull();
+		}
+	}
+
+	@AfterEach
+	public void after() {
+		if (this.mcpServerTransportProvider != null) {
+			this.mcpServerTransportProvider.closeGracefully().block();
+		}
+		if (this.tomcatServer.appContext() != null) {
+			this.tomcatServer.appContext().close();
+		}
+		if (this.tomcatServer.tomcat() != null) {
+			try {
+				this.tomcatServer.tomcat().stop();
+				this.tomcatServer.tomcat().destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider() {
+
+			return WebMvcSseServerTransportProvider.builder()
+				.baseUrl("http://localhost:" + PORT + "/")
+				.messageEndpoint(MESSAGE_ENDPOINT)
+				.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
+				.jsonMapper(McpJsonMapper.getDefault())
+				.contextExtractor(req -> McpTransportContext.EMPTY)
+				.build();
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/test/resources/logback.xml
+++ b/mcp/transport/mcp-spring-webmvc/src/test/resources/logback.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Main MCP package -->
+    <logger name="io.modelcontextprotocol" level="INFO"/>
+
+    <!-- Client packages -->
+    <logger name="io.modelcontextprotocol.client" level="INFO"/>
+
+    <!-- Server transport package -->
+    <logger name="io.modelcontextprotocol.server.transport" level="INFO"/>
+
+    <!-- Spec package -->
+    <logger name="io.modelcontextprotocol.spec" level="INFO"/>
+
+    <!-- Root logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,8 @@
 
 		<module>mcp/common</module>
 		<module>mcp/mcp-annotations-spring</module>
+		<module>mcp/transport/mcp-spring-webflux</module>
+		<module>mcp/transport/mcp-spring-webmvc</module>
 	</modules>
 
 	<organization>
@@ -353,7 +355,7 @@
 		<json-unit-assertj.version>4.1.0</json-unit-assertj.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>0.17.1</mcp.sdk.version>
+		<mcp.sdk.version>0.18.0-SNAPSHOT</mcp.sdk.version>
 		<mcp-annotations.version>0.8.0</mcp-annotations.version>
 
 		<!-- plugin versions -->

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -149,6 +149,18 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>mcp-spring-webflux</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>mcp-spring-webmvc</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
 			<!-- Spring AI Document Readers -->
 
 			<dependency>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -259,7 +259,7 @@ public McpSyncClient mcpClient() {
                 .build();
     }
 
-    return McpClient.sync(new StdioClientTransport(stdioParams, McpJsonMapper.createDefault()))
+    return McpClient.sync(new StdioClientTransport(stdioParams, McpJsonMapper.getDefault()))
             .requestTimeout(Duration.ofSeconds(10))
             .build()
             .initialize();

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-migration-guide.md
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-migration-guide.md
@@ -1,0 +1,140 @@
+# MCP Spring Transport Migration Guide
+
+This guide covers the migration of MCP Spring transport modules from the MCP Java SDK to Spring AI, introduced with MCP Java SDK 0.18.0 and Spring AI 2.0.0.
+
+## Overview
+
+The Spring-specific MCP transport implementations (`mcp-spring-webflux` and `mcp-spring-webmvc`) have moved from the MCP Java SDK project into the Spring AI project. This gives the Spring AI team direct ownership of the Spring transport layer while the MCP Java SDK focuses on the core protocol.
+
+## MCP Java SDK Version
+
+| Before | After |
+|--------|-------|
+| `0.17.1` | `0.18.0` |
+
+## Dependency Coordinate Changes
+
+The `mcp-spring-webflux` and `mcp-spring-webmvc` artifacts changed their Maven `groupId`:
+
+### mcp-spring-webflux
+
+```xml
+<!-- Before -->
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp-spring-webflux</artifactId>
+</dependency>
+
+<!-- After -->
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>mcp-spring-webflux</artifactId>
+</dependency>
+```
+
+### mcp-spring-webmvc
+
+```xml
+<!-- Before -->
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp-spring-webmvc</artifactId>
+</dependency>
+
+<!-- After -->
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>mcp-spring-webmvc</artifactId>
+</dependency>
+```
+
+> **Note:** If you only use the Spring AI Boot Starters (`spring-ai-starter-mcp-*`), these dependencies are managed transitively and no changes are needed in your POM.
+
+## Package Renames
+
+All Spring transport classes retain their original class names but have moved to new packages under `org.springframework.ai.mcp`.
+
+### Client Transports
+
+| Before | After |
+|--------|-------|
+| `io.modelcontextprotocol.client.transport.WebFluxSseClientTransport` | `org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport` |
+| `io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport` | `org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport` |
+
+### Server Transports (WebFlux)
+
+| Before | After |
+|--------|-------|
+| `io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider` | `org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider` |
+| `io.modelcontextprotocol.server.transport.WebFluxStatelessServerTransport` | `org.springframework.ai.mcp.server.webflux.transport.WebFluxStatelessServerTransport` |
+| `io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider` | `org.springframework.ai.mcp.server.webflux.transport.WebFluxStreamableServerTransportProvider` |
+
+### Server Transports (WebMvc)
+
+| Before | After |
+|--------|-------|
+| `io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider` | `org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider` |
+| `io.modelcontextprotocol.server.transport.WebMvcStatelessServerTransport` | `org.springframework.ai.mcp.server.webmvc.transport.WebMvcStatelessServerTransport` |
+| `io.modelcontextprotocol.server.transport.WebMvcStreamableServerTransportProvider` | `org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider` |
+
+### Unchanged
+
+The following transports remain in the MCP Java SDK and are **not affected**:
+
+- `io.modelcontextprotocol.client.transport.StdioClientTransport`
+- `io.modelcontextprotocol.client.transport.HttpClientSseClientTransport`
+- `io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport`
+- `io.modelcontextprotocol.server.transport.StdioServerTransportProvider`
+
+## JSON Mapper Changes
+
+The explicit dependency on `JacksonMcpJsonMapper` and `ObjectMapper` has been replaced with the SDK's built-in default abstraction.
+
+### Before
+
+```java
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+
+// In transport construction:
+var transport = new StdioClientTransport(params, new JacksonMcpJsonMapper(new ObjectMapper()));
+
+// Or in builder pattern:
+HttpClientStreamableHttpTransport.builder(url)
+    .jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+    .build();
+```
+
+### After
+
+```java
+import io.modelcontextprotocol.json.McpJsonMapper;
+
+// In transport construction:
+var transport = new StdioClientTransport(params, McpJsonMapper.getDefault());
+
+// Or in builder pattern:
+HttpClientStreamableHttpTransport.builder(url)
+    .jsonMapper(McpJsonMapper.getDefault())
+    .build();
+```
+
+> **Note:** `McpJsonMapper.getDefault()` uses the Jackson-based implementation internally via SPI. You no longer need to inject or construct `ObjectMapper` instances for MCP transport configuration.
+
+## Auto-Configuration Changes
+
+If you rely on Spring AI auto-configuration (the Boot Starters), these changes are handled automatically. The key behavioral changes are:
+
+1. **ObjectMapper no longer injected** — Transport beans no longer accept `ObjectMapper` or `@Qualifier("mcpServerObjectMapper") ObjectMapper` parameters. Custom `ObjectMapper` beans configured for MCP serialization are no longer picked up by the auto-configuration.
+
+2. **keepAliveInterval is conditionally applied** — The `spring.ai.mcp.server.keep-alive-interval` property is now only set on the transport builder when explicitly configured (non-null), rather than always being passed through.
+
+## Migration Checklist
+
+- [ ] Update `mcp-spring-webflux` dependency `groupId` from `io.modelcontextprotocol.sdk` to `org.springframework.ai` (if declared directly)
+- [ ] Update `mcp-spring-webmvc` dependency `groupId` from `io.modelcontextprotocol.sdk` to `org.springframework.ai` (if declared directly)
+- [ ] Update imports for any Spring transport classes (see package rename tables above)
+- [ ] Replace `new JacksonMcpJsonMapper(objectMapper)` with `McpJsonMapper.getDefault()`
+- [ ] Remove unused `ObjectMapper` injections that were only used for MCP JSON mapper construction
+- [ ] Remove `import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper` and `import com.fasterxml.jackson.databind.ObjectMapper` where no longer needed
+- [ ] Verify any custom `@Qualifier("mcpServerObjectMapper")` beans — they are no longer consumed by MCP auto-configuration

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-security.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-security.adoc
@@ -454,13 +454,12 @@ Configure MCP clients programmatically instead of using Spring Boot properties. 
 ----
 @Bean
 McpSyncClient client(
-        ObjectMapper objectMapper,
         McpSyncHttpClientRequestCustomizer requestCustomizer,
         McpClientCommonProperties commonProps
 ) {
     var transport = HttpClientStreamableHttpTransport.builder(mcpServerUrl)
             .clientBuilder(HttpClient.newBuilder())
-            .jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+            .jsonMapper(McpJsonMapper.getDefault())
             .httpRequestCustomizer(requestCustomizer)
             .build();
 
@@ -481,12 +480,11 @@ For WebClient-based clients:
 @Bean
 McpSyncClient client(
         WebClient.Builder mcpWebClientBuilder,
-        ObjectMapper objectMapper,
         McpClientCommonProperties commonProperties
 ) {
     var builder = mcpWebClientBuilder.baseUrl(mcpServerUrl);
     var transport = WebClientStreamableHttpTransport.builder(builder)
-            .jsonMapper(new JacksonMcpJsonMapper(objectMapper))
+            .jsonMapper(McpJsonMapper.getDefault())
             .build();
 
     var clientInfo = new McpSchema.Implementation("clientName", commonProperties.getVersion());

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
@@ -53,7 +53,7 @@ Full MCP Server feature support with `SSE` (Server-Sent Events) server transport
 </dependency>
 ----
 
-The starter activates the `McpWebFluxServerAutoConfiguration` and `McpServerAutoConfiguration` auto-configurations to provide:
+The starter activates the `McpServerSseWebFluxAutoConfiguration` and `McpServerAutoConfiguration` auto-configurations to provide:
 
 * Reactive transport using Spring WebFlux (`WebFluxSseServerTransportProvider`)
 * Automatically configured reactive SSE endpoints

--- a/spring-ai-docs/src/main/asciidoc/mcp.md
+++ b/spring-ai-docs/src/main/asciidoc/mcp.md
@@ -90,7 +90,7 @@ spring:
 Required dependencies:
 ```xml
 <dependency>
-    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <groupId>org.springframework.ai</groupId>
     <artifactId>mcp-spring-webmvc</artifactId>
 </dependency>
 <dependency>
@@ -115,7 +115,7 @@ spring:
 Required dependencies:
 ```xml
 <dependency>
-    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <groupId>org.springframework.ai</groupId>
     <artifactId>mcp-spring-webflux</artifactId>
 </dependency>
 <dependency>
@@ -171,8 +171,8 @@ spring:
 The MCP server auto-configuration is provided through:
 
 1. `McpServerAutoConfiguration`: Core server configuration supporting both sync and async modes
-2. `McpWebMvcServerAutoConfiguration`: WebMvc transport configuration (activated when WebMvc dependencies are present)
-3. `McpWebFluxServerAutoConfiguration`: WebFlux transport configuration (activated when WebFlux dependencies are present)
+2. `McpServerSseWebMvcAutoConfiguration`: WebMvc transport configuration (activated when WebMvc dependencies are present)
+3. `McpServerSseWebFluxAutoConfiguration`: WebFlux transport configuration (activated when WebFlux dependencies are present)
 
 The auto-configuration will automatically set up the appropriate server type and transport based on your configuration and available dependencies.
 

--- a/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server-webmvc/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-mcp-server-webmvc/pom.xml
@@ -63,8 +63,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <groupId>org.springframework.ai</groupId>
             <artifactId>mcp-spring-webmvc</artifactId>
+            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Move mcp-spring-webflux and mcp-spring-webmvc transport modules from io.modelcontextprotocol.sdk to org.springframework.ai, giving Spring AI direct ownership of the Spring transport layer.

- Bump MCP Java SDK from 0.17.1 to 0.18.0-SNAPSHOT
- Repackage WebFlux/WebMvc transport classes under org.springframework.ai.mcp.*
- Replace JacksonMcpJsonMapper(ObjectMapper) with McpJsonMapper.getDefault()
- Remove ObjectMapper injection from all transport auto-configurations
- Add mcp-spring-webflux and mcp-spring-webmvc to Spring AI BOM
- Fix checkstyle
- Fix nulable spec
- Update documentation and add migration guide