### PR TITLE
Use Locale.ROOT for schema type uppercase normalization

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -407,7 +408,7 @@ public abstract class ModelOptionsUtils {
 				}
 				else if (value.isTextual() && entry.getKey().equals("type")) {
 					String oldValue = ((ObjectNode) node).get("type").asText();
-					((ObjectNode) node).put("type", oldValue.toUpperCase());
+					((ObjectNode) node).put("type", oldValue.toUpperCase(Locale.ROOT));
 				}
 			});
 		}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -273,7 +274,7 @@ public final class JsonSchemaGenerator {
 				}
 				else if (value.isTextual() && entry.getKey().equals("type")) {
 					String oldValue = node.get("type").asText();
-					node.put("type", oldValue.toUpperCase());
+					node.put("type", oldValue.toUpperCase(Locale.ROOT));
 				}
 			});
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/ModelOptionsUtilsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/ModelOptionsUtilsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.model;
 
+import java.util.Locale;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -261,6 +263,25 @@ public class ModelOptionsUtilsTests {
 		assertThatThrownBy(
 				() -> ModelOptionsUtils.JSON_MAPPER.readValue(jsonWithInvalidFinishReason, TestApiResponse.class))
 			.hasMessageContaining("INVALID_VALUE");
+	}
+
+	@Test
+	public void toUpperCaseTypeValuesShouldBeLocaleIndependent() {
+		Locale previousDefault = Locale.getDefault();
+		Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+		try {
+			ObjectNode root = JsonMapper.builder().build().createObjectNode();
+			root.put("type", "integer");
+			root.putObject("properties").putObject("id").put("type", "string");
+
+			ModelOptionsUtils.toUpperCaseTypeValues(root);
+
+			assertThat(root.get("type").asText()).isEqualTo("INTEGER");
+			assertThat(root.get("properties").get("id").get("type").asText()).isEqualTo("STRING");
+		}
+		finally {
+			Locale.setDefault(previousDefault);
+		}
 	}
 
 	public enum ColorEnum {

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
+import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -613,6 +614,24 @@ class JsonSchemaGeneratorTests {
 				""";
 
 		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForTypeWithUpperCaseValuesShouldBeLocaleIndependent() {
+		Locale previousDefault = Locale.getDefault();
+		Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+		try {
+			String schema = JsonSchemaGenerator.generateForType(Person.class,
+					JsonSchemaGenerator.SchemaOption.UPPER_CASE_TYPE_VALUES);
+
+			assertThat(schema).contains("\"type\" : \"INTEGER\"");
+			assertThat(schema).contains("\"type\" : \"STRING\"");
+			assertThat(schema).doesNotContain("İNTEGER");
+			assertThat(schema).doesNotContain("STRİNG");
+		}
+		finally {
+			Locale.setDefault(previousDefault);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Problem
When JVM default locale is Turkish (`tr_TR`), calling `String#toUpperCase()` on schema `type` values can produce invalid tokens such as `İNTEGER` / `STRİNG`.
This breaks strict enum validation in providers like Gemini.

Closes #5340.

## Changes
- Updated schema type normalization to use `toUpperCase(Locale.ROOT)` in:
  - `JsonSchemaGenerator.convertTypeValuesToUpperCase(...)`
  - `ModelOptionsUtils.toUpperCaseTypeValues(...)`
- Added regression tests to guarantee locale-independent behavior under `tr-TR`:
  - `JsonSchemaGeneratorTests.generateSchemaForTypeWithUpperCaseValuesShouldBeLocaleIndependent`
  - `ModelOptionsUtilsTests.toUpperCaseTypeValuesShouldBeLocaleIndependent`

## Verification
- `JAVA_HOME=/usr/local/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl spring-ai-model -Dtest=JsonSchemaGeneratorTests,ModelOptionsUtilsTests test`
- `JAVA_HOME=/usr/local/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw -pl spring-ai-model -Ptest-coverage -DsurefireArgLine='${argLine}' -Dtest=JsonSchemaGeneratorTests,ModelOptionsUtilsTests test jacoco:report`

Both commands pass locally.
