### PR TITLE
Document local formatting checks before opening PRs

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -145,6 +145,22 @@ You can enable them by doing the following:
 ./mvnw clean package -DskipTests -Ddisable.checks=false
 ----
 
+== Run Formatting Checks
+
+Before opening a pull request, run Java format locally so that the `pr-check` workflow does not fail on style issues.
+
+[source,shell]
+----
+./mvnw io.spring.javaformat:spring-javaformat-maven-plugin:apply
+----
+
+You can also use the short alias:
+
+[source,shell]
+----
+./mvnw spring-javaformat:apply
+----
+
 === Source Code Style
 
 Spring AI source code checkstyle tries to follow the checkstyle guidelines used by the core Spring Framework project with some exceptions.


### PR DESCRIPTION
## Summary
Updates `CONTRIBUTING.adoc` to explicitly document local formatting checks that contributors should run before opening a pull request.

Closes #5245.

## Changes
- Added a **Run Formatting Checks** section to `CONTRIBUTING.adoc`
- Documented the full plugin invocation:
  - `./mvnw io.spring.javaformat:spring-javaformat-maven-plugin:apply`
- Documented the short alias:
  - `./mvnw spring-javaformat:apply`

## Validation
- `JAVA_HOME=/usr/local/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./mvnw io.spring.javaformat:spring-javaformat-maven-plugin:validate -DskipTests`

Validation passed locally.
