### PR TITLE
fix(vectorstore): parse long integer literals in text filters

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
@@ -215,7 +215,13 @@ public class FilterExpressionTextParser {
 
 		@Override
 		public Filter.Operand visitIntegerConstant(FiltersParser.IntegerConstantContext ctx) {
-			return new Filter.Value(Integer.valueOf(ctx.getText()));
+			String value = ctx.getText();
+			try {
+				return new Filter.Value(Integer.valueOf(value));
+			}
+			catch (NumberFormatException ex) {
+				return new Filter.Value(Long.valueOf(value));
+			}
 		}
 
 		@Override

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
@@ -198,9 +198,13 @@ public class FilterExpressionTextParserTests {
 	public void testLong() {
 		Expression exp2 = this.parser.parse("biz_id == 3L");
 		Expression exp3 = this.parser.parse("biz_id == -5L");
+		Expression exp4 = this.parser.parse("biz_id == " + Long.MAX_VALUE);
+		Expression exp5 = this.parser.parse("biz_id == " + Long.MIN_VALUE);
 
 		assertThat(exp2).isEqualTo(new Expression(EQ, new Key("biz_id"), new Value(3L)));
 		assertThat(exp3).isEqualTo(new Expression(EQ, new Key("biz_id"), new Value(-5L)));
+		assertThat(exp4).isEqualTo(new Expression(EQ, new Key("biz_id"), new Value(Long.MAX_VALUE)));
+		assertThat(exp5).isEqualTo(new Expression(EQ, new Key("biz_id"), new Value(Long.MIN_VALUE)));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes #4705.

`FilterExpressionTextParser` currently parses all integer tokens as `Integer`, which throws `NumberFormatException` for values outside the 32-bit range (for example `Long.MAX_VALUE`).

## What changed

- Updated integer constant parsing in `FilterExpressionTextParser`:
  - First try `Integer.valueOf(...)`
  - On overflow, fallback to `Long.valueOf(...)`
- Extended parser tests to cover large signed long literals:
  - `Long.MAX_VALUE`
  - `Long.MIN_VALUE`

## Validation

Executed locally:

```bash
export JAVA_HOME=/usr/local/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home
./mvnw -pl spring-ai-vector-store -Dtest=FilterExpressionTextParserTests test
```

Result: `BUILD SUCCESS` (`15` tests, `0` failures)
