### PR TITLE
fix(ollama): bind think as top-level request field

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaChatOptions.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -37,6 +38,7 @@ import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Helper class for creating strongly-typed Ollama options.
@@ -54,7 +56,8 @@ import org.springframework.util.Assert;
 @JsonInclude(Include.NON_NULL)
 public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutputChatOptions {
 
-	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "format", "keep_alive", "truncate");
+	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "format", "keep_alive", "truncate",
+			"think");
 
 	// Following fields are options which must be set when the model is loaded into
 	// memory.
@@ -735,8 +738,43 @@ public class OllamaChatOptions implements ToolCallingChatOptions, StructuredOutp
 		return this.thinkOption;
 	}
 
+	@JsonIgnore
 	public void setThinkOption(@Nullable ThinkOption thinkOption) {
 		this.thinkOption = thinkOption;
+	}
+
+	/**
+	 * Supports property binding from values such as true/false/high/medium/low.
+	 * @param think the think property value
+	 */
+	@JsonProperty("think")
+	public void setThink(@Nullable Object think) {
+		if (think == null) {
+			this.thinkOption = null;
+			return;
+		}
+		if (think instanceof ThinkOption parsedThinkOption) {
+			this.thinkOption = parsedThinkOption;
+			return;
+		}
+		if (think instanceof Boolean enabled) {
+			this.thinkOption = enabled ? ThinkOption.ThinkBoolean.ENABLED : ThinkOption.ThinkBoolean.DISABLED;
+			return;
+		}
+
+		String normalized = think.toString().trim().toLowerCase(Locale.ROOT);
+		if (!StringUtils.hasText(normalized)) {
+			this.thinkOption = null;
+		}
+		else if ("true".equals(normalized)) {
+			this.thinkOption = ThinkOption.ThinkBoolean.ENABLED;
+		}
+		else if ("false".equals(normalized)) {
+			this.thinkOption = ThinkOption.ThinkBoolean.DISABLED;
+		}
+		else {
+			this.thinkOption = new ThinkOption.ThinkLevel(normalized);
+		}
 	}
 
 	@Override

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
@@ -32,6 +32,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
+import org.springframework.ai.ollama.api.ThinkOption;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
@@ -142,6 +143,17 @@ class OllamaChatRequestTests {
 		assertThat(request.options().get("top_p")).isEqualTo(0.5); // new field introduced
 		// by the
 		// promptOptions.
+	}
+
+	@Test
+	void createRequestWithThinkOptionShouldSetTopLevelThink() {
+		OllamaChatOptions promptOptions = OllamaChatOptions.builder().enableThinking().build();
+		var prompt = this.chatModel.buildRequestPrompt(new Prompt("Test message content", promptOptions));
+
+		var request = this.chatModel.ollamaChatRequest(prompt, true);
+
+		assertThat(request.think()).isEqualTo(ThinkOption.ThinkBoolean.ENABLED);
+		assertThat(request.options()).doesNotContainKey("think");
 	}
 
 	@Test

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaChatOptionsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/OllamaChatOptionsTests.java
@@ -47,6 +47,44 @@ class OllamaChatOptionsTests {
 	}
 
 	@Test
+	void testThinkOptionSerializedAsScalar() {
+		var enabledThinkingOptions = OllamaChatOptions.builder().enableThinking().build();
+		assertThat(enabledThinkingOptions.toMap()).containsEntry("think", true);
+
+		var levelThinkingOptions = OllamaChatOptions.builder().thinkHigh().build();
+		assertThat(levelThinkingOptions.toMap()).containsEntry("think", "high");
+	}
+
+	@Test
+	void testSetThinkParsesBooleanAndStringValues() {
+		var options = OllamaChatOptions.builder().build();
+
+		options.setThink(true);
+		assertThat(options.getThinkOption()).isEqualTo(ThinkOption.ThinkBoolean.ENABLED);
+
+		options.setThink(false);
+		assertThat(options.getThinkOption()).isEqualTo(ThinkOption.ThinkBoolean.DISABLED);
+
+		options.setThink("false");
+		assertThat(options.getThinkOption()).isEqualTo(ThinkOption.ThinkBoolean.DISABLED);
+
+		options.setThink("true");
+		assertThat(options.getThinkOption()).isEqualTo(ThinkOption.ThinkBoolean.ENABLED);
+
+		options.setThink("medium");
+		assertThat(options.getThinkOption()).isEqualTo(ThinkOption.ThinkLevel.MEDIUM);
+
+		options.setThink("   ");
+		assertThat(options.getThinkOption()).isNull();
+
+		options.setThink(ThinkOption.ThinkLevel.HIGH);
+		assertThat(options.getThinkOption()).isEqualTo(ThinkOption.ThinkLevel.HIGH);
+
+		options.setThink(null);
+		assertThat(options.getThinkOption()).isNull();
+	}
+
+	@Test
 	void testAllNumericOptions() {
 		var options = OllamaChatOptions.builder()
 			.numCtx(2048)


### PR DESCRIPTION
## Summary\nThis fixes  handling for  so the request payload matches Ollama API expectations.\n\n## Problem\nWhen  was provided via options/binding, it could end up in the  map instead of the top-level request field, and binding paths were inconsistent.\n\n## Changes\n- Exclude  from the generic options map ().\n- Add explicit  binding path in  to normalize:\n  -  / \n  - \n  - blank/null handling\n- Mark  as  to avoid Jackson setter conflicts and keep typed API usage intact.\n- Add regression tests to verify:\n  -  serializes as scalar\n  -  is sent at top-level request field\n  -  map does not contain \n  - parsing behavior for boolean/string/object/null inputs\n\n## Testing\n- [INFO] Cache disabled by command line flag, project will be built fully and not cached
[INFO] Scanning for projects...
[INFO] 
[INFO] --------------< org.springframework.ai:spring-ai-ollama >---------------
[INFO] Building Spring AI Model - Ollama 2.0.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] Cache is disabled on project level for org.springframework.ai:spring-ai-ollama
[INFO] 
[INFO] --- enforcer:3.6.2:enforce (maven-enforcer) @ spring-ai-ollama ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] Rule 1: org.apache.maven.enforcer.rules.BanDuplicatePomDependencyVersions passed
[INFO] Rule 2: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] 
[INFO] --- jacoco:0.8.10:prepare-agent (prepare-agent) @ spring-ai-ollama ---
[INFO] argLine set to -javaagent:/Users/liweiguang/.m2/repository/org/jacoco/org.jacoco.agent/0.8.10/org.jacoco.agent-0.8.10-runtime.jar=destfile=/Users/liweiguang/aiagent/spring-ai/models/spring-ai-ollama/target/jacoco.exec
[INFO] 
[INFO] --- spring-javaformat:0.0.47:apply (format-apply) @ spring-ai-ollama ---
[INFO] 
[INFO] --- checkstyle:3.6.0:check (checkstyle-validation) @ spring-ai-ollama ---
[INFO] Starting audit...
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ spring-ai-ollama ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] 
[INFO] --- flatten:1.5.0:flatten (flatten) @ spring-ai-ollama ---
[INFO] Generating flattened POM of project org.springframework.ai:spring-ai-ollama:jar:2.0.0-SNAPSHOT...
[INFO] 
[INFO] --- kotlin:2.2.21:compile (compile) @ spring-ai-ollama ---
[INFO] No sources to compile
[INFO] 
[INFO] --- compiler:3.14.1:compile (java-compile) @ spring-ai-ollama ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ spring-ai-ollama ---
[INFO] Copying 5 resources from src/test/resources to target/test-classes
[INFO] 
[INFO] --- kotlin:2.2.21:test-compile (test-compile) @ spring-ai-ollama ---
[INFO] No sources to compile
[INFO] 
[INFO] --- compiler:3.14.1:testCompile (java-test-compile) @ spring-ai-ollama ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- surefire:3.1.2:test (default-test) @ spring-ai-ollama ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.springframework.ai.ollama.api.OllamaChatOptionsTests
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.033 s -- in org.springframework.ai.ollama.api.OllamaChatOptionsTests
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testModelAndFormat -- Time elapsed: 1.548 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testSetThinkParsesBooleanAndStringValues -- Time elapsed: 0.090 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testGetOutputSchemaHandlesAllFormatTypes -- Time elapsed: 0.083 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testFromOptions -- Time elapsed: 0.024 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testOutputSchemaOptionWithJsonSchemaObjectAsString -- Time elapsed: 0.005 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testNullValuesNotIncludedInMap -- Time elapsed: 0.003 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testThinkOptionSerializedAsScalar -- Time elapsed: 0.027 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testDeprecatedMethods -- Time elapsed: 0.023 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testAllNumericOptions -- Time elapsed: 0.004 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testFunctionAndToolOptions -- Time elapsed: 0.005 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testEmptyOptions -- Time elapsed: 0.004 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testZeroValuesIncludedInMap -- Time elapsed: 0.005 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testOutputSchemaOptionWithJsonAsString -- Time elapsed: 0.006 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testBooleanOptions -- Time elapsed: 0.003 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testFunctionOptionsNotInMap -- Time elapsed: 0.004 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testSimpleJsonFormatDirectAccess -- Time elapsed: 0.007 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testSimpleJsonFormatVsJsonSchema -- Time elapsed: 0.018 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testFunctionOptionsWithMutableSet -- Time elapsed: 0.005 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testSetOutputSchemaWithValidJsonSchema -- Time elapsed: 0.007 s
[INFO] org.springframework.ai.ollama.api.OllamaChatOptionsTests.testBasicOptions -- Time elapsed: 0.020 s
[INFO] Running org.springframework.ai.ollama.OllamaChatRequestTests
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.669 s -- in org.springframework.ai.ollama.OllamaChatRequestTests
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithThinkOptionShouldSetTopLevelThink -- Time elapsed: 0.230 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.whenToolRuntimeOptionsThenMergeWithDefaults -- Time elapsed: 0.043 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithPromptPortableChatOptions -- Time elapsed: 0.225 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithPromptOptionsModelOverride -- Time elapsed: 0.009 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithDefaultOptionsModelOverride -- Time elapsed: 0.015 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithDefaultOptionsModelChatOptionsOverride -- Time elapsed: 0.022 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithPromptOllamaOptions -- Time elapsed: 0.007 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithAllMessageTypes -- Time elapsed: 0.012 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithDefaultOptions -- Time elapsed: 0.004 s
[INFO] org.springframework.ai.ollama.OllamaChatRequestTests.createRequestWithPromptOllamaChatOptions -- Time elapsed: 0.014 s
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.10:report (default-cli) @ spring-ai-ollama ---
[INFO] Loading execution data file /Users/liweiguang/aiagent/spring-ai/models/spring-ai-ollama/target/jacoco.exec
[INFO] Analyzed bundle 'Spring AI Model - Ollama' with 45 classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  32.123 s
[INFO] Finished at: 2026-02-10T09:15:45+08:00
[INFO] ------------------------------------------------------------------------\n- Result: 30/30 tests passed.\n- Changed executable production lines coverage: 100% (19/19).\n\nCloses #5425