### PR TITLE
Fix MetadataMode being ignored in batched embedding path

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,12 @@ public class AzureOpenAiEmbeddingModel extends AbstractEmbeddingModel {
 		this.metadataMode = metadataMode;
 		this.defaultOptions = options;
 		this.observationRegistry = observationRegistry;
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.metadataMode);
 	}
 
 	@Override

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,6 +140,12 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.metadataMode);
 	}
 
 	@Override

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Jason Smith
  * @author Nicolas Krier
+ * @author Soby Chacko
  * @since 1.0.0
  */
 public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
@@ -167,6 +168,12 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 			.requireNonNull(request.getOptions());
 		return new MistralAiApi.EmbeddingRequest<>(request.getInstructions(), requestOptions.getModel(),
 				requestOptions.getEncodingFormat());
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.metadataMode);
 	}
 
 	@Override

--- a/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkEmbeddingModel.java
+++ b/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/OpenAiSdkEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-2025 the original author or authors.
+ * Copyright 2025-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import org.springframework.util.CollectionUtils;
  * Embedding Model implementation using the OpenAI Java SDK.
  *
  * @author Julien Dubois
+ * @author Soby Chacko
  */
 public class OpenAiSdkEmbeddingModel extends AbstractEmbeddingModel {
 
@@ -168,6 +169,12 @@ public class OpenAiSdkEmbeddingModel extends AbstractEmbeddingModel {
 						this.options.getCustomHeaders()));
 		this.metadataMode = Objects.requireNonNullElse(metadataMode, MetadataMode.EMBED);
 		this.observationRegistry = Objects.requireNonNullElse(observationRegistry, ObservationRegistry.NOOP);
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.metadataMode);
 	}
 
 	@Override

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Josh Long
+ * @author Soby Chacko
  *
  */
 public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
@@ -139,6 +140,12 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.metadataMode);
 	}
 
 	@Override

--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Toshiaki Maki
  * @author Christian Tzolov
+ * @author Soby Chacko
  */
 public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements InitializingBean {
 
@@ -95,6 +96,12 @@ public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements 
 				"SELECT pgml.embed(?, ?, ?::JSONB)" + this.defaultOptions.getVectorType().cast + " AS embedding",
 				this.defaultOptions.getVectorType().rowMapper, this.defaultOptions.getTransformer(), text,
 				ModelOptionsUtils.toJsonString(this.defaultOptions.getKwargs()));
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.defaultOptions.getMetadataMode());
 	}
 
 	@Override

--- a/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
+++ b/models/spring-ai-transformers/src/main/java/org/springframework/ai/transformers/TransformersEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ import org.springframework.util.StringUtils;
  * </p>
  *
  * @author Christian Tzolov
+ * @author Soby Chacko
  * @since 1.0.0
  */
 public class TransformersEmbeddingModel extends AbstractEmbeddingModel implements InitializingBean {
@@ -259,6 +260,12 @@ public class TransformersEmbeddingModel extends AbstractEmbeddingModel implement
 	@Override
 	public float[] embed(String text) {
 		return embed(List.of(text)).get(0);
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.metadataMode);
 	}
 
 	@Override

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,6 +142,12 @@ public class ZhiPuAiEmbeddingModel extends AbstractEmbeddingModel {
 		this.defaultOptions = options;
 		this.retryTemplate = retryTemplate;
 		this.observationRegistry = observationRegistry;
+	}
+
+	@Override
+	public String getEmbeddingContent(Document document) {
+		Assert.notNull(document, "Document must not be null");
+		return document.getFormattedContent(this.metadataMode);
 	}
 
 	@Override

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings.adoc
@@ -53,6 +53,17 @@ public interface EmbeddingModel extends Model<EmbeddingRequest, EmbeddingRespons
 	float[] embed(Document document);
 
 	/**
+	 * Extracts the text content from a Document to be used for embedding.
+	 * By default, returns Document.getText(). Implementations that support
+	 * MetadataMode should override this to return
+	 * Document.getFormattedContent(MetadataMode) so that metadata is
+	 * included in the text sent to the embedding API.
+	 */
+	default String getEmbeddingContent(Document document) {
+		return document.getText();
+	}
+
+	/**
 	 * Embeds the given text into a vector.
 	 * @param text the text to embed.
 	 * @return the embedded vector.
@@ -101,6 +112,10 @@ The embed methods offer various options for converting text into embeddings, acc
 
 Multiple shortcut methods are provided for embedding text, including the `embed(String text)` method, which takes a single string and returns the corresponding embedding vector.
 All shortcuts are implemented around the `call` method, which is the primary method for invoking the embedding model.
+
+The `getEmbeddingContent(Document)` method controls how text is extracted from a `Document` before embedding.
+By default it returns `Document.getText()`, but embedding model implementations that support `MetadataMode` (such as OpenAI, Azure OpenAI, and Mistral AI) override this method to return `Document.getFormattedContent(MetadataMode)`, ensuring that document metadata is included in the text sent to the embedding API when configured.
+This method is used by the batched embedding path that vector stores rely on.
 
 Typically the embedding returns a lists of floats, representing the embeddings in a numerical vector format.
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-ai/issues/5442

The default EmbeddingModel.embed(List<Document>, EmbeddingOptions, BatchingStrategy) method used Document::getText, ignoring MetadataMode. Since all vector stores use this batched path, MetadataMode configuration on embedding models was effectively dead code.

Add getEmbeddingContent(Document) default method to EmbeddingModel that returns document.getText() for backward compatibility. Models with MetadataMode support (OpenAI, Azure OpenAI, MistralAI, ZhiPuAI, MiniMax, Transformers, OpenAI SDK, PostgresML) override it to return document.getFormattedContent(metadataMode). The batched embed method now delegates to getEmbeddingContent() instead of getText().