### PR TITLE
Rename ToolCallAdvisor's disableMemory into disableInternalConversati…

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/TOOLCALLADVISOR_STREAMING_DESIGN.md
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/TOOLCALLADVISOR_STREAMING_DESIGN.md
@@ -4,7 +4,7 @@ This document describes the design and implementation of streaming support in `T
 
 ## Problem Statement
 
-When using `ToolCallAdvisor` with `disableMemory()` and an external `MessageChatMemoryAdvisor`, the non-streaming (call) implementation works correctly, but the original streaming implementation failed due to:
+When using `ToolCallAdvisor` with `disableInternalConversationHistory()` and an external `MessageChatMemoryAdvisor`, the non-streaming (call) implementation works correctly, but the original streaming implementation failed due to:
 
 1. **Tool call detection on individual chunks**: The original implementation checked `hasToolCalls()` on each streaming chunk instead of the complete aggregated response
 2. **Race conditions with memory updates**: `MessageChatMemoryAdvisor.after()` fires via `doOnComplete` after all chunks are emitted, but tool call detection happened per-chunk, causing memory inconsistency

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -490,7 +490,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 		 * registered next in the chain.
 		 * @return this Builder instance for method chaining
 		 */
-		public T disableMemory() {
+		public T disableInternalConversationHistory() {
 			this.conversationHistoryEnabled = false;
 			return self();
 		}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
@@ -663,10 +663,10 @@ public class ToolCallAdvisorTests {
 	}
 
 	@Test
-	void testDisableMemoryBuilderMethod() {
+	void testDisableInternalConversationHistoryBuilderMethod() {
 		ToolCallAdvisor advisor = ToolCallAdvisor.builder()
 			.toolCallingManager(this.toolCallingManager)
-			.disableMemory()
+			.disableInternalConversationHistory()
 			.build();
 
 		ChatClientRequest request = createMockRequestWithSystemMessage();

--- a/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorIT.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorIT.java
@@ -104,7 +104,7 @@ public abstract class AbstractToolCallAdvisorIT {
 
 			var response = ChatClient.create(getChatModel())
 				.prompt()
-				.advisors(ToolCallAdvisor.builder().disableMemory().build(),
+				.advisors(ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 							.build())
 				.user(u -> u.text("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?"))
@@ -139,7 +139,7 @@ public abstract class AbstractToolCallAdvisorIT {
 		void callDefaultAdvisorConfigurationWithExternalMemory() {
 
 			var chatClient = ChatClient.builder(getChatModel())
-				.defaultAdvisors(ToolCallAdvisor.builder().disableMemory().build(),
+				.defaultAdvisors(ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
 				.build();
 
@@ -199,7 +199,7 @@ public abstract class AbstractToolCallAdvisorIT {
 
 			Flux<String> response = ChatClient.create(getChatModel())
 				.prompt()
-				.advisors(ToolCallAdvisor.builder().disableMemory().build(),
+				.advisors(ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 							.build())
 				.user("What's the weather like in San Francisco, Tokyo, and Paris in Celsius?")
@@ -238,7 +238,7 @@ public abstract class AbstractToolCallAdvisorIT {
 		void streamDefaultAdvisorConfigurationWithExternalMemory() {
 
 			var chatClient = ChatClient.builder(getChatModel())
-				.defaultAdvisors(ToolCallAdvisor.builder().disableMemory().build(),
+				.defaultAdvisors(ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
 						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
 				.build();
 


### PR DESCRIPTION
…onHistory

 - This avoid confusion with the name disableMemory being compared to Chat memory