### PR TITLE
Remove adding toolcall history into toolcontext

### DIFF
--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.anthropic.client;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -32,7 +31,6 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.anthropic.AnthropicTestConfiguration;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.ToolContext;
@@ -195,9 +193,8 @@ class AnthropicChatClientMethodInvokingFunctionCallbackIT {
 
 		assertThat(response).contains("30", "10", "15");
 		assertThat(arguments).containsEntry("tool", "value");
-		assertThat(arguments).containsKey(ToolContext.TOOL_CALL_HISTORY);
-		List<Message> tootConversationMessages = (List<Message>) arguments.get(ToolContext.TOOL_CALL_HISTORY);
-		assertThat(tootConversationMessages.size() == 6 || tootConversationMessages.size() == 2).isTrue();
+		// TOOL_CALL_HISTORY is no longer automatically added to ToolContext
+		assertThat(arguments).doesNotContainKey("TOOL_CALL_HISTORY");
 	}
 
 	@Test
@@ -350,7 +347,7 @@ class AnthropicChatClientMethodInvokingFunctionCallbackIT {
 
 		public String getWeatherWithContext(String city, Unit unit, ToolContext context) {
 			arguments.put("tool", context.getContext().get("tool"));
-			arguments.put(ToolContext.TOOL_CALL_HISTORY, context.getToolCallHistory());
+			// TOOL_CALL_HISTORY no longer available - removed
 			return getWeatherStatic(city, unit);
 		}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -1,6 +1,76 @@
 [[upgrade-notes]]
 = Upgrade Notes
 
+[[upgrading-to-2-0-0-M3]]
+== Upgrading to 2.0.0-M3
+
+==== Conversation History Removed from ToolContext
+
+Conversation history is no longer automatically added to `ToolContext`. The `TOOL_CALL_HISTORY` constant and `getToolCallHistory()` method have been removed from the `ToolContext` class.
+
+===== Impact
+
+* `ToolContext.TOOL_CALL_HISTORY` constant no longer exists
+* `ToolContext.getToolCallHistory()` method no longer exists
+* Conversation history is no longer automatically populated in `ToolContext`
+
+===== Why This Change?
+
+1. **Memory Efficiency**: Prevents unbounded memory growth in long conversations
+2. **Separation of Concerns**: Tools should operate on their parameters, not manage conversation state
+3. **Architecture Alignment**: Conversation context belongs at the advisor level, not in tool execution
+
+===== Migration
+
+If your application needs conversation history management, use `ToolCallAdvisor`:
+
+.Managing Conversation History with ToolCallAdvisor
+[source,java]
+----
+ChatClient chatClient = ChatClient.builder()
+    .defaultAdvisors(
+        new ToolCallAdvisor()
+            .conversationHistoryEnabled(true)  // Full history (default)
+    )
+    .build();
+----
+
+**How ToolCallAdvisor Works:**
+
+The `ToolCallAdvisor` manages conversation history at the advisor level:
+
+* **conversationHistoryEnabled=true** (default): Full conversation history is maintained and sent to the LLM between tool call iterations, allowing the LLM to synthesize results with full context
+* **conversationHistoryEnabled=false**: Only the most recent tool response is sent to the LLM (useful when ChatMemory advisor manages history separately)
+
+**Key Point:** The conversation history is used by the *LLM* to understand context and formulate responses, not by the *tools* themselves. Tools receive only their input parameters and any custom context you explicitly provide.
+
+**Custom Context in Tools:**
+
+`ToolContext` remains available for passing custom, application-specific data to tools:
+
+.Passing Custom Context to Tools
+[source,java]
+----
+ChatResponse response = chatClient.prompt()
+    .user("What's the weather in SF?")
+    .options(ChatOptionsBuilder.builder()
+        .toolContext("userId", "user123")
+        .toolContext("apiKey", "secret")
+        .build())
+    .call()
+    .chatResponse();
+----
+
+**Example Flow:**
+
+1. User asks: "What's the weather in SF and LA?"
+2. LLM requests tool calls: `getWeather(SF)` and `getWeather(LA)`
+3. Tools execute with only their parameters (no conversation history)
+4. ToolCallAdvisor collects tool results and conversation history
+5. LLM receives conversation context from advisor and synthesizes: "The weather in SF is 72°F and in LA is 85°F"
+
+The LLM sees the full conversation through the advisor chain, not through ToolContext.
+
 [[upgrading-to-2-0-0-M2]]
 == Upgrading to 2.0.0-M2
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ToolContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ToolContext.java
@@ -17,10 +17,7 @@
 package org.springframework.ai.chat.model;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-
-import org.springframework.ai.chat.messages.Message;
 
 /**
  * Represents the context for tool execution in a function calling scenario.
@@ -45,11 +42,6 @@ import org.springframework.ai.chat.messages.Message;
  */
 public final class ToolContext {
 
-	/**
-	 * The key for the running, tool call history stored in the context map.
-	 */
-	public static final String TOOL_CALL_HISTORY = "TOOL_CALL_HISTORY";
-
 	private final Map<String, Object> context;
 
 	/**
@@ -67,16 +59,6 @@ public final class ToolContext {
 	 */
 	public Map<String, Object> getContext() {
 		return this.context;
-	}
-
-	/**
-	 * Returns the tool call history from the context map.
-	 * @return The tool call history. TODO: review whether we still need this or
-	 * ToolCallingManager solves the original issue
-	 */
-	@SuppressWarnings({ "unchecked", "NullAway" })
-	public List<Message> getToolCallHistory() {
-		return (List<Message>) this.context.get(TOOL_CALL_HISTORY);
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -159,23 +159,9 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 		if (prompt.getOptions() instanceof ToolCallingChatOptions toolCallingChatOptions
 				&& !CollectionUtils.isEmpty(toolCallingChatOptions.getToolContext())) {
 			toolContextMap = new HashMap<>(toolCallingChatOptions.getToolContext());
-
-			toolContextMap.put(ToolContext.TOOL_CALL_HISTORY,
-					buildConversationHistoryBeforeToolExecution(prompt, assistantMessage));
 		}
 
 		return new ToolContext(toolContextMap);
-	}
-
-	private static List<Message> buildConversationHistoryBeforeToolExecution(Prompt prompt,
-			AssistantMessage assistantMessage) {
-		List<Message> messageHistory = new ArrayList<>(prompt.copy().getInstructions());
-		messageHistory.add(AssistantMessage.builder()
-			.content(Objects.requireNonNullElse(assistantMessage.getText(), ""))
-			.properties(assistantMessage.getMetadata())
-			.toolCalls(assistantMessage.getToolCalls())
-			.build());
-		return messageHistory;
 	}
 
 	/**


### PR DESCRIPTION
  - By default, the toolcall history is added into the toolcontext under TOOL_CALL_HISTORY key when the tool execution is handled by Spring AI's default toolcalling manager (via the implementing ChatModel's internal tool execution). This caused memory growth issues in long conversations and created an unnecessary coupling between tool execution and conversation management.
    - Given the toolcall history can be enabled using the advisor chain via the newly added ToolCallAdvisor, removing the tool call history from ToolContext avoids overloading the Spring AI's internal tool call response with the conversation history.
  - Update upgrade notes

Fixes #5455