### PR TITLE
feat(mcp): add TTL-based cache invalidation for MCP tool callbacks

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpToolCallbackAutoConfiguration.java
@@ -64,6 +64,7 @@ public class McpToolCallbackAutoConfiguration {
 	 * filter the discovered tools
 	 * @param syncMcpClients provider of MCP sync clients
 	 * @param mcpToolNamePrefixGenerator the tool name prefix generator
+	 * @param properties the MCP client common properties
 	 * @return list of tool callbacks for MCP integration
 	 */
 	@Bean
@@ -72,7 +73,8 @@ public class McpToolCallbackAutoConfiguration {
 	public SyncMcpToolCallbackProvider mcpToolCallbacks(ObjectProvider<McpToolFilter> syncClientsToolFilter,
 			ObjectProvider<List<McpSyncClient>> syncMcpClients,
 			ObjectProvider<McpToolNamePrefixGenerator> mcpToolNamePrefixGenerator,
-			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter) {
+			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter,
+			McpClientCommonProperties properties) {
 
 		List<McpSyncClient> mcpClients = syncMcpClients.stream().flatMap(List::stream).toList();
 
@@ -83,6 +85,7 @@ public class McpToolCallbackAutoConfiguration {
 					mcpToolNamePrefixGenerator.getIfUnique(() -> McpToolNamePrefixGenerator.noPrefix()))
 			.toolContextToMcpMetaConverter(
 					toolContextToMcpMetaConverter.getIfUnique(() -> ToolContextToMcpMetaConverter.defaultConverter()))
+			.cacheTtl(properties.getToolcallback().getCacheTtl())
 			.build();
 	}
 
@@ -91,7 +94,8 @@ public class McpToolCallbackAutoConfiguration {
 	public AsyncMcpToolCallbackProvider mcpAsyncToolCallbacks(ObjectProvider<McpToolFilter> asyncClientsToolFilter,
 			ObjectProvider<List<McpAsyncClient>> mcpClientsProvider,
 			ObjectProvider<McpToolNamePrefixGenerator> toolNamePrefixGenerator,
-			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter) { // TODO
+			ObjectProvider<ToolContextToMcpMetaConverter> toolContextToMcpMetaConverter,
+			McpClientCommonProperties properties) {
 		List<McpAsyncClient> mcpClients = mcpClientsProvider.stream().flatMap(List::stream).toList();
 		return AsyncMcpToolCallbackProvider.builder()
 			.toolFilter(asyncClientsToolFilter.getIfUnique(() -> (McpAsyncClient, tool) -> true))
@@ -99,6 +103,7 @@ public class McpToolCallbackAutoConfiguration {
 			.toolContextToMcpMetaConverter(
 					toolContextToMcpMetaConverter.getIfUnique(() -> ToolContextToMcpMetaConverter.defaultConverter()))
 			.mcpClients(mcpClients)
+			.cacheTtl(properties.getToolcallback().getCacheTtl())
 			.build();
 	}
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpClientCommonProperties.java
@@ -184,12 +184,32 @@ public class McpClientCommonProperties {
 		 */
 		private boolean enabled = true;
 
+		/**
+		 * Time-to-live (TTL) for cached tool callbacks.
+		 * <p>
+		 * When set to a positive duration, the cached tools will be refreshed after the
+		 * specified duration has elapsed since the last cache update. This is useful when
+		 * working with stateless MCP servers that don't send tool change notifications.
+		 * <p>
+		 * By default, this is -1 second, meaning tools are cached indefinitely and only
+		 * refreshed when a tool change notification is received from the MCP server.
+		 */
+		private Duration cacheTtl = Duration.ofSeconds(-1);
+
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
 		}
 
 		public boolean isEnabled() {
 			return this.enabled;
+		}
+
+		public Duration getCacheTtl() {
+			return this.cacheTtl;
+		}
+
+		public void setCacheTtl(Duration cacheTtl) {
+			this.cacheTtl = cacheTtl;
 		}
 
 	}

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mcp;
 
+import java.time.Duration;
 import java.util.List;
 
 import io.modelcontextprotocol.client.McpSyncClient;
@@ -31,6 +32,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -440,6 +443,124 @@ class SyncMcpToolCallbackProviderTests {
 		var callbacks = provider.getToolCallbacks();
 
 		assertThat(callbacks).hasSize(1);
+	}
+
+	@Test
+	void cacheShouldNotRefreshBeforeTtlExpires() {
+		var clientInfo = new Implementation("testClient", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		var clientCapabilities = new ClientCapabilities(null, null, null, null);
+		when(this.mcpClient.getClientCapabilities()).thenReturn(clientCapabilities);
+
+		Tool tool1 = mock(Tool.class);
+		when(tool1.name()).thenReturn("tool1");
+
+		ListToolsResult listToolsResult = mock(ListToolsResult.class);
+		when(listToolsResult.tools()).thenReturn(List.of(tool1));
+		when(this.mcpClient.listTools()).thenReturn(listToolsResult);
+
+		// Use a long TTL to ensure it doesn't expire during the test
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
+			.mcpClients(this.mcpClient)
+			.cacheTtl(Duration.ofHours(1))
+			.build();
+
+		// First call - should fetch tools
+		provider.getToolCallbacks();
+		// Second call - should use cache (TTL not expired)
+		provider.getToolCallbacks();
+		// Third call - should use cache (TTL not expired)
+		provider.getToolCallbacks();
+
+		// listTools should only be called once since cache should not have expired
+		verify(this.mcpClient, times(1)).listTools();
+	}
+
+	@Test
+	void cacheWithNullTtlShouldNotExpire() {
+		var clientInfo = new Implementation("testClient", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		var clientCapabilities = new ClientCapabilities(null, null, null, null);
+		when(this.mcpClient.getClientCapabilities()).thenReturn(clientCapabilities);
+
+		Tool tool1 = mock(Tool.class);
+		when(tool1.name()).thenReturn("tool1");
+
+		ListToolsResult listToolsResult = mock(ListToolsResult.class);
+		when(listToolsResult.tools()).thenReturn(List.of(tool1));
+		when(this.mcpClient.listTools()).thenReturn(listToolsResult);
+
+		// No cacheTtl set (null by default) - should cache indefinitely
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder().mcpClients(this.mcpClient).build();
+
+		// Multiple calls should all use the cache
+		provider.getToolCallbacks();
+		provider.getToolCallbacks();
+		provider.getToolCallbacks();
+
+		// listTools should only be called once
+		verify(this.mcpClient, times(1)).listTools();
+	}
+
+	@Test
+	void cacheWithZeroTtlShouldNotExpire() {
+		var clientInfo = new Implementation("testClient", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		var clientCapabilities = new ClientCapabilities(null, null, null, null);
+		when(this.mcpClient.getClientCapabilities()).thenReturn(clientCapabilities);
+
+		Tool tool1 = mock(Tool.class);
+		when(tool1.name()).thenReturn("tool1");
+
+		ListToolsResult listToolsResult = mock(ListToolsResult.class);
+		when(listToolsResult.tools()).thenReturn(List.of(tool1));
+		when(this.mcpClient.listTools()).thenReturn(listToolsResult);
+
+		// Zero duration should be treated as infinite cache
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
+			.mcpClients(this.mcpClient)
+			.cacheTtl(Duration.ZERO)
+			.build();
+
+		// Multiple calls should all use the cache
+		provider.getToolCallbacks();
+		provider.getToolCallbacks();
+		provider.getToolCallbacks();
+
+		// listTools should only be called once
+		verify(this.mcpClient, times(1)).listTools();
+	}
+
+	@Test
+	void invalidateCacheShouldForceRefreshEvenWithTtl() {
+		var clientInfo = new Implementation("testClient", "1.0.0");
+		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
+		var clientCapabilities = new ClientCapabilities(null, null, null, null);
+		when(this.mcpClient.getClientCapabilities()).thenReturn(clientCapabilities);
+
+		Tool tool1 = mock(Tool.class);
+		when(tool1.name()).thenReturn("tool1");
+
+		ListToolsResult listToolsResult = mock(ListToolsResult.class);
+		when(listToolsResult.tools()).thenReturn(List.of(tool1));
+		when(this.mcpClient.listTools()).thenReturn(listToolsResult);
+
+		// Long TTL
+		SyncMcpToolCallbackProvider provider = SyncMcpToolCallbackProvider.builder()
+			.mcpClients(this.mcpClient)
+			.cacheTtl(Duration.ofHours(1))
+			.build();
+
+		// First call - should fetch tools
+		provider.getToolCallbacks();
+		verify(this.mcpClient, times(1)).listTools();
+
+		// Invalidate cache explicitly
+		provider.invalidateCache();
+
+		// Second call - should refresh because cache was invalidated
+		provider.getToolCallbacks();
+		verify(this.mcpClient, times(2)).listTools();
 	}
 
 }


### PR DESCRIPTION
Adds configurable TTL for the tool cache in SyncMcpToolCallbackProvider and AsyncMcpToolCallbackProvider, addressing issues when MCP servers are stateless or restart with tool changes.

- Added cacheTtl configuration to both Sync and Async providers via Builder
- Cache automatically refreshes after the TTL expires
- Default is Duration.ofSeconds(-1) (negative = infinite cache)
- Added auto-configuration property: spring.ai.mcp.client.toolcallback.cache-ttl
- Added comprehensive tests for TTL behavior

Fixes https://github.com/spring-projects/spring-ai/issues/4928
