### PR TITLE
Fix missing configured options in MistralAI request

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -656,6 +656,9 @@ public class MistralAiApi {
 			@JsonProperty("temperature") @Nullable Double temperature,
 			@JsonProperty("top_p") @Nullable Double topP,
 			@JsonProperty("max_tokens") @Nullable Integer maxTokens,
+			@JsonProperty("n") @Nullable Integer n,
+			@JsonProperty("presence_penalty") @Nullable Double presencePenalty,
+			@JsonProperty("frequency_penalty") @Nullable Double frequencyPenalty,
 			@JsonProperty("stream") @Nullable Boolean stream,
 			@JsonProperty("safe_prompt") @Nullable Boolean safePrompt,
 			@JsonProperty("stop") @Nullable List<String> stop,
@@ -671,7 +674,7 @@ public class MistralAiApi {
 		 * @param model ID of the model to use.
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model) {
-			this(model, messages, null, null, 0.7, 1.0, null, false, false, null, null, null);
+			this(model, messages, null, null, 0.7, 1.0, null, null, null, null, false, false, null, null, null);
 		}
 
 		/**
@@ -686,7 +689,8 @@ public class MistralAiApi {
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Double temperature,
 				boolean stream) {
-			this(model, messages, null, null, temperature, 1.0, null, stream, false, null, null, null);
+			this(model, messages, null, null, temperature, 1.0, null, null, null, null, stream, false, null, null,
+					null);
 		}
 
 		/**
@@ -699,7 +703,7 @@ public class MistralAiApi {
 		 *
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, Double temperature) {
-			this(model, messages, null, null, temperature, 1.0, null, false, false, null, null, null);
+			this(model, messages, null, null, temperature, 1.0, null, null, null, null, false, false, null, null, null);
 		}
 
 		/**
@@ -714,7 +718,7 @@ public class MistralAiApi {
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, String model, List<FunctionTool> tools,
 				ToolChoice toolChoice) {
-			this(model, messages, tools, toolChoice, null, 1.0, null, false, false, null, null, null);
+			this(model, messages, tools, toolChoice, null, 1.0, null, null, null, null, false, false, null, null, null);
 		}
 
 		/**
@@ -722,7 +726,7 @@ public class MistralAiApi {
 		 * stream.
 		 */
 		public ChatCompletionRequest(List<ChatCompletionMessage> messages, Boolean stream) {
-			this(null, messages, null, null, 0.7, 1.0, null, stream, false, null, null, null);
+			this(null, messages, null, null, 0.7, 1.0, null, null, null, null, stream, false, null, null, null);
 		}
 
 		/**

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatCompletionRequestTests.java
@@ -74,18 +74,47 @@ class MistralAiChatCompletionRequestTests {
 		assertThat(request.temperature()).isEqualTo(0.7);
 		assertThat(request.safePrompt()).isFalse();
 		assertThat(request.maxTokens()).isNull();
+		assertThat(request.n()).isNull();
+		assertThat(request.frequencyPenalty()).isNull();
+		assertThat(request.presencePenalty()).isNull();
 		assertThat(request.stream()).isFalse();
 	}
 
 	@Test
 	void chatCompletionRequestWithOptionsTest() {
-		var options = MistralAiChatOptions.builder().temperature(0.5).topP(0.8).build();
+		var options = MistralAiChatOptions.builder()
+			.model(MistralAiApi.ChatModel.MISTRAL_SMALL.getValue())
+			.temperature(0.5)
+			.topP(0.8)
+			.maxTokens(100)
+			.safePrompt(true)
+			.randomSeed(5)
+			.stop(List.of("stop1", "stop2"))
+			.frequencyPenalty(0.5)
+			.presencePenalty(0.3)
+			.n(2)
+			.tools(List.of(new MistralAiApi.FunctionTool()))
+			.toolChoice(MistralAiApi.ChatCompletionRequest.ToolChoice.AUTO)
+			.build();
+
 		var prompt = this.chatModel.buildRequestPrompt(new Prompt("test content", options));
 		var request = this.chatModel.createRequest(prompt, true);
 
 		assertThat(request.messages()).hasSize(1);
-		assertThat(request.topP()).isEqualTo(0.8);
+		assertThat(request.model()).isEqualTo(MistralAiApi.ChatModel.MISTRAL_SMALL.getValue());
 		assertThat(request.temperature()).isEqualTo(0.5);
+		assertThat(request.topP()).isEqualTo(0.8);
+		assertThat(request.maxTokens()).isEqualTo(100);
+		assertThat(request.safePrompt()).isTrue();
+		assertThat(request.randomSeed()).isEqualTo(5);
+		assertThat(request.stop()).containsExactly("stop1", "stop2");
+		assertThat(request.frequencyPenalty()).isEqualTo(0.5);
+		assertThat(request.presencePenalty()).isEqualTo(0.3);
+		assertThat(request.n()).isEqualTo(2);
+		assertThat(request.tools()).isNotEmpty()
+			.extracting(MistralAiApi.FunctionTool::getType)
+			.containsExactly(MistralAiApi.FunctionTool.Type.FUNCTION);
+		assertThat(request.toolChoice()).isEqualTo(MistralAiApi.ChatCompletionRequest.ToolChoice.AUTO);
 		assertThat(request.stream()).isTrue();
 	}
 


### PR DESCRIPTION
The [`ChatCompletionRequest`](https://github.com/spring-projects/spring-ai/blob/6ab332528f38f01b9fd63b4bd5e497c830b0d597/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java#L650) record does not cover all the options you can configure via [`MistralAiChatOptions`](https://github.com/spring-projects/spring-ai/blob/6ab332528f38f01b9fd63b4bd5e497c830b0d597/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatOptions.java#L54).

Missing options from request:
* frequency_penalty
* presence_penalty
* n

Fixes #5474