### PR TITLE
docs: document MCP Spring transport migration to Spring AI 2.0

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
@@ -148,6 +148,114 @@ Key features include:
 * *Automatic Discovery*: Annotation scanning with configurable package inclusion/exclusion
 * *Spring Boot Integration*: Seamless integration with MCP Boot Starters
 
+== Upgrading to Spring AI 2.0
+
+Starting with **Spring AI 2.0**, the Spring-specific MCP transport implementations (`mcp-spring-webflux` and `mcp-spring-webmvc`) are no longer shipped by the MCP Java SDK. They have been moved into the Spring AI project itself. This is a breaking change that requires dependency and import updates for applications that directly reference these transport artifacts or classes.
+
+=== Maven Dependency Group ID Change
+
+The `mcp-spring-webflux` and `mcp-spring-webmvc` artifacts have moved from the `io.modelcontextprotocol.sdk` group to `org.springframework.ai`.
+
+.Before (MCP Java SDK < 1.0.x and Spring AI < 2.0.x)
+[source,xml]
+----
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp-spring-webflux</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp-spring-webmvc</artifactId>
+</dependency>
+----
+
+.After (MCP Java SDK >= 1.0.x and Spring AI >= 2.0.x)
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>mcp-spring-webflux</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>mcp-spring-webmvc</artifactId>
+</dependency>
+----
+
+NOTE: When using the `spring-ai-bom` or the Spring AI starter dependencies (`spring-ai-starter-mcp-server-webflux`, `spring-ai-starter-mcp-server-webmvc`, `spring-ai-starter-mcp-client-webflux`) **no explicit version is needed** — the BOM manages it automatically.
+
+=== Java Package Relocation
+
+All transport classes have been relocated to `org.springframework.ai` packages.
+
+.Server transport classes
+|===
+|Class |Old package (MCP SDK) |New package (Spring AI)
+
+|`WebFluxSseServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webflux.transport`
+
+|`WebFluxStreamableServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webflux.transport`
+
+|`WebFluxStatelessServerTransport`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webflux.transport`
+
+|`WebMvcSseServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webmvc.transport`
+
+|`WebMvcStreamableServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webmvc.transport`
+
+|`WebMvcStatelessServerTransport`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webmvc.transport`
+|===
+
+.Client transport classes
+|===
+|Class |Old package (MCP SDK) |New package (Spring AI)
+
+|`WebFluxSseClientTransport`
+|`io.modelcontextprotocol.client.transport`
+|`org.springframework.ai.mcp.client.webflux.transport`
+
+|`WebClientStreamableHttpTransport`
+|`io.modelcontextprotocol.client.transport`
+|`org.springframework.ai.mcp.client.webflux.transport`
+|===
+
+.Example import update
+[source,java]
+----
+// Before
+import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
+import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
+
+// After
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+----
+
+=== MCP SDK Version Requirement
+
+Spring AI 2.0 requires **MCP Java SDK 1.0.0** (RC1 or later). The SDK version has been bumped from `0.18.x` to the `1.0.x` release line. Update your BOM or explicit version accordingly.
+
+=== Spring Boot Auto-configuration Users
+
+If you rely **exclusively on Spring Boot auto-configuration** via the Spring AI starters, you do **not** need to change any Java code. The auto-configurations have already been updated internally to reference the new packages. Only update your `pom.xml`/`build.gradle` dependency coordinates as described above.
+
 == Additional Resources
 
 * xref:api/mcp/mcp-annotations-overview.adoc[MCP Annotations Documentation]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
@@ -39,7 +39,7 @@ Full MCP Server feature support with `SSE` (Server-Sent Events) server transport
 * HTTP-based transport using Spring MVC (`WebMvcSseServerTransportProvider`)
 * Automatically configured SSE endpoints
 * Optional `STDIO` transport (enabled by setting `spring.ai.mcp.server.stdio=true`)
-* Includes `spring-boot-starter-web` and `mcp-spring-webmvc` dependencies
+* Includes `spring-boot-starter-web` and `org.springframework.ai:mcp-spring-webmvc` dependencies
 
 === SSE WebFlux Server
 
@@ -58,7 +58,7 @@ The starter activates the `McpWebFluxServerAutoConfiguration` and `McpServerAuto
 * Reactive transport using Spring WebFlux (`WebFluxSseServerTransportProvider`)
 * Automatically configured reactive SSE endpoints
 * Optional `STDIO` transport (enabled by setting `spring.ai.mcp.server.stdio=true`)
-* Includes `spring-boot-starter-webflux` and `mcp-spring-webflux` dependencies
+* Includes `spring-boot-starter-webflux` and `org.springframework.ai:mcp-spring-webflux` dependencies
 
 [NOTE]
 ====

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -4,23 +4,23 @@
 [[upgrading-to-2-0-0-M3]]
 == Upgrading to 2.0.0-M3
 
-==== Conversation History Removed from ToolContext
+=== Conversation History Removed from ToolContext
 
 Conversation history is no longer automatically added to `ToolContext`. The `TOOL_CALL_HISTORY` constant and `getToolCallHistory()` method have been removed from the `ToolContext` class.
 
-===== Impact
+==== Impact
 
 * `ToolContext.TOOL_CALL_HISTORY` constant no longer exists
 * `ToolContext.getToolCallHistory()` method no longer exists
 * Conversation history is no longer automatically populated in `ToolContext`
 
-===== Why This Change?
+==== Why This Change?
 
 1. **Memory Efficiency**: Prevents unbounded memory growth in long conversations
 2. **Separation of Concerns**: Tools should operate on their parameters, not manage conversation state
 3. **Architecture Alignment**: Conversation context belongs at the advisor level, not in tool execution
 
-===== Migration
+==== Migration
 
 If your application needs conversation history management, use `ToolCallAdvisor`:
 
@@ -94,6 +94,117 @@ Flux<ChatResponse> responseFlux = model.internalStream(prompt, previousChatRespo
 ChatResponse response = model.call(prompt);
 Flux<ChatResponse> responseFlux = model.stream(prompt);
 ----
+
+=== MCP Spring Transport Modules Moved to Spring AI
+
+The `mcp-spring-webflux` and `mcp-spring-webmvc` transport modules are no longer shipped by the MCP Java SDK. Starting with Spring AI 2.0, they are part of the Spring AI project itself.
+
+==== Impact
+
+* The Maven group ID for both artifacts has changed.
+* Java package names for all Spring-specific transport classes have changed.
+* The MCP Java SDK version requirement has been bumped from `0.18.x` to `1.0.x`.
+
+==== Maven Dependency Group ID Change
+
+.Before
+[source,xml]
+----
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp-spring-webflux</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>io.modelcontextprotocol.sdk</groupId>
+    <artifactId>mcp-spring-webmvc</artifactId>
+</dependency>
+----
+
+.After
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>mcp-spring-webflux</artifactId>
+</dependency>
+
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>mcp-spring-webmvc</artifactId>
+</dependency>
+----
+
+NOTE: When using the `spring-ai-bom` or a Spring AI MCP starter (`spring-ai-starter-mcp-server-webflux`, `spring-ai-starter-mcp-server-webmvc`, `spring-ai-starter-mcp-client-webflux`), **no explicit version is needed** — the BOM manages it automatically.
+
+==== Java Package Relocation
+
+All Spring-specific transport classes have moved to `org.springframework.ai` packages.
+
+.Server transports
+|===
+|Class |Old package |New package
+
+|`WebFluxSseServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webflux.transport`
+
+|`WebFluxStreamableServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webflux.transport`
+
+|`WebFluxStatelessServerTransport`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webflux.transport`
+
+|`WebMvcSseServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webmvc.transport`
+
+|`WebMvcStreamableServerTransportProvider`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webmvc.transport`
+
+|`WebMvcStatelessServerTransport`
+|`io.modelcontextprotocol.server.transport`
+|`org.springframework.ai.mcp.server.webmvc.transport`
+|===
+
+.Client transports
+|===
+|Class |Old package |New package
+
+|`WebFluxSseClientTransport`
+|`io.modelcontextprotocol.client.transport`
+|`org.springframework.ai.mcp.client.webflux.transport`
+
+|`WebClientStreamableHttpTransport`
+|`io.modelcontextprotocol.client.transport`
+|`org.springframework.ai.mcp.client.webflux.transport`
+|===
+
+==== Migration
+
+Update your Java imports:
+
+[source,java]
+----
+// Before
+import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
+import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
+
+// After
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcSseServerTransportProvider;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
+----
+
+NOTE: If you rely exclusively on Spring Boot auto-configuration via the Spring AI starters, **no Java code changes are required**. Only update your `pom.xml`/`build.gradle` dependency coordinates as described above.
+
+For the full MCP transport migration reference, see xref:api/mcp/mcp-overview.adoc#_upgrading_to_spring_ai_2_0[Upgrading to Spring AI 2.0].
 
 [[upgrading-to-2-0-0-M2]]
 == Upgrading to 2.0.0-M2


### PR DESCRIPTION
mcp-spring-webflux and mcp-spring-webmvc moved from io.modelcontextprotocol.sdk to org.springframework.ai (Spring AI 2.0 / MCP SDK 1.0.x).

- upgrade-notes.adoc: add MCP breaking changes under "Upgrading to 2.0.0-M3"
- mcp-overview.adoc: add "Upgrading to Spring AI 2.0" migration section
- mcp-stdio-sse-server-boot-starter-docs.adoc: qualify transitive transport artifact references with new org.springframework.ai group ID