### PR TITLE
Fix MCP integration tests port assignment issue

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxSseIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxSseIntegrationTests.java
@@ -28,7 +28,6 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.SingleSessionSyncSpecification;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
-import io.modelcontextprotocol.server.TestUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
@@ -46,8 +45,6 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 
 @Timeout(15)
 class WebFluxSseIntegrationTests extends AbstractMcpClientServerIntegrationTests {
-
-	private static final int PORT = TestUtil.findAvailablePort();
 
 	private static final String CUSTOM_SSE_ENDPOINT = "/somePath/sse";
 
@@ -69,13 +66,13 @@ class WebFluxSseIntegrationTests extends AbstractMcpClientServerIntegrationTests
 
 		clientBuilders
 			.put("httpclient",
-					McpClient.sync(HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+					McpClient.sync(HttpClientSseClientTransport.builder("http://localhost:" + port)
 						.sseEndpoint(CUSTOM_SSE_ENDPOINT)
 						.build()).requestTimeout(Duration.ofHours(10)));
 
 		clientBuilders.put("webflux",
 				McpClient
-					.sync(WebFluxSseClientTransport.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+					.sync(WebFluxSseClientTransport.builder(WebClient.builder().baseUrl("http://localhost:" + port))
 						.sseEndpoint(CUSTOM_SSE_ENDPOINT)
 						.build())
 					.requestTimeout(Duration.ofHours(10)));
@@ -103,9 +100,9 @@ class WebFluxSseIntegrationTests extends AbstractMcpClientServerIntegrationTests
 
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(this.mcpServerTransportProvider.getRouterFunction());
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
 
-		prepareClients(PORT, null);
+		prepareClients(this.httpServer.port(), null);
 	}
 
 	@AfterEach

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStatelessIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStatelessIntegrationTests.java
@@ -25,7 +25,6 @@ import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTranspor
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification;
-import io.modelcontextprotocol.server.TestUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
@@ -43,8 +42,6 @@ import org.springframework.web.reactive.function.server.RouterFunctions;
 @Timeout(15)
 class WebFluxStatelessIntegrationTests extends AbstractStatelessIntegrationTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String CUSTOM_MESSAGE_ENDPOINT = "/otherPath/mcp/message";
 
 	private DisposableServer httpServer;
@@ -59,12 +56,12 @@ class WebFluxStatelessIntegrationTests extends AbstractStatelessIntegrationTests
 	protected void prepareClients(int port, String mcpEndpoint) {
 		clientBuilders
 			.put("httpclient",
-					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + port)
 						.endpoint(CUSTOM_MESSAGE_ENDPOINT)
 						.build()).initializationTimeout(Duration.ofHours(10)).requestTimeout(Duration.ofHours(10)));
 		clientBuilders
 			.put("webflux", McpClient
-				.sync(WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+				.sync(WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl("http://localhost:" + port))
 					.endpoint(CUSTOM_MESSAGE_ENDPOINT)
 					.build())
 				.initializationTimeout(Duration.ofHours(10))
@@ -89,9 +86,9 @@ class WebFluxStatelessIntegrationTests extends AbstractStatelessIntegrationTests
 
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(this.mcpStreamableServerTransport.getRouterFunction());
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
 
-		prepareClients(PORT, null);
+		prepareClients(this.httpServer.port(), null);
 	}
 
 	@AfterEach

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIntegrationTests.java
@@ -27,7 +27,6 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.ProtocolVersions;
 import org.junit.jupiter.api.AfterEach;
@@ -51,9 +50,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class WebFluxStreamableHttpVersionNegotiationIntegrationTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private DisposableServer httpServer;
+
+	private int port;
 
 	private final McpTestRequestRecordingExchangeFilterFunction recordingFilterFunction = new McpTestRequestRecordingExchangeFilterFunction();
 
@@ -86,7 +85,8 @@ class WebFluxStreamableHttpVersionNegotiationIntegrationTests {
 
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
 
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
+		this.port = this.httpServer.port();
 	}
 
 	@AfterEach
@@ -102,7 +102,7 @@ class WebFluxStreamableHttpVersionNegotiationIntegrationTests {
 	@Test
 	void usesLatestVersion() {
 		var client = McpClient
-			.sync(WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+			.sync(WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl("http://localhost:" + this.port))
 				.build())
 			.requestTimeout(Duration.ofHours(10))
 			.build();
@@ -131,7 +131,7 @@ class WebFluxStreamableHttpVersionNegotiationIntegrationTests {
 	@Test
 	void usesServerSupportedVersion() {
 		var transport = WebClientStreamableHttpTransport
-			.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+			.builder(WebClient.builder().baseUrl("http://localhost:" + this.port))
 			.supportedProtocolVersions(List.of(ProtocolVersions.MCP_2025_11_25, "2263-03-18"))
 			.build();
 		var client = McpClient.sync(transport).requestTimeout(Duration.ofHours(10)).build();

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableIntegrationTests.java
@@ -28,7 +28,6 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.SyncSpecification;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
-import io.modelcontextprotocol.server.TestUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
@@ -46,8 +45,6 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 
 @Timeout(15)
 class WebFluxStreamableIntegrationTests extends AbstractMcpClientServerIntegrationTests {
-
-	private static final int PORT = TestUtil.findAvailablePort();
 
 	private static final String CUSTOM_MESSAGE_ENDPOINT = "/otherPath/mcp/message";
 
@@ -67,13 +64,13 @@ class WebFluxStreamableIntegrationTests extends AbstractMcpClientServerIntegrati
 
 		clientBuilders
 			.put("httpclient",
-					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + port)
 						.endpoint(CUSTOM_MESSAGE_ENDPOINT)
 						.build()).requestTimeout(Duration.ofHours(10)));
 		clientBuilders.put("webflux",
 				McpClient
 					.sync(WebClientStreamableHttpTransport
-						.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+						.builder(WebClient.builder().baseUrl("http://localhost:" + port))
 						.endpoint(CUSTOM_MESSAGE_ENDPOINT)
 						.build())
 					.requestTimeout(Duration.ofHours(10)));
@@ -100,9 +97,9 @@ class WebFluxStreamableIntegrationTests extends AbstractMcpClientServerIntegrati
 		HttpHandler httpHandler = RouterFunctions
 			.toHttpHandler(this.mcpStreamableServerTransportProvider.getRouterFunction());
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
 
-		prepareClients(PORT, null);
+		prepareClients(this.httpServer.port(), null);
 	}
 
 	@AfterEach

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportErrorHandlingTest.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportErrorHandlingTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import com.sun.net.httpserver.HttpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.HttpHeaders;
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -56,9 +55,7 @@ import static org.mockito.Mockito.verify;
 @Timeout(15)
 public class WebClientStreamableHttpTransportErrorHandlingTest {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
-	private static final String HOST = "http://localhost:" + PORT;
+	private String host;
 
 	private HttpServer server;
 
@@ -85,7 +82,7 @@ public class WebClientStreamableHttpTransportErrorHandlingTest {
 		this.secondRequestLatch = new CountDownLatch(1);
 		this.getRequestLatch = new CountDownLatch(1);
 
-		this.server = HttpServer.create(new InetSocketAddress(PORT), 0);
+		this.server = HttpServer.create(new InetSocketAddress(0), 0);
 
 		// Configure the /mcp endpoint with dynamic response
 		this.server.createContext("/mcp", exchange -> {
@@ -136,8 +133,9 @@ public class WebClientStreamableHttpTransportErrorHandlingTest {
 
 		this.server.setExecutor(null);
 		this.server.start();
+		this.host = "http://localhost:" + this.server.getAddress().getPort();
 
-		this.transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(HOST)).build();
+		this.transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(this.host)).build();
 	}
 
 	@AfterEach
@@ -378,7 +376,7 @@ public class WebClientStreamableHttpTransportErrorHandlingTest {
 		this.serverResponseStatus.set(200);
 		this.currentServerSessionId.set("sse-session-1");
 
-		var transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(HOST))
+		var transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(this.host))
 			.endpoint("/mcp-sse")
 			.openConnectionOnStartup(true) // This will trigger GET request on connect
 			.build();

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/security/WebFluxServerTransportSecurityIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/security/WebFluxServerTransportSecurityIntegrationTests.java
@@ -23,7 +23,6 @@ import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.server.transport.DefaultServerTransportSecurityValidator;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.AfterAll;
@@ -80,9 +79,7 @@ public class WebFluxServerTransportSecurityIntegrationTests {
 
 	@BeforeParameterizedClassInvocation
 	static void createTransportAndStartServer(Transport transport) {
-		var port = TestUtil.findAvailablePort();
-		baseUrl = "http://localhost:" + port;
-		startServer(transport.routerFunction(), port);
+		startServer(transport.routerFunction());
 	}
 
 	@AfterAll
@@ -165,10 +162,11 @@ public class WebFluxServerTransportSecurityIntegrationTests {
 	// Server management
 	// ----------------------------------------------------
 
-	private static void startServer(RouterFunction<?> routerFunction, int port) {
+	private static void startServer(RouterFunction<?> routerFunction) {
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(routerFunction);
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		httpServer = HttpServer.create().port(port).handle(adapter).bindNow();
+		httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
+		baseUrl = "http://localhost:" + httpServer.port();
 	}
 
 	private static void stopServer() {

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpAsyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpAsyncServerTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webflux.transport;
 import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import org.junit.jupiter.api.Timeout;
 import reactor.netty.DisposableServer;
@@ -37,8 +36,6 @@ import org.springframework.web.reactive.function.server.RouterFunctions;
 @Timeout(15) // Giving extra time beyond the client timeout
 class WebFluxSseMcpAsyncServerTests extends AbstractMcpAsyncServerTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
 	private DisposableServer httpServer;
@@ -49,7 +46,7 @@ class WebFluxSseMcpAsyncServerTests extends AbstractMcpAsyncServerTests {
 
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(transportProvider.getRouterFunction());
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
 		return transportProvider;
 	}
 

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpSyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseMcpSyncServerTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webflux.transport;
 import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import org.junit.jupiter.api.Timeout;
 import reactor.netty.DisposableServer;
@@ -36,8 +35,6 @@ import org.springframework.web.reactive.function.server.RouterFunctions;
  */
 @Timeout(15) // Giving extra time beyond the client timeout
 class WebFluxSseMcpSyncServerTests extends AbstractMcpSyncServerTests {
-
-	private static final int PORT = TestUtil.findAvailablePort();
 
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
@@ -60,7 +57,7 @@ class WebFluxSseMcpSyncServerTests extends AbstractMcpSyncServerTests {
 	protected void onStart() {
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(this.transportProvider.getRouterFunction());
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
 	}
 
 	@Override

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpAsyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpAsyncServerTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webflux.transport;
 import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 import org.junit.jupiter.api.Timeout;
 import reactor.netty.DisposableServer;
@@ -39,8 +38,6 @@ import org.springframework.web.reactive.function.server.RouterFunctions;
 @Timeout(15) // Giving extra time beyond the client timeout
 class WebFluxStreamableMcpAsyncServerTests extends AbstractMcpAsyncServerTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
 	private DisposableServer httpServer;
@@ -52,7 +49,7 @@ class WebFluxStreamableMcpAsyncServerTests extends AbstractMcpAsyncServerTests {
 
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(transportProvider.getRouterFunction());
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
 		return transportProvider;
 	}
 

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpSyncServerTests.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableMcpSyncServerTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webflux.transport;
 import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 import org.junit.jupiter.api.Timeout;
 import reactor.netty.DisposableServer;
@@ -39,8 +38,6 @@ import org.springframework.web.reactive.function.server.RouterFunctions;
 @Timeout(15) // Giving extra time beyond the client timeout
 class WebFluxStreamableMcpSyncServerTests extends AbstractMcpSyncServerTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
 	private DisposableServer httpServer;
@@ -52,7 +49,7 @@ class WebFluxStreamableMcpSyncServerTests extends AbstractMcpSyncServerTests {
 
 		HttpHandler httpHandler = RouterFunctions.toHttpHandler(transportProvider.getRouterFunction());
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(httpHandler);
-		this.httpServer = HttpServer.create().port(PORT).handle(adapter).bindNow();
+		this.httpServer = HttpServer.create().port(0).handle(adapter).bindNow();
 		return transportProvider;
 	}
 

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/security/ServerTransportSecurityIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/security/ServerTransportSecurityIntegrationTests.java
@@ -31,7 +31,6 @@ import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.server.transport.DefaultServerTransportSecurityValidator;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.catalina.LifecycleException;
@@ -85,9 +84,7 @@ public class ServerTransportSecurityIntegrationTests {
 
 	@BeforeParameterizedClassInvocation
 	static void createTransportAndStartTomcat(Class<?> configClass) {
-		var port = TestUtil.findAvailablePort();
-		baseUrl = "http://localhost:" + port;
-		startTomcat(configClass, port);
+		startTomcat(configClass);
 	}
 
 	@AfterAll
@@ -172,8 +169,8 @@ public class ServerTransportSecurityIntegrationTests {
 	// Tomcat management
 	// ----------------------------------------------------
 
-	private static void startTomcat(Class<?> componentClass, int port) {
-		tomcatServer = TomcatTestUtil.createTomcatServer("", port, componentClass);
+	private static void startTomcat(Class<?> componentClass) {
+		tomcatServer = TomcatTestUtil.createTomcatServer("", 0, componentClass);
 		try {
 			tomcatServer.tomcat().start();
 			assertThat(tomcatServer.tomcat().getServer().getState()).isEqualTo(LifecycleState.STARTED);
@@ -181,6 +178,7 @@ public class ServerTransportSecurityIntegrationTests {
 		catch (Exception e) {
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
+		baseUrl = "http://localhost:" + tomcatServer.tomcat().getConnector().getLocalPort();
 	}
 
 	private static void stopTomcat() {

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMcpStreamableAsyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMcpStreamableAsyncServerTransportTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server;
 import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
@@ -45,8 +44,6 @@ import org.springframework.web.servlet.function.ServerResponse;
 @Timeout(15) // Giving extra time beyond the client timeout
 class WebMcpStreamableAsyncServerTransportTests extends AbstractMcpAsyncServerTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String MCP_ENDPOINT = "/mcp";
 
 	private DisposableServer httpServer;
@@ -60,7 +57,7 @@ class WebMcpStreamableAsyncServerTransportTests extends AbstractMcpAsyncServerTe
 	private McpStreamableServerTransportProvider createMcpTransportProvider() {
 		// Set up Tomcat first
 		this.tomcat = new Tomcat();
-		this.tomcat.setPort(PORT);
+		this.tomcat.setPort(0);
 
 		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
 		String baseDir = System.getProperty("java.io.tmpdir");

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMcpStreamableSyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMcpStreamableSyncServerTransportTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server;
 import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpStreamableServerTransportProvider;
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
@@ -44,8 +43,6 @@ import org.springframework.web.servlet.function.ServerResponse;
 @Timeout(15) // Giving extra time beyond the client timeout
 class WebMcpStreamableSyncServerTransportTests extends AbstractMcpSyncServerTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String MCP_ENDPOINT = "/mcp";
 
 	private DisposableServer httpServer;
@@ -59,7 +56,7 @@ class WebMcpStreamableSyncServerTransportTests extends AbstractMcpSyncServerTest
 	private McpStreamableServerTransportProvider createMcpTransportProvider() {
 		// Set up Tomcat first
 		this.tomcat = new Tomcat();
-		this.tomcat.setPort(PORT);
+		this.tomcat.setPort(0);
 
 		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
 		String baseDir = System.getProperty("java.io.tmpdir");

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseAsyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseAsyncServerTransportTests.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server;
 
 import io.modelcontextprotocol.server.AbstractMcpAsyncServerTests;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
@@ -39,8 +38,6 @@ class WebMvcSseAsyncServerTransportTests extends AbstractMcpAsyncServerTests {
 
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private Tomcat tomcat;
 
 	private McpServerTransportProvider transportProvider;
@@ -50,7 +47,7 @@ class WebMvcSseAsyncServerTransportTests extends AbstractMcpAsyncServerTests {
 	private McpServerTransportProvider createMcpTransportProvider() {
 		// Set up Tomcat first
 		this.tomcat = new Tomcat();
-		this.tomcat.setPort(PORT);
+		this.tomcat.setPort(0);
 
 		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
 		String baseDir = System.getProperty("java.io.tmpdir");

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseCustomContextPathTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseCustomContextPathTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
@@ -40,8 +39,6 @@ class WebMvcSseCustomContextPathTests {
 
 	private static final String CUSTOM_CONTEXT_PATH = "/app/1";
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
 	private WebMvcSseServerTransportProvider mcpServerTransportProvider;
@@ -53,7 +50,7 @@ class WebMvcSseCustomContextPathTests {
 	@BeforeEach
 	public void before() {
 
-		this.tomcatServer = TomcatTestUtil.createTomcatServer(CUSTOM_CONTEXT_PATH, PORT, TestConfig.class);
+		this.tomcatServer = TomcatTestUtil.createTomcatServer(CUSTOM_CONTEXT_PATH, 0, TestConfig.class);
 
 		try {
 			this.tomcatServer.tomcat().start();
@@ -63,7 +60,8 @@ class WebMvcSseCustomContextPathTests {
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
 
-		var clientTransport = HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+		int port = this.tomcatServer.tomcat().getConnector().getLocalPort();
+		var clientTransport = HttpClientSseClientTransport.builder("http://localhost:" + port)
 			.sseEndpoint(CUSTOM_CONTEXT_PATH + WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
 			.build();
 

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseIntegrationTests.java
@@ -28,7 +28,6 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.SingleSessionSyncSpecification;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
-import io.modelcontextprotocol.server.TestUtil;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.junit.jupiter.api.AfterEach;
@@ -51,8 +50,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Timeout(15)
 class WebMvcSseIntegrationTests extends AbstractMcpClientServerIntegrationTests {
-
-	private static final int PORT = TestUtil.findAvailablePort();
 
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
@@ -82,7 +79,7 @@ class WebMvcSseIntegrationTests extends AbstractMcpClientServerIntegrationTests 
 	@BeforeEach
 	public void before() {
 
-		this.tomcatServer = TomcatTestUtil.createTomcatServer("", PORT, TestConfig.class);
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", 0, TestConfig.class);
 
 		try {
 			this.tomcatServer.tomcat().start();
@@ -92,7 +89,8 @@ class WebMvcSseIntegrationTests extends AbstractMcpClientServerIntegrationTests 
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
 
-		prepareClients(PORT, MESSAGE_ENDPOINT);
+		int port = this.tomcatServer.tomcat().getConnector().getLocalPort();
+		prepareClients(port, MESSAGE_ENDPOINT);
 
 		// Get the transport from Spring context
 		this.mcpServerTransportProvider = this.tomcatServer.appContext()

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseSyncServerTransportTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcSseSyncServerTransportTests.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server;
 
 import io.modelcontextprotocol.server.AbstractMcpSyncServerTests;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.startup.Tomcat;
@@ -38,8 +37,6 @@ class WebMvcSseSyncServerTransportTests extends AbstractMcpSyncServerTests {
 
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private Tomcat tomcat;
 
 	private WebMvcSseServerTransportProvider transportProvider;
@@ -54,7 +51,7 @@ class WebMvcSseSyncServerTransportTests extends AbstractMcpSyncServerTests {
 	private WebMvcSseServerTransportProvider createMcpTransportProvider() {
 		// Set up Tomcat first
 		this.tomcat = new Tomcat();
-		this.tomcat.setPort(PORT);
+		this.tomcat.setPort(0);
 
 		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
 		String baseDir = System.getProperty("java.io.tmpdir");

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStatelessIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStatelessIntegrationTests.java
@@ -25,7 +25,6 @@ import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTranspor
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification;
-import io.modelcontextprotocol.server.TestUtil;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.junit.jupiter.api.AfterEach;
@@ -47,8 +46,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Timeout(15)
 class WebMvcStatelessIntegrationTests extends AbstractStatelessIntegrationTests {
-
-	private static final int PORT = TestUtil.findAvailablePort();
 
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
@@ -89,7 +86,7 @@ class WebMvcStatelessIntegrationTests extends AbstractStatelessIntegrationTests 
 	@BeforeEach
 	public void before() {
 
-		this.tomcatServer = TomcatTestUtil.createTomcatServer("", PORT, TestConfig.class);
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", 0, TestConfig.class);
 
 		try {
 			this.tomcatServer.tomcat().start();
@@ -99,7 +96,8 @@ class WebMvcStatelessIntegrationTests extends AbstractStatelessIntegrationTests 
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
 
-		prepareClients(PORT, MESSAGE_ENDPOINT);
+		int port = this.tomcatServer.tomcat().getConnector().getLocalPort();
+		prepareClients(port, MESSAGE_ENDPOINT);
 
 		// Get the transport from Spring context
 		this.mcpServerTransport = this.tomcatServer.appContext().getBean(WebMvcStatelessServerTransport.class);

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStreamableIntegrationTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/WebMvcStreamableIntegrationTests.java
@@ -28,7 +28,6 @@ import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.AsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.SyncSpecification;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
-import io.modelcontextprotocol.server.TestUtil;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
 import org.junit.jupiter.api.AfterEach;
@@ -52,8 +51,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Timeout(15)
 class WebMvcStreamableIntegrationTests extends AbstractMcpClientServerIntegrationTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
 
 	private WebMvcStreamableServerTransportProvider mcpServerTransportProvider;
@@ -70,7 +67,7 @@ class WebMvcStreamableIntegrationTests extends AbstractMcpClientServerIntegratio
 	@BeforeEach
 	public void before() {
 
-		this.tomcatServer = TomcatTestUtil.createTomcatServer("", PORT, TestConfig.class);
+		this.tomcatServer = TomcatTestUtil.createTomcatServer("", 0, TestConfig.class);
 
 		try {
 			this.tomcatServer.tomcat().start();
@@ -80,15 +77,17 @@ class WebMvcStreamableIntegrationTests extends AbstractMcpClientServerIntegratio
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
 
+		int port = this.tomcatServer.tomcat().getConnector().getLocalPort();
+
 		this.clientBuilders
 			.put("httpclient",
-					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + PORT)
+					McpClient.sync(HttpClientStreamableHttpTransport.builder("http://localhost:" + port)
 						.endpoint(MESSAGE_ENDPOINT)
 						.build()).initializationTimeout(Duration.ofHours(10)).requestTimeout(Duration.ofHours(10)));
 
 		this.clientBuilders.put("webflux",
 				McpClient.sync(WebClientStreamableHttpTransport
-					.builder(WebClient.builder().baseUrl("http://localhost:" + PORT))
+					.builder(WebClient.builder().baseUrl("http://localhost:" + port))
 					.endpoint(MESSAGE_ENDPOINT)
 					.build()));
 

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProviderTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProviderTests.java
@@ -21,7 +21,6 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.server.McpServer;
-import io.modelcontextprotocol.server.TestUtil;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.LifecycleState;
@@ -45,8 +44,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class WebMvcSseServerTransportProviderTests {
 
-	private static final int PORT = TestUtil.findAvailablePort();
-
 	private static final String CUSTOM_CONTEXT_PATH = "";
 
 	private static final String MESSAGE_ENDPOINT = "/mcp/message";
@@ -59,7 +56,7 @@ class WebMvcSseServerTransportProviderTests {
 
 	@BeforeEach
 	public void before() {
-		this.tomcatServer = TomcatTestUtil.createTomcatServer(CUSTOM_CONTEXT_PATH, PORT, TestConfig.class);
+		this.tomcatServer = TomcatTestUtil.createTomcatServer(CUSTOM_CONTEXT_PATH, 0, TestConfig.class);
 
 		try {
 			this.tomcatServer.tomcat().start();
@@ -69,7 +66,8 @@ class WebMvcSseServerTransportProviderTests {
 			throw new RuntimeException("Failed to start Tomcat", e);
 		}
 
-		HttpClientSseClientTransport transport = HttpClientSseClientTransport.builder("http://localhost:" + PORT)
+		int port = this.tomcatServer.tomcat().getConnector().getLocalPort();
+		HttpClientSseClientTransport transport = HttpClientSseClientTransport.builder("http://localhost:" + port)
 			.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
 			.build();
 
@@ -114,7 +112,6 @@ class WebMvcSseServerTransportProviderTests {
 		public WebMvcSseServerTransportProvider webMvcSseServerTransportProvider() {
 
 			return WebMvcSseServerTransportProvider.builder()
-				.baseUrl("http://localhost:" + PORT + "/")
 				.messageEndpoint(MESSAGE_ENDPOINT)
 				.sseEndpoint(WebMvcSseServerTransportProvider.DEFAULT_SSE_ENDPOINT)
 				.jsonMapper(McpJsonDefaults.getMapper())


### PR DESCRIPTION
Use dynamic port binding (port=0) instead of TestUtil.findAvailablePort() to avoid race conditions between port lookup and server binding. 
The actual port is now retrieved after server starts via httpServer.port().
