### PR TITLE
Add Claude 4.6 models and remove deprecated Claude 3.x models

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfigurationIT.java
@@ -61,7 +61,7 @@ public class AnthropicChatAutoConfigurationIT {
 	void callWith8KResponseContext() {
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getValue())
+					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.run(context -> {
 				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);
 				var options = AnthropicChatOptions.builder().maxTokens(8192).build();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
@@ -57,7 +57,7 @@ class FunctionCallWithFunctionBeanIT {
 
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getValue())
+					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.run(context -> {
 
 				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);
@@ -87,7 +87,7 @@ class FunctionCallWithFunctionBeanIT {
 
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getValue())
+					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.run(context -> {
 
 				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
@@ -49,7 +49,7 @@ public class FunctionCallWithPromptFunctionIT {
 	void functionCallTest() {
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getValue())
+					"spring.ai.anthropic.chat.options.model=" + AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.run(context -> {
 
 				AnthropicChatModel chatModel = context.getBean(AnthropicChatModel.class);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfigurationIT.java
@@ -44,7 +44,7 @@ public class BedrockConverseProxyChatAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = BedrockTestUtils.getContextRunner()
 		.withPropertyValues(
-				"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0",
+				"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-haiku-4-5-20251001-v1:0",
 				"spring.ai.bedrock.converse.chat.options.temperature=0.5")
 		.withConfiguration(SpringAiTestAutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class));
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
@@ -55,7 +55,7 @@ class FunctionCallWithFunctionBeanIT {
 
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0")
+					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-haiku-4-5-20251001-v1:0")
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);
@@ -84,7 +84,7 @@ class FunctionCallWithFunctionBeanIT {
 
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0")
+					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-haiku-4-5-20251001-v1:0")
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
@@ -48,7 +48,7 @@ public class FunctionCallWithPromptFunctionIT {
 	void functionCallTest() {
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-3-5-sonnet-20240620-v1:0")
+					"spring.ai.bedrock.converse.chat.options.model=" + "anthropic.claude-haiku-4-5-20251001-v1:0")
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -103,7 +103,7 @@ import org.springframework.util.StringUtils;
  */
 public class AnthropicChatModel implements ChatModel {
 
-	public static final String DEFAULT_MODEL_NAME = AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getValue();
+	public static final String DEFAULT_MODEL_NAME = AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue();
 
 	public static final Integer DEFAULT_MAX_TOKENS = 500;
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -393,6 +393,21 @@ public final class AnthropicApi {
 
 		// @formatter:off
 		/**
+		 * The claude-opus-4-6 model.
+		 */
+		CLAUDE_OPUS_4_6("claude-opus-4-6"),
+
+		/**
+		 * The claude-sonnet-4-6 model.
+		 */
+		CLAUDE_SONNET_4_6("claude-sonnet-4-6"),
+
+		/**
+		 * The claude-haiku-4-5 model.
+		 */
+		CLAUDE_HAIKU_4_5("claude-haiku-4-5"),
+
+		/**
 		 * The claude-sonnet-4-5 model.
 		 */
 		CLAUDE_SONNET_4_5("claude-sonnet-4-5"),
@@ -403,19 +418,9 @@ public final class AnthropicApi {
 		CLAUDE_OPUS_4_5("claude-opus-4-5"),
 
 		/**
-		 * The claude-haiku-4-5 model.
-		 */
-		CLAUDE_HAIKU_4_5("claude-haiku-4-5"),
-
-		/**
 		 * The claude-opus-4-1 model.
 		 */
 		CLAUDE_OPUS_4_1("claude-opus-4-1"),
-
-		/**
-		 * The claude-opus-4-0 model.
-		 */
-		CLAUDE_OPUS_4_0("claude-opus-4-0"),
 
 		/**
 		 * The claude-sonnet-4-0 model.
@@ -423,34 +428,9 @@ public final class AnthropicApi {
 		CLAUDE_SONNET_4_0("claude-sonnet-4-0"),
 
 		/**
-		 * The claude-3-7-sonnet-latest model.
+		 * The claude-opus-4-0 model.
 		 */
-		CLAUDE_3_7_SONNET("claude-3-7-sonnet-latest"),
-
-		/**
-		 * The claude-3-5-sonnet-latest model.(Deprecated on October 28, 2025)
-		 */
-		CLAUDE_3_5_SONNET("claude-3-5-sonnet-latest"),
-
-		/**
-		 * The CLAUDE_3_OPUS
-		 */
-		CLAUDE_3_OPUS("claude-3-opus-latest"),
-
-		/**
-		 * The CLAUDE_3_SONNET (Deprecated. To be removed on July 21, 2025)
-		 */
-		CLAUDE_3_SONNET("claude-3-sonnet-20240229"),
-
-		/**
-		 * The CLAUDE 3.5 HAIKU
-		 */
-		CLAUDE_3_5_HAIKU("claude-3-5-haiku-latest"),
-
-		/**
-		 * The CLAUDE_3_HAIKU
-		 */
-		CLAUDE_3_HAIKU("claude-3-haiku-20240307");
+		CLAUDE_OPUS_4_0("claude-opus-4-0");
 
 		// @formatter:on
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelIT.java
@@ -88,7 +88,7 @@ class AnthropicChatModelIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "claude-3-7-sonnet-latest" })
+	@ValueSource(strings = { "claude-haiku-4-5" })
 	void roleTest(String modelName) {
 		UserMessage userMessage = new UserMessage(
 				"Tell me about 3 famous pirates from the Golden Age of Piracy and why they did.");
@@ -116,7 +116,7 @@ class AnthropicChatModelIT {
 		SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(this.systemResource);
 		Message systemMessage = systemPromptTemplate.createMessage(Map.of("name", "Bob", "voice", "pirate"));
 		Prompt prompt = new Prompt(List.of(userMessage, systemMessage),
-				AnthropicChatOptions.builder().model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET).build());
+				AnthropicChatOptions.builder().model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5).build());
 
 		ChatResponse response = this.chatModel.call(prompt);
 		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard", "Bartholomew");
@@ -269,7 +269,7 @@ class AnthropicChatModelIT {
 			.build();
 
 		var response = this.chatModel.call(new Prompt(List.of(userMessage),
-				ToolCallingChatOptions.builder().model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName()).build()));
+				ToolCallingChatOptions.builder().model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName()).build()));
 
 		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Spring AI", "portable API");
 	}
@@ -283,7 +283,7 @@ class AnthropicChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -315,7 +315,7 @@ class AnthropicChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -345,7 +345,7 @@ class AnthropicChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -366,7 +366,7 @@ class AnthropicChatModelIT {
 
 	@Test
 	void validateCallResponseMetadata() {
-		String model = AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName();
+		String model = AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName();
 		// @formatter:off
 		ChatResponse response = ChatClient.create(this.chatModel).prompt()
 				.options(AnthropicChatOptions.builder().model(model).build())
@@ -381,7 +381,7 @@ class AnthropicChatModelIT {
 
 	@Test
 	void validateStreamCallResponseMetadata() {
-		String model = AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName();
+		String model = AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName();
 		// @formatter:off
 		ChatResponse response = ChatClient.create(this.chatModel).prompt()
 				.options(AnthropicChatOptions.builder().model(model).build())
@@ -393,7 +393,7 @@ class AnthropicChatModelIT {
 
 		logger.info(response.toString());
 		// Note, brittle test.
-		validateChatResponseMetadata(response, "claude-3-5-sonnet-latest");
+		validateChatResponseMetadata(response, "claude-haiku-4-5-latest");
 	}
 
 	@Test
@@ -402,7 +402,7 @@ class AnthropicChatModelIT {
 				"Are there an infinite number of prime numbers such that n mod 4 == 3?");
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.temperature(1.0) // temperature should be set to 1 when thinking is enabled
 			.maxTokens(8192)
 			.thinking(AnthropicApi.ThinkingType.ENABLED, 2048) // Must be ≥1024 && <
@@ -434,7 +434,7 @@ class AnthropicChatModelIT {
 				"Are there an infinite number of prime numbers such that n mod 4 == 3?");
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_6.getName())
 			.temperature(1.0) // Temperature should be set to 1 when thinking is enabled
 			.maxTokens(8192)
 			.thinking(AnthropicApi.ThinkingType.ENABLED, 2048) // Must be ≥1024 && <
@@ -457,7 +457,7 @@ class AnthropicChatModelIT {
 		logger.info("Response: {}", content);
 
 		assertThat(content).isNotBlank();
-		assertThat(content).contains("prime numbers");
+		assertThat(content).contains("primes");
 	}
 
 	@Test
@@ -468,7 +468,7 @@ class AnthropicChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -499,7 +499,7 @@ class AnthropicChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.toolChoice(new AnthropicApi.ToolChoiceAny())
 			.internalToolExecutionEnabled(false)
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
@@ -528,7 +528,7 @@ class AnthropicChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.toolChoice(new AnthropicApi.ToolChoiceTool("getFunResponse", true))
 			.internalToolExecutionEnabled(false)
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
@@ -566,7 +566,7 @@ class AnthropicChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.toolChoice(new AnthropicApi.ToolChoiceNone())
 			.toolCallbacks(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelObservationIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelObservationIT.java
@@ -69,12 +69,11 @@ public class AnthropicChatModelObservationIT {
 	@Test
 	void observationForChatOperation() {
 		var options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_HAIKU.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.maxTokens(2048)
 			.stopSequences(List.of("this-is-the-end"))
 			.temperature(0.7)
 			.topK(1)
-			.topP(1.0)
 			.build();
 
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
@@ -91,12 +90,11 @@ public class AnthropicChatModelObservationIT {
 	@Test
 	void observationForStreamingChatOperation() {
 		var options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_HAIKU.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.maxTokens(2048)
 			.stopSequences(List.of("this-is-the-end"))
 			.temperature(0.7)
 			.topK(1)
-			.topP(1.0)
 			.build();
 
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
@@ -127,12 +125,12 @@ public class AnthropicChatModelObservationIT {
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
-			.hasContextualNameEqualTo("chat " + AnthropicApi.ChatModel.CLAUDE_3_HAIKU.getValue())
+			.hasContextualNameEqualTo("chat " + AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.CHAT.value())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.ANTHROPIC.value())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.REQUEST_MODEL.asString(),
-					AnthropicApi.ChatModel.CLAUDE_3_HAIKU.getValue())
+					AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.RESPONSE_MODEL.asString(), responseMetadata.getModel())
 			.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString())
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString(), "2048")
@@ -141,7 +139,6 @@ public class AnthropicChatModelObservationIT {
 					"[\"this-is-the-end\"]")
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_TEMPERATURE.asString(), "0.7")
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_TOP_K.asString(), "1")
-			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_TOP_P.asString(), "1.0")
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.RESPONSE_ID.asString(), responseMetadata.getId())
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.RESPONSE_FINISH_REASONS.asString(), finishReasons)
 			.hasHighCardinalityKeyValue(HighCardinalityKeyNames.USAGE_INPUT_TOKENS.asString(),

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicCitationIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicCitationIT.java
@@ -68,7 +68,7 @@ class AnthropicCitationIT {
 				"Based solely on the provided document, where is the Eiffel Tower located and when was it completed?");
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.maxTokens(2048)
 			.temperature(0.0) // Use temperature 0 for more deterministic responses
 			.citationDocuments(document)
@@ -128,7 +128,7 @@ class AnthropicCitationIT {
 				"Based solely on the provided documents, what is the capital of France and who designed the Eiffel Tower?");
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.maxTokens(1024)
 			.temperature(0.0) // Use temperature 0 for more deterministic responses
 			.citationDocuments(parisDoc, eiffelDoc)
@@ -190,7 +190,7 @@ class AnthropicCitationIT {
 				"Based solely on the provided document, how long is the Great Wall of China and when was it started?");
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.maxTokens(1024)
 			.temperature(0.0)
 			.citationDocuments(document)
@@ -239,7 +239,7 @@ class AnthropicCitationIT {
 		UserMessage userMessage = new UserMessage("Based solely on the provided document, what is Spring AI?");
 
 		AnthropicChatOptions options = AnthropicChatOptions.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getName())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getName())
 			.maxTokens(1024)
 			.temperature(0.0)
 			.citationDocuments(document)

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicPromptCachingMockTest.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicPromptCachingMockTest.java
@@ -89,7 +89,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "Hello! I understand you want to test caching."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"stop_sequence": null,
 					"usage": {
@@ -161,7 +161,7 @@ class AnthropicPromptCachingMockTest {
 					"type": "message",
 					"role": "assistant",
 					"content": [ { "type": "text", "text": "ok" } ],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": { "input_tokens": 10, "output_tokens": 2 }
 				}
@@ -195,7 +195,7 @@ class AnthropicPromptCachingMockTest {
 					"type": "message",
 					"role": "assistant",
 					"content": [ { "type": "text", "text": "ok" } ],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": { "input_tokens": 10, "output_tokens": 2 }
 				}
@@ -237,7 +237,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "I'll help you with the weather information."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": {
 						"input_tokens": 150,
@@ -313,7 +313,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "Based on our previous conversation, I can help with that."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": {
 						"input_tokens": 200,
@@ -380,7 +380,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "Simple response without caching."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": {
 						"input_tokens": 20,
@@ -430,7 +430,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "Response with 1-hour cache TTL."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": {
 						"input_tokens": 30,
@@ -477,7 +477,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "Response with maximum cache breakpoints."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": {
 						"input_tokens": 500,
@@ -557,7 +557,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "Response for wire format test."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": {
 						"input_tokens": 200,
@@ -627,7 +627,7 @@ class AnthropicPromptCachingMockTest {
 							"text": "Response for complex multi-breakpoint scenario."
 						}
 					],
-					"model": "claude-3-7-sonnet",
+					"model": "claude-haiku-4-5",
 					"stop_reason": "end_turn",
 					"usage": {
 						"input_tokens": 800,

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiBuilderTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiBuilderTests.java
@@ -253,7 +253,7 @@ public class AnthropicApiBuilderTests {
 			AnthropicApi.AnthropicMessage chatCompletionMessage = new AnthropicApi.AnthropicMessage(
 					List.of(new AnthropicApi.ContentBlock("Hello world")), AnthropicApi.Role.USER);
 			AnthropicApi.ChatCompletionRequest request = AnthropicApi.ChatCompletionRequest.builder()
-				.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU)
+				.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5)
 				.maxTokens(500)
 				.temperature(0.8)
 				.messages(List.of(chatCompletionMessage))
@@ -301,7 +301,7 @@ public class AnthropicApiBuilderTests {
 			AnthropicApi.AnthropicMessage chatCompletionMessage = new AnthropicApi.AnthropicMessage(
 					List.of(new AnthropicApi.ContentBlock("Hello world")), AnthropicApi.Role.USER);
 			AnthropicApi.ChatCompletionRequest request = AnthropicApi.ChatCompletionRequest.builder()
-				.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU)
+				.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5)
 				.maxTokens(500)
 				.temperature(0.8)
 				.messages(List.of(chatCompletionMessage))
@@ -351,7 +351,7 @@ public class AnthropicApiBuilderTests {
 			AnthropicApi.AnthropicMessage chatCompletionMessage = new AnthropicApi.AnthropicMessage(
 					List.of(new AnthropicApi.ContentBlock("Hello world")), AnthropicApi.Role.USER);
 			AnthropicApi.ChatCompletionRequest request = AnthropicApi.ChatCompletionRequest.builder()
-				.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU)
+				.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5)
 				.maxTokens(500)
 				.temperature(0.8)
 				.messages(List.of(chatCompletionMessage))
@@ -403,7 +403,7 @@ public class AnthropicApiBuilderTests {
 			AnthropicApi.AnthropicMessage chatCompletionMessage = new AnthropicApi.AnthropicMessage(
 					List.of(new AnthropicApi.ContentBlock("Hello world")), AnthropicApi.Role.USER);
 			AnthropicApi.ChatCompletionRequest request = AnthropicApi.ChatCompletionRequest.builder()
-				.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU)
+				.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5)
 				.maxTokens(500)
 				.temperature(0.8)
 				.messages(List.of(chatCompletionMessage))

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/AnthropicApiIT.java
@@ -85,7 +85,7 @@ public class AnthropicApiIT {
 				Role.USER);
 
 		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(
-				AnthropicApi.ChatModel.CLAUDE_3_HAIKU.getValue(), List.of(chatCompletionMessage), null, 100, 0.8,
+				AnthropicApi.ChatModel.CLAUDE_SONNET_4_6.getValue(), List.of(chatCompletionMessage), null, 100, 0.8,
 				false);
 
 		// First request - creates cache
@@ -112,7 +112,7 @@ public class AnthropicApiIT {
 				Role.USER);
 		ResponseEntity<ChatCompletionResponse> response = this.anthropicApi
 			.chatCompletionEntity(ChatCompletionRequest.builder()
-				.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getValue())
+				.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 				.messages(List.of(chatCompletionMessage))
 				.maxTokens(100)
 				.temperature(0.8)
@@ -134,7 +134,7 @@ public class AnthropicApiIT {
 				Role.USER);
 
 		ChatCompletionRequest request = ChatCompletionRequest.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.messages(List.of(chatCompletionMessage))
 			.maxTokens(8192)
 			.temperature(1.0) // temperature should be set to 1 when thinking is enabled
@@ -179,7 +179,7 @@ public class AnthropicApiIT {
 				Role.USER);
 
 		Flux<ChatCompletionResponse> response = this.anthropicApi.chatCompletionStream(ChatCompletionRequest.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.messages(List.of(chatCompletionMessage))
 			.maxTokens(100)
 			.temperature(0.8)
@@ -221,7 +221,7 @@ public class AnthropicApiIT {
 				Role.USER);
 
 		ChatCompletionRequest request = ChatCompletionRequest.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.messages(List.of(chatCompletionMessage))
 			.maxTokens(2048)
 			.temperature(1.0)
@@ -310,7 +310,7 @@ public class AnthropicApiIT {
 		messageConversation.add(chatCompletionMessage);
 
 		ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU)
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.messages(messageConversation)
 			.maxTokens(1500)
 			.stream(true)
@@ -347,7 +347,7 @@ public class AnthropicApiIT {
 		AnthropicApi api = AnthropicApi.builder().apiKey("FAKE_KEY_FOR_ERROR_RESPONSE").build();
 
 		Flux<ChatCompletionResponse> response = api.chatCompletionStream(ChatCompletionRequest.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU.getValue())
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5.getValue())
 			.messages(List.of(chatCompletionMessage))
 			.maxTokens(100)
 			.temperature(0.8)

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/StreamHelperTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/StreamHelperTests.java
@@ -54,7 +54,7 @@ class StreamHelperTests {
 		// Initialize content block reference with a message start event. This ensures
 		// that message id, model and content are set in the contentBlockReference
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, null, null);
+				"claude-haiku-4-5", null, null, null, null);
 		streamHelper.eventToChatCompletionResponse(new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message),
 				contentBlockReference);
 
@@ -74,7 +74,7 @@ class StreamHelperTests {
 		// Initialize content block reference with a message start event. This ensures
 		// that message id, model and content are set in the contentBlockReference
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, null, null);
+				"claude-haiku-4-5", null, null, null, null);
 		streamHelper.eventToChatCompletionResponse(new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message),
 				contentBlockReference);
 
@@ -99,7 +99,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(10, 20, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 
 		ChatCompletionResponse response = streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
@@ -108,7 +108,7 @@ class StreamHelperTests {
 		assertThat(response.id()).isEqualTo("msg-1");
 		assertThat(response.type()).isEqualTo("MESSAGE_START");
 		assertThat(response.role()).isEqualTo(Role.ASSISTANT);
-		assertThat(response.model()).isEqualTo("claude-3-5-sonnet");
+		assertThat(response.model()).isEqualTo("claude-haiku-4-5");
 		assertThat(response.usage().inputTokens()).isEqualTo(10);
 		assertThat(response.usage().outputTokens()).isEqualTo(20);
 	}
@@ -120,7 +120,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -146,7 +146,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -171,7 +171,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -193,7 +193,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse initialMessage = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT,
-				List.of(), "claude-3-5-sonnet", null, null, usage, null);
+				List.of(), "claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, initialMessage);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -216,7 +216,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -236,7 +236,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -287,7 +287,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -314,7 +314,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -339,7 +339,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -364,7 +364,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -383,7 +383,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -404,7 +404,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -425,7 +425,7 @@ class StreamHelperTests {
 
 		Usage usage = new Usage(0, 0, null, null);
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, usage, null);
+				"claude-haiku-4-5", null, null, usage, null);
 		MessageStartEvent startEvent = new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message);
 		streamHelper.eventToChatCompletionResponse(startEvent, contentBlockReference);
 
@@ -507,7 +507,7 @@ class StreamHelperTests {
 		// Initialize content block reference with a message start event. This ensures
 		// that message id, model and content are set in the contentBlockReference
 		ChatCompletionResponse message = new ChatCompletionResponse("msg-1", "message", Role.ASSISTANT, List.of(),
-				"claude-3-5-sonnet", null, null, null, null);
+				"claude-haiku-4-5", null, null, null, null);
 		streamHelper.eventToChatCompletionResponse(new MessageStartEvent(AnthropicApi.EventType.MESSAGE_START, message),
 				contentBlockReference);
 

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/tool/AnthropicApiToolIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/tool/AnthropicApiToolIT.java
@@ -102,7 +102,7 @@ public class AnthropicApiToolIT {
 	private ResponseEntity<ChatCompletionResponse> doCall(List<AnthropicMessage> messageConversation) {
 
 		ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest.builder()
-			.model(AnthropicApi.ChatModel.CLAUDE_3_5_HAIKU)
+			.model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5)
 			.messages(messageConversation)
 			.maxTokens(1500)
 			.temperature(0.8)

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientIT.java
@@ -306,7 +306,7 @@ class AnthropicChatClientIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "claude-3-7-sonnet-latest", "claude-sonnet-4-0" })
+	@ValueSource(strings = { "claude-haiku-4-5", "claude-sonnet-4-0" })
 	void multiModalityEmbeddedImage(String modelName) throws IOException {
 
 		// @formatter:off
@@ -323,7 +323,7 @@ class AnthropicChatClientIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "claude-3-7-sonnet-latest", "claude-sonnet-4-0" })
+	@ValueSource(strings = { "claude-haiku-4-5", "claude-sonnet-4-0" })
 	void multiModalityImageUrl(String modelName) throws IOException {
 
 		// TODO: add url method that wraps the checked exception.
@@ -347,7 +347,7 @@ class AnthropicChatClientIT {
 
 		// @formatter:off
 		Flux<String> response = ChatClient.create(this.chatModel).prompt()
-				.options(AnthropicChatOptions.builder().model(AnthropicApi.ChatModel.CLAUDE_3_7_SONNET)
+				.options(AnthropicChatOptions.builder().model(AnthropicApi.ChatModel.CLAUDE_HAIKU_4_5)
 						.build())
 				.user(u -> u.text("Explain what do you see on this picture?")
 						.media(MimeTypeUtils.IMAGE_PNG, new ClassPathResource("/test.png")))
@@ -362,7 +362,7 @@ class AnthropicChatClientIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "claude-3-7-sonnet-latest", "claude-sonnet-4-0" })
+	@ValueSource(strings = { "claude-haiku-4-5", "claude-sonnet-4-0" })
 	void streamToolCallingResponseShouldNotContainToolCallMessages(String modelName) {
 
 		ChatClient chatClient = ChatClient.builder(this.chatModel).build();

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/client/AnthropicChatClientMethodInvokingFunctionCallbackIT.java
@@ -270,7 +270,7 @@ class AnthropicChatClientMethodInvokingFunctionCallbackIT {
 
 	// https://github.com/spring-projects/spring-ai/issues/1878
 	@ParameterizedTest
-	@ValueSource(strings = { "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-3-7-sonnet-latest" })
+	@ValueSource(strings = { "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5" })
 	void streamingParameterLessTool(String modelName) {
 
 		ChatClient chatClient = ChatClient.builder(this.chatModel).build();

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseChatClientIT.java
@@ -363,7 +363,7 @@ class BedrockConverseChatClientIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "us.anthropic.claude-3-5-sonnet-20240620-v1:0" })
+	@ValueSource(strings = { "us.anthropic.claude-haiku-4-5-20251001-v1:0" })
 	void multiModalityEmbeddedImage(String modelName) throws IOException {
 
 		// @formatter:off
@@ -380,7 +380,7 @@ class BedrockConverseChatClientIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "us.anthropic.claude-3-5-sonnet-20240620-v1:0" })
+	@ValueSource(strings = { "us.anthropic.claude-haiku-4-5-20251001-v1:0" })
 	void multiModalityImageUrl2(String modelName) throws IOException {
 
 		// TODO: add url method that wraps the checked exception.
@@ -400,7 +400,7 @@ class BedrockConverseChatClientIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "us.anthropic.claude-3-5-sonnet-20240620-v1:0" })
+	@ValueSource(strings = { "us.anthropic.claude-haiku-4-5-20251001-v1:0" })
 	void multiModalityImageUrl(String modelName) throws IOException {
 
 		// TODO: add url method that wraps the checked exception.

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseTestConfiguration.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockConverseTestConfiguration.java
@@ -30,11 +30,7 @@ public class BedrockConverseTestConfiguration {
 	@Bean
 	public BedrockProxyChatModel bedrockConverseChatModel() {
 
-		// String modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0";
-		// String modelId = "anthropic.claude-3-5-sonnet-20241022-v2:0";
-		// String modelId = "meta.llama3-8b-instruct-v1:0";
-		// String modelId = "ai21.jamba-1-5-large-v1:0";
-		String modelId = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
+		String modelId = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 		return BedrockProxyChatModel.builder()
 			.credentialsProvider(EnvironmentVariableCredentialsProvider.create())

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelIT.java
@@ -86,8 +86,8 @@ class BedrockProxyChatModelIT {
 	}
 
 	@ParameterizedTest(name = "{0} : {displayName} ")
-	@ValueSource(strings = { "us.anthropic.claude-3-haiku-20240307-v1:0", "anthropic.claude-3-sonnet-20240229-v1:0",
-			"us.anthropic.claude-3-5-sonnet-20240620-v1:0" })
+	@ValueSource(strings = { "us.anthropic.claude-haiku-4-5-20251001-v1:0", "us.anthropic.claude-sonnet-4-6",
+			"us.anthropic.claude-opus-4-6-v1" })
 	void roleTest(String modelName) {
 		UserMessage userMessage = new UserMessage(
 				"Tell me about 3 famous pirates from the Golden Age of Piracy and why they did.");
@@ -318,7 +318,7 @@ class BedrockProxyChatModelIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = BedrockChatOptions.builder()
-			.model("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+			.model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -352,7 +352,7 @@ class BedrockProxyChatModelIT {
 
 		var promptOptions = BedrockChatOptions.builder()
 			.maxTokens(maxTokens)
-			.model("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+			.model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description(
 						"Get the weather in location. Return temperature in 36°F or 36°C format. Use multi-turn if needed.")
@@ -370,7 +370,7 @@ class BedrockProxyChatModelIT {
 
 	@Test
 	void validateCallResponseMetadata() {
-		String model = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 		// @formatter:off
 		ChatResponse response = ChatClient.create(this.chatModel).prompt()
 				.options(BedrockChatOptions.builder().model(model).build())
@@ -385,7 +385,7 @@ class BedrockProxyChatModelIT {
 
 	@Test
 	void validateStreamCallResponseMetadata() {
-		String model = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 		// @formatter:off
 		ChatResponse response = ChatClient.create(this.chatModel).prompt()
 				.options(BedrockChatOptions.builder().model(model).build())
@@ -412,13 +412,13 @@ class BedrockProxyChatModelIT {
 		// If you get ValidationException about "on-demand throughput isn't supported",
 		// you need to:
 		// 1. Use an inference profile ARN/ID (e.g.,
-		// "us.anthropic.claude-3-5-haiku-20241022-v1:0")
+		// "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 		// 2. Ensure your AWS account/region has cross-region inference profiles enabled
 		// 3. Or use Amazon Nova models which work with direct model IDs
 		//
 		// Amazon Nova models work without inference profiles and are used in this test
 		// for reliability.
-		String model = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 		// Create a large system prompt (needs to exceed minimum token threshold for
 		// caching)
@@ -507,7 +507,7 @@ class BedrockProxyChatModelIT {
 		// 3.7 Sonnet)
 		// Amazon Nova models do NOT support tool caching and will return
 		// ValidationException
-		String model = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 		// Create multiple tool callbacks to exceed the 1K token minimum for caching
 		// Each tool definition adds ~200-300 tokens, so we need 4-5 tools
@@ -569,7 +569,7 @@ class BedrockProxyChatModelIT {
 		// 3.7 Sonnet)
 		// Amazon Nova models do NOT support tool caching and will return
 		// ValidationException
-		String model = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 		// Create large system prompt (1K+ tokens)
 		String basePrompt = """
@@ -662,7 +662,7 @@ class BedrockProxyChatModelIT {
 		// NOTE: Conversation history caching is verified to work with Claude models
 		// Amazon Nova models theoretically support this but haven't been verified in
 		// tests
-		String model = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
+		String model = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 		// Create a large system prompt to contribute to total token count
 		// Need 1024+ tokens total for caching to activate

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelObservationIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelObservationIT.java
@@ -67,7 +67,7 @@ public class BedrockProxyChatModelObservationIT {
 	@Test
 	void observationForChatOperation() {
 		var options = BedrockChatOptions.builder()
-			.model("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+			.model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.maxTokens(2048)
 			.stopSequences(List.of("this-is-the-end"))
 			.temperature(0.7)
@@ -89,7 +89,7 @@ public class BedrockProxyChatModelObservationIT {
 	@Test
 	void observationForStreamingChatOperation() {
 		var options = BedrockChatOptions.builder()
-			.model("us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+			.model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.maxTokens(2048)
 			.stopSequences(List.of("this-is-the-end"))
 			.temperature(0.7)
@@ -124,13 +124,13 @@ public class BedrockProxyChatModelObservationIT {
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
-			.hasContextualNameEqualTo("chat " + "us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+			.hasContextualNameEqualTo("chat " + "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.CHAT.value())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(),
 					AiProvider.BEDROCK_CONVERSE.value())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.REQUEST_MODEL.asString(),
-					"us.anthropic.claude-3-5-sonnet-20240620-v1:0")
+					"us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			// .hasLowCardinalityKeyValue(LowCardinalityKeyNames.RESPONSE_MODEL.asString(),
 			// responseMetadata.getModel())
 			.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString())
@@ -166,7 +166,7 @@ public class BedrockProxyChatModelObservationIT {
 		@Bean
 		public BedrockProxyChatModel bedrockConverseChatModel(ObservationRegistry observationRegistry) {
 
-			String modelId = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
+			String modelId = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 			return BedrockProxyChatModel.builder()
 				.credentialsProvider(EnvironmentVariableCredentialsProvider.create())

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaChatClientIT.java
@@ -191,7 +191,7 @@ public class BedrockNovaChatClientIT {
 
 	// https://github.com/spring-projects/spring-ai/issues/1878
 	@ParameterizedTest
-	@ValueSource(strings = { "us.amazon.nova-pro-v1:0", "us.anthropic.claude-3-7-sonnet-20250219-v1:0" })
+	@ValueSource(strings = { "us.amazon.nova-pro-v1:0", "us.anthropic.claude-haiku-4-5-20251001-v1:0" })
 	void toolAnnotationWeatherForecastStreaming(String modelName) {
 
 		ChatClient chatClient = ChatClient.builder(this.chatModel).build();
@@ -263,7 +263,6 @@ public class BedrockNovaChatClientIT {
 		public BedrockProxyChatModel bedrockConverseChatModel() {
 
 			String modelId = "us.amazon.nova-pro-v1:0";
-			// String modelId = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
 
 			return BedrockProxyChatModel.builder()
 				.credentialsProvider(EnvironmentVariableCredentialsProvider.create())

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaToolCallAdvisorIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/client/BedrockNovaToolCallAdvisorIT.java
@@ -44,7 +44,6 @@ class BedrockNovaToolCallAdvisorIT extends AbstractToolCallAdvisorIT {
 	@Override
 	protected ChatModel getChatModel() {
 		String modelId = "us.amazon.nova-pro-v1:0";
-		// String modelId = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
 
 		return BedrockProxyChatModel.builder()
 			.credentialsProvider(EnvironmentVariableCredentialsProvider.create())

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/experiments/BedrockConverseChatModelMain.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/experiments/BedrockConverseChatModelMain.java
@@ -38,7 +38,6 @@ public final class BedrockConverseChatModelMain {
 
 	public static void main(String[] args) {
 
-		// String modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0";
 		String modelId = "ai21.jamba-1-5-large-v1:0";
 		var prompt = new Prompt("Tell me a joke?", ChatOptions.builder().model(modelId).build());
 

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/experiments/BedrockConverseChatModelMain3.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/experiments/BedrockConverseChatModelMain3.java
@@ -38,9 +38,7 @@ public final class BedrockConverseChatModelMain3 {
 
 	public static void main(String[] args) {
 
-		// String modelId = "anthropic.claude-3-5-sonnet-20240620-v1:0";
-		// String modelId = "ai21.jamba-1-5-large-v1:0";
-		String modelId = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
+		String modelId = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
 
 		// var prompt = new Prompt("Tell me a joke?",
 		// ChatOptions.builder().model(modelId).build();

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiStreamingFinishReasonTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiStreamingFinishReasonTests.java
@@ -118,7 +118,7 @@ public class OpenAiStreamingFinishReasonTests {
 					"id": "chatcmpl-msg_bdrk_012bpm3yfa9inEuftTWYQ46F",
 					"object": "chat.completion.chunk",
 					"created": 1726239401,
-					"model": "claude-3-5-sonnet-20240620",
+					"model": "claude-haiku-4-5",
 					"choices": [{
 						"index": 0,
 						"delta": {
@@ -189,8 +189,7 @@ public class OpenAiStreamingFinishReasonTests {
 			// deserialized
 			var choice = new ChunkChoice(null, 0, new ChatCompletionMessage("", Role.ASSISTANT), null);
 			ChatCompletionChunk chunk = new ChatCompletionChunk("chatcmpl-msg_bdrk_012bpm3yfa9inEuftTWYQ46F",
-					List.of(choice), 1726239401L, "claude-3-5-sonnet-20240620", null, null, "chat.completion.chunk",
-					null);
+					List.of(choice), 1726239401L, "claude-haiku-4-5", null, null, "chat.completion.chunk", null);
 
 			given(this.openAiApi.chatCompletionStream(isA(ChatCompletionRequest.class), any()))
 				.willReturn(Flux.just(chunk));
@@ -221,7 +220,7 @@ public class OpenAiStreamingFinishReasonTests {
 					"id": "chatcmpl-msg_bdrk_012bpm3yfa9inEuftTWYQ46F",
 					"object": "chat.completion.chunk",
 					"created": 1726239401,
-					"model": "claude-3-5-sonnet-20240620",
+					"model": "claude-haiku-4-5",
 					"choices": [{
 						"index": 0,
 						"delta": {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -149,7 +149,7 @@ The prefix `spring.ai.anthropic.chat` is the property prefix that lets you confi
 
 | spring.ai.anthropic.chat.enabled (Removed and no longer valid) | Enable Anthropic chat model.  | true
 | spring.ai.model.chat | Enable Anthropic chat model.  | anthropic
-| spring.ai.anthropic.chat.options.model | This is the Anthropic Chat model to use. Supports: `claude-sonnet-4-5`, `claude-opus-4-5`, `claude-haiku-4-5`, `claude-opus-4-1`, `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-7-sonnet-latest`, `claude-3-5-sonnet-latest`, `claude-3-5-haiku-latest`, `claude-3-opus-latest`, `claude-3-haiku-20240307` | `claude-sonnet-4-5`
+| spring.ai.anthropic.chat.options.model | This is the Anthropic Chat model to use. Supports: `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-sonnet-4-5`, `claude-opus-4-5`, `claude-opus-4-1`, `claude-sonnet-4-0`, `claude-opus-4-0` | `claude-sonnet-4-6`
 | spring.ai.anthropic.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8
 | spring.ai.anthropic.chat.options.max-tokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | 500
 | spring.ai.anthropic.chat.options.stop-sequence | Custom text sequences that will cause the model to stop generating. Our models will normally stop when they have naturally completed their turn, which will result in a response stop_reason of "end_turn". If you want the model to stop generating when it encounters custom strings of text, you can use the stop_sequences parameter. If the model encounters one of the custom sequences, the response stop_reason value will be "stop_sequence" and the response stop_sequence value will contain the matched stop sequence. | -
@@ -181,7 +181,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Generate the names of 5 famous pirates.",
         AnthropicChatOptions.builder()
-            .model("claude-3-7-sonnet-latest")
+            .model("claude-sonnet-4-6")
             .temperature(0.4)
         .build()
     ));
@@ -266,7 +266,7 @@ ChatResponse response = chatModel.call(
             new UserMessage("What is machine learning?")
         ),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -290,7 +290,7 @@ ChatResponse response = chatModel.call(
             new UserMessage("What's the weather like in San Francisco?")
         ),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.TOOLS_ONLY)
                 .build())
@@ -316,7 +316,7 @@ ChatResponse response = chatModel.call(
             new UserMessage("What's the weather like in San Francisco?")
         ),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.SYSTEM_AND_TOOLS)
                 .build())
@@ -342,7 +342,7 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 String response = chatClient.prompt()
     .user("What career advice would you give me?")
     .options(AnthropicChatOptions.builder()
-        .model("claude-sonnet-4")
+        .model("claude-sonnet-4-6")
         .cacheOptions(AnthropicCacheOptions.builder()
             .strategy(AnthropicCacheStrategy.CONVERSATION_HISTORY)
             .build())
@@ -361,7 +361,7 @@ String response = ChatClient.create(chatModel)
     .system("You are an expert document analyst...")
     .user("Analyze this large document: " + document)
     .options(AnthropicChatOptions.builder()
-        .model("claude-sonnet-4")
+        .model("claude-sonnet-4-6")
         .cacheOptions(AnthropicCacheOptions.builder()
             .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
             .build())
@@ -384,7 +384,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         List.of(new SystemMessage(largeSystemPrompt)),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                 .messageTypeTtl(MessageType.SYSTEM, AnthropicCacheTtl.ONE_HOUR)
@@ -415,7 +415,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         List.of(/* messages */),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(cache)
             .build()
     )
@@ -441,7 +441,7 @@ ChatResponse firstResponse = chatModel.call(
             new UserMessage("What is microservices architecture?")
         ),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -465,7 +465,7 @@ ChatResponse secondResponse = chatModel.call(
             new UserMessage("What are the benefits of event sourcing?")
         ),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -529,7 +529,7 @@ ChatResponse riskAnalysis = chatModel.call(
             new UserMessage("What are the key termination clauses and associated penalties?")
         ),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -546,7 +546,7 @@ ChatResponse obligationAnalysis = chatModel.call(
             new UserMessage("List all financial obligations and payment schedules.")
         ),
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .cacheOptions(AnthropicCacheOptions.builder()
                 .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -588,7 +588,7 @@ for (String filename : codeFiles) {
                 new UserMessage("Review this " + filename + " code:\n\n" + sourceCode)
             ),
             AnthropicChatOptions.builder()
-                .model("claude-sonnet-4")
+                .model("claude-sonnet-4-6")
                 .cacheOptions(AnthropicCacheOptions.builder()
                     .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                     .build())
@@ -640,7 +640,7 @@ public class MultiTenantAIService {
                     new UserMessage(userQuery)
                 ),
                 AnthropicChatOptions.builder()
-                    .model("claude-sonnet-4")
+                    .model("claude-sonnet-4-6")
                     .cacheOptions(AnthropicCacheOptions.builder()
                         .strategy(AnthropicCacheStrategy.TOOLS_ONLY) // Cache tools only
                         .build())
@@ -687,7 +687,7 @@ public class CustomerSupportService {
                     new UserMessage("Customer " + customerId + " asks: " + customerQuery)
                 ),
                 AnthropicChatOptions.builder()
-                    .model("claude-sonnet-4")
+                    .model("claude-sonnet-4-6")
                     .cacheOptions(AnthropicCacheOptions.builder()
                         .strategy(AnthropicCacheStrategy.SYSTEM_ONLY)
                         .build())
@@ -779,13 +779,15 @@ Anthropic Claude models support a "thinking" feature that allows the model to sh
 
 The thinking feature is supported by the following Claude models:
 
-* Claude 4 models (`claude-opus-4-20250514`, `claude-sonnet-4-20250514`)
-* Claude 3.7 Sonnet (`claude-3-7-sonnet-20250219`)
+* Claude 4.6 models (`claude-opus-4-6`, `claude-sonnet-4-6`)
+* Claude 4.5 models (`claude-opus-4-5`, `claude-sonnet-4-5`)
+* Claude Haiku 4.5 (`claude-haiku-4-5`)
 
 *Model capabilities:*
 
-* *Claude 3.7 Sonnet*: Returns full thinking output. Behavior is consistent but does not support summarized or interleaved thinking.
-* *Claude 4 models*: Support summarized thinking, interleaved thinking, and enhanced tool integration.
+* *Claude 4.6 models*: Support summarized thinking, interleaved thinking, adaptive thinking, and enhanced tool integration.
+* *Claude 4.5 models*: Support summarized thinking, interleaved thinking, and enhanced tool integration.
+* *Claude Haiku 4.5*: Supports extended thinking but not adaptive thinking.
 
 API request structure is the same across all supported models, but output behavior varies.
 ====
@@ -808,10 +810,10 @@ To enable thinking on any supported Claude model, include the following configur
 
 ==== Key Considerations
 
-* **Claude 3.7** returns full thinking content in the response
-* **Claude 4** returns a *summarized* version of the model's internal reasoning to reduce latency and protect sensitive content
+* **All current Claude models** return a *summarized* version of the model's internal reasoning to reduce latency and protect sensitive content
 * **Thinking tokens are billable** as part of output tokens (even if not all are visible in response)
-* **Interleaved Thinking** is only available on Claude 4 models and requires the beta header `interleaved-thinking-2025-05-14`
+* **Interleaved Thinking** is only available on Claude 4.5+ models and requires the beta header `interleaved-thinking-2025-05-14`
+* **Adaptive Thinking** is available on Claude 4.6 models (Opus and Sonnet)
 
 ==== Tool Integration and Interleaved Thinking
 
@@ -832,22 +834,21 @@ Here's how to enable thinking in a non-streaming request using the ChatClient AP
 ----
 ChatClient chatClient = ChatClient.create(chatModel);
 
-// For Claude 3.7 Sonnet - explicit thinking configuration required
+// Enable thinking with explicit configuration
 ChatResponse response = chatClient.prompt()
     .options(AnthropicChatOptions.builder()
-        .model("claude-3-7-sonnet-latest")
+        .model("claude-sonnet-4-6")
         .temperature(1.0)  // Temperature should be set to 1 when thinking is enabled
         .maxTokens(8192)
-        .thinking(AnthropicApi.ThinkingType.ENABLED, 2048)  // Must be ≥1024 && < max_tokens
         .build())
     .user("Are there an infinite number of prime numbers such that n mod 4 == 3?")
     .call()
     .chatResponse();
 
-// For Claude 4 models - thinking is enabled by default
+// Use a more capable model for complex reasoning
 ChatResponse response4 = chatClient.prompt()
     .options(AnthropicChatOptions.builder()
-        .model("claude-opus-4-0")
+        .model("claude-opus-4-6")
         .maxTokens(8192)
         // No explicit thinking configuration needed
         .build())
@@ -881,7 +882,7 @@ ChatClient chatClient = ChatClient.create(chatModel);
 // For Claude 3.7 Sonnet - explicit thinking configuration
 Flux<ChatResponse> responseFlux = chatClient.prompt()
     .options(AnthropicChatOptions.builder()
-        .model("claude-3-7-sonnet-latest")
+        .model("claude-sonnet-4-6")
         .temperature(1.0)
         .maxTokens(8192)
         .thinking(AnthropicApi.ThinkingType.ENABLED, 2048)
@@ -1207,7 +1208,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "When was the Eiffel Tower built and how tall is it?",
         AnthropicChatOptions.builder()
-            .model("claude-3-7-sonnet-latest")
+            .model("claude-sonnet-4-6")
             .maxTokens(1024)
             .citationDocuments(document)
             .build()
@@ -1237,7 +1238,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "What is the capital of France and who designed the Eiffel Tower?",
         AnthropicChatOptions.builder()
-            .model("claude-3-7-sonnet-latest")
+            .model("claude-sonnet-4-6")
             .citationDocuments(parisDoc, eiffelDoc)
             .build()
     )
@@ -1338,7 +1339,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "What is Spring AI?",
         AnthropicChatOptions.builder()
-            .model("claude-3-7-sonnet-latest")
+            .model("claude-sonnet-4-6")
             .maxTokens(1024)
             .citationDocuments(document)
             .build()
@@ -1390,7 +1391,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "What are the key termination clauses in this contract?",
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .maxTokens(2000)
             .citationDocuments(contract)
             .build()
@@ -1422,7 +1423,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "How do I reset my password and update my billing information?",
         AnthropicChatOptions.builder()
-            .model("claude-3-7-sonnet-latest")
+            .model("claude-sonnet-4-6")
             .citationDocuments(kbArticle1, kbArticle2)
             .build()
     )
@@ -1453,7 +1454,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "Summarize the efficacy findings and regulatory implications.",
         AnthropicChatOptions.builder()
-            .model("claude-sonnet-4")
+            .model("claude-sonnet-4-6")
             .maxTokens(3000)
             .citationDocuments(clinicalStudy, regulatoryGuidance)
             .build()
@@ -2271,7 +2272,7 @@ Next, create a `AnthropicChatModel` and use it for text generations:
 ----
 var anthropicApi = new AnthropicApi(System.getenv("ANTHROPIC_API_KEY"));
 var anthropicChatOptions = AnthropicChatOptions.builder()
-            .model("claude-3-7-sonnet-20250219")
+            .model("claude-sonnet-4-6")
             .temperature(0.4)
             .maxTokens(200)
         .build()

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -123,7 +123,7 @@ At run-time you can override the default options by adding new, request specific
 [source,java]
 ----
 var options = BedrockChatOptions.builder()
-        .model("anthropic.claude-3-5-sonnet-20240620-v1:0")
+        .model("anthropic.claude-haiku-4-5-20251001-v1:0")
         .temperature(0.6)
         .maxTokens(300)
         .toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new WeatherService())
@@ -198,7 +198,7 @@ ChatResponse response = chatModel.call(
             new UserMessage("What is machine learning?")
         ),
         BedrockChatOptions.builder()
-            .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
             .cacheOptions(BedrockCacheOptions.builder()
                 .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -219,7 +219,7 @@ ChatResponse response = chatModel.call(
     new Prompt(
         "What's the weather in San Francisco?",
         BedrockChatOptions.builder()
-            .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
             .cacheOptions(BedrockCacheOptions.builder()
                 .strategy(BedrockCacheStrategy.TOOLS_ONLY)
                 .build())
@@ -247,7 +247,7 @@ ChatResponse response = chatModel.call(
             new UserMessage("What's the weather like in Tokyo?")
         ),
         BedrockChatOptions.builder()
-            .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
             .cacheOptions(BedrockCacheOptions.builder()
                 .strategy(BedrockCacheStrategy.SYSTEM_AND_TOOLS)
                 .build())
@@ -278,7 +278,7 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 String response = chatClient.prompt()
     .user("What career advice would you give me?")
     .options(BedrockChatOptions.builder()
-        .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+        .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
         .cacheOptions(BedrockCacheOptions.builder()
             .strategy(BedrockCacheStrategy.CONVERSATION_HISTORY)
             .build())
@@ -297,7 +297,7 @@ String response = ChatClient.create(chatModel)
     .system("You are an expert document analyst...")
     .user("Analyze this large document: " + document)
     .options(BedrockChatOptions.builder()
-        .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+        .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
         .cacheOptions(BedrockCacheOptions.builder()
             .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
             .build())
@@ -324,7 +324,7 @@ ChatResponse firstResponse = chatModel.call(
             new UserMessage("What is microservices architecture?")
         ),
         BedrockChatOptions.builder()
-            .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
             .cacheOptions(BedrockCacheOptions.builder()
                 .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -352,7 +352,7 @@ ChatResponse secondResponse = chatModel.call(
             new UserMessage("What are the benefits of event sourcing?")
         ),
         BedrockChatOptions.builder()
-            .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
             .cacheOptions(BedrockCacheOptions.builder()
                 .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -453,7 +453,7 @@ ChatResponse riskAnalysis = chatModel.call(
             new UserMessage("What are the key termination clauses and associated penalties?")
         ),
         BedrockChatOptions.builder()
-            .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
             .cacheOptions(BedrockCacheOptions.builder()
                 .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -470,7 +470,7 @@ ChatResponse obligationAnalysis = chatModel.call(
             new UserMessage("List all financial obligations and payment schedules.")
         ),
         BedrockChatOptions.builder()
-            .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+            .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
             .cacheOptions(BedrockCacheOptions.builder()
                 .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
                 .build())
@@ -512,7 +512,7 @@ for (String filename : codeFiles) {
                 new UserMessage("Review this " + filename + " code:\n\n" + sourceCode)
             ),
             BedrockChatOptions.builder()
-                .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+                .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
                 .cacheOptions(BedrockCacheOptions.builder()
                     .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
                     .build())
@@ -555,7 +555,7 @@ public class CustomerSupportService {
                     new UserMessage("Customer " + customerId + " asks: " + customerQuery)
                 ),
                 BedrockChatOptions.builder()
-                    .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+                    .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
                     .cacheOptions(BedrockCacheOptions.builder()
                         .strategy(BedrockCacheStrategy.SYSTEM_ONLY)
                         .build())
@@ -596,7 +596,7 @@ public class MultiTenantAIService {
                     new UserMessage(userQuery)
                 ),
                 BedrockChatOptions.builder()
-                    .model("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+                    .model("us.anthropic.claude-haiku-4-5-20251001-v1:0")
                     .cacheOptions(BedrockCacheOptions.builder()
                         .strategy(BedrockCacheStrategy.TOOLS_ONLY)
                         .build())

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/prompt-engineering-patterns.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/prompt-engineering-patterns.adoc
@@ -30,7 +30,7 @@ You can specify the LLM model name like this:
 [source,java]
 ----
 .options(ChatOptions.builder()
-        .model("claude-3-7-sonnet-latest")  // Use Anthropic's Claude model
+        .model("claude-sonnet-4-6")  // Use Anthropic's Claude model
         .build())
 ----
 
@@ -135,7 +135,7 @@ String result = chatClient.prompt("...")
 
 // Using Anthropic-specific options
 AnthropicChatOptions anthropicOptions = AnthropicChatOptions.builder()
-        .model("claude-3-7-sonnet-latest")
+        .model("claude-sonnet-4-6")
         .temperature(0.2)
         .topK(40)                   // Anthropic-specific parameter
         .thinking(AnthropicApi.ThinkingType.ENABLED, 1000)  // Anthropic-specific thinking configuration
@@ -178,7 +178,7 @@ public void pt_zero_shot(ChatClient chatClient) {
             Sentiment:
             """)
             .options(ChatOptions.builder()
-                    .model("claude-3-7-sonnet-latest")
+                    .model("claude-sonnet-4-6")
                     .temperature(0.1)
                     .maxTokens(5)
                     .build())
@@ -232,7 +232,7 @@ public void pt_one_shot_few_shots(ChatClient chatClient) {
             And the other tomato sauce, ham and pineapple.
             """)
             .options(ChatOptions.builder()
-                    .model("claude-3-7-sonnet-latest")
+                    .model("claude-sonnet-4-6")
                     .temperature(0.1)
                     .maxTokens(250)
                     .build())
@@ -268,7 +268,7 @@ public void pt_system_prompting_1(ChatClient chatClient) {
                     Sentiment:
                     """)
             .options(ChatOptions.builder()
-                    .model("claude-3-7-sonnet-latest")
+                    .model("claude-sonnet-4-6")
                     .temperature(1.0)
                     .topK(40)
                     .topP(0.8)
@@ -408,7 +408,7 @@ public void pt_step_back_prompting(ChatClient.Builder chatClientBuilder) {
     // Set common options for the chat client
     var chatClient = chatClientBuilder
             .defaultOptions(ChatOptions.builder()
-                    .model("claude-3-7-sonnet-latest")
+                    .model("claude-sonnet-4-6")
                     .temperature(1.0)
                     .topK(40)
                     .topP(0.8)


### PR DESCRIPTION
- Add CLAUDE_OPUS_4_6 and CLAUDE_SONNET_4_6 to AnthropicApi.ChatModel enum
- Remove deprecated Claude 3.x and 3.7 model variants
- Change default model to claude-haiku-4-5
- Update tests and documentation accordingly
