### PR TITLE
Ensure CosmosDB chat memory auto-configuration is applied first

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/model/chat/memory/repository/cosmosdb/autoconfigure/CosmosDBChatMemoryRepositoryAutoConfiguration.java
@@ -22,6 +22,7 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 
 import org.springframework.ai.chat.memory.repository.cosmosdb.CosmosDBChatMemoryRepository;
 import org.springframework.ai.chat.memory.repository.cosmosdb.CosmosDBChatMemoryRepositoryConfig;
+import org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -35,7 +36,7 @@ import org.springframework.context.annotation.Bean;
  * @author Theo van Kraay
  * @since 1.1.0
  */
-@AutoConfiguration
+@AutoConfiguration(before = ChatMemoryAutoConfiguration.class)
 @ConditionalOnClass({ CosmosDBChatMemoryRepository.class, CosmosAsyncClient.class })
 @EnableConfigurationProperties(CosmosDBChatMemoryRepositoryProperties.class)
 public class CosmosDBChatMemoryRepositoryAutoConfiguration {


### PR DESCRIPTION
Apply explicit ordering so CosmosDBChatMemoryRepositoryAutoConfiguration runs before ChatMemoryAutoConfiguration.

This prevents premature default bean creation that would otherwise override or bypass the CosmosDB repository setup.