### PR TITLE
GH-4659: implement pdf reference doc generation

### DIFF
--- a/spring-ai-docs/pom.xml
+++ b/spring-ai-docs/pom.xml
@@ -93,4 +93,59 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>pdf</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>asciidoctorj-pdf</artifactId>
+                                <version>2.3.19</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>generate-pdf-doc</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceDirectory>${project.basedir}/src/main/asciidoc</sourceDirectory>
+                                    <sourceDocumentName>spring-ai-reference.adoc</sourceDocumentName>
+                                    <outputDirectory>${project.build.directory}/pdf</outputDirectory>
+                                    <backend>pdf</backend>
+                                    <attributes>
+                                        <pdf-stylesdir>${project.basedir}/src/main/asciidoc/themes</pdf-stylesdir>
+                                        <pdf-style>spring</pdf-style>
+                                        <doctype>book</doctype>
+                                        <toc/>
+                                        <toclevels>3</toclevels>
+                                        <sectnums/>
+                                        <icons>font</icons>
+                                        <imagesdir>${project.basedir}/src/main/antora/modules/ROOT/images</imagesdir>
+                                        <!-- Suppress unresolved Antora-style xref warnings -->
+                                        <xrefstyle>short</xrefstyle>
+                                        <!-- Project version for title page -->
+                                        <revnumber>${project.version}</revnumber>
+                                        <revdate>${maven.build.timestamp}</revdate>
+                                        <!-- Antora-specific attributes (no-op in standalone mode) -->
+                                        <page-pagination/>
+                                        <hide-uri-scheme>@</hide-uri-scheme>
+                                    </attributes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/spring-ai-docs/src/main/asciidoc/spring-ai-reference.adoc
+++ b/spring-ai-docs/src/main/asciidoc/spring-ai-reference.adoc
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+= Spring AI Reference Documentation
+:doctype: book
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+:source-highlighter: rouge
+:imagesdir: ../antora/modules/ROOT/images
+// Antora-specific macros are not resolved in standalone mode; define them as passthrough
+:page-pagination: ''
+// Suppress unresolved xref warnings from Antora-style cross-references
+:xrefstyle: short
+
+// ============================================================
+// Part I – Introduction
+// ============================================================
+include::../antora/modules/ROOT/pages/index.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/concepts.adoc[leveloffset=+1]
+
+// ============================================================
+// Part II – Getting Started
+// ============================================================
+include::../antora/modules/ROOT/pages/getting-started.adoc[leveloffset=+1]
+
+// ============================================================
+// Part III – Reference
+// ============================================================
+
+// -- ChatClient API --
+include::../antora/modules/ROOT/pages/api/chatclient.adoc[leveloffset=+1]
+
+// -- Advisors --
+include::../antora/modules/ROOT/pages/api/advisors.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/advisors-recursive.adoc[leveloffset=+3]
+
+// -- Prompt --
+include::../antora/modules/ROOT/pages/api/prompt.adoc[leveloffset=+1]
+
+// -- Structured Output --
+include::../antora/modules/ROOT/pages/api/structured-output-converter.adoc[leveloffset=+1]
+
+// -- Multimodality --
+include::../antora/modules/ROOT/pages/api/multimodality.adoc[leveloffset=+1]
+
+// -- Models Overview --
+include::../antora/modules/ROOT/pages/api/index.adoc[leveloffset=+1]
+
+// ---- Chat Models ----
+include::../antora/modules/ROOT/pages/api/chatmodel.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/chat/comparison.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/azure-openai-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/dmr-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/google-vertexai.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/vertexai-gemini-chat.adoc[leveloffset=+4]
+include::../antora/modules/ROOT/pages/api/chat/groq-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/huggingface.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/minimax-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/moonshot-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/nvidia-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/ollama-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/perplexity-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/oci-genai/cohere-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/openai-sdk-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/openai-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/qianfan-chat.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/chat/zhipuai-chat.adoc[leveloffset=+3]
+
+// ---- Embedding Models ----
+include::../antora/modules/ROOT/pages/api/embeddings.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/bedrock.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/bedrock-cohere-embedding.adoc[leveloffset=+4]
+include::../antora/modules/ROOT/pages/api/embeddings/bedrock-titan-embedding.adoc[leveloffset=+4]
+include::../antora/modules/ROOT/pages/api/embeddings/azure-openai-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/google-genai-embeddings-text.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/mistralai-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/minimax-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/oci-genai-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/ollama-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/onnx.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/openai-sdk-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/postgresml-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/qianfan-embeddings.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/vertexai-embeddings-text.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/vertexai-embeddings-multimodal.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/embeddings/zhipuai-embeddings.adoc[leveloffset=+3]
+
+// ---- Image Models ----
+include::../antora/modules/ROOT/pages/api/imageclient.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/image/azure-openai-image.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/image/openai-sdk-image.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/image/openai-image.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/image/stabilityai-image.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/image/zhipuai-image.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/image/qianfan-image.adoc[leveloffset=+3]
+
+// ---- Audio Models ----
+include::../antora/modules/ROOT/pages/api/audio/transcriptions.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/audio/transcriptions/azure-openai-transcriptions.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/audio/speech.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/audio/speech/elevenlabs-speech.adoc[leveloffset=+3]
+
+// ---- Moderation Models ----
+include::../antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/moderation/mistral-ai-moderation.adoc[leveloffset=+3]
+
+// -- Chat Memory --
+include::../antora/modules/ROOT/pages/api/chat-memory.adoc[leveloffset=+1]
+
+// -- Tool Calling --
+include::../antora/modules/ROOT/pages/api/tools.adoc[leveloffset=+1]
+
+// -- Model Context Protocol (MCP) --
+include::../antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-security.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-annotations-overview.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-annotations-client.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-annotations-server.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-annotations-special-params.adoc[leveloffset=+3]
+include::../antora/modules/ROOT/pages/api/mcp/mcp-annotations-examples.adoc[leveloffset=+3]
+
+// -- RAG --
+include::../antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/api/etl-pipeline.adoc[leveloffset=+2]
+
+// -- Model Evaluation --
+include::../antora/modules/ROOT/pages/api/testing.adoc[leveloffset=+1]
+
+// -- Vector Stores --
+include::../antora/modules/ROOT/pages/api/vectordbs.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/api/vectordbs/azure.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/azure-cosmos-db.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/bedrock-knowledge-base.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/apache-cassandra.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/chroma.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/couchbase.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/gemfire.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/mariadb.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/milvus.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/mongodb.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/neo4j.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/opensearch.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/oracle.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/pgvector.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/pinecone.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/qdrant.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/redis.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/hana.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/typesense.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/weaviate.adoc[leveloffset=+2]
+include::../antora/modules/ROOT/pages/api/vectordbs/s3-vector-store.adoc[leveloffset=+2]
+
+// -- Observability --
+include::../antora/modules/ROOT/pages/observability/index.adoc[leveloffset=+1]
+
+// -- Development-time Services --
+include::../antora/modules/ROOT/pages/api/docker-compose.adoc[leveloffset=+1]
+
+// -- Testing --
+include::../antora/modules/ROOT/pages/api/testcontainers.adoc[leveloffset=+1]
+
+// ============================================================
+// Part IV – Guides
+// ============================================================
+include::../antora/modules/ROOT/pages/guides/getting-started-mcp.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/guides/dynamic-tool-search.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/guides/llm-as-judge.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/api/chat/prompt-engineering-patterns.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/api/effective-agents.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/api/cloud-bindings.adoc[leveloffset=+1]
+
+// ============================================================
+// Part V – Upgrade Notes
+// ============================================================
+include::../antora/modules/ROOT/pages/upgrade-notes.adoc[leveloffset=+1]
+include::../antora/modules/ROOT/pages/api/tools-migration.adoc[leveloffset=+2]

--- a/spring-ai-docs/src/main/asciidoc/themes/spring-pdf-theme.yml
+++ b/spring-ai-docs/src/main/asciidoc/themes/spring-pdf-theme.yml
@@ -1,0 +1,208 @@
+extends: default
+
+# ============================================================
+# Spring AI PDF Theme
+# Based on the Spring Framework branding
+# ============================================================
+
+font:
+  catalog:
+    Roboto:
+      normal: GEM_FONTS_DIR/roboto/Roboto-Regular.ttf
+      bold: GEM_FONTS_DIR/roboto/Roboto-Bold.ttf
+      italic: GEM_FONTS_DIR/roboto/Roboto-Italic.ttf
+      bold_italic: GEM_FONTS_DIR/roboto/Roboto-BoldItalic.ttf
+    RobotoMono:
+      normal: GEM_FONTS_DIR/roboto-mono/RobotoMono-Regular.ttf
+      bold: GEM_FONTS_DIR/roboto-mono/RobotoMono-Bold.ttf
+      italic: GEM_FONTS_DIR/roboto-mono/RobotoMono-Italic.ttf
+      bold_italic: GEM_FONTS_DIR/roboto-mono/RobotoMono-BoldItalic.ttf
+
+page:
+  layout: portrait
+  margin: [20mm, 20mm, 25mm, 20mm]
+  size: A4
+
+base:
+  font_family: Roboto
+  font_color: '#333333'
+  font_size: 10
+  line_height_length: 15
+  line_height: $base_line_height_length / $base_font_size
+
+# ---------------------------------------------------------------
+# Cover / Title page
+# ---------------------------------------------------------------
+title_page:
+  align: center
+  title:
+    font_size: 32
+    font_style: bold
+    font_color: '#6db33f'
+    line_height: 1.2
+    top: 35%
+  subtitle:
+    font_size: 18
+    font_style: normal
+    font_color: '#555555'
+    margin_top: 8
+  authors:
+    font_size: 12
+    font_style: italic
+    font_color: '#6db33f'
+    margin_top: 8
+  revision:
+    font_size: 10
+    font_color: '#888888'
+    margin_top: 4
+
+# ---------------------------------------------------------------
+# Headings
+# ---------------------------------------------------------------
+heading:
+  font_family: Roboto
+  font_style: bold
+  font_color: '#34302d'
+  line_height: 1.2
+  margin_bottom: 8
+
+h1:
+  font_size: 26
+  font_color: '#6db33f'
+  border_bottom_width: 1
+  border_bottom_color: '#6db33f'
+  border_bottom_style: solid
+  margin_bottom: 12
+
+h2:
+  font_size: 20
+  font_color: '#34302d'
+
+h3:
+  font_size: 16
+  font_color: '#34302d'
+
+h4:
+  font_size: 13
+  font_color: '#555555'
+
+h5:
+  font_size: 11
+  font_style: italic
+
+h6:
+  font_size: 10
+  font_style: italic
+
+# ---------------------------------------------------------------
+# Code blocks
+# ---------------------------------------------------------------
+code:
+  font_family: RobotoMono
+  font_size: 8.5
+  font_color: '#333333'
+  background_color: '#f5f5f5'
+  border_radius: 3
+  border_width: 0.5
+  border_color: '#dddddd'
+  padding: [3, 5, 3, 5]
+  line_height: 1.4
+
+codespan:
+  font_family: RobotoMono
+  font_size: 0.9em
+  font_color: '#c0392b'
+  background_color: '#f9f2f4'
+
+# ---------------------------------------------------------------
+# Sidebar / Admonitions
+# ---------------------------------------------------------------
+admonition:
+  label:
+    font_style: bold
+  column_rule_color: '#6db33f'
+  column_rule_width: 1
+
+note:
+  label:
+    font_color: '#6db33f'
+
+tip:
+  label:
+    font_color: '#2ecc71'
+
+warning:
+  label:
+    font_color: '#e67e22'
+
+caution:
+  label:
+    font_color: '#e74c3c'
+
+important:
+  label:
+    font_color: '#9b59b6'
+
+# ---------------------------------------------------------------
+# Table of Contents
+# ---------------------------------------------------------------
+toc:
+  indent: 20
+  line_height: 1.5
+  dot_leader:
+    font_color: '#aaaaaa'
+  h2_font_size: 11
+  h3_font_size: 10
+  h4_font_size: 9.5
+  h2_font_style: bold
+  h2_font_color: '#34302d'
+
+# ---------------------------------------------------------------
+# Header / Footer
+# ---------------------------------------------------------------
+header:
+  height: 14mm
+  border_bottom_width: 0.25
+  border_bottom_color: '#6db33f'
+  font_size: 9
+  font_color: '#888888'
+  recto:
+    right:
+      content: 'Spring AI Reference'
+  verso:
+    left:
+      content: 'Spring AI Reference'
+
+footer:
+  height: 14mm
+  border_top_width: 0.25
+  border_top_color: '#6db33f'
+  font_size: 9
+  font_color: '#888888'
+  recto:
+    right:
+      content: '{page-number}'
+  verso:
+    left:
+      content: '{page-number}'
+
+# ---------------------------------------------------------------
+# Links
+# ---------------------------------------------------------------
+link:
+  font_color: '#6db33f'
+
+# ---------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------
+table:
+  border_color: '#dddddd'
+  border_width: 0.5
+  head:
+    background_color: '#6db33f'
+    font_style: bold
+    font_color: '#ffffff'
+  body:
+    stripe_background_color: '#f9f9f9'
+  cell:
+    padding: [4, 8, 4, 8]


### PR DESCRIPTION
fixes [4659](https://github.com/spring-projects/spring-ai/issues/4659)

generated pdf: [spring-ai-reference.zip](https://github.com/user-attachments/files/25475376/spring-ai-reference.zip)

This is my first contribution to this repo, so let me know if I missed anything. I tried to follow the contributions guide.

> (Disclaimer: This implementation was done with AI assisted coding using Google Antigravity)

Implemented the ability to generate a single, combined PDF document for the Spring AI Reference from the ~130 underlying AsciiDoc pages.

### What Was Done

1. Maven Profile Configuration
Added a new pdf Maven profile to spring-ai-docs/pom.xml that uses the asciidoctor-maven-plugin and asciidoctorj-pdf backend. This cleanly separates PDF generation from the normal Antora HTML site generation without slowing down default builds.

1. Master Aggregator File
Created src/main/asciidoc/spring-ai-reference.adoc which acts as the master document. It uses include:: directives to pull in all 130+ individual AsciiDoc pages strictly following the order defined in the Antora nav.adoc.
Standalone Asciidoctor processing doesn't understand Antora's xref:page$ macros, so we suppressed those warnings by defining :xrefstyle: short as a workaround.

1. Spring PDF Theme
Created a custom PDF theme (src/main/asciidoc/themes/spring-pdf-theme.yml) matching the Spring Framework branding with:
  - Spring Green (#6db33f) for primary accents
  - Clean, modern Roboto/RobotoMono typography
  - Structured headers, footers (with page numbers), and syntax-highlighted code blocks
  
  Samples:
  
  
<img width="923" height="458" alt="image" src="https://github.com/user-attachments/assets/ee1800c1-aceb-490a-811b-589647168bd4" />

<img width="912" height="699" alt="image" src="https://github.com/user-attachments/assets/700aa93a-3b05-4d27-be71-a032bae821e4" />

