### PR TITLE
fix: adapt to breaking changes (`McpSchema`/`McpError`) of latest MCP

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpToolCallbackParameterlessToolIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpToolCallbackParameterlessToolIT.java
@@ -115,14 +115,10 @@ class McpToolCallbackParameterlessToolIT {
 
 				// Create a tool specification that returns a simple response
 				McpServerFeatures.SyncToolSpecification toolSpec = new McpServerFeatures.SyncToolSpecification(
-						parameterlessTool, (exchange, arguments) -> {
+						parameterlessTool, (exchange, request) -> {
 							McpSchema.TextContent content = new McpSchema.TextContent(
 									"Current time: " + Instant.now().toString());
-							return new McpSchema.CallToolResult(List.of(content), false, null);
-						}, (exchange, request) -> {
-							McpSchema.TextContent content = new McpSchema.TextContent(
-									"Current time: " + Instant.now().toString());
-							return new McpSchema.CallToolResult(List.of(content), false, null);
+							return new McpSchema.CallToolResult(List.of(content), false, null, null);
 						});
 
 				// Add the tool with incomplete schema to the server

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/SseWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/SseWebClientWebFluxServerIT.java
@@ -355,7 +355,7 @@ public class SseWebClientWebFluxServerIT {
 
 					return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(
 							"CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString())),
-							null);
+							false, null, null);
 				})
 				.build();
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StatelessWebClientWebFluxServerIT.java
@@ -269,7 +269,8 @@ public class StatelessWebClientWebFluxServerIT {
 							"properties": {}
 						}
 						""").build())
-				.callHandler((exchange, request) -> new CallToolResult(List.of(new TextContent("CALL RESPONSE")), null))
+				.callHandler((exchange, request) -> new CallToolResult(List.of(new TextContent("CALL RESPONSE")), false,
+						null, null))
 				.build();
 
 			// Tool 2

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableWebClientWebFluxServerIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableWebClientWebFluxServerIT.java
@@ -354,7 +354,7 @@ public class StreamableWebClientWebFluxServerIT {
 
 					return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(
 							"CALL RESPONSE: " + samplingResponse.toString() + ", " + elicitationResult.toString())),
-							null);
+							false, null, null);
 				})
 				.build();
 

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -203,8 +203,6 @@ public final class McpToolUtils {
 		SharedSyncToolSpecification sharedSpec = toSharedSyncToolSpecification(toolCallback, mimeType);
 
 		return new McpServerFeatures.SyncToolSpecification(sharedSpec.tool(),
-				(exchange, map) -> sharedSpec.sharedHandler()
-					.apply(exchange, new CallToolRequest(sharedSpec.tool().name(), map)),
 				(exchange, request) -> sharedSpec.sharedHandler().apply(exchange, request));
 	}
 
@@ -262,12 +260,14 @@ public final class McpToolUtils {
 				if (mimeType != null && mimeType.toString().startsWith("image")) {
 					McpSchema.Annotations annotations = new McpSchema.Annotations(List.of(Role.ASSISTANT), null);
 					return new McpSchema.CallToolResult(
-							List.of(new McpSchema.ImageContent(annotations, callResult, mimeType.toString())), false);
+							List.of(new McpSchema.ImageContent(annotations, callResult, mimeType.toString())), false,
+							null, null);
 				}
-				return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(callResult)), false);
+				return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(callResult)), false, null, null);
 			}
 			catch (Exception e) {
-				return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(e.getMessage())), true);
+				return new McpSchema.CallToolResult(List.of(new McpSchema.TextContent(e.getMessage())), true, null,
+						null);
 			}
 		});
 	}

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -27,6 +27,7 @@ import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
@@ -228,7 +229,8 @@ class ToolUtilsTests {
 		assertThat(toolSpecification).isNotNull();
 		assertThat(toolSpecification.tool().name()).isEqualTo("test");
 
-		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new CallToolRequest("test", Map.of()));
 		TextContent content = (TextContent) result.content().get(0);
 		assertThat(content.text()).isEqualTo("success");
 		assertThat(result.isError()).isFalse();
@@ -241,7 +243,8 @@ class ToolUtilsTests {
 		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
 
 		assertThat(toolSpecification).isNotNull();
-		CallToolResult result = toolSpecification.call().apply(mock(McpSyncServerExchange.class), Map.of());
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new CallToolRequest("test", Map.of()));
 		TextContent content = (TextContent) result.content().get(0);
 		assertThat(content.text()).isEqualTo("error");
 		assertThat(result.isError()).isTrue();

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
@@ -155,7 +155,9 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 							catch (IOException e) {
 								logger.error("Failed to serialize response: {}", e.getMessage());
 								return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-									.bodyValue(new McpError("Failed to serialize response"));
+									.bodyValue(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(
+											McpSchema.ErrorCodes.INTERNAL_ERROR, "Failed to serialize response",
+											null)));
 							}
 						});
 				}
@@ -166,12 +168,16 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 				}
 				else {
 					return ServerResponse.badRequest()
-						.bodyValue(new McpError("The server accepts either requests or notifications"));
+						.bodyValue(new McpError(
+								new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_REQUEST,
+										"The server accepts either requests or notifications", null)));
 				}
 			}
 			catch (IllegalArgumentException | IOException e) {
 				logger.error("Failed to deserialize message: {}", e.getMessage());
-				return ServerResponse.badRequest().bodyValue(new McpError("Invalid message format"));
+				return ServerResponse.badRequest()
+					.bodyValue(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.PARSE_ERROR,
+							"Invalid message format", null)));
 			}
 		}).contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext));
 	}

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/WebFluxStreamableHttpVersionNegotiationIT.java
@@ -63,7 +63,8 @@ class WebFluxStreamableHttpVersionNegotiationIT {
 
 	private final BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult> toolHandler = (
 			exchange, request) -> new McpSchema.CallToolResult(
-					exchange.transportContext().get("protocol-version").toString(), null);
+					List.of(new McpSchema.TextContent(exchange.transportContext().get("protocol-version").toString())),
+					false, null, null);
 
 	private final WebFluxStreamableServerTransportProvider mcpStreamableServerTransportProvider = WebFluxStreamableServerTransportProvider
 		.builder()
@@ -73,7 +74,7 @@ class WebFluxStreamableHttpVersionNegotiationIT {
 
 	private final McpSyncServer mcpServer = McpServer.sync(this.mcpStreamableServerTransportProvider)
 		.capabilities(McpSchema.ServerCapabilities.builder().tools(false).build())
-		.tools(new McpServerFeatures.SyncToolSpecification(this.toolSpec, null, this.toolHandler))
+		.tools(new McpServerFeatures.SyncToolSpecification(this.toolSpec, this.toolHandler))
 		.build();
 
 	@BeforeEach

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.client.webflux.transport;
 
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.ProtocolVersions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class WebClientStreamableHttpTransportIT {
 
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 
-		var initializeRequest = new McpSchema.InitializeRequest(McpSchema.LATEST_PROTOCOL_VERSION,
+		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25,
 				McpSchema.ClientCapabilities.builder().roots(true).build(),
 				new McpSchema.Implementation("MCP Client", "0.3.1"));
 		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,
@@ -73,7 +74,7 @@ class WebClientStreamableHttpTransportIT {
 	void testCloseInitialized() {
 		var transport = WebClientStreamableHttpTransport.builder(builder).build();
 
-		var initializeRequest = new McpSchema.InitializeRequest(McpSchema.LATEST_PROTOCOL_VERSION,
+		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_11_25,
 				McpSchema.ClientCapabilities.builder().roots(true).build(),
 				new McpSchema.Implementation("MCP Client", "0.3.1"));
 		var testMessage = new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE,

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/AsyncServerMcpTransportContextIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/AsyncServerMcpTransportContextIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mcp.common;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -100,8 +101,10 @@ public class AsyncServerMcpTransportContextIT {
 		.build();
 
 	private final BiFunction<McpTransportContext, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> asyncStatelessHandler = (
-			transportContext, request) -> Mono
-				.just(new McpSchema.CallToolResult(transportContext.get("server-side-header-value").toString(), null));
+			transportContext,
+			request) -> Mono.just(new McpSchema.CallToolResult(
+					List.of(new McpSchema.TextContent(transportContext.get("server-side-header-value").toString())),
+					false, null, null));
 
 	private final BiFunction<McpAsyncServerExchange, McpSchema.CallToolRequest, Mono<McpSchema.CallToolResult>> asyncStatefulHandler = (
 			exchange, request) -> this.asyncStatelessHandler.apply(exchange.transportContext(), request);
@@ -194,7 +197,7 @@ public class AsyncServerMcpTransportContextIT {
 
 		var mcpServer = McpServer.async(this.streamableServerTransport)
 			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
-			.tools(new McpServerFeatures.AsyncToolSpecification(this.tool, null, this.asyncStatefulHandler))
+			.tools(new McpServerFeatures.AsyncToolSpecification(this.tool, this.asyncStatefulHandler))
 			.build();
 
 		StepVerifier.create(this.asyncStreamableClient.initialize())
@@ -226,7 +229,7 @@ public class AsyncServerMcpTransportContextIT {
 
 		var mcpServer = McpServer.async(this.sseServerTransport)
 			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
-			.tools(new McpServerFeatures.AsyncToolSpecification(this.tool, null, this.asyncStatefulHandler))
+			.tools(new McpServerFeatures.AsyncToolSpecification(this.tool, this.asyncStatefulHandler))
 			.build();
 
 		StepVerifier.create(this.asyncSseClient.initialize())

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/SyncServerMcpTransportContextIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/common/SyncServerMcpTransportContextIT.java
@@ -195,7 +195,7 @@ public class SyncServerMcpTransportContextIT {
 
 		var mcpServer = McpServer.sync(this.streamableServerTransport)
 			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
-			.tools(new McpServerFeatures.SyncToolSpecification(this.tool, null, this.statefulHandler))
+			.tools(new McpServerFeatures.SyncToolSpecification(this.tool, this.statefulHandler))
 			.build();
 
 		McpSchema.InitializeResult initResult = this.streamableClient.initialize();
@@ -221,7 +221,7 @@ public class SyncServerMcpTransportContextIT {
 
 		var mcpServer = McpServer.sync(this.sseServerTransport)
 			.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
-			.tools(new McpServerFeatures.SyncToolSpecification(this.tool, null, this.statefulHandler))
+			.tools(new McpServerFeatures.SyncToolSpecification(this.tool, this.statefulHandler))
 			.build();
 
 		McpSchema.InitializeResult initResult = this.sseClient.initialize();

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
@@ -365,14 +365,18 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 		}
 
 		if (request.param(SESSION_ID).isEmpty()) {
-			return ServerResponse.badRequest().body(new McpError("Session ID missing in message endpoint"));
+			return ServerResponse.badRequest()
+				.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS,
+						"Session ID missing in message endpoint", null)));
 		}
 
 		String sessionId = request.param(SESSION_ID).get();
 		McpServerSession session = this.sessions.get(sessionId);
 
 		if (session == null) {
-			return ServerResponse.status(HttpStatus.NOT_FOUND).body(new McpError("Session not found: " + sessionId));
+			return ServerResponse.status(HttpStatus.NOT_FOUND)
+				.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS,
+						"Session not found: " + sessionId, null)));
 		}
 
 		try {
@@ -391,11 +395,15 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 		}
 		catch (IllegalArgumentException | IOException e) {
 			logger.error("Failed to deserialize message: {}", e.getMessage());
-			return ServerResponse.badRequest().body(new McpError("Invalid message format"));
+			return ServerResponse.badRequest()
+				.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.PARSE_ERROR,
+						"Invalid message format", null)));
 		}
 		catch (Exception e) {
 			logger.error("Error handling message: {}", e.getMessage());
-			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new McpError(e.getMessage()));
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+						e.getMessage(), null)));
 		}
 	}
 

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
@@ -146,7 +146,8 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 		var handler = this.mcpHandler;
 		if (handler == null) {
 			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(new McpError("MCP handler not configured"));
+				.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+						"MCP handler not configured", null)));
 		}
 
 		try {
@@ -164,7 +165,9 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 				catch (Exception e) {
 					logger.error("Failed to handle request: {}", e.getMessage());
 					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-						.body(new McpError("Failed to handle request: " + e.getMessage()));
+						.body(new McpError(
+								new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+										"Failed to handle request: " + e.getMessage(), null)));
 				}
 			}
 			else if (message instanceof McpSchema.JSONRPCNotification jsonrpcNotification) {
@@ -177,22 +180,28 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 				catch (Exception e) {
 					logger.error("Failed to handle notification: {}", e.getMessage());
 					return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-						.body(new McpError("Failed to handle notification: " + e.getMessage()));
+						.body(new McpError(
+								new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+										"Failed to handle notification: " + e.getMessage(), null)));
 				}
 			}
 			else {
 				return ServerResponse.badRequest()
-					.body(new McpError("The server accepts either requests or notifications"));
+					.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_REQUEST,
+							"The server accepts either requests or notifications", null)));
 			}
 		}
 		catch (IllegalArgumentException | IOException e) {
 			logger.error("Failed to deserialize message: {}", e.getMessage());
-			return ServerResponse.badRequest().body(new McpError("Invalid message format"));
+			return ServerResponse.badRequest()
+				.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.PARSE_ERROR,
+						"Invalid message format", null)));
 		}
 		catch (Exception e) {
 			logger.error("Unexpected error handling message: {}", e.getMessage());
 			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR)
-				.body(new McpError("Unexpected error: " + e.getMessage()));
+				.body(new McpError(new McpSchema.JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INTERNAL_ERROR,
+						"Unexpected error: " + e.getMessage(), null)));
 		}
 	}
 

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/common/McpTransportContextIT.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/common/McpTransportContextIT.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mcp.common;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -102,8 +103,9 @@ public class McpTransportContextIT {
 	};
 
 	private static final BiFunction<McpTransportContext, McpSchema.CallToolRequest, McpSchema.CallToolResult> statelessHandler = (
-			transportContext,
-			request) -> new McpSchema.CallToolResult(transportContext.get("server-side-header-value").toString(), null);
+			transportContext, request) -> new McpSchema.CallToolResult(
+					List.of(new McpSchema.TextContent(transportContext.get("server-side-header-value").toString())),
+					false, null, null);
 
 	private static final BiFunction<McpSyncServerExchange, McpSchema.CallToolRequest, McpSchema.CallToolResult> statefulHandler = (
 			exchange, request) -> statelessHandler.apply(exchange.transportContext(), request);
@@ -275,7 +277,7 @@ public class McpTransportContextIT {
 		public McpSyncServer mcpStreamableServer(WebMvcStreamableServerTransportProvider transportProvider) {
 			return McpServer.sync(transportProvider)
 				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
-				.tools(new McpServerFeatures.SyncToolSpecification(tool, null, statefulHandler))
+				.tools(new McpServerFeatures.SyncToolSpecification(tool, statefulHandler))
 				.build();
 		}
 
@@ -303,7 +305,7 @@ public class McpTransportContextIT {
 		public McpSyncServer mcpSseServer(WebMvcSseServerTransportProvider transportProvider) {
 			return McpServer.sync(transportProvider)
 				.capabilities(McpSchema.ServerCapabilities.builder().tools(true).build())
-				.tools(new McpServerFeatures.SyncToolSpecification(tool, null, statefulHandler))
+				.tools(new McpServerFeatures.SyncToolSpecification(tool, statefulHandler))
 				.build();
 
 		}


### PR DESCRIPTION
The upstream dependency `io.modelcontextprotocol.spec` recently made breaking changes to `McpSchema` / `MCPError` in the new version `1.0.0-SNAPSHOT/mcp-core-1.0.0-20260220.213530-5.jar`.

- `McpError` constructor expects `JSONRPCError` now, instead of `String` in older version
- `McpServerFeatures.SyncToolSpecification` constructor parameter counts: 3→2 
- `McpServerFeatures.SyncToolSpecification` replaced `.call()` with `.callHandler()`
- `McpSchema.CallToolResult` constructor parameter counts: 2→4 (null for missing args)
- `McpSchema.LATEST_PROTOCOL_VERSION` is removed 

Many PRs failed on CI/CD because of them, so this PR tries to adapt these breaking changes.