### PR TITLE
Improve TokenTextSplitter EncodingType support

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/acme/AcmeIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/acme/AcmeIT.java
@@ -77,7 +77,7 @@ public class AcmeIT extends AbstractIT {
 		// Step 1 - load documents
 		JsonReader jsonReader = new JsonReader(this.bikesResource, "name", "price", "shortDescription", "description");
 
-		var textSplitter = new TokenTextSplitter();
+		var textSplitter = TokenTextSplitter.builder().build();
 
 		// Step 2 - Create embeddings and save to vector store
 

--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/TokenTextSplitter.java
@@ -71,34 +71,56 @@ public class TokenTextSplitter extends TextSplitter {
 
 	private final List<Character> punctuationMarks;
 
+	/**
+	 * @deprecated since 2.0.0-M3, use {@link #builder()} instead.
+	 */
+	@Deprecated(since = "2.0.0-M3", forRemoval = true)
+	@SuppressWarnings("deprecation")
 	public TokenTextSplitter() {
 		this(DEFAULT_CHUNK_SIZE, MIN_CHUNK_SIZE_CHARS, MIN_CHUNK_LENGTH_TO_EMBED, MAX_NUM_CHUNKS, KEEP_SEPARATOR,
 				DEFAULT_PUNCTUATION_MARKS);
 	}
 
+	/**
+	 * @deprecated since 2.0.0-M3, use {@link #builder()} instead.
+	 */
+	@Deprecated(since = "2.0.0-M3", forRemoval = true)
 	public TokenTextSplitter(boolean keepSeparator) {
 		this(DEFAULT_CHUNK_SIZE, MIN_CHUNK_SIZE_CHARS, MIN_CHUNK_LENGTH_TO_EMBED, MAX_NUM_CHUNKS, keepSeparator,
 				DEFAULT_PUNCTUATION_MARKS);
 	}
 
+	/**
+	 * @deprecated since 2.0.0-M3, use {@link #builder()} instead.
+	 */
+	@Deprecated(since = "2.0.0-M3", forRemoval = true)
 	public TokenTextSplitter(EncodingType encodingType) {
 		this(encodingType, DEFAULT_CHUNK_SIZE, MIN_CHUNK_SIZE_CHARS, MIN_CHUNK_LENGTH_TO_EMBED, MAX_NUM_CHUNKS,
 				KEEP_SEPARATOR, DEFAULT_PUNCTUATION_MARKS);
 	}
 
+	/**
+	 * @deprecated since 2.0.0-M3, use {@link #builder()} instead.
+	 */
+	@Deprecated(since = "2.0.0-M3", forRemoval = true)
 	public TokenTextSplitter(EncodingType encodingType, boolean keepSeparator) {
 		this(encodingType, DEFAULT_CHUNK_SIZE, MIN_CHUNK_SIZE_CHARS, MIN_CHUNK_LENGTH_TO_EMBED, MAX_NUM_CHUNKS,
 				keepSeparator, DEFAULT_PUNCTUATION_MARKS);
 	}
 
+	/**
+	 * @deprecated since 2.0.0-M3, use {@link #builder()} instead.
+	 */
+	@Deprecated(since = "2.0.0-M3", forRemoval = true)
 	public TokenTextSplitter(int chunkSize, int minChunkSizeChars, int minChunkLengthToEmbed, int maxNumChunks,
 			boolean keepSeparator, List<Character> punctuationMarks) {
 		this(DEFAULT_ENCODING_TYPE, chunkSize, minChunkSizeChars, minChunkLengthToEmbed, maxNumChunks, keepSeparator,
 				punctuationMarks);
 	}
 
-	public TokenTextSplitter(EncodingType encodingType, int chunkSize, int minChunkSizeChars, int minChunkLengthToEmbed,
-			int maxNumChunks, boolean keepSeparator, List<Character> punctuationMarks) {
+	private TokenTextSplitter(EncodingType encodingType, int chunkSize, int minChunkSizeChars,
+			int minChunkLengthToEmbed, int maxNumChunks, boolean keepSeparator, List<Character> punctuationMarks) {
+		Assert.notNull(encodingType, "encodingType must not be null");
 		this.encoding = this.registry.getEncoding(encodingType);
 		this.chunkSize = chunkSize;
 		this.minChunkSizeChars = minChunkSizeChars;

--- a/spring-ai-commons/src/test/java/org/springframework/ai/reader/TextReaderTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/reader/TextReaderTests.java
@@ -49,7 +49,7 @@ public class TextReaderTests {
 
 		List<Document> documents0 = textReader.get();
 
-		List<Document> documents = new TokenTextSplitter().apply(documents0);
+		List<Document> documents = TokenTextSplitter.builder().build().apply(documents0);
 
 		assertThat(documents.size()).isEqualTo(54);
 

--- a/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TextSplitterTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TextSplitterTests.java
@@ -144,7 +144,7 @@ public class TextSplitterTests {
 				+ "4being forced to choose. It isn’t the lack of an exit, but the abundance of exits that is so disorienting.",
 				Map.of("file_name", "sample1.pdf", "page_number", 4));
 
-		var tokenTextSplitter = new TokenTextSplitter();
+		var tokenTextSplitter = TokenTextSplitter.builder().build();
 
 		// when
 		List<Document> splitedDocument = tokenTextSplitter.apply(List.of(doc1, doc2, doc3, doc4));
@@ -212,7 +212,7 @@ public class TextSplitterTests {
 				+ "3being forced to choose. It isn’t the lack of an exit, but the abundance of exits that is so disorienting.",
 				Map.of("file_name", "sample1.pdf", "page_number", 3));
 
-		var tokenTextSplitter = new TokenTextSplitter();
+		var tokenTextSplitter = TokenTextSplitter.builder().build();
 
 		// when
 		List<Document> splitedDocument = tokenTextSplitter.apply(List.of(doc1, doc2, doc3));

--- a/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TokenTextSplitterTest.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/TokenTextSplitterTest.java
@@ -26,6 +26,7 @@ import org.springframework.ai.document.DefaultContentFormatter;
 import org.springframework.ai.document.Document;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author Ricken Bazolo
@@ -50,7 +51,7 @@ public class TokenTextSplitterTest {
 				Map.of("key2", "value22", "key3", "value3"));
 		doc2.setContentFormatter(contentFormatter2);
 
-		var tokenTextSplitter = new TokenTextSplitter();
+		var tokenTextSplitter = TokenTextSplitter.builder().build();
 
 		var chunks = tokenTextSplitter.apply(List.of(doc1, doc2));
 
@@ -205,6 +206,13 @@ public class TokenTextSplitterTest {
 		assertThat(chunks.get(5).getText()).isEqualTo("business logic。");
 		assertThat(chunks.get(6).getText()).isEqualTo("We just want to test it works or not？");
 
+	}
+
+	@Test
+	public void testTokenTextSplitterWithNullEncodingTypeThrows() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> TokenTextSplitter.builder().withEncodingType(null).build())
+			.withMessage("encodingType must not be null");
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/etl-pipeline.adoc
@@ -282,7 +282,7 @@ The `TextReader` processes text content as follows:
 [source,java]
 ----
 List<Document> documents = textReader.get();
-List<Document> splitDocuments = new TokenTextSplitter().apply(this.documents);
+List<Document> splitDocuments = TokenTextSplitter.builder().build().apply(this.documents);
 ----
 
 * The reader uses Spring's `Resource` abstraction, allowing it to read from various sources (classpath, file system, URL, etc.).
@@ -676,7 +676,7 @@ The `TextSplitter` an abstract base class that helps divides documents to fit th
 
 
 === TokenTextSplitter
-The `TokenTextSplitter` is an implementation of `TextSplitter` that splits text into chunks based on token count, using the CL100K_BASE encoding.
+The `TokenTextSplitter` is an implementation of `TextSplitter` that splits text into chunks based on token count. It supports configurable encoding types (e.g., `CL100K_BASE`, `P50K_BASE`, `O200K_BASE`) and defaults to `CL100K_BASE`.
 
 ==== Usage
 
@@ -688,27 +688,11 @@ The `TokenTextSplitter` is an implementation of `TextSplitter` that splits text 
 class MyTokenTextSplitter {
 
     public List<Document> splitDocuments(List<Document> documents) {
-        TokenTextSplitter splitter = new TokenTextSplitter();
+        TokenTextSplitter splitter = TokenTextSplitter.builder().build();
         return splitter.apply(documents);
     }
 
     public List<Document> splitCustomized(List<Document> documents) {
-        TokenTextSplitter splitter = new TokenTextSplitter(1000, 400, 10, 5000, true, List.of('.', '?', '!', '\n'));
-        return splitter.apply(documents);
-    }
-}
-----
-
-===== Using the Builder Pattern
-
-The recommended way to create a `TokenTextSplitter` is using the builder pattern, which provides a more readable and flexible API:
-
-[source,java]
-----
-@Component
-class MyTokenTextSplitter {
-
-    public List<Document> splitWithBuilder(List<Document> documents) {
         TokenTextSplitter splitter = TokenTextSplitter.builder()
             .withChunkSize(1000)
             .withMinChunkSizeChars(400)
@@ -716,10 +700,21 @@ class MyTokenTextSplitter {
             .withMaxNumChunks(5000)
             .withKeepSeparator(true)
             .build();
-
         return splitter.apply(documents);
     }
 }
+----
+
+===== Custom Encoding Type
+
+You can configure the encoding type used for tokenization. This is useful when working with models that use different tokenizers:
+
+[source,java]
+----
+TokenTextSplitter splitter = TokenTextSplitter.builder()
+    .withEncodingType(EncodingType.O200K_BASE)
+    .withChunkSize(1000)
+    .build();
 ----
 
 ===== Custom Punctuation Marks
@@ -754,18 +749,13 @@ class MyInternationalTextSplitter {
 }
 ----
 
-==== Constructor Options
+==== Configuration
 
-The `TokenTextSplitter` provides three constructor options:
-
-1. `TokenTextSplitter()`: Creates a splitter with default settings.
-2. `TokenTextSplitter(boolean keepSeparator)`: Creates a splitter with custom separator behavior.
-3. `TokenTextSplitter(int chunkSize, int minChunkSizeChars, int minChunkLengthToEmbed, int maxNumChunks, boolean keepSeparator, List<Character> punctuationMarks)`: Full constructor with all customization options.
-
-NOTE: The builder pattern (shown above) is the recommended approach for creating instances with custom configurations.
+Use `TokenTextSplitter.builder()` to create instances. All constructors are deprecated in favor of the builder.
 
 ==== Parameters
 
+* `encodingType`: The tokenizer encoding type to use (default: `CL100K_BASE`). Supported values include `CL100K_BASE`, `P50K_BASE`, and `O200K_BASE`.
 * `chunkSize`: The target size of each text chunk in tokens (default: 800).
 * `minChunkSizeChars`: The minimum size of each text chunk in characters (default: 350).
 * `minChunkLengthToEmbed`: The minimum length of a chunk to be included (default: 5).
@@ -799,8 +789,8 @@ Document doc1 = new Document("This is a long piece of text that needs to be spli
 Document doc2 = new Document("Another document with content that will be split based on token count.",
         Map.of("source", "example2.txt"));
 
-TokenTextSplitter splitter = new TokenTextSplitter();
-List<Document> splitDocuments = this.splitter.apply(List.of(this.doc1, this.doc2));
+TokenTextSplitter splitter = TokenTextSplitter.builder().build();
+List<Document> splitDocuments = splitter.apply(List.of(doc1, doc2));
 
 for (Document doc : splitDocuments) {
     System.out.println("Chunk: " + doc.getContent());

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/hana.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/hana.adoc
@@ -270,7 +270,7 @@ public class CricketWorldCupHanaController {
     public ResponseEntity<String> handleFileUpload(@RequestParam("pdf") MultipartFile file) throws IOException {
         Resource pdf = file.getResource();
         Supplier<List<Document>> reader = new PagePdfDocumentReader(pdf);
-        Function<List<Document>, List<Document>> splitter = new TokenTextSplitter();
+        Function<List<Document>, List<Document>> splitter = TokenTextSplitter.builder().build();
         List<Document> documents = splitter.apply(reader.get());
         log.info("{} documents created from pdf file: {}", documents.size(), pdf.getFilename());
 		this.hanaCloudVectorStore.accept(documents);

--- a/vector-stores/spring-ai-hanadb-store/src/test/java/org/springframework/ai/vectorstore/hanadb/CricketWorldCupHanaController.java
+++ b/vector-stores/spring-ai-hanadb-store/src/test/java/org/springframework/ai/vectorstore/hanadb/CricketWorldCupHanaController.java
@@ -74,7 +74,7 @@ public class CricketWorldCupHanaController {
 	public ResponseEntity<String> handleFileUpload(@RequestParam("pdf") MultipartFile file) throws IOException {
 		Resource pdf = file.getResource();
 		Supplier<List<Document>> reader = new PagePdfDocumentReader(pdf);
-		Function<List<Document>, List<Document>> splitter = new TokenTextSplitter();
+		Function<List<Document>, List<Document>> splitter = TokenTextSplitter.builder().build();
 		List<Document> documents = splitter.apply(reader.get());
 		logger.info("{} documents created from pdf file: {}", documents.size(), pdf.getFilename());
 		this.hanaCloudVectorStore.accept(documents);

--- a/vector-stores/spring-ai-hanadb-store/src/test/java/org/springframework/ai/vectorstore/hanadb/HanaCloudVectorStoreIT.java
+++ b/vector-stores/spring-ai-hanadb-store/src/test/java/org/springframework/ai/vectorstore/hanadb/HanaCloudVectorStoreIT.java
@@ -68,7 +68,7 @@ public class HanaCloudVectorStoreIT {
 			logger.info("Purged all embeddings: count={}", deleteCount);
 
 			Supplier<List<Document>> reader = new PagePdfDocumentReader("classpath:Cricket_World_Cup.pdf");
-			Function<List<Document>, List<Document>> splitter = new TokenTextSplitter();
+			Function<List<Document>, List<Document>> splitter = TokenTextSplitter.builder().build();
 			List<Document> documents = splitter.apply(reader.get());
 			vectorStore.accept(documents);
 


### PR DESCRIPTION
  Follow-up to cfbe546e04 (Allow TokenTextSplitter to accept EncodingType).

  - Make the full constructor private, accessible only via builder
  - Deprecate parameterized constructors in favor of builder
  - Add null validation for encodingType
  - Update docs to use builder pattern and document encodingType
  - Add test for null encodingType rejection

