### PR TITLE
test: add metadata preservation tests for Qdrant vector store

### DIFF
--- a/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
+++ b/vector-stores/spring-ai-qdrant-store/src/test/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStoreIT.java
@@ -392,16 +392,18 @@ public class QdrantVectorStoreIT extends BaseVectorStoreTests {
 			VectorStore vectorStore = context.getBean(VectorStore.class);
 
 			// Create documents with numeric metadata for filtering
-			var doc1 = new Document("Spring Framework documentation", Map.of("version", 3.0, "source", "spring-docs"));
+			var doc1 = new Document("metadata test content with numeric version filtering capability",
+					Map.of("version", 3.0, "source", "metadata-test"));
 
-			var doc2 = new Document("Kubernetes documentation", Map.of("version", 2.0, "source", "k8s-docs"));
+			var doc2 = new Document("metadata test reference with numeric version comparison value",
+					Map.of("version", 2.0, "source", "metadata-test"));
 
 			// Add documents to vector store
 			vectorStore.add(List.of(doc1, doc2));
 
 			// Search with filter expression on numeric metadata
 			List<Document> filteredResults = vectorStore.similaritySearch(SearchRequest.builder()
-				.query("documentation")
+				.query("numeric version filtering")
 				.topK(5)
 				.similarityThresholdAll()
 				.filterExpression("version > 2.5")
@@ -413,7 +415,7 @@ public class QdrantVectorStoreIT extends BaseVectorStoreTests {
 
 			// Verify all metadata fields are present and correct in filtered results
 			Map<String, Object> metadata = filteredDoc.getMetadata();
-			assertThat(metadata).containsEntry("version", 3.0).containsEntry("source", "spring-docs");
+			assertThat(metadata).containsEntry("version", 3.0).containsEntry("source", "metadata-test");
 
 			// Clean up
 			vectorStore.delete(List.of(doc1.getId(), doc2.getId()));


### PR DESCRIPTION
Adds two focused integration tests that validate metadata field preservation:

1. metadataTypePreservationInSearchResults: Validates metadata types (String, Double, Boolean) are preserved correctly and not silently converted during search operations.

2. metadataPreservationInFilteredResults: Validates metadata is preserved when using filter expressions, ensuring filter integration works correctly with metadata.

These tests address a gap where metadata handling was not comprehensively tested. Metadata is critical for production deployments:
- Source tracking (where documents came from)
- Version management (which version was indexed)
- Filtering (numeric and boolean metadata in queries)
- Compliance (audit trails)

Fixes #5496

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc