### PR TITLE
GH-5488: Sanitize document name for Bedrock Converse API compliance

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -614,13 +614,27 @@ public class BedrockProxyChatModel implements ChatModel {
 		else if (BedrockMediaFormat.isSupportedDocumentFormat(mimeType)) { // Document
 
 			return ContentBlock.fromDocument(DocumentBlock.builder()
-				.name(media.getName())
+				.name(sanitizeDocumentName(media.getName()))
 				.format(BedrockMediaFormat.getDocumentFormat(mimeType))
 				.source(DocumentSource.builder().bytes(SdkBytes.fromByteArray(media.getDataAsByteArray())).build())
 				.build());
 		}
 
 		throw new IllegalArgumentException("Unsupported media format: " + mimeType);
+	}
+
+	/**
+	 * Sanitizes a document name to conform to Amazon Bedrock's naming restrictions. The
+	 * name can only contain alphanumeric characters, whitespace characters (no more than
+	 * one in a row), hyphens, parentheses, and square brackets.
+	 * @param name the document name to sanitize
+	 * @return the sanitized document name
+	 * @see <a href=
+	 * "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html">DocumentBlock
+	 * API Reference</a>
+	 */
+	static String sanitizeDocumentName(String name) {
+		return name.replaceAll("[^a-zA-Z0-9\\s\\-()\\[\\]]", "-");
 	}
 
 	private static byte[] getContentMediaData(Object mediaData) {

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +43,25 @@ class BedrockProxyChatModelTest {
 			mocked.when(DefaultAwsRegionProviderChain::builder).thenReturn(this.awsRegionProviderBuilder);
 			BedrockProxyChatModel.builder().build();
 		}
+	}
+
+	@Test
+	void sanitizeDocumentNameShouldReplaceDotsWithHyphens() {
+		String name = "media-vnd.openxmlformats-officedocument.spreadsheetml.sheet-abc123";
+		assertThat(BedrockProxyChatModel.sanitizeDocumentName(name))
+			.isEqualTo("media-vnd-openxmlformats-officedocument-spreadsheetml-sheet-abc123");
+	}
+
+	@Test
+	void sanitizeDocumentNameShouldPreserveValidName() {
+		String name = "media-pdf-abc123";
+		assertThat(BedrockProxyChatModel.sanitizeDocumentName(name)).isEqualTo(name);
+	}
+
+	@Test
+	void sanitizeDocumentNameShouldPreserveAllowedSpecialCharacters() {
+		String name = "my document (1) [draft]";
+		assertThat(BedrockProxyChatModel.sanitizeDocumentName(name)).isEqualTo(name);
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-ai/issues/5488

The auto-generated Media name includes the MIME subtype directly (e.g., vnd.openxmlformats-officedocument.spreadsheetml.sheet), which contains dots that Bedrock rejects. The fix sanitizes the name in the Bedrock layer before passing it to the AWS SDK.