### PR TITLE
Fix empty assistant content serialization for tool-call messages

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -617,6 +617,10 @@ public class OpenAiChatModel implements ChatModel {
 						return new ToolCall(toolCall.id(), toolCall.type(), function);
 					}).toList();
 				}
+				String assistantContent = assistantMessage.getText();
+				if (!CollectionUtils.isEmpty(toolCalls) && !StringUtils.hasText(assistantContent)) {
+					assistantContent = null;
+				}
 				AudioOutput audioOutput = null;
 				if (!CollectionUtils.isEmpty(assistantMessage.getMedia())) {
 					Assert.isTrue(assistantMessage.getMedia().size() == 1,
@@ -624,8 +628,8 @@ public class OpenAiChatModel implements ChatModel {
 					audioOutput = new AudioOutput(assistantMessage.getMedia().get(0).getId(), null, null, null);
 
 				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
-						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null, audioOutput, null, null));
+				return List.of(new ChatCompletionMessage(assistantContent, ChatCompletionMessage.Role.ASSISTANT, null,
+						null, toolCalls, null, audioOutput, null, null));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;


### PR DESCRIPTION
## Summary
This PR fixes issue #5480 by normalizing assistant message content to `null` when a tool-call assistant message has no textual content.

## Problem
When an assistant message contains tool calls but no text, Spring AI currently serializes `content` as an empty string (`""`). Some OpenAI-compatible backends validate this field strictly and reject the request with HTTP 400.

## Changes
- In `OpenAiChatModel#createRequest`, convert assistant content to `null` only when:
  - the message includes tool calls, and
  - assistant text is empty/blank.
- Preserve existing behavior for:
  - tool-call messages with non-empty text, and
  - assistant messages without tool calls.
- Added focused regression tests in `ChatCompletionRequestTests` to cover all three cases.

## Validation
- `./mvnw -pl models/spring-ai-openai -Dtest=ChatCompletionRequestTests test`
- `./mvnw -pl models/spring-ai-openai test`

Closes #5480
