### PR TITLE
Fix: Set content to null for assistant messages with tool_calls only

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatModel.java
@@ -596,7 +596,14 @@ public class AzureOpenAiChatModel implements ChatModel {
 						.map(tc -> ((ChatCompletionsToolCall) tc)) // !!!
 						.toList();
 				}
-				var azureAssistantMessage = new ChatRequestAssistantMessage(message.getText());
+				// If there are tool calls but no text content, set content to null for compatibility
+				// with Anthropic API (and other OpenAI-compatible backends that require content to be
+				// either null or non-empty string)
+				String content = message.getText();
+				if ((content == null || content.isEmpty()) && !CollectionUtils.isEmpty(toolCalls)) {
+					content = null;
+				}
+				var azureAssistantMessage = new ChatRequestAssistantMessage(content);
 				azureAssistantMessage.setToolCalls(toolCalls);
 				return List.of(azureAssistantMessage);
 			case TOOL:

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -624,7 +624,14 @@ public class OpenAiChatModel implements ChatModel {
 					audioOutput = new AudioOutput(assistantMessage.getMedia().get(0).getId(), null, null, null);
 
 				}
-				return List.of(new ChatCompletionMessage(assistantMessage.getText(),
+				// If there are tool calls but no text content, set content to null for compatibility
+				// with Anthropic API (and other OpenAI-compatible backends that require content to be
+				// either null or non-empty string)
+				String content = assistantMessage.getText();
+				if ((content == null || content.isEmpty()) && !CollectionUtils.isEmpty(toolCalls)) {
+					content = null;
+				}
+				return List.of(new ChatCompletionMessage(content,
 						ChatCompletionMessage.Role.ASSISTANT, null, null, toolCalls, null, audioOutput, null, null));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {


### PR DESCRIPTION
## Summary
When an assistant message contains only tool_calls without text content, set the content to `null` instead of an empty string `""`. This ensures compatibility with Anthropic API and other OpenAI-compatible backends that require content to be either null or a non-empty string.

## Fixes
Fixes #5480

## Changes
- **OpenAiChatModel.java**: Added logic to set content to null when there are tool_calls but no text content
- **AzureOpenAiChatModel.java**: Same fix applied for Azure OpenAI

## Testing
This fix addresses the HTTP 400 error "messages[N]: content is required" that occurs when using OpenAI-compatible backends that proxy to Anthropic/Claude.