### PR TITLE
Add MetadataFields auto configuration in AzureVectorStore

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/main/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/main/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStoreProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.ai.vectorstore.azure.autoconfigure;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.vectorstore.azure.AzureVectorStore;
@@ -50,6 +53,43 @@ public class AzureVectorStoreProperties extends CommonVectorStoreProperties {
 	private @Nullable String embeddingFieldName;
 
 	private @Nullable String metadataFieldName;
+
+	/**
+	 * List of metadata fields that can be used in similarity search filter expressions.
+	 * Each entry defines a field name and type (string, int32, int64, decimal, bool,
+	 * date).
+	 */
+	private List<MetadataFieldEntry> metadataFields = new ArrayList<>();
+
+	/**
+	 * Configuration entry for a filterable metadata field.
+	 */
+	public static class MetadataFieldEntry {
+
+		private String name;
+
+		private String fieldType;
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		/**
+		 * Field type: string, int32, int64, decimal, bool, date.
+		 */
+		public String getFieldType() {
+			return this.fieldType;
+		}
+
+		public void setFieldType(String fieldType) {
+			this.fieldType = fieldType;
+		}
+
+	}
 
 	public @Nullable String getUrl() {
 		return this.url;
@@ -121,6 +161,23 @@ public class AzureVectorStoreProperties extends CommonVectorStoreProperties {
 
 	public void setMetadataFieldName(@Nullable String metadataFieldName) {
 		this.metadataFieldName = metadataFieldName;
+	}
+
+	public List<MetadataFieldEntry> getMetadataFields() {
+		return this.metadataFields;
+	}
+
+	public void setMetadataFields(List<MetadataFieldEntry> metadataFields) {
+		this.metadataFields = metadataFields != null ? metadataFields : new ArrayList<>();
+	}
+
+	/**
+	 * Alias for {@link #setMetadataFields(List)} to support the common typo
+	 * "metadata-fileds" in configuration. Both "metadata-fields" and
+	 * "metadata-fileds" are accepted.
+	 */
+	public void setMetadataFileds(List<MetadataFieldEntry> metadataFileds) {
+		setMetadataFields(metadataFileds);
 	}
 
 }

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/test/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStoreAutoConfigurationIT.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/test/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStoreAutoConfigurationIT.java
@@ -173,6 +173,44 @@ public class AzureVectorStoreAutoConfigurationIT {
 		});
 	}
 
+	@Test
+	public void metadataFieldsAreBoundFromProperties() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.vectorstore.type=azure",
+					"spring.ai.vectorstore.azure.metadata-fields[0].name=department",
+					"spring.ai.vectorstore.azure.metadata-fields[0].field-type=string",
+					"spring.ai.vectorstore.azure.metadata-fields[1].name=year",
+					"spring.ai.vectorstore.azure.metadata-fields[1].field-type=int64")
+			.run(context -> {
+				AzureVectorStoreProperties properties = context.getBean(AzureVectorStoreProperties.class);
+				assertThat(properties.getMetadataFields()).hasSize(2);
+				assertThat(properties.getMetadataFields().get(0).getName()).isEqualTo("department");
+				assertThat(properties.getMetadataFields().get(0).getFieldType()).isEqualTo("string");
+				assertThat(properties.getMetadataFields().get(1).getName()).isEqualTo("year");
+				assertThat(properties.getMetadataFields().get(1).getFieldType()).isEqualTo("int64");
+
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+				assertThat(vectorStore).isInstanceOf(AzureVectorStore.class);
+			});
+	}
+
+	@Test
+	public void metadataFiledsTypoAliasIsSupported() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.vectorstore.type=azure",
+					"spring.ai.vectorstore.azure.metadata-fileds[0].name=filterField",
+					"spring.ai.vectorstore.azure.metadata-fileds[0].fieldType=string")
+			.run(context -> {
+				AzureVectorStoreProperties properties = context.getBean(AzureVectorStoreProperties.class);
+				assertThat(properties.getMetadataFields()).hasSize(1);
+				assertThat(properties.getMetadataFields().get(0).getName()).isEqualTo("filterField");
+				assertThat(properties.getMetadataFields().get(0).getFieldType()).isEqualTo("string");
+
+				VectorStore vectorStore = context.getBean(VectorStore.class);
+				assertThat(vectorStore).isInstanceOf(AzureVectorStore.class);
+			});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class Config {
 

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/test/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStorePropertiesTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/src/test/java/org/springframework/ai/vectorstore/azure/autoconfigure/AzureVectorStorePropertiesTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.azure.autoconfigure;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.vectorstore.azure.AzureVectorStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Karan Bhardwaj
+ */
+class AzureVectorStorePropertiesTests {
+
+	@Test
+	void defaultMetadataFieldsIsEmpty() {
+		var props = new AzureVectorStoreProperties();
+		assertThat(props.getMetadataFields()).isEmpty();
+	}
+
+	@Test
+	void metadataFieldsCanBeSet() {
+		var props = new AzureVectorStoreProperties();
+
+		var entry1 = new AzureVectorStoreProperties.MetadataFieldEntry();
+		entry1.setName("department");
+		entry1.setFieldType("string");
+
+		var entry2 = new AzureVectorStoreProperties.MetadataFieldEntry();
+		entry2.setName("year");
+		entry2.setFieldType("int64");
+
+		props.setMetadataFields(List.of(entry1, entry2));
+
+		assertThat(props.getMetadataFields()).hasSize(2);
+		assertThat(props.getMetadataFields().get(0).getName()).isEqualTo("department");
+		assertThat(props.getMetadataFields().get(0).getFieldType()).isEqualTo("string");
+		assertThat(props.getMetadataFields().get(1).getName()).isEqualTo("year");
+		assertThat(props.getMetadataFields().get(1).getFieldType()).isEqualTo("int64");
+	}
+
+	@Test
+	void metadataFieldsDefaultValues() {
+		var props = new AzureVectorStoreProperties();
+		assertThat(props.getIndexName()).isEqualTo(AzureVectorStore.DEFAULT_INDEX_NAME);
+	}
+
+	@Test
+	void metadataFiledsTypoAliasWorks() {
+		var props = new AzureVectorStoreProperties();
+
+		var entry = new AzureVectorStoreProperties.MetadataFieldEntry();
+		entry.setName("filterField");
+		entry.setFieldType("string");
+
+		props.setMetadataFileds(List.of(entry));
+
+		assertThat(props.getMetadataFields()).hasSize(1);
+		assertThat(props.getMetadataFields().get(0).getName()).isEqualTo("filterField");
+		assertThat(props.getMetadataFields().get(0).getFieldType()).isEqualTo("string");
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/azure.adoc
@@ -115,8 +115,28 @@ You can use the following properties in your Spring Boot configuration to custom
 |`spring.ai.vectorstore.azure.content-field-name`|content
 |`spring.ai.vectorstore.azure.embedding-field-name`|embedding
 |`spring.ai.vectorstore.azure.metadata-field-name`|metadata
+|`spring.ai.vectorstore.azure.metadata-fields`|[] (empty list). List of filterable metadata fields with `name` and `field-type` (string, int32, int64, decimal, bool, date). Also accepts `metadata-fileds` (typo alias)
 |===
 
+You can configure filterable metadata fields via YAML (both `metadata-fields` and `metadata-fileds` work):
+
+[source,yaml]
+----
+spring:
+  ai:
+    vectorstore:
+      azure:
+        url: https://your-search-endpoint.search.windows.net
+        api-key: ${AZURE_AI_SEARCH_API_KEY}
+        initialize-schema: true
+        metadata-fields:
+          - name: department
+            field-type: string
+          - name: year
+            field-type: int64
+          - name: created_date
+            field-type: date
+----
 
 == Sample Code
 


### PR DESCRIPTION
**Summary**
Enables configuring Azure Vector Store metadata fields via application properties/YAML, instead of defining them programmatically.

**Related issue**
Fixes #2340

**Changes**
AzureVectorStoreProperties: 
Added metadata-fields plus alias metadata-fileds.
MetadataFieldEntry: 
New nested type with name and field-type for filterable metadata fields.
AzureVectorStoreAutoConfiguration: 
Maps metadata-fields to AzureVectorStore.filterMetadataFields().
Supported field types: 
string, text, int32, int64, long, decimal, double, bool, boolean, date, datetime, datetimeoffset.
Validation: 
Skips entries with blank name or field-type; trims values before mapping.
Tests: 
Added unit tests and integration tests for property binding and typo alias.
Docs: 
Updated Azure vector store docs with property table and YAML example.
Configuration example : 
spring:
  ai:
    vectorstore:
      azure:
        url: https://your-search-endpoint.search.windows.net
        api-key: ${AZURE_AI_SEARCH_API_KEY}
        initialize-schema: true
        metadata-fields:
          - name: department
            field-type: string
          - name: year
            field-type: int64
          - name: created_date
            field-type: date
Checklist
[x] Code follows project style guidelines (Checkstyle)
[x] Self-review done
[x] Commented non-trivial sections where needed
[x] Documentation updated
[x] Tests added for new behavior
[x] All tests passing locally
[x] DCO sign-off in commit