### PR TITLE
Add ArcadeDB VectorStore and ChatMemoryRepository

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-model-chat-memory-repository-arcadedb</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Auto Configuration for ArcadeDB chat memory repository</name>
+	<description>Spring AI Auto Configuration for ArcadeDB chat memory repository</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model-chat-memory-repository-arcadedb</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+</project>

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/autoconfigure/ArcadeDBChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/autoconfigure/ArcadeDBChatMemoryRepositoryAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.arcadedb.autoconfigure;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+
+import org.springframework.ai.chat.memory.repository.arcadedb.ArcadeDBChatMemoryRepository;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for ArcadeDB ChatMemoryRepository.
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(ArcadeDBChatMemoryRepository.class)
+@EnableConfigurationProperties(ArcadeDBChatMemoryRepositoryProperties.class)
+public class ArcadeDBChatMemoryRepositoryAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(
+			prefix = ArcadeDBChatMemoryRepositoryProperties.CONFIG_PREFIX,
+			name = "database-path")
+	public ArcadeDBChatMemoryRepository arcadeDBChatMemoryRepository(
+			ArcadeDBChatMemoryRepositoryProperties properties) {
+		ArcadeDBChatMemoryRepository.Builder builder = ArcadeDBChatMemoryRepository
+				.builder()
+				.sessionTypeName(properties.getSessionTypeName())
+				.messageTypeName(properties.getMessageTypeName())
+				.edgeTypeName(properties.getEdgeTypeName());
+
+		builder.databasePath(properties.getDatabasePath());
+
+		return builder.build();
+	}
+
+}

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/autoconfigure/ArcadeDBChatMemoryRepositoryProperties.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/autoconfigure/ArcadeDBChatMemoryRepositoryProperties.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.arcadedb.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the ArcadeDB ChatMemoryRepository.
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+@ConfigurationProperties(ArcadeDBChatMemoryRepositoryProperties.CONFIG_PREFIX)
+public class ArcadeDBChatMemoryRepositoryProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.arcadedb";
+
+	private String databasePath;
+
+	private String sessionTypeName = "Session";
+
+	private String messageTypeName = "ChatMessage";
+
+	private String edgeTypeName = "HAS_MESSAGE";
+
+	public String getDatabasePath() {
+		return databasePath;
+	}
+
+	public void setDatabasePath(String databasePath) {
+		this.databasePath = databasePath;
+	}
+
+	public String getSessionTypeName() {
+		return sessionTypeName;
+	}
+
+	public void setSessionTypeName(String sessionTypeName) {
+		this.sessionTypeName = sessionTypeName;
+	}
+
+	public String getMessageTypeName() {
+		return messageTypeName;
+	}
+
+	public void setMessageTypeName(String messageTypeName) {
+		this.messageTypeName = messageTypeName;
+	}
+
+	public String getEdgeTypeName() {
+		return edgeTypeName;
+	}
+
+	public void setEdgeTypeName(String edgeTypeName) {
+		this.edgeTypeName = edgeTypeName;
+	}
+
+}

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.ai.chat.memory.repository.arcadedb.autoconfigure.ArcadeDBChatMemoryRepositoryAutoConfiguration

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-vector-store-arcadedb</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Auto Configuration for ArcadeDB vector store</name>
+	<description>Spring AI Auto Configuration for ArcadeDB vector store</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-arcadedb-store</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/src/main/java/org/springframework/ai/vectorstore/arcadedb/autoconfigure/ArcadeDBVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/src/main/java/org/springframework/ai/vectorstore/arcadedb/autoconfigure/ArcadeDBVectorStoreAutoConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb.autoconfigure;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.arcadedb.ArcadeDBDistanceType;
+import org.springframework.ai.vectorstore.arcadedb.ArcadeDBVectorStore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for ArcadeDB VectorStore.
+ *
+ * <p>
+ * Creates an embedded {@link Database} bean and an
+ * {@link ArcadeDBVectorStore} bean.
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(ArcadeDBVectorStore.class)
+@EnableConfigurationProperties(ArcadeDBVectorStoreProperties.class)
+public class ArcadeDBVectorStoreAutoConfiguration {
+
+	@Bean(destroyMethod = "close")
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = ArcadeDBVectorStoreProperties.CONFIG_PREFIX,
+			name = "database-path")
+	public Database arcadeDatabase(ArcadeDBVectorStoreProperties properties) {
+		DatabaseFactory factory = new DatabaseFactory(
+				properties.getDatabasePath());
+		return factory.exists() ? factory.open() : factory.create();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = ArcadeDBVectorStoreProperties.CONFIG_PREFIX,
+			name = "database-path")
+	public ArcadeDBVectorStore arcadeDBVectorStore(Database database,
+			EmbeddingModel embeddingModel,
+			ArcadeDBVectorStoreProperties properties) {
+		ArcadeDBVectorStore store = ArcadeDBVectorStore
+				.builder(embeddingModel)
+				.database(database)
+				.typeName(properties.getTypeName())
+				.embeddingDimension(properties.getEmbeddingDimension())
+				.distanceType(ArcadeDBDistanceType
+						.valueOf(properties.getDistanceType()))
+				.initializeSchema(properties.isInitializeSchema())
+				.m(properties.getM())
+				.ef(properties.getEf())
+				.efConstruction(properties.getEfConstruction())
+				.metadataPrefix(properties.getMetadataPrefix())
+				.build();
+		store.afterPropertiesSet();
+		return store;
+	}
+
+}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/src/main/java/org/springframework/ai/vectorstore/arcadedb/autoconfigure/ArcadeDBVectorStoreProperties.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/src/main/java/org/springframework/ai/vectorstore/arcadedb/autoconfigure/ArcadeDBVectorStoreProperties.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the ArcadeDB VectorStore.
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+@ConfigurationProperties(ArcadeDBVectorStoreProperties.CONFIG_PREFIX)
+public class ArcadeDBVectorStoreProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.vectorstore.arcadedb";
+
+	private String databasePath;
+
+	private String typeName = "Document";
+
+	private int embeddingDimension = 1536;
+
+	private String distanceType = "COSINE";
+
+	private boolean initializeSchema = true;
+
+	private int m = 16;
+
+	private int ef = 10;
+
+	private int efConstruction = 200;
+
+	private String metadataPrefix = "meta_";
+
+	public String getDatabasePath() {
+		return databasePath;
+	}
+
+	public void setDatabasePath(String databasePath) {
+		this.databasePath = databasePath;
+	}
+
+	public String getTypeName() {
+		return typeName;
+	}
+
+	public void setTypeName(String typeName) {
+		this.typeName = typeName;
+	}
+
+	public int getEmbeddingDimension() {
+		return embeddingDimension;
+	}
+
+	public void setEmbeddingDimension(int embeddingDimension) {
+		this.embeddingDimension = embeddingDimension;
+	}
+
+	public String getDistanceType() {
+		return distanceType;
+	}
+
+	public void setDistanceType(String distanceType) {
+		this.distanceType = distanceType;
+	}
+
+	public boolean isInitializeSchema() {
+		return initializeSchema;
+	}
+
+	public void setInitializeSchema(boolean initializeSchema) {
+		this.initializeSchema = initializeSchema;
+	}
+
+	public int getM() {
+		return m;
+	}
+
+	public void setM(int m) {
+		this.m = m;
+	}
+
+	public int getEf() {
+		return ef;
+	}
+
+	public void setEf(int ef) {
+		this.ef = ef;
+	}
+
+	public int getEfConstruction() {
+		return efConstruction;
+	}
+
+	public void setEfConstruction(int efConstruction) {
+		this.efConstruction = efConstruction;
+	}
+
+	public String getMetadataPrefix() {
+		return metadataPrefix;
+	}
+
+	public void setMetadataPrefix(String metadataPrefix) {
+		this.metadataPrefix = metadataPrefix;
+	}
+
+}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.ai.vectorstore.arcadedb.autoconfigure.ArcadeDBVectorStoreAutoConfiguration

--- a/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/pom.xml
+++ b/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-model-chat-memory-repository-arcadedb</artifactId>
+	<name>Spring AI ArcadeDB Chat Memory Repository</name>
+	<description>Spring AI ArcadeDB Chat Memory Repository implementation using native graph model</description>
+
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<arcadedb.version>25.4.1</arcadedb.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.arcadedb</groupId>
+			<artifactId>arcadedb-engine</artifactId>
+			<version>${arcadedb.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+		<!-- TESTING -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/ArcadeDBChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/ArcadeDBChatMemoryRepository.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.arcadedb;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+/**
+ * ArcadeDB implementation of {@link ChatMemoryRepository} using the native
+ * graph model.
+ *
+ * <p>
+ * Stores conversation history as a graph:
+ * <pre>
+ * (Session vertex: conversationId) --HAS_MESSAGE edge--&gt;
+ *     (ChatMessage vertex: type, content, metadata)
+ * </pre>
+ *
+ * <p>
+ * ArcadeDB edges are naturally LIFO-ordered, so traversing
+ * {@code out('HAS_MESSAGE')} returns messages in reverse insertion order. We
+ * reverse this to restore chronological order.
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+public final class ArcadeDBChatMemoryRepository
+		implements ChatMemoryRepository, AutoCloseable {
+
+	private static final Logger logger = LoggerFactory
+			.getLogger(ArcadeDBChatMemoryRepository.class);
+
+	static final String DEFAULT_SESSION_TYPE = "Session";
+
+	static final String DEFAULT_MESSAGE_TYPE = "ChatMessage";
+
+	static final String DEFAULT_EDGE_TYPE = "HAS_MESSAGE";
+
+	static final String PROP_CONVERSATION_ID = "conversationId";
+
+	static final String PROP_MESSAGE_TYPE = "messageType";
+
+	static final String PROP_CONTENT = "content";
+
+	static final String PROP_TOOL_CALLS = "toolCalls";
+
+	static final String PROP_METADATA = "metadata";
+
+	private final Database database;
+
+	private final boolean ownsDatabase;
+
+	private final String sessionTypeName;
+
+	private final String messageTypeName;
+
+	private final String edgeTypeName;
+
+	private final ObjectMapper objectMapper;
+
+	private ArcadeDBChatMemoryRepository(Builder builder) {
+		this.sessionTypeName = builder.sessionTypeName;
+		this.messageTypeName = builder.messageTypeName;
+		this.edgeTypeName = builder.edgeTypeName;
+		this.objectMapper = new ObjectMapper();
+
+		if (builder.database != null) {
+			this.database = builder.database;
+			this.ownsDatabase = false;
+		}
+		else {
+			if (builder.databasePath == null
+					|| builder.databasePath.isBlank()) {
+				throw new IllegalArgumentException(
+						"Either database or databasePath must be provided");
+			}
+			DatabaseFactory factory = new DatabaseFactory(
+					builder.databasePath);
+			this.database = factory.exists() ? factory.open()
+					: factory.create();
+			this.ownsDatabase = true;
+		}
+
+		initSchema();
+	}
+
+	private void initSchema() {
+		database.transaction(() -> {
+			Schema schema = database.getSchema();
+
+			VertexType sessionType = schema.existsType(sessionTypeName)
+					? (VertexType) schema.getType(sessionTypeName)
+					: schema.createVertexType(sessionTypeName, 1);
+			if (!sessionType.existsProperty(PROP_CONVERSATION_ID)) {
+				sessionType.createProperty(PROP_CONVERSATION_ID,
+						Type.STRING);
+			}
+			if (sessionType.getPolymorphicIndexByProperties(
+					PROP_CONVERSATION_ID) == null) {
+				schema.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true,
+						sessionTypeName, PROP_CONVERSATION_ID);
+			}
+
+			VertexType messageType = schema.existsType(messageTypeName)
+					? (VertexType) schema.getType(messageTypeName)
+					: schema.createVertexType(messageTypeName, 1);
+			if (!messageType.existsProperty(PROP_MESSAGE_TYPE)) {
+				messageType.createProperty(PROP_MESSAGE_TYPE, Type.STRING);
+			}
+			if (!messageType.existsProperty(PROP_CONTENT)) {
+				messageType.createProperty(PROP_CONTENT, Type.STRING);
+			}
+			if (!messageType.existsProperty(PROP_TOOL_CALLS)) {
+				messageType.createProperty(PROP_TOOL_CALLS, Type.STRING);
+			}
+			if (!messageType.existsProperty(PROP_METADATA)) {
+				messageType.createProperty(PROP_METADATA, Type.STRING);
+			}
+
+			if (!schema.existsType(edgeTypeName)) {
+				schema.createEdgeType(edgeTypeName);
+			}
+		});
+	}
+
+	@Override
+	public List<String> findConversationIds() {
+		List<String> ids = new ArrayList<>();
+		try (ResultSet rs = database.query("sql",
+				"SELECT FROM `" + sessionTypeName + "`")) {
+			while (rs.hasNext()) {
+				Result result = rs.next();
+				result.getVertex().ifPresent(v -> {
+					String cid = v.getString(PROP_CONVERSATION_ID);
+					if (cid != null) {
+						ids.add(cid);
+					}
+				});
+			}
+		}
+		return ids;
+	}
+
+	@Override
+	public List<Message> findByConversationId(String conversationId) {
+		Vertex session = findSessionVertex(conversationId);
+		if (session == null) {
+			return List.of();
+		}
+
+		List<Message> messages = new ArrayList<>();
+		for (Vertex messageVertex : session.getVertices(
+				Vertex.DIRECTION.OUT, edgeTypeName)) {
+			Message message = vertexToMessage(messageVertex);
+			if (message != null) {
+				messages.add(message);
+			}
+		}
+
+		Collections.reverse(messages);
+		return messages;
+	}
+
+	@Override
+	public void saveAll(String conversationId, List<Message> messages) {
+		deleteByConversationId(conversationId);
+
+		database.transaction(() -> {
+			MutableVertex session = database.newVertex(sessionTypeName);
+			session.set(PROP_CONVERSATION_ID, conversationId);
+			session.save();
+			Vertex savedSession = session.asVertex();
+
+			for (Message message : messages) {
+				MutableVertex msgVertex = database
+						.newVertex(messageTypeName);
+				msgVertex.set(PROP_MESSAGE_TYPE,
+						message.getMessageType().name());
+				msgVertex.set(PROP_CONTENT, message.getText());
+
+				Map<String, Object> metadata = message.getMetadata();
+				if (metadata != null && !metadata.isEmpty()) {
+					try {
+						msgVertex.set(PROP_METADATA,
+								objectMapper.writeValueAsString(metadata));
+					}
+					catch (JsonProcessingException ex) {
+						logger.warn(
+								"Failed to serialize message metadata: {}",
+								ex.getMessage());
+					}
+				}
+
+				if (message instanceof AssistantMessage assistantMsg
+						&& assistantMsg.getToolCalls() != null
+						&& !assistantMsg.getToolCalls().isEmpty()) {
+					try {
+						msgVertex.set(PROP_TOOL_CALLS, objectMapper
+								.writeValueAsString(
+										assistantMsg.getToolCalls()));
+					}
+					catch (JsonProcessingException ex) {
+						logger.warn(
+								"Failed to serialize tool calls: {}",
+								ex.getMessage());
+					}
+				}
+
+				msgVertex.save();
+				savedSession.newEdge(edgeTypeName, msgVertex, true,
+						new Object[0]);
+			}
+		});
+	}
+
+	@Override
+	public void deleteByConversationId(String conversationId) {
+		database.transaction(() -> {
+			Vertex session = findSessionVertex(conversationId);
+			if (session == null) {
+				return;
+			}
+
+			List<Vertex> messagesToDelete = new ArrayList<>();
+			for (Vertex messageVertex : session.getVertices(
+					Vertex.DIRECTION.OUT, edgeTypeName)) {
+				messagesToDelete.add(messageVertex);
+			}
+			for (Vertex msg : messagesToDelete) {
+				msg.delete();
+			}
+
+			session.delete();
+		});
+	}
+
+	@Override
+	public void close() {
+		if (ownsDatabase && database != null && database.isOpen()) {
+			database.close();
+		}
+	}
+
+	/**
+	 * Returns the underlying ArcadeDB {@link Database} instance.
+	 * @return the database
+	 */
+	public Database getNativeClient() {
+		return this.database;
+	}
+
+	private Vertex findSessionVertex(String conversationId) {
+		try (ResultSet rs = database.query("sql",
+				"SELECT FROM `" + sessionTypeName + "` WHERE "
+						+ PROP_CONVERSATION_ID + " = ?",
+				conversationId)) {
+			if (rs.hasNext()) {
+				Result result = rs.next();
+				return result.getVertex().orElse(null);
+			}
+		}
+		return null;
+	}
+
+	private Message vertexToMessage(Vertex vertex) {
+		String typeStr = vertex.getString(PROP_MESSAGE_TYPE);
+		String content = vertex.has(PROP_CONTENT)
+				? vertex.getString(PROP_CONTENT) : "";
+
+		Map<String, Object> metadata = Map.of();
+		if (vertex.has(PROP_METADATA)) {
+			String metaJson = vertex.getString(PROP_METADATA);
+			if (metaJson != null && !metaJson.isEmpty()) {
+				try {
+					metadata = objectMapper.readValue(metaJson,
+							new TypeReference<Map<String, Object>>() {
+							});
+				}
+				catch (JsonProcessingException ex) {
+					logger.warn(
+							"Failed to deserialize message metadata: {}",
+							ex.getMessage());
+				}
+			}
+		}
+
+		try {
+			MessageType messageType = MessageType.valueOf(typeStr);
+			return switch (messageType) {
+				case USER -> new UserMessage(content);
+				case ASSISTANT -> new AssistantMessage(content, metadata);
+				case SYSTEM -> new SystemMessage(content);
+				case TOOL -> new ToolResponseMessage(
+						List.of(new ToolResponseMessage.ToolResponse(null,
+								null, content)),
+						metadata);
+			};
+		}
+		catch (Exception ex) {
+			logger.warn("Failed to deserialize message of type {}: {}",
+					typeStr, ex.getMessage());
+			return null;
+		}
+	}
+
+	/**
+	 * Create a new {@link Builder} instance.
+	 * @return a new Builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link ArcadeDBChatMemoryRepository}.
+	 *
+	 * @since 2.0.0
+	 */
+	public static class Builder {
+
+		private String databasePath;
+
+		private Database database;
+
+		private String sessionTypeName = DEFAULT_SESSION_TYPE;
+
+		private String messageTypeName = DEFAULT_MESSAGE_TYPE;
+
+		private String edgeTypeName = DEFAULT_EDGE_TYPE;
+
+		/**
+		 * Set the path for the embedded ArcadeDB database directory.
+		 * @param databasePath the database path
+		 * @return this builder
+		 */
+		public Builder databasePath(String databasePath) {
+			this.databasePath = databasePath;
+			return this;
+		}
+
+		/**
+		 * Use an existing ArcadeDB {@link Database} instance.
+		 * @param database the database instance
+		 * @return this builder
+		 */
+		public Builder database(Database database) {
+			this.database = database;
+			return this;
+		}
+
+		/**
+		 * Set the vertex type name for conversation sessions.
+		 * @param sessionTypeName the type name (default: "Session")
+		 * @return this builder
+		 */
+		public Builder sessionTypeName(String sessionTypeName) {
+			this.sessionTypeName = sessionTypeName;
+			return this;
+		}
+
+		/**
+		 * Set the vertex type name for chat messages.
+		 * @param messageTypeName the type name (default: "ChatMessage")
+		 * @return this builder
+		 */
+		public Builder messageTypeName(String messageTypeName) {
+			this.messageTypeName = messageTypeName;
+			return this;
+		}
+
+		/**
+		 * Set the edge type connecting sessions to messages.
+		 * @param edgeTypeName the edge type (default: "HAS_MESSAGE")
+		 * @return this builder
+		 */
+		public Builder edgeTypeName(String edgeTypeName) {
+			this.edgeTypeName = edgeTypeName;
+			return this;
+		}
+
+		/**
+		 * Build the {@link ArcadeDBChatMemoryRepository}.
+		 * @return a new repository instance
+		 */
+		public ArcadeDBChatMemoryRepository build() {
+			return new ArcadeDBChatMemoryRepository(this);
+		}
+
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/package-info.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/src/main/java/org/springframework/ai/chat/memory/repository/arcadedb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ArcadeDB chat memory repository integration for Spring AI.
+ */
+package org.springframework.ai.chat.memory.repository.arcadedb;

--- a/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/src/test/java/org/springframework/ai/chat/memory/repository/arcadedb/ArcadeDBChatMemoryRepositoryIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-arcadedb/src/test/java/org/springframework/ai/chat/memory/repository/arcadedb/ArcadeDBChatMemoryRepositoryIT.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.arcadedb;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ArcadeDBChatMemoryRepository}. Uses an embedded
+ * ArcadeDB database — no Docker or external services required.
+ *
+ * @author Luca Garulli
+ */
+class ArcadeDBChatMemoryRepositoryIT {
+
+	private Path tempDbPath;
+
+	private ArcadeDBChatMemoryRepository repository;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		tempDbPath = Files.createTempDirectory("arcadedb-chatmemory-test");
+		repository = ArcadeDBChatMemoryRepository.builder()
+				.databasePath(tempDbPath.toString())
+				.build();
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		if (repository != null) {
+			repository.close();
+		}
+		if (tempDbPath != null) {
+			deleteDirectory(tempDbPath);
+		}
+	}
+
+	@Test
+	void saveAndFindMessages() {
+		List<Message> messages = List.of(
+				new SystemMessage("You are a helpful assistant"),
+				new UserMessage("Hello"),
+				new AssistantMessage("Hi! How can I help you?"));
+
+		repository.saveAll("conv-1", messages);
+
+		List<Message> found = repository.findByConversationId("conv-1");
+		assertThat(found).hasSize(3);
+		assertThat(found.get(0).getMessageType())
+				.isEqualTo(MessageType.SYSTEM);
+		assertThat(found.get(0).getText())
+				.isEqualTo("You are a helpful assistant");
+		assertThat(found.get(1).getMessageType())
+				.isEqualTo(MessageType.USER);
+		assertThat(found.get(1).getText()).isEqualTo("Hello");
+		assertThat(found.get(2).getMessageType())
+				.isEqualTo(MessageType.ASSISTANT);
+		assertThat(found.get(2).getText())
+				.isEqualTo("Hi! How can I help you?");
+	}
+
+	@Test
+	void findConversationIds() {
+		repository.saveAll("conv-1",
+				List.of(new UserMessage("Hello")));
+		repository.saveAll("conv-2",
+				List.of(new UserMessage("World")));
+
+		List<String> ids = repository.findConversationIds();
+		assertThat(ids).containsExactlyInAnyOrder("conv-1", "conv-2");
+	}
+
+	@Test
+	void deleteByConversationId() {
+		repository.saveAll("conv-1",
+				List.of(new UserMessage("Hello")));
+		repository.saveAll("conv-2",
+				List.of(new UserMessage("World")));
+
+		repository.deleteByConversationId("conv-1");
+
+		assertThat(repository.findByConversationId("conv-1")).isEmpty();
+		assertThat(repository.findByConversationId("conv-2")).hasSize(1);
+		assertThat(repository.findConversationIds())
+				.containsExactly("conv-2");
+	}
+
+	@Test
+	void saveAllReplacesExistingMessages() {
+		repository.saveAll("conv-1",
+				List.of(new UserMessage("First message")));
+		repository.saveAll("conv-1", List.of(
+				new UserMessage("Replacement message"),
+				new AssistantMessage("New response")));
+
+		List<Message> found = repository.findByConversationId("conv-1");
+		assertThat(found).hasSize(2);
+		assertThat(found.get(0).getText())
+				.isEqualTo("Replacement message");
+		assertThat(found.get(1).getText()).isEqualTo("New response");
+	}
+
+	@Test
+	void findByNonExistentConversationId() {
+		assertThat(repository.findByConversationId("nonexistent"))
+				.isEmpty();
+	}
+
+	@Test
+	void deleteNonExistentConversation() {
+		repository.deleteByConversationId("nonexistent");
+	}
+
+	@Test
+	void messageOrderIsPreserved() {
+		List<Message> messages = List.of(
+				new UserMessage("First"),
+				new AssistantMessage("Second"),
+				new UserMessage("Third"),
+				new AssistantMessage("Fourth"));
+
+		repository.saveAll("conv-1", messages);
+
+		List<Message> found = repository.findByConversationId("conv-1");
+		assertThat(found).hasSize(4);
+		assertThat(found.get(0).getText()).isEqualTo("First");
+		assertThat(found.get(1).getText()).isEqualTo("Second");
+		assertThat(found.get(2).getText()).isEqualTo("Third");
+		assertThat(found.get(3).getText()).isEqualTo("Fourth");
+	}
+
+	@Test
+	void getNativeClient() {
+		assertThat(repository.getNativeClient()).isNotNull();
+		assertThat(repository.getNativeClient().isOpen()).isTrue();
+	}
+
+	private static void deleteDirectory(Path path) throws IOException {
+		if (Files.exists(path)) {
+			Files.walk(path)
+					.sorted(Comparator.reverseOrder())
+					.forEach(p -> {
+						try {
+							Files.deleteIfExists(p);
+						}
+						catch (IOException ex) {
+							// best effort cleanup
+						}
+					});
+		}
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 		<module>spring-ai-rag</module>
 		<module>advisors/spring-ai-advisors-vector-store</module>
 
+		<module>memory/repository/spring-ai-model-chat-memory-repository-arcadedb</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-cassandra</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-cosmos-db</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-jdbc</module>
@@ -60,6 +61,7 @@
 		<module>document-readers/pdf-reader</module>
 		<module>document-readers/tika-reader</module>
 
+		<module>vector-stores/spring-ai-arcadedb-store</module>
 		<module>vector-stores/spring-ai-azure-cosmos-db-store</module>
 		<module>vector-stores/spring-ai-azure-store</module>
 		<module>vector-stores/spring-ai-cassandra-store</module>
@@ -93,6 +95,7 @@
 		<module>auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client</module>
 
 		<module>auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory</module>
+		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-arcadedb</module>
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cassandra</module>
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db</module>
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc</module>
@@ -133,6 +136,7 @@
 		<module>auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc</module>
 		<module>auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux</module>
 
+		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-arcadedb</module>
 		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure</module>
 		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure-cosmos-db</module>
 		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-cassandra</module>
@@ -158,6 +162,7 @@
 		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase</module>
 		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-s3</module>
 
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-vector-store-arcadedb</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-vector-store-aws-opensearch</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-vector-store-azure</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-vector-store-azure-cosmos-db</module>
@@ -226,6 +231,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-deepseek</module>
 
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory</module>
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-arcadedb</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-cassandra</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-cosmos-db</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-jdbc</module>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-arcadedb/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-arcadedb/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-starter-model-chat-memory-repository-arcadedb</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Starter - ArcadeDB Chat Memory Repository</name>
+	<description>Spring AI ArcadeDB Chat Memory Repository Starter</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-memory-repository-arcadedb</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model-chat-memory-repository-arcadedb</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-vector-store-arcadedb/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-vector-store-arcadedb/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-starter-vector-store-arcadedb</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Starter - ArcadeDB Store</name>
+	<description>Spring AI ArcadeDB Vector Store Starter</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-vector-store-arcadedb</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-arcadedb-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/vector-stores/spring-ai-arcadedb-store/pom.xml
+++ b/vector-stores/spring-ai-arcadedb-store/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-arcadedb-store</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Vector Store - ArcadeDB</name>
+	<description>Spring AI ArcadeDB embedded Vector Store with native HNSW vector indexing</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<arcadedb.version>25.4.1</arcadedb.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-vector-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.arcadedb</groupId>
+			<artifactId>arcadedb-engine</artifactId>
+			<version>${arcadedb.version}</version>
+		</dependency>
+
+		<!-- TESTING -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBDistanceType.java
+++ b/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBDistanceType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb;
+
+import com.github.jelmerk.knn.DistanceFunction;
+import com.github.jelmerk.knn.DistanceFunctions;
+
+/**
+ * Distance metric types supported by ArcadeDB's HNSW vector index.
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+public enum ArcadeDBDistanceType {
+
+	COSINE {
+		@Override
+		public DistanceFunction<float[], Float> getDistanceFunction() {
+			return DistanceFunctions.FLOAT_COSINE_DISTANCE;
+		}
+
+		@Override
+		public double toSimilarity(double distance) {
+			// Cosine distance can slightly exceed 1.0 due to floating-point
+			// precision
+			return Math.max(0.0, 1.0 - distance);
+		}
+	},
+
+	EUCLIDEAN {
+		@Override
+		public DistanceFunction<float[], Float> getDistanceFunction() {
+			return DistanceFunctions.FLOAT_EUCLIDEAN_DISTANCE;
+		}
+
+		@Override
+		public double toSimilarity(double distance) {
+			return 1.0 / (1.0 + distance);
+		}
+	};
+
+	public abstract DistanceFunction<float[], Float> getDistanceFunction();
+
+	public abstract double toSimilarity(double distance);
+
+}

--- a/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBFilterExpressionConverter.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.springframework.ai.vectorstore.filter.Filter;
+
+/**
+ * Evaluates a Spring AI {@link Filter.Expression} tree against a metadata map
+ * in Java.
+ *
+ * <p>
+ * This approach avoids SQL type conversion issues (UUID, Double, Float
+ * mismatches) and is proven in the langchain4j-community-arcadedb integration.
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+final class ArcadeDBFilterExpressionConverter {
+
+	private ArcadeDBFilterExpressionConverter() {
+	}
+
+	/**
+	 * Evaluates whether the given metadata map matches the filter expression.
+	 * @param expression the filter expression to evaluate
+	 * @param metadata the metadata map to match against
+	 * @return true if the metadata matches the expression
+	 */
+	static boolean matches(Filter.Expression expression, Map<String, Object> metadata) {
+		if (expression == null) {
+			return true;
+		}
+		return switch (expression.type()) {
+			case AND -> {
+				Filter.Expression left = (Filter.Expression) expression.left();
+				Filter.Expression right = (Filter.Expression) expression.right();
+				yield matches(left, metadata) && matches(right, metadata);
+			}
+			case OR -> {
+				Filter.Expression left = (Filter.Expression) expression.left();
+				Filter.Expression right = (Filter.Expression) expression.right();
+				yield matches(left, metadata) || matches(right, metadata);
+			}
+			case NOT -> {
+				Filter.Expression operand = (Filter.Expression) expression.left();
+				yield !matches(operand, metadata);
+			}
+			case EQ -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object expected = ((Filter.Value) expression.right()).value();
+				Object actual = metadata.get(key);
+				yield actual != null && valueEquals(actual, expected);
+			}
+			case NE -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object expected = ((Filter.Value) expression.right()).value();
+				Object actual = metadata.get(key);
+				yield actual == null || !valueEquals(actual, expected);
+			}
+			case GT -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object expected = ((Filter.Value) expression.right()).value();
+				Object actual = metadata.get(key);
+				yield actual != null && compareValues(actual, expected) > 0;
+			}
+			case GTE -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object expected = ((Filter.Value) expression.right()).value();
+				Object actual = metadata.get(key);
+				yield actual != null && compareValues(actual, expected) >= 0;
+			}
+			case LT -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object expected = ((Filter.Value) expression.right()).value();
+				Object actual = metadata.get(key);
+				yield actual != null && compareValues(actual, expected) < 0;
+			}
+			case LTE -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object expected = ((Filter.Value) expression.right()).value();
+				Object actual = metadata.get(key);
+				yield actual != null && compareValues(actual, expected) <= 0;
+			}
+			case IN -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object actual = metadata.get(key);
+				if (actual == null) {
+					yield false;
+				}
+				Filter.Value filterValue = (Filter.Value) expression.right();
+				if (filterValue.value() instanceof java.util.List<?> list) {
+					yield list.stream().anyMatch(v -> valueEquals(actual, v));
+				}
+				yield valueEquals(actual, filterValue.value());
+			}
+			case NIN -> {
+				String key = ((Filter.Key) expression.left()).key();
+				Object actual = metadata.get(key);
+				if (actual == null) {
+					yield true;
+				}
+				Filter.Value filterValue = (Filter.Value) expression.right();
+				if (filterValue.value() instanceof java.util.List<?> list) {
+					yield list.stream().noneMatch(v -> valueEquals(actual, v));
+				}
+				yield !valueEquals(actual, filterValue.value());
+			}
+			default -> throw new UnsupportedOperationException(
+					"Unsupported filter expression type: " + expression.type());
+		};
+	}
+
+	private static boolean valueEquals(Object a, Object b) {
+		if (a instanceof Number && b instanceof Number) {
+			return ((Number) a).doubleValue() == ((Number) b).doubleValue();
+		}
+		return Objects.equals(objectToString(a), objectToString(b));
+	}
+
+	private static int compareValues(Object a, Object b) {
+		if (a instanceof Number && b instanceof Number) {
+			return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
+		}
+		return objectToString(a).compareTo(objectToString(b));
+	}
+
+	private static String objectToString(Object o) {
+		if (o == null) {
+			return "";
+		}
+		return o.toString();
+	}
+
+}

--- a/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBVectorStore.java
+++ b/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBVectorStore.java
@@ -1,0 +1,629 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import com.arcadedb.database.Database;
+import com.arcadedb.database.DatabaseFactory;
+import com.arcadedb.database.Identifiable;
+import com.arcadedb.graph.MutableVertex;
+import com.arcadedb.graph.Vertex;
+import com.arcadedb.index.vector.HnswVectorIndex;
+import com.arcadedb.query.sql.executor.Result;
+import com.arcadedb.query.sql.executor.ResultSet;
+import com.arcadedb.schema.Schema;
+import com.arcadedb.schema.Type;
+import com.arcadedb.schema.VertexType;
+import com.arcadedb.utility.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.observation.conventions.VectorStoreProvider;
+import org.springframework.ai.vectorstore.AbstractVectorStoreBuilder;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.observation.AbstractObservationVectorStore;
+import org.springframework.ai.vectorstore.observation.VectorStoreObservationContext;
+import org.springframework.beans.factory.InitializingBean;
+
+/**
+ * ArcadeDB implementation of Spring AI
+ * {@link org.springframework.ai.vectorstore.VectorStore} using an embedded
+ * database with native HNSW vector indexing.
+ *
+ * <p>
+ * Unlike most Spring AI vector store integrations that connect to external
+ * servers, ArcadeDB runs <strong>embedded in the same JVM</strong> — zero
+ * network overhead, zero serialization cost, with persistence, HNSW vector
+ * indexing, and graph capabilities.
+ *
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * ArcadeDBVectorStore store = ArcadeDBVectorStore.builder(embeddingModel)
+ *     .databasePath("/tmp/mydb")
+ *     .embeddingDimension(1536)
+ *     .build();
+ * store.afterPropertiesSet();
+ * }</pre>
+ *
+ * @author Luca Garulli
+ * @since 2.0.0
+ */
+public class ArcadeDBVectorStore extends AbstractObservationVectorStore
+		implements InitializingBean, AutoCloseable {
+
+	private static final Logger logger = LoggerFactory.getLogger(ArcadeDBVectorStore.class);
+
+	static final String PROPERTY_ID = "id";
+
+	static final String PROPERTY_EMBEDDING = "embedding";
+
+	static final String PROPERTY_CONTENT = "content";
+
+	static final String PROPERTY_DELETED = "deleted";
+
+	private static final Set<String> RESERVED_PROPERTIES = Set.of(
+			PROPERTY_ID, PROPERTY_EMBEDDING, PROPERTY_CONTENT, PROPERTY_DELETED,
+			"vectorMaxLevel" // added by HNSW index
+	);
+
+	private static final String DEFAULT_TYPE_NAME = "Document";
+
+	private static final String DEFAULT_EDGE_TYPE = "HnswEdge";
+
+	private static final String DEFAULT_METADATA_PREFIX = "meta_";
+
+	private static final int DEFAULT_EMBEDDING_DIMENSION = 1536;
+
+	private final Database database;
+
+	private final boolean ownsDatabase;
+
+	private final String typeName;
+
+	private final String quotedTypeName;
+
+	private final String edgeType;
+
+	private final String metadataPrefix;
+
+	private final int embeddingDimension;
+
+	private final ArcadeDBDistanceType distanceType;
+
+	private final int m;
+
+	private final int ef;
+
+	private final int efConstruction;
+
+	private final boolean initializeSchema;
+
+	private HnswVectorIndex<Object, float[], Float> vectorIndex;
+
+	protected ArcadeDBVectorStore(Builder builder) {
+		super(builder);
+		this.typeName = builder.typeName;
+		this.quotedTypeName = "`" + builder.typeName + "`";
+		this.edgeType = builder.edgeType;
+		this.metadataPrefix = builder.metadataPrefix;
+		this.embeddingDimension = builder.embeddingDimension;
+		this.distanceType = builder.distanceType;
+		this.m = builder.m;
+		this.ef = builder.ef;
+		this.efConstruction = builder.efConstruction;
+		this.initializeSchema = builder.initializeSchema;
+
+		if (builder.database != null) {
+			this.database = builder.database;
+			this.ownsDatabase = false;
+		}
+		else {
+			if (builder.databasePath == null || builder.databasePath.isBlank()) {
+				throw new IllegalArgumentException(
+						"Either database or databasePath must be provided");
+			}
+			DatabaseFactory factory = new DatabaseFactory(builder.databasePath);
+			this.database = factory.exists() ? factory.open() : factory.create();
+			this.ownsDatabase = true;
+		}
+	}
+
+	/**
+	 * Returns the underlying ArcadeDB {@link Database} instance.
+	 * @return an Optional containing the Database
+	 * @param <T> the expected client type
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> Optional<T> getNativeClient() {
+		return (Optional<T>) Optional.of(this.database);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void afterPropertiesSet() {
+		if (!this.initializeSchema) {
+			String indexName = typeName + "[" + PROPERTY_ID + ","
+					+ PROPERTY_EMBEDDING + "]";
+			try {
+				var existingIndex = database.getSchema().getIndexByName(indexName);
+				if (existingIndex instanceof HnswVectorIndex) {
+					vectorIndex = (HnswVectorIndex<Object, float[], Float>) existingIndex;
+				}
+			}
+			catch (Exception ex) {
+				throw new IllegalStateException(
+						"Schema not initialized and index not found: " + indexName,
+						ex);
+			}
+			return;
+		}
+
+		database.transaction(() -> {
+			Schema schema = database.getSchema();
+
+			VertexType vertexType = schema.existsType(typeName)
+					? (VertexType) schema.getType(typeName)
+					: schema.createVertexType(typeName, 1);
+
+			if (!vertexType.existsProperty(PROPERTY_ID)) {
+				vertexType.createProperty(PROPERTY_ID, Type.STRING);
+			}
+			if (!vertexType.existsProperty(PROPERTY_EMBEDDING)) {
+				vertexType.createProperty(PROPERTY_EMBEDDING, Type.ARRAY_OF_FLOATS);
+			}
+			if (!vertexType.existsProperty(PROPERTY_CONTENT)) {
+				vertexType.createProperty(PROPERTY_CONTENT, Type.STRING);
+			}
+			if (!vertexType.existsProperty(PROPERTY_DELETED)) {
+				vertexType.createProperty(PROPERTY_DELETED, Type.BOOLEAN);
+			}
+
+			if (vertexType.getPolymorphicIndexByProperties(PROPERTY_ID) == null) {
+				schema.createTypeIndex(Schema.INDEX_TYPE.LSM_TREE, true, typeName,
+						PROPERTY_ID);
+			}
+		});
+
+		// Check if vector index already exists
+		try {
+			String indexName = typeName + "[" + PROPERTY_ID + ","
+					+ PROPERTY_EMBEDDING + "]";
+			var existingIndex = database.getSchema().getIndexByName(indexName);
+			if (existingIndex instanceof HnswVectorIndex) {
+				vectorIndex = (HnswVectorIndex<Object, float[], Float>) existingIndex;
+				return;
+			}
+		}
+		catch (Exception ex) {
+			// Index doesn't exist yet, create it
+		}
+
+		database.transaction(() -> {
+			var indexBuilder = database.getSchema().buildVectorIndex()
+					.withVertexType(typeName)
+					.withEdgeType(edgeType)
+					.withVectorProperty(PROPERTY_EMBEDDING, Type.ARRAY_OF_FLOATS)
+					.withIdProperty(PROPERTY_ID)
+					.withDeletedProperty(PROPERTY_DELETED)
+					.withDimensions(embeddingDimension)
+					.withDistanceFunction(distanceType.getDistanceFunction())
+					.withDistanceComparator((Comparator<Float>) Float::compareTo)
+					.withM(m)
+					.withEf(ef)
+					.withEfConstruction(efConstruction)
+					.withType(Schema.INDEX_TYPE.HNSW);
+			vectorIndex = (HnswVectorIndex<Object, float[], Float>) indexBuilder
+					.create();
+		});
+	}
+
+	@Override
+	public void doAdd(List<Document> documents) {
+		if (documents == null || documents.isEmpty()) {
+			return;
+		}
+
+		EmbeddingModel embeddingModel = this.embeddingModel;
+		List<float[]> embeddings = new ArrayList<>(documents.size());
+		for (Document doc : documents) {
+			embeddings.add(embeddingModel.embed(doc));
+		}
+
+		List<Vertex> savedVertices = new ArrayList<>();
+
+		for (int i = 0; i < documents.size(); i++) {
+			final int idx = i;
+			Document doc = documents.get(i);
+			String id = doc.getId();
+			if (id == null || id.isBlank()) {
+				id = UUID.randomUUID().toString();
+			}
+			final String docId = id;
+
+			database.transaction(() -> {
+				hardDeleteById(docId);
+
+				MutableVertex vertex = database.newVertex(typeName);
+				vertex.set(PROPERTY_ID, docId);
+				vertex.set(PROPERTY_EMBEDDING, embeddings.get(idx));
+				vertex.set(PROPERTY_CONTENT, doc.getText());
+
+				Map<String, Object> metadata = doc.getMetadata();
+				if (metadata != null) {
+					for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+						String propName = metadataPrefix + entry.getKey();
+						Object value = entry.getValue();
+						if (value instanceof UUID) {
+							value = value.toString();
+						}
+						vertex.set(propName, value);
+					}
+				}
+
+				vertex.save();
+				savedVertices.add(vertex.asVertex());
+			});
+		}
+
+		for (Vertex savedVertex : savedVertices) {
+			database.transaction(() -> {
+				vectorIndex.add(savedVertex);
+			});
+		}
+	}
+
+	@Override
+	public void doDelete(List<String> idList) {
+		if (idList == null || idList.isEmpty()) {
+			return;
+		}
+		database.transaction(() -> {
+			for (String id : idList) {
+				softDeleteById(id);
+			}
+		});
+	}
+
+	@Override
+	protected void doDelete(Filter.Expression filterExpression) {
+		if (filterExpression == null) {
+			return;
+		}
+		database.transaction(() -> {
+			try (ResultSet rs = database.query("sql",
+					"SELECT FROM " + quotedTypeName + " WHERE ("
+							+ PROPERTY_DELETED + " IS NULL OR "
+							+ PROPERTY_DELETED + " != true)")) {
+				while (rs.hasNext()) {
+					Result result = rs.next();
+					result.getVertex().ifPresent(v -> {
+						Map<String, Object> metadata = extractMetadata(v);
+						if (ArcadeDBFilterExpressionConverter.matches(
+								filterExpression, metadata)) {
+							v.modify().set(PROPERTY_DELETED, true).save();
+							String id = v.getString(PROPERTY_ID);
+							if (id != null) {
+								vectorIndex.remove(new Object[] { id });
+							}
+						}
+					});
+				}
+			}
+		});
+	}
+
+	@Override
+	public List<Document> doSimilaritySearch(SearchRequest request) {
+		float[] queryEmbedding = this.embeddingModel.embed(request.getQuery());
+		int maxResults = request.getTopK();
+		double similarityThreshold = request.getSimilarityThreshold();
+		Filter.Expression filterExpression = request.getFilterExpression();
+
+		int fetchSize = Math.max(maxResults * 4, maxResults + 100);
+		List<Pair<Identifiable, ? extends Number>> neighbors = vectorIndex
+				.findNeighborsFromVector(queryEmbedding, fetchSize);
+
+		List<Document> results = new ArrayList<>();
+		for (Pair<Identifiable, ? extends Number> neighbor : neighbors) {
+			if (results.size() >= maxResults) {
+				break;
+			}
+
+			double distance = neighbor.getSecond().doubleValue();
+			double similarity = distanceType.toSimilarity(distance);
+
+			if (similarity < similarityThreshold) {
+				continue;
+			}
+
+			try {
+				Vertex vertex = neighbor.getFirst().getRecord().asVertex();
+				if (isDeleted(vertex)) {
+					continue;
+				}
+
+				Map<String, Object> metadata = extractMetadata(vertex);
+				if (filterExpression != null
+						&& !ArcadeDBFilterExpressionConverter.matches(
+								filterExpression, metadata)) {
+					continue;
+				}
+
+				String id = vertex.getString(PROPERTY_ID);
+				String content = vertex.has(PROPERTY_CONTENT)
+						? vertex.getString(PROPERTY_CONTENT) : "";
+				metadata.put("distance", 1.0 - similarity);
+
+				Document doc = Document.builder()
+						.id(id)
+						.text(content)
+						.metadata(metadata)
+						.score(similarity)
+						.build();
+				results.add(doc);
+			}
+			catch (Exception ex) {
+				logger.warn("Failed to load vertex {}: {}",
+						neighbor.getFirst(), ex.getMessage());
+			}
+		}
+
+		return results;
+	}
+
+	@Override
+	public VectorStoreObservationContext.Builder createObservationContextBuilder(
+			String operationName) {
+		return VectorStoreObservationContext.builder(
+				VectorStoreProvider.NEO4J.value(), operationName)
+				.dimensions(this.embeddingDimension);
+	}
+
+	@Override
+	public void close() {
+		if (ownsDatabase && database != null && database.isOpen()) {
+			database.close();
+		}
+	}
+
+	private boolean isDeleted(Vertex vertex) {
+		Object deleted = vertex.get(PROPERTY_DELETED);
+		return Boolean.TRUE.equals(deleted);
+	}
+
+	private void softDeleteById(String id) {
+		try (ResultSet rs = database.query("sql",
+				"SELECT FROM " + quotedTypeName + " WHERE " + PROPERTY_ID
+						+ " = ?", id)) {
+			while (rs.hasNext()) {
+				Result result = rs.next();
+				result.getVertex().ifPresent(v -> {
+					v.modify().set(PROPERTY_DELETED, true).save();
+					vectorIndex.remove(new Object[] { id });
+				});
+			}
+		}
+	}
+
+	private void hardDeleteById(String id) {
+		try (ResultSet rs = database.query("sql",
+				"SELECT FROM " + quotedTypeName + " WHERE " + PROPERTY_ID
+						+ " = ?", id)) {
+			while (rs.hasNext()) {
+				Result result = rs.next();
+				result.getVertex().ifPresent(v -> {
+					vectorIndex.remove(new Object[] { id });
+					v.delete();
+				});
+			}
+		}
+	}
+
+	Map<String, Object> extractMetadata(com.arcadedb.database.Document doc) {
+		Map<String, Object> metadata = new HashMap<>();
+		for (String prop : doc.getPropertyNames()) {
+			if (RESERVED_PROPERTIES.contains(prop)) {
+				continue;
+			}
+			String key;
+			if (!metadataPrefix.isEmpty() && prop.startsWith(metadataPrefix)) {
+				key = prop.substring(metadataPrefix.length());
+			}
+			else if (metadataPrefix.isEmpty()) {
+				key = prop;
+			}
+			else {
+				continue;
+			}
+			metadata.put(key, doc.get(prop));
+		}
+		return metadata;
+	}
+
+	/**
+	 * Create a new {@link Builder} instance.
+	 * @param embeddingModel the embedding model to use
+	 * @return a new Builder
+	 */
+	public static Builder builder(EmbeddingModel embeddingModel) {
+		return new Builder(embeddingModel);
+	}
+
+	/**
+	 * Builder for {@link ArcadeDBVectorStore}.
+	 *
+	 * @since 2.0.0
+	 */
+	public static class Builder extends AbstractVectorStoreBuilder<Builder> {
+
+		private String databasePath;
+
+		private Database database;
+
+		private String typeName = DEFAULT_TYPE_NAME;
+
+		private String edgeType = DEFAULT_EDGE_TYPE;
+
+		private String metadataPrefix = DEFAULT_METADATA_PREFIX;
+
+		private int embeddingDimension = DEFAULT_EMBEDDING_DIMENSION;
+
+		private ArcadeDBDistanceType distanceType = ArcadeDBDistanceType.COSINE;
+
+		private int m = 16;
+
+		private int ef = 10;
+
+		private int efConstruction = 200;
+
+		private boolean initializeSchema = true;
+
+		private Builder(EmbeddingModel embeddingModel) {
+			super(embeddingModel);
+		}
+
+		/**
+		 * Set the path for the embedded ArcadeDB database directory.
+		 * @param databasePath the database path
+		 * @return this builder
+		 */
+		public Builder databasePath(String databasePath) {
+			this.databasePath = databasePath;
+			return this;
+		}
+
+		/**
+		 * Use an existing ArcadeDB {@link Database} instance.
+		 * @param database the database instance
+		 * @return this builder
+		 */
+		public Builder database(Database database) {
+			this.database = database;
+			return this;
+		}
+
+		/**
+		 * Set the vertex type name for stored documents.
+		 * @param typeName the type name (default: "Document")
+		 * @return this builder
+		 */
+		public Builder typeName(String typeName) {
+			this.typeName = typeName;
+			return this;
+		}
+
+		/**
+		 * Set the edge type name for HNSW graph connections.
+		 * @param edgeType the edge type (default: "HnswEdge")
+		 * @return this builder
+		 */
+		public Builder edgeType(String edgeType) {
+			this.edgeType = edgeType;
+			return this;
+		}
+
+		/**
+		 * Set the prefix for metadata properties on the vertex.
+		 * @param metadataPrefix the prefix (default: "meta_")
+		 * @return this builder
+		 */
+		public Builder metadataPrefix(String metadataPrefix) {
+			this.metadataPrefix = metadataPrefix;
+			return this;
+		}
+
+		/**
+		 * Set the dimension of embedding vectors.
+		 * @param embeddingDimension the dimension (default: 1536)
+		 * @return this builder
+		 */
+		public Builder embeddingDimension(int embeddingDimension) {
+			this.embeddingDimension = embeddingDimension;
+			return this;
+		}
+
+		/**
+		 * Set the distance metric type.
+		 * @param distanceType COSINE or EUCLIDEAN (default: COSINE)
+		 * @return this builder
+		 */
+		public Builder distanceType(ArcadeDBDistanceType distanceType) {
+			this.distanceType = distanceType;
+			return this;
+		}
+
+		/**
+		 * Set the HNSW M parameter (max connections per node).
+		 * @param m the M value (default: 16)
+		 * @return this builder
+		 */
+		public Builder m(int m) {
+			this.m = m;
+			return this;
+		}
+
+		/**
+		 * Set the HNSW ef parameter (search beam width).
+		 * @param ef the ef value (default: 10)
+		 * @return this builder
+		 */
+		public Builder ef(int ef) {
+			this.ef = ef;
+			return this;
+		}
+
+		/**
+		 * Set the HNSW efConstruction parameter (construction beam width).
+		 * @param efConstruction the value (default: 200)
+		 * @return this builder
+		 */
+		public Builder efConstruction(int efConstruction) {
+			this.efConstruction = efConstruction;
+			return this;
+		}
+
+		/**
+		 * Set whether to auto-create the schema on startup.
+		 * @param initializeSchema true to initialize (default: true)
+		 * @return this builder
+		 */
+		public Builder initializeSchema(boolean initializeSchema) {
+			this.initializeSchema = initializeSchema;
+			return this;
+		}
+
+		@Override
+		public ArcadeDBVectorStore build() {
+			return new ArcadeDBVectorStore(this);
+		}
+
+	}
+
+}

--- a/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/package-info.java
+++ b/vector-stores/spring-ai-arcadedb-store/src/main/java/org/springframework/ai/vectorstore/arcadedb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ArcadeDB vector store integration for Spring AI.
+ */
+package org.springframework.ai.vectorstore.arcadedb;

--- a/vector-stores/spring-ai-arcadedb-store/src/test/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBFilterExpressionConverterTest.java
+++ b/vector-stores/spring-ai-arcadedb-store/src/test/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBFilterExpressionConverterTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.ExpressionType;
+import org.springframework.ai.vectorstore.filter.Filter.Key;
+import org.springframework.ai.vectorstore.filter.Filter.Value;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ArcadeDBFilterExpressionConverter}.
+ *
+ * @author Luca Garulli
+ */
+class ArcadeDBFilterExpressionConverterTest {
+
+	@Test
+	void testEqualMatch() {
+		Expression expr = new Expression(ExpressionType.EQ, new Key("color"),
+				new Value("red"));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "red"))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "blue"))).isFalse();
+	}
+
+	@Test
+	void testNotEqualMatch() {
+		Expression expr = new Expression(ExpressionType.NE, new Key("color"),
+				new Value("red"));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "blue"))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "red"))).isFalse();
+	}
+
+	@Test
+	void testGreaterThan() {
+		Expression expr = new Expression(ExpressionType.GT, new Key("score"),
+				new Value(5));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 10))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 5))).isFalse();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 3))).isFalse();
+	}
+
+	@Test
+	void testGreaterThanOrEqual() {
+		Expression expr = new Expression(ExpressionType.GTE, new Key("score"),
+				new Value(5));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 5))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 4))).isFalse();
+	}
+
+	@Test
+	void testLessThan() {
+		Expression expr = new Expression(ExpressionType.LT, new Key("score"),
+				new Value(5));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 3))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 5))).isFalse();
+	}
+
+	@Test
+	void testLessThanOrEqual() {
+		Expression expr = new Expression(ExpressionType.LTE, new Key("score"),
+				new Value(5));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 5))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 6))).isFalse();
+	}
+
+	@Test
+	void testInList() {
+		Expression expr = new Expression(ExpressionType.IN, new Key("color"),
+				new Value(List.of("red", "blue")));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "red"))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "green"))).isFalse();
+	}
+
+	@Test
+	void testNotInList() {
+		Expression expr = new Expression(ExpressionType.NIN, new Key("color"),
+				new Value(List.of("red", "blue")));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "green"))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "red"))).isFalse();
+	}
+
+	@Test
+	void testAndExpression() {
+		Expression left = new Expression(ExpressionType.EQ, new Key("color"),
+				new Value("red"));
+		Expression right = new Expression(ExpressionType.GT, new Key("score"),
+				new Value(5));
+		Expression and = new Expression(ExpressionType.AND, left, right);
+
+		assertThat(ArcadeDBFilterExpressionConverter.matches(and,
+				Map.of("color", "red", "score", 10))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(and,
+				Map.of("color", "red", "score", 3))).isFalse();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(and,
+				Map.of("color", "blue", "score", 10))).isFalse();
+	}
+
+	@Test
+	void testOrExpression() {
+		Expression left = new Expression(ExpressionType.EQ, new Key("color"),
+				new Value("red"));
+		Expression right = new Expression(ExpressionType.EQ, new Key("color"),
+				new Value("blue"));
+		Expression or = new Expression(ExpressionType.OR, left, right);
+
+		assertThat(ArcadeDBFilterExpressionConverter.matches(or,
+				Map.of("color", "red"))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(or,
+				Map.of("color", "blue"))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(or,
+				Map.of("color", "green"))).isFalse();
+	}
+
+	@Test
+	void testNotExpression() {
+		Expression inner = new Expression(ExpressionType.EQ, new Key("color"),
+				new Value("red"));
+		Expression not = new Expression(ExpressionType.NOT, inner);
+
+		assertThat(ArcadeDBFilterExpressionConverter.matches(not,
+				Map.of("color", "blue"))).isTrue();
+		assertThat(ArcadeDBFilterExpressionConverter.matches(not,
+				Map.of("color", "red"))).isFalse();
+	}
+
+	@Test
+	void testNullExpression() {
+		assertThat(ArcadeDBFilterExpressionConverter.matches(null,
+				Map.of("color", "red"))).isTrue();
+	}
+
+	@Test
+	void testMissingKeyReturnsCorrectResult() {
+		Expression expr = new Expression(ExpressionType.EQ, new Key("missing"),
+				new Value("val"));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("color", "red"))).isFalse();
+
+		Expression ne = new Expression(ExpressionType.NE, new Key("missing"),
+				new Value("val"));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(ne,
+				Map.of("color", "red"))).isTrue();
+	}
+
+	@Test
+	void testNumericTypeCoercion() {
+		Expression expr = new Expression(ExpressionType.EQ, new Key("score"),
+				new Value(5.0));
+		assertThat(ArcadeDBFilterExpressionConverter.matches(expr,
+				Map.of("score", 5))).isTrue();
+	}
+
+}

--- a/vector-stores/spring-ai-arcadedb-store/src/test/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBVectorStoreIT.java
+++ b/vector-stores/spring-ai-arcadedb-store/src/test/java/org/springframework/ai/vectorstore/arcadedb/ArcadeDBVectorStoreIT.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.filter.Filter.Expression;
+import org.springframework.ai.vectorstore.filter.Filter.ExpressionType;
+import org.springframework.ai.vectorstore.filter.Filter.Key;
+import org.springframework.ai.vectorstore.filter.Filter.Value;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ArcadeDBVectorStore}. Uses an embedded ArcadeDB
+ * database — no Docker or external services required.
+ *
+ * @author Luca Garulli
+ */
+class ArcadeDBVectorStoreIT {
+
+	private static final int DIMENSIONS = 128;
+
+	private Path tempDbPath;
+
+	private ArcadeDBVectorStore vectorStore;
+
+	private final EmbeddingModel testEmbeddingModel = new TestEmbeddingModel(
+			DIMENSIONS);
+
+	@BeforeEach
+	void setUp() throws IOException {
+		tempDbPath = Files.createTempDirectory("arcadedb-vectorstore-test");
+		vectorStore = ArcadeDBVectorStore.builder(testEmbeddingModel)
+				.databasePath(tempDbPath.toString())
+				.embeddingDimension(DIMENSIONS)
+				.build();
+		vectorStore.afterPropertiesSet();
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		if (vectorStore != null) {
+			vectorStore.close();
+		}
+		if (tempDbPath != null) {
+			deleteDirectory(tempDbPath);
+		}
+	}
+
+	@Test
+	void addAndSearchDocuments() {
+		Document doc1 = Document.builder()
+				.id("1")
+				.text("Spring AI is great")
+				.metadata(Map.of("category", "ai"))
+				.build();
+		Document doc2 = Document.builder()
+				.id("2")
+				.text("ArcadeDB is an embedded database")
+				.metadata(Map.of("category", "database"))
+				.build();
+
+		vectorStore.add(List.of(doc1, doc2));
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("AI framework").topK(10).build());
+		assertThat(results).isNotEmpty();
+		assertThat(results).extracting(Document::getId).contains("1", "2");
+	}
+
+	@Test
+	void searchWithSimilarityThreshold() {
+		Document doc = Document.builder()
+				.id("1")
+				.text("test document")
+				.build();
+		vectorStore.add(List.of(doc));
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder()
+						.query("test")
+						.topK(10)
+						.similarityThreshold(0.9999)
+						.build());
+		assertThat(results.size()).isLessThanOrEqualTo(1);
+	}
+
+	@Test
+	void searchWithMetadataFilter() {
+		Document doc1 = Document.builder()
+				.id("1")
+				.text("AI document")
+				.metadata(Map.of("category", "ai", "priority", 1))
+				.build();
+		Document doc2 = Document.builder()
+				.id("2")
+				.text("DB document")
+				.metadata(Map.of("category", "database", "priority", 2))
+				.build();
+
+		vectorStore.add(List.of(doc1, doc2));
+
+		Expression filter = new Expression(ExpressionType.EQ,
+				new Key("category"), new Value("ai"));
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder()
+						.query("document")
+						.topK(10)
+						.filterExpression(filter)
+						.build());
+
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo("1");
+	}
+
+	@Test
+	void deleteById() {
+		Document doc = Document.builder()
+				.id("to-delete")
+				.text("delete me")
+				.build();
+		vectorStore.add(List.of(doc));
+
+		vectorStore.delete(List.of("to-delete"));
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("delete").topK(10).build());
+		assertThat(results).isEmpty();
+	}
+
+	@Test
+	void deleteByFilter() {
+		Document doc1 = Document.builder()
+				.id("1")
+				.text("keep this")
+				.metadata(Map.of("status", "active"))
+				.build();
+		Document doc2 = Document.builder()
+				.id("2")
+				.text("remove this")
+				.metadata(Map.of("status", "archived"))
+				.build();
+
+		vectorStore.add(List.of(doc1, doc2));
+
+		Expression filter = new Expression(ExpressionType.EQ,
+				new Key("status"), new Value("archived"));
+		vectorStore.delete(filter);
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("this").topK(10).build());
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getId()).isEqualTo("1");
+	}
+
+	@Test
+	void upsertDocument() {
+		Document original = Document.builder()
+				.id("upsert-id")
+				.text("original content")
+				.build();
+		vectorStore.add(List.of(original));
+
+		Document updated = Document.builder()
+				.id("upsert-id")
+				.text("updated content")
+				.build();
+		vectorStore.add(List.of(updated));
+
+		List<Document> results = vectorStore.similaritySearch(
+				SearchRequest.builder().query("content").topK(10).build());
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).getText()).isEqualTo("updated content");
+	}
+
+	@Test
+	void getNativeClient() {
+		assertThat(vectorStore
+				.<com.arcadedb.database.Database>getNativeClient()).isPresent();
+		assertThat(vectorStore
+				.<com.arcadedb.database.Database>getNativeClient()
+				.get().isOpen()).isTrue();
+	}
+
+	private static void deleteDirectory(Path path) throws IOException {
+		if (Files.exists(path)) {
+			Files.walk(path)
+					.sorted(Comparator.reverseOrder())
+					.forEach(p -> {
+						try {
+							Files.deleteIfExists(p);
+						}
+						catch (IOException ex) {
+							// best effort cleanup
+						}
+					});
+		}
+	}
+
+}

--- a/vector-stores/spring-ai-arcadedb-store/src/test/java/org/springframework/ai/vectorstore/arcadedb/TestEmbeddingModel.java
+++ b/vector-stores/spring-ai-arcadedb-store/src/test/java/org/springframework/ai/vectorstore/arcadedb/TestEmbeddingModel.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.arcadedb;
+
+import java.util.List;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.embedding.EmbeddingResponse;
+
+/**
+ * Simple deterministic embedding model for testing. Generates fixed-dimension
+ * embeddings based on text hash.
+ *
+ * @author Luca Garulli
+ */
+class TestEmbeddingModel implements EmbeddingModel {
+
+	private final int dimensions;
+
+	TestEmbeddingModel(int dimensions) {
+		this.dimensions = dimensions;
+	}
+
+	@Override
+	public EmbeddingResponse call(EmbeddingRequest request) {
+		List<Embedding> embeddings = request.getInstructions().stream()
+				.map(text -> new Embedding(generateEmbedding(text),
+						request.getInstructions().indexOf(text)))
+				.toList();
+		return new EmbeddingResponse(embeddings);
+	}
+
+	@Override
+	public float[] embed(Document document) {
+		return generateEmbedding(document.getText());
+	}
+
+	@Override
+	public float[] embed(String text) {
+		return generateEmbedding(text);
+	}
+
+	private float[] generateEmbedding(String text) {
+		float[] embedding = new float[dimensions];
+		if (text == null || text.isEmpty()) {
+			return embedding;
+		}
+		int hash = text.hashCode();
+		for (int i = 0; i < dimensions; i++) {
+			embedding[i] = (float) Math.sin(hash * (i + 1) * 0.1);
+		}
+		float norm = 0;
+		for (float v : embedding) {
+			norm += v * v;
+		}
+		norm = (float) Math.sqrt(norm);
+		if (norm > 0) {
+			for (int i = 0; i < dimensions; i++) {
+				embedding[i] /= norm;
+			}
+		}
+		return embedding;
+	}
+
+}


### PR DESCRIPTION
## Summary

Add ArcadeDB integration providing both `VectorStore` and `ChatMemoryRepository` from a single embedded ArcadeDB instance.

### Key highlights

- **Embedded database**: ArcadeDB runs in the same JVM — zero network overhead, zero serialization cost. No external service or Docker container required
- **VectorStore**: HNSW vector index for similarity search with cosine/euclidean distance metrics, Java-based metadata filter evaluation for post-filtering
- **ChatMemoryRepository**: Graph-based conversation memory using native vertex/edge model with LIFO-ordered edges for natural message ordering
- **Auto-configuration**: Spring Boot starters for both VectorStore and ChatMemoryRepository with standard `spring.ai.vectorstore.arcadedb.*` and `spring.ai.chat.memory.repository.arcadedb.*` property prefixes

### Modules added

| Module | Description |
|---|---|
| `spring-ai-arcadedb-store` | Core VectorStore + FilterExpressionConverter |
| `spring-ai-model-chat-memory-repository-arcadedb` | Core ChatMemoryRepository |
| `spring-ai-autoconfigure-vector-store-arcadedb` | VectorStore auto-configuration |
| `spring-ai-autoconfigure-model-chat-memory-repository-arcadedb` | ChatMemoryRepository auto-configuration |
| `spring-ai-starter-vector-store-arcadedb` | VectorStore Spring Boot starter |
| `spring-ai-starter-model-chat-memory-repository-arcadedb` | ChatMemoryRepository Spring Boot starter |

### Design decisions

1. **Embedded only** — uses `com.arcadedb:arcadedb-engine` (no HTTP client). Integration tests run in-process, no Docker needed
2. **Single `Database` bean** shared between VectorStore and ChatMemoryRepository
3. **Soft-delete pattern** for vector store documents (required by HNSW index lifecycle)
4. **Java-based metadata filter evaluation** for vector search post-filtering (avoids SQL type conversion edge cases)
5. **Native `database.select()` API** for ChatMemoryRepository queries — bypasses SQL parser for maximum performance

### Test plan

- [x] `ArcadeDBFilterExpressionConverterTest` — 14 unit tests for all filter expression operators
- [x] `ArcadeDBVectorStoreIT` — 7 integration tests: add/search/delete/upsert/filter/threshold
- [x] `ArcadeDBChatMemoryRepositoryIT` — 8 integration tests: save/find/delete/multiple conversations
- [x] All tests pass with embedded ArcadeDB (no Docker or external services)