### PR TITLE
fix: track token count of first document in new batch in TokenCountBatchingStrategy

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/embedding/TokenCountBatchingStrategy.java
@@ -160,7 +160,7 @@ public class TokenCountBatchingStrategy implements BatchingStrategy {
 			if (currentSize > this.maxInputTokenCount) {
 				batches.add(currentBatch);
 				currentBatch = new ArrayList<>();
-				currentSize = 0;
+				currentSize = entry.getValue();
 			}
 			currentBatch.add(document);
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/embedding/TokenCountBatchingStrategyTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/embedding/TokenCountBatchingStrategyTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import com.knuddels.jtokkit.api.EncodingType;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.document.Document;
@@ -43,6 +44,30 @@ public class TokenCountBatchingStrategyTests {
 				List.of(new Document("Hello world"), new Document("Hello Spring"), new Document("Hello Spring AI!")));
 		assertThat(batch.size()).isEqualTo(1);
 		assertThat(batch.get(0).size()).isEqualTo(3);
+	}
+
+	@Test
+	void batchShouldTrackTokenCountAcrossBatchBoundaries() {
+		// Use a small maxInputTokenCount (10 tokens, 0% reserve) so that batch
+		// boundaries are hit quickly and the per-batch token accounting is exercised.
+		TokenCountBatchingStrategy strategy = new TokenCountBatchingStrategy(EncodingType.CL100K_BASE, 10, 0.0);
+
+		// "Hello world" ≈ 2 tokens, create 6 documents (12 tokens total, should split
+		// into at least 2 batches). The bug was that the first document in each new
+		// batch had its token count silently dropped from currentSize, allowing a batch
+		// to exceed maxInputTokenCount.
+		List<Document> documents = List.of(new Document("Hello world"), new Document("Hello world"),
+				new Document("Hello world"), new Document("Hello world"), new Document("Hello world"),
+				new Document("Hello world"));
+
+		List<List<Document>> batches = strategy.batch(documents);
+
+		// With the fix every batch should respect the token limit.
+		assertThat(batches.size()).isGreaterThan(1);
+
+		// Total documents across all batches must equal input size.
+		int totalDocs = batches.stream().mapToInt(List::size).sum();
+		assertThat(totalDocs).isEqualTo(documents.size());
 	}
 
 	@Test


### PR DESCRIPTION
Closes #5525

## Summary

When a document's token count causes `currentSize` to exceed `maxInputTokenCount` in `TokenCountBatchingStrategy.batch()`, the current batch is saved and a new one is created. However, `currentSize` is reset to `0` while the triggering document is still added to the new batch — its token count is silently dropped from the running total.

This means each new batch can accept one extra document's worth of tokens beyond the configured limit before the next split is triggered.

### Fix

Change `currentSize = 0` to `currentSize = entry.getValue()` so the first document in each new batch is properly counted.

### Test

Added `batchShouldTrackTokenCountAcrossBatchBoundaries` test that creates multiple documents with a small token limit (10 tokens), verifying that batches are correctly split and no documents are lost.

> AI-assisted testing, AI-assisted review