### PR TITLE
Add MCP 2025-03-26 and 2025-06-18 feature support

### DIFF
--- a/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/AsyncMcpToolCallback.java
@@ -32,6 +32,7 @@ import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.ToolExecutionException;
+import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -95,6 +96,11 @@ public class AsyncMcpToolCallback implements ToolCallback {
 		return McpToolUtils.createToolDefinition(this.prefixedToolName, this.tool);
 	}
 
+	@Override
+	public ToolMetadata getToolMetadata() {
+		return McpToolMetadata.from(this.tool.annotations());
+	}
+
 	public String getOriginalToolName() {
 		return this.tool.name();
 	}
@@ -142,6 +148,11 @@ public class AsyncMcpToolCallback implements ToolCallback {
 			logger.error("Error calling tool: {}", response.content());
 			throw new ToolExecutionException(this.getToolDefinition(),
 					new IllegalStateException("Error calling tool: " + response.content()));
+		}
+		// Prefer structuredContent (MCP 2025-06-18) when available, as it provides
+		// machine-readable output conforming to the tool's outputSchema.
+		if (response.structuredContent() != null) {
+			return ModelOptionsUtils.toJsonString(response.structuredContent());
 		}
 		return ModelOptionsUtils.toJsonString(response.content());
 	}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolMetadata.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolMetadata.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.tool.metadata.ToolMetadata;
+
+/**
+ * MCP-aware implementation of {@link ToolMetadata} that exposes MCP tool annotations
+ * (introduced in MCP spec 2025-03-26) to Spring AI consumers.
+ *
+ * <p>
+ * Tool annotations provide hints about a tool's behavior, such as whether it is
+ * read-only, destructive, or idempotent. These hints help clients make informed decisions
+ * about tool execution, including safety checks and user confirmation prompts.
+ *
+ * @author Mehdi Ghaeini
+ * @since 2.0.0
+ * @see McpSchema.ToolAnnotations
+ */
+public class McpToolMetadata implements ToolMetadata {
+
+	private final @Nullable McpSchema.ToolAnnotations annotations;
+
+	private McpToolMetadata(@Nullable McpSchema.ToolAnnotations annotations) {
+		this.annotations = annotations;
+	}
+
+	/**
+	 * Creates McpToolMetadata from MCP tool annotations.
+	 * @param annotations the MCP tool annotations, may be null
+	 * @return a new McpToolMetadata instance
+	 */
+	public static McpToolMetadata from(@Nullable McpSchema.ToolAnnotations annotations) {
+		return new McpToolMetadata(annotations);
+	}
+
+	@Override
+	public boolean returnDirect() {
+		if (this.annotations != null && this.annotations.returnDirect() != null) {
+			return this.annotations.returnDirect();
+		}
+		return false;
+	}
+
+	/**
+	 * Whether the tool performs only read operations and does not modify state.
+	 * @return true if the tool is read-only, null if unknown
+	 */
+	public @Nullable Boolean readOnlyHint() {
+		return this.annotations != null ? this.annotations.readOnlyHint() : null;
+	}
+
+	/**
+	 * Whether the tool may perform destructive operations (e.g., deleting data).
+	 * @return true if the tool may be destructive, null if unknown
+	 */
+	public @Nullable Boolean destructiveHint() {
+		return this.annotations != null ? this.annotations.destructiveHint() : null;
+	}
+
+	/**
+	 * Whether calling the tool multiple times with the same arguments produces the same
+	 * result.
+	 * @return true if the tool is idempotent, null if unknown
+	 */
+	public @Nullable Boolean idempotentHint() {
+		return this.annotations != null ? this.annotations.idempotentHint() : null;
+	}
+
+	/**
+	 * Whether the tool interacts with entities outside the client's controlled
+	 * environment (e.g., external APIs, the internet).
+	 * @return true if the tool operates in an open-world context, null if unknown
+	 */
+	public @Nullable Boolean openWorldHint() {
+		return this.annotations != null ? this.annotations.openWorldHint() : null;
+	}
+
+	/**
+	 * Returns the underlying MCP tool annotations, or null if none were provided.
+	 * @return the MCP tool annotations
+	 */
+	public @Nullable McpSchema.ToolAnnotations getAnnotations() {
+		return this.annotations;
+	}
+
+}

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/McpToolUtils.java
@@ -236,9 +236,15 @@ public final class McpToolUtils {
 	 * @return a ToolDefinition with normalized input schema
 	 */
 	public static ToolDefinition createToolDefinition(String prefixedToolName, McpSchema.Tool tool) {
+		// Use tool title (MCP 2025-06-18) as description when the description is missing,
+		// or use description as-is when available
+		String description = tool.description();
+		if (StringUtils.isEmpty(description) && !StringUtils.isEmpty(tool.title())) {
+			description = tool.title();
+		}
 		return DefaultToolDefinition.builder()
 			.name(prefixedToolName)
-			.description(tool.description())
+			.description(description)
 			.inputSchema(JsonSchemaUtils.ensureValidInputSchema(ModelOptionsUtils.toJsonString(tool.inputSchema())))
 			.build();
 	}
@@ -246,23 +252,41 @@ public final class McpToolUtils {
 	private static SharedSyncToolSpecification toSharedSyncToolSpecification(ToolCallback toolCallback,
 			@Nullable MimeType mimeType) {
 
-		var tool = McpSchema.Tool.builder()
+		var toolBuilder = McpSchema.Tool.builder()
 			.name(toolCallback.getToolDefinition().name())
 			.description(toolCallback.getToolDefinition().description())
 			.inputSchema(ModelOptionsUtils.jsonToObject(toolCallback.getToolDefinition().inputSchema(),
-					McpSchema.JsonSchema.class))
-			.build();
+					McpSchema.JsonSchema.class));
+
+		// Propagate returnDirect from ToolMetadata as MCP ToolAnnotations (MCP
+		// 2025-03-26)
+		if (toolCallback.getToolMetadata().returnDirect()) {
+			toolBuilder.annotations(McpSchema.ToolAnnotations.builder().returnDirect(true).build());
+		}
+
+		var tool = toolBuilder.build();
 
 		return new SharedSyncToolSpecification(tool, (exchangeOrContext, request) -> {
 			try {
 				String callResult = toolCallback.call(ModelOptionsUtils.toJsonString(request.arguments()),
 						new ToolContext(Map.of(TOOL_CONTEXT_MCP_EXCHANGE_KEY, exchangeOrContext)));
-				if (mimeType != null && mimeType.toString().startsWith("image")) {
+				if (mimeType != null) {
 					McpSchema.Annotations annotations = new McpSchema.Annotations(List.of(Role.ASSISTANT), null);
-					return McpSchema.CallToolResult.builder()
-						.content(List.of(new McpSchema.ImageContent(annotations, callResult, mimeType.toString())))
-						.isError(false)
-						.build();
+					String mimeTypeStr = mimeType.toString();
+					if (mimeTypeStr.startsWith("image")) {
+						return McpSchema.CallToolResult.builder()
+							.content(
+									List.of(new McpSchema.ImageContent(annotations, callResult, mimeTypeStr)))
+							.isError(false)
+							.build();
+					}
+					if (mimeTypeStr.startsWith("audio")) {
+						return McpSchema.CallToolResult.builder()
+							.content(
+									List.of(new McpSchema.AudioContent(annotations, callResult, mimeTypeStr)))
+							.isError(false)
+							.build();
+					}
 				}
 				return McpSchema.CallToolResult.builder()
 					.content(List.of(new McpSchema.TextContent(callResult)))

--- a/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
+++ b/mcp/common/src/main/java/org/springframework/ai/mcp/SyncMcpToolCallback.java
@@ -31,6 +31,7 @@ import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.ToolExecutionException;
+import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -92,6 +93,11 @@ public class SyncMcpToolCallback implements ToolCallback {
 		return McpToolUtils.createToolDefinition(this.prefixedToolName, this.tool);
 	}
 
+	@Override
+	public ToolMetadata getToolMetadata() {
+		return McpToolMetadata.from(this.tool.annotations());
+	}
+
 	/**
 	 * Returns the original MCP tool name without prefixing.
 	 * @return the original tool name
@@ -141,6 +147,11 @@ public class SyncMcpToolCallback implements ToolCallback {
 			logger.error("Error calling tool: {}", response.content());
 			throw new ToolExecutionException(this.getToolDefinition(),
 					new IllegalStateException("Error calling tool: " + response.content()));
+		}
+		// Prefer structuredContent (MCP 2025-06-18) when available, as it provides
+		// machine-readable output conforming to the tool's outputSchema.
+		if (response.structuredContent() != null) {
+			return ModelOptionsUtils.toJsonString(response.structuredContent());
 		}
 		return ModelOptionsUtils.toJsonString(response.content());
 	}

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -16,6 +16,7 @@
 
 package org.springframework.ai.mcp;
 
+import java.util.List;
 import java.util.Map;
 
 import io.modelcontextprotocol.client.McpAsyncClient;
@@ -304,6 +305,94 @@ class AsyncMcpToolCallbackTest {
 		// Assert
 		assertThat(callback.getOriginalToolName()).isEqualTo("testTool");
 		assertThat(callback.getToolDefinition().description()).isEqualTo("Test description");
+	}
+
+	@Test
+	void callShouldPreferStructuredContentWhenPresent() {
+		when(this.tool.name()).thenReturn("testTool");
+		var callToolResult = McpSchema.CallToolResult.builder()
+			.addTextContent("{\"result\":42}")
+			.structuredContent(Map.of("result", 42, "status", "ok"))
+			.isError(false)
+			.build();
+		when(this.mcpClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(Mono.just(callToolResult));
+
+		var callback = AsyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testTool")
+			.build();
+
+		String result = callback.call("{\"param\":\"value\"}");
+
+		// Should return structuredContent, not content
+		assertThat(result).contains("\"result\"");
+		assertThat(result).contains("42");
+		assertThat(result).contains("\"status\"");
+		assertThat(result).contains("\"ok\"");
+	}
+
+	@Test
+	void callShouldFallBackToContentWhenStructuredContentIsNull() {
+		when(this.tool.name()).thenReturn("testTool");
+		var callToolResult = McpSchema.CallToolResult.builder()
+			.addTextContent("fallback content")
+			.isError(false)
+			.build();
+		when(this.mcpClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(Mono.just(callToolResult));
+
+		var callback = AsyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testTool")
+			.build();
+
+		String result = callback.call("{\"param\":\"value\"}");
+
+		assertThat(result).contains("fallback content");
+	}
+
+	@Test
+	void getToolMetadataShouldReturnMcpToolMetadata() {
+		when(this.tool.name()).thenReturn("testTool");
+		var annotations = McpSchema.ToolAnnotations.builder()
+			.readOnlyHint(true)
+			.destructiveHint(false)
+			.returnDirect(true)
+			.build();
+		when(this.tool.annotations()).thenReturn(annotations);
+
+		var callback = AsyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testTool")
+			.build();
+
+		var metadata = callback.getToolMetadata();
+
+		assertThat(metadata).isInstanceOf(McpToolMetadata.class);
+		assertThat(metadata.returnDirect()).isTrue();
+
+		McpToolMetadata mcpMetadata = (McpToolMetadata) metadata;
+		assertThat(mcpMetadata.readOnlyHint()).isTrue();
+		assertThat(mcpMetadata.destructiveHint()).isFalse();
+	}
+
+	@Test
+	void getToolMetadataShouldHandleNullAnnotations() {
+		when(this.tool.name()).thenReturn("testTool");
+		when(this.tool.annotations()).thenReturn(null);
+
+		var callback = AsyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testTool")
+			.build();
+
+		var metadata = callback.getToolMetadata();
+
+		assertThat(metadata).isInstanceOf(McpToolMetadata.class);
+		assertThat(metadata.returnDirect()).isFalse();
 	}
 
 	@Test

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/McpToolMetadataTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/McpToolMetadataTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpToolMetadataTests {
+
+	@Test
+	void fromAnnotationsShouldExposeAllHints() {
+		var annotations = McpSchema.ToolAnnotations.builder()
+			.readOnlyHint(true)
+			.destructiveHint(false)
+			.idempotentHint(true)
+			.openWorldHint(false)
+			.returnDirect(true)
+			.build();
+
+		McpToolMetadata metadata = McpToolMetadata.from(annotations);
+
+		assertThat(metadata.returnDirect()).isTrue();
+		assertThat(metadata.readOnlyHint()).isTrue();
+		assertThat(metadata.destructiveHint()).isFalse();
+		assertThat(metadata.idempotentHint()).isTrue();
+		assertThat(metadata.openWorldHint()).isFalse();
+		assertThat(metadata.getAnnotations()).isSameAs(annotations);
+	}
+
+	@Test
+	void fromNullAnnotationsShouldReturnSafeDefaults() {
+		McpToolMetadata metadata = McpToolMetadata.from(null);
+
+		assertThat(metadata.returnDirect()).isFalse();
+		assertThat(metadata.readOnlyHint()).isNull();
+		assertThat(metadata.destructiveHint()).isNull();
+		assertThat(metadata.idempotentHint()).isNull();
+		assertThat(metadata.openWorldHint()).isNull();
+		assertThat(metadata.getAnnotations()).isNull();
+	}
+
+	@Test
+	void fromAnnotationsWithNullReturnDirectShouldDefaultToFalse() {
+		var annotations = McpSchema.ToolAnnotations.builder().readOnlyHint(true).build();
+
+		McpToolMetadata metadata = McpToolMetadata.from(annotations);
+
+		assertThat(metadata.returnDirect()).isFalse();
+		assertThat(metadata.readOnlyHint()).isTrue();
+	}
+
+	@Test
+	void fromAnnotationsWithPartialHintsShouldHandleNulls() {
+		var annotations = McpSchema.ToolAnnotations.builder().destructiveHint(true).build();
+
+		McpToolMetadata metadata = McpToolMetadata.from(annotations);
+
+		assertThat(metadata.readOnlyHint()).isNull();
+		assertThat(metadata.destructiveHint()).isTrue();
+		assertThat(metadata.idempotentHint()).isNull();
+		assertThat(metadata.openWorldHint()).isNull();
+	}
+
+}

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackTests.java
@@ -246,6 +246,94 @@ class SyncMcpToolCallbackTests {
 	}
 
 	@Test
+	void callShouldPreferStructuredContentWhenPresent() {
+		when(this.tool.name()).thenReturn("testTool");
+		CallToolResult callResult = mock(CallToolResult.class);
+		when(callResult.isError()).thenReturn(false);
+		when(callResult.structuredContent()).thenReturn(Map.of("result", 42, "status", "ok"));
+		when(callResult.content())
+			.thenReturn(List.of(new McpSchema.TextContent("{\"result\":42,\"status\":\"ok\"}")));
+		when(this.mcpClient.callTool(any(CallToolRequest.class))).thenReturn(callResult);
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testClient_testTool")
+			.build();
+
+		String response = callback.call("{\"param\":\"value\"}");
+
+		// Should return structuredContent, not content
+		assertThat(response).contains("\"result\"");
+		assertThat(response).contains("42");
+		assertThat(response).contains("\"status\"");
+		assertThat(response).contains("\"ok\"");
+	}
+
+	@Test
+	void callShouldFallBackToContentWhenStructuredContentIsNull() {
+		when(this.tool.name()).thenReturn("testTool");
+		CallToolResult callResult = mock(CallToolResult.class);
+		when(callResult.isError()).thenReturn(false);
+		when(callResult.structuredContent()).thenReturn(null);
+		when(callResult.content()).thenReturn(List.of(new McpSchema.TextContent("fallback content")));
+		when(this.mcpClient.callTool(any(CallToolRequest.class))).thenReturn(callResult);
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testClient_testTool")
+			.build();
+
+		String response = callback.call("{\"param\":\"value\"}");
+
+		assertThat(response).contains("fallback content");
+	}
+
+	@Test
+	void getToolMetadataShouldReturnMcpToolMetadata() {
+		when(this.tool.name()).thenReturn("testTool");
+		var annotations = McpSchema.ToolAnnotations.builder()
+			.readOnlyHint(true)
+			.destructiveHint(false)
+			.returnDirect(true)
+			.build();
+		when(this.tool.annotations()).thenReturn(annotations);
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testClient_testTool")
+			.build();
+
+		var metadata = callback.getToolMetadata();
+
+		assertThat(metadata).isInstanceOf(McpToolMetadata.class);
+		assertThat(metadata.returnDirect()).isTrue();
+
+		McpToolMetadata mcpMetadata = (McpToolMetadata) metadata;
+		assertThat(mcpMetadata.readOnlyHint()).isTrue();
+		assertThat(mcpMetadata.destructiveHint()).isFalse();
+	}
+
+	@Test
+	void getToolMetadataShouldHandleNullAnnotations() {
+		when(this.tool.name()).thenReturn("testTool");
+		when(this.tool.annotations()).thenReturn(null);
+
+		SyncMcpToolCallback callback = SyncMcpToolCallback.builder()
+			.mcpClient(this.mcpClient)
+			.tool(this.tool)
+			.prefixedToolName("testClient_testTool")
+			.build();
+
+		var metadata = callback.getToolMetadata();
+
+		assertThat(metadata).isInstanceOf(McpToolMetadata.class);
+		assertThat(metadata.returnDirect()).isFalse();
+	}
+
+	@Test
 	void builderShouldUseDefaultPrefixWhenNotSpecified() {
 		when(this.tool.name()).thenReturn("testTool");
 

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -27,8 +27,10 @@ import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.AudioContent;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
+import io.modelcontextprotocol.spec.McpSchema.ImageContent;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
@@ -337,6 +339,106 @@ class ToolUtilsTests {
 		when(callback.getToolDefinition()).thenReturn(definition);
 		when(callback.call(anyString(), any())).thenThrow(error);
 		return callback;
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldHandleAudioMimeType() {
+		ToolCallback callback = createMockToolCallback("audioTool", "base64AudioData");
+
+		SyncToolSpecification toolSpecification = McpToolUtils
+			.toSyncToolSpecification(callback, org.springframework.util.MimeType.valueOf("audio/wav"));
+
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new McpSchema.CallToolRequest("audioTool", Map.of()));
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(AudioContent.class);
+		AudioContent audioContent = (AudioContent) result.content().get(0);
+		assertThat(audioContent.data()).isEqualTo("base64AudioData");
+		assertThat(audioContent.mimeType()).isEqualTo("audio/wav");
+		assertThat(result.isError()).isFalse();
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldHandleImageMimeType() {
+		ToolCallback callback = createMockToolCallback("imageTool", "base64ImageData");
+
+		SyncToolSpecification toolSpecification = McpToolUtils
+			.toSyncToolSpecification(callback, org.springframework.util.MimeType.valueOf("image/png"));
+
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new McpSchema.CallToolRequest("imageTool", Map.of()));
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(ImageContent.class);
+		ImageContent imageContent = (ImageContent) result.content().get(0);
+		assertThat(imageContent.data()).isEqualTo("base64ImageData");
+		assertThat(imageContent.mimeType()).isEqualTo("image/png");
+		assertThat(result.isError()).isFalse();
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldDefaultToTextForUnknownMimeType() {
+		ToolCallback callback = createMockToolCallback("textTool", "plain text data");
+
+		SyncToolSpecification toolSpecification = McpToolUtils
+			.toSyncToolSpecification(callback, org.springframework.util.MimeType.valueOf("application/json"));
+
+		CallToolResult result = toolSpecification.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new McpSchema.CallToolRequest("textTool", Map.of()));
+
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
+		TextContent textContent = (TextContent) result.content().get(0);
+		assertThat(textContent.text()).isEqualTo("plain text data");
+	}
+
+	@Test
+	void toSyncToolSpecificationShouldPropagateReturnDirectAnnotation() {
+		ToolCallback callback = mock(ToolCallback.class);
+		ToolDefinition definition = DefaultToolDefinition.builder()
+			.name("directTool")
+			.description("Tool with returnDirect")
+			.inputSchema("{}")
+			.build();
+		when(callback.getToolDefinition()).thenReturn(definition);
+		when(callback.call(anyString(), any())).thenReturn("result");
+		when(callback.getToolMetadata())
+			.thenReturn(org.springframework.ai.tool.metadata.ToolMetadata.builder().returnDirect(true).build());
+
+		SyncToolSpecification toolSpecification = McpToolUtils.toSyncToolSpecification(callback);
+
+		assertThat(toolSpecification.tool().annotations()).isNotNull();
+		assertThat(toolSpecification.tool().annotations().returnDirect()).isTrue();
+	}
+
+	@Test
+	void createToolDefinitionShouldUseTitleAsFallbackDescription() {
+		Tool tool = McpSchema.Tool.builder()
+			.name("myTool")
+			.title("My Awesome Tool")
+			.inputSchema(McpSchema.JsonSchema.builder().build())
+			.build();
+
+		ToolDefinition toolDef = McpToolUtils.createToolDefinition("prefix_myTool", tool);
+
+		// When description is null, title should be used as fallback
+		assertThat(toolDef.name()).isEqualTo("prefix_myTool");
+		assertThat(toolDef.description()).isEqualTo("My Awesome Tool");
+	}
+
+	@Test
+	void createToolDefinitionShouldPreferDescriptionOverTitle() {
+		Tool tool = McpSchema.Tool.builder()
+			.name("myTool")
+			.title("My Title")
+			.description("My detailed description")
+			.inputSchema(McpSchema.JsonSchema.builder().build())
+			.build();
+
+		ToolDefinition toolDef = McpToolUtils.createToolDefinition("prefix_myTool", tool);
+
+		assertThat(toolDef.description()).isEqualTo("My detailed description");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Closes the gap between what the MCP Java SDK 1.0.0 provides and what Spring AI exposes to developers. The SDK supports features from MCP spec versions **2025-03-26** and **2025-06-18** that were not yet utilized by Spring AI's integration layer.

- **Structured tool output** — Client-side tool callbacks now prefer `structuredContent` (MCP 2025-06-18) when present, giving consumers machine-readable output conforming to `outputSchema`
- **AudioContent support** — Server-side tool result creation now handles `audio/*` MIME types alongside existing `image/*` support (MCP 2025-03-26)
- **ToolAnnotations via `McpToolMetadata`** — New `McpToolMetadata` class exposes MCP tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`, `returnDirect`) through Spring AI's `ToolMetadata` interface (MCP 2025-03-26)
- **Tool title fallback** — `createToolDefinition` uses `tool.title()` as description when `description` is missing (MCP 2025-06-18)
- **returnDirect propagation** — When exposing Spring AI tools as MCP tools, `ToolMetadata.returnDirect()` is propagated as `ToolAnnotations.returnDirect`

## Files Changed

| File | Change |
|------|--------|
| `McpToolMetadata.java` | **New** — MCP-aware `ToolMetadata` implementation wrapping `ToolAnnotations` |
| `SyncMcpToolCallback.java` | Add `structuredContent` preference + `getToolMetadata()` override |
| `AsyncMcpToolCallback.java` | Same as sync variant |
| `McpToolUtils.java` | AudioContent handling, title fallback, returnDirect annotation propagation |

## Test plan

- [x] `SyncMcpToolCallbackTests` — structuredContent preference, fallback to content, McpToolMetadata with/without annotations
- [x] `AsyncMcpToolCallbackTest` — same coverage as sync
- [x] `McpToolMetadataTests` — all hints, null annotations, partial hints, returnDirect mapping
- [x] `ToolUtilsTests` — audio/image/text MIME handling, returnDirect annotation propagation, title fallback, description preference

## References

- [MCP 2025-03-26 changelog](https://modelcontextprotocol.io/specification/2025-03-26/changelog)
- [MCP 2025-06-18 changelog](https://modelcontextprotocol.io/specification/2025-06-18/changelog)
- [MCP Java SDK v1.0.0](https://github.com/modelcontextprotocol/java-sdk/releases/tag/v1.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)