### PR TITLE
Fix OpenAiChatModel internalCall metadata not include reasoningContent

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -219,7 +219,8 @@ public class OpenAiChatModel implements ChatModel {
 							"index", choice.index() != null ? choice.index() : 0,
 							"finishReason", getFinishReasonJson(choice.finishReason()),
 							"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
-							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(Map.of()));
+							"annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of(),
+							"reasoningContent", choice.message().reasoningContent() != null ? choice.message().reasoningContent() : "");
 					return buildGeneration(choice, metadata, request);
 				}).toList();
 				// @formatter:on


### PR DESCRIPTION
#5533 

List<Generation> generations = choices.stream().map(choice -> {
	Map<String, Object> metadata = Map.of(
			"id", chatCompletion.id() != null ? chatCompletion.id() : "",
			"role", choice.message().role() != null ? choice.message().role().name() : "",
			"index", choice.index() != null ? choice.index() : 0,
			"finishReason", getFinishReasonJson(choice.finishReason()),
			"refusal", StringUtils.hasText(choice.message().refusal()) ? choice.message().refusal() : "",
                        "annotations", choice.message().annotations() != null ? choice.message().annotations() : List.of();
	return buildGeneration(choice, metadata, request);
}).toList();

Add the following content

"reasoningContent", choice.message().reasoningContent() != null ? choice.message().reasoningContent() : "")