### PR TITLE
fix(tool): improve error for empty numeric tool arguments

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
@@ -145,24 +145,24 @@ public final class JsonParser {
 			return value.toString();
 		}
 		else if (javaType == Byte.class) {
-			return Byte.parseByte(value.toString());
+			return Byte.parseByte(requireNonEmptyNumericValue(value, javaType));
 		}
 		else if (javaType == Integer.class) {
-			BigDecimal bigDecimal = new BigDecimal(value.toString());
+			BigDecimal bigDecimal = new BigDecimal(requireNonEmptyNumericValue(value, javaType));
 			return bigDecimal.intValueExact();
 		}
 		else if (javaType == Short.class) {
-			return Short.parseShort(value.toString());
+			return Short.parseShort(requireNonEmptyNumericValue(value, javaType));
 		}
 		else if (javaType == Long.class) {
-			BigDecimal bigDecimal = new BigDecimal(value.toString());
+			BigDecimal bigDecimal = new BigDecimal(requireNonEmptyNumericValue(value, javaType));
 			return bigDecimal.longValueExact();
 		}
 		else if (javaType == Double.class) {
-			return Double.parseDouble(value.toString());
+			return Double.parseDouble(requireNonEmptyNumericValue(value, javaType));
 		}
 		else if (javaType == Float.class) {
-			return Float.parseFloat(value.toString());
+			return Float.parseFloat(requireNonEmptyNumericValue(value, javaType));
 		}
 		else if (javaType == Boolean.class) {
 			return Boolean.parseBoolean(value.toString());
@@ -187,6 +187,15 @@ public final class JsonParser {
 		}
 
 		return result;
+	}
+
+	private static String requireNonEmptyNumericValue(Object value, Class<?> type) {
+		String valueAsString = value.toString();
+		if (valueAsString.isBlank()) {
+			throw new IllegalArgumentException(
+					"Cannot convert value '%s' to numeric type '%s'".formatted(valueAsString, type.getName()));
+		}
+		return valueAsString;
 	}
 
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackExceptionHandlingTest.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/method/MethodToolCallbackExceptionHandlingTest.java
@@ -16,10 +16,12 @@
 
 package org.springframework.ai.tool.method;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.execution.ToolExecutionException;
 
@@ -36,7 +38,11 @@ public class MethodToolCallbackExceptionHandlingTest {
 		// Create a test object with a method that takes a List<String>
 		TestTools testObject = new TestTools();
 
-		var callback = MethodToolCallbackProvider.builder().toolObjects(testObject).build().getToolCallbacks()[0];
+		ToolCallback callback = Arrays
+			.stream(MethodToolCallbackProvider.builder().toolObjects(testObject).build().getToolCallbacks())
+			.filter(toolCallback -> "stringList".equals(toolCallback.getToolDefinition().name()))
+			.findFirst()
+			.orElseThrow();
 
 		// Create a JSON input with a list of strings
 		String toolInput = """
@@ -73,11 +79,36 @@ public class MethodToolCallbackExceptionHandlingTest {
 			.hasMessageContaining("Unrecognized token");
 	}
 
+	@Test
+	void testNumericEmptyStringInputProvidesClearMessage() {
+		TestTools testObject = new TestTools();
+
+		ToolCallback callback = Arrays
+			.stream(MethodToolCallbackProvider.builder().toolObjects(testObject).build().getToolCallbacks())
+			.filter(toolCallback -> "longInput".equals(toolCallback.getToolDefinition().name()))
+			.findFirst()
+			.orElseThrow();
+
+		String invalidToolInput = """
+				{
+					"id": ""
+				}
+				""";
+
+		assertThatThrownBy(() -> callback.call(invalidToolInput)).isInstanceOf(ToolExecutionException.class)
+			.hasMessageContaining("Cannot convert value '' to numeric type 'java.lang.Long'");
+	}
+
 	public static class TestTools {
 
 		@Tool(description = "Process a list of strings")
 		public String stringList(List<String> strings) {
 			return strings.size() + " strings processed: " + strings;
+		}
+
+		@Tool(description = "Accepts a long id")
+		public String longInput(Long id) {
+			return "ID: " + id;
 		}
 
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
@@ -272,6 +272,19 @@ class JsonParserTests {
 	}
 
 	@Test
+	void fromEmptyStringToLongThrowsMeaningfulException() {
+		assertThatThrownBy(() -> JsonParser.toTypedObject("", Long.class)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Cannot convert value '' to numeric type 'java.lang.Long'");
+	}
+
+	@Test
+	void fromBlankStringToIntegerThrowsMeaningfulException() {
+		assertThatThrownBy(() -> JsonParser.toTypedObject("   ", Integer.class))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Cannot convert value '   ' to numeric type 'java.lang.Integer'");
+	}
+
+	@Test
 	void doesNotDoubleSerializeValidJsonString() {
 		String input = "[1,2,3]";
 		String result = JsonParser.toJson(input);


### PR DESCRIPTION
## Summary

This PR improves the error handling for tool numeric arguments when the input is an empty or blank string.

Previously, values like `""` or `"   "` for numeric types could fail with unclear conversion/parsing messages.  
Now the conversion fails fast with a consistent and actionable message.

Fixes #3884.

## What Changed

- Added explicit empty/blank checks for numeric conversions in `JsonParser`.
- Numeric branches (`Byte`, `Short`, `Integer`, `Long`, `Float`, `Double`) now raise:
  - `IllegalArgumentException("Cannot convert value '%s' to numeric type '%s'")`
- Added/updated tests:
  - `JsonParserTests`
    - `fromEmptyStringToLongThrowsMeaningfulException`
    - `fromBlankStringToIntegerThrowsMeaningfulException`
  - `MethodToolCallbackExceptionHandlingTest`
    - `testNumericEmptyStringInputProvidesClearMessage`
  - Adjusted callback lookup in tests to be name-based (order-independent), avoiding index-based fragility.

## Why

- Improves developer and user feedback for invalid numeric tool inputs.
- Ensures message consistency across numeric target types.
- Prevents confusing low-level parse errors from leaking into tool error responses.

## Verification

Executed:

```bash
./mvnw -pl spring-ai-model -Dtest=JsonParserTests,MethodToolCallbackExceptionHandlingTest test
