### PR TITLE
Add `@Nullable` to `ChatClientResponse.Builder#context` value parameter

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientResponse.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientResponse.java
@@ -71,7 +71,7 @@ public record ChatClientResponse(@Nullable ChatResponse chatResponse, Map<String
 			return this;
 		}
 
-		public Builder context(String key, Object value) {
+		public Builder context(String key, @Nullable Object value) {
 			Assert.notNull(key, "key cannot be null");
 			this.context.put(key, value);
 			return this;

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientResponseTests.java
@@ -133,6 +133,17 @@ class ChatClientResponseTests {
 	}
 
 	@Test
+	void whenBuilderContextWithNullValueThenCreateSuccessfully() {
+		ChatClientResponse response = ChatClientResponse.builder()
+			.context("key1", "value1")
+			.context("key2", null)
+			.build();
+
+		assertThat(response.context()).containsEntry("key1", "value1");
+		assertThat(response.context()).containsEntry("key2", null);
+	}
+
+	@Test
 	void whenCopyWithNullChatResponseThenPreserveNull() {
 		Map<String, Object> context = Map.of("key", "value");
 		ChatClientResponse response = new ChatClientResponse(null, context);


### PR DESCRIPTION
## Summary

Adds `@Nullable` to the `value` parameter in `ChatClientResponse.Builder.context(String key, Object value)` for consistency with `ChatClientRequest.Builder.context(String key, @Nullable Object value)` and with the context map type `Map<String, @Nullable Object>`.

## Changes

* **ChatClientResponse.java**: `context(String key, @Nullable Object value)` — add `@Nullable` to `value`
* **ChatClientResponseTests.java**: Add `whenBuilderContextWithNullValueThenCreateSuccessfully()` to verify that the builder accepts null as context value

Fixes GH-5546