### PR TITLE
Add interceptor for MCP SSE/Streamable client transports

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpSseConnectionInterceptor.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpSseConnectionInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties.SseParameters;
+
+/**
+ * Interceptor for modifying SSE connection parameters before transport creation.
+ *
+ * <p>
+ * This functional interface allows users to intercept and modify SSE connection
+ * parameters (such as URL and SSE endpoint) before the transport is created. This is
+ * particularly useful for service discovery scenarios where service names need to be
+ * resolved to actual host:port addresses at runtime.
+ *
+ * <p>
+ * Multiple interceptors can be registered as Spring beans and will be applied in order
+ * determined by {@link org.springframework.core.annotation.Order @Order} annotation.
+ *
+ * @author Haotian Zhang
+ * @since 1.1.3
+ * @see SseParameters
+ */
+@FunctionalInterface
+public interface McpSseConnectionInterceptor {
+
+	/**
+	 * Intercept and optionally modify the SSE connection parameters.
+	 * @param connectionName the name of the connection being created
+	 * @param originalParams the original SSE parameters from configuration
+	 * @return the (potentially modified) SSE parameters to use for transport creation
+	 */
+	SseParameters intercept(String connectionName, SseParameters originalParams);
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpConnectionInterceptor.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpConnectionInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
+
+/**
+ * Interceptor for modifying Streamable HTTP connection parameters before transport
+ * creation.
+ *
+ * <p>
+ * This functional interface allows users to intercept and modify Streamable HTTP
+ * connection parameters (such as URL and endpoint) before the transport is created. This
+ * is particularly useful for service discovery scenarios where service names need to be
+ * resolved to actual host:port addresses at runtime.
+ *
+ * <p>
+ * Multiple interceptors can be registered as Spring beans and will be applied in order
+ * determined by {@link org.springframework.core.annotation.Order @Order} annotation.
+ *
+ * @author Haotian Zhang
+ * @since 1.1.3
+ * @see ConnectionParameters
+ */
+@FunctionalInterface
+public interface McpStreamableHttpConnectionInterceptor {
+
+	/**
+	 * Intercept and optionally modify the Streamable HTTP connection parameters.
+	 * @param connectionName the name of the connection being created
+	 * @param originalParams the original connection parameters from configuration
+	 * @return the (potentially modified) connection parameters to use for transport
+	 * creation
+	 */
+	ConnectionParameters intercept(String connectionName, ConnectionParameters originalParams);
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -16,11 +16,6 @@
 
 package org.springframework.ai.mcp.client.httpclient.autoconfigure;
 
-import java.net.http.HttpClient;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
@@ -28,8 +23,8 @@ import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientReq
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
-
 import org.springframework.ai.mcp.client.common.autoconfigure.McpSseClientConnectionDetails;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.PropertiesMcpSseClientConnectionDetails;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
@@ -42,6 +37,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.log.LogAccessor;
+
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Auto-configuration for Server-Sent Events (SSE) HTTP client transport in the Model
@@ -102,15 +102,22 @@ public class SseHttpClientTransportAutoConfiguration {
 	public List<NamedClientMcpTransport> sseHttpClientTransports(McpSseClientConnectionDetails connectionDetails,
 			ObjectProvider<ObjectMapper> objectMapperProvider,
 			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
-			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
+			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer,
+			ObjectProvider<List<McpSseConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
+		List<McpSseConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		List<NamedClientMcpTransport> sseTransports = new ArrayList<>();
 
 		for (Map.Entry<String, SseParameters> serverParameters : connectionDetails.getConnections().entrySet()) {
 			String connectionName = serverParameters.getKey();
 			SseParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpSseConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
 
 			String baseUrl = params.url();
 			String sseEndpoint = params.sseEndpoint() != null ? params.sseEndpoint() : "/sse";

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
@@ -16,11 +16,6 @@
 
 package org.springframework.ai.mcp.client.httpclient.autoconfigure;
 
-import java.net.http.HttpClient;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
@@ -28,7 +23,7 @@ import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientReq
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
-
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
@@ -40,6 +35,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.log.LogAccessor;
+
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Auto-configuration for Streamable HTTP client transport in the Model Context Protocol
@@ -97,18 +97,28 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 	public List<NamedClientMcpTransport> streamableHttpHttpClientTransports(
 			McpStreamableHttpClientProperties streamableProperties, ObjectProvider<ObjectMapper> objectMapperProvider,
 			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
-			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
+			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer,
+			ObjectProvider<List<McpStreamableHttpConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		ObjectMapper objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
+		List<McpStreamableHttpConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		List<NamedClientMcpTransport> streamableHttpTransports = new ArrayList<>();
 
 		for (Map.Entry<String, ConnectionParameters> serverParameters : streamableProperties.getConnections()
 			.entrySet()) {
 
-			String baseUrl = serverParameters.getValue().url();
-			String streamableHttpEndpoint = serverParameters.getValue().endpoint() != null
-					? serverParameters.getValue().endpoint() : "/mcp";
+			String connectionName = serverParameters.getKey();
+
+			ConnectionParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpStreamableHttpConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
+
+			String baseUrl = params.url();
+			String streamableHttpEndpoint = params.endpoint() != null ? params.endpoint() : "/mcp";
 
 			HttpClientStreamableHttpTransport.Builder transportBuilder = HttpClientStreamableHttpTransport
 				.builder(baseUrl)
@@ -127,7 +137,7 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 
 			HttpClientStreamableHttpTransport transport = transportBuilder.build();
 
-			streamableHttpTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
+			streamableHttpTransports.add(new NamedClientMcpTransport(connectionName, transport));
 		}
 
 		return streamableHttpTransports;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationTests.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties.SseParameters;
 import org.springframework.ai.mcp.client.httpclient.autoconfigure.SseHttpClientTransportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -153,10 +155,60 @@ public class SseHttpClientTransportAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	void urlInterceptorModifiesConnectionUrl() {
+		this.applicationContext.withUserConfiguration(SingleSseUrlInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.server1.url=http://service-name:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseHttpClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("server1");
+				assertThat(transports.get(0).transport()).isInstanceOf(HttpClientSseClientTransport.class);
+				// The interceptor should have replaced the URL
+				assertThat(getBaseUrl((HttpClientSseClientTransport) transports.get(0).transport()))
+					.isEqualTo("http://resolved-host:9090");
+			});
+	}
+
+	@Test
+	void urlInterceptorModifiesSseEndpoint() {
+		this.applicationContext.withUserConfiguration(SseEndpointInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.server1.url=http://localhost:8080",
+					"spring.ai.mcp.client.sse.connections.server1.sse-endpoint=/original-sse")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseHttpClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(getSseEndpoint((HttpClientSseClientTransport) transports.get(0).transport()))
+					.isEqualTo("/intercepted-sse");
+			});
+	}
+
+	@Test
+	void multipleUrlInterceptorsAppliedInOrder() {
+		this.applicationContext.withUserConfiguration(MultipleSseUrlInterceptorsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.server1.url=http://original:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseHttpClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				// First interceptor (Order 1) changes URL to
+				// http://first-interceptor:8080
+				// Second interceptor (Order 2) changes URL to
+				// http://second-interceptor:9090
+				assertThat(getBaseUrl((HttpClientSseClientTransport) transports.get(0).transport()))
+					.isEqualTo("http://second-interceptor:9090");
+			});
+	}
+
 	private String getSseEndpoint(HttpClientSseClientTransport transport) {
 		Field privateField = ReflectionUtils.findField(HttpClientSseClientTransport.class, "sseEndpoint");
 		ReflectionUtils.makeAccessible(privateField);
 		return (String) ReflectionUtils.getField(privateField, transport);
+	}
+
+	private String getBaseUrl(HttpClientSseClientTransport transport) {
+		Field privateField = ReflectionUtils.findField(HttpClientSseClientTransport.class, "baseUri");
+		ReflectionUtils.makeAccessible(privateField);
+		return ReflectionUtils.getField(privateField, transport).toString();
 	}
 
 	@Configuration
@@ -165,6 +217,41 @@ public class SseHttpClientTransportAutoConfigurationTests {
 		@Bean
 		ObjectMapper objectMapper() {
 			return new ObjectMapper();
+		}
+
+	}
+
+	@Configuration
+	static class SingleSseUrlInterceptorConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseUrlInterceptors() {
+			return List
+				.of((connectionName, params) -> new SseParameters("http://resolved-host:9090", params.sseEndpoint()));
+		}
+
+	}
+
+	@Configuration
+	static class SseEndpointInterceptorConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseUrlInterceptors() {
+			return List.of((connectionName, params) -> new SseParameters(params.url(), "/intercepted-sse"));
+		}
+
+	}
+
+	@Configuration
+	static class MultipleSseUrlInterceptorsConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseUrlInterceptors() {
+			McpSseConnectionInterceptor first = (connectionName,
+					params) -> new SseParameters("http://first-interceptor:8080", params.sseEndpoint());
+			McpSseConnectionInterceptor second = (connectionName,
+					params) -> new SseParameters("http://second-interceptor:9090", params.sseEndpoint());
+			return List.of(first, second);
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
 import org.springframework.ai.mcp.client.httpclient.autoconfigure.StreamableHttpHttpClientTransportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -162,10 +164,63 @@ public class StreamableHttpHttpClientTransportAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	void urlInterceptorModifiesConnectionUrl() {
+		this.applicationContext.withUserConfiguration(SingleStreamableHttpUrlInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://service-name:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpHttpClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("server1");
+				assertThat(transports.get(0).transport()).isInstanceOf(HttpClientStreamableHttpTransport.class);
+				// The interceptor should have replaced the URL
+				assertThat(getBaseUrl((HttpClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("http://resolved-host:9090");
+			});
+	}
+
+	@Test
+	void urlInterceptorModifiesEndpoint() {
+		this.applicationContext.withUserConfiguration(EndpointInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:8080",
+					"spring.ai.mcp.client.streamable-http.connections.server1.endpoint=/original-mcp")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpHttpClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(getStreamableHttpEndpoint((HttpClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("/intercepted-mcp");
+			});
+	}
+
+	@Test
+	void multipleUrlInterceptorsAppliedInOrder() {
+		this.applicationContext.withUserConfiguration(MultipleStreamableHttpUrlInterceptorsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://original:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpHttpClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				// First interceptor (Order 1) changes URL to
+				// http://first-interceptor:8080
+				// Second interceptor (Order 2) changes URL to
+				// http://second-interceptor:9090
+				assertThat(getBaseUrl((HttpClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("http://second-interceptor:9090");
+			});
+	}
+
 	private String getStreamableHttpEndpoint(HttpClientStreamableHttpTransport transport) {
 		Field privateField = ReflectionUtils.findField(HttpClientStreamableHttpTransport.class, "endpoint");
 		ReflectionUtils.makeAccessible(privateField);
 		return (String) ReflectionUtils.getField(privateField, transport);
+	}
+
+	private String getBaseUrl(HttpClientStreamableHttpTransport transport) {
+		Field privateField = ReflectionUtils.findField(HttpClientStreamableHttpTransport.class, "baseUri");
+		ReflectionUtils.makeAccessible(privateField);
+		return ReflectionUtils.getField(privateField, transport).toString();
 	}
 
 	@Configuration
@@ -174,6 +229,41 @@ public class StreamableHttpHttpClientTransportAutoConfigurationTests {
 		@Bean
 		ObjectMapper objectMapper() {
 			return new ObjectMapper();
+		}
+
+	}
+
+	@Configuration
+	static class SingleStreamableHttpUrlInterceptorConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpUrlInterceptors() {
+			return List.of((connectionName, params) -> new ConnectionParameters("http://resolved-host:9090",
+					params.endpoint()));
+		}
+
+	}
+
+	@Configuration
+	static class EndpointInterceptorConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpUrlInterceptors() {
+			return List.of((connectionName, params) -> new ConnectionParameters(params.url(), "/intercepted-mcp"));
+		}
+
+	}
+
+	@Configuration
+	static class MultipleStreamableHttpUrlInterceptorsConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpUrlInterceptors() {
+			McpStreamableHttpConnectionInterceptor first = (connectionName,
+					params) -> new ConnectionParameters("http://first-interceptor:8080", params.endpoint());
+			McpStreamableHttpConnectionInterceptor second = (connectionName,
+					params) -> new ConnectionParameters("http://second-interceptor:9090", params.endpoint());
+			return List.of(first, second);
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
@@ -16,15 +16,11 @@
 
 package org.springframework.ai.mcp.client.webflux.autoconfigure;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-
 import org.springframework.ai.mcp.client.common.autoconfigure.McpSseClientConnectionDetails;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.PropertiesMcpSseClientConnectionDetails;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
@@ -37,6 +33,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Auto-configuration for WebFlux-based Server-Sent Events (SSE) client transport in the
@@ -90,22 +90,31 @@ public class SseWebFluxTransportAutoConfiguration {
 	@Bean
 	public List<NamedClientMcpTransport> sseWebFluxClientTransports(McpSseClientConnectionDetails connectionDetails,
 			ObjectProvider<WebClient.Builder> webClientBuilderProvider,
-			ObjectProvider<ObjectMapper> objectMapperProvider) {
+			ObjectProvider<ObjectMapper> objectMapperProvider,
+			ObjectProvider<List<McpSseConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		List<NamedClientMcpTransport> sseTransports = new ArrayList<>();
 
 		var webClientBuilderTemplate = webClientBuilderProvider.getIfAvailable(WebClient::builder);
 		var objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
+		List<McpSseConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		for (Map.Entry<String, SseParameters> serverParameters : connectionDetails.getConnections().entrySet()) {
-			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(serverParameters.getValue().url());
-			String sseEndpoint = serverParameters.getValue().sseEndpoint() != null
-					? serverParameters.getValue().sseEndpoint() : "/sse";
+			String connectionName = serverParameters.getKey();
+			SseParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpSseConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
+
+			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(params.url());
+			String sseEndpoint = params.sseEndpoint() != null ? params.sseEndpoint() : "/sse";
 			var transport = WebFluxSseClientTransport.builder(webClientBuilder)
 				.sseEndpoint(sseEndpoint)
 				.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
 				.build();
-			sseTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
+			sseTransports.add(new NamedClientMcpTransport(connectionName, transport));
 		}
 
 		return sseTransports;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
@@ -16,14 +16,10 @@
 
 package org.springframework.ai.mcp.client.webflux.autoconfigure;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
-
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
@@ -35,6 +31,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Auto-configuration for WebFlux-based Streamable HTTP client transport in the Model
@@ -86,25 +86,36 @@ public class StreamableHttpWebFluxTransportAutoConfiguration {
 	public List<NamedClientMcpTransport> streamableHttpWebFluxClientTransports(
 			McpStreamableHttpClientProperties streamableProperties,
 			ObjectProvider<WebClient.Builder> webClientBuilderProvider,
-			ObjectProvider<ObjectMapper> objectMapperProvider) {
+			ObjectProvider<ObjectMapper> objectMapperProvider,
+			ObjectProvider<List<McpStreamableHttpConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		List<NamedClientMcpTransport> streamableHttpTransports = new ArrayList<>();
 
 		var webClientBuilderTemplate = webClientBuilderProvider.getIfAvailable(WebClient::builder);
 		var objectMapper = objectMapperProvider.getIfAvailable(ObjectMapper::new);
+		List<McpStreamableHttpConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		for (Map.Entry<String, ConnectionParameters> serverParameters : streamableProperties.getConnections()
 			.entrySet()) {
-			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(serverParameters.getValue().url());
-			String streamableHttpEndpoint = serverParameters.getValue().endpoint() != null
-					? serverParameters.getValue().endpoint() : "/mcp";
+
+			String connectionName = serverParameters.getKey();
+
+			ConnectionParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpStreamableHttpConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
+
+			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(params.url());
+			String streamableHttpEndpoint = params.endpoint() != null ? params.endpoint() : "/mcp";
 
 			var transport = WebClientStreamableHttpTransport.builder(webClientBuilder)
 				.endpoint(streamableHttpEndpoint)
 				.jsonMapper(new JacksonMcpJsonMapper(objectMapper))
 				.build();
 
-			streamableHttpTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
+			streamableHttpTransports.add(new NamedClientMcpTransport(connectionName, transport));
 		}
 
 		return streamableHttpTransports;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfigurationTests.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties.SseParameters;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -177,6 +179,44 @@ public class SseWebFluxTransportAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	void urlInterceptorModifiesConnectionUrl() {
+		this.applicationContext.withUserConfiguration(SingleSseUrlInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.server1.url=http://service-name:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseWebFluxClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("server1");
+				assertThat(transports.get(0).transport()).isInstanceOf(WebFluxSseClientTransport.class);
+			});
+	}
+
+	@Test
+	void urlInterceptorModifiesSseEndpoint() {
+		this.applicationContext.withUserConfiguration(SseEndpointInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.server1.url=http://localhost:8080",
+					"spring.ai.mcp.client.sse.connections.server1.sse-endpoint=/original-sse")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseWebFluxClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(getSseEndpoint((WebFluxSseClientTransport) transports.get(0).transport()))
+					.isEqualTo("/intercepted-sse");
+			});
+	}
+
+	@Test
+	void multipleUrlInterceptorsAppliedInOrder() {
+		this.applicationContext.withUserConfiguration(MultipleSseUrlInterceptorsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.server1.url=http://original:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseWebFluxClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				// Interceptors applied in order: first changes URL, second changes it again
+				assertThat(getSseEndpoint((WebFluxSseClientTransport) transports.get(0).transport()))
+					.isEqualTo("/second-sse");
+			});
+	}
+
 	private String getSseEndpoint(WebFluxSseClientTransport transport) {
 		Field privateField = ReflectionUtils.findField(WebFluxSseClientTransport.class, "sseEndpoint");
 		ReflectionUtils.makeAccessible(privateField);
@@ -199,6 +239,41 @@ public class SseWebFluxTransportAutoConfigurationTests {
 		@Bean
 		ObjectMapper objectMapper() {
 			return new ObjectMapper();
+		}
+
+	}
+
+	@Configuration
+	static class SingleSseUrlInterceptorConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseUrlInterceptors() {
+			return List.of((connectionName, params) -> new SseParameters("http://resolved-host:9090",
+					params.sseEndpoint()));
+		}
+
+	}
+
+	@Configuration
+	static class SseEndpointInterceptorConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseUrlInterceptors() {
+			return List.of((connectionName, params) -> new SseParameters(params.url(), "/intercepted-sse"));
+		}
+
+	}
+
+	@Configuration
+	static class MultipleSseUrlInterceptorsConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseUrlInterceptors() {
+			McpSseConnectionInterceptor first = (connectionName, params) -> new SseParameters(params.url(),
+					"/first-sse");
+			McpSseConnectionInterceptor second = (connectionName, params) -> new SseParameters(params.url(),
+					"/second-sse");
+			return List.of(first, second);
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.modelcontextprotocol.client.transport.WebClientStreamableHttpTransport;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -189,6 +191,48 @@ public class StreamableHttpWebFluxTransportAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	void urlInterceptorModifiesConnectionUrl() {
+		this.applicationContext
+			.withUserConfiguration(SingleStreamableHttpUrlInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://service-name:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpWebFluxClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("server1");
+				assertThat(transports.get(0).transport()).isInstanceOf(WebClientStreamableHttpTransport.class);
+			});
+	}
+
+	@Test
+	void urlInterceptorModifiesEndpoint() {
+		this.applicationContext.withUserConfiguration(EndpointInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://localhost:8080",
+					"spring.ai.mcp.client.streamable-http.connections.server1.endpoint=/original-mcp")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpWebFluxClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(getStreamableHttpEndpoint((WebClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("/intercepted-mcp");
+			});
+	}
+
+	@Test
+	void multipleUrlInterceptorsAppliedInOrder() {
+		this.applicationContext.withUserConfiguration(MultipleStreamableHttpUrlInterceptorsConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.server1.url=http://original:8080")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpWebFluxClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				// Interceptors applied in order: first changes endpoint, second changes it again
+				assertThat(getStreamableHttpEndpoint((WebClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("/second-mcp");
+			});
+	}
+
 	private String getStreamableHttpEndpoint(WebClientStreamableHttpTransport transport) {
 		Field privateField = ReflectionUtils.findField(WebClientStreamableHttpTransport.class, "endpoint");
 		ReflectionUtils.makeAccessible(privateField);
@@ -211,6 +255,41 @@ public class StreamableHttpWebFluxTransportAutoConfigurationTests {
 		@Bean
 		ObjectMapper objectMapper() {
 			return new ObjectMapper();
+		}
+
+	}
+
+	@Configuration
+	static class SingleStreamableHttpUrlInterceptorConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpUrlInterceptors() {
+			return List.of((connectionName, params) -> new ConnectionParameters("http://resolved-host:9090",
+					params.endpoint()));
+		}
+
+	}
+
+	@Configuration
+	static class EndpointInterceptorConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpUrlInterceptors() {
+			return List.of((connectionName, params) -> new ConnectionParameters(params.url(), "/intercepted-mcp"));
+		}
+
+	}
+
+	@Configuration
+	static class MultipleStreamableHttpUrlInterceptorsConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpUrlInterceptors() {
+			McpStreamableHttpConnectionInterceptor first = (connectionName, params) -> new ConnectionParameters(
+					params.url(), "/first-mcp");
+			McpStreamableHttpConnectionInterceptor second = (connectionName, params) -> new ConnectionParameters(
+					params.url(), "/second-mcp");
+			return List.of(first, second);
 		}
 
 	}


### PR DESCRIPTION
## What

Add `McpSseConnectionInterceptor` and `McpStreamableHttpConnectionInterceptor` interfaces that allow users to intercept and modify connection parameters (URL, endpoint) before MCP client transports are created.

The interceptors are applied in all four transport auto-configurations:
- `SseHttpClientTransportAutoConfiguration`
- `StreamableHttpHttpClientTransportAutoConfiguration`
- `SseWebFluxTransportAutoConfiguration`
- `StreamableHttpWebFluxTransportAutoConfiguration`

## Why

This is useful for service discovery scenarios where service names in configuration need to be resolved to actual `host:port` addresses at runtime, without requiring users to hard-code URLs in their application properties.

Closes GH-5453 (https://github.com/spring-projects/spring-ai/issues/5453)

## Usage

```java
@Bean
List<McpSseConnectionInterceptor> sseInterceptors(DiscoveryClient discoveryClient) {
    return List.of((name, params) -> {
        String resolvedUrl = discoveryClient.resolve(name);
        return new SseParameters(resolvedUrl, params.sseEndpoint());
    });
}
```

## Test plan

- [x] Unit tests added for all four transport auto-configurations verifying interceptor is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)