### PR TITLE
GH-1611: Add health indicators for Qdrant and Weaviate

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/pom.xml
@@ -61,6 +61,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-health</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreHealthAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreHealthAutoConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.qdrant.autoconfigure;
+
+import java.time.Duration;
+
+import io.qdrant.client.QdrantClient;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link AutoConfiguration Auto-configuration} for Qdrant health indicator.
+ *
+ * @author DDINGJOO
+ */
+@AutoConfiguration(after = QdrantVectorStoreAutoConfiguration.class)
+@ConditionalOnClass({ QdrantClient.class, HealthIndicator.class })
+@ConditionalOnBean(QdrantClient.class)
+@ConditionalOnEnabledHealthIndicator("qdrant")
+public class QdrantVectorStoreHealthAutoConfiguration {
+
+	private static final Duration HEALTH_CHECK_TIMEOUT = Duration.ofSeconds(5);
+
+	@Bean
+	@ConditionalOnMissingBean(name = "qdrantHealthIndicator")
+	HealthIndicator qdrantHealthIndicator(QdrantClient qdrantClient,
+			ObjectProvider<QdrantConnectionDetails> connectionDetailsProvider) {
+		return () -> {
+			@Nullable
+			QdrantConnectionDetails connectionDetails = connectionDetailsProvider.getIfAvailable();
+			try {
+				var response = qdrantClient.healthCheckAsync(HEALTH_CHECK_TIMEOUT).get();
+				Health.Builder builder = Health.up()
+					.withDetail("title", response.getTitle())
+					.withDetail("version", response.getVersion());
+				if (response.hasCommit()) {
+					builder.withDetail("commit", response.getCommit());
+				}
+				addConnectionDetails(builder, connectionDetails);
+				return builder.build();
+			}
+			catch (Exception exception) {
+				Health.Builder builder = Health.down(exception);
+				addConnectionDetails(builder, connectionDetails);
+				return builder.build();
+			}
+		};
+	}
+
+	private static void addConnectionDetails(Health.Builder builder,
+			@Nullable QdrantConnectionDetails connectionDetails) {
+		if (connectionDetails == null) {
+			return;
+		}
+		builder.withDetail("host", connectionDetails.getHost()).withDetail("port", connectionDetails.getPort());
+	}
+
+}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 org.springframework.ai.vectorstore.qdrant.autoconfigure.QdrantVectorStoreAutoConfiguration
+org.springframework.ai.vectorstore.qdrant.autoconfigure.QdrantVectorStoreHealthAutoConfiguration

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/test/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreHealthAutoConfigurationTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/src/test/java/org/springframework/ai/vectorstore/qdrant/autoconfigure/QdrantVectorStoreHealthAutoConfigurationTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.qdrant.autoconfigure;
+
+import com.google.common.util.concurrent.Futures;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.grpc.QdrantOuterClass;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link QdrantVectorStoreHealthAutoConfiguration}.
+ *
+ * @author DDINGJOO
+ */
+class QdrantVectorStoreHealthAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(QdrantVectorStoreHealthAutoConfiguration.class));
+
+	@Test
+	void healthIndicatorIsUp() {
+		QdrantClient qdrantClient = mock(QdrantClient.class);
+		when(qdrantClient.healthCheckAsync(any())).thenReturn(Futures.immediateFuture(
+				QdrantOuterClass.HealthCheckReply.newBuilder().setTitle("qdrant").setVersion("1.13.0").build()));
+
+		this.contextRunner.withBean(QdrantClient.class, () -> qdrantClient)
+			.withBean(QdrantConnectionDetails.class, TestQdrantConnectionDetails::new)
+			.run(context -> {
+				assertThat(context).hasSingleBean(HealthIndicator.class);
+				assertThat(context).hasBean("qdrantHealthIndicator");
+
+				var health = context.getBean("qdrantHealthIndicator", HealthIndicator.class).health();
+				assertThat(health.getStatus()).isEqualTo(Status.UP);
+				assertThat(health.getDetails()).containsEntry("host", "localhost")
+					.containsEntry("port", 6334)
+					.containsEntry("title", "qdrant")
+					.containsEntry("version", "1.13.0");
+			});
+	}
+
+	@Test
+	void healthIndicatorIsDownWhenQdrantIsUnavailable() {
+		QdrantClient qdrantClient = mock(QdrantClient.class);
+		when(qdrantClient.healthCheckAsync(any()))
+			.thenReturn(Futures.immediateFailedFuture(new IllegalStateException("Qdrant unavailable")));
+
+		this.contextRunner.withBean(QdrantClient.class, () -> qdrantClient)
+			.withBean(QdrantConnectionDetails.class, TestQdrantConnectionDetails::new)
+			.run(context -> {
+				assertThat(context).hasSingleBean(HealthIndicator.class);
+
+				var health = context.getBean("qdrantHealthIndicator", HealthIndicator.class).health();
+				assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+				assertThat(health.getDetails()).containsEntry("host", "localhost").containsEntry("port", 6334);
+			});
+	}
+
+	@Test
+	void healthIndicatorIsDisabled() {
+		this.contextRunner.withPropertyValues("management.health.qdrant.enabled=false")
+			.withBean(QdrantClient.class, () -> mock(QdrantClient.class))
+			.run(context -> assertThat(context).doesNotHaveBean("qdrantHealthIndicator"));
+	}
+
+	@Test
+	void customHealthIndicatorIsPreserved() {
+		this.contextRunner.withBean(QdrantClient.class, () -> mock(QdrantClient.class))
+			.withBean("qdrantHealthIndicator", HealthIndicator.class, () -> () -> Health.up().build())
+			.run(context -> assertThat(context).hasBean("qdrantHealthIndicator").hasSingleBean(HealthIndicator.class));
+	}
+
+	private static final class TestQdrantConnectionDetails implements QdrantConnectionDetails {
+
+		@Override
+		public String getHost() {
+			return "localhost";
+		}
+
+		@Override
+		public int getPort() {
+			return 6334;
+		}
+
+		@Override
+		public String getApiKey() {
+			return null;
+		}
+
+	}
+
+}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/pom.xml
@@ -51,6 +51,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-health</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreHealthAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreHealthAutoConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.weaviate.autoconfigure;
+
+import io.weaviate.client.WeaviateClient;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link AutoConfiguration Auto-configuration} for Weaviate health indicator.
+ *
+ * @author DDINGJOO
+ */
+@AutoConfiguration(after = WeaviateVectorStoreAutoConfiguration.class)
+@ConditionalOnClass({ WeaviateClient.class, HealthIndicator.class })
+@ConditionalOnBean(WeaviateClient.class)
+@ConditionalOnEnabledHealthIndicator("weaviate")
+public class WeaviateVectorStoreHealthAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(name = "weaviateHealthIndicator")
+	HealthIndicator weaviateHealthIndicator(WeaviateClient weaviateClient,
+			ObjectProvider<WeaviateConnectionDetails> connectionDetailsProvider) {
+		return () -> {
+			@Nullable
+			WeaviateConnectionDetails connectionDetails = connectionDetailsProvider.getIfAvailable();
+			try {
+				var response = weaviateClient.misc().liveChecker().run();
+				Health.Builder builder = (response.hasErrors() || !Boolean.TRUE.equals(response.getResult())) ? Health.down()
+						: Health.up();
+				builder.withDetail("live", response.getResult()).withDetail("hasErrors", response.hasErrors());
+				if (response.hasErrors() && response.getError() != null) {
+					builder.withDetail("error", response.getError().toString());
+				}
+				addConnectionDetails(builder, connectionDetails);
+				return builder.build();
+			}
+			catch (Exception exception) {
+				Health.Builder builder = Health.down(exception);
+				addConnectionDetails(builder, connectionDetails);
+				return builder.build();
+			}
+		};
+	}
+
+	private static void addConnectionDetails(Health.Builder builder,
+			@Nullable WeaviateConnectionDetails connectionDetails) {
+		if (connectionDetails == null) {
+			return;
+		}
+		builder.withDetail("host", connectionDetails.getHost());
+	}
+
+}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 org.springframework.ai.vectorstore.weaviate.autoconfigure.WeaviateVectorStoreAutoConfiguration
+org.springframework.ai.vectorstore.weaviate.autoconfigure.WeaviateVectorStoreHealthAutoConfiguration

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreHealthAutoConfigurationTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/src/test/java/org/springframework/ai/vectorstore/weaviate/autoconfigure/WeaviateVectorStoreHealthAutoConfigurationTests.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.weaviate.autoconfigure;
+
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.misc.Misc;
+import io.weaviate.client.v1.misc.api.LiveChecker;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link WeaviateVectorStoreHealthAutoConfiguration}.
+ *
+ * @author DDINGJOO
+ */
+class WeaviateVectorStoreHealthAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(WeaviateVectorStoreHealthAutoConfiguration.class));
+
+	@Test
+	void healthIndicatorIsUp() {
+		WeaviateClient weaviateClient = mock(WeaviateClient.class);
+		Misc misc = mock(Misc.class);
+		LiveChecker liveChecker = mock(LiveChecker.class);
+		@SuppressWarnings("unchecked")
+		Result<Boolean> result = mock(Result.class);
+
+		when(weaviateClient.misc()).thenReturn(misc);
+		when(misc.liveChecker()).thenReturn(liveChecker);
+		when(liveChecker.run()).thenReturn(result);
+		when(result.hasErrors()).thenReturn(false);
+		when(result.getResult()).thenReturn(true);
+
+		this.contextRunner.withBean(WeaviateClient.class, () -> weaviateClient)
+			.withBean(WeaviateConnectionDetails.class, TestWeaviateConnectionDetails::new)
+			.run(context -> {
+				assertThat(context).hasSingleBean(HealthIndicator.class);
+				assertThat(context).hasBean("weaviateHealthIndicator");
+
+				var health = context.getBean("weaviateHealthIndicator", HealthIndicator.class).health();
+				assertThat(health.getStatus()).isEqualTo(Status.UP);
+				assertThat(health.getDetails()).containsEntry("host", "localhost:8080")
+					.containsEntry("live", true)
+					.containsEntry("hasErrors", false);
+			});
+	}
+
+	@Test
+	void healthIndicatorIsDownWhenWeaviateReturnsErrors() {
+		WeaviateClient weaviateClient = mock(WeaviateClient.class);
+		Misc misc = mock(Misc.class);
+		LiveChecker liveChecker = mock(LiveChecker.class);
+		@SuppressWarnings("unchecked")
+		Result<Boolean> result = mock(Result.class);
+
+		when(weaviateClient.misc()).thenReturn(misc);
+		when(misc.liveChecker()).thenReturn(liveChecker);
+		when(liveChecker.run()).thenReturn(result);
+		when(result.hasErrors()).thenReturn(true);
+		when(result.getResult()).thenReturn(true);
+
+		this.contextRunner.withBean(WeaviateClient.class, () -> weaviateClient).run(context -> {
+			assertThat(context).hasSingleBean(HealthIndicator.class);
+
+			var health = context.getBean("weaviateHealthIndicator", HealthIndicator.class).health();
+			assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		});
+	}
+
+	@Test
+	void healthIndicatorIsDownWhenWeaviateIsUnavailable() {
+		WeaviateClient weaviateClient = mock(WeaviateClient.class);
+		Misc misc = mock(Misc.class);
+		LiveChecker liveChecker = mock(LiveChecker.class);
+
+		when(weaviateClient.misc()).thenReturn(misc);
+		when(misc.liveChecker()).thenReturn(liveChecker);
+		when(liveChecker.run()).thenThrow(new IllegalStateException("Weaviate unavailable"));
+
+		this.contextRunner.withBean(WeaviateClient.class, () -> weaviateClient)
+			.withBean(WeaviateConnectionDetails.class, TestWeaviateConnectionDetails::new)
+			.run(context -> {
+				assertThat(context).hasSingleBean(HealthIndicator.class);
+
+				var health = context.getBean("weaviateHealthIndicator", HealthIndicator.class).health();
+				assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+				assertThat(health.getDetails()).containsEntry("host", "localhost:8080");
+			});
+	}
+
+	@Test
+	void healthIndicatorIsDisabled() {
+		this.contextRunner.withPropertyValues("management.health.weaviate.enabled=false")
+			.withBean(WeaviateClient.class, () -> mock(WeaviateClient.class))
+			.run(context -> assertThat(context).doesNotHaveBean("weaviateHealthIndicator"));
+	}
+
+	@Test
+	void customHealthIndicatorIsPreserved() {
+		this.contextRunner.withBean(WeaviateClient.class, () -> mock(WeaviateClient.class))
+			.withBean("weaviateHealthIndicator", HealthIndicator.class, () -> () -> Health.up().build())
+			.run(context -> assertThat(context).hasBean("weaviateHealthIndicator").hasSingleBean(HealthIndicator.class));
+	}
+
+	private static final class TestWeaviateConnectionDetails implements WeaviateConnectionDetails {
+
+		@Override
+		public String getHost() {
+			return "localhost:8080";
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary
This PR adds Actuator health indicators for two external vector stores:
- Qdrant
- Weaviate

The indicators are conditionally auto-configured and can be disabled with:
- `management.health.qdrant.enabled=false`
- `management.health.weaviate.enabled=false`

## Why
Issue #1611 requests health indicators for vector stores that can become unavailable independently from the application.

## Changes
- Added `QdrantVectorStoreHealthAutoConfiguration`
- Added `WeaviateVectorStoreHealthAutoConfiguration`
- Registered both in each module's `AutoConfiguration.imports`
- Added optional dependency `org.springframework.boot:spring-boot-health` in both autoconfigure modules
- Added unit tests for both health auto-configurations

## Behavior
Qdrant health indicator:
- Calls `QdrantClient.healthCheckAsync(Duration.ofSeconds(5))`
- Reports `UP` with details (`title`, `version`, optional `commit`, `host`, `port`)
- Reports `DOWN` on exception

Weaviate health indicator:
- Calls `weaviateClient.misc().liveChecker().run()`
- Reports `UP` when result is true and no errors
- Reports `DOWN` when response has errors, result is false/null, or exception occurs
- Includes details (`live`, `hasErrors`, optional `error`, `host`)

## Tests
Qdrant:
- should be UP on healthy response
- should be DOWN on client failure
- should not register when `management.health.qdrant.enabled=false`
- should back off when custom `qdrantHealthIndicator` bean is provided

Weaviate:
- should be UP on healthy response
- should be DOWN when response has errors
- should be DOWN when `run()` throws
- should not register when `management.health.weaviate.enabled=false`
- should back off when custom `weaviateHealthIndicator` bean is provided

## Build Verification
- `./mvnw -pl auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant -Dmaven.build.cache.enabled=false -Denforcer.skip=true -Dkotlin.compiler.skip=true test`
- `./mvnw -pl auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate -Dmaven.build.cache.enabled=false -Denforcer.skip=true -Dkotlin.compiler.skip=true test`

Related to #1611

