### PR TITLE
Fixes #5555 Update Google GenAI SDK version to enable new features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
 		<onnxruntime.version>1.19.2</onnxruntime.version>
 		<oci-sdk-version>3.63.1</oci-sdk-version>
 		<com.google.cloud.version>26.72.0</com.google.cloud.version>
-		<com.google.genai.version>1.37.0</com.google.genai.version>
+		<com.google.genai.version>1.42.0</com.google.genai.version>
 		<ibm.sdk.version>9.20.0</ibm.sdk.version>
 		<jsonschema.version>5.0.0</jsonschema.version>
 		<swagger-annotations.version>2.2.38</swagger-annotations.version>


### PR DESCRIPTION
Updated from 1.37.0 to 1.42.0 with these key features:

v1.38.0: Logging fixes, Apache HTTP Components made optional
v1.39.0: Encryption spec support for tuning jobs
v1.40.0: Multimodal embedding, registerFiles, UnifiedMetric for tuning evaluation
v1.41.0: Server-side MCP support, Image Grounding for GoogleSearch
v1.42.0: ApiClient made AutoCloseable, data type updates from discovery doc