### PR TITLE
Fix retry auto-configuration when RetryTemplate is missing

### DIFF
--- a/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryAutoConfiguration.java
+++ b/auto-configurations/common/spring-ai-autoconfigure-retry/src/main/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
@@ -58,31 +59,6 @@ import org.springframework.web.client.ResponseErrorHandler;
 public class SpringAiRetryAutoConfiguration {
 
 	private static final Logger logger = LoggerFactory.getLogger(SpringAiRetryAutoConfiguration.class);
-
-	@Bean
-	@ConditionalOnMissingBean
-	public RetryTemplate retryTemplate(SpringAiRetryProperties properties) {
-		RetryPolicy retryPolicy = RetryPolicy.builder()
-			.maxRetries(properties.getMaxAttempts())
-			.includes(TransientAiException.class)
-			.includes(ResourceAccessException.class)
-			.delay(properties.getBackoff().getInitialInterval())
-			.multiplier(properties.getBackoff().getMultiplier())
-			.maxDelay(properties.getBackoff().getMaxInterval())
-			.build();
-
-		RetryTemplate retryTemplate = new RetryTemplate(retryPolicy);
-		retryTemplate.setRetryListener(new RetryListener() {
-			private final AtomicInteger retryCount = new AtomicInteger(0);
-
-			@Override
-			public void onRetryFailure(RetryPolicy policy, Retryable<?> retryable, Throwable throwable) {
-				int currentRetries = this.retryCount.incrementAndGet();
-				logger.warn("Retry error. Retry count:{}", currentRetries, throwable);
-			}
-		});
-		return retryTemplate;
-	}
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -133,6 +109,37 @@ public class SpringAiRetryAutoConfiguration {
 				throw new TransientAiException(message);
 			}
 		};
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(RetryTemplate.class)
+	static class RetryTemplateConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		RetryTemplate retryTemplate(SpringAiRetryProperties properties) {
+			RetryPolicy retryPolicy = RetryPolicy.builder()
+				.maxRetries(properties.getMaxAttempts())
+				.includes(TransientAiException.class)
+				.includes(ResourceAccessException.class)
+				.delay(properties.getBackoff().getInitialInterval())
+				.multiplier(properties.getBackoff().getMultiplier())
+				.maxDelay(properties.getBackoff().getMaxInterval())
+				.build();
+
+			RetryTemplate retryTemplate = new RetryTemplate(retryPolicy);
+			retryTemplate.setRetryListener(new RetryListener() {
+				private final AtomicInteger retryCount = new AtomicInteger(0);
+
+				@Override
+				public void onRetryFailure(RetryPolicy policy, Retryable<?> retryable, Throwable throwable) {
+					int currentRetries = this.retryCount.incrementAndGet();
+					logger.warn("Retry error. Retry count:{}", currentRetries, throwable);
+				}
+			});
+			return retryTemplate;
+		}
+
 	}
 
 }

--- a/auto-configurations/common/spring-ai-autoconfigure-retry/src/test/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryPropertiesTests.java
+++ b/auto-configurations/common/spring-ai-autoconfigure-retry/src/test/java/org/springframework/ai/retry/autoconfigure/SpringAiRetryPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@ package org.springframework.ai.retry.autoconfigure;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.web.client.ResponseErrorHandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -73,6 +76,15 @@ public class SpringAiRetryPropertiesTests {
 				assertThat(retryProperties.getBackoff().getMultiplier()).isEqualTo(2);
 				assertThat(retryProperties.getBackoff().getMaxInterval().toMillis()).isEqualTo(60000);
 			});
+	}
+
+	@Test
+	public void retryTemplateBeanBacksOffWhenRetryTemplateClassIsMissing() {
+
+		new ApplicationContextRunner().withClassLoader(new FilteredClassLoader(RetryTemplate.class))
+			.withConfiguration(AutoConfigurations.of(SpringAiRetryAutoConfiguration.class))
+			.run(context -> assertThat(context).hasSingleBean(ResponseErrorHandler.class)
+				.doesNotHaveBean("retryTemplate"));
 	}
 
 }


### PR DESCRIPTION
Fixes #5540

## Summary
- isolate the retry template bean behind a nested `@ConditionalOnClass(RetryTemplate.class)` configuration
- keep the response error handler auto-configuration available when `RetryTemplate` is not on the classpath
- add a regression test using `FilteredClassLoader` for the missing `RetryTemplate` case

## Testing
- `./mvnw -q -Dmaven.build.cache.enabled=false -pl auto-configurations/common/spring-ai-autoconfigure-retry -Dtest=SpringAiRetryPropertiesTests -DforkCount=0 -DreuseForks=false test`