### PR TITLE
Codex/fix thinkoption serialization 5560

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/ThinkOption.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/ThinkOption.java
@@ -100,6 +100,7 @@ public sealed interface ThinkOption {
 	 *
 	 * @param enabled whether thinking is enabled
 	 */
+	@JsonSerialize(using = ThinkOption.ThinkOptionSerializer.class)
 	record ThinkBoolean(boolean enabled) implements ThinkOption {
 
 		/**
@@ -124,6 +125,7 @@ public sealed interface ThinkOption {
 	 *
 	 * @param level the thinking level: "low", "medium", or "high"
 	 */
+	@JsonSerialize(using = ThinkOption.ThinkOptionSerializer.class)
 	record ThinkLevel(String level) implements ThinkOption {
 
 		private static final List<String> VALID_LEVELS = List.of("low", "medium", "high");

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/ThinkOptionTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/ThinkOptionTests.java
@@ -29,9 +29,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class ThinkOptionTests {
 
-	private record ThinkWrapper(Object think) {
-	}
-
 	@Test
 	void testThinkBooleanEnabledSerialization() {
 		ThinkOption option = ThinkOption.ThinkBoolean.ENABLED;
@@ -162,6 +159,9 @@ class ThinkOptionTests {
 		assertThat(ThinkOption.ThinkLevel.LOW.toJsonValue()).isEqualTo("low");
 		assertThat(ThinkOption.ThinkLevel.MEDIUM.toJsonValue()).isEqualTo("medium");
 		assertThat(ThinkOption.ThinkLevel.HIGH.toJsonValue()).isEqualTo("high");
+	}
+
+	private record ThinkWrapper(Object think) {
 	}
 
 }

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/ThinkOptionTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/ThinkOptionTests.java
@@ -29,6 +29,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class ThinkOptionTests {
 
+	private record ThinkWrapper(Object think) {
+	}
+
 	@Test
 	void testThinkBooleanEnabledSerialization() {
 		ThinkOption option = ThinkOption.ThinkBoolean.ENABLED;
@@ -39,6 +42,13 @@ class ThinkOptionTests {
 	@Test
 	void testThinkBooleanDisabledSerialization() {
 		ThinkOption option = ThinkOption.ThinkBoolean.DISABLED;
+		String json = JsonMapper.shared().writeValueAsString(option);
+		assertThat(json).isEqualTo("false");
+	}
+
+	@Test
+	void testThinkBooleanConcreteTypeSerialization() {
+		ThinkOption.ThinkBoolean option = ThinkOption.ThinkBoolean.DISABLED;
 		String json = JsonMapper.shared().writeValueAsString(option);
 		assertThat(json).isEqualTo("false");
 	}
@@ -62,6 +72,19 @@ class ThinkOptionTests {
 		ThinkOption option = ThinkOption.ThinkLevel.HIGH;
 		String json = JsonMapper.shared().writeValueAsString(option);
 		assertThat(json).isEqualTo("\"high\"");
+	}
+
+	@Test
+	void testThinkLevelConcreteTypeSerialization() {
+		ThinkOption.ThinkLevel option = ThinkOption.ThinkLevel.HIGH;
+		String json = JsonMapper.shared().writeValueAsString(option);
+		assertThat(json).isEqualTo("\"high\"");
+	}
+
+	@Test
+	void testThinkBooleanSerializationInsideWrapperObject() {
+		String json = JsonMapper.shared().writeValueAsString(new ThinkWrapper(ThinkOption.ThinkBoolean.DISABLED));
+		assertThat(json).isEqualTo("{\"think\":false}");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
Fix `ThinkOption` concrete serialization so `ThinkBoolean` / `ThinkLevel` serialize as scalar values, not record objects.

Closes #5560

## What I changed
- Added `@JsonSerialize(using = ThinkOption.ThinkOptionSerializer.class)` to:
  - `ThinkOption.ThinkBoolean`
  - `ThinkOption.ThinkLevel`
- Added regression coverage in `ThinkOptionTests` for:
  - concrete type serialization (`ThinkBoolean`, `ThinkLevel`)
  - wrapper-object serialization (`{"think":false}`)
- Adjusted test helper record placement to satisfy repo checkstyle (`InnerTypeLast`).

## Proof
- Before (reported in issue): `ThinkOption.ThinkBoolean.DISABLED` could serialize as:
  - `{"enabled":false}`
- After this change:
  - concrete `ThinkBoolean` serializes to: `false`
  - concrete `ThinkLevel.HIGH` serializes to: `"high"`
  - wrapped payload serializes to: `{"think":false}`

## Validation
- Command run:
  - `mvn -pl models/spring-ai-ollama -Dtest=ThinkOptionTests test -DskipITs`
- Result:
  - `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0`
  - `BUILD SUCCESS`
- Checkstyle in this module also passed:
  - `You have 0 Checkstyle violations.`
