### PR TITLE
GH-5568: Null-safety regression in DeepSeek tool call contents merging

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
@@ -79,7 +79,8 @@ public class DeepSeekStreamFunctionCallingHelper {
 	}
 
 	private ChatCompletionMessage merge(@Nullable ChatCompletionMessage previous, ChatCompletionMessage current) {
-		String content = previous != null ? previous.content() + current.content() : current.content();
+		String content = (previous != null && previous.content() != null ? previous.content() : "")
+				+ (current.content() != null ? current.content() : "");
 		Role role = current.role();
 		String name = (current.name() != null ? current.name() : (previous != null ? previous.name() : null));
 		String toolCallId = (current.toolCallId() != null ? current.toolCallId()


### PR DESCRIPTION
Close #5568

Ensure null-safe content merging in `DeepSeekStreamFunctionCallingHelper`, as what the Spring AI 1.x does.