### PR TITLE
Elasticsearch chat memory implementation

### DIFF
--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/pom.xml
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-autoconfigure-model-chat-memory-elasticsearch</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Elasticsearch Chat Memory Auto Configuration</name>
+	<description>Spring AI Elasticsearch Chat Memory Auto Configuration</description>
+
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model-chat-memory-repository-elasticsearch</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-elasticsearch</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-elasticsearch</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,19 +41,18 @@ import org.springframework.context.annotation.Bean;
  * @since 2.0.0
  */
 @AutoConfiguration(after = ElasticsearchRestClientAutoConfiguration.class)
-@ConditionalOnClass({ElasticsearchChatMemoryRepository.class, Rest5Client.class})
+@ConditionalOnClass({ ElasticsearchChatMemoryRepository.class, Rest5Client.class })
 @EnableConfigurationProperties(ElasticsearchChatMemoryProperties.class)
 public class ElasticsearchChatMemoryAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean({ElasticsearchChatMemoryRepository.class, ChatMemory.class,
-			ChatMemoryRepository.class})
+	@ConditionalOnMissingBean({ ElasticsearchChatMemoryRepository.class, ChatMemory.class, ChatMemoryRepository.class })
 	public ElasticsearchChatMemoryRepository elasticsearchChatMemoryRepository(Rest5Client restClient,
-																			   ElasticsearchChatMemoryProperties properties) {
+			ElasticsearchChatMemoryProperties properties) {
 		ElasticsearchChatMemoryRepository.Builder builder = ElasticsearchChatMemoryRepository.builder(restClient)
-				.indexName(properties.getIndexName())
-				.initializeSchema(properties.isInitializeSchema())
-				.maxResults(properties.getMaxResults());
+			.indexName(properties.getIndexName())
+			.initializeSchema(properties.isInitializeSchema())
+			.maxResults(properties.getMaxResults());
 
 		return builder.build();
 	}

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.chat.memory.elasticsearch.autoconfigure;
+
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.repository.elasticsearch.ElasticsearchChatMemoryRepository;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for Elasticsearch-based chat memory implementation.
+ *
+ * <p>
+ * The {@link Rest5Client} bean is provided by Spring Boot's
+ * {@link ElasticsearchRestClientAutoConfiguration}, configured via standard
+ * {@code spring.elasticsearch.*} properties.
+ * </p>
+ *
+ * @author Laura
+ * @since 2.0.0
+ */
+@AutoConfiguration(after = ElasticsearchRestClientAutoConfiguration.class)
+@ConditionalOnClass({ElasticsearchChatMemoryRepository.class, Rest5Client.class})
+@EnableConfigurationProperties(ElasticsearchChatMemoryProperties.class)
+public class ElasticsearchChatMemoryAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean({ElasticsearchChatMemoryRepository.class, ChatMemory.class,
+			ChatMemoryRepository.class})
+	public ElasticsearchChatMemoryRepository elasticsearchChatMemoryRepository(Rest5Client restClient,
+																			   ElasticsearchChatMemoryProperties properties) {
+		ElasticsearchChatMemoryRepository.Builder builder = ElasticsearchChatMemoryRepository.builder(restClient)
+				.indexName(properties.getIndexName())
+				.initializeSchema(properties.isInitializeSchema())
+				.maxResults(properties.getMaxResults());
+
+		return builder.build();
+	}
+
+}

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryProperties.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryProperties.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryProperties.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.chat.memory.elasticsearch.autoconfigure;
+
+import org.springframework.ai.chat.memory.repository.elasticsearch.ElasticsearchChatMemoryConfig;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Elasticsearch-based chat memory.
+ *
+ * <p>
+ * Connection properties (host, port, authentication) are managed by Spring Boot's
+ * standard {@code spring.elasticsearch.*} properties, which provide the
+ * {@code Rest5Client} bean.
+ * </p>
+ *
+ * @author Laura
+ * @since 2.0.0
+ */
+@ConfigurationProperties(prefix = "spring.ai.chat.memory.elasticsearch")
+public class ElasticsearchChatMemoryProperties {
+
+	/**
+	 * Name of the Elasticsearch index for chat memory.
+	 */
+	private String indexName = ElasticsearchChatMemoryConfig.DEFAULT_INDEX_NAME;
+
+	/**
+	 * Whether to initialize the Elasticsearch index schema on startup. Default is true.
+	 */
+	private boolean initializeSchema = true;
+
+	/**
+	 * Maximum number of results to return (defaults to 1000).
+	 */
+	private int maxResults = ElasticsearchChatMemoryConfig.DEFAULT_MAX_RESULTS;
+
+	public String getIndexName() {
+		return this.indexName;
+	}
+
+	public void setIndexName(String indexName) {
+		this.indexName = indexName;
+	}
+
+	public boolean isInitializeSchema() {
+		return this.initializeSchema;
+	}
+
+	public void setInitializeSchema(boolean initializeSchema) {
+		this.initializeSchema = initializeSchema;
+	}
+
+	public int getMaxResults() {
+		return this.maxResults;
+	}
+
+	public void setMaxResults(int maxResults) {
+		this.maxResults = maxResults;
+	}
+
+}

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/package-info.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/package-info.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.model.chat.memory.elasticsearch.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.ai.model.chat.memory.elasticsearch.autoconfigure.ElasticsearchChatMemoryAutoConfiguration

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/test/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfigurationIT.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/test/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfigurationIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.chat.memory.elasticsearch.autoconfigure;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.repository.elasticsearch.ElasticsearchChatMemoryRepository;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class ElasticsearchChatMemoryAutoConfigurationIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(ElasticsearchChatMemoryAutoConfigurationIT.class);
+
+	@Container
+	static ElasticsearchContainer elasticsearch = new ElasticsearchContainer("elasticsearch:9.3.0")
+		.withEnv("xpack.security.enabled", "false");
+
+	@BeforeAll
+	static void setup() {
+		logger.info("Elasticsearch container running at: {}", elasticsearch.getHttpHostAddress());
+	}
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(ElasticsearchChatMemoryAutoConfiguration.class,
+				ElasticsearchRestClientAutoConfiguration.class))
+		.withPropertyValues("spring.elasticsearch.uris=" + elasticsearch.getHttpHostAddress());
+
+	@Test
+	void autoConfigurationRegistersExpectedBeans() {
+		this.contextRunner.run(context -> {
+			assertThat(context).hasSingleBean(ElasticsearchChatMemoryRepository.class);
+			assertThat(context).hasSingleBean(ChatMemoryRepository.class);
+		});
+	}
+
+	@Test
+	void customPropertiesAreApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.memory.elasticsearch.index-name=custom-index",
+					"spring.ai.chat.memory.elasticsearch.initialize-schema=false",
+					"spring.ai.chat.memory.elasticsearch.max-results=500")
+			.run(context -> {
+				ElasticsearchChatMemoryProperties properties = context
+					.getBean(ElasticsearchChatMemoryProperties.class);
+				assertThat(properties.getIndexName()).isEqualTo("custom-index");
+				assertThat(properties.isInitializeSchema()).isFalse();
+				assertThat(properties.getMaxResults()).isEqualTo(500);
+			});
+	}
+
+	@Test
+	void chatMemoryRepositoryIsProvidedByElasticsearchChatMemory() {
+		this.contextRunner.run(context -> {
+			ElasticsearchChatMemoryRepository elasticsearchChatMemory = context
+				.getBean(ElasticsearchChatMemoryRepository.class);
+			ChatMemoryRepository repository = context.getBean(ChatMemoryRepository.class);
+
+			assertThat(repository).isSameAs(elasticsearchChatMemory);
+		});
+	}
+
+}

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/test/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfigurationIT.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/test/java/org/springframework/ai/model/chat/memory/elasticsearch/autoconfigure/ElasticsearchChatMemoryAutoConfigurationIT.java
@@ -66,8 +66,7 @@ class ElasticsearchChatMemoryAutoConfigurationIT {
 					"spring.ai.chat.memory.elasticsearch.initialize-schema=false",
 					"spring.ai.chat.memory.elasticsearch.max-results=500")
 			.run(context -> {
-				ElasticsearchChatMemoryProperties properties = context
-					.getBean(ElasticsearchChatMemoryProperties.class);
+				ElasticsearchChatMemoryProperties properties = context.getBean(ElasticsearchChatMemoryProperties.class);
 				assertThat(properties.getIndexName()).isEqualTo("custom-index");
 				assertThat(properties.isInitializeSchema()).isFalse();
 				assertThat(properties.getMaxResults()).isEqualTo(500);

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/test/resources/logback-test.xml
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.springframework.ai" level="INFO"/>
+    <logger name="org.springframework.ai.chat.memory.elasticsearch" level="DEBUG"/>
+    <logger name="org.springframework.ai.model.chat.memory.elasticsearch" level="DEBUG"/>
+</configuration>

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/pom.xml
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-model-chat-memory-repository-elasticsearch</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Chat Memory Repository - Elasticsearch</name>
+	<description>Elasticsearch-based persistent implementation of the Spring AI ChatMemoryRepository interface</description>
+
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>co.elastic.clients</groupId>
+			<artifactId>elasticsearch-java</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-elasticsearch</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>checkstyle-validation</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/AdvancedElasticsearchChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/AdvancedElasticsearchChatMemoryRepository.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import java.time.Instant;
+import java.util.List;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+
+/**
+ * Elasticsearch-specific extended interface for ChatMemoryRepository with advanced query
+ * capabilities, similar to AdvancedRedisChatMemoryRepository.
+ *
+ * @author Laura Trotta
+ * @since 2.0.0
+ */
+public interface AdvancedElasticsearchChatMemoryRepository extends ChatMemoryRepository {
+
+	/**
+	 * Find messages by content across all conversations.
+	 * @param contentPattern The text pattern to search for in message content
+	 * @param limit Maximum number of results to return
+	 * @return List of messages matching the pattern
+	 */
+	List<MessageWithConversation> findByContent(String contentPattern, int limit);
+
+	/**
+	 * Find messages by type across all conversations.
+	 * @param messageType The message type to filter by
+	 * @param limit Maximum number of results to return
+	 * @return List of messages of the specified type
+	 */
+	List<MessageWithConversation> findByType(MessageType messageType, int limit);
+
+	/**
+	 * Find messages by timestamp range.
+	 * @param conversationId Optional conversation ID to filter by (null for all
+	 * conversations)
+	 * @param fromTime Start of time range (inclusive)
+	 * @param toTime End of time range (inclusive)
+	 * @param limit Maximum number of results to return
+	 * @return List of messages within the time range
+	 */
+	List<MessageWithConversation> findByTimeRange(String conversationId, Instant fromTime, Instant toTime, int limit);
+
+	/**
+	 * Find messages with a specific metadata key-value pair.
+	 * @param metadataKey The metadata key to search for
+	 * @param metadataValue The metadata value to match
+	 * @param limit Maximum number of results to return
+	 * @return List of messages with matching metadata
+	 */
+	List<MessageWithConversation> findByMetadata(String metadataKey, Object metadataValue, int limit);
+
+	/**
+	 * Execute a custom query using Elasticsearch Query DSL JSON syntax.
+	 * @param query The Elasticsearch query JSON string
+	 * @param limit Maximum number of results to return
+	 * @return List of messages matching the query
+	 */
+	List<MessageWithConversation> executeQuery(String query, int limit);
+
+	/**
+	 * Execute a custom query using Elasticsearch Java Client Query
+	 * @param query An Elasticsearch Query object
+	 * @param limit Maximum number of results to return
+	 * @return List of messages matching the query
+	 */
+	List<MessageWithConversation> executeQuery(Query query, int limit);
+
+	/**
+	 * A wrapper class to return messages with their conversation context.
+	 *
+	 * @param conversationId the conversation identifier
+	 * @param message the message content
+	 * @param timestamp the message timestamp
+	 */
+	record MessageWithConversation(String conversationId, Message message, long timestamp) {
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/AdvancedElasticsearchChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/AdvancedElasticsearchChatMemoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryConfig.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryConfig.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryConfig.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import org.springframework.util.Assert;
+
+/**
+ * Configuration class for ElasticsearchChatMemoryRepository.
+ *
+ * @author Laura Trotta
+ */
+public class ElasticsearchChatMemoryConfig {
+
+	public static final String DEFAULT_INDEX_NAME = "spring-ai-chat-memory";
+
+	/**
+	 * Default maximum number of results to return (Elasticsearch defaults to 10, while
+	 * the max is 10000).
+	 */
+	public static final int DEFAULT_MAX_RESULTS = 1000;
+
+	/** The Elasticsearch index name */
+	private final String indexName;
+
+	/**
+	 * Maximum number of results to return.
+	 */
+	private final int maxResults;
+
+	/** Whether to automatically initialize the schema */
+	private final boolean initializeSchema;
+
+	/** Elasticsearch rest client instance */
+	private final Rest5Client esRestClient;
+
+	private ElasticsearchChatMemoryConfig(final Builder builder) {
+		this.indexName = builder.indexName;
+		this.initializeSchema = builder.initializeSchema;
+		this.maxResults = builder.maxResults;
+		this.esRestClient = builder.esRestClient;
+	}
+
+	public static Builder builder(Rest5Client esRestClient) {
+		return new Builder(esRestClient);
+	}
+
+	public String getIndexName() {
+		return indexName;
+	}
+
+	public boolean isInitializeSchema() {
+		return initializeSchema;
+	}
+
+	public int getMaxResults() {
+		return maxResults;
+	}
+
+	public Rest5Client getEsRestClient() {
+		return esRestClient;
+	}
+
+	/**
+	 * Builder for ElasticsearchChatMemoryConfig.
+	 */
+	public static class Builder {
+
+		/** The index name */
+		private String indexName = DEFAULT_INDEX_NAME;
+
+		/** Whether to initialize the schema */
+		private boolean initializeSchema = true;
+
+		/** Maximum number of results to return. */
+		private int maxResults = DEFAULT_MAX_RESULTS;
+
+		/** Elasticsearch rest client instance */
+		private final Rest5Client esRestClient;
+
+		private Builder(final Rest5Client esRestClient) {
+			Assert.notNull(esRestClient, "Rest5Client must not be null");
+			this.esRestClient = esRestClient;
+		}
+
+		/**
+		 * Sets the index name.
+		 * @param indexName the index name to use
+		 * @return the builder instance
+		 */
+		public Builder indexName(final String indexName) {
+			this.indexName = indexName;
+			return this;
+		}
+
+		/**
+		 * Sets whether to initialize the schema.
+		 * @param initialize true to initialize schema, false otherwise
+		 * @return the builder instance
+		 */
+		public Builder initializeSchema(final boolean initialize) {
+			this.initializeSchema = initialize;
+			return this;
+		}
+
+		/**
+		 * Sets the max number of results to return.
+		 * @param maxResults the number of results
+		 * @return the builder instance
+		 */
+		public Builder maxResults(final int maxResults) {
+			this.maxResults = maxResults;
+			return this;
+		}
+
+		/**
+		 * Builds a new ElasticsearchChatMemoryConfig instance.
+		 * @return the new configuration instance
+		 */
+		public ElasticsearchChatMemoryConfig build() {
+			return new ElasticsearchChatMemoryConfig(this);
+		}
+
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepository.java
@@ -1,0 +1,540 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
+import co.elastic.clients.transport.Version;
+import co.elastic.clients.transport.rest5_client.Rest5ClientTransport;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.content.Media;
+import org.springframework.ai.content.MediaContent;
+import org.springframework.util.Assert;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * Elasticsearch implementation of {@link ChatMemoryRepository} with advanced query
+ * capabilities. Stores chat messages as documents in an Elasticsearch index.
+ *
+ * <p>
+ * Client creation follows the same pattern as
+ * {@code org.springframework.ai.vectorstore.elasticsearch.ElasticsearchVectorStore}:
+ * accepts a {@link Rest5Client} and internally builds an {@link ElasticsearchClient} via
+ * {@link Rest5ClientTransport} + {@link Jackson3JsonpMapper}.
+ * </p>
+ *
+ * @author Laura Trotta
+ * @since 2.0.0
+ */
+public final class ElasticsearchChatMemoryRepository
+		implements ChatMemoryRepository, AdvancedElasticsearchChatMemoryRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(ElasticsearchChatMemoryRepository.class);
+
+	private static final String CONVERSATION_FIELD = "conversation_id";
+
+	private static final String TYPE_FIELD = "type";
+
+	private static final String CONTENT_FIELD = "content";
+
+	private static final String TIMESTAMP_FIELD = "timestamp";
+
+	private final JsonMapper jsonMapper = JsonMapper.builder()
+		.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+		.enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+		.changeDefaultPropertyInclusion(v -> v.withValueInclusion(JsonInclude.Include.NON_NULL))
+		.build();
+
+	private final ElasticsearchClient elasticsearchClient;
+
+	private final String indexName;
+
+	private final boolean initializeSchema;
+
+	private final int maxResults;
+
+	public ElasticsearchChatMemoryRepository(ElasticsearchChatMemoryConfig config) {
+		Assert.notNull(config, "Config must not be null");
+		this.indexName = config.getIndexName();
+		this.initializeSchema = config.isInitializeSchema();
+		this.maxResults = config.getMaxResults();
+		String version = Version.VERSION == null ? "Unknown" : Version.VERSION.toString();
+		this.elasticsearchClient = new ElasticsearchClient(
+				new Rest5ClientTransport(config.getEsRestClient(), new Jackson3JsonpMapper(this.jsonMapper)))
+			.withTransportOptions(t -> t.addHeader("user-agent", "spring-ai elastic-java/" + version));
+
+		if (initializeSchema) {
+			initializeSchema();
+		}
+	}
+
+	public static Builder builder(Rest5Client restClient) {
+		return new Builder(restClient);
+	}
+
+	@Override
+	public List<String> findConversationIds() {
+		try {
+			SearchResponse<Void> response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+				.size(0)
+				.aggregations("conversation_ids",
+						a -> a.terms(t -> t.field(CONVERSATION_FIELD).size(this.maxResults))));
+
+			Aggregate aggregation = response.aggregations().get("conversation_ids");
+			if (aggregation == null) {
+				return Collections.emptyList();
+			}
+			List<String> ids = aggregation.sterms()
+				.buckets()
+				.array()
+				.stream()
+				.map(bucket -> bucket.key().stringValue())
+				.collect(Collectors.toList());
+
+			if (logger.isDebugEnabled()) {
+				logger.debug("Found {} unique conversation IDs", ids.size());
+			}
+			return ids;
+		}
+		catch (IOException e) {
+			logger.error("Failed to find conversation IDs: {}", e.getMessage());
+			throw new RuntimeException("Failed to find conversation IDs", e);
+		}
+	}
+
+	@Override
+	public List<Message> findByConversationId(String conversationId) {
+		Assert.notNull(conversationId, "Conversation ID must not be null");
+		return getMessages(conversationId);
+	}
+
+	@Override
+	public void saveAll(String conversationId, List<Message> messages) {
+		Assert.notNull(conversationId, "Conversation ID must not be null");
+		Assert.notNull(messages, "Messages must not be null");
+
+		deleteByConversationId(conversationId);
+		if (!messages.isEmpty()) {
+			addMessages(conversationId, messages);
+		}
+	}
+
+	@Override
+	public void deleteByConversationId(String conversationId) {
+		Assert.notNull(conversationId, "Conversation ID must not be null");
+		try {
+			this.elasticsearchClient.deleteByQuery(d -> d.index(this.indexName)
+				.query(q -> q.term(t -> t.field(CONVERSATION_FIELD).value(conversationId))));
+			this.elasticsearchClient.indices().refresh(r -> r.index(this.indexName));
+		}
+		catch (IOException e) {
+			logger.error("Failed to delete messages for conversation {}: {}", conversationId, e.getMessage());
+			throw new RuntimeException("Failed to delete messages for conversation " + conversationId, e);
+		}
+	}
+
+	// advanced interface method overrides from here
+
+	@Override
+	public List<MessageWithConversation> findByContent(String contentPattern, int limit) {
+		Assert.notNull(contentPattern, "Content pattern must not be null");
+		Assert.isTrue(limit > 0, "Limit must be greater than 0");
+
+		try {
+			SearchResponse<MessageDocument> response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+				.query(q -> q.match(m -> m.field(CONTENT_FIELD).query(contentPattern)))
+				.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+				.size(limit), MessageDocument.class);
+			return processSearchResponse(response);
+		}
+		catch (IOException e) {
+			logger.error("Failed to find messages by content: {}", e.getMessage());
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public List<MessageWithConversation> findByType(MessageType messageType, int limit) {
+		Assert.notNull(messageType, "Message type must not be null");
+		Assert.isTrue(limit > 0, "Limit must be greater than 0");
+
+		try {
+			SearchResponse<MessageDocument> response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+				.query(q -> q.term(t -> t.field(TYPE_FIELD).value(messageType.toString())))
+				.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+				.size(limit), MessageDocument.class);
+			return processSearchResponse(response);
+		}
+		catch (IOException e) {
+			logger.error("Failed to find messages by type: {}", e.getMessage());
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public List<MessageWithConversation> findByTimeRange(String conversationId, Instant fromTime, Instant toTime,
+			int limit) {
+		Assert.notNull(fromTime, "From time must not be null");
+		Assert.notNull(toTime, "To time must not be null");
+		Assert.isTrue(limit > 0, "Limit must be greater than 0");
+		Assert.isTrue(!toTime.isBefore(fromTime), "To time must not be before from time");
+
+		long fromTimeMs = fromTime.toEpochMilli();
+		long toTimeMs = toTime.toEpochMilli();
+
+		try {
+			SearchResponse<MessageDocument> response = this.elasticsearchClient.search(s -> {
+				s.index(this.indexName)
+					.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+					.size(limit);
+
+				if (conversationId != null && !conversationId.isEmpty()) {
+					s.query(q -> q.bool(b -> b
+						.must(m -> m.range(r -> r
+							.number(n -> n.field(TIMESTAMP_FIELD).gte((double) fromTimeMs).lte((double) toTimeMs))))
+						.must(m -> m.term(t -> t.field(CONVERSATION_FIELD).value(conversationId)))));
+				}
+				else {
+					s.query(q -> q.range(r -> r
+						.number(n -> n.field(TIMESTAMP_FIELD).gte((double) fromTimeMs).lte((double) toTimeMs))));
+				}
+				return s;
+			}, MessageDocument.class);
+			return processSearchResponse(response);
+		}
+		catch (IOException e) {
+			logger.error("Failed to find messages by time range: {}", e.getMessage());
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public List<MessageWithConversation> findByMetadata(String metadataKey, Object metadataValue, int limit) {
+		Assert.notNull(metadataKey, "Metadata key must not be null");
+		Assert.notNull(metadataValue, "Metadata value must not be null");
+		Assert.isTrue(limit > 0, "Limit must be greater than 0");
+
+		String field = "metadata." + metadataKey;
+
+		try {
+			SearchResponse<MessageDocument> response;
+			if (metadataValue instanceof Number number) {
+				response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+					.query(q -> q.term(t -> t.field(field).value(number.doubleValue())))
+					.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+					.size(limit), MessageDocument.class);
+			}
+			else {
+				String stringValue = metadataValue.toString();
+				response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+					.query(q -> q.term(t -> t.field(field).value(stringValue)))
+					.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+					.size(limit), MessageDocument.class);
+			}
+			return processSearchResponse(response);
+		}
+		catch (IOException e) {
+			logger.error("Failed to find messages by metadata: {}", e.getMessage());
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public List<MessageWithConversation> executeQuery(String query, int limit) {
+		Assert.notNull(query, "Query must not be null");
+		Assert.isTrue(limit > 0, "Limit must be greater than 0");
+
+		try {
+			SearchResponse<MessageDocument> response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+				.query(q -> q.withJson(new StringReader(query)))
+				.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+				.size(limit), MessageDocument.class);
+			return processSearchResponse(response);
+		}
+		catch (IOException e) {
+			logger.error("Failed to execute custom query: {}", e.getMessage());
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public List<MessageWithConversation> executeQuery(Query query, int limit) {
+		Assert.notNull(query, "Query must not be null");
+		Assert.isTrue(limit > 0, "Limit must be greater than 0");
+
+		try {
+			SearchResponse<MessageDocument> response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+				.query(query)
+				.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+				.size(limit), MessageDocument.class);
+			return processSearchResponse(response);
+		}
+		catch (IOException e) {
+			logger.error("Failed to execute custom query: {}", e.getMessage());
+			return Collections.emptyList();
+		}
+	}
+
+	public String getIndexName() {
+		return this.indexName;
+	}
+
+	private void initializeSchema() {
+		try {
+			boolean exists = this.elasticsearchClient.indices().exists(e -> e.index(this.indexName)).value();
+			if (!exists) {
+				this.elasticsearchClient.indices()
+					.create(c -> c.index(this.indexName)
+						.mappings(m -> m.properties(CONVERSATION_FIELD, p -> p.keyword(k -> k))
+							.properties(TYPE_FIELD, p -> p.keyword(k -> k))
+							.properties(CONTENT_FIELD, p -> p.text(t -> t))
+							.properties(TIMESTAMP_FIELD, p -> p.long_(l -> l))
+							.properties("media",
+									p -> p.object(o -> o.properties("contentString", pr -> pr.text(k -> k))
+										.properties("name", pr -> pr.keyword(k -> k))
+										.properties("id", pr -> pr.keyword(k -> k))
+										.properties("mimeType", pr -> pr.keyword(k -> k))
+										.properties("contentBytes", pr -> pr.binary(k -> k))))
+							.properties("toolResponses",
+									p -> p.object(o -> o.properties("name", pr -> pr.keyword(k -> k))
+										.properties("responseData", pr -> pr.text(k -> k))
+										.properties("id", pr -> pr.keyword(k -> k))))
+							.properties("toolCalls",
+									p -> p.object(o -> o.properties("name", pr -> pr.keyword(k -> k))
+										.properties("arguments", pr -> pr.text(k -> k))
+										.properties("id", pr -> pr.keyword(k -> k))
+										.properties("type", pr -> pr.keyword(k -> k))))
+							.properties("metadata", p -> p.object(o -> o))));
+				if (logger.isDebugEnabled()) {
+					logger.debug("Created Elasticsearch index '{}'", this.indexName);
+				}
+			}
+			else if (logger.isDebugEnabled()) {
+				logger.debug("Elasticsearch index '{}' already exists", this.indexName);
+			}
+		}
+		catch (IOException e) {
+			logger.error("Failed to initialize Elasticsearch schema: {}", e.getMessage());
+			throw new IllegalStateException("Could not initialize Elasticsearch schema", e);
+		}
+	}
+
+	private List<Message> getMessages(String conversationId) {
+		try {
+			SearchResponse<MessageDocument> response = this.elasticsearchClient.search(s -> s.index(this.indexName)
+				.query(q -> q.term(t -> t.field(CONVERSATION_FIELD).value(conversationId)))
+				.sort(so -> so.field(f -> f.field(TIMESTAMP_FIELD).order(SortOrder.Asc)))
+				.size(this.maxResults), MessageDocument.class);
+
+			List<Message> messages = new ArrayList<>();
+			for (Hit<MessageDocument> hit : response.hits().hits()) {
+				MessageDocument source = hit.source();
+				if (source != null) {
+					messages.add(convertMessageDocumentToSpecificMessage(source));
+				}
+			}
+
+			if (logger.isDebugEnabled()) {
+				logger.debug("Returning {} messages for conversation {}", messages.size(), conversationId);
+			}
+			return messages;
+		}
+		catch (IOException e) {
+			logger.error("Failed to get messages for conversation {}: {}", conversationId, e.getMessage());
+			throw new RuntimeException("Failed to get messages for conversation " + conversationId, e);
+		}
+	}
+
+	private void addMessages(String conversationId, List<Message> messages) {
+		long baseTimestamp = Instant.now().toEpochMilli();
+		AtomicLong timestampSequence = new AtomicLong(baseTimestamp);
+
+		BulkRequest.Builder bulkBuilder = new BulkRequest.Builder();
+		for (Message message : messages) {
+			long timestamp = timestampSequence.getAndIncrement();
+			MessageDocument doc = createMessageDocument(conversationId, message, timestamp);
+			bulkBuilder.operations(op -> op.index(idx -> idx.index(this.indexName).document(doc)));
+		}
+
+		try {
+			BulkResponse bulkResponse = this.elasticsearchClient.bulk(bulkBuilder.build());
+			if (bulkResponse.errors()) {
+				logger.error("Errors occurred during bulk indexing for conversation {}", conversationId);
+				bulkResponse.items().stream().filter(item -> item.error() != null).forEach(item -> {
+					logger.error("Bulk item error: {}", item.error().reason());
+				});
+			}
+			this.elasticsearchClient.indices().refresh(r -> r.index(this.indexName));
+		}
+		catch (IOException e) {
+			logger.error("Failed to add messages for conversation {}: {}", conversationId, e.getMessage());
+			throw new RuntimeException("Failed to add messages for conversation " + conversationId, e);
+		}
+	}
+
+	private List<MessageWithConversation> processSearchResponse(SearchResponse<MessageDocument> response) {
+		List<MessageWithConversation> results = new ArrayList<>();
+		for (Hit<MessageDocument> hit : response.hits().hits()) {
+			MessageDocument source = hit.source();
+			if (source != null) {
+				String conversationId = source.conversation_id();
+				long timestamp = source.timestamp();
+				Message message = convertMessageDocumentToSpecificMessage(source);
+				results.add(new MessageWithConversation(conversationId, message, timestamp));
+			}
+		}
+		return results;
+	}
+
+	private MessageDocument createMessageDocument(String conversationId, Message message, long timestamp) {
+
+		List<AssistantMessage.ToolCall> toolCalls = null;
+		List<ToolResponseMessage.ToolResponse> toolResponses = null;
+		List<MediaForDocument> media = null;
+
+		if (message instanceof AssistantMessage assistantMessage && assistantMessage.hasToolCalls()) {
+			toolCalls = assistantMessage.getToolCalls();
+		}
+		if (message instanceof ToolResponseMessage toolResponseMessage) {
+			toolResponses = toolResponseMessage.getResponses();
+		}
+		if (message instanceof MediaContent mediaContent && !mediaContent.getMedia().isEmpty()) {
+			media = mediaContent.getMedia().stream().map(MediaForDocument::fromMedia).collect(Collectors.toList());
+		}
+
+		String content = message.getText() != null ? message.getText() : "";
+		return new MessageDocument(conversationId, message.getMessageType().toString(), content, timestamp,
+				message.getMetadata(), toolCalls, toolResponses, media);
+	}
+
+	private Message convertMessageDocumentToSpecificMessage(MessageDocument source) {
+		List<Media> media = Optional.ofNullable(source.media())
+			.map(x -> x.stream().map(MediaForDocument::toMedia).toList())
+			.orElse(List.of());
+		List<ToolResponseMessage.ToolResponse> toolResponses = Optional.ofNullable(source.toolResponses())
+			.orElse(List.of());
+		return switch (MessageType.valueOf(source.type())) {
+			case ASSISTANT -> {
+				List<AssistantMessage.ToolCall> toolCalls = Optional.ofNullable(source.toolCalls()).orElse(List.of());
+				yield AssistantMessage.builder()
+					.content(source.content())
+					.properties(source.metadata())
+					.toolCalls(toolCalls)
+					.media(media)
+					.build();
+			}
+			case USER -> UserMessage.builder().text(source.content()).metadata(source.metadata()).media(media).build();
+			case SYSTEM -> SystemMessage.builder().text(source.content()).metadata(source.metadata()).build();
+			case TOOL -> ToolResponseMessage.builder().responses(toolResponses).metadata(source.metadata()).build();
+		};
+	}
+
+	/**
+	 * Builder for constructing {@link ElasticsearchChatMemoryRepository} instances.
+	 */
+	public static class Builder {
+
+		private final Rest5Client restClient;
+
+		private String indexName = ElasticsearchChatMemoryConfig.DEFAULT_INDEX_NAME;
+
+		private boolean initializeSchema = true;
+
+		private int maxResults = ElasticsearchChatMemoryConfig.DEFAULT_MAX_RESULTS;
+
+		private Builder(Rest5Client restClient) {
+			Assert.notNull(restClient, "Rest5Client must not be null");
+			this.restClient = restClient;
+		}
+
+		/**
+		 * Sets the Elasticsearch index name.
+		 * @param indexName the index name to use
+		 * @return this builder
+		 */
+		public Builder indexName(String indexName) {
+			this.indexName = indexName;
+			return this;
+		}
+
+		/**
+		 * Sets whether to initialize the index schema on startup.
+		 * @param initializeSchema whether to initialize the schema
+		 * @return this builder
+		 */
+		public Builder initializeSchema(boolean initializeSchema) {
+			this.initializeSchema = initializeSchema;
+			return this;
+		}
+
+		/**
+		 * Sets the maximum number of results to return.
+		 * @param maxResults the maximum number of results.
+		 * @return this builder
+		 */
+		public Builder maxResults(int maxResults) {
+			this.maxResults = maxResults;
+			return this;
+		}
+
+		/**
+		 * Builds and returns a new {@link ElasticsearchChatMemoryRepository} instance.
+		 * @return a new ElasticsearchChatMemoryRepository
+		 */
+		public ElasticsearchChatMemoryRepository build() {
+			ElasticsearchChatMemoryConfig config = ElasticsearchChatMemoryConfig.builder(restClient)
+				.indexName(indexName)
+				.initializeSchema(initializeSchema)
+				.maxResults(maxResults)
+				.build();
+
+			return new ElasticsearchChatMemoryRepository(config);
+		}
+
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MediaForDocument.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MediaForDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MediaForDocument.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MediaForDocument.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.ai.content.Media;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+
+public record MediaForDocument(@Nullable String id, String name, String mimeType, @Nullable String contentString,
+		byte @Nullable [] contentBytes) {
+
+	public static MediaForDocument fromMedia(Media media) {
+		if (media.getData() instanceof byte[] mediaBytes) {
+			return new MediaForDocument(media.getId(), media.getName(), media.getMimeType().toString(), null,
+					mediaBytes);
+		}
+		return new MediaForDocument(media.getId(), media.getName(), media.getMimeType().toString(),
+				(String) media.getData(), null);
+	}
+
+	public static Media toMedia(MediaForDocument mediaForDocument) {
+		Object data = mediaForDocument.contentBytes == null ? mediaForDocument.contentString
+				: mediaForDocument.contentBytes;
+		// data will never be null, because it will be either string or byte, but this
+		// fixes compilation
+		Assert.notNull(data, "Data must not be null");
+		Media.Builder builder = Media.builder()
+			.name(mediaForDocument.name())
+			.data(data)
+			.mimeType(MimeType.valueOf(mediaForDocument.mimeType()));
+		if (mediaForDocument.id() != null) {
+			builder.id(mediaForDocument.id());
+		}
+		return builder.build();
+
+	}
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MessageDocument.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MessageDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MessageDocument.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/MessageDocument.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+
+import org.jspecify.annotations.Nullable;
+import java.util.List;
+import java.util.Map;
+
+public record MessageDocument(String conversation_id, String type, String content, long timestamp,
+		Map<String, Object> metadata, @Nullable List<AssistantMessage.ToolCall> toolCalls,
+		@Nullable List<ToolResponseMessage.ToolResponse> toolResponses, @Nullable List<MediaForDocument> media) {
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/package-info.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/package-info.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/main/java/org/springframework/ai/chat/memory/repository/elasticsearch/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import org.jspecify.annotations.NullMarked;

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryErrorHandlingIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryErrorHandlingIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Integration tests for ElasticsearchChatMemoryRepository focused on error handling
+ * scenarios.
+ *
+ * @author Laura Trotta
+ */
+@Testcontainers
+class ElasticsearchChatMemoryErrorHandlingIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(ElasticsearchChatMemoryErrorHandlingIT.class);
+
+	@Container
+	static ElasticsearchContainer elasticsearch = new ElasticsearchContainer("elasticsearch:9.3.0")
+		.withEnv("xpack.security.enabled", "false");
+
+	private ElasticsearchChatMemoryRepository repository;
+
+	@BeforeEach
+	void setUp() throws URISyntaxException {
+		Rest5Client restClient = Rest5Client.builder(HttpHost.create(elasticsearch.getHttpHostAddress())).build();
+
+		repository = ElasticsearchChatMemoryRepository.builder(restClient).indexName("test-chat-memory").build();
+
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@Test
+	void shouldHandleInvalidConversationId() {
+		// Using null conversation ID
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> repository.saveAll(null, List.of(new UserMessage("Test message"))))
+			.withMessageContaining("Conversation ID must not be null");
+
+		// Using empty conversation ID
+		UserMessage message = new UserMessage("Test message");
+		assertThatCode(() -> repository.saveAll("", List.of(message))).doesNotThrowAnyException();
+
+		// Reading with null conversation ID
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> repository.findByConversationId(null))
+			.withMessageContaining("Conversation ID must not be null");
+
+		// Reading with non-existent conversation ID should return empty list
+		List<Message> messages = repository.findByConversationId("non-existent-id");
+		assertThat(messages).isNotNull().isEmpty();
+
+		// Clearing with null conversation ID
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> repository.deleteByConversationId(null))
+			.withMessageContaining("Conversation ID must not be null");
+
+		// Clearing non-existent conversation should not throw exception
+		assertThatCode(() -> repository.deleteByConversationId("non-existent-id")).doesNotThrowAnyException();
+	}
+
+	@Test
+	void shouldHandleInvalidMessageParameters() {
+		String conversationId = UUID.randomUUID().toString();
+
+		// Null message list
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> repository.saveAll(conversationId, null))
+			.withMessageContaining("Messages must not be null");
+
+		// Empty message list should not throw exception
+		assertThatCode(() -> repository.saveAll(conversationId, List.of())).doesNotThrowAnyException();
+
+		// Message with empty content (not null - which is not allowed)
+		UserMessage emptyContentMessage = UserMessage.builder().text("").build();
+		assertThatCode(() -> repository.saveAll(conversationId, List.of(emptyContentMessage)))
+			.doesNotThrowAnyException();
+
+		// Message with empty metadata
+		UserMessage userMessage = UserMessage.builder().text("Hello").build();
+		assertThatCode(() -> repository.saveAll(conversationId, List.of(userMessage))).doesNotThrowAnyException();
+	}
+
+	@Test
+	void shouldHandleEdgeCaseConversationIds() {
+		// Test with a simple conversation ID first to verify basic functionality
+		String simpleId = "simple-test-id";
+		UserMessage simpleMessage = new UserMessage("Simple test message");
+		repository.saveAll(simpleId, List.of(simpleMessage));
+
+		List<Message> simpleMessages = repository.findByConversationId(simpleId);
+		assertThat(simpleMessages).hasSize(1);
+		assertThat(simpleMessages.get(0).getText()).isEqualTo("Simple test message");
+
+		// Test with conversation IDs containing special characters
+		String specialCharsId = "test_conversation_with_special_chars_123";
+		String specialMessage = "Message with special character conversation ID";
+		UserMessage message = new UserMessage(specialMessage);
+
+		repository.saveAll(specialCharsId, List.of(message));
+
+		List<Message> specialCharMessages = repository.findByConversationId(specialCharsId);
+		assertThat(specialCharMessages).hasSize(1);
+		assertThat(specialCharMessages.get(0).getText()).isEqualTo(specialMessage);
+
+		// Test with non-alphanumeric characters in ID
+		String complexId = "test-with:complex@chars#123";
+		String complexMessage = "Message with complex ID";
+		UserMessage complexIdMessage = new UserMessage(complexMessage);
+
+		repository.saveAll(complexId, List.of(complexIdMessage));
+		List<Message> complexIdMessages = repository.findByConversationId(complexId);
+		assertThat(complexIdMessages).hasSize(1);
+		assertThat(complexIdMessages.get(0).getText()).isEqualTo(complexMessage);
+
+		// Test with long IDs
+		StringBuilder longIdBuilder = new StringBuilder();
+		for (int i = 0; i < 50; i++) {
+			longIdBuilder.append("a");
+		}
+		String longId = longIdBuilder.toString();
+		String longIdMessageText = "Message with long conversation ID";
+		UserMessage longIdMessage = new UserMessage(longIdMessageText);
+
+		repository.saveAll(longId, List.of(longIdMessage));
+		List<Message> longIdMessages = repository.findByConversationId(longId);
+		assertThat(longIdMessages).hasSize(1);
+		assertThat(longIdMessages.get(0).getText()).isEqualTo(longIdMessageText);
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryErrorHandlingIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryErrorHandlingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMediaIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMediaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMediaIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMediaIT.java
@@ -1,0 +1,646 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.content.Media;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.util.MimeType;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for ElasticsearchChatMemoryRepository to verify proper handling of
+ * Media content.
+ *
+ * @author Laura Trotta
+ */
+@Testcontainers
+class ElasticsearchChatMemoryMediaIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(ElasticsearchChatMemoryMediaIT.class);
+
+	@Container
+	static ElasticsearchContainer elasticsearch = new ElasticsearchContainer("elasticsearch:9.3.0")
+		.withEnv("xpack.security.enabled", "false");
+
+	private ElasticsearchChatMemoryRepository repository;
+
+	@BeforeEach
+	void setUp() throws URISyntaxException {
+		Rest5Client restClient = Rest5Client.builder(HttpHost.create(elasticsearch.getHttpHostAddress())).build();
+
+		repository = ElasticsearchChatMemoryRepository.builder(restClient).indexName("test-chat-memory").build();
+
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@Test
+	void shouldStoreAndRetrieveUserMessageWithUriMedia() {
+		// Create a URI media object
+		URI mediaUri = URI.create("https://example.com/image.png");
+		Media imageMedia = Media.builder()
+			.mimeType(Media.Format.IMAGE_PNG)
+			.data(mediaUri)
+			.id("test-image-id")
+			.name("test-image")
+			.build();
+
+		// Create a user message with the media
+		UserMessage userMessage = UserMessage.builder()
+			.text("Message with image")
+			.media(imageMedia)
+			.metadata(Map.of("test-key", "test-value"))
+			.build();
+
+		// Store the message
+		repository.saveAll("test-conversation", List.of(userMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId("test-conversation");
+
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
+
+		UserMessage retrievedMessage = (UserMessage) messages.get(0);
+		assertThat(retrievedMessage.getText()).isEqualTo("Message with image");
+		assertThat(retrievedMessage.getMetadata()).containsEntry("test-key", "test-value");
+
+		// Verify media content
+		assertThat(retrievedMessage.getMedia()).hasSize(1);
+		Media retrievedMedia = retrievedMessage.getMedia().get(0);
+		assertThat(retrievedMedia.getMimeType()).isEqualTo(Media.Format.IMAGE_PNG);
+		assertThat(retrievedMedia.getId()).isEqualTo("test-image-id");
+		assertThat(retrievedMedia.getName()).isEqualTo("test-image");
+		assertThat(retrievedMedia.getData()).isEqualTo(mediaUri.toString());
+	}
+
+	@Test
+	void shouldStoreAndRetrieveAssistantMessageWithByteArrayMedia() {
+		// Create a byte array media object
+		byte[] imageData = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+		Media byteArrayMedia = Media.builder()
+			.mimeType(Media.Format.IMAGE_JPEG)
+			.data(imageData)
+			.id("test-jpeg-id")
+			.name("test-jpeg")
+			.build();
+
+		// Create a list of tool calls
+		List<AssistantMessage.ToolCall> toolCalls = List
+			.of(new AssistantMessage.ToolCall("tool1", "function", "testFunction", "{\"param" + "\":\"value\"}"));
+
+		// Create an assistant message with media and tool calls
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("Response with image")
+			.properties(Map.of("assistant-key", "assistant-value"))
+			.toolCalls(toolCalls)
+			.media(List.of(byteArrayMedia))
+			.build();
+
+		// Store the message
+		repository.saveAll("test-conversation", List.of(assistantMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId("test-conversation");
+
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(AssistantMessage.class);
+
+		AssistantMessage retrievedMessage = (AssistantMessage) messages.get(0);
+		assertThat(retrievedMessage.getText()).isEqualTo("Response with image");
+		assertThat(retrievedMessage.getMetadata()).containsEntry("assistant-key", "assistant-value");
+
+		// Verify tool calls
+		assertThat(retrievedMessage.getToolCalls()).hasSize(1);
+		AssistantMessage.ToolCall retrievedToolCall = retrievedMessage.getToolCalls().get(0);
+		assertThat(retrievedToolCall.id()).isEqualTo("tool1");
+		assertThat(retrievedToolCall.type()).isEqualTo("function");
+		assertThat(retrievedToolCall.name()).isEqualTo("testFunction");
+		assertThat(retrievedToolCall.arguments()).isEqualTo("{\"param\":\"value\"}");
+
+		// Verify media content
+		assertThat(retrievedMessage.getMedia()).hasSize(1);
+		Media retrievedMedia = retrievedMessage.getMedia().get(0);
+		assertThat(retrievedMedia.getMimeType()).isEqualTo(Media.Format.IMAGE_JPEG);
+		assertThat(retrievedMedia.getId()).isEqualTo("test-jpeg-id");
+		assertThat(retrievedMedia.getName()).isEqualTo("test-jpeg");
+		assertThat(retrievedMedia.getDataAsByteArray()).isEqualTo(imageData);
+	}
+
+	@Test
+	void shouldStoreAndRetrieveMultipleMessagesWithDifferentMediaTypes() {
+
+		// Create media objects with different types
+		Media pngMedia = Media.builder()
+			.mimeType(Media.Format.IMAGE_PNG)
+			.data(URI.create("https://example.com/image.png"))
+			.id("png-id")
+			.build();
+
+		Media jpegMedia = Media.builder()
+			.mimeType(Media.Format.IMAGE_JPEG)
+			.data(new byte[] { 0x10, 0x20, 0x30, 0x40 })
+			.id("jpeg-id")
+			.build();
+
+		Media pdfMedia = Media.builder()
+			.mimeType(Media.Format.DOC_PDF)
+			.data(new ByteArrayResource("PDF content".getBytes()))
+			.id("pdf-id")
+			.build();
+
+		// Create messages
+		UserMessage userMessage1 = UserMessage.builder().text("Message with PNG").media(pngMedia).build();
+
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("Response with JPEG")
+			.properties(Map.of())
+			.toolCalls(List.of())
+			.media(List.of(jpegMedia))
+			.build();
+
+		UserMessage userMessage2 = UserMessage.builder().text("Message with PDF").media(pdfMedia).build();
+
+		// Store all messages
+		repository.saveAll("media-conversation", List.of(userMessage1, assistantMessage, userMessage2));
+
+		// Retrieve the messages
+		List<Message> messages = repository.findByConversationId("media-conversation");
+
+		assertThat(messages).hasSize(3);
+
+		// Verify first user message with PNG
+		UserMessage retrievedUser1 = (UserMessage) messages.get(0);
+		assertThat(retrievedUser1.getText()).isEqualTo("Message with PNG");
+		assertThat(retrievedUser1.getMedia()).hasSize(1);
+		assertThat(retrievedUser1.getMedia().get(0).getMimeType()).isEqualTo(Media.Format.IMAGE_PNG);
+		assertThat(retrievedUser1.getMedia().get(0).getId()).isEqualTo("png-id");
+		assertThat(retrievedUser1.getMedia().get(0).getData()).isEqualTo("https://example.com/image" + ".png");
+
+		// Verify assistant message with JPEG
+		AssistantMessage retrievedAssistant = (AssistantMessage) messages.get(1);
+		assertThat(retrievedAssistant.getText()).isEqualTo("Response with JPEG");
+		assertThat(retrievedAssistant.getMedia()).hasSize(1);
+		assertThat(retrievedAssistant.getMedia().get(0).getMimeType()).isEqualTo(Media.Format.IMAGE_JPEG);
+		assertThat(retrievedAssistant.getMedia().get(0).getId()).isEqualTo("jpeg-id");
+		assertThat(retrievedAssistant.getMedia().get(0).getDataAsByteArray())
+			.isEqualTo(new byte[] { 0x10, 0x20, 0x30, 0x40 });
+
+		// Verify second user message with PDF
+		UserMessage retrievedUser2 = (UserMessage) messages.get(2);
+		assertThat(retrievedUser2.getText()).isEqualTo("Message with PDF");
+		assertThat(retrievedUser2.getMedia()).hasSize(1);
+		assertThat(retrievedUser2.getMedia().get(0).getMimeType()).isEqualTo(Media.Format.DOC_PDF);
+		assertThat(retrievedUser2.getMedia().get(0).getId()).isEqualTo("pdf-id");
+		// Data should be a byte array from the ByteArrayResource
+		assertThat(retrievedUser2.getMedia().get(0).getDataAsByteArray()).isEqualTo("PDF content".getBytes());
+
+	}
+
+	@Test
+	void shouldStoreAndRetrieveMessageWithMultipleMedia() {
+
+		// Create multiple media objects
+		Media textMedia = Media.builder()
+			.mimeType(Media.Format.DOC_TXT)
+			.data("This is text content".getBytes())
+			.id("text-id")
+			.name("text-file")
+			.build();
+
+		Media imageMedia = Media.builder()
+			.mimeType(Media.Format.IMAGE_PNG)
+			.data(URI.create("https://example.com/image.png"))
+			.id("image-id")
+			.name("image-file")
+			.build();
+
+		// Create a message with multiple media attachments
+		UserMessage userMessage = UserMessage.builder()
+			.text("Message with multiple attachments")
+			.media(textMedia, imageMedia)
+			.build();
+
+		// Store the message
+		repository.saveAll("multi-media-conversation", List.of(userMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId("multi-media-conversation");
+
+		assertThat(messages).hasSize(1);
+		UserMessage retrievedMessage = (UserMessage) messages.get(0);
+		assertThat(retrievedMessage.getText()).isEqualTo("Message with multiple attachments");
+
+		// Verify multiple media contents
+		List<Media> retrievedMedia = retrievedMessage.getMedia();
+		assertThat(retrievedMedia).hasSize(2);
+
+		// The media should be retrieved in the same order
+		Media retrievedTextMedia = retrievedMedia.get(0);
+		assertThat(retrievedTextMedia.getMimeType()).isEqualTo(Media.Format.DOC_TXT);
+		assertThat(retrievedTextMedia.getId()).isEqualTo("text-id");
+		assertThat(retrievedTextMedia.getName()).isEqualTo("text-file");
+		assertThat(retrievedTextMedia.getDataAsByteArray()).isEqualTo("This is text content".getBytes());
+
+		Media retrievedImageMedia = retrievedMedia.get(1);
+		assertThat(retrievedImageMedia.getMimeType()).isEqualTo(Media.Format.IMAGE_PNG);
+		assertThat(retrievedImageMedia.getId()).isEqualTo("image-id");
+		assertThat(retrievedImageMedia.getName()).isEqualTo("image-file");
+		assertThat(retrievedImageMedia.getData()).isEqualTo("https://example.com/image.png");
+	}
+
+	@Test
+	void shouldClearConversationWithMedia() {
+
+		// Create a message with media
+		Media imageMedia = Media.builder()
+			.mimeType(Media.Format.IMAGE_PNG)
+			.data(new byte[] { 0x01, 0x02, 0x03 })
+			.id("test-clear-id")
+			.build();
+
+		UserMessage userMessage = UserMessage.builder().text("Message to be cleared").media(imageMedia).build();
+
+		// Store the message
+		String conversationId = "conversation-to-clear";
+		repository.saveAll(conversationId, List.of(userMessage));
+
+		// Verify it was stored
+		assertThat(repository.findByConversationId(conversationId)).hasSize(1);
+
+		// Clear the conversation
+		repository.deleteByConversationId(conversationId);
+
+		// Verify it was cleared
+		assertThat(repository.findByConversationId(conversationId)).isEmpty();
+		assertThat(repository.findConversationIds()).doesNotContain(conversationId);
+	}
+
+	@Test
+	void shouldHandleLargeBinaryData() {
+
+		// Create a larger binary payload (around 50KB)
+		byte[] largeImageData = new byte[50 * 1024];
+		// Fill with a recognizable pattern for verification
+		for (int i = 0; i < largeImageData.length; i++) {
+			largeImageData[i] = (byte) (i % 256);
+		}
+
+		// Create media with the large data
+		Media largeMedia = Media.builder()
+			.mimeType(Media.Format.IMAGE_PNG)
+			.data(largeImageData)
+			.id("large-image-id")
+			.name("large-image.png")
+			.build();
+
+		// Create a message with large media
+		UserMessage userMessage = UserMessage.builder()
+			.text("Message with large image attachment")
+			.media(largeMedia)
+			.build();
+
+		// Store the message
+		String conversationId = "large-media-conversation";
+		repository.saveAll(conversationId, List.of(userMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify
+		assertThat(messages).hasSize(1);
+		UserMessage retrievedMessage = (UserMessage) messages.get(0);
+		assertThat(retrievedMessage.getMedia()).hasSize(1);
+
+		// Verify the large binary data was preserved exactly
+		Media retrievedMedia = retrievedMessage.getMedia().get(0);
+		assertThat(retrievedMedia.getMimeType()).isEqualTo(Media.Format.IMAGE_PNG);
+		byte[] retrievedData = retrievedMedia.getDataAsByteArray();
+		assertThat(retrievedData).hasSize(50 * 1024);
+		assertThat(retrievedData).isEqualTo(largeImageData);
+	}
+
+	@Test
+	void shouldHandleMediaWithEmptyOrNullValues() {
+
+		// Create media with null or empty values where allowed
+		Media edgeCaseMedia1 = Media.builder()
+			.mimeType(Media.Format.IMAGE_PNG) // MimeType is required
+			.data(new byte[0]) // Empty byte array
+			.id(null) // No ID
+			.name("") // Empty name
+			.build();
+
+		// Second media with only required fields
+		Media edgeCaseMedia2 = Media.builder()
+			.mimeType(Media.Format.DOC_TXT) // Only required field
+			.data(new byte[0]) // Empty byte array instead of null
+			.build();
+
+		// Create message with these edge case media objects
+		UserMessage userMessage = UserMessage.builder()
+			.text("Edge case media test")
+			.media(edgeCaseMedia1, edgeCaseMedia2)
+			.build();
+
+		// Store the message
+		String conversationId = "edge-case-media";
+		repository.saveAll(conversationId, List.of(userMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify the message was stored and retrieved
+		assertThat(messages).hasSize(1);
+		UserMessage retrievedMessage = (UserMessage) messages.get(0);
+
+		// Verify the media objects
+		List<Media> retrievedMedia = retrievedMessage.getMedia();
+		assertThat(retrievedMedia).hasSize(2);
+
+		// Check first media with empty/null values
+		Media firstMedia = retrievedMedia.get(0);
+		assertThat(firstMedia.getMimeType()).isEqualTo(Media.Format.IMAGE_PNG);
+		assertThat(firstMedia.getDataAsByteArray()).isNotNull().isEmpty();
+		assertThat(firstMedia.getId()).isNull();
+		assertThat(firstMedia.getName()).isEmpty();
+
+		// Check second media with only required field
+		Media secondMedia = retrievedMedia.get(1);
+		assertThat(secondMedia.getMimeType()).isEqualTo(Media.Format.DOC_TXT);
+		assertThat(secondMedia.getDataAsByteArray()).isNotNull().isEmpty();
+		assertThat(secondMedia.getId()).isNull();
+		assertThat(secondMedia.getName()).isNotNull();
+	}
+
+	@Test
+	void shouldHandleComplexBinaryDataTypes() {
+
+		// Create audio sample data (simple WAV header + sine wave)
+		byte[] audioData = createSampleAudioData(8000, 2); // 2 seconds of 8kHz audio
+
+		// Create video sample data (mock MP4 data with recognizable pattern)
+		byte[] videoData = createSampleVideoData(10 * 1024); // 10KB mock video data
+
+		// Create custom MIME types for specialized formats
+		MimeType customAudioType = new MimeType("audio", "wav");
+		MimeType customVideoType = new MimeType("video", "mp4");
+
+		// Create media objects with the complex binary data
+		Media audioMedia = Media.builder()
+			.mimeType(customAudioType)
+			.data(audioData)
+			.id("audio-sample-id")
+			.name("audio-sample.wav")
+			.build();
+
+		Media videoMedia = Media.builder()
+			.mimeType(customVideoType)
+			.data(videoData)
+			.id("video-sample-id")
+			.name("video-sample.mp4")
+			.build();
+
+		// Create messages with the complex media
+		UserMessage userMessage = UserMessage.builder().text("Message with audio attachment").media(audioMedia).build();
+
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("Response with video attachment")
+			.properties(Map.of())
+			.toolCalls(List.of())
+			.media(List.of(videoMedia))
+			.build();
+
+		// Store the messages
+		String conversationId = "complex-media-conversation";
+		repository.saveAll(conversationId, List.of(userMessage, assistantMessage));
+
+		// Retrieve the messages
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify
+		assertThat(messages).hasSize(2);
+
+		// Verify audio data in user message
+		UserMessage retrievedUserMessage = (UserMessage) messages.get(0);
+		assertThat(retrievedUserMessage.getText()).isEqualTo("Message with audio attachment");
+		assertThat(retrievedUserMessage.getMedia()).hasSize(1);
+
+		Media retrievedAudioMedia = retrievedUserMessage.getMedia().get(0);
+		assertThat(retrievedAudioMedia.getMimeType().toString()).isEqualTo(customAudioType.toString());
+		assertThat(retrievedAudioMedia.getId()).isEqualTo("audio-sample-id");
+		assertThat(retrievedAudioMedia.getName()).isEqualTo("audio-sample.wav");
+		assertThat(retrievedAudioMedia.getDataAsByteArray()).isEqualTo(audioData);
+
+		// Verify binary pattern data integrity
+		byte[] retrievedAudioData = retrievedAudioMedia.getDataAsByteArray();
+		// Check RIFF header (first 4 bytes of WAV)
+		assertThat(Arrays.copyOfRange(retrievedAudioData, 0, 4)).isEqualTo(new byte[] { 'R', 'I', 'F', 'F' });
+
+		// Verify video data in assistant message
+		AssistantMessage retrievedAssistantMessage = (AssistantMessage) messages.get(1);
+		assertThat(retrievedAssistantMessage.getText()).isEqualTo("Response with video attachment");
+		assertThat(retrievedAssistantMessage.getMedia()).hasSize(1);
+
+		Media retrievedVideoMedia = retrievedAssistantMessage.getMedia().get(0);
+		assertThat(retrievedVideoMedia.getMimeType().toString()).isEqualTo(customVideoType.toString());
+		assertThat(retrievedVideoMedia.getId()).isEqualTo("video-sample-id");
+		assertThat(retrievedVideoMedia.getName()).isEqualTo("video-sample.mp4");
+		assertThat(retrievedVideoMedia.getDataAsByteArray()).isEqualTo(videoData);
+
+		// Verify the MP4 header pattern
+		byte[] retrievedVideoData = retrievedVideoMedia.getDataAsByteArray();
+		// Check mock MP4 signature (first 4 bytes should be ftyp)
+		assertThat(Arrays.copyOfRange(retrievedVideoData, 4, 8)).isEqualTo(new byte[] { 'f', 't', 'y', 'p' });
+	}
+
+	/**
+	 * Creates a sample audio data byte array with WAV format.
+	 * @param sampleRate Sample rate of the audio in Hz
+	 * @param durationSeconds Duration of the audio in seconds
+	 * @return Byte array containing a simple WAV file
+	 */
+	private byte[] createSampleAudioData(int sampleRate, int durationSeconds) {
+		// Calculate sizes
+		int headerSize = 44; // Standard WAV header size
+		int dataSize = sampleRate * durationSeconds; // 1 byte per sample, mono
+		int totalSize = headerSize + dataSize;
+
+		byte[] audioData = new byte[totalSize];
+
+		// Write WAV header (RIFF chunk)
+		audioData[0] = 'R';
+		audioData[1] = 'I';
+		audioData[2] = 'F';
+		audioData[3] = 'F';
+
+		// File size - 8 (4 bytes little endian)
+		int fileSizeMinus8 = totalSize - 8;
+		audioData[4] = (byte) (fileSizeMinus8 & 0xFF);
+		audioData[5] = (byte) ((fileSizeMinus8 >> 8) & 0xFF);
+		audioData[6] = (byte) ((fileSizeMinus8 >> 16) & 0xFF);
+		audioData[7] = (byte) ((fileSizeMinus8 >> 24) & 0xFF);
+
+		// WAVE chunk
+		audioData[8] = 'W';
+		audioData[9] = 'A';
+		audioData[10] = 'V';
+		audioData[11] = 'E';
+
+		// fmt chunk
+		audioData[12] = 'f';
+		audioData[13] = 'm';
+		audioData[14] = 't';
+		audioData[15] = ' ';
+
+		// fmt chunk size (16 for PCM)
+		audioData[16] = 16;
+		audioData[17] = 0;
+		audioData[18] = 0;
+		audioData[19] = 0;
+
+		// Audio format (1 = PCM)
+		audioData[20] = 1;
+		audioData[21] = 0;
+
+		// Channels (1 = mono)
+		audioData[22] = 1;
+		audioData[23] = 0;
+
+		// Sample rate
+		audioData[24] = (byte) (sampleRate & 0xFF);
+		audioData[25] = (byte) ((sampleRate >> 8) & 0xFF);
+		audioData[26] = (byte) ((sampleRate >> 16) & 0xFF);
+		audioData[27] = (byte) ((sampleRate >> 24) & 0xFF);
+
+		// Byte rate (SampleRate * NumChannels * BitsPerSample/8)
+		int byteRate = sampleRate * 1 * 8 / 8;
+		audioData[28] = (byte) (byteRate & 0xFF);
+		audioData[29] = (byte) ((byteRate >> 8) & 0xFF);
+		audioData[30] = (byte) ((byteRate >> 16) & 0xFF);
+		audioData[31] = (byte) ((byteRate >> 24) & 0xFF);
+
+		// Block align (NumChannels * BitsPerSample/8)
+		audioData[32] = 1;
+		audioData[33] = 0;
+
+		// Bits per sample
+		audioData[34] = 8;
+		audioData[35] = 0;
+
+		// Data chunk
+		audioData[36] = 'd';
+		audioData[37] = 'a';
+		audioData[38] = 't';
+		audioData[39] = 'a';
+
+		// Data size
+		audioData[40] = (byte) (dataSize & 0xFF);
+		audioData[41] = (byte) ((dataSize >> 8) & 0xFF);
+		audioData[42] = (byte) ((dataSize >> 16) & 0xFF);
+		audioData[43] = (byte) ((dataSize >> 24) & 0xFF);
+
+		// Generate a simple sine wave for audio data
+		for (int i = 0; i < dataSize; i++) {
+			// Simple sine wave pattern (0-255)
+			audioData[headerSize + i] = (byte) (128 + 127 * Math.sin(2 * Math.PI * 440 * i / sampleRate));
+		}
+
+		return audioData;
+	}
+
+	/**
+	 * Creates sample video data with a mock MP4 structure.
+	 * @param sizeBytes Size of the video data in bytes
+	 * @return Byte array containing mock MP4 data
+	 */
+	private byte[] createSampleVideoData(int sizeBytes) {
+		byte[] videoData = new byte[sizeBytes];
+
+		// Write MP4 header
+		// First 4 bytes: size of the first atom
+		int firstAtomSize = 24; // Standard size for ftyp atom
+		videoData[0] = 0;
+		videoData[1] = 0;
+		videoData[2] = 0;
+		videoData[3] = (byte) firstAtomSize;
+
+		// Next 4 bytes: ftyp (file type atom)
+		videoData[4] = 'f';
+		videoData[5] = 't';
+		videoData[6] = 'y';
+		videoData[7] = 'p';
+
+		// Major brand (mp42)
+		videoData[8] = 'm';
+		videoData[9] = 'p';
+		videoData[10] = '4';
+		videoData[11] = '2';
+
+		// Minor version
+		videoData[12] = 0;
+		videoData[13] = 0;
+		videoData[14] = 0;
+		videoData[15] = 1;
+
+		// Compatible brands (mp42, mp41)
+		videoData[16] = 'm';
+		videoData[17] = 'p';
+		videoData[18] = '4';
+		videoData[19] = '2';
+		videoData[20] = 'm';
+		videoData[21] = 'p';
+		videoData[22] = '4';
+		videoData[23] = '1';
+
+		// Fill the rest with a recognizable pattern
+		for (int i = firstAtomSize; i < sizeBytes; i++) {
+			// Create a repeating pattern with some variation
+			videoData[i] = (byte) ((i % 64) + ((i / 64) % 64));
+		}
+
+		return videoData;
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMessageTypesIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMessageTypesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMessageTypesIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryMessageTypesIT.java
@@ -1,0 +1,608 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for ElasticsearchChatMemoryRepository focusing on different message
+ * types.
+ *
+ * @author Laura Trotta
+ */
+@Testcontainers
+class ElasticsearchChatMemoryMessageTypesIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(ElasticsearchChatMemoryMessageTypesIT.class);
+
+	@Container
+	static ElasticsearchContainer elasticsearch = new ElasticsearchContainer("elasticsearch:9.3.0")
+		.withEnv("xpack.security.enabled", "false");
+
+	private ElasticsearchChatMemoryRepository repository;
+
+	@BeforeEach
+	void setUp() throws URISyntaxException {
+		Rest5Client restClient = Rest5Client.builder(HttpHost.create(elasticsearch.getHttpHostAddress())).build();
+
+		repository = ElasticsearchChatMemoryRepository.builder(restClient).indexName("test-chat-memory").build();
+
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@Test
+	void shouldHandleAllMessageTypes() {
+		String conversationId = "test-conversation";
+
+		// Create messages of different types with various content
+		SystemMessage systemMessage = new SystemMessage("You are a helpful assistant");
+		UserMessage userMessage = new UserMessage("What's the capital of France?");
+		AssistantMessage assistantMessage = new AssistantMessage("The capital of France is Paris.");
+
+		// Store each message type
+		repository.saveAll(conversationId, List.of(systemMessage, userMessage, assistantMessage));
+
+		// Retrieve and verify messages
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify correct number of messages
+		assertThat(messages).hasSize(3);
+
+		// Verify message order and content
+		assertThat(messages.get(0).getText()).isEqualTo("You are a helpful assistant");
+		assertThat(messages.get(1).getText()).isEqualTo("What's the capital of France?");
+		assertThat(messages.get(2).getText()).isEqualTo("The capital of France is Paris.");
+
+		// Verify message types
+		assertThat(messages.get(0)).isInstanceOf(SystemMessage.class);
+		assertThat(messages.get(1)).isInstanceOf(UserMessage.class);
+		assertThat(messages.get(2)).isInstanceOf(AssistantMessage.class);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "Message from assistant,ASSISTANT", "Message from user,USER", "Message from system,SYSTEM" })
+	void shouldStoreAndRetrieveSingleMessage(String content, MessageType messageType) {
+		String conversationId = UUID.randomUUID().toString();
+
+		// Create a message of the specified type
+		Message message = switch (messageType) {
+			case ASSISTANT -> new AssistantMessage(content + " - " + conversationId);
+			case USER -> new UserMessage(content + " - " + conversationId);
+			case SYSTEM -> new SystemMessage(content + " - " + conversationId);
+			default -> throw new IllegalArgumentException("Type not supported: " + messageType);
+		};
+
+		// Store the message
+		repository.saveAll(conversationId, List.of(message));
+
+		// Retrieve messages
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify message was stored and retrieved correctly
+		assertThat(messages).hasSize(1);
+		Message retrievedMessage = messages.get(0);
+
+		// Verify the message type
+		assertThat(retrievedMessage.getMessageType()).isEqualTo(messageType);
+
+		// Verify the content
+		assertThat(retrievedMessage.getText()).isEqualTo(content + " - " + conversationId);
+
+		// Verify the correct class type
+		switch (messageType) {
+			case ASSISTANT -> assertThat(retrievedMessage).isInstanceOf(AssistantMessage.class);
+			case USER -> assertThat(retrievedMessage).isInstanceOf(UserMessage.class);
+			case SYSTEM -> assertThat(retrievedMessage).isInstanceOf(SystemMessage.class);
+			default -> throw new IllegalArgumentException("Type not supported: " + messageType);
+		}
+	}
+
+	@Test
+	void shouldHandleSystemMessageWithMetadata() {
+		String conversationId = "test-conversation-system";
+
+		// Create a System message with metadata using builder
+		SystemMessage systemMessage = SystemMessage.builder()
+			.text("You are a specialized AI assistant for legal questions")
+			.metadata(Map.of("domain", "legal", "version", "2.0", "restricted", "true"))
+			.build();
+
+		// Store the message
+		repository.saveAll(conversationId, List.of(systemMessage));
+
+		// Retrieve messages
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify message count
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(SystemMessage.class);
+
+		// Verify content
+		SystemMessage retrievedMessage = (SystemMessage) messages.get(0);
+		assertThat(retrievedMessage.getText()).isEqualTo("You are a specialized AI assistant for legal " + "questions");
+
+		// Verify metadata is preserved
+		assertThat(retrievedMessage.getMetadata()).containsEntry("domain", "legal");
+		assertThat(retrievedMessage.getMetadata()).containsEntry("version", "2.0");
+		assertThat(retrievedMessage.getMetadata()).containsEntry("restricted", "true");
+	}
+
+	@Test
+	void shouldHandleMultipleSystemMessages() {
+		String conversationId = "multi-system-test";
+
+		// Create multiple system messages with different content
+		SystemMessage systemMessage1 = new SystemMessage("You are a helpful assistant");
+		SystemMessage systemMessage2 = new SystemMessage("Always provide concise answers");
+		SystemMessage systemMessage3 = new SystemMessage("Do not share personal information");
+
+		// Create a batch of system messages
+		List<Message> systemMessages = List.of(systemMessage1, systemMessage2, systemMessage3);
+
+		// Store all messages at once
+		repository.saveAll(conversationId, systemMessages);
+
+		// Retrieve messages
+		List<Message> retrievedMessages = repository.findByConversationId(conversationId);
+
+		// Verify all messages were stored and retrieved
+		assertThat(retrievedMessages).hasSize(3);
+		retrievedMessages.forEach(message -> assertThat(message).isInstanceOf(SystemMessage.class));
+
+		// Verify content
+		assertThat(retrievedMessages.get(0).getText()).isEqualTo(systemMessage1.getText());
+		assertThat(retrievedMessages.get(1).getText()).isEqualTo(systemMessage2.getText());
+		assertThat(retrievedMessages.get(2).getText()).isEqualTo(systemMessage3.getText());
+	}
+
+	@Test
+	void shouldHandleMessageWithMetadata() {
+		String conversationId = "test-conversation";
+
+		// Create messages with metadata using builder
+		UserMessage userMessage = UserMessage.builder()
+			.text("Hello with metadata")
+			.metadata(Map.of("source", "web", "user_id", "12345"))
+			.build();
+
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("Hi there!")
+			.properties(Map.of("model", "gpt-4", "temperature", "0.7"))
+			.build();
+
+		// Store messages with metadata
+		repository.saveAll(conversationId, List.of(userMessage, assistantMessage));
+
+		// Retrieve messages
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify message count
+		assertThat(messages).hasSize(2);
+
+		// Verify metadata is preserved
+		assertThat(messages.get(0).getMetadata()).containsEntry("source", "web");
+		assertThat(messages.get(0).getMetadata()).containsEntry("user_id", "12345");
+		assertThat(messages.get(1).getMetadata()).containsEntry("model", "gpt-4");
+		assertThat(messages.get(1).getMetadata()).containsEntry("temperature", "0.7");
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "ASSISTANT,model=gpt-4;temperature=0.7;api_version=1.0",
+			"USER,source=web;user_id=12345;" + "client=mobile", "SYSTEM,domain=legal;version=2.0;restricted=true" })
+	void shouldStoreAndRetrieveMessageWithMetadata(MessageType messageType, String metadataString) {
+		String conversationId = UUID.randomUUID().toString();
+		String content = "Message with metadata - " + messageType;
+
+		// Parse metadata from string
+		Map<String, Object> metadata = parseMetadata(metadataString);
+
+		// Create a message with metadata
+		Message message = switch (messageType) {
+			case ASSISTANT -> AssistantMessage.builder().content(content).properties(metadata).build();
+			case USER -> UserMessage.builder().text(content).metadata(metadata).build();
+			case SYSTEM -> SystemMessage.builder().text(content).metadata(metadata).build();
+			default -> throw new IllegalArgumentException("Type not supported: " + messageType);
+		};
+
+		// Store the message
+		repository.saveAll(conversationId, List.of(message));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify message was stored correctly
+		assertThat(messages).hasSize(1);
+		Message retrievedMessage = messages.get(0);
+
+		// Verify message type
+		assertThat(retrievedMessage.getMessageType()).isEqualTo(messageType);
+
+		// Verify all metadata entries are present
+		metadata.forEach((key, value) -> assertThat(retrievedMessage.getMetadata()).containsEntry(key, value));
+	}
+
+	// Helper method to parse metadata from string in format
+	// "key1=value1;key2=value2;key3=value3"
+	private Map<String, Object> parseMetadata(String metadataString) {
+		Map<String, Object> metadata = new HashMap<>();
+		String[] pairs = metadataString.split(";");
+
+		for (String pair : pairs) {
+			String[] keyValue = pair.split("=");
+			if (keyValue.length == 2) {
+				metadata.put(keyValue[0], keyValue[1]);
+			}
+		}
+
+		return metadata;
+	}
+
+	@Test
+	void shouldHandleAssistantMessageWithToolCalls() {
+		String conversationId = "test-conversation";
+
+		// Create an AssistantMessage with tool calls
+		List<AssistantMessage.ToolCall> toolCalls = Arrays.asList(
+				new AssistantMessage.ToolCall("tool-1", "function", "weather", "{\"location\": " + "\"Paris\"}"),
+				new AssistantMessage.ToolCall("tool-2", "function", "calculator",
+						"{\"operation\": \"add\", \"args\": [1, 2]}"));
+
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("I'll check that for you.")
+			.properties(Map.of("model", "gpt-4"))
+			.toolCalls(toolCalls)
+			.media(List.of())
+			.build();
+
+		// Store message with tool calls
+		repository.saveAll(conversationId, List.of(assistantMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify we get back the same type of message
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(AssistantMessage.class);
+
+		// Cast and verify tool calls
+		AssistantMessage retrievedMessage = (AssistantMessage) messages.get(0);
+		assertThat(retrievedMessage.getToolCalls()).hasSize(2);
+
+		// Verify tool call content
+		AssistantMessage.ToolCall firstToolCall = retrievedMessage.getToolCalls().get(0);
+		assertThat(firstToolCall.name()).isEqualTo("weather");
+		assertThat(firstToolCall.arguments()).isEqualTo("{\"location\": \"Paris\"}");
+
+		AssistantMessage.ToolCall secondToolCall = retrievedMessage.getToolCalls().get(1);
+		assertThat(secondToolCall.name()).isEqualTo("calculator");
+		assertThat(secondToolCall.arguments()).contains("\"operation\": \"add\"");
+	}
+
+	@Test
+	void shouldHandleBasicToolResponseMessage() {
+		String conversationId = "tool-response-conversation";
+
+		// Create a simple ToolResponseMessage with a single tool response
+		ToolResponseMessage.ToolResponse weatherResponse = new ToolResponseMessage.ToolResponse("tool-1", "weather",
+				"{\"location\":\"Paris\",\"temperature\":\"22°C\",\"conditions\":\"Partly Cloudy\"}");
+
+		// Create the message with a single tool response
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(weatherResponse))
+			.build();
+
+		// Store the message
+		repository.saveAll(conversationId, List.of(toolResponseMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify we get back the correct message
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(ToolResponseMessage.class);
+		assertThat(messages.get(0).getMessageType()).isEqualTo(MessageType.TOOL);
+
+		// Cast and verify tool responses
+		ToolResponseMessage retrievedMessage = (ToolResponseMessage) messages.get(0);
+		List<ToolResponseMessage.ToolResponse> toolResponses = retrievedMessage.getResponses();
+
+		// Verify tool response content
+		assertThat(toolResponses).hasSize(1);
+		ToolResponseMessage.ToolResponse response = toolResponses.get(0);
+		assertThat(response.id()).isEqualTo("tool-1");
+		assertThat(response.name()).isEqualTo("weather");
+		assertThat(response.responseData()).contains("Paris");
+		assertThat(response.responseData()).contains("22°C");
+	}
+
+	@Test
+	void shouldHandleToolResponseMessageWithMultipleResponses() {
+		String conversationId = "multi-tool-response-conversation";
+
+		// Create multiple tool responses
+		ToolResponseMessage.ToolResponse weatherResponse = new ToolResponseMessage.ToolResponse("tool-1", "weather",
+				"{\"location\":\"Paris\",\"temperature\":\"22°C\",\"conditions\":\"Partly Cloudy\"}");
+
+		ToolResponseMessage.ToolResponse calculatorResponse = new ToolResponseMessage.ToolResponse("tool" + "-2",
+				"calculator", "{\"operation\":\"add\",\"args\":[1,2],\"result\":3}");
+
+		ToolResponseMessage.ToolResponse databaseResponse = new ToolResponseMessage.ToolResponse("tool" + "-3",
+				"database", "{\"query\":\"SELECT * FROM users\",\"count\":42}");
+
+		// Create the message with multiple tool responses and metadata
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(weatherResponse, calculatorResponse, databaseResponse))
+			.metadata(Map.of("source", "tools-api", "version", "1.0"))
+			.build();
+
+		// Store the message
+		repository.saveAll(conversationId, List.of(toolResponseMessage));
+
+		// Retrieve the message
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify message type and count
+		assertThat(messages).hasSize(1);
+		assertThat(messages.get(0)).isInstanceOf(ToolResponseMessage.class);
+
+		// Cast and verify
+		ToolResponseMessage retrievedMessage = (ToolResponseMessage) messages.get(0);
+
+		// Verify metadata
+		assertThat(retrievedMessage.getMetadata()).containsEntry("source", "tools-api");
+		assertThat(retrievedMessage.getMetadata()).containsEntry("version", "1.0");
+
+		// Verify tool responses
+		List<ToolResponseMessage.ToolResponse> toolResponses = retrievedMessage.getResponses();
+		assertThat(toolResponses).hasSize(3);
+
+		// Verify first response (weather)
+		ToolResponseMessage.ToolResponse response1 = toolResponses.get(0);
+		assertThat(response1.id()).isEqualTo("tool-1");
+		assertThat(response1.name()).isEqualTo("weather");
+		assertThat(response1.responseData()).contains("Paris");
+
+		// Verify second response (calculator)
+		ToolResponseMessage.ToolResponse response2 = toolResponses.get(1);
+		assertThat(response2.id()).isEqualTo("tool-2");
+		assertThat(response2.name()).isEqualTo("calculator");
+		assertThat(response2.responseData()).contains("result");
+
+		// Verify third response (database)
+		ToolResponseMessage.ToolResponse response3 = toolResponses.get(2);
+		assertThat(response3.id()).isEqualTo("tool-3");
+		assertThat(response3.name()).isEqualTo("database");
+		assertThat(response3.responseData()).contains("count");
+	}
+
+	@Test
+	void shouldHandleToolResponseInConversationFlow() {
+		String conversationId = "tool-conversation-flow";
+
+		// Create a typical conversation flow with tool responses
+		UserMessage userMessage = new UserMessage("What's the weather in Paris?");
+
+		// Assistant requests weather information via tool
+		List<AssistantMessage.ToolCall> toolCalls = List.of(new AssistantMessage.ToolCall("weather-req-1", "function",
+				"weather", "{\"location" + "\":\"Paris" + "\"}"));
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("I'll check the weather for you.")
+			.properties(Map.of())
+			.toolCalls(toolCalls)
+			.media(List.of())
+			.build();
+
+		// Tool provides weather information
+		ToolResponseMessage.ToolResponse weatherResponse = new ToolResponseMessage.ToolResponse("weather" + "-req-1",
+				"weather", "{\"location\":\"Paris\",\"temperature\":\"22°C\",\"conditions\":\"Partly " + "Cloudy\"}");
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(weatherResponse))
+			.build();
+
+		// Assistant summarizes the information
+		AssistantMessage finalResponse = new AssistantMessage(
+				"The current weather in Paris is 22°C and partly cloudy.");
+
+		// Store the conversation
+		List<Message> conversation = List.of(userMessage, assistantMessage, toolResponseMessage, finalResponse);
+		repository.saveAll(conversationId, conversation);
+
+		// Retrieve the conversation
+		List<Message> messages = repository.findByConversationId(conversationId);
+
+		// Verify the conversation flow
+		assertThat(messages).hasSize(4);
+		assertThat(messages.get(0)).isInstanceOf(UserMessage.class);
+		assertThat(messages.get(1)).isInstanceOf(AssistantMessage.class);
+		assertThat(messages.get(2)).isInstanceOf(ToolResponseMessage.class);
+		assertThat(messages.get(3)).isInstanceOf(AssistantMessage.class);
+
+		// Verify the tool response
+		ToolResponseMessage retrievedToolResponse = (ToolResponseMessage) messages.get(2);
+		assertThat(retrievedToolResponse.getResponses()).hasSize(1);
+		assertThat(retrievedToolResponse.getResponses().get(0).name()).isEqualTo("weather");
+		assertThat(retrievedToolResponse.getResponses().get(0).responseData()).contains("Paris");
+
+		// Verify the final response includes information from the tool
+		AssistantMessage retrievedFinalResponse = (AssistantMessage) messages.get(3);
+		assertThat(retrievedFinalResponse.getText()).contains("22°C");
+		assertThat(retrievedFinalResponse.getText()).contains("partly cloudy");
+	}
+
+	@Test
+	void getMessages_withAllMessageTypes_shouldPreserveMessageOrder() {
+		String conversationId = "complex-order-test";
+
+		// Create a complex conversation with all message types in a specific order
+		SystemMessage systemMessage = new SystemMessage("You are a helpful AI assistant.");
+		UserMessage userMessage1 = new UserMessage("What's the capital of France?");
+		AssistantMessage assistantMessage1 = new AssistantMessage("The capital of France is Paris.");
+		UserMessage userMessage2 = new UserMessage("What's the weather there?");
+
+		// Assistant using tool to check weather
+		List<AssistantMessage.ToolCall> toolCalls = List.of(new AssistantMessage.ToolCall("weather-tool-1", "function",
+				"weather", "{\"location" + "\":\"Paris" + "\"}"));
+		AssistantMessage assistantToolCall = AssistantMessage.builder()
+			.content("I'll check the weather in Paris for you.")
+			.properties(Map.of())
+			.toolCalls(toolCalls)
+			.media(List.of())
+			.build();
+
+		// Tool response
+		ToolResponseMessage.ToolResponse weatherResponse = new ToolResponseMessage.ToolResponse(
+				"weather" + "-tool" + "-1", "weather",
+				"{\"location\":\"Paris\",\"temperature\":\"24°C\",\"conditions\":\"Sunny\"}");
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(weatherResponse))
+			.build();
+
+		// Final assistant response using the tool information
+		AssistantMessage assistantFinal = new AssistantMessage(
+				"The weather in Paris is currently 24°C " + "and sunny.");
+
+		// Create ordered list of messages
+		List<Message> expectedMessages = List.of(systemMessage, userMessage1, assistantMessage1, userMessage2,
+				assistantToolCall, toolResponseMessage, assistantFinal);
+
+		// Store all messages at once
+		repository.saveAll(conversationId, expectedMessages);
+
+		// Retrieve and verify messages
+		List<Message> retrievedMessages = repository.findByConversationId(conversationId);
+
+		// Check the total count matches
+		assertThat(retrievedMessages).hasSize(expectedMessages.size());
+
+		// Check each message is in the expected order
+		for (int i = 0; i < expectedMessages.size(); i++) {
+			Message expected = expectedMessages.get(i);
+			Message actual = retrievedMessages.get(i);
+
+			// Verify message types match
+			assertThat(actual.getMessageType()).isEqualTo(expected.getMessageType());
+
+			// Verify message content matches
+			assertThat(actual.getText()).isEqualTo(expected.getText());
+
+			// For each specific message type, verify type-specific properties
+			if (expected instanceof SystemMessage) {
+				assertThat(actual).isInstanceOf(SystemMessage.class);
+			}
+			else if (expected instanceof UserMessage) {
+				assertThat(actual).isInstanceOf(UserMessage.class);
+			}
+			else if (expected instanceof AssistantMessage) {
+				assertThat(actual).isInstanceOf(AssistantMessage.class);
+
+				// If the original had tool calls, verify they're preserved
+				if (((AssistantMessage) expected).hasToolCalls()) {
+					AssistantMessage expectedAssistant = (AssistantMessage) expected;
+					AssistantMessage actualAssistant = (AssistantMessage) actual;
+
+					assertThat(actualAssistant.hasToolCalls()).isTrue();
+					assertThat(actualAssistant.getToolCalls()).hasSameSizeAs(expectedAssistant.getToolCalls());
+
+					// Check first tool call details
+					assertThat(actualAssistant.getToolCalls().get(0).name())
+						.isEqualTo(expectedAssistant.getToolCalls().get(0).name());
+				}
+			}
+			else if (expected instanceof ToolResponseMessage) {
+				assertThat(actual).isInstanceOf(ToolResponseMessage.class);
+
+				ToolResponseMessage expectedTool = (ToolResponseMessage) expected;
+				ToolResponseMessage actualTool = (ToolResponseMessage) actual;
+
+				assertThat(actualTool.getResponses()).hasSameSizeAs(expectedTool.getResponses());
+
+				// Check response details
+				assertThat(actualTool.getResponses().get(0).name())
+					.isEqualTo(expectedTool.getResponses().get(0).name());
+				assertThat(actualTool.getResponses().get(0).id()).isEqualTo(expectedTool.getResponses().get(0).id());
+			}
+		}
+	}
+
+	@Test
+	void getMessages_afterMultipleAdds_shouldReturnMessagesInCorrectOrder() {
+		String conversationId = "sequential-adds-test";
+
+		// Create messages that will be added individually
+		UserMessage userMessage1 = new UserMessage("First user message");
+		AssistantMessage assistantMessage1 = new AssistantMessage("First assistant response");
+		UserMessage userMessage2 = new UserMessage("Second user message");
+		AssistantMessage assistantMessage2 = new AssistantMessage("Second assistant response");
+		UserMessage userMessage3 = new UserMessage("Third user message");
+		AssistantMessage assistantMessage3 = new AssistantMessage("Third assistant response");
+
+		// Store all messages at once
+		List<Message> expectedMessages = List.of(userMessage1, assistantMessage1, userMessage2, assistantMessage2,
+				userMessage3, assistantMessage3);
+		repository.saveAll(conversationId, expectedMessages);
+
+		// Retrieve all messages
+		List<Message> retrievedMessages = repository.findByConversationId(conversationId);
+
+		// Check count matches
+		assertThat(retrievedMessages).hasSize(expectedMessages.size());
+
+		// Verify each message is in the correct order with correct content
+		for (int i = 0; i < expectedMessages.size(); i++) {
+			Message expected = expectedMessages.get(i);
+			Message actual = retrievedMessages.get(i);
+
+			assertThat(actual.getMessageType()).isEqualTo(expected.getMessageType());
+			assertThat(actual.getText()).isEqualTo(expected.getText());
+		}
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepositoryIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepositoryIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryRepositoryIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.memory.repository.elasticsearch.AdvancedElasticsearchChatMemoryRepository.MessageWithConversation;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ElasticsearchChatMemoryRepository}.
+ *
+ * @author Laura Trotta
+ */
+@Testcontainers
+class ElasticsearchChatMemoryRepositoryIT {
+
+	@Container
+	static ElasticsearchContainer elasticsearch = new ElasticsearchContainer("elasticsearch:9.3.0")
+		.withEnv("xpack.security.enabled", "false");
+
+	private ElasticsearchChatMemoryRepository repository;
+
+	@BeforeEach
+	void setUp() throws URISyntaxException {
+		Rest5Client restClient = Rest5Client.builder(HttpHost.create(elasticsearch.getHttpHostAddress())).build();
+
+		repository = ElasticsearchChatMemoryRepository.builder(restClient).indexName("test-chat-memory").build();
+
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@Test
+	void shouldSaveAndFindByConversationId() {
+		List<Message> messages = List.of(new UserMessage("Hello"), new AssistantMessage("Hi there!"));
+		repository.saveAll("conv-1", messages);
+
+		List<Message> retrieved = repository.findByConversationId("conv-1");
+		assertThat(retrieved).hasSize(2);
+		assertThat(retrieved.get(0).getText()).isEqualTo("Hello");
+		assertThat(retrieved.get(1).getText()).isEqualTo("Hi there!");
+	}
+
+	@Test
+	void shouldFindConversationIds() {
+		repository.saveAll("conv-1", List.of(new UserMessage("Hello")));
+		repository.saveAll("conv-2", List.of(new UserMessage("World")));
+
+		List<String> ids = repository.findConversationIds();
+		assertThat(ids).containsExactlyInAnyOrder("conv-1", "conv-2");
+	}
+
+	@Test
+	void shouldDeleteByConversationId() {
+		repository.saveAll("conv-1", List.of(new UserMessage("Hello")));
+		assertThat(repository.findByConversationId("conv-1")).hasSize(1);
+
+		repository.deleteByConversationId("conv-1");
+
+		assertThat(repository.findByConversationId("conv-1")).isEmpty();
+	}
+
+	@Test
+	void shouldFindByContent() {
+		repository.saveAll("conv-1", List.of(new UserMessage("The weather is nice today")));
+		repository.saveAll("conv-2", List.of(new UserMessage("Something else entirely")));
+
+		List<MessageWithConversation> results = repository.findByContent("weather", 10);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).conversationId()).isEqualTo("conv-1");
+	}
+
+	@Test
+	void shouldFindByType() {
+		repository.saveAll("conv-1", List.of(new UserMessage("Hello"), new AssistantMessage("Hi")));
+
+		List<MessageWithConversation> results = repository.findByType(MessageType.ASSISTANT, 10);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).message().getText()).isEqualTo("Hi");
+	}
+
+	@Test
+	void shouldFindByTimeRange() {
+		Instant before = Instant.now();
+		repository.saveAll("conv-1", List.of(new UserMessage("Hello")));
+		Instant after = Instant.now().plusSeconds(1);
+
+		List<MessageWithConversation> results = repository.findByTimeRange("conv-1", before, after, 10);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).message().getText()).isEqualTo("Hello");
+	}
+
+	@Test
+	void shouldFindByMetadata() {
+		Message msg = UserMessage.builder().text("tagged message").metadata(Map.of("priority", "high")).build();
+		repository.saveAll("conv-1", List.of(msg));
+
+		List<MessageWithConversation> results = repository.findByMetadata("priority", "high", 10);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).message().getText()).isEqualTo("tagged message");
+	}
+
+	@Test
+	void shouldExecuteCustomQuery() {
+		repository.saveAll("conv-1", List.of(new UserMessage("findme")));
+
+		// with json query
+		String query = """
+				{"match": {"content": "findme"}}
+				""";
+
+		List<MessageWithConversation> results = repository.executeQuery(query, 10);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).message().getText()).isEqualTo("findme");
+
+		// with elasticsearch java client Query
+		Query query1 = Query.of(q -> q.match(m -> m.field("content").query("findme")));
+
+		results = repository.executeQuery(query1, 10);
+		assertThat(results).hasSize(1);
+		assertThat(results.get(0).message().getText()).isEqualTo("findme");
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryWithSchemaIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryWithSchemaIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.chat.memory.repository.elasticsearch;
+
+import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.memory.repository.elasticsearch.AdvancedElasticsearchChatMemoryRepository.MessageWithConversation;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ElasticsearchChatMemoryRepository} with metadata schema
+ * validation. Demonstrates that Elasticsearch's dynamic mapping properly indexes metadata
+ * fields with appropriate types (string and numeric).
+ *
+ * @author Laura Trotta
+ */
+@Testcontainers
+class ElasticsearchChatMemoryWithSchemaIT {
+
+	@Container
+	static ElasticsearchContainer elasticsearch = new ElasticsearchContainer("elasticsearch:9.3.0")
+		.withEnv("xpack.security.enabled", "false");
+
+	private ElasticsearchChatMemoryRepository repository;
+
+	@BeforeEach
+	void setUp() throws URISyntaxException {
+		Rest5Client restClient = Rest5Client.builder(HttpHost.create(elasticsearch.getHttpHostAddress())).build();
+
+		String uniqueIndexName = "test-schema-" + System.currentTimeMillis();
+
+		repository = ElasticsearchChatMemoryRepository.builder(restClient).indexName(uniqueIndexName).build();
+	}
+
+	@AfterEach
+	void tearDown() {
+		for (String id : repository.findConversationIds()) {
+			repository.deleteByConversationId(id);
+		}
+	}
+
+	@Test
+	void shouldFindMessagesByMetadataWithProperSchema() {
+		String conversationId = "test-metadata-schema";
+
+		UserMessage userMsg1 = UserMessage.builder()
+			.text("High priority task")
+			.metadata(Map.of("priority", "high", "category", "task", "score", 95))
+			.build();
+
+		AssistantMessage assistantMsg = AssistantMessage.builder()
+			.content("I'll help with that")
+			.properties(Map.of("model", "gpt-4", "confidence", 0.95, "category", "response"))
+			.build();
+
+		UserMessage userMsg2 = UserMessage.builder()
+			.text("Low priority question")
+			.metadata(Map.of("priority", "low", "category", "question", "score", 75))
+			.build();
+
+		repository.saveAll(conversationId, List.of(userMsg1, assistantMsg, userMsg2));
+
+		// Find by string metadata (priority)
+		List<MessageWithConversation> highPriorityMessages = repository.findByMetadata("priority", "high", 10);
+
+		assertThat(highPriorityMessages).hasSize(1);
+		assertThat(highPriorityMessages.get(0).message().getText()).isEqualTo("High priority task");
+
+		// Find by string metadata (category)
+		List<MessageWithConversation> taskMessages = repository.findByMetadata("category", "task", 10);
+
+		assertThat(taskMessages).hasSize(1);
+
+		// Find by numeric metadata (integer score)
+		List<MessageWithConversation> highScoreMessages = repository.findByMetadata("score", 95, 10);
+
+		assertThat(highScoreMessages).hasSize(1);
+		assertThat(highScoreMessages.get(0).message().getText()).isEqualTo("High priority task");
+
+		// Find by numeric metadata (floating-point confidence)
+		List<MessageWithConversation> confidentMessages = repository.findByMetadata("confidence", 0.95, 10);
+
+		assertThat(confidentMessages).hasSize(1);
+		assertThat(confidentMessages.get(0).message().getMetadata().get("model")).isEqualTo("gpt-4");
+
+		// Non-existent metadata key should return empty results
+		List<MessageWithConversation> nonExistentMessages = repository.findByMetadata("nonexistent", "value", 10);
+
+		assertThat(nonExistentMessages).isEmpty();
+	}
+
+	@Test
+	void shouldSearchDynamicallyMappedMetadataFields() {
+		String conversationId = "test-dynamic-metadata";
+
+		UserMessage userMsg = UserMessage.builder()
+			.text("Message with custom metadata")
+			.metadata(Map.of("customfield", "customvalue", "priority", "medium"))
+			.build();
+
+		repository.saveAll(conversationId, List.of(userMsg));
+
+		// Explicitly defined-style field should work
+		List<MessageWithConversation> priorityMessages = repository.findByMetadata("priority", "medium", 10);
+
+		assertThat(priorityMessages).hasSize(1);
+
+		// Dynamically mapped custom field should also be searchable since
+		// Elasticsearch auto-detects and indexes all metadata sub-fields
+		List<MessageWithConversation> customMessages = repository.findByMetadata("customfield", "customvalue", 10);
+
+		assertThat(customMessages).hasSize(1);
+		assertThat(customMessages.get(0).message().getText()).isEqualTo("Message with custom metadata");
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryWithSchemaIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/src/test/java/org/springframework/ai/chat/memory/repository/elasticsearch/ElasticsearchChatMemoryWithSchemaIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-2026 the original author or authors.
+ * Copyright 2023-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 		<module>memory/repository/spring-ai-model-chat-memory-repository-mongodb</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-neo4j</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-redis</module>
+		<module>memory/repository/spring-ai-model-chat-memory-repository-elasticsearch</module>
 
 
 
@@ -99,6 +100,7 @@
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb</module>
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-neo4j</module>
 		<module>auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis</module>
+		<module>auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch</module>
 
 		<module>auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation</module>
 
@@ -232,6 +234,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-mongodb</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-neo4j</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-redis</module>
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-elasticsearch</module>
 
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-mcp-client</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-mcp-server</module>

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -239,6 +239,12 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-model-chat-memory-repository-elasticsearch</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
 			<!-- Spring AI Models -->
 
 			<dependency>
@@ -581,6 +587,12 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-chat-memory-redis</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-autoconfigure-model-chat-memory-elasticsearch</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
@@ -1266,6 +1278,12 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-chat-memory-repository-redis</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-starter-model-chat-memory-repository-elasticsearch</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat-memory.adoc
@@ -623,6 +623,146 @@ You can disable this behavior by setting `spring.ai.chat.memory.redis.initialize
 * Redis Stack 7.0 or higher (includes Redis Query Engine and RedisJSON modules)
 * Jedis client library (included as a dependency)
 
+=== ElasticsearchChatMemoryRepository
+
+`ElasticsearchChatMemoryRepository` is a built-in implementation that uses Elasticsearch to store chat messages.
+It is suitable for applications that require fast, document-oriented chat memory persistence with advanced querying capabilities.
+
+Messages are stored as JSON documents in a single index, with extended query capabilities through the `AdvancedElasticsearchChatMemoryRepository` interface for searching messages by content, type, time range, and metadata.
+
+Messages are retrieved in ascending timestamp order (oldest-to-newest), which is the expected format for LLM conversation history.
+
+First, add the following dependency to your project:
+
+[tabs]
+======
+Maven::
++
+[source, xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-chat-memory-repository-elasticsearch</artifactId>
+</dependency>
+----
+
+Gradle::
++
+[source,groovy]
+----
+dependencies {
+    implementation 'org.springframework.ai:spring-ai-starter-model-chat-memory-repository-elasticsearch'
+}
+----
+======
+
+Spring AI provides auto-configuration for the `ElasticsearchChatMemoryRepository`, which you can use directly in your application.
+
+[source,java]
+----
+@Autowired
+ElasticsearchChatMemoryRepository chatMemoryRepository;
+
+ChatMemory chatMemory = MessageWindowChatMemory.builder()
+    .chatMemoryRepository(chatMemoryRepository)
+    .maxMessages(10)
+    .build();
+----
+
+If you'd rather create the `ElasticsearchChatMemoryRepository` manually, you can do so by providing a `Rest5Client` instance:
+
+[source,java]
+----
+Rest5Client restClient = Rest5Client.builder(HttpHost.create("http://localhost:9200")).build();
+
+ChatMemoryRepository chatMemoryRepository = ElasticsearchChatMemoryRepository.builder(restClient)
+    .indexName("my-chat-index")
+    .build();
+
+ChatMemory chatMemory = MessageWindowChatMemory.builder()
+    .chatMemoryRepository(chatMemoryRepository)
+    .maxMessages(10)
+    .build();
+----
+
+==== Configuration Properties
+
+The Spring Boot properties starting with `spring.elasticsearch.*` are used to configure the Elasticsearch client:
+
+[cols="2,5,1",stripes=even]
+|===
+|Property | Description | Default Value
+
+| `spring.elasticsearch.connection-timeout` | Connection timeout used when communicating with Elasticsearch. | `1s`
+| `spring.elasticsearch.password` | Password for authentication with Elasticsearch. | -
+| `spring.elasticsearch.username` | Username for authentication with Elasticsearch.| -
+| `spring.elasticsearch.apikey` | Api key for authentication with Elasticsearch.| -
+| `spring.elasticsearch.uris` | Comma-separated list of the Elasticsearch instances to use. | `+http://localhost:9200+`
+| `spring.elasticsearch.path-prefix` | Prefix added to the path of every request sent to Elasticsearch. | -
+| `spring.elasticsearch.restclient.sniffer.delay-after-failure` | Delay of a sniff execution scheduled after a failure.| `1m`
+| `spring.elasticsearch.restclient.sniffer.interval` | Interval between consecutive ordinary sniff executions. | `5m`
+| `spring.elasticsearch.restclient.ssl.bundle` | SSL bundle name. | -
+| `spring.elasticsearch.socket-keep-alive` | Whether to enable socket keep alive between client and Elasticsearch. | `false`
+| `spring.elasticsearch.socket-timeout` | Socket timeout used when communicating with Elasticsearch. | `30s`
+|===
+
+Properties starting with `spring.ai.chat.memory.elasticsearch.*` are used to configure the `ElasticsearchChatMemoryRepository`:
+
+[cols="2,5,1",stripes=even]
+|===
+|Property | Description | Default Value
+
+|`spring.ai.chat.memory.elasticsearch.initialize-schema`| Whether to initialize the required schema | `true`
+|`spring.ai.vectorstore.elasticsearch.index-name` | The name of the index to store the messages | `spring-ai-chat-memory`
+|`spring.ai.vectorstore.elasticsearch.max-results` | Maximum number of results to return | `1000`
+|===
+
+==== Advanced Querying
+
+The `ElasticsearchChatMemoryRepository` also implements `AdvancedElasticsearchChatMemoryRepository`, which provides extended query capabilities:
+
+[source,java]
+----
+// Cast to access advanced features
+AdvancedElasticsearchChatMemoryRepository advancedRepo = (AdvancedElasticsearchChatMemoryRepository) chatMemoryRepository;
+
+// Find messages by type across all conversations
+List<MessageWithConversation> userMessages = advancedRepo.findByType(MessageType.USER, 100);
+
+// Find messages containing specific content
+List<MessageWithConversation> results = advancedRepo.findByContent("Spring AI", 50);
+
+// Find messages within a time range
+List<MessageWithConversation> recentMessages = advancedRepo.findByTimeRange(
+    conversationId,
+    Instant.now().minus(Duration.ofHours(1)),
+    Instant.now(),
+    100
+);
+
+// Find messages by metadata
+List<MessageWithConversation> priorityMessages = advancedRepo.findByMetadata("priority", "high", 50);
+
+// Execute custom Elasticsearch queries with JSON syntax
+String queryString = """
+				{"match": {"content": "findme"}}
+				""";
+List<MessageWithConversation> customResults = advancedRepo.executeQuery(queryString, 100);
+
+// Execute custom Elasticsearch queries with java client Query object
+Query queryObject = Query.of(q -> q.match(m -> m.field("content").query("findme")));
+List<MessageWithConversation> customResults = advancedRepo.executeQuery(queryObject, 100);
+----
+
+==== Schema Initialization
+
+The auto-configuration will automatically create the Elasticsearch index on startup if it does not already exist.
+You can disable this behavior by setting `spring.ai.chat.memory.elasticsearch.initialize-schema=false`.
+
+==== Requirements
+
+* Elasticsearch 9.0 or later
+
 == Memory in Chat Client
 
 When using the ChatClient API, you can provide a `ChatMemory` implementation to maintain conversation context across multiple interactions.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -769,7 +769,7 @@ If a new system message is added, all previous system messages are removed from 
 This ensures that the most recent context is always available for the conversation while keeping memory usage bounded.
 
 The `MessageWindowChatMemory` is backed by the `ChatMemoryRepository` abstraction which provides storage implementations for the chat conversation memory.
-There are several implementations available, including the `InMemoryChatMemoryRepository`, `JdbcChatMemoryRepository`, `CassandraChatMemoryRepository`, `Neo4jChatMemoryRepository`, `CosmosDBChatMemoryRepository`, `MongoChatMemoryRepository`, and `RedisChatMemoryRepository`.
+There are several implementations available, including the `InMemoryChatMemoryRepository`, `JdbcChatMemoryRepository`, `CassandraChatMemoryRepository`, `Neo4jChatMemoryRepository`, `CosmosDBChatMemoryRepository`, `MongoChatMemoryRepository`, `RedisChatMemoryRepository` and `ElasticsearchChatMemoryRepository`.
 
 For more details and usage examples, see the xref:api/chat-memory.adoc[Chat Memory] documentation.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs/elasticsearch.adoc
@@ -138,6 +138,7 @@ The Spring Boot properties starting with `spring.elasticsearch.*` are used to co
 | `spring.elasticsearch.connection-timeout` | Connection timeout used when communicating with Elasticsearch. | `1s`
 | `spring.elasticsearch.password` | Password for authentication with Elasticsearch. | -
 | `spring.elasticsearch.username` | Username for authentication with Elasticsearch.| -
+| `spring.elasticsearch.apikey` | Api key for authentication with Elasticsearch.| -
 | `spring.elasticsearch.uris` | Comma-separated list of the Elasticsearch instances to use. | `+http://localhost:9200+`
 | `spring.elasticsearch.path-prefix` | Prefix added to the path of every request sent to Elasticsearch. | -
 | `spring.elasticsearch.restclient.sniffer.delay-after-failure` | Delay of a sniff execution scheduled after a failure.| `1m`

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-elasticsearch/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-elasticsearch/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-starter-model-chat-memory-repository-elasticsearch</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Starter - Elasticsearch Chat Memory Repository</name>
+	<description>Spring AI Elasticsearch Chat Memory Repository Starter</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>git@github.com:spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-memory-elasticsearch</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model-chat-memory-repository-elasticsearch</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+	</dependencies>
+
+</project>


### PR DESCRIPTION
## Summary
Implementation of chat memory with Elasticsearch, following the existing Redis implementation with its advanced interface.

## Details
The structure of the code is basically the same as the Redis one, with `ElasticsearchChatMemoryRepository` implementing both the basic interface `ChatMemoryRepository` and the advanced interface `AdvancedElasticsearchChatMemoryRepository`, and `ElasticsearchChatMemoryConfig` to provide configuration options. 

`AdvancedElasticsearchChatMemoryRepository` is the same as `AdvancedRedisChatMemoryRepository`, with an additional method to allow custom querying with a `Query` elasticsearch java client object, so I'm wondering if it would be better to introduce a shared advanced interface?

The serialization of message objects into json documents is handled by the elasticsearch java client through the jackson library, thus the addition of classes `MessageDocument` and `MediaForDocument`, which represent respectively the spring ai Message and Media, but have all the necessary getter/setter that allow jackson to automatically serialize/deserialize them into json. 

## Modules Added
- `memory/repository/spring-ai-model-chat-memory-repository-elasticsearch/` - Core implementation
- `auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-elasticsearch/` - Auto-configuration
- `spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-elasticsearch/` - Starter

## Tests
Unit tests have been added for each module.

(disclaimer: I work for Elastic)