### PR TITLE
Add extraBody and fast mode support for Anthropic

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -609,6 +609,8 @@ public class AnthropicChatModel implements ChatModel {
 			}
 			requestOptions.setHttpHeaders(
 					mergeHttpHeaders(runtimeOptions.getHttpHeaders(), this.defaultOptions.getHttpHeaders()));
+			requestOptions
+				.setExtraBody(mergeExtraBody(runtimeOptions.getExtraBody(), this.defaultOptions.getExtraBody()));
 			requestOptions.setInternalToolExecutionEnabled(
 					ModelOptionsUtils.mergeOption(runtimeOptions.getInternalToolExecutionEnabled(),
 							this.defaultOptions.getInternalToolExecutionEnabled()));
@@ -640,6 +642,7 @@ public class AnthropicChatModel implements ChatModel {
 		}
 		else {
 			requestOptions.setHttpHeaders(this.defaultOptions.getHttpHeaders());
+			requestOptions.setExtraBody(this.defaultOptions.getExtraBody());
 			requestOptions.setInternalToolExecutionEnabled(this.defaultOptions.getInternalToolExecutionEnabled());
 			requestOptions.setToolNames(this.defaultOptions.getToolNames());
 			requestOptions.setToolCallbacks(this.defaultOptions.getToolCallbacks());
@@ -658,6 +661,21 @@ public class AnthropicChatModel implements ChatModel {
 		var mergedHttpHeaders = new HashMap<>(defaultHttpHeaders);
 		mergedHttpHeaders.putAll(runtimeHttpHeaders);
 		return mergedHttpHeaders;
+	}
+
+	private @Nullable Map<String, Object> mergeExtraBody(@Nullable Map<String, Object> runtimeExtraBody,
+			@Nullable Map<String, Object> defaultExtraBody) {
+		if (defaultExtraBody == null && runtimeExtraBody == null) {
+			return null;
+		}
+		var merged = new HashMap<String, Object>();
+		if (defaultExtraBody != null) {
+			merged.putAll(defaultExtraBody);
+		}
+		if (runtimeExtraBody != null) {
+			merged.putAll(runtimeExtraBody);
+		}
+		return merged.isEmpty() ? null : merged;
 	}
 
 	ChatCompletionRequest createRequest(Prompt prompt, boolean stream) {
@@ -780,6 +798,18 @@ public class AnthropicChatModel implements ChatModel {
 				}
 				else if (existingBeta == null) {
 					headers.put("anthropic-beta", AnthropicApi.BETA_EXTENDED_CACHE_TTL);
+				}
+				needsUpdate = true;
+			}
+
+			// Add fast mode beta header if speed is "fast"
+			if ("fast".equals(requestOptions.getSpeed())) {
+				String existingBeta = headers.get("anthropic-beta");
+				if (existingBeta != null && !existingBeta.contains(AnthropicApi.BETA_FAST_MODE)) {
+					headers.put("anthropic-beta", existingBeta + "," + AnthropicApi.BETA_FAST_MODE);
+				}
+				else if (existingBeta == null) {
+					headers.put("anthropic-beta", AnthropicApi.BETA_FAST_MODE);
 				}
 				needsUpdate = true;
 			}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -145,6 +145,17 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 	 */
 	private @JsonProperty("output_format") @Nullable OutputFormat outputFormat;
 
+	/**
+	 * Speed mode for inference. Set to "fast" for faster output (up to 2.5x).
+	 */
+	private @JsonProperty("speed") @Nullable String speed;
+
+	/**
+	 * Additional parameters to pass to the Anthropic API. Accepts any key-value pairs
+	 * that will be included at the top level of the JSON request.
+	 */
+	private @JsonProperty("extra_body") @Nullable Map<String, Object> extraBody;
+
 	// @formatter:on
 
 	public static AnthropicChatOptions.Builder<?> builder() {
@@ -171,6 +182,8 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 			.citationDocuments(new ArrayList<>(fromOptions.getCitationDocuments()))
 			.outputFormat(fromOptions.getOutputFormat())
 			.skillContainer(fromOptions.getSkillContainer())
+			.speed(fromOptions.getSpeed())
+			.extraBody(fromOptions.getExtraBody())
 			.build();
 	}
 
@@ -363,6 +376,22 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 		this.outputFormat = outputFormat;
 	}
 
+	public @Nullable String getSpeed() {
+		return this.speed;
+	}
+
+	public void setSpeed(@Nullable String speed) {
+		this.speed = speed;
+	}
+
+	public @Nullable Map<String, Object> getExtraBody() {
+		return this.extraBody;
+	}
+
+	public void setExtraBody(@Nullable Map<String, Object> extraBody) {
+		this.extraBody = extraBody;
+	}
+
 	@Override
 	@JsonIgnore
 	public @Nullable String getOutputSchema() {
@@ -407,7 +436,9 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 			.citationDocuments(this.getCitationDocuments())
 			.cacheOptions(this.getCacheOptions())
 			.skillContainer(this.getSkillContainer())
-			.httpHeaders(this.getHttpHeaders());
+			.httpHeaders(this.getHttpHeaders())
+			.speed(this.speed)
+			.extraBody(this.extraBody);
 	}
 
 	@Override
@@ -432,7 +463,8 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 				&& Objects.equals(this.cacheOptions, that.cacheOptions)
 				&& Objects.equals(this.outputFormat, that.outputFormat)
 				&& Objects.equals(this.citationDocuments, that.citationDocuments)
-				&& Objects.equals(this.skillContainer, that.skillContainer);
+				&& Objects.equals(this.skillContainer, that.skillContainer) && Objects.equals(this.speed, that.speed)
+				&& Objects.equals(this.extraBody, that.extraBody);
 	}
 
 	@Override
@@ -440,7 +472,7 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 		return Objects.hash(this.model, this.maxTokens, this.metadata, this.stopSequences, this.temperature, this.topP,
 				this.topK, this.toolChoice, this.thinking, this.toolCallbacks, this.toolNames,
 				this.internalToolExecutionEnabled, this.toolContext, this.httpHeaders, this.cacheOptions,
-				this.outputFormat, this.citationDocuments, this.skillContainer);
+				this.outputFormat, this.citationDocuments, this.skillContainer, this.speed, this.extraBody);
 	}
 
 	public static class Builder<B extends Builder<B>> extends DefaultToolCallingChatOptions.Builder<B>
@@ -461,6 +493,10 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 		private Map<String, String> httpHeaders = new HashMap<>();
 
 		private @Nullable OutputFormat outputFormat;
+
+		private @Nullable String speed;
+
+		private @Nullable Map<String, Object> extraBody;
 
 		@Override
 		public B outputSchema(@Nullable String outputSchema) {
@@ -548,6 +584,16 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 
 		public B outputFormat(@Nullable OutputFormat outputFormat) {
 			this.outputFormat = outputFormat;
+			return self();
+		}
+
+		public B speed(@Nullable String speed) {
+			this.speed = speed;
+			return self();
+		}
+
+		public B extraBody(@Nullable Map<String, Object> extraBody) {
+			this.extraBody = extraBody;
 			return self();
 		}
 
@@ -748,6 +794,12 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 				if (options.outputFormat != null) {
 					this.outputFormat = options.outputFormat;
 				}
+				if (options.speed != null) {
+					this.speed = options.speed;
+				}
+				if (options.extraBody != null) {
+					this.extraBody = options.extraBody;
+				}
 			}
 			return self();
 		}
@@ -776,6 +828,8 @@ public class AnthropicChatOptions implements ToolCallingChatOptions, StructuredO
 			options.toolContext = this.toolContext;
 			options.httpHeaders = this.httpHeaders;
 			options.outputFormat = this.outputFormat;
+			options.speed = this.speed;
+			options.extraBody = this.extraBody;
 			options.validateCitationConsistency();
 			return options;
 		}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/api/AnthropicApi.java
@@ -27,6 +27,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -99,6 +101,8 @@ public final class AnthropicApi {
 	public static final String BETA_FILES_API = "files-api-2025-04-14";
 
 	public static final String BETA_CODE_EXECUTION = "code-execution-2025-08-25";
+
+	public static final String BETA_FAST_MODE = "fast-mode-2026-02-01";
 
 	public static final String CODE_EXECUTION_TOOL_TYPE = "code_execution_20250825";
 
@@ -1023,20 +1027,51 @@ public final class AnthropicApi {
 		@JsonProperty("tool_choice") @Nullable ToolChoice toolChoice,
 		@JsonProperty("thinking") @Nullable ThinkingConfig thinking,
 		@JsonProperty("output_format") @Nullable OutputFormat outputFormat,
-		@JsonProperty("container") @Nullable SkillContainer container) {
+		@JsonProperty("container") @Nullable SkillContainer container,
+		@JsonProperty("speed") @Nullable String speed,
+		@JsonProperty("extra_body") @Nullable Map<String, Object> extraBody) {
 		// @formatter:on
+
+		public ChatCompletionRequest {
+			if (extraBody == null) {
+				extraBody = new java.util.HashMap<>();
+			}
+		}
+
+		/**
+		 * Overrides the default accessor to add @JsonAnyGetter annotation. This causes
+		 * Jackson to flatten the extraBody map contents to the top level of the JSON.
+		 * @return The extraBody map, never null (initialized in compact constructor).
+		 */
+		@SuppressWarnings("NullAway")
+		@JsonAnyGetter
+		public Map<String, Object> extraBody() {
+			return this.extraBody;
+		}
+
+		/**
+		 * Handles deserialization of unknown properties into the extraBody map.
+		 * @param key The property name
+		 * @param value The property value
+		 */
+		@JsonAnySetter
+		private void setExtraBodyProperty(String key, Object value) {
+			if (this.extraBody != null) {
+				this.extraBody.put(key, value);
+			}
+		}
 
 		public ChatCompletionRequest(String model, List<AnthropicMessage> messages, @Nullable Object system,
 				Integer maxTokens, @Nullable Double temperature, @Nullable Boolean stream) {
 			this(model, messages, system, maxTokens, null, null, stream, temperature, null, null, null, null, null,
-					null, null);
+					null, null, null, null);
 		}
 
 		public ChatCompletionRequest(String model, List<AnthropicMessage> messages, @Nullable Object system,
 				Integer maxTokens, @Nullable List<String> stopSequences, @Nullable Double temperature,
 				@Nullable Boolean stream) {
 			this(model, messages, system, maxTokens, null, stopSequences, stream, temperature, null, null, null, null,
-					null, null, null);
+					null, null, null, null, null);
 		}
 
 		public static ChatCompletionRequestBuilder builder() {
@@ -1127,6 +1162,10 @@ public final class AnthropicApi {
 
 		private @Nullable SkillContainer container;
 
+		private @Nullable String speed;
+
+		private @Nullable Map<String, Object> extraBody;
+
 		private ChatCompletionRequestBuilder() {
 		}
 
@@ -1146,6 +1185,8 @@ public final class AnthropicApi {
 			this.thinking = request.thinking;
 			this.outputFormat = request.outputFormat;
 			this.container = request.container;
+			this.speed = request.speed;
+			this.extraBody = request.extraBody;
 		}
 
 		public ChatCompletionRequestBuilder model(ChatModel model) {
@@ -1240,6 +1281,16 @@ public final class AnthropicApi {
 			return this;
 		}
 
+		public ChatCompletionRequestBuilder speed(String speed) {
+			this.speed = speed;
+			return this;
+		}
+
+		public ChatCompletionRequestBuilder extraBody(Map<String, Object> extraBody) {
+			this.extraBody = extraBody;
+			return this;
+		}
+
 		public ChatCompletionRequest build() {
 			Assert.state(this.model != null, "model can't be null");
 			Assert.state(this.messages != null, "messages can't be null");
@@ -1247,7 +1298,7 @@ public final class AnthropicApi {
 
 			return new ChatCompletionRequest(this.model, this.messages, this.system, this.maxTokens, this.metadata,
 					this.stopSequences, this.stream, this.temperature, this.topP, this.topK, this.tools,
-					this.toolChoice, this.thinking, this.outputFormat, this.container);
+					this.toolChoice, this.thinking, this.outputFormat, this.container, this.speed, this.extraBody);
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelFastModeTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelFastModeTests.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionRequest;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.core.retry.RetryTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link AnthropicChatModel} with fast mode support.
+ *
+ * @author Spring AI
+ * @since 2.0.0
+ */
+@ExtendWith(MockitoExtension.class)
+class AnthropicChatModelFastModeTests {
+
+	@Mock
+	private AnthropicApi anthropicApi;
+
+	private AnthropicChatModel createChatModel(AnthropicChatOptions defaultOptions) {
+		RetryTemplate retryTemplate = RetryUtils.SHORT_RETRY_TEMPLATE;
+		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+		ToolCallingManager toolCallingManager = ToolCallingManager.builder().build();
+		return new AnthropicChatModel(this.anthropicApi, defaultOptions, toolCallingManager, retryTemplate,
+				observationRegistry);
+	}
+
+	@Test
+	void shouldSetSpeedInRequestBody() {
+		AnthropicChatOptions defaultOptions = AnthropicChatOptions.builder()
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_5)
+			.maxTokens(1024)
+			.build();
+
+		AnthropicChatModel chatModel = createChatModel(defaultOptions);
+
+		AnthropicChatOptions requestOptions = AnthropicChatOptions.builder().speed("fast").build();
+
+		Prompt prompt = new Prompt("Hello", requestOptions);
+
+		ChatCompletionRequest request = chatModel.createRequest(prompt, false);
+
+		assertThat(request.speed()).isEqualTo("fast");
+	}
+
+	@Test
+	void shouldAddFastModeBetaHeaderWhenSpeedIsFast() {
+		AnthropicChatOptions defaultOptions = AnthropicChatOptions.builder()
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_5)
+			.maxTokens(1024)
+			.build();
+
+		AnthropicChatModel chatModel = createChatModel(defaultOptions);
+
+		AnthropicChatOptions requestOptions = AnthropicChatOptions.builder().speed("fast").build();
+
+		Prompt prompt = new Prompt("Hello", requestOptions);
+
+		chatModel.createRequest(prompt, false);
+
+		assertThat(requestOptions.getHttpHeaders()).containsKey("anthropic-beta");
+		String betaHeader = requestOptions.getHttpHeaders().get("anthropic-beta");
+		assertThat(betaHeader).contains(AnthropicApi.BETA_FAST_MODE);
+	}
+
+	@Test
+	void shouldNotAddFastModeBetaHeaderWhenNoSpeed() {
+		AnthropicChatOptions defaultOptions = AnthropicChatOptions.builder()
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_5)
+			.maxTokens(1024)
+			.build();
+
+		AnthropicChatModel chatModel = createChatModel(defaultOptions);
+
+		AnthropicChatOptions requestOptions = AnthropicChatOptions.builder().build();
+
+		Prompt prompt = new Prompt("Hello", requestOptions);
+
+		chatModel.createRequest(prompt, false);
+
+		String betaHeader = requestOptions.getHttpHeaders().get("anthropic-beta");
+		assertThat(betaHeader).isNull();
+	}
+
+	@Test
+	void shouldNotAddFastModeBetaHeaderWhenSpeedIsNotFast() {
+		AnthropicChatOptions defaultOptions = AnthropicChatOptions.builder()
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_5)
+			.maxTokens(1024)
+			.build();
+
+		AnthropicChatModel chatModel = createChatModel(defaultOptions);
+
+		AnthropicChatOptions requestOptions = AnthropicChatOptions.builder().speed("standard").build();
+
+		Prompt prompt = new Prompt("Hello", requestOptions);
+
+		chatModel.createRequest(prompt, false);
+
+		String betaHeader = requestOptions.getHttpHeaders().get("anthropic-beta");
+		assertThat(betaHeader).isNull();
+	}
+
+	@Test
+	void shouldAppendFastModeBetaHeaderToExistingBetaHeaders() {
+		AnthropicChatOptions defaultOptions = AnthropicChatOptions.builder()
+			.model(AnthropicApi.ChatModel.CLAUDE_SONNET_4_5)
+			.maxTokens(1024)
+			.build();
+
+		AnthropicChatModel chatModel = createChatModel(defaultOptions);
+
+		java.util.Map<String, String> existingHeaders = new java.util.HashMap<>();
+		existingHeaders.put("anthropic-beta", "some-other-beta");
+
+		AnthropicChatOptions requestOptions = AnthropicChatOptions.builder()
+			.speed("fast")
+			.httpHeaders(existingHeaders)
+			.build();
+
+		Prompt prompt = new Prompt("Hello", requestOptions);
+
+		chatModel.createRequest(prompt, false);
+
+		String betaHeader = requestOptions.getHttpHeaders().get("anthropic-beta");
+		assertThat(betaHeader).contains("some-other-beta").contains(AnthropicApi.BETA_FAST_MODE);
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/ExtraBodySerializationTest.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/api/ExtraBodySerializationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.api;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.anthropic.api.AnthropicApi.AnthropicMessage;
+import org.springframework.ai.anthropic.api.AnthropicApi.ChatCompletionRequest;
+import org.springframework.ai.anthropic.api.AnthropicApi.ContentBlock;
+import org.springframework.ai.anthropic.api.AnthropicApi.Role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for extraBody serialization/deserialization in
+ * {@link AnthropicApi.ChatCompletionRequest}.
+ *
+ * @author Spring AI
+ * @since 2.0.0
+ */
+class ExtraBodySerializationTest {
+
+	@Test
+	void shouldFlattenExtraBodyToTopLevel() throws Exception {
+		List<AnthropicMessage> messages = List.of(new AnthropicMessage(List.of(new ContentBlock("Hello")), Role.USER));
+
+		ChatCompletionRequest request = new ChatCompletionRequest("claude-opus-4-6", messages, null, 1024, null, null,
+				false, null, null, null, null, null, null, null, null, null, Map.of("custom_param", "value"));
+
+		String json = JsonMapper.shared().writeValueAsString(request);
+
+		// extraBody should be flattened - custom_param should be at top level
+		assertThat(json).contains("\"custom_param\":\"value\"");
+		// extra_body key should NOT appear in the JSON
+		assertThat(json).doesNotContain("\"extra_body\"");
+	}
+
+	@Test
+	void shouldHandleEmptyExtraBody() throws Exception {
+		List<AnthropicMessage> messages = List.of(new AnthropicMessage(List.of(new ContentBlock("Hello")), Role.USER));
+
+		ChatCompletionRequest request = new ChatCompletionRequest("claude-opus-4-6", messages, null, 1024, null, null);
+
+		String json = JsonMapper.shared().writeValueAsString(request);
+
+		assertThat(json).doesNotContain("\"extra_body\"");
+	}
+
+	@Test
+	void shouldCaptureUnknownPropertiesDuringDeserialization() throws Exception {
+		String json = """
+				{
+					"model": "claude-opus-4-6",
+					"messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}],
+					"max_tokens": 1024,
+					"custom_field": "custom_value",
+					"another_field": 42
+				}
+				""";
+
+		ChatCompletionRequest request = JsonMapper.shared().readValue(json, ChatCompletionRequest.class);
+
+		assertThat(request.model()).isEqualTo("claude-opus-4-6");
+		assertThat(request.extraBody()).containsEntry("custom_field", "custom_value");
+		assertThat(request.extraBody()).containsEntry("another_field", 42);
+	}
+
+	@Test
+	void shouldRoundTripSerializeAndDeserialize() throws Exception {
+		List<AnthropicMessage> messages = List.of(new AnthropicMessage(List.of(new ContentBlock("Hello")), Role.USER));
+
+		ChatCompletionRequest original = new ChatCompletionRequest("claude-opus-4-6", messages, null, 1024, null, null,
+				false, null, null, null, null, null, null, null, null, null, Map.of("custom_param", "test_value"));
+
+		String json = JsonMapper.shared().writeValueAsString(original);
+		ChatCompletionRequest deserialized = JsonMapper.shared().readValue(json, ChatCompletionRequest.class);
+
+		assertThat(deserialized.model()).isEqualTo("claude-opus-4-6");
+		assertThat(deserialized.extraBody()).containsEntry("custom_param", "test_value");
+	}
+
+	@Test
+	void shouldMergeExtraBodyViaModelOptionsUtils() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.model("claude-opus-4-6")
+			.maxTokens(1024)
+			.extraBody(Map.of("custom_param", "value"))
+			.build();
+
+		assertThat(options.getExtraBody()).containsEntry("custom_param", "value");
+	}
+
+	@Test
+	void shouldSerializeSpeedField() throws Exception {
+		List<AnthropicMessage> messages = List.of(new AnthropicMessage(List.of(new ContentBlock("Hello")), Role.USER));
+
+		ChatCompletionRequest request = new ChatCompletionRequest("claude-opus-4-6", messages, null, 1024, null, null,
+				false, null, null, null, null, null, null, null, null, "fast", null);
+
+		String json = JsonMapper.shared().writeValueAsString(request);
+
+		assertThat(json).contains("\"speed\":\"fast\"");
+	}
+
+}


### PR DESCRIPTION
Add speed field and extraBody map to ChatCompletionRequest for Anthropic API. The speed option enables fast inference mode (up to 2.5x faster output) with automatic beta header management, following the same pattern used for Skills and cache TTL headers. The extraBody map uses @JsonAnyGetter/@JsonAnySetter to flatten arbitrary parameters to the top level of the JSON request (similar to https://github.com/spring-projects/spring-ai/pull/4309 for OpenAI).

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc