### PR TITLE
Fix checkstyle header file path to resolve IDEA plugin compatibility

### DIFF
--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -36,7 +36,7 @@
 
 	<!-- Root Checks -->
 	<module name="com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck">
-		<property name="headerFile" value="${checkstyle.header.file}" />
+		<property name="headerFile" value="src/checkstyle/checkstyle-header.txt" />
 		<property name="fileExtensions" value="java" />
 	</module>
 	<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck" />


### PR DESCRIPTION
## What

Replace the `${checkstyle.header.file}` property reference in `checkstyle.xml` with the hardcoded path `src/checkstyle/checkstyle-header.txt`.

## Why

The IDEA CheckStyle plugin fails to initialize with the following error when using a property placeholder for the header file path:

```
com.puppycrawl.tools.checkstyle.api.CheckstyleException: cannot initialize module
io.spring.javaformat.checkstyle.filter.RequiresOuterThisFilter
```

Using a hardcoded relative path resolves the initialization issue and allows the IDEA plugin to correctly load the checkstyle configuration.

## Test plan

- [ ] Run `./mvnw clean package -DskipTests -Ddisable.checks=false` to verify checkstyle passes via Maven
- [ ] Verify IDEA CheckStyle plugin loads without errors