### PR TITLE
Add interceptor for MCP SSE/Streamable client transports

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpSseConnectionInterceptor.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpSseConnectionInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties.SseParameters;
+
+/**
+ * Interceptor for modifying SSE connection parameters before transport creation.
+ *
+ * <p>
+ * This functional interface allows users to intercept and modify SSE connection
+ * parameters (such as URL and SSE endpoint) before the transport is created. This is
+ * particularly useful for service discovery scenarios where service names need to be
+ * resolved to actual host:port addresses at runtime.
+ *
+ * <p>
+ * Multiple interceptors can be registered as Spring beans and will be applied in order
+ * determined by {@link org.springframework.core.annotation.Order @Order} annotation.
+ *
+ * @author Haotian Zhang
+ * @see SseParameters
+ * @since 1.0.0
+ */
+@FunctionalInterface
+public interface McpSseConnectionInterceptor {
+
+	/**
+	 * Intercept and optionally modify the SSE connection parameters.
+	 *
+	 * @param connectionName the name of the connection being created
+	 * @param originalParams the original SSE parameters from configuration
+	 * @return the (potentially modified) SSE parameters to use for transport creation
+	 */
+	SseParameters intercept(String connectionName, SseParameters originalParams);
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpConnectionInterceptor.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/McpStreamableHttpConnectionInterceptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client.common.autoconfigure;
+
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
+
+/**
+ * Interceptor for modifying Streamable HTTP connection parameters before transport
+ * creation.
+ *
+ * <p>
+ * This functional interface allows users to intercept and modify Streamable HTTP
+ * connection parameters (such as URL and endpoint) before the transport is created. This
+ * is particularly useful for service discovery scenarios where service names need to be
+ * resolved to actual host:port addresses at runtime.
+ *
+ * <p>
+ * Multiple interceptors can be registered as Spring beans and will be applied in order
+ * determined by {@link org.springframework.core.annotation.Order @Order} annotation.
+ *
+ * @author Haotian Zhang
+ * @see ConnectionParameters
+ * @since 1.0.0
+ */
+@FunctionalInterface
+public interface McpStreamableHttpConnectionInterceptor {
+
+	/**
+	 * Intercept and optionally modify the Streamable HTTP connection parameters.
+	 *
+	 * @param connectionName the name of the connection being created
+	 * @param originalParams the original connection parameters from configuration
+	 * @return the (potentially modified) connection parameters to use for transport
+	 * creation
+	 */
+	ConnectionParameters intercept(String connectionName, ConnectionParameters originalParams);
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -16,20 +16,14 @@
 
 package org.springframework.ai.mcp.client.httpclient.autoconfigure;
 
-import java.net.http.HttpClient;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
-import tools.jackson.databind.json.JsonMapper;
-
 import org.springframework.ai.mcp.client.common.autoconfigure.McpSseClientConnectionDetails;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.PropertiesMcpSseClientConnectionDetails;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
@@ -42,6 +36,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.log.LogAccessor;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Auto-configuration for Server-Sent Events (SSE) HTTP client transport in the Model
@@ -102,15 +102,22 @@ public class SseHttpClientTransportAutoConfiguration {
 	public List<NamedClientMcpTransport> sseHttpClientTransports(McpSseClientConnectionDetails connectionDetails,
 			ObjectProvider<JsonMapper> jsonMapperProvider,
 			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
-			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
+																 ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer,
+																 ObjectProvider<List<McpSseConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		JsonMapper jsonMapper = jsonMapperProvider.getIfAvailable(JsonMapper::new);
+		List<McpSseConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		List<NamedClientMcpTransport> sseTransports = new ArrayList<>();
 
 		for (Map.Entry<String, SseParameters> serverParameters : connectionDetails.getConnections().entrySet()) {
 			String connectionName = serverParameters.getKey();
 			SseParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpSseConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
 
 			String baseUrl = params.url();
 			String sseEndpoint = params.sseEndpoint() != null ? params.sseEndpoint() : "/sse";

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/StreamableHttpHttpClientTransportAutoConfiguration.java
@@ -16,19 +16,13 @@
 
 package org.springframework.ai.mcp.client.httpclient.autoconfigure;
 
-import java.net.http.HttpClient;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
 import io.modelcontextprotocol.client.transport.customizer.McpAsyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.client.transport.customizer.McpSyncHttpClientRequestCustomizer;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema;
-import tools.jackson.databind.json.JsonMapper;
-
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
@@ -40,6 +34,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.log.LogAccessor;
+
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Auto-configuration for Streamable HTTP client transport in the Model Context Protocol
@@ -97,18 +96,28 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 	public List<NamedClientMcpTransport> streamableHttpHttpClientTransports(
 			McpStreamableHttpClientProperties streamableProperties, ObjectProvider<JsonMapper> jsonMapperProvider,
 			ObjectProvider<McpSyncHttpClientRequestCustomizer> syncHttpRequestCustomizer,
-			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer) {
+			ObjectProvider<McpAsyncHttpClientRequestCustomizer> asyncHttpRequestCustomizer,
+			ObjectProvider<List<McpStreamableHttpConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		JsonMapper jsonMapper = jsonMapperProvider.getIfAvailable(JsonMapper::shared);
+		List<McpStreamableHttpConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		List<NamedClientMcpTransport> streamableHttpTransports = new ArrayList<>();
 
 		for (Map.Entry<String, ConnectionParameters> serverParameters : streamableProperties.getConnections()
 			.entrySet()) {
 
-			String baseUrl = serverParameters.getValue().url();
-			String streamableHttpEndpoint = serverParameters.getValue().endpoint() != null
-					? serverParameters.getValue().endpoint() : "/mcp";
+			String connectionName = serverParameters.getKey();
+
+			ConnectionParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpStreamableHttpConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
+
+			String baseUrl = params.url();
+			String streamableHttpEndpoint = params.endpoint() != null ? params.endpoint() : "/mcp";
 
 			HttpClientStreamableHttpTransport.Builder transportBuilder = HttpClientStreamableHttpTransport
 				.builder(baseUrl)
@@ -127,7 +136,7 @@ public class StreamableHttpHttpClientTransportAutoConfiguration {
 
 			HttpClientStreamableHttpTransport transport = transportBuilder.build();
 
-			streamableHttpTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
+			streamableHttpTransports.add(new NamedClientMcpTransport(connectionName, transport));
 		}
 
 		return streamableHttpTransports;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/SseHttpClientTransportAutoConfigurationTests.java
@@ -23,7 +23,9 @@ import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties.SseParameters;
 import org.springframework.ai.mcp.client.httpclient.autoconfigure.SseHttpClientTransportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -159,12 +161,36 @@ public class SseHttpClientTransportAutoConfigurationTests {
 		return (String) ReflectionUtils.getField(privateField, transport);
 	}
 
+	@Test
+	void interceptorCanModifyConnectionParameters() {
+		this.applicationContext.withUserConfiguration(SseInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.myservice.url=http://myservice")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseHttpClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("myservice");
+				assertThat(transports.get(0).transport()).isInstanceOf(HttpClientSseClientTransport.class);
+				assertThat(getSseEndpoint((HttpClientSseClientTransport) transports.get(0).transport()))
+					.isEqualTo("/custom-intercepted-sse");
+			});
+	}
+
 	@Configuration
 	static class CustomJsonMapperConfiguration {
 
 		@Bean
 		JsonMapper jsonMapper() {
 			return new JsonMapper();
+		}
+
+	}
+
+	@Configuration
+	static class SseInterceptorConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseInterceptors() {
+			return List.of((name, params) -> new SseParameters(params.url(), "/custom-intercepted-sse"));
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/test/java/org/springframework/ai/mcp/client/autoconfigure/StreamableHttpHttpClientTransportAutoConfigurationTests.java
@@ -23,7 +23,9 @@ import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTranspor
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
 import org.springframework.ai.mcp.client.httpclient.autoconfigure.StreamableHttpHttpClientTransportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -168,12 +170,38 @@ public class StreamableHttpHttpClientTransportAutoConfigurationTests {
 		return (String) ReflectionUtils.getField(privateField, transport);
 	}
 
+	@Test
+	void interceptorCanModifyConnectionParameters() {
+		this.applicationContext.withUserConfiguration(StreamableHttpInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.myservice.url=http://myservice")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpHttpClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("myservice");
+				assertThat(transports.get(0).transport()).isInstanceOf(HttpClientStreamableHttpTransport.class);
+				assertThat(
+						getStreamableHttpEndpoint((HttpClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("/custom-intercepted-mcp");
+			});
+	}
+
 	@Configuration
 	static class CustomJsonMapperConfiguration {
 
 		@Bean
 		JsonMapper jsonMapper() {
 			return new JsonMapper();
+		}
+
+	}
+
+	@Configuration
+	static class StreamableHttpInterceptorConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpInterceptors() {
+			return List.of((name, params) -> new ConnectionParameters(params.url(), "/custom-intercepted-mcp"));
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
@@ -16,15 +16,9 @@
 
 package org.springframework.ai.mcp.client.webflux.autoconfigure;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
-import tools.jackson.databind.json.JsonMapper;
-
 import org.springframework.ai.mcp.client.common.autoconfigure.McpSseClientConnectionDetails;
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.PropertiesMcpSseClientConnectionDetails;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
@@ -38,6 +32,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.reactive.function.client.WebClient;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Auto-configuration for WebFlux-based Server-Sent Events (SSE) client transport in the
@@ -90,23 +90,32 @@ public class SseWebFluxTransportAutoConfiguration {
 	 */
 	@Bean
 	public List<NamedClientMcpTransport> sseWebFluxClientTransports(McpSseClientConnectionDetails connectionDetails,
-			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ObjectProvider<JsonMapper> jsonMapperProvider) {
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ObjectProvider<JsonMapper> jsonMapperProvider,
+			ObjectProvider<List<McpSseConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		List<NamedClientMcpTransport> sseTransports = new ArrayList<>();
 
 		var webClientBuilderTemplate = webClientBuilderProvider.getIfAvailable(WebClient::builder);
 		var jsonMapper = jsonMapperProvider.getIfAvailable(JsonMapper::shared);
+		List<McpSseConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		for (Map.Entry<String, SseParameters> serverParameters : connectionDetails.getConnections().entrySet()) {
-			String url = Objects.requireNonNull(serverParameters.getValue().url(),
-					"Missing url for server named " + serverParameters.getKey());
+			String connectionName = serverParameters.getKey();
+			SseParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpSseConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
+
+			String url = Objects.requireNonNull(params.url(), "Missing url for server named " + connectionName);
 			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(url);
-			String sseEndpoint = Objects.requireNonNullElse(serverParameters.getValue().sseEndpoint(), "/sse");
+			String sseEndpoint = Objects.requireNonNullElse(params.sseEndpoint(), "/sse");
 			var transport = WebFluxSseClientTransport.builder(webClientBuilder)
 				.sseEndpoint(sseEndpoint)
 				.jsonMapper(new JacksonMcpJsonMapper(jsonMapper))
 				.build();
-			sseTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
+			sseTransports.add(new NamedClientMcpTransport(connectionName, transport));
 		}
 
 		return sseTransports;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfiguration.java
@@ -16,14 +16,8 @@
 
 package org.springframework.ai.mcp.client.webflux.autoconfigure;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
-import tools.jackson.databind.json.JsonMapper;
-
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties;
@@ -36,6 +30,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.reactive.function.client.WebClient;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Auto-configuration for WebFlux-based Streamable HTTP client transport in the Model
@@ -86,26 +86,36 @@ public class StreamableHttpWebFluxTransportAutoConfiguration {
 	@Bean
 	public List<NamedClientMcpTransport> streamableHttpWebFluxClientTransports(
 			McpStreamableHttpClientProperties streamableProperties,
-			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ObjectProvider<JsonMapper> jsonMapperProvider) {
+			ObjectProvider<WebClient.Builder> webClientBuilderProvider, ObjectProvider<JsonMapper> jsonMapperProvider,
+			ObjectProvider<List<McpStreamableHttpConnectionInterceptor>> connectionInterceptorsProvider) {
 
 		List<NamedClientMcpTransport> streamableHttpTransports = new ArrayList<>();
 
 		var webClientBuilderTemplate = webClientBuilderProvider.getIfAvailable(WebClient::builder);
 		var jsonMapper = jsonMapperProvider.getIfAvailable(JsonMapper::new);
+		List<McpStreamableHttpConnectionInterceptor> connectionInterceptors = connectionInterceptorsProvider.getIfAvailable(List::of);
 
 		for (Map.Entry<String, ConnectionParameters> serverParameters : streamableProperties.getConnections()
 			.entrySet()) {
-			String url = Objects.requireNonNull(serverParameters.getValue().url(),
-					"Missing url for server named " + serverParameters.getKey());
+
+			String connectionName = serverParameters.getKey();
+			ConnectionParameters params = serverParameters.getValue();
+
+			// Apply connection interceptors in order
+			for (McpStreamableHttpConnectionInterceptor interceptor : connectionInterceptors) {
+				params = interceptor.intercept(connectionName, params);
+			}
+
+			String url = Objects.requireNonNull(params.url(), "Missing url for server named " + connectionName);
 			var webClientBuilder = webClientBuilderTemplate.clone().baseUrl(url);
-			String streamableHttpEndpoint = Objects.requireNonNullElse(serverParameters.getValue().endpoint(), "/mcp");
+			String streamableHttpEndpoint = Objects.requireNonNullElse(params.endpoint(), "/mcp");
 
 			var transport = WebClientStreamableHttpTransport.builder(webClientBuilder)
 				.endpoint(streamableHttpEndpoint)
 				.jsonMapper(new JacksonMcpJsonMapper(jsonMapper))
 				.build();
 
-			streamableHttpTransports.add(new NamedClientMcpTransport(serverParameters.getKey(), transport));
+			streamableHttpTransports.add(new NamedClientMcpTransport(connectionName, transport));
 		}
 
 		return streamableHttpTransports;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfigurationTests.java
@@ -22,7 +22,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpSseConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties.SseParameters;
 import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -183,6 +185,20 @@ public class SseWebFluxTransportAutoConfigurationTests {
 		return (String) ReflectionUtils.getField(privateField, transport);
 	}
 
+	@Test
+	void interceptorCanModifyConnectionParameters() {
+		this.applicationContext.withUserConfiguration(SseInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.sse.connections.myservice.url=http://myservice")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("sseWebFluxClientTransports", List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("myservice");
+				assertThat(transports.get(0).transport()).isInstanceOf(WebFluxSseClientTransport.class);
+				assertThat(getSseEndpoint((WebFluxSseClientTransport) transports.get(0).transport()))
+					.isEqualTo("/custom-intercepted-sse");
+			});
+	}
+
 	@Configuration
 	static class CustomWebClientConfiguration {
 
@@ -199,6 +215,16 @@ public class SseWebFluxTransportAutoConfigurationTests {
 		@Bean
 		JsonMapper jsonMapper() {
 			return new JsonMapper();
+		}
+
+	}
+
+	@Configuration
+	static class SseInterceptorConfiguration {
+
+		@Bean
+		List<McpSseConnectionInterceptor> sseInterceptors() {
+			return List.of((name, params) -> new SseParameters(params.url(), "/custom-intercepted-sse"));
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/autoconfigure/StreamableHttpWebFluxTransportAutoConfigurationTests.java
@@ -22,7 +22,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
+import org.springframework.ai.mcp.client.common.autoconfigure.McpStreamableHttpConnectionInterceptor;
 import org.springframework.ai.mcp.client.common.autoconfigure.NamedClientMcpTransport;
+import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpStreamableHttpClientProperties.ConnectionParameters;
 import org.springframework.ai.mcp.client.webflux.transport.WebClientStreamableHttpTransport;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -196,6 +198,22 @@ public class StreamableHttpWebFluxTransportAutoConfigurationTests {
 		return (String) ReflectionUtils.getField(privateField, transport);
 	}
 
+	@Test
+	void interceptorCanModifyConnectionParameters() {
+		this.applicationContext.withUserConfiguration(StreamableHttpInterceptorConfiguration.class)
+			.withPropertyValues("spring.ai.mcp.client.streamable-http.connections.myservice.url=http://myservice")
+			.run(context -> {
+				List<NamedClientMcpTransport> transports = context.getBean("streamableHttpWebFluxClientTransports",
+						List.class);
+				assertThat(transports).hasSize(1);
+				assertThat(transports.get(0).name()).isEqualTo("myservice");
+				assertThat(transports.get(0).transport()).isInstanceOf(WebClientStreamableHttpTransport.class);
+				assertThat(
+						getStreamableHttpEndpoint((WebClientStreamableHttpTransport) transports.get(0).transport()))
+					.isEqualTo("/custom-intercepted-mcp");
+			});
+	}
+
 	@Configuration
 	static class CustomWebClientConfiguration {
 
@@ -212,6 +230,16 @@ public class StreamableHttpWebFluxTransportAutoConfigurationTests {
 		@Bean
 		JsonMapper jsonMapper() {
 			return new JsonMapper();
+		}
+
+	}
+
+	@Configuration
+	static class StreamableHttpInterceptorConfiguration {
+
+		@Bean
+		List<McpStreamableHttpConnectionInterceptor> streamableHttpInterceptors() {
+			return List.of((name, params) -> new ConnectionParameters(params.url(), "/custom-intercepted-mcp"));
 		}
 
 	}


### PR DESCRIPTION
## What

Add `McpSseConnectionInterceptor` and `McpStreamableHttpConnectionInterceptor` interfaces that allow users to intercept and modify connection parameters (URL, endpoint) before MCP client transports are created.

The interceptors are applied in all four transport auto-configurations:
- `SseHttpClientTransportAutoConfiguration`
- `StreamableHttpHttpClientTransportAutoConfiguration`
- `SseWebFluxTransportAutoConfiguration`
- `StreamableHttpWebFluxTransportAutoConfiguration`

## Why

This is useful for service discovery scenarios where service names in configuration need to be resolved to actual `host:port` addresses at runtime, without requiring users to hard-code URLs in their application properties.

Closes GH-5453 (https://github.com/spring-projects/spring-ai/issues/5453)

## Usage

```java
@Bean
List<McpSseConnectionInterceptor> sseInterceptors(DiscoveryClient discoveryClient) {
    return List.of((name, params) -> {
        String resolvedUrl = discoveryClient.resolve(name);
        return new SseParameters(resolvedUrl, params.sseEndpoint());
    });
}
```

## Test plan

- [x] Unit tests added for all four transport auto-configurations verifying interceptor is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)