### PR TITLE
Enable PropertiesMcpSseClientConnectionDetails bean only when missing bean McpSseClientConnectionDetails

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseC
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -73,6 +74,7 @@ public class SseHttpClientTransportAutoConfiguration {
 	private static final LogAccessor logger = new LogAccessor(SseHttpClientTransportAutoConfiguration.class);
 
 	@Bean
+	@ConditionalOnMissingBean(McpSseClientConnectionDetails.class)
 	PropertiesMcpSseClientConnectionDetails mcpSseClientConnectionDetails(McpSseClientProperties sseProperties) {
 		return new PropertiesMcpSseClientConnectionDetails(sseProperties);
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTrans
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -68,6 +69,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class SseWebFluxTransportAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean(McpSseClientConnectionDetails.class)
 	PropertiesMcpSseClientConnectionDetails mcpSseClientConnectionDetails(McpSseClientProperties sseProperties) {
 		return new PropertiesMcpSseClientConnectionDetails(sseProperties);
 	}


### PR DESCRIPTION
Signed-off-by: Eddú Meléndez <eddu.melendez@gmail.com>
