### PR TITLE
#fix-not-exist-tool-error#

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -203,7 +203,9 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 
 			if (toolCallback == null) {
 				logger.warn(POSSIBLE_LLM_TOOL_NAME_CHANGE_WARNING, toolName);
-				throw new IllegalStateException("No ToolCallback found for tool name: " + toolName);
+				toolResponses.add(new ToolResponseMessage.ToolResponse(toolCall.id(), toolName,
+						"No ToolCallback found for tool name: " + toolName));
+				continue;
 			}
 
 			if (returnDirect == null) {


### PR DESCRIPTION
Due LLM hallucinations causing the invocation of non-existent tool names, enforcing validation at this point would lead to system failure. This fix aims to relax validation by sending information about the large model invoking non-existent tools back to the large model for handling.

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc