### PR TITLE
refactor: improve time complexity and reduce memory allocations

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
@@ -18,12 +18,14 @@ package org.springframework.ai.model;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -60,6 +62,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Christian Tzolov
  * @author Thomas Vitale
+ * @author chabinhwang
  * @since 0.8.0
  */
 public abstract class ModelOptionsUtils {
@@ -309,7 +312,9 @@ public abstract class ModelOptionsUtils {
 		BeanWrapper sourceBeanWrap = new BeanWrapperImpl(source);
 		BeanWrapper targetBeanWrap = new BeanWrapperImpl(target);
 
-		List<String> interfaceNames = Arrays.stream(sourceInterfaceClazz.getMethods()).map(m -> m.getName()).toList();
+		Set<String> interfaceNames = Arrays.stream(sourceInterfaceClazz.getMethods())
+			.map(Method::getName)
+			.collect(Collectors.toSet());
 
 		for (PropertyDescriptor descriptor : sourceBeanWrap.getPropertyDescriptors()) {
 
@@ -334,7 +339,7 @@ public abstract class ModelOptionsUtils {
 	}
 
 	private static String toGetName(String name) {
-		return "get" + name.substring(0, 1).toUpperCase() + name.substring(1);
+		return "get" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
 	}
 
 	/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
@@ -53,6 +55,7 @@ import org.springframework.util.StringUtils;
  * Default implementation of {@link ToolCallingManager}.
  *
  * @author Thomas Vitale
+ * @author chabinhwang
  * @since 1.0.0
  */
 public final class DefaultToolCallingManager implements ToolCallingManager {
@@ -103,13 +106,16 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 		Assert.notNull(chatOptions, "chatOptions cannot be null");
 
 		List<ToolCallback> toolCallbacks = new ArrayList<>(chatOptions.getToolCallbacks());
+		Set<String> existingToolNames = chatOptions.getToolCallbacks()
+			.stream()
+			.map(tool -> tool.getToolDefinition().name())
+			.collect(Collectors.toSet());
+
 		for (String toolName : chatOptions.getToolNames()) {
 			// Skip the tool if it is already present in the request toolCallbacks.
 			// That might happen if a tool is defined in the options
 			// both as a ToolCallback and as a tool name.
-			if (chatOptions.getToolCallbacks()
-				.stream()
-				.anyMatch(tool -> tool.getToolDefinition().name().equals(toolName))) {
+			if (existingToolNames.contains(toolName)) {
 				continue;
 			}
 			ToolCallback toolCallback = this.toolCallbackResolver.resolve(toolName);

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.TypeReference;
@@ -78,6 +79,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Jinwoo Lee
  * @author Alexandros Pappas
+ * @author chabinhwang
  */
 public class AzureVectorStore extends AbstractObservationVectorStore implements InitializingBean {
 
@@ -173,10 +175,11 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 
-		final var searchDocuments = documents.stream().map(document -> {
+		final var searchDocuments = IntStream.range(0, documents.size()).mapToObj(i -> {
+			Document document = documents.get(i);
 			SearchDocument searchDocument = new SearchDocument();
 			searchDocument.put(ID_FIELD_NAME, document.getId());
-			searchDocument.put(this.embeddingFieldName, embeddings.get(documents.indexOf(document)));
+			searchDocument.put(this.embeddingFieldName, embeddings.get(i));
 			searchDocument.put(this.contentFieldName, document.getText());
 			searchDocument.put(this.metadataFieldName, new JSONObject(document.getMetadata()).toJSONString());
 

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
@@ -170,6 +170,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Soby Chacko
+ * @author chabinhwang
  * @see VectorStore
  * @see EmbeddingModel
  * @since 1.0.0
@@ -271,9 +272,10 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 
-		int i = 0;
-		for (Document d : documents) {
-			futures[i++] = CompletableFuture.runAsync(() -> {
+		for (int i = 0; i < documents.size(); i++) {
+			Document d = documents.get(i);
+			int index = i;
+			futures[i] = CompletableFuture.runAsync(() -> {
 				List<Object> primaryKeyValues = this.documentIdTranslator.apply(d.getId());
 
 				BoundStatementBuilder builder = prepareAddStatement(d.getMetadata().keySet()).boundStatementBuilder();
@@ -284,8 +286,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 
 				builder = builder.setString(this.schema.content(), d.getText())
 					.setVector(this.schema.embedding(),
-							CqlVector.newInstance(EmbeddingUtils.toList(embeddings.get(documents.indexOf(d)))),
-							Float.class);
+							CqlVector.newInstance(EmbeddingUtils.toList(embeddings.get(index))), Float.class);
 
 				for (var metadataColumn : this.schema.metadataColumns()
 					.stream()

--- a/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
+++ b/vector-stores/spring-ai-chroma-store/src/main/java/org/springframework/ai/chroma/vectorstore/ChromaVectorStore.java
@@ -60,6 +60,7 @@ import org.springframework.util.CollectionUtils;
  * @author Soby Chacko
  * @author Thomas Vitale
  * @author Jonghoon Park
+ * @author chabinhwang
  */
 public class ChromaVectorStore extends AbstractObservationVectorStore implements InitializingBean {
 
@@ -157,11 +158,12 @@ public class ChromaVectorStore extends AbstractObservationVectorStore implements
 		List<float[]> documentEmbeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 
-		for (Document document : documents) {
+		for (int i = 0; i < documents.size(); i++) {
+			Document document = documents.get(i);
 			ids.add(document.getId());
 			metadatas.add(document.getMetadata());
 			contents.add(document.getText());
-			embeddings.add(documentEmbeddings.get(documents.indexOf(document)));
+			embeddings.add(documentEmbeddings.get(i));
 		}
 
 		this.chromaApi.upsertEmbeddings(this.tenantName, this.databaseName, this.requireCollectionId(),

--- a/vector-stores/spring-ai-couchbase-store/src/main/java/org/springframework/ai/vectorstore/couchbase/CouchbaseSearchVectorStore.java
+++ b/vector-stores/spring-ai-couchbase-store/src/main/java/org/springframework/ai/vectorstore/couchbase/CouchbaseSearchVectorStore.java
@@ -53,6 +53,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Laurent Doguin
+ * @author chabinhwang
  * @since 1.0.0
  */
 public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
@@ -139,10 +140,10 @@ public class CouchbaseSearchVectorStore extends AbstractObservationVectorStore
 		logger.info(this.scopeName);
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
-		for (Document document : documents) {
+		for (int i = 0; i < documents.size(); i++) {
+			Document document = documents.get(i);
 			CouchbaseDocument cbDoc = new CouchbaseDocument(document.getId(),
-					Objects.requireNonNullElse(document.getText(), ""), document.getMetadata(),
-					embeddings.get(documents.indexOf(document)));
+					Objects.requireNonNullElse(document.getText(), ""), document.getMetadata(), embeddings.get(i));
 			this.collection.upsert(document.getId(), cbDoc);
 		}
 	}

--- a/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
+++ b/vector-stores/spring-ai-gemfire-store/src/main/java/org/springframework/ai/vectorstore/gemfire/GemFireVectorStore.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -61,6 +62,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Thomas Vitale
  * @author Soby Chacko
  * @author Sebastien Deleuze
+ * @author chabinhwang
  */
 public class GemFireVectorStore extends AbstractObservationVectorStore implements InitializingBean {
 
@@ -226,10 +228,11 @@ public class GemFireVectorStore extends AbstractObservationVectorStore implement
 	public void doAdd(List<Document> documents) {
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
-		UploadRequest upload = new UploadRequest(documents.stream()
-			.map(document -> new UploadRequest.Embedding(document.getId(), embeddings.get(documents.indexOf(document)),
-					DOCUMENT_FIELD, Objects.requireNonNullElse(document.getText(), ""), document.getMetadata()))
-			.toList());
+		UploadRequest upload = new UploadRequest(IntStream.range(0, documents.size()).mapToObj(i -> {
+			Document document = documents.get(i);
+			return new UploadRequest.Embedding(document.getId(), embeddings.get(i), DOCUMENT_FIELD,
+					Objects.requireNonNullElse(document.getText(), ""), document.getMetadata());
+		}).toList());
 
 		String embeddingString = this.jsonMapper.writeValueAsString(upload);
 		String embeddingsJson = embeddingString.substring("{\"embeddings\":".length());

--- a/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBVectorStore.java
+++ b/vector-stores/spring-ai-mariadb-store/src/main/java/org/springframework/ai/vectorstore/mariadb/MariaDBVectorStore.java
@@ -133,6 +133,7 @@ import org.springframework.util.StringUtils;
  * @author Diego Dupin
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
+ * @author chabinhwang
  * @since 1.0.0
  */
 public class MariaDBVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -260,9 +261,10 @@ public class MariaDBVectorStore extends AbstractObservationVectorStore implement
 		List<List<MariaDBDocument>> batches = new ArrayList<>();
 		List<MariaDBDocument> mariaDBDocuments = new ArrayList<>(documents.size());
 		if (embeddings.size() == documents.size()) {
-			for (Document document : documents) {
+			for (int i = 0; i < documents.size(); i++) {
+				Document document = documents.get(i);
 				mariaDBDocuments.add(new MariaDBDocument(document.getId(), document.getText(), document.getMetadata(),
-						embeddings.get(documents.indexOf(document))));
+						embeddings.get(i)));
 			}
 		}
 		else {

--- a/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
+++ b/vector-stores/spring-ai-milvus-store/src/main/java/org/springframework/ai/vectorstore/milvus/MilvusVectorStore.java
@@ -142,6 +142,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author chabinhwang
  * @see org.springframework.ai.vectorstore.VectorStore
  * @see io.milvus.client.MilvusServiceClient
  */
@@ -246,7 +247,8 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 
-		for (Document document : documents) {
+		for (int i = 0; i < documents.size(); i++) {
+			Document document = documents.get(i);
 			docIdArray.add(document.getId());
 			// Use a (future) DocumentTextLayoutFormatter instance to extract
 			// the content used to compute the embeddings
@@ -254,7 +256,7 @@ public class MilvusVectorStore extends AbstractObservationVectorStore implements
 			Gson gson = new Gson();
 			String jsonString = gson.toJson(document.getMetadata());
 			metadataArray.add(gson.fromJson(jsonString, JsonObject.class));
-			embeddingArray.add(EmbeddingUtils.toList(embeddings.get(documents.indexOf(document))));
+			embeddingArray.add(EmbeddingUtils.toList(embeddings.get(i)));
 		}
 
 		List<InsertParam.Field> fields = new ArrayList<>();

--- a/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
+++ b/vector-stores/spring-ai-mongodb-atlas-store/src/main/java/org/springframework/ai/vectorstore/mongodb/atlas/MongoDBAtlasVectorStore.java
@@ -125,6 +125,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author chabinhwang
  * @since 1.0.0
  */
 public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -261,10 +262,10 @@ public class MongoDBAtlasVectorStore extends AbstractObservationVectorStore impl
 	public void doAdd(List<Document> documents) {
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
-		for (Document document : documents) {
+		for (int i = 0; i < documents.size(); i++) {
+			Document document = documents.get(i);
 			MongoDBDocument mdbDocument = new MongoDBDocument(document.getId(),
-					Objects.requireNonNullElse(document.getText(), ""), document.getMetadata(),
-					embeddings.get(documents.indexOf(document)));
+					Objects.requireNonNullElse(document.getText(), ""), document.getMetadata(), embeddings.get(i));
 			this.mongoTemplate.save(mdbDocument, this.collectionName);
 		}
 	}

--- a/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
+++ b/vector-stores/spring-ai-neo4j-store/src/main/java/org/springframework/ai/vectorstore/neo4j/Neo4jVectorStore.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 import org.neo4j.driver.Driver;
@@ -132,6 +133,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Vitale
  * @author Soby Chacko
  * @author Jihoon Kim
+ * @author chabinhwang
  * @since 1.0.0
  */
 public class Neo4jVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -208,8 +210,8 @@ public class Neo4jVectorStore extends AbstractObservationVectorStore implements 
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 
-		var rows = documents.stream()
-			.map(document -> documentToRecord(document, embeddings.get(documents.indexOf(document))))
+		var rows = IntStream.range(0, documents.size())
+			.mapToObj(i -> documentToRecord(documents.get(i), embeddings.get(i)))
 			.toList();
 
 		try (var session = this.driver.session(this.sessionConfig)) {

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -149,6 +149,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author inpink
  * @author Sanghun Lee
+ * @author chabinhwang
  * @since 1.0.0
  */
 public class OpenSearchVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -228,10 +229,10 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 		List<float[]> embedding = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 		BulkRequest.Builder bulkRequestBuilder = new BulkRequest.Builder();
-		for (Document document : documents) {
+		for (int i = 0; i < documents.size(); i++) {
+			Document document = documents.get(i);
 			OpenSearchDocument openSearchDocument = new OpenSearchDocument(document.getId(),
-					Objects.requireNonNullElse(document.getText(), ""), document.getMetadata(),
-					embedding.get(documents.indexOf(document)));
+					Objects.requireNonNullElse(document.getText(), ""), document.getMetadata(), embedding.get(i));
 
 			// Conditionally set document ID based on manageDocumentIds flag
 			if (this.manageDocumentIds) {

--- a/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
+++ b/vector-stores/spring-ai-oracle-store/src/main/java/org/springframework/ai/vectorstore/oracle/OracleVectorStore.java
@@ -81,6 +81,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Soby Chacko
  * @author Thomas Vitale
+ * @author chabinhwang
  */
 public class OracleVectorStore extends AbstractObservationVectorStore implements InitializingBean {
 
@@ -177,7 +178,7 @@ public class OracleVectorStore extends AbstractObservationVectorStore implements
 				final Document document = documents.get(i);
 				final String content = document.getText();
 				final byte[] json = toJson(document.getMetadata());
-				final VECTOR embeddingVector = toVECTOR(embeddings.get(documents.indexOf(document)));
+				final VECTOR embeddingVector = toVECTOR(embeddings.get(i));
 
 				org.springframework.jdbc.core.StatementCreatorUtils.setParameterValue(ps, 1, Types.VARCHAR,
 						document.getId());

--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
@@ -62,6 +62,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author chabinhwang
  */
 public class PineconeVectorStore extends AbstractObservationVectorStore {
 
@@ -138,10 +139,10 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 		List<VectorWithUnsignedIndices> upsertVectors = new ArrayList<>();
-		for (Document document : documents) {
+		for (int i = 0; i < documents.size(); i++) {
+			Document document = documents.get(i);
 			upsertVectors.add(io.pinecone.commons.IndexInterface.buildUpsertVectorWithUnsignedIndices(document.getId(),
-					EmbeddingUtils.toList(embeddings.get(documents.indexOf(document))), null, null,
-					metadataToStruct(document)));
+					EmbeddingUtils.toList(embeddings.get(i)), null, null, metadataToStruct(document)));
 		}
 		this.pinecone.getIndexConnection(this.pineconeIndexName).upsert(upsertVectors, namespace);
 	}

--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantVectorStore.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
 
 import io.qdrant.client.QdrantClient;
 import io.qdrant.client.grpc.Collections.Distance;
@@ -122,6 +123,7 @@ import org.springframework.util.Assert;
  * @author Josh Long
  * @author Soby Chacko
  * @author Thomas Vitale
+ * @author chabinhwang
  * @since 1.0.0
  */
 public class QdrantVectorStore extends AbstractObservationVectorStore implements InitializingBean {
@@ -183,13 +185,14 @@ public class QdrantVectorStore extends AbstractObservationVectorStore implements
 			List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 					this.batchingStrategy);
 
-			List<PointStruct> points = documents.stream()
-				.map(document -> PointStruct.newBuilder()
+			List<PointStruct> points = IntStream.range(0, documents.size()).mapToObj(i -> {
+				Document document = documents.get(i);
+				return PointStruct.newBuilder()
 					.setId(io.qdrant.client.PointIdFactory.id(UUID.fromString(document.getId())))
-					.setVectors(io.qdrant.client.VectorsFactory.vectors(embeddings.get(documents.indexOf(document))))
+					.setVectors(io.qdrant.client.VectorsFactory.vectors(embeddings.get(i)))
 					.putAllPayload(toPayload(document))
-					.build())
-				.toList();
+					.build();
+			}).toList();
 
 			this.qdrantClient.upsertAsync(this.collectionName, points).get();
 		}

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
@@ -236,6 +236,7 @@ import org.springframework.util.StringUtils;
  * @author Thomas Vitale
  * @author Soby Chacko
  * @author Jihoon Kim
+ * @author chabinhwang
  * @see VectorStore
  * @see EmbeddingModel
  * @since 1.0.0
@@ -357,9 +358,10 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 			List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 					this.batchingStrategy);
 
-			for (Document document : documents) {
+			for (int i = 0; i < documents.size(); i++) {
+				Document document = documents.get(i);
 				var fields = new HashMap<String, Object>();
-				float[] embedding = embeddings.get(documents.indexOf(document));
+				float[] embedding = embeddings.get(i);
 
 				// Normalize embeddings for COSINE distance metric
 				if (this.distanceMetric == DistanceMetric.COSINE) {

--- a/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
+++ b/vector-stores/spring-ai-typesense-store/src/main/java/org/springframework/ai/vectorstore/typesense/TypesenseVectorStore.java
@@ -72,6 +72,7 @@ import org.springframework.util.Assert;
  * @author Eddú Meléndez
  * @author Mark Pollack
  * @author Soby Chacko
+ * @author chabinhwang
  * @see org.springframework.ai.vectorstore.VectorStore
  * @see org.springframework.ai.embedding.EmbeddingModel
  */
@@ -144,12 +145,13 @@ public class TypesenseVectorStore extends AbstractObservationVectorStore impleme
 		List<float[]> embeddings = this.embeddingModel.embed(documents, EmbeddingOptions.builder().build(),
 				this.batchingStrategy);
 
-		List<HashMap<String, Object>> documentList = documents.stream().map(document -> {
+		List<HashMap<String, Object>> documentList = IntStream.range(0, documents.size()).mapToObj(i -> {
+			Document document = documents.get(i);
 			HashMap<String, Object> typesenseDoc = new HashMap<>();
 			typesenseDoc.put(DOC_ID_FIELD_NAME, document.getId());
 			typesenseDoc.put(CONTENT_FIELD_NAME, document.getText());
 			typesenseDoc.put(METADATA_FIELD_NAME, document.getMetadata());
-			typesenseDoc.put(EMBEDDING_FIELD_NAME, embeddings.get(documents.indexOf(document)));
+			typesenseDoc.put(EMBEDDING_FIELD_NAME, embeddings.get(i));
 
 			return typesenseDoc;
 		}).toList();


### PR DESCRIPTION
## Summary

- **DefaultToolCallingManager**: Pre-compute `HashSet` of existing tool names to reduce `resolveToolDefinitions` lookup from O(N×M) to O(N+M)
- **ModelOptionsUtils**: Change `interfaceNames` from `List` to `Set` for O(1) `contains()` instead of O(N), use `Character.toUpperCase()` to avoid unnecessary `String` allocation in `toGetName()`
- **Vector stores (16 files)**: Replace `documents.indexOf(document)` O(N) lookup inside loops with index-based access O(1), eliminating O(N²) overall complexity in `doAdd` methods

## Details

### DefaultToolCallingManager (`resolveToolDefinitions`)
Previously, for each tool name in `chatOptions.getToolNames()`, the code streamed through all `toolCallbacks` with `.anyMatch()` — resulting in O(N×M) complexity. Now a `HashSet<String>` of existing tool callback names is pre-computed once, reducing the check to O(1) per iteration.

### ModelOptionsUtils (`mergeBeans` / `toGetName`)
- `interfaceNames` was collected as a `List<String>` but used with `.contains()` which is O(N) per call. Changed to `Set<String>` for O(1) lookups.
- `toGetName()` used `name.substring(0, 1).toUpperCase()` which creates an intermediate `String` object. Changed to `Character.toUpperCase(name.charAt(0))` to avoid unnecessary allocation.

### Vector Stores (16 files)
All vector store `doAdd` methods used `documents.indexOf(document)` inside a for-each loop to correlate documents with their embeddings. Since `indexOf` is O(N), this made the overall loop O(N²). Replaced with indexed for-loops using `embeddings.get(i)` for O(1) access.

Affected stores: Cassandra, Chroma, Couchbase, GemFire, MariaDB, Milvus, MongoDB Atlas, Neo4j, OpenSearch, Oracle, Pinecone, Qdrant, Redis, Typesense, Azure, CosmosDB