### PR TITLE
Fix/OpenAI sdk api key azure

### DIFF
--- a/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/setup/OpenAiSdkSetup.java
+++ b/models/spring-ai-openai-sdk/src/main/java/org/springframework/ai/openaisdk/setup/OpenAiSdkSetup.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.openai.azure.AzureOpenAIServiceVersion;
+import com.openai.azure.credential.AzureApiKeyCredential;
 import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -74,7 +75,12 @@ public final class OpenAiSdkSetup {
 
 		String calculatedApiKey = apiKey != null ? apiKey : detectApiKey(modelProvider);
 		if (calculatedApiKey != null) {
-			builder.apiKey(calculatedApiKey);
+			if (modelProvider == ModelProvider.MICROSOFT_FOUNDRY) {
+				builder.credential(AzureApiKeyCredential.create(calculatedApiKey));
+			}
+			else {
+				builder.apiKey(calculatedApiKey);
+			}
 		}
 		else {
 			if (credential != null) {
@@ -127,7 +133,12 @@ public final class OpenAiSdkSetup {
 
 		String calculatedApiKey = apiKey != null ? apiKey : detectApiKey(modelProvider);
 		if (calculatedApiKey != null) {
-			builder.apiKey(calculatedApiKey);
+			if (modelProvider == ModelProvider.MICROSOFT_FOUNDRY) {
+				builder.credential(AzureApiKeyCredential.create(calculatedApiKey));
+			}
+			else {
+				builder.apiKey(calculatedApiKey);
+			}
 		}
 		else {
 			if (credential != null) {

--- a/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/setup/OpenAiSdkSetupTests.java
+++ b/models/spring-ai-openai-sdk/src/test/java/org/springframework/ai/openaisdk/setup/OpenAiSdkSetupTests.java
@@ -16,16 +16,21 @@
 
 package org.springframework.ai.openaisdk.setup;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
+import com.openai.azure.credential.AzureApiKeyCredential;
 import com.openai.client.OpenAIClient;
+import com.openai.core.ClientOptions;
 import com.openai.models.ChatModel;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class OpenAiSdkSetupTests {
 
@@ -117,6 +122,19 @@ public class OpenAiSdkSetupTests {
 				false, null, Duration.ofSeconds(30), 2, null, null);
 
 		assertNotNull(client);
+	}
+
+	@Test
+	void setupSyncClient_usesApiKeyHeader_notBearerToken_forMicrosoftFoundry() throws Exception {
+		OpenAIClient client = OpenAiSdkSetup.setupSyncClient("https://my-resource.openai.azure.com/", "my-foundry-key",
+				null, null, null, null, true, false, null, Duration.ofSeconds(30), 2, null, null);
+
+		Field field = client.getClass().getDeclaredField("clientOptions");
+		field.setAccessible(true);
+		ClientOptions options = (ClientOptions) field.get(client);
+		assertInstanceOf(AzureApiKeyCredential.class, options.credential());
+		assertThat(options.headers().values("api-key")).containsExactly("my-foundry-key");
+		assertThat(options.headers().values("Authorization")).isEmpty();
 	}
 
 }


### PR DESCRIPTION
Hey Spring Team!

I've been using the Open AI SDK for a bit and I noticed that the wrong credentials are used for Azure during auto-configuration. When doing the following in my project:
```yaml
spring:
  application:
    name: spring-ai
  ai:
    openai-sdk:
      api-key: ${GEN_AI_KEY}
      base-url: https://example/openai/v1
      chat:
        options:
          model: gpt-51
        microsoft-foundry: true
```

The key is set within the Authorization header but [Azure expects](https://learn.microsoft.com/en-us/azure/foundry/openai/reference-preview-latest#request-header) it to be set within the `api-key` header when using an API key and not passwordless auth. 

I suggest that when Azure is used and an API key is set we add the AzureApiKeyCredential. 