### PR TITLE
MCP WebMvc transports: fix header usage

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/security/WebFluxServerTransportSecurityIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/security/WebFluxServerTransportSecurityIT.java
@@ -28,7 +28,6 @@ import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.BeforeParameterizedClassInvocation;
@@ -63,7 +62,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Daniel Garnier-Moiroux
  */
-@Disabled
 @ParameterizedClass
 @MethodSource("transports")
 public class WebFluxServerTransportSecurityIT {

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtils.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.web.servlet.function.ServerRequest;
+
+/**
+ * Utility class for working with HTTP headers. Internal use only.
+ *
+ * @author Daniel Garnier-Moiroux
+ */
+final class HeaderUtils {
+
+	private HeaderUtils() {
+	}
+
+	static Map<String, List<String>> collectHeaders(ServerRequest request) {
+		return request.headers()
+			.asHttpHeaders()
+			.headerNames()
+			.stream()
+			.collect(Collectors.toUnmodifiableMap(String::toLowerCase, name -> request.headers().header(name),
+					(l1, l2) -> {
+						var merged = new ArrayList<>(l1);
+						merged.addAll(l2);
+						return Collections.unmodifiableList(merged);
+					}));
+	}
+
+}

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
@@ -19,7 +19,6 @@ package org.springframework.ai.mcp.server.webmvc.transport;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -296,7 +295,7 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {
@@ -368,7 +367,7 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
@@ -18,7 +18,6 @@ package org.springframework.ai.mcp.server.webmvc.transport;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.json.McpJsonDefaults;
@@ -127,7 +126,7 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -361,7 +361,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {
@@ -498,7 +498,7 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		}
 
 		try {
-			Map<String, List<String>> headers = request.headers().asHttpHeaders().asMultiValueMap();
+			var headers = HeaderUtils.collectHeaders(request);
 			this.securityValidator.validateHeaders(headers);
 		}
 		catch (ServerTransportSecurityException e) {

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/security/ServerTransportSecurityIT.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/security/ServerTransportSecurityIT.java
@@ -38,7 +38,6 @@ import org.apache.catalina.LifecycleState;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.BeforeParameterizedClassInvocation;
@@ -68,7 +67,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Daniel Garnier-Moiroux
  */
-@Disabled
 @ParameterizedClass
 @MethodSource("transports")
 public class ServerTransportSecurityIT {

--- a/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtilsTests.java
+++ b/mcp/transport/mcp-spring-webmvc/src/test/java/org/springframework/ai/mcp/server/webmvc/transport/HeaderUtilsTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.webmvc.transport;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.function.ServerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HeaderUtilsTests {
+
+	@Test
+	void collectHeaders() {
+		ServerRequest request = mock(ServerRequest.class);
+		ServerRequest.Headers headers = mock(ServerRequest.Headers.class);
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.add("Content-Type", "application/json");
+		httpHeaders.add("Authorization", "Bearer token");
+		httpHeaders.add("Custom-Header", "value1");
+		httpHeaders.add("Custom-Header", "value2");
+
+		when(request.headers()).thenReturn(headers);
+		when(headers.asHttpHeaders()).thenReturn(httpHeaders);
+		when(headers.header("Content-Type")).thenReturn(List.of("application/json"));
+		when(headers.header("Authorization")).thenReturn(List.of("Bearer token"));
+		when(headers.header("Custom-Header")).thenReturn(List.of("value1", "value2"));
+
+		Map<String, List<String>> result = HeaderUtils.collectHeaders(request);
+
+		assertThat(result).hasSize(3);
+		assertThat(result).containsEntry("content-type", List.of("application/json"));
+		assertThat(result).containsEntry("authorization", List.of("Bearer token"));
+		assertThat(result).containsEntry("custom-header", List.of("value1", "value2"));
+	}
+
+	@Test
+	void collectHeadersEmpty() {
+		ServerRequest request = mock(ServerRequest.class);
+		ServerRequest.Headers headers = mock(ServerRequest.Headers.class);
+		HttpHeaders httpHeaders = new HttpHeaders();
+
+		when(request.headers()).thenReturn(headers);
+		when(headers.asHttpHeaders()).thenReturn(httpHeaders);
+
+		Map<String, List<String>> result = HeaderUtils.collectHeaders(request);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void collectHeadersMixedCase() {
+		ServerRequest request = mock(ServerRequest.class);
+		ServerRequest.Headers headers = mock(ServerRequest.Headers.class);
+		HttpHeaders httpHeaders = mock(HttpHeaders.class);
+
+		when(request.headers()).thenReturn(headers);
+		when(headers.asHttpHeaders()).thenReturn(httpHeaders);
+
+		// Mock headerNames to return mixed case keys
+		when(httpHeaders.headerNames()).thenReturn(Set.of("X-Custom", "x-custom"));
+
+		// Mock header values for each key
+		when(headers.header("X-Custom")).thenReturn(List.of("one", "two"));
+		when(headers.header("x-custom")).thenReturn(List.of("three"));
+
+		Map<String, List<String>> result = HeaderUtils.collectHeaders(request);
+
+		assertThat(result).hasSize(1);
+		assertThat(result).containsKey("x-custom");
+		assertThat(result.get("x-custom")).containsExactlyInAnyOrder("one", "two", "three");
+	}
+
+}


### PR DESCRIPTION
`ServerTransportSecurityIT` was broken, because Spring FW 7 `ServerRequest` 's HTTP headers don't support map operations anymore.
This introduces a function to collect headers in a map.

It reintroduces some `@Disabled` integration tests.

It is not very efficient, but I have an issue opened to improve this: https://github.com/modelcontextprotocol/java-sdk/issues/870

