### PR TITLE
Bump openai-sdk version to 4.28.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,11 +290,9 @@
 		<spring-boot.version>4.1.0-M2</spring-boot.version>
 		<ST4.version>4.3.4</ST4.version>
 		<azure-open-ai-client.version>1.0.0-beta.16</azure-open-ai-client.version>
-		<openai-sdk.version>4.17.0</openai-sdk.version>
 		<azure-identity.version>1.18.2</azure-identity.version>
-		<openai-sdk.version>4.13.0</openai-sdk.version>
+		<openai-sdk.version>4.28.0</openai-sdk.version>
 		<anthropic-sdk.version>2.16.1</anthropic-sdk.version>
-		<azure-identity.version>1.18.1</azure-identity.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
 		<kotlin.version>2.2.21</kotlin.version>
 


### PR DESCRIPTION
- Bump openai-sdk version to 4.28.0
- Remove duplicate entries in the pom.xml 