### PR TITLE
Fix ToolCallingAdvisor streaming suppression

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisor.java
@@ -280,11 +280,20 @@ public class ToolCallingAdvisor implements CallAdvisor, StreamAdvisor, ToolAdvis
 		ChatResponse previousAccumulatedResponse = usageAccumulator.accumulatedResponse();
 
 		return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(responseFlux, aggregatedResponseRef::set)
-			.map(chatClientResponse -> UsageAccumulator.applyPreviousAccumulatedUsageToChunk(chatClientResponse,
-					previousAccumulatedResponse))
-			.concatWith(Flux.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest,
-					streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator)))
-			.filter(ccr -> !this.toolExecutionEligibilityChecker.isToolCallResponse(ccr.chatResponse()));
+			.collectList()
+			.flatMapMany(roundResponses -> Flux.defer(() -> {
+				ChatClientResponse aggregatedResponse = aggregatedResponseRef.get();
+				boolean isToolCall = aggregatedResponse != null
+						&& this.toolExecutionEligibilityChecker.isToolCallResponse(aggregatedResponse.chatResponse());
+
+				Flux<ChatClientResponse> roundFlux = isToolCall ? Flux.empty()
+						: Flux.fromIterable(roundResponses)
+							.map(chatClientResponse -> UsageAccumulator
+								.applyPreviousAccumulatedUsageToChunk(chatClientResponse, previousAccumulatedResponse));
+
+				return roundFlux.concatWith(this.handleToolCallRecursion(aggregatedResponse, finalRequest,
+						streamAdvisorChain, originalRequest, optionsCopy, usageAccumulator));
+			}));
 	}
 
 	/**

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallingAdvisorTests.java
@@ -602,6 +602,36 @@ public class ToolCallingAdvisorTests {
 	}
 
 	@Test
+	void testAdviseStreamSuppressesAllChunksFromIntermediateToolCallIteration() {
+		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse partialToolCallChunk = createMockResponse(false);
+		ChatClientResponse finalToolCallChunk = createMockResponse(true);
+		ChatClientResponse finalResponse = createMockResponse(false);
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return callCount[0] == 1 ? Flux.just(partialToolCallChunk, finalToolCallChunk) : Flux.just(finalResponse);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(createToolExecutionResult(false));
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		assertThat(results).isNotNull().hasSize(1);
+		assertThat(results.get(0).chatResponse()).isEqualTo(finalResponse.chatResponse());
+		assertThat(callCount[0]).isEqualTo(2);
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	@Test
 	void adviseStreamAccumulatesPreviousLoopUsageOnUsageBearingChunk() {
 		ToolCallingAdvisor advisor = ToolCallingAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
 


### PR DESCRIPTION
Fix `ToolCallingAdvisor` streaming suppression for intermediate tool-call iterations.

When streaming returns a non-tool-call chunk before the chunk that completes a tool call, filtering each chunk independently can emit part of an intermediate tool-call iteration even though the completed iteration should be suppressed.

This change buffers a single streaming iteration until the aggregate response is available, suppresses the whole iteration when it contains a tool call, and then continues tool-call recursion. Non-tool-call final iterations are replayed unchanged, with existing usage accumulation preserved.

Tests:
- Adds a regression test that verifies a partial non-tool chunk followed by a final tool-call chunk does not leak before the final answer.