### PR TITLE
Fix AzureOpenAiChatOptions defaulting stop to empty list instead of null

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -169,7 +169,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	 * A collection of textual sequences that will end completions generation.
 	 */
 	@JsonProperty("stop")
-	private List<String> stop = new ArrayList<>();
+	private List<String> stop;
 
 	/**
 	 * A value that influences the probability of generated tokens appearing based on

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptionsTests.java
@@ -214,6 +214,21 @@ class AzureOpenAiChatOptionsTests extends AbstractChatOptionsTests<AzureOpenAiCh
 	}
 
 	@Test
+	void testNoArgConstructorDefaultValues() {
+		AzureOpenAiChatOptions options = new AzureOpenAiChatOptions();
+
+		assertThat(options.getStop()).isNull();
+		assertThat(options.getStopSequences()).isNull();
+		assertThat(options.getDeploymentName()).isNull();
+		assertThat(options.getFrequencyPenalty()).isNull();
+		assertThat(options.getMaxTokens()).isNull();
+		assertThat(options.getN()).isNull();
+		assertThat(options.getPresencePenalty()).isNull();
+		assertThat(options.getTemperature()).isNull();
+		assertThat(options.getTopP()).isNull();
+	}
+
+	@Test
 	void testModelAndDeploymentNameRelationship() {
 		AzureOpenAiChatOptions options = new AzureOpenAiChatOptions();
 


### PR DESCRIPTION
The stop field was initialized to new ArrayList<>() causing "stop": [] to be serialized in every request, even when no stop sequences were configured. Models that don't support the stop parameter (e.g. gpt-5-mini) reject requests with this empty list present.

Changed the default to null so @JsonInclude(NON_NULL) correctly omits it from serialization.

Fixes #5627