### PR TITLE
Fix CosmosDBVectorStore metadata isolation in search results

### DIFF
--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
@@ -78,6 +78,7 @@ import org.springframework.util.Assert;
  * @author Theo van Kraay
  * @author Soby Chacko
  * @author Thomas Vitale
+ * @author Yaklede
  * @since 1.0.0
  */
 public class CosmosDBVectorStore extends AbstractObservationVectorStore implements AutoCloseable {
@@ -330,7 +331,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 								+ "' not found in metadata for document with id: " + id);
 					}
 
-					partitionKeyValue = metadataNode.get(metadataKey).asText();
+					partitionKeyValue = metadataNode.get(metadataKey).asString();
 				}
 				else {
 					throw new IllegalArgumentException("Unsupported partition key path: " + this.partitionKeyPath);
@@ -415,31 +416,38 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 				documents = new ArrayList<>();
 			}
 
-			// Collect metadata fields from the documents
-			Map<String, Object> docFields = new HashMap<>();
-			for (var doc : documents) {
-				JsonNode metadata = doc.get("metadata");
-				metadata.propertyNames().forEach(property -> {
-					JsonNode value = metadata.get(property);
-					Object parsedValue = value.isTextual() ? value.asText() : value.isNumber() ? value.numberValue()
-							: value.isBoolean() ? value.booleanValue() : value.toString();
-					docFields.put(property, parsedValue);
-				});
-			}
-
-			// Convert JsonNode to Document
-			return documents.stream()
-				.map(doc -> Document.builder()
-					.id(doc.get("id").asText())
-					.text(doc.get("content").asText())
-					.metadata(docFields)
-					.build())
-				.collect(Collectors.toList());
+			return mapSimilaritySearchDocuments(documents);
 		}
 		catch (Exception e) {
 			logger.error("Error during similarity search: {}", e.getMessage());
 			return List.of();
 		}
+	}
+
+	static List<Document> mapSimilaritySearchDocuments(List<JsonNode> documents) {
+		return documents.stream().map(CosmosDBVectorStore::mapSimilaritySearchDocument).collect(Collectors.toList());
+	}
+
+	private static Document mapSimilaritySearchDocument(JsonNode doc) {
+		return Document.builder()
+			.id(doc.get("id").asString())
+			.text(doc.get("content").asString())
+			.metadata(extractMetadata(doc.get("metadata")))
+			.build();
+	}
+
+	private static Map<String, Object> extractMetadata(@Nullable JsonNode metadataNode) {
+		Map<String, Object> metadata = new HashMap<>();
+		if (metadataNode == null) {
+			return metadata;
+		}
+
+		metadataNode.propertyNames().forEach(property -> {
+			JsonNode value = metadataNode.get(property);
+			metadata.put(property, value.isString() ? value.stringValue() : value.isNumber() ? value.numberValue()
+					: value.isBoolean() ? value.booleanValue() : value.toString());
+		});
+		return metadata;
 	}
 
 	@Override

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStoreTests.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStoreTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.cosmosdb;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+import org.springframework.ai.document.Document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for similarity-search document mapping in the Cosmos DB vector store.
+ *
+ * @author Yaklede
+ * @since 2.0.0
+ */
+class CosmosDBVectorStoreTests {
+
+	@Test
+	void mapSimilaritySearchDocumentsShouldKeepMetadataScopedToEachDocument() {
+		ObjectNode first = JsonMapper.shared().createObjectNode();
+		first.put("id", "1");
+		first.put("content", "First");
+		first.set("metadata", metadataNode("country", "UK", "year", 2021, "active", true, "score", List.of(1, 2)));
+
+		ObjectNode second = JsonMapper.shared().createObjectNode();
+		second.put("id", "2");
+		second.put("content", "Second");
+		second.set("metadata",
+				metadataNode("country", "NL", "year", 2022, "active", false, "score", Map.of("value", 7)));
+
+		List<Document> documents = CosmosDBVectorStore.mapSimilaritySearchDocuments(List.of(first, second));
+
+		assertThat(documents).hasSize(2);
+		assertThat(documents.get(0).getMetadata()).containsExactlyInAnyOrderEntriesOf(
+				Map.of("country", "UK", "year", 2021, "active", true, "score", "[1,2]"));
+		assertThat(documents.get(1).getMetadata()).containsExactlyInAnyOrderEntriesOf(
+				Map.of("country", "NL", "year", 2022, "active", false, "score", "{\"value\":7}"));
+	}
+
+	@Test
+	void mapSimilaritySearchDocumentsShouldHandleMissingMetadataNode() {
+		ObjectNode doc = JsonMapper.shared().createObjectNode();
+		doc.put("id", "1");
+		doc.put("content", "First");
+
+		List<Document> documents = CosmosDBVectorStore.mapSimilaritySearchDocuments(List.of(doc));
+
+		assertThat(documents).singleElement().extracting(Document::getMetadata).isEqualTo(Map.of());
+	}
+
+	private static ObjectNode metadataNode(String countryKey, String country, String yearKey, int year,
+			String activeKey, boolean active, String scoreKey, Object score) {
+		ObjectNode metadata = JsonMapper.shared().createObjectNode();
+		metadata.put(countryKey, country);
+		metadata.put(yearKey, year);
+		metadata.put(activeKey, active);
+		metadata.set(scoreKey, JsonMapper.shared().valueToTree(score));
+		return metadata;
+	}
+
+}


### PR DESCRIPTION
Fixes #5632

## Summary

`CosmosDBVectorStore.doSimilaritySearch()` was accumulating metadata from all matched documents into a single shared map and then assigning that merged map to every returned `Document`.

This change keeps the fix minimal and localized to the document conversion path:
- build a fresh metadata map for each returned document
- keep the existing value conversion behavior for string, number, boolean, and fallback string conversion
- handle a missing `metadata` node defensively
- add regression coverage for the broken behavior

## Root Cause

The similarity-search result mapping logic created one metadata map outside the per-document conversion loop, populated it while iterating over all result documents, and then reused that accumulated map for every returned `Document`.

That caused:
- metadata from multiple results to be merged together
- same-key collisions to become last-write-wins
- returned documents to no longer reflect their own stored metadata

## Changes

- Refactored the similarity-search document conversion so each result document builds its own metadata map from its own `metadata` node.
- Added a null check for the `metadata` node and return an empty metadata map when it is absent.
- Kept the existing conversion behavior:
  - string -> `String`
  - number -> `Number`
  - boolean -> `Boolean`
  - everything else -> `toString()`

## Testing

Added unit tests in:

- `vector-stores/spring-ai-azure-cosmos-db-store/src/test/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStoreTests.java`

What the tests verify:

- `mapSimilaritySearchDocumentsShouldKeepMetadataScopedToEachDocument`
  - creates two similarity-search result documents with different metadata values
  - verifies that each returned `Document` contains only its own metadata
  - verifies that metadata does not leak across results
  - verifies that string, number, boolean, and fallback string conversion behavior is preserved

- `mapSimilaritySearchDocumentsShouldHandleMissingMetadataNode`
  - verifies that a result without a `metadata` node is handled safely
  - verifies that the returned `Document` receives an empty metadata map instead of failing

## Why this fix is safe

This change only affects the read-side conversion of similarity-search results into Spring AI `Document` instances.

It does not change:
- query generation
- filtering behavior
- persistence format
- add/delete behavior
- metadata value conversion semantics

So the behavioral change is limited to correcting the returned metadata for search results.
