### PR TITLE
force properties mode for DeepSeek ResponseFormat deserialization

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/ResponseFormat.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/ResponseFormat.java
@@ -18,6 +18,7 @@ package org.springframework.ai.deepseek.api;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -61,7 +62,8 @@ public final class ResponseFormat {
 		this.type = type;
 	}
 
-	private ResponseFormat(Type type) {
+	@JsonCreator
+	public ResponseFormat(@JsonProperty("type") Type type) {
 		this.type = type;
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-client-boot-starter-docs.adoc
@@ -499,7 +499,7 @@ Clients can control logging verbosity by setting minimum log levels
 
 ==== Client Customization Example
 
-You can implement `McpCustomizer<McpClient.SyncSpec>` for synchronous clients or `McpCustomizer<McpClient.AsyncSpec>` for asynchronous clients, depending on your application's needs.
+You can implement `McpClientCustomizer<McpClient.SyncSpec>` for synchronous clients or `McpClientCustomizer<McpClient.AsyncSpec>` for asynchronous clients, depending on your application's needs.
 
 [tabs]
 ======
@@ -567,7 +567,7 @@ Async::
 [source,java]
 ----
 @Component
-public class CustomMcpAsyncClientCustomizer implements McpCustomizer<McpClient.AsyncSpec> {
+public class CustomMcpAsyncClientCustomizer implements McpClientCustomizer<McpClient.AsyncSpec> {
     @Override
     public void customize(String serverConfigurationName, McpClient.AsyncSpec spec) {
         // Customize the async client configuration


### PR DESCRIPTION
Fixes a deserialization error in DeepSeekChatOptions where Jackson fails to map the response_format object to its single-parameter constructor. Forced PROPERTIES mode to ensure correct field binding.
error:
```
Exception in thread "main" tools.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `org.springframework.ai.deepseek.api.ResponseFormat` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); byte offset: #UNKNOWN] (through reference chain: org.springframework.ai.deepseek.DeepSeekChatOptions["response_format"])
```