### PR TITLE
GH-5633: Apply ArraySchema constraints to method input schema

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -35,6 +35,7 @@ import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import com.github.victools.jsonschema.module.jackson.JacksonSchemaModule;
 import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
@@ -147,6 +148,7 @@ public final class JsonSchemaGenerator {
 			if (StringUtils.hasText(parameterDescription)) {
 				parameterNode.put("description", parameterDescription);
 			}
+			applyMethodParameterAnnotations(parameterNode, method.getParameters()[i]);
 			properties.set(parameterName, parameterNode);
 		}
 
@@ -254,6 +256,25 @@ public final class JsonSchemaGenerator {
 		}
 
 		return null;
+	}
+
+	private static void applyMethodParameterAnnotations(ObjectNode parameterNode, Parameter parameter) {
+		var arraySchemaAnnotation = parameter.getAnnotation(ArraySchema.class);
+		if (arraySchemaAnnotation != null) {
+			applyArraySchemaAnnotation(parameterNode, arraySchemaAnnotation);
+		}
+	}
+
+	private static void applyArraySchemaAnnotation(ObjectNode parameterNode, ArraySchema arraySchemaAnnotation) {
+		if (arraySchemaAnnotation.minItems() != Integer.MAX_VALUE) {
+			parameterNode.put("minItems", arraySchemaAnnotation.minItems());
+		}
+		if (arraySchemaAnnotation.maxItems() != Integer.MIN_VALUE) {
+			parameterNode.put("maxItems", arraySchemaAnnotation.maxItems());
+		}
+		if (arraySchemaAnnotation.uniqueItems()) {
+			parameterNode.put("uniqueItems", true);
+		}
 	}
 
 	// Based on the method in ModelOptionsUtils.

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -332,6 +333,20 @@ class JsonSchemaGeneratorTests {
 				""";
 
 		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithArraySchemaAnnotations() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("arraySchemaMethod", List.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.getJsonMapper().readTree(schema);
+
+		assertThat(schemaNode.at("/properties/buildIds/type").asText()).isEqualTo("array");
+		assertThat(schemaNode.at("/properties/buildIds/items/type").asText()).isEqualTo("string");
+		assertThat(schemaNode.at("/properties/buildIds/minItems").intValue()).isEqualTo(1);
+		assertThat(schemaNode.at("/properties/buildIds/maxItems").intValue()).isEqualTo(50);
+		assertThat(schemaNode.at("/required/0").asText()).isEqualTo("buildIds");
 	}
 
 	@Test
@@ -731,6 +746,10 @@ class JsonSchemaGeneratorTests {
 		}
 
 		public void complexMethod(List<String> items, TestData data, MoreTestData moreData) {
+		}
+
+		public void arraySchemaMethod(@ToolParam(description = "List of build identifiers") @ArraySchema(minItems = 1,
+				maxItems = 50) List<String> buildIds) {
 		}
 
 		public void timeMethod(Duration duration, LocalDateTime localDateTime, Instant instant) {


### PR DESCRIPTION
Fixes GH-5633 (https://github.com/spring-projects/spring-ai/issues/5633)

When generating JSON Schema for method input parameters, Spring AI was applying
parameter descriptions and required flags, but it was not propagating parameter-level
`@ArraySchema` constraints such as `minItems`, `maxItems`, and `uniqueItems`.

This change applies `@ArraySchema` metadata to generated method parameter schemas.

Changes:
- apply `@ArraySchema(minItems, maxItems, uniqueItems)` to method input parameter schemas
- add regression coverage for `List<String>` parameters annotated with `@ArraySchema`

Tests:
- `./mvnw -pl spring-ai-model -Dtest=JsonSchemaGeneratorTests#generateSchemaForMethodWithArraySchemaAnnotations test`
- `./mvnw -pl spring-ai-model -Dtest=JsonSchemaGeneratorTests test`