### PR TITLE
GH-5642: Add thinking display setting support to Anthropic module

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -718,10 +718,32 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		}
 
 		/**
+		 * Convenience method to enable thinking with a specific budget and display
+		 * setting.
+		 * @param budgetTokens the thinking budget (must be >= 1024 and < maxTokens)
+		 * @param display controls how thinking content appears in the response
+		 * (SUMMARIZED or OMITTED)
+		 */
+		public B thinkingEnabled(long budgetTokens, ThinkingConfigEnabled.Display display) {
+			return thinking(ThinkingConfigParam
+				.ofEnabled(ThinkingConfigEnabled.builder().budgetTokens(budgetTokens).display(display).build()));
+		}
+
+		/**
 		 * Convenience method to let Claude adaptively decide whether to think.
 		 */
 		public B thinkingAdaptive() {
 			return thinking(ThinkingConfigParam.ofAdaptive(ThinkingConfigAdaptive.builder().build()));
+		}
+
+		/**
+		 * Convenience method to let Claude adaptively decide whether to think, with a
+		 * display setting.
+		 * @param display controls how thinking content appears in the response
+		 * (SUMMARIZED or OMITTED)
+		 */
+		public B thinkingAdaptive(ThinkingConfigAdaptive.Display display) {
+			return thinking(ThinkingConfigParam.ofAdaptive(ThinkingConfigAdaptive.builder().display(display).build()));
 		}
 
 		/**

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -28,6 +28,9 @@ import com.anthropic.models.messages.JsonOutputFormat;
 import com.anthropic.models.messages.Metadata;
 import com.anthropic.models.messages.Model;
 import com.anthropic.models.messages.OutputConfig;
+import com.anthropic.models.messages.ThinkingConfigAdaptive;
+import com.anthropic.models.messages.ThinkingConfigEnabled;
+import com.anthropic.models.messages.ThinkingConfigParam;
 import com.anthropic.models.messages.ToolChoice;
 import com.anthropic.models.messages.ToolChoiceAuto;
 import org.junit.jupiter.api.Test;
@@ -566,6 +569,105 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 		AnthropicChatOptions noOverride = AnthropicChatOptions.builder().build();
 		AnthropicChatOptions merged2 = base.mutate().combineWith(noOverride.mutate()).build();
 		assertThat(merged2.getInferenceGeo()).isEqualTo("us");
+	}
+
+	@Test
+	void testThinkingEnabledWithDisplay() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.thinkingEnabled(2048, ThinkingConfigEnabled.Display.SUMMARIZED)
+			.maxTokens(16384)
+			.build();
+
+		assertThat(options.getThinking()).isNotNull();
+		ThinkingConfigParam thinking = options.getThinking();
+		ThinkingConfigEnabled enabled = thinking.enabled().get();
+		assertThat(enabled.budgetTokens()).isEqualTo(2048);
+		assertThat(enabled.display()).isPresent();
+		assertThat(enabled.display().get()).isEqualTo(ThinkingConfigEnabled.Display.SUMMARIZED);
+	}
+
+	@Test
+	void testThinkingEnabledWithOmittedDisplay() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.thinkingEnabled(4096, ThinkingConfigEnabled.Display.OMITTED)
+			.maxTokens(16384)
+			.build();
+
+		ThinkingConfigEnabled enabled = options.getThinking().enabled().get();
+		assertThat(enabled.display()).isPresent();
+		assertThat(enabled.display().get()).isEqualTo(ThinkingConfigEnabled.Display.OMITTED);
+	}
+
+	@Test
+	void testThinkingEnabledWithoutDisplayHasNoDisplay() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().thinkingEnabled(2048).maxTokens(16384).build();
+
+		ThinkingConfigEnabled enabled = options.getThinking().enabled().get();
+		assertThat(enabled.display()).isEmpty();
+	}
+
+	@Test
+	void testThinkingAdaptiveWithDisplay() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.thinkingAdaptive(ThinkingConfigAdaptive.Display.SUMMARIZED)
+			.maxTokens(16384)
+			.build();
+
+		assertThat(options.getThinking()).isNotNull();
+		ThinkingConfigAdaptive adaptive = options.getThinking().adaptive().get();
+		assertThat(adaptive.display()).isPresent();
+		assertThat(adaptive.display().get()).isEqualTo(ThinkingConfigAdaptive.Display.SUMMARIZED);
+	}
+
+	@Test
+	void testThinkingAdaptiveWithOmittedDisplay() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder()
+			.thinkingAdaptive(ThinkingConfigAdaptive.Display.OMITTED)
+			.maxTokens(16384)
+			.build();
+
+		ThinkingConfigAdaptive adaptive = options.getThinking().adaptive().get();
+		assertThat(adaptive.display()).isPresent();
+		assertThat(adaptive.display().get()).isEqualTo(ThinkingConfigAdaptive.Display.OMITTED);
+	}
+
+	@Test
+	void testThinkingAdaptiveWithoutDisplayHasNoDisplay() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().thinkingAdaptive().maxTokens(16384).build();
+
+		ThinkingConfigAdaptive adaptive = options.getThinking().adaptive().get();
+		assertThat(adaptive.display()).isEmpty();
+	}
+
+	@Test
+	void testThinkingDisplayPreservedInMutate() {
+		AnthropicChatOptions original = AnthropicChatOptions.builder()
+			.thinkingEnabled(2048, ThinkingConfigEnabled.Display.SUMMARIZED)
+			.maxTokens(16384)
+			.build();
+
+		AnthropicChatOptions copied = original.mutate().build();
+
+		ThinkingConfigEnabled enabled = copied.getThinking().enabled().get();
+		assertThat(enabled.budgetTokens()).isEqualTo(2048);
+		assertThat(enabled.display()).isPresent();
+		assertThat(enabled.display().get()).isEqualTo(ThinkingConfigEnabled.Display.SUMMARIZED);
+	}
+
+	@Test
+	void testThinkingDisplayPreservedInCombineWith() {
+		AnthropicChatOptions base = AnthropicChatOptions.builder().model("base-model").maxTokens(16384).build();
+
+		AnthropicChatOptions override = AnthropicChatOptions.builder()
+			.thinkingAdaptive(ThinkingConfigAdaptive.Display.OMITTED)
+			.build();
+
+		AnthropicChatOptions merged = base.mutate().combineWith(override.mutate()).build();
+
+		assertThat(merged.getModel()).isEqualTo("base-model");
+		ThinkingConfigAdaptive adaptive = merged.getThinking().adaptive().get();
+		assertThat(adaptive.display()).isPresent();
+		assertThat(adaptive.display().get()).isEqualTo(ThinkingConfigAdaptive.Display.OMITTED);
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -178,7 +178,7 @@ ChatResponse response = chatModel.call(
 | proxy | Proxy settings for the HTTP client. | -
 | customHeaders | Custom HTTP headers to include on all requests (client-level). | -
 | httpHeaders | Per-request HTTP headers. These are added to individual API calls via `MessageCreateParams.putAdditionalHeader()`. Useful for request-level tracking, beta API headers, or routing. | -
-| thinking | Thinking configuration. Use the convenience builders `thinkingEnabled(budgetTokens)`, `thinkingAdaptive()`, or `thinkingDisabled()`, or pass a raw `ThinkingConfigParam`. | -
+| thinking | Thinking configuration. Use the convenience builders `thinkingEnabled(budgetTokens)`, `thinkingEnabled(budgetTokens, display)`, `thinkingAdaptive()`, `thinkingAdaptive(display)`, or `thinkingDisabled()`, or pass a raw `ThinkingConfigParam`. The `display` parameter controls how thinking content appears in the response: `SUMMARIZED` (condensed summary) or `OMITTED` (redacted, signature only). | -
 | outputConfig | Output configuration for structured output (JSON schema) and effort control. Use `outputConfig(OutputConfig)` for full control, or the convenience methods `outputSchema(String)` and `effort(OutputConfig.Effort)`. Requires `claude-sonnet-4-6` or newer. | -
 | inferenceGeo | Controls the geographic region where the request is processed. Supported values: `us`, `eu`. Used for data residency compliance. Configurable via `spring.ai.anthropic.chat.options.inference-geo`. | -
 |====
@@ -330,7 +330,7 @@ To enable thinking, configure the following:
 
 === Convenience Builder Methods
 
-`AnthropicChatOptions.Builder` provides convenience methods for the three thinking modes:
+`AnthropicChatOptions.Builder` provides convenience methods for thinking configuration:
 
 [source,java]
 ----
@@ -367,6 +367,45 @@ var options = AnthropicChatOptions.builder()
         ThinkingConfigEnabled.builder().budgetTokens(10000L).build()))
     .build();
 ----
+
+=== Thinking Display Setting
+
+By default, full thinking output is returned in the response. You can control this with the `display` parameter to reduce token costs:
+
+* **`SUMMARIZED`** — Claude still thinks fully, but returns a condensed summary instead of the raw chain-of-thought. Reduces output tokens while still providing insight into the reasoning.
+* **`OMITTED`** — Thinking is performed but completely redacted from the response. Only a cryptographic signature is returned (needed for multi-turn continuity). Lowest output token cost.
+
+[source,java]
+----
+import com.anthropic.models.messages.ThinkingConfigEnabled;
+import com.anthropic.models.messages.ThinkingConfigAdaptive;
+
+// Enabled thinking with summarized display
+var options = AnthropicChatOptions.builder()
+    .model("claude-sonnet-4-20250514")
+    .temperature(1.0)
+    .maxTokens(16000)
+    .thinkingEnabled(10000L, ThinkingConfigEnabled.Display.SUMMARIZED)
+    .build();
+
+// Enabled thinking with omitted display
+var options = AnthropicChatOptions.builder()
+    .model("claude-sonnet-4-20250514")
+    .temperature(1.0)
+    .maxTokens(16000)
+    .thinkingEnabled(10000L, ThinkingConfigEnabled.Display.OMITTED)
+    .build();
+
+// Adaptive thinking with summarized display
+var options = AnthropicChatOptions.builder()
+    .model("claude-sonnet-4-20250514")
+    .temperature(1.0)
+    .maxTokens(16000)
+    .thinkingAdaptive(ThinkingConfigAdaptive.Display.SUMMARIZED)
+    .build();
+----
+
+NOTE: The display setting does not affect the quality of the final answer — Claude performs the same amount of thinking regardless. It only controls what thinking content is returned in the response.
 
 === Non-streaming Example
 


### PR DESCRIPTION
Add convenience builder methods for controlling how Claude models' thinking content appears in responses: thinkingEnabled(budgetTokens, display) and thinkingAdaptive(display) with Display.SUMMARIZED and Display.OMITTED.

Update ref docs with new Thinking Display Setting section.

Fixes: https://github.com/spring-projects/spring-ai/issues/5642