### PR TITLE
GH-5623: Prefer Redis chat memory auto-configuration

### DIFF
--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/pom.xml
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/pom.xml
@@ -59,6 +59,13 @@
 
 		<!-- Test dependencies -->
 		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/main/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.ai.model.chat.memory.redis.autoconfigure;
 
 import redis.clients.jedis.JedisPooled;
 
-import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.memory.repository.redis.RedisChatMemoryRepository;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -34,7 +33,9 @@ import org.springframework.util.StringUtils;
  *
  * @author Brian Sam-Bodden
  */
-@AutoConfiguration(after = DataRedisAutoConfiguration.class)
+// Ordering is to make sure ChatMemoryRepository bean is redis one
+@AutoConfiguration(after = DataRedisAutoConfiguration.class,
+		beforeName = "org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration")
 @ConditionalOnClass({ RedisChatMemoryRepository.class, JedisPooled.class })
 @EnableConfigurationProperties(RedisChatMemoryProperties.class)
 public class RedisChatMemoryAutoConfiguration {
@@ -46,7 +47,7 @@ public class RedisChatMemoryAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean({ RedisChatMemoryRepository.class, ChatMemory.class, ChatMemoryRepository.class })
+	@ConditionalOnMissingBean(ChatMemoryRepository.class)
 	public RedisChatMemoryRepository redisChatMemory(JedisPooled jedisClient, RedisChatMemoryProperties properties) {
 		RedisChatMemoryRepository.Builder builder = RedisChatMemoryRepository.builder().jedisClient(jedisClient);
 

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/test/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfigurationIT.java
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/src/test/java/org/springframework/ai/model/chat/memory/redis/autoconfigure/RedisChatMemoryAutoConfigurationIT.java
@@ -16,46 +16,26 @@
 
 package org.springframework.ai.model.chat.memory.redis.autoconfigure;
 
-import com.redis.testcontainers.RedisStackContainer;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
+import redis.clients.jedis.JedisPooled;
 
 import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.repository.redis.RedisChatMemoryRepository;
+import org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
-@Testcontainers
 class RedisChatMemoryAutoConfigurationIT {
-
-	private static final Logger logger = LoggerFactory.getLogger(RedisChatMemoryAutoConfigurationIT.class);
-
-	@Container
-	static RedisStackContainer redisContainer = new RedisStackContainer(
-			RedisStackContainer.DEFAULT_IMAGE_NAME.withTag(RedisStackContainer.DEFAULT_TAG))
-		.withExposedPorts(6379);
-
-	@BeforeAll
-	static void setup() {
-		logger.info("Redis container running on host: {} and port: {}", redisContainer.getHost(),
-				redisContainer.getFirstMappedPort());
-	}
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(
-				AutoConfigurations.of(RedisChatMemoryAutoConfiguration.class, DataRedisAutoConfiguration.class))
-		.withPropertyValues("spring.data.redis.host=" + redisContainer.getHost(),
-				"spring.data.redis.port=" + redisContainer.getFirstMappedPort(),
-				// Pass the same Redis connection properties to our chat memory properties
-				"spring.ai.chat.memory.redis.host=" + redisContainer.getHost(),
-				"spring.ai.chat.memory.redis.port=" + redisContainer.getFirstMappedPort());
+				AutoConfigurations.of(ChatMemoryAutoConfiguration.class, RedisChatMemoryAutoConfiguration.class))
+		.withBean(JedisPooled.class, () -> mock(JedisPooled.class))
+		.withPropertyValues("spring.ai.chat.memory.redis.initialize-schema=false");
 
 	@Test
 	void autoConfigurationRegistersExpectedBeans() {
@@ -84,6 +64,7 @@ class RedisChatMemoryAutoConfigurationIT {
 			ChatMemoryRepository repository = context.getBean(ChatMemoryRepository.class);
 
 			assertThat(repository).isSameAs(redisChatMemory);
+			assertThat(repository).isNotInstanceOf(InMemoryChatMemoryRepository.class);
 		});
 	}
 


### PR DESCRIPTION
Fixes GH-5623 (https://github.com/spring-projects/spring-ai/issues/5623)

When `spring-ai-starter-model-chat-memory-repository-redis` is used together with the
default chat memory auto-configuration, the Redis repository can be skipped and the
application falls back to `InMemoryChatMemoryRepository`.

This change makes the Redis auto-configuration run before the default fallback and
creates the Redis repository only when no `ChatMemoryRepository` bean is already defined.

Changes:
- order `RedisChatMemoryAutoConfiguration` before the default chat memory auto-configuration
- narrow the missing-bean condition to `ChatMemoryRepository`
- add regression coverage for the auto-configuration interaction

Tests:
- `./mvnw -pl auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis -Dtest=RedisChatMemoryAutoConfigurationIT test`
