### PR TITLE
Fix missing fallback in JsonParser.toTypedObject for String values

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
@@ -176,7 +176,7 @@ public final class JsonParser {
 			try {
 				result = JsonParser.fromJson(jsonString, javaType);
 			}
-			catch (JacksonException e) {
+			catch (Exception e) {
 				// ignore
 			}
 		}


### PR DESCRIPTION
JsonParser.toTypedObject() tries fromJson() first and should fallback to toJson(value) if it fails.

But fromJson() throws IllegalStateException, while only JacksonException is caught,
so fallback is never executed for plain String values (e.g. "2026-01-01").

Was this intentional?