### PR TITLE
Add Eclipse jdtls .factorypath to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target
 .classpath
 .project
 .settings
+.factorypath
 .env
 bin
 build.log


### PR DESCRIPTION
This is needed due to the Eclipse JDT Language Server. When using Claude Code with https://claude.com/plugins/jdtls-lsp the Eclipse jdtls creates `.factorypath` files in every module.

