### PR TITLE
Fix `AzureOpenAiChatOptions#stop` field initializer regression

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptions.java
@@ -169,7 +169,7 @@ public class AzureOpenAiChatOptions implements ToolCallingChatOptions {
 	 * A collection of textual sequences that will end completions generation.
 	 */
 	@JsonProperty("stop")
-	private List<String> stop = new ArrayList<>();
+	private List<String> stop;
 
 	/**
 	 * A value that influences the probability of generated tokens appearing based on

--- a/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptionsTests.java
+++ b/models/spring-ai-azure-openai/src/test/java/org/springframework/ai/azure/openai/AzureOpenAiChatOptionsTests.java
@@ -24,6 +24,7 @@ import com.azure.ai.openai.models.AzureChatGroundingEnhancementConfiguration;
 import com.azure.ai.openai.models.AzureChatOCREnhancementConfiguration;
 import com.azure.ai.openai.models.ChatCompletionStreamOptions;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.model.ModelOptionsUtils;
 
 import org.springframework.ai.azure.openai.AzureOpenAiChatOptions.Builder;
 import org.springframework.ai.test.options.AbstractChatOptionsTests;
@@ -406,6 +407,20 @@ class AzureOpenAiChatOptionsTests extends AbstractChatOptionsTests<AzureOpenAiCh
 
 		assertThat(optionsWithMaxCompletionTokens.getMaxTokens()).isNull();
 		assertThat(optionsWithMaxCompletionTokens.getMaxCompletionTokens()).isEqualTo(300);
+	}
+
+	@Test
+	void stopFieldShouldBeNullAfterJacksonRoundtrip() {
+		// Create options where stop is null (via builder)
+		var options = AzureOpenAiChatOptions.builder().deploymentName("gpt-4o").build();
+		assertThat(options.getStop()).isNull();
+
+		// ModelOptionsUtils.merge() uses Jackson roundtrip internally
+		var source = AzureOpenAiChatOptions.builder().temperature(0.7).build();
+		var merged = ModelOptionsUtils.merge(source, options, AzureOpenAiChatOptions.class);
+
+		// Should be null, not []
+		assertThat(merged.getStop()).isNull();
 	}
 
 }


### PR DESCRIPTION
This PR fixes a regression where the `stop` field in `AzureOpenAiChatOptions` was initialized to an empty `ArrayList`. This caused the JSON payload to always include `"stop": []`, which is rejected by Azure OpenAI reasoning models (e.g., o1, o3).

### Changes:
- Removed the default initialization of the `stop` field.
- Added a regression test in `AzureOpenAiChatOptionsTests` to ensure the `stop` field remains `null` after options merging and Jackson roundtrips.

**Fixes #5656**