### PR TITLE
Add Anthropic inference geo support for geographic data residency con…

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -845,6 +845,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		if (requestOptions.getThinking() != null) {
 			builder.thinking(requestOptions.getThinking());
 		}
+		if (requestOptions.getInferenceGeo() != null) {
+			builder.inferenceGeo(requestOptions.getInferenceGeo());
+		}
 
 		// Add output configuration if specified (structured output / effort)
 		if (requestOptions.getOutputConfig() != null) {

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -187,6 +187,12 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 	@JsonIgnore
 	private @Nullable AnthropicSkillContainer skillContainer;
 
+	/**
+	 * Controls the geographic region for inference processing. Supported values: "us",
+	 * "eu". Used for data residency compliance.
+	 */
+	private @Nullable String inferenceGeo;
+
 	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
 
 	/**
@@ -384,6 +390,14 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		this.skillContainer = skillContainer;
 	}
 
+	public @Nullable String getInferenceGeo() {
+		return this.inferenceGeo;
+	}
+
+	public void setInferenceGeo(@Nullable String inferenceGeo) {
+		this.inferenceGeo = inferenceGeo;
+	}
+
 	@Override
 	@JsonIgnore
 	public @Nullable String getOutputSchema() {
@@ -518,7 +532,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			.cacheOptions(this.getCacheOptions())
 			.outputConfig(this.outputConfig)
 			.httpHeaders(this.getHttpHeaders())
-			.skillContainer(this.getSkillContainer());
+			.skillContainer(this.getSkillContainer())
+			.inferenceGeo(this.inferenceGeo);
 	}
 
 	@Override
@@ -544,7 +559,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				&& Objects.equals(this.cacheOptions, that.cacheOptions)
 				&& Objects.equals(this.outputConfig, that.outputConfig)
 				&& Objects.equals(this.httpHeaders, that.httpHeaders)
-				&& Objects.equals(this.skillContainer, that.skillContainer);
+				&& Objects.equals(this.skillContainer, that.skillContainer)
+				&& Objects.equals(this.inferenceGeo, that.inferenceGeo);
 	}
 
 	@Override
@@ -552,7 +568,7 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		return Objects.hash(this.getModel(), this.maxTokens, this.metadata, this.stopSequences, this.temperature,
 				this.topP, this.topK, this.toolChoice, this.thinking, this.disableParallelToolUse, this.toolCallbacks,
 				this.toolNames, this.internalToolExecutionEnabled, this.toolContext, this.citationDocuments,
-				this.cacheOptions, this.outputConfig, this.httpHeaders, this.skillContainer);
+				this.cacheOptions, this.outputConfig, this.httpHeaders, this.skillContainer, this.inferenceGeo);
 	}
 
 	@Override
@@ -565,7 +581,7 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				+ ", internalToolExecutionEnabled=" + this.internalToolExecutionEnabled + ", toolContext="
 				+ this.toolContext + ", citationDocuments=" + this.citationDocuments + ", cacheOptions="
 				+ this.cacheOptions + ", outputConfig=" + this.outputConfig + ", httpHeaders=" + this.httpHeaders
-				+ ", skillContainer=" + this.skillContainer + '}';
+				+ ", skillContainer=" + this.skillContainer + ", inferenceGeo=" + this.inferenceGeo + '}';
 	}
 
 	/**
@@ -611,6 +627,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		private Map<String, String> httpHeaders = new HashMap<>();
 
 		private @Nullable AnthropicSkillContainer skillContainer;
+
+		private @Nullable String inferenceGeo;
 
 		@Override
 		public B outputSchema(@Nullable String outputSchema) {
@@ -833,6 +851,16 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			return self();
 		}
 
+		/**
+		 * Sets the geographic region for inference processing.
+		 * @param inferenceGeo the region identifier ("us" or "eu")
+		 * @return this builder
+		 */
+		public B inferenceGeo(@Nullable String inferenceGeo) {
+			this.inferenceGeo = inferenceGeo;
+			return self();
+		}
+
 		@Override
 		public B combineWith(ChatOptions.Builder<?> other) {
 			super.combineWith(other);
@@ -882,6 +910,9 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				if (options.skillContainer != null) {
 					this.skillContainer = options.skillContainer;
 				}
+				if (options.inferenceGeo != null) {
+					this.inferenceGeo = options.inferenceGeo;
+				}
 			}
 			return self();
 		}
@@ -919,6 +950,7 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			options.outputConfig = this.outputConfig;
 			options.httpHeaders = this.httpHeaders;
 			options.skillContainer = this.skillContainer;
+			options.inferenceGeo = this.inferenceGeo;
 			options.validateCitationConsistency();
 			return options;
 		}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -541,4 +541,31 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 		assertThat(options.getSkillContainer()).isNull();
 	}
 
+	@Test
+	void testInferenceGeoBuilder() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().inferenceGeo("eu").build();
+		assertThat(options.getInferenceGeo()).isEqualTo("eu");
+	}
+
+	@Test
+	void testInferenceGeoPreservedInMutate() {
+		AnthropicChatOptions original = AnthropicChatOptions.builder().inferenceGeo("us").build();
+		AnthropicChatOptions copied = original.mutate().build();
+		assertThat(copied.getInferenceGeo()).isEqualTo("us");
+	}
+
+	@Test
+	void testInferenceGeoCombineWith() {
+		AnthropicChatOptions base = AnthropicChatOptions.builder().inferenceGeo("us").build();
+		AnthropicChatOptions override = AnthropicChatOptions.builder().inferenceGeo("eu").build();
+
+		AnthropicChatOptions merged = base.mutate().combineWith(override.mutate()).build();
+		assertThat(merged.getInferenceGeo()).isEqualTo("eu");
+
+		// Null doesn't override
+		AnthropicChatOptions noOverride = AnthropicChatOptions.builder().build();
+		AnthropicChatOptions merged2 = base.mutate().combineWith(noOverride.mutate()).build();
+		assertThat(merged2.getInferenceGeo()).isEqualTo("us");
+	}
+
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -180,6 +180,7 @@ ChatResponse response = chatModel.call(
 | httpHeaders | Per-request HTTP headers. These are added to individual API calls via `MessageCreateParams.putAdditionalHeader()`. Useful for request-level tracking, beta API headers, or routing. | -
 | thinking | Thinking configuration. Use the convenience builders `thinkingEnabled(budgetTokens)`, `thinkingAdaptive()`, or `thinkingDisabled()`, or pass a raw `ThinkingConfigParam`. | -
 | outputConfig | Output configuration for structured output (JSON schema) and effort control. Use `outputConfig(OutputConfig)` for full control, or the convenience methods `outputSchema(String)` and `effort(OutputConfig.Effort)`. Requires `claude-sonnet-4-6` or newer. | -
+| inferenceGeo | Controls the geographic region where the request is processed. Supported values: `us`, `eu`. Used for data residency compliance. Configurable via `spring.ai.anthropic.chat.options.inference-geo`. | -
 |====
 
 === Tool Calling Options


### PR DESCRIPTION
…trol

Organizations operating under GDPR, data sovereignty, or compliance requirements need to ensure AI inference requests are processed within specific geographic regions. Anthropic's inference geo parameter enables per-request routing to US or EU data centers.

This adds the inferenceGeo option to AnthropicChatOptions, wired through to the SDK's MessageCreateParams builder. The value is kept as a String (not an enum) for forward compatibility as Anthropic adds new regions.

Supports programmatic use via the builder API and Spring Boot auto-configuration via spring.ai.anthropic.chat.options.inference-geo.