### PR TITLE
Add Anthropic service tier support for priority capacity selection

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -848,6 +848,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		if (requestOptions.getInferenceGeo() != null) {
 			builder.inferenceGeo(requestOptions.getInferenceGeo());
 		}
+		if (requestOptions.getServiceTier() != null) {
+			builder.serviceTier(requestOptions.getServiceTier().toSdkServiceTier());
+		}
 
 		// Add output configuration if specified (structured output / effort)
 		if (requestOptions.getOutputConfig() != null) {

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -193,6 +193,13 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 	 */
 	private @Nullable String inferenceGeo;
 
+	/**
+	 * Determines whether to use priority capacity (if available) or standard capacity for
+	 * this request. See <a href="https://docs.claude.com/en/api/service-tiers">Service
+	 * Tiers</a>.
+	 */
+	private @Nullable AnthropicServiceTier serviceTier;
+
 	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
 
 	/**
@@ -398,6 +405,14 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		this.inferenceGeo = inferenceGeo;
 	}
 
+	public @Nullable AnthropicServiceTier getServiceTier() {
+		return this.serviceTier;
+	}
+
+	public void setServiceTier(@Nullable AnthropicServiceTier serviceTier) {
+		this.serviceTier = serviceTier;
+	}
+
 	@Override
 	@JsonIgnore
 	public @Nullable String getOutputSchema() {
@@ -533,7 +548,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			.outputConfig(this.outputConfig)
 			.httpHeaders(this.getHttpHeaders())
 			.skillContainer(this.getSkillContainer())
-			.inferenceGeo(this.inferenceGeo);
+			.inferenceGeo(this.inferenceGeo)
+			.serviceTier(this.serviceTier);
 	}
 
 	@Override
@@ -560,7 +576,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				&& Objects.equals(this.outputConfig, that.outputConfig)
 				&& Objects.equals(this.httpHeaders, that.httpHeaders)
 				&& Objects.equals(this.skillContainer, that.skillContainer)
-				&& Objects.equals(this.inferenceGeo, that.inferenceGeo);
+				&& Objects.equals(this.inferenceGeo, that.inferenceGeo)
+				&& Objects.equals(this.serviceTier, that.serviceTier);
 	}
 
 	@Override
@@ -568,7 +585,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		return Objects.hash(this.getModel(), this.maxTokens, this.metadata, this.stopSequences, this.temperature,
 				this.topP, this.topK, this.toolChoice, this.thinking, this.disableParallelToolUse, this.toolCallbacks,
 				this.toolNames, this.internalToolExecutionEnabled, this.toolContext, this.citationDocuments,
-				this.cacheOptions, this.outputConfig, this.httpHeaders, this.skillContainer, this.inferenceGeo);
+				this.cacheOptions, this.outputConfig, this.httpHeaders, this.skillContainer, this.inferenceGeo,
+				this.serviceTier);
 	}
 
 	@Override
@@ -581,7 +599,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				+ ", internalToolExecutionEnabled=" + this.internalToolExecutionEnabled + ", toolContext="
 				+ this.toolContext + ", citationDocuments=" + this.citationDocuments + ", cacheOptions="
 				+ this.cacheOptions + ", outputConfig=" + this.outputConfig + ", httpHeaders=" + this.httpHeaders
-				+ ", skillContainer=" + this.skillContainer + ", inferenceGeo=" + this.inferenceGeo + '}';
+				+ ", skillContainer=" + this.skillContainer + ", inferenceGeo=" + this.inferenceGeo + ", serviceTier="
+				+ this.serviceTier + '}';
 	}
 
 	/**
@@ -629,6 +648,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		private @Nullable AnthropicSkillContainer skillContainer;
 
 		private @Nullable String inferenceGeo;
+
+		private @Nullable AnthropicServiceTier serviceTier;
 
 		@Override
 		public B outputSchema(@Nullable String outputSchema) {
@@ -794,6 +815,16 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			return self();
 		}
 
+		/**
+		 * Sets the service tier for capacity routing.
+		 * @param serviceTier the service tier (AUTO or STANDARD_ONLY)
+		 * @return this builder
+		 */
+		public B serviceTier(@Nullable AnthropicServiceTier serviceTier) {
+			this.serviceTier = serviceTier;
+			return self();
+		}
+
 		public B skill(String skillIdOrName) {
 			Assert.hasText(skillIdOrName, "Skill ID or name cannot be empty");
 			AnthropicSkill prebuilt = AnthropicSkill.fromId(skillIdOrName);
@@ -913,6 +944,9 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				if (options.inferenceGeo != null) {
 					this.inferenceGeo = options.inferenceGeo;
 				}
+				if (options.serviceTier != null) {
+					this.serviceTier = options.serviceTier;
+				}
 			}
 			return self();
 		}
@@ -951,6 +985,7 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			options.httpHeaders = this.httpHeaders;
 			options.skillContainer = this.skillContainer;
 			options.inferenceGeo = this.inferenceGeo;
+			options.serviceTier = this.serviceTier;
 			options.validateCitationConsistency();
 			return options;
 		}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicServiceTier.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicServiceTier.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import com.anthropic.models.messages.MessageCreateParams;
+
+/**
+ * Service tier for controlling capacity routing on Anthropic API requests.
+ *
+ * @author Soby Chacko
+ * @since 1.0.0
+ * @see <a href="https://docs.claude.com/en/api/service-tiers">Anthropic Service Tiers</a>
+ */
+public enum AnthropicServiceTier {
+
+	/**
+	 * Use priority capacity if available, otherwise fall back to standard capacity.
+	 */
+	AUTO,
+
+	/**
+	 * Always use standard capacity.
+	 */
+	STANDARD_ONLY;
+
+	/**
+	 * Converts this enum to the corresponding SDK {@link MessageCreateParams.ServiceTier}
+	 * value.
+	 * @return the SDK service tier
+	 */
+	public MessageCreateParams.ServiceTier toSdkServiceTier() {
+		return switch (this) {
+			case AUTO -> MessageCreateParams.ServiceTier.AUTO;
+			case STANDARD_ONLY -> MessageCreateParams.ServiceTier.STANDARD_ONLY;
+		};
+	}
+
+}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -568,4 +568,35 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 		assertThat(merged2.getInferenceGeo()).isEqualTo("us");
 	}
 
+	@Test
+	void testServiceTierBuilder() {
+		AnthropicChatOptions options = AnthropicChatOptions.builder().serviceTier(AnthropicServiceTier.AUTO).build();
+		assertThat(options.getServiceTier()).isEqualTo(AnthropicServiceTier.AUTO);
+	}
+
+	@Test
+	void testServiceTierPreservedInMutate() {
+		AnthropicChatOptions original = AnthropicChatOptions.builder()
+			.serviceTier(AnthropicServiceTier.STANDARD_ONLY)
+			.build();
+		AnthropicChatOptions copied = original.mutate().build();
+		assertThat(copied.getServiceTier()).isEqualTo(AnthropicServiceTier.STANDARD_ONLY);
+	}
+
+	@Test
+	void testServiceTierCombineWith() {
+		AnthropicChatOptions base = AnthropicChatOptions.builder()
+			.serviceTier(AnthropicServiceTier.STANDARD_ONLY)
+			.build();
+		AnthropicChatOptions override = AnthropicChatOptions.builder().serviceTier(AnthropicServiceTier.AUTO).build();
+
+		AnthropicChatOptions merged = base.mutate().combineWith(override.mutate()).build();
+		assertThat(merged.getServiceTier()).isEqualTo(AnthropicServiceTier.AUTO);
+
+		// Null doesn't override
+		AnthropicChatOptions noOverride = AnthropicChatOptions.builder().build();
+		AnthropicChatOptions merged2 = base.mutate().combineWith(noOverride.mutate()).build();
+		assertThat(merged2.getServiceTier()).isEqualTo(AnthropicServiceTier.STANDARD_ONLY);
+	}
+
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -60,6 +60,7 @@ Use the `spring.ai.anthropic.*` properties to configure the Anthropic connection
 | `spring.ai.anthropic.chat.options.temperature` | Sampling temperature | -
 | `spring.ai.anthropic.chat.options.top-p` | Top-p sampling | -
 | `spring.ai.anthropic.chat.options.top-k` | Top-k sampling | -
+| `spring.ai.anthropic.chat.options.service-tier` | Capacity routing: `auto` (use priority if available) or `standard_only` (always standard). See https://docs.claude.com/en/api/service-tiers[Service Tiers]. | -
 |====
 
 == Manual Configuration
@@ -181,6 +182,7 @@ ChatResponse response = chatModel.call(
 | thinking | Thinking configuration. Use the convenience builders `thinkingEnabled(budgetTokens)`, `thinkingAdaptive()`, or `thinkingDisabled()`, or pass a raw `ThinkingConfigParam`. | -
 | outputConfig | Output configuration for structured output (JSON schema) and effort control. Use `outputConfig(OutputConfig)` for full control, or the convenience methods `outputSchema(String)` and `effort(OutputConfig.Effort)`. Requires `claude-sonnet-4-6` or newer. | -
 | inferenceGeo | Controls the geographic region where the request is processed. Supported values: `us`, `eu`. Used for data residency compliance. Configurable via `spring.ai.anthropic.chat.options.inference-geo`. | -
+| serviceTier | Controls capacity routing for the request. Use `MessageCreateParams.ServiceTier.AUTO` to opportunistically use priority capacity, or `STANDARD_ONLY` to always use standard capacity. See https://docs.claude.com/en/api/service-tiers[Service Tiers]. | -
 |====
 
 === Tool Calling Options
@@ -1071,6 +1073,28 @@ ChatResponse response = chatModel.call(new Prompt("Tell me about France.", optio
 === StructuredOutputChatOptions Interface
 
 `AnthropicChatOptions` implements the `StructuredOutputChatOptions` interface, which provides portable `getOutputSchema()` and `setOutputSchema(String)` methods. This allows structured output to work with Spring AI's generic structured output infrastructure.
+
+== Service Tier
+
+Anthropic offers different https://docs.claude.com/en/api/service-tiers[service tiers] that control capacity routing for API requests. You can use `AnthropicServiceTier.AUTO` to opportunistically use priority capacity (lower latency) when available, or `STANDARD_ONLY` to always use standard capacity.
+
+Via Spring Boot properties:
+
+[source,properties]
+----
+spring.ai.anthropic.chat.options.service-tier=auto
+----
+
+Or programmatically per-request:
+
+[source,java]
+----
+var options = AnthropicChatOptions.builder()
+    .serviceTier(AnthropicServiceTier.AUTO)
+    .build();
+
+ChatResponse response = chatModel.call(new Prompt("Hello", options));
+----
 
 == Per-Request HTTP Headers
 


### PR DESCRIPTION
Anthropic offers priority and standard capacity tiers for API requests. This adds service tier configuration so users can control whether requests opportunistically use priority capacity (lower latency) or always use standard capacity.

Introduces AnthropicServiceTier as a Java enum rather than exposing the SDK's Kotlin sealed class directly, enabling Spring Boot property binding via spring.ai.anthropic.chat.options.service-tier.