### PR TITLE
Upgraded Google GenAI SDK to 1.44.0 and support search with custom tools in Gemini 3.x models

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -521,6 +521,9 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 			requestOptions.setGoogleSearchRetrieval(ModelOptionsUtils.mergeOption(
 					runtimeOptions.getGoogleSearchRetrieval(), this.defaultOptions.getGoogleSearchRetrieval()));
+			requestOptions.setIncludeServerSideToolInvocations(
+					ModelOptionsUtils.mergeOption(runtimeOptions.getIncludeServerSideToolInvocations(),
+							this.defaultOptions.getIncludeServerSideToolInvocations()));
 			requestOptions.setSafetySettings(ModelOptionsUtils.mergeOption(runtimeOptions.getSafetySettings(),
 					this.defaultOptions.getSafetySettings()));
 			requestOptions
@@ -533,6 +536,8 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			requestOptions.setToolContext(this.defaultOptions.getToolContext());
 
 			requestOptions.setGoogleSearchRetrieval(this.defaultOptions.getGoogleSearchRetrieval());
+			requestOptions
+				.setIncludeServerSideToolInvocations(this.defaultOptions.getIncludeServerSideToolInvocations());
 			requestOptions.setSafetySettings(this.defaultOptions.getSafetySettings());
 			requestOptions.setLabels(this.defaultOptions.getLabels());
 		}
@@ -658,6 +663,32 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			if (!thoughtSignatures.isEmpty()) {
 				messageMetadata.put("thoughtSignatures", thoughtSignatures);
 			}
+
+			// Extract server-side tool invocations if present
+			List<Map<String, Object>> serverSideToolInvocations = new ArrayList<>();
+			for (Part part : parts) {
+				if (part.toolCall().isPresent()) {
+					com.google.genai.types.ToolCall tc = part.toolCall().get();
+					Map<String, Object> inv = new HashMap<>();
+					inv.put("type", "toolCall");
+					inv.put("id", tc.id().orElse(""));
+					inv.put("toolType", tc.toolType().map(Object::toString).orElse(""));
+					inv.put("args", tc.args().orElse(Map.of()));
+					serverSideToolInvocations.add(inv);
+				}
+				if (part.toolResponse().isPresent()) {
+					com.google.genai.types.ToolResponse tr = part.toolResponse().get();
+					Map<String, Object> inv = new HashMap<>();
+					inv.put("type", "toolResponse");
+					inv.put("id", tr.id().orElse(""));
+					inv.put("toolType", tr.toolType().map(Object::toString).orElse(""));
+					inv.put("response", tr.response().orElse(Map.of()));
+					serverSideToolInvocations.add(inv);
+				}
+			}
+			if (!serverSideToolInvocations.isEmpty()) {
+				messageMetadata.put("serverSideToolInvocations", serverSideToolInvocations);
+			}
 		}
 
 		ChatGenerationMetadata chatGenerationMetadata = ChatGenerationMetadata.builder()
@@ -665,7 +696,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			.build();
 
 		boolean isFunctionCall = candidate.content().isPresent() && candidate.content().get().parts().isPresent()
-				&& candidate.content().get().parts().get().stream().allMatch(part -> part.functionCall().isPresent());
+				&& candidate.content().get().parts().get().stream().anyMatch(part -> part.functionCall().isPresent());
 
 		if (isFunctionCall) {
 			List<AssistantMessage.ToolCall> assistantToolCalls = candidate.content()
@@ -691,14 +722,34 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			return List.of(new Generation(assistantMessage, chatGenerationMetadata));
 		}
 		else {
-			return candidate.content().get().parts().orElse(List.of()).stream().map(part -> {
-				var partMessageMetadata = new HashMap<>(messageMetadata);
-				partMessageMetadata.put("isThought", part.thought().orElse(false));
-				return AssistantMessage.builder()
-					.content(part.text().orElse(""))
-					.properties(partMessageMetadata)
+			List<Generation> generations = candidate.content()
+				.get()
+				.parts()
+				.orElse(List.of())
+				.stream()
+				.filter(part -> part.toolCall().isEmpty() && part.toolResponse().isEmpty())
+				.map(part -> {
+					var partMessageMetadata = new HashMap<>(messageMetadata);
+					partMessageMetadata.put("isThought", part.thought().orElse(false));
+					return AssistantMessage.builder()
+						.content(part.text().orElse(""))
+						.properties(partMessageMetadata)
+						.build();
+				})
+				.map(assistantMessage -> new Generation(assistantMessage, chatGenerationMetadata))
+				.toList();
+
+			// If all parts were server-side tool invocations, return a single generation
+			// with empty text but with the server-side tool invocation metadata
+			if (generations.isEmpty()) {
+				AssistantMessage assistantMessage = AssistantMessage.builder()
+					.content("")
+					.properties(messageMetadata)
 					.build();
-			}).map(assistantMessage -> new Generation(assistantMessage, chatGenerationMetadata)).toList();
+				return List.of(new Generation(assistantMessage, chatGenerationMetadata));
+			}
+
+			return generations;
 		}
 	}
 
@@ -821,6 +872,12 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 		if (!CollectionUtils.isEmpty(tools)) {
 			configBuilder.tools(tools);
+		}
+
+		// Build ToolConfig if includeServerSideToolInvocations is enabled
+		if (Boolean.TRUE.equals(requestOptions.getIncludeServerSideToolInvocations())) {
+			configBuilder
+				.toolConfig(com.google.genai.types.ToolConfig.builder().includeServerSideToolInvocations(true));
 		}
 
 		// Handle cached content
@@ -1093,27 +1150,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	public enum ChatModel implements ChatModelDescription {
 
 		/**
-		 * <b>gemini-1.5-pro</b> is recommended to upgrade to <b>gemini-2.0-flash</b>
-		 * <p>
-		 * Discontinuation date: September 24, 2025
-		 * <p>
-		 * See: <a href=
-		 * "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#stable-version">stable-version</a>
-		 */
-		GEMINI_1_5_PRO("gemini-1.5-pro-002"),
-
-		/**
-		 * <b>gemini-1.5-flash</b> is recommended to upgrade to
-		 * <b>gemini-2.0-flash-lite</b>
-		 * <p>
-		 * Discontinuation date: September 24, 2025
-		 * <p>
-		 * See: <a href=
-		 * "https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#stable-version">stable-version</a>
-		 */
-		GEMINI_1_5_FLASH("gemini-1.5-flash-002"),
-
-		/**
 		 * <b>gemini-2.0-flash</b> delivers next-gen features and improved capabilities,
 		 * including superior speed, built-in tool use, multimodal generation, and a 1M
 		 * token context window.
@@ -1196,9 +1232,11 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 		 */
 		GEMINI_2_5_FLASH_LIGHT("gemini-2.5-flash-lite"),
 
-		GEMINI_3_PRO_PREVIEW("gemini-3-pro-preview"),
+		GEMINI_3_PRO_PREVIEW("gemini-3.1-pro-preview"),
 
-		GEMINI_3_FLASH_PREVIEW("gemini-3-flash-preview");
+		GEMINI_3_FLASH_PREVIEW("gemini-3-flash-preview"),
+
+		GEMINI_3_1_FLASH_LITE_PREVIEW("gemini-3.1-flash-lite-preview");
 
 		public final String value;
 

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -205,6 +205,15 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	@JsonIgnore
 	private Boolean googleSearchRetrieval = false;
 
+	/**
+	 * Optional. When true, the API response will include server-side tool calls and
+	 * responses (e.g., Google Search invocations) within Content message parts.
+	 * This allows clients to observe the server's tool invocations without executing them.
+	 * Only supported with MLDev (Google AI) API, not Vertex AI.
+	 */
+	@JsonIgnore
+	private Boolean includeServerSideToolInvocations = false;
+
 	@JsonIgnore
 	private List<GoogleGenAiSafetySetting> safetySettings = new ArrayList<>();
 
@@ -223,7 +232,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			String responseMimeType, String responseSchema, Integer thinkingBudget, Boolean includeThoughts,
 			GoogleGenAiThinkingLevel thinkingLevel, Boolean includeExtendedUsageMetadata, String cachedContentName,
 			Boolean useCachedContent, Integer autoCacheThreshold, Duration autoCacheTtl, Boolean googleSearchRetrieval,
-			List<GoogleGenAiSafetySetting> safetySettings, Map<String, String> labels) {
+			Boolean includeServerSideToolInvocations, List<GoogleGenAiSafetySetting> safetySettings,
+			Map<String, String> labels) {
 		this.model = model;
 		this.frequencyPenalty = frequencyPenalty;
 		this.maxOutputTokens = maxOutputTokens;
@@ -248,6 +258,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		this.autoCacheThreshold = autoCacheThreshold;
 		this.autoCacheTtl = autoCacheTtl;
 		this.googleSearchRetrieval = Boolean.TRUE.equals(googleSearchRetrieval);
+		this.includeServerSideToolInvocations = Boolean.TRUE.equals(includeServerSideToolInvocations);
 		this.safetySettings = safetySettings;
 		this.labels = labels;
 	}
@@ -473,6 +484,14 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		this.googleSearchRetrieval = googleSearchRetrieval;
 	}
 
+	public Boolean getIncludeServerSideToolInvocations() {
+		return this.includeServerSideToolInvocations;
+	}
+
+	public void setIncludeServerSideToolInvocations(Boolean includeServerSideToolInvocations) {
+		this.includeServerSideToolInvocations = includeServerSideToolInvocations;
+	}
+
 	public List<GoogleGenAiSafetySetting> getSafetySettings() {
 		return this.safetySettings;
 	}
@@ -522,6 +541,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			return false;
 		}
 		return Objects.equals(this.googleSearchRetrieval, that.googleSearchRetrieval)
+				&& Objects.equals(this.includeServerSideToolInvocations, that.includeServerSideToolInvocations)
 				&& Objects.equals(this.stopSequences, that.stopSequences)
 				&& Objects.equals(this.temperature, that.temperature) && Objects.equals(this.topP, that.topP)
 				&& Objects.equals(this.topK, that.topK) && Objects.equals(this.candidateCount, that.candidateCount)
@@ -545,8 +565,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		return Objects.hash(this.stopSequences, this.temperature, this.topP, this.topK, this.candidateCount,
 				this.frequencyPenalty, this.presencePenalty, this.thinkingBudget, this.includeThoughts,
 				this.thinkingLevel, this.maxOutputTokens, this.model, this.responseMimeType, this.responseSchema,
-				this.toolCallbacks, this.toolNames, this.googleSearchRetrieval, this.safetySettings,
-				this.internalToolExecutionEnabled, this.toolContext, this.labels);
+				this.toolCallbacks, this.toolNames, this.googleSearchRetrieval, this.includeServerSideToolInvocations,
+				this.safetySettings, this.internalToolExecutionEnabled, this.toolContext, this.labels);
 	}
 
 	@Override
@@ -558,8 +578,9 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 				+ ", candidateCount=" + this.candidateCount + ", maxOutputTokens=" + this.maxOutputTokens + ", model='"
 				+ this.model + '\'' + ", responseMimeType='" + this.responseMimeType + '\'' + ", toolCallbacks="
 				+ this.toolCallbacks + ", toolNames=" + this.toolNames + ", googleSearchRetrieval="
-				+ this.googleSearchRetrieval + ", safetySettings=" + this.safetySettings + ", labels=" + this.labels
-				+ '}';
+				+ this.googleSearchRetrieval + ", includeServerSideToolInvocations="
+				+ this.includeServerSideToolInvocations + ", safetySettings=" + this.safetySettings + ", labels="
+				+ this.labels + '}';
 	}
 
 	@Override
@@ -598,6 +619,7 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			.autoCacheThreshold(this.autoCacheThreshold)
 			.autoCacheTtl(this.autoCacheTtl)
 			.googleSearchRetrieval(this.googleSearchRetrieval)
+			.includeServerSideToolInvocations(this.includeServerSideToolInvocations)
 			.safetySettings(this.safetySettings)
 			.labels(this.labels);
 	}
@@ -642,6 +664,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		protected @Nullable Duration autoCacheTtl;
 
 		protected @Nullable Boolean googleSearchRetrieval;
+
+		protected @Nullable Boolean includeServerSideToolInvocations;
 
 		protected List<GoogleGenAiSafetySetting> safetySettings = new ArrayList<>();
 
@@ -688,6 +712,11 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 
 		public B googleSearchRetrieval(@Nullable Boolean googleSearch) {
 			this.googleSearchRetrieval = googleSearch;
+			return self();
+		}
+
+		public B includeServerSideToolInvocations(@Nullable Boolean includeServerSideToolInvocations) {
+			this.includeServerSideToolInvocations = includeServerSideToolInvocations;
 			return self();
 		}
 
@@ -782,6 +811,9 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 				if (that.googleSearchRetrieval != null) {
 					this.googleSearchRetrieval = that.googleSearchRetrieval;
 				}
+				if (that.includeServerSideToolInvocations != null) {
+					this.includeServerSideToolInvocations = that.includeServerSideToolInvocations;
+				}
 				if (that.safetySettings != null) {
 					this.safetySettings = that.safetySettings;
 				}
@@ -799,8 +831,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 					this.toolCallbacks, this.toolNames, this.toolContext, this.candidateCount, this.responseMimeType,
 					this.responseSchema, this.thinkingBudget, this.includeThoughts, this.thinkingLevel,
 					this.includeExtendedUsageMetadata, this.cachedContentName, this.useCachedContent,
-					this.autoCacheThreshold, this.autoCacheTtl, this.googleSearchRetrieval, this.safetySettings,
-					this.labels);
+					this.autoCacheThreshold, this.autoCacheTtl, this.googleSearchRetrieval,
+					this.includeServerSideToolInvocations, this.safetySettings, this.labels);
 		}
 
 	}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -704,4 +704,73 @@ public class CreateGeminiRequestTests {
 			.hasMessageContaining("not supported");
 	}
 
+	@Test
+	public void createRequestWithIncludeServerSideToolInvocationsEnabled() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.defaultOptions(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.googleSearchRetrieval(true)
+					.includeServerSideToolInvocations(true)
+					.build())));
+
+		assertThat(request.config().toolConfig()).isPresent();
+		assertThat(request.config().toolConfig().get().includeServerSideToolInvocations()).isPresent();
+		assertThat(request.config().toolConfig().get().includeServerSideToolInvocations().get()).isTrue();
+		assertThat(request.config().tools()).isPresent();
+	}
+
+	@Test
+	public void createRequestWithIncludeServerSideToolInvocationsDisabled() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.defaultOptions(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.googleSearchRetrieval(true)
+					.includeServerSideToolInvocations(false)
+					.build())));
+
+		assertThat(request.config().toolConfig()).isNotPresent();
+	}
+
+	@Test
+	public void createRequestWithIncludeServerSideToolInvocationsDefault() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.defaultOptions(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").googleSearchRetrieval(true).build())
+			.build();
+
+		GeminiRequest request = client
+			.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content")));
+
+		// Default is false, so no ToolConfig should be set
+		assertThat(request.config().toolConfig()).isNotPresent();
+	}
+
+	@Test
+	public void createRequestWithIncludeServerSideToolInvocationsRuntimeOverride() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.defaultOptions(GoogleGenAiChatOptions.builder()
+				.model("DEFAULT_MODEL")
+				.includeServerSideToolInvocations(false)
+				.build())
+			.build();
+
+		GeminiRequest request = client.createGeminiRequest(client.buildRequestPrompt(new Prompt("Test message content",
+				GoogleGenAiChatOptions.builder()
+					.googleSearchRetrieval(true)
+					.includeServerSideToolInvocations(true)
+					.build())));
+
+		assertThat(request.config().toolConfig()).isPresent();
+		assertThat(request.config().toolConfig().get().includeServerSideToolInvocations().get()).isTrue();
+	}
+
 }

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelMLDevIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelMLDevIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.google.genai;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.genai.Client;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.google.genai.GoogleGenAiChatModel.ChatModel;
+import org.springframework.ai.google.genai.tool.MockWeatherService;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Google GenAI using MLDev (Google AI) API. These tests require a
+ * GOOGLE_API_KEY environment variable and use vertexAI=false. This is needed for features
+ * like includeServerSideToolInvocations which are MLDev-only.
+ *
+ * @author Dan Dobrin
+ */
+@SpringBootTest
+@EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".*")
+class GoogleGenAiChatModelMLDevIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(GoogleGenAiChatModelMLDevIT.class);
+
+	@Autowired
+	private GoogleGenAiChatModel chatModel;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void googleSearchWithServerSideToolInvocations() {
+		Prompt prompt = new Prompt(
+				new UserMessage("What are the top 3 most famous pirates in history? Use Google Search."),
+				GoogleGenAiChatOptions.builder()
+					.model(ChatModel.GEMINI_2_0_FLASH)
+					.googleSearchRetrieval(true)
+					.includeServerSideToolInvocations(false)
+					.build());
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		logger.info("Response: {}", response.getResult().getOutput().getText());
+
+		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void googleSearchWithServerSideToolInvocationsGemini3x() {
+		Prompt prompt = new Prompt(
+				new UserMessage("What are the top 3 most famous pirates in history? Use Google Search."),
+				GoogleGenAiChatOptions.builder()
+					.model(ChatModel.GEMINI_3_PRO_PREVIEW)
+					.googleSearchRetrieval(true)
+					.includeServerSideToolInvocations(true)
+					.build());
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		logger.info("Response: {}", response.getResult().getOutput().getText());
+
+		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+
+		Map<String, Object> metadata = response.getResult().getOutput().getMetadata();
+		assertThat(metadata).containsKey("serverSideToolInvocations");
+
+		List<Map<String, Object>> invocations = (List<Map<String, Object>>) metadata.get("serverSideToolInvocations");
+		assertThat(invocations).isNotEmpty();
+		assertThat(invocations).anyMatch(inv -> "toolCall".equals(inv.get("type")));
+		assertThat(invocations).anyMatch(inv -> "toolResponse".equals(inv.get("type")));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void functionCallingWithGoogleSearchAndServerSideToolInvocations() {
+		var promptOptions = GoogleGenAiChatOptions.builder()
+			.model(ChatModel.GEMINI_2_5_FLASH)
+			.googleSearchRetrieval(false)
+			.includeServerSideToolInvocations(false)
+			.toolCallbacks(List.of(FunctionToolCallback.builder("get_current_weather", new MockWeatherService())
+				.description("Get the current weather in a given location")
+				.inputType(MockWeatherService.Request.class)
+				.build()))
+			.build();
+
+		Prompt prompt = new Prompt(new UserMessage(
+				"What's the weather like in San Francisco? Return the temperature in Celsius. Also, search online for the latest news about San Francisco."),
+				promptOptions);
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		logger.info("Response: {}", response.getResult().getOutput().getText());
+
+		// Function call should have been executed — weather data should be in response
+		assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("30");
+
+		// Check that server-side tool invocations were captured somewhere in the
+		// conversation. The final response may or may not contain them depending on
+		// whether the model's last turn included Google Search parts.
+		// The primary validation is that the call succeeded without errors,
+		// proving mixed parts (functionCall + toolCall/toolResponse) are handled
+		// correctly.
+		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void functionCallingWithGoogleSearchAndServerSideToolInvocationsGemini3x() {
+		var promptOptions = GoogleGenAiChatOptions.builder()
+			.model(ChatModel.GEMINI_3_FLASH_PREVIEW)
+			.googleSearchRetrieval(true)
+			.includeServerSideToolInvocations(true)
+			.toolCallbacks(List.of(FunctionToolCallback.builder("get_current_weather", new MockWeatherService())
+				.description("Get the current weather in a given location")
+				.inputType(MockWeatherService.Request.class)
+				.build()))
+			.build();
+
+		Prompt prompt = new Prompt(new UserMessage(
+				"What's the weather like in San Francisco? Return the temperature in Celsius. Also, search online for the latest news about San Francisco."),
+				promptOptions);
+
+		ChatResponse response = this.chatModel.call(prompt);
+
+		logger.info("Response: {}", response.getResult().getOutput().getText());
+
+		// Function call should have been executed — weather data should be in response
+		assertThat(response.getResult().getOutput().getText()).containsIgnoringCase("30");
+
+		// Check that server-side tool invocations were captured somewhere in the
+		// conversation. The final response may or may not contain them depending on
+		// whether the model's last turn included Google Search parts.
+		// The primary validation is that the call succeeded without errors,
+		// proving mixed parts (functionCall + toolCall/toolResponse) are handled
+		// correctly.
+		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public Client genAiClient() {
+			String apiKey = System.getenv("GOOGLE_API_KEY");
+			return Client.builder().apiKey(apiKey).build();
+		}
+
+		@Bean
+		public GoogleGenAiChatModel googleGenAiChatModel(Client genAiClient) {
+			return GoogleGenAiChatModel.builder()
+				.genAiClient(genAiClient)
+				.defaultOptions(GoogleGenAiChatOptions.builder()
+					.model(GoogleGenAiChatModel.ChatModel.GEMINI_3_FLASH_PREVIEW)
+					.build())
+				.toolCallingManager(ToolCallingManager.builder().build())
+				.build();
+		}
+
+	}
+
+}

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
@@ -294,4 +294,87 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 		}
 	}
 
+	@Test
+	public void testIncludeServerSideToolInvocationsGetterSetter() {
+		GoogleGenAiChatOptions options = new GoogleGenAiChatOptions();
+
+		assertThat(options.getIncludeServerSideToolInvocations()).isFalse();
+
+		options.setIncludeServerSideToolInvocations(true);
+		assertThat(options.getIncludeServerSideToolInvocations()).isTrue();
+
+		options.setIncludeServerSideToolInvocations(false);
+		assertThat(options.getIncludeServerSideToolInvocations()).isFalse();
+	}
+
+	@Test
+	public void testIncludeServerSideToolInvocationsWithBuilder() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.includeServerSideToolInvocations(true)
+			.build();
+
+		assertThat(options.getModel()).isEqualTo("test-model");
+		assertThat(options.getIncludeServerSideToolInvocations()).isTrue();
+	}
+
+	@Test
+	public void testFromOptionsWithIncludeServerSideToolInvocations() {
+		GoogleGenAiChatOptions original = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.includeServerSideToolInvocations(true)
+			.build();
+
+		GoogleGenAiChatOptions copy = GoogleGenAiChatOptions.fromOptions(original);
+
+		assertThat(copy.getIncludeServerSideToolInvocations()).isTrue();
+		assertThat(copy).isNotSameAs(original);
+	}
+
+	@Test
+	public void testCopyWithIncludeServerSideToolInvocations() {
+		GoogleGenAiChatOptions original = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.includeServerSideToolInvocations(true)
+			.build();
+
+		GoogleGenAiChatOptions copy = original.copy();
+
+		assertThat(copy.getIncludeServerSideToolInvocations()).isTrue();
+		assertThat(copy).isNotSameAs(original);
+	}
+
+	@Test
+	public void testEqualsAndHashCodeWithIncludeServerSideToolInvocations() {
+		GoogleGenAiChatOptions options1 = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.includeServerSideToolInvocations(true)
+			.build();
+
+		GoogleGenAiChatOptions options2 = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.includeServerSideToolInvocations(true)
+			.build();
+
+		GoogleGenAiChatOptions options3 = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.includeServerSideToolInvocations(false)
+			.build();
+
+		assertThat(options1).isEqualTo(options2);
+		assertThat(options1.hashCode()).isEqualTo(options2.hashCode());
+		assertThat(options1).isNotEqualTo(options3);
+	}
+
+	@Test
+	public void testToStringWithIncludeServerSideToolInvocations() {
+		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+			.model("test-model")
+			.includeServerSideToolInvocations(true)
+			.build();
+
+		String toString = options.toString();
+		assertThat(toString).contains("includeServerSideToolInvocations=true");
+	}
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
 		<onnxruntime.version>1.19.2</onnxruntime.version>
 		<oci-sdk-version>3.63.1</oci-sdk-version>
 		<com.google.cloud.version>26.72.0</com.google.cloud.version>
-		<com.google.genai.version>1.42.0</com.google.genai.version>
+		<com.google.genai.version>1.44.0</com.google.genai.version>
 		<ibm.sdk.version>9.20.0</ibm.sdk.version>
 		<jsonschema.version>5.0.0</jsonschema.version>
 		<swagger-annotations.version>2.2.38</swagger-annotations.version>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -108,6 +108,7 @@ The prefix `spring.ai.google.genai.chat` is the property prefix that lets you co
 | spring.ai.google.genai.chat.options.model | Supported https://ai.google.dev/gemini-api/docs/models[Google GenAI Chat models] to use include `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-pro`, and `gemini-1.5-flash`. | gemini-2.0-flash
 | spring.ai.google.genai.chat.options.response-mime-type | Output response mimetype of the generated candidate text. |  `text/plain`: (default) Text output or `application/json`: JSON response.
 | spring.ai.google.genai.chat.options.google-search-retrieval | Use Google search Grounding feature | `true` or `false`, default `false`.
+| spring.ai.google.genai.chat.options.include-server-side-tool-invocations | When true, the API response includes server-side tool calls and responses (e.g., Google Search invocations) in the response metadata, allowing observation of the server's tool usage. Only supported with Gemini Developer API (MLDev), not Vertex AI. See <<server-side-tool-invocations>>. | `false`
 | spring.ai.google.genai.chat.options.temperature | Controls the randomness of the output. Values can range over [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied, while a value closer to 0.0 will typically result in less surprising responses from the generative. | -
 | spring.ai.google.genai.chat.options.top-k | The maximum number of tokens to consider when sampling. The generative uses combined Top-k and nucleus sampling. Top-k sampling considers the set of topK most probable tokens. | -
 | spring.ai.google.genai.chat.options.top-p | The maximum cumulative probability of tokens to consider when sampling. The generative uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least topP.  | -
@@ -196,6 +197,112 @@ String response = ChatClient.create(this.chatModel)
 ----
 
 Find more in xref:api/tools.adoc[Tools] documentation.
+
+== Server-Side Tool Invocations [[server-side-tool-invocations]]
+
+When Google Search or other server-side tools are enabled via `googleSearchRetrieval(true)`, the model executes these tools on the server. By default, these invocations are invisible to the client — you only see the final text response. Setting `includeServerSideToolInvocations(true)` makes the API include the server's tool calls and responses in the response content, allowing you to observe what the model searched for and what results it received.
+
+[IMPORTANT]
+====
+This feature is only supported with the **Gemini Developer API** (MLDev / API key authentication), and models from Gemini 3.x and up. It is **not supported** on Vertex AI.
+====
+
+=== Configuration
+
+Enable via application properties:
+
+[source,application.properties]
+----
+spring.ai.google.genai.chat.options.google-search-retrieval=true
+spring.ai.google.genai.chat.options.include-server-side-tool-invocations=true
+----
+
+Or programmatically at runtime:
+
+[source,java]
+----
+ChatResponse response = chatModel.call(
+    new Prompt(
+        "What are the latest developments in quantum computing?",
+        GoogleGenAiChatOptions.builder()
+            .model("gemini-2.0-flash")
+            .googleSearchRetrieval(true)
+            .includeServerSideToolInvocations(true)
+            .build()
+    ));
+----
+
+=== Accessing Server-Side Tool Invocation Metadata
+
+When enabled, server-side tool invocations are available in the response message metadata under the `serverSideToolInvocations` key:
+
+[source,java]
+----
+ChatResponse response = chatModel.call(prompt);
+
+Map<String, Object> metadata = response.getResult().getOutput().getMetadata();
+
+@SuppressWarnings("unchecked")
+List<Map<String, Object>> invocations =
+    (List<Map<String, Object>>) metadata.get("serverSideToolInvocations");
+
+if (invocations != null) {
+    for (Map<String, Object> invocation : invocations) {
+        String type = (String) invocation.get("type");       // "toolCall" or "toolResponse"
+        String id = (String) invocation.get("id");            // Unique invocation ID
+        String toolType = (String) invocation.get("toolType"); // e.g., "GOOGLE_SEARCH_WEB"
+
+        if ("toolCall".equals(type)) {
+            Map<String, Object> args = (Map<String, Object>) invocation.get("args");
+            // Inspect what the model searched for
+        } else if ("toolResponse".equals(type)) {
+            Map<String, Object> responseData = (Map<String, Object>) invocation.get("response");
+            // Inspect what search results the model received
+        }
+    }
+}
+----
+
+Each entry in the list contains:
+
+[cols="1,3", stripes=even]
+|====
+| Field | Description
+
+| `type` | Either `"toolCall"` (the model's invocation request) or `"toolResponse"` (the server's result)
+| `id` | Unique identifier linking a `toolCall` to its corresponding `toolResponse`
+| `toolType` | The type of server-side tool (e.g., `GOOGLE_SEARCH_WEB`, `GOOGLE_SEARCH_IMAGE`, `URL_CONTEXT`, `GOOGLE_MAPS`)
+| `args` | (toolCall only) The arguments passed to the tool
+| `response` | (toolResponse only) The results returned by the tool
+|====
+
+=== Combined with Function Calling
+
+Server-side tool invocations work alongside client-side function calling. You can enable both Google Search (server-side) and custom functions (client-side) in the same request:
+
+[source,java]
+----
+ChatResponse response = chatModel.call(
+    new Prompt(
+        "What's the weather in San Francisco? Also search for the latest news about the city.",
+        GoogleGenAiChatOptions.builder()
+            .model("gemini-2.0-flash")
+            .googleSearchRetrieval(true)
+            .includeServerSideToolInvocations(true)
+            .toolCallbacks(List.of(
+                FunctionToolCallback.builder("get_current_weather", new WeatherService())
+                    .description("Get the current weather in a given location")
+                    .inputType(WeatherRequest.class)
+                    .build()))
+            .build()
+    ));
+
+// The response contains:
+// - Weather data from the client-side function call (executed locally)
+// - Google Search invocations visible in metadata (executed server-side)
+----
+
+NOTE: Server-side tool invocations are observational only — the client does not execute them. They are surfaced in metadata separately from client-side function calls to avoid interfering with the tool execution loop.
 
 == Thinking Configuration [[thinking-config]]
 


### PR DESCRIPTION
- Upgraded to the latest version of Google GenAI SDK 1.44
- Support configurable Google Search + custom tooling in the same call for Gemini 3.x models
- Removed deprecated Gemini models 1.5