### PR TITLE
GH-1523 Fix outdated Javadoc URL in upgrade notes

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -1426,7 +1426,7 @@ On our march to release 1.0.0 M1 we have made several breaking changes.  Apologi
 
 === ChatClient changes
 
-A major change was made that took the 'old' `ChatClient` and moved the functionality into `ChatModel`.  The 'new' `ChatClient` now takes an instance of `ChatModel`. This was done to support a fluent API for creating and executing prompts in a style similar to other client classes in the Spring ecosystem, such as `RestClient`, `WebClient`, and `JdbcClient`.  Refer to the [JavaDoc](https://docs.spring.io/spring-ai/docs/api) for more information on the Fluent API, proper reference documentation is coming shortly.
+A major change was made that took the 'old' `ChatClient` and moved the functionality into `ChatModel`.  The 'new' `ChatClient` now takes an instance of `ChatModel`. This was done to support a fluent API for creating and executing prompts in a style similar to other client classes in the Spring ecosystem, such as `RestClient`, `WebClient`, and `JdbcClient`. Refer to the [JavaDoc](https://docs.spring.io/spring-ai/docs/current/api/) for more information on the Fluent API, proper reference documentation is coming shortly.
 
 We renamed the 'old' `ModelClient` to `Model` and renamed implementing classes, for example `ImageClient` was renamed to `ImageModel`.  The `Model` implementation represents the portability layer that converts between the Spring AI API and the underlying AI Model API.
 


### PR DESCRIPTION
## Summary

Update the outdated Javadoc URL in the upgrade notes to point to the current Spring AI API documentation.

## Related Issues

Related to #1523

## What Changed

- replaced the broken `https://docs.spring.io/spring-ai/docs/api` link in `spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc`
- updated it to `https://docs.spring.io/spring-ai/docs/current/api/`

## Verification

- verified the old URL returns `404`
- verified the new URL returns `200`

## Build / Checks

I attempted to run:

```bash
./mvnw package
