### PR TITLE
GH-4790: Fix streaming tool call merge for same-ID chunks

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
@@ -99,14 +99,15 @@ public class DeepSeekStreamFunctionCallingHelper {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (StringUtils.hasText(currentToolCall.id())) {
+			if (!StringUtils.hasText(currentToolCall.id())
+					|| (lastPreviousTooCall != null && currentToolCall.id().equals(lastPreviousTooCall.id()))) {
+				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
+			}
+			else {
 				if (lastPreviousTooCall != null) {
 					toolCalls.add(lastPreviousTooCall);
 				}
 				toolCalls.add(currentToolCall);
-			}
-			else {
-				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
 			}
 		}
 		else {

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
@@ -208,6 +208,41 @@ class DeepSeekStreamFunctionCallingHelperTest {
 	}
 
 	@Test
+	void mergeSameIdToolCallChunksShouldMergeProperly() {
+		// Simulate DeepSeek/Qwen streaming pattern: same ID across chunks, name only in
+		// first chunk
+		var func1 = new ChatCompletionFunction("todoList", "");
+		var toolCall1 = new ToolCall("868f7f42", "function", func1);
+		var delta1 = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall1));
+		var choice1 = new ChatCompletionChunk.ChunkChoice(null, 0, delta1, null);
+		var chunk1 = new ChatCompletionChunk("chatcmpl-1", List.of(choice1), 1L, "deepseek", null, null, null, null);
+
+		// Chunk 2: same ID, null name, partial arguments
+		var func2 = new ChatCompletionFunction(null, "{\"page");
+		var toolCall2 = new ToolCall("868f7f42", "function", func2);
+		var delta2 = new ChatCompletionMessage(null, null, null, null, List.of(toolCall2));
+		var choice2 = new ChatCompletionChunk.ChunkChoice(null, 0, delta2, null);
+		var chunk2 = new ChatCompletionChunk("chatcmpl-1", List.of(choice2), 1L, "deepseek", null, null, null, null);
+
+		// Chunk 3: same ID, null name, more arguments
+		var func3 = new ChatCompletionFunction(null, "No\":1}");
+		var toolCall3 = new ToolCall("868f7f42", "function", func3);
+		var delta3 = new ChatCompletionMessage(null, null, null, null, List.of(toolCall3));
+		var choice3 = new ChatCompletionChunk.ChunkChoice(null, 0, delta3, null);
+		var chunk3 = new ChatCompletionChunk("chatcmpl-1", List.of(choice3), 1L, "deepseek", null, null, null, null);
+
+		// Simulate reduce
+		var result = this.helper.merge(this.helper.merge(chunk1, chunk2), chunk3);
+
+		// Should have exactly 1 tool call with correct name and combined arguments
+		var mergedDelta = result.choices().get(0).delta();
+		assertThat(mergedDelta.toolCalls()).hasSize(1);
+		assertThat(mergedDelta.toolCalls().get(0).id()).isEqualTo("868f7f42");
+		assertThat(mergedDelta.toolCalls().get(0).function().name()).isEqualTo("todoList");
+		assertThat(mergedDelta.toolCalls().get(0).function().arguments()).isEqualTo("{\"pageNo\":1}");
+	}
+
+	@Test
 	void mergeWhenCurrentToolCallsIsEmptyListShouldNotThrowException() {
 		// Given
 		ToolCall toolCall = new ToolCall("call_1", "function", new ChatCompletionFunction("func1", "{}"));

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiStreamFunctionCallingHelper.java
@@ -131,14 +131,15 @@ public class MistralAiStreamFunctionCallingHelper {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (currentToolCall.id() != null) {
+			if (currentToolCall.id() == null
+					|| (lastPreviousTooCall != null && currentToolCall.id().equals(lastPreviousTooCall.id()))) {
+				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
+			}
+			else {
 				if (lastPreviousTooCall != null) {
 					toolCalls.add(lastPreviousTooCall);
 				}
 				toolCalls.add(currentToolCall);
-			}
-			else {
-				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
 			}
 		}
 		else {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
@@ -126,14 +126,15 @@ public class OpenAiStreamFunctionCallingHelper {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (StringUtils.hasText(currentToolCall.id())) {
+			if (!StringUtils.hasText(currentToolCall.id())
+					|| (lastPreviousTooCall != null && currentToolCall.id().equals(lastPreviousTooCall.id()))) {
+				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
+			}
+			else {
 				if (lastPreviousTooCall != null) {
 					toolCalls.add(lastPreviousTooCall);
 				}
 				toolCalls.add(currentToolCall);
-			}
-			else {
-				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
 			}
 		}
 		else {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelperTest.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelperTest.java
@@ -314,6 +314,47 @@ public class OpenAiStreamFunctionCallingHelperTest {
 	}
 
 	@Test
+	public void merge_sameIdToolCallChunks_shouldMergeProperly() {
+		// Simulate Qwen streaming pattern: same ID across chunks, name only in first
+		// chunk
+		var func1 = new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction("init_work_status", "");
+		var toolCall1 = new OpenAiApi.ChatCompletionMessage.ToolCall(0, "call_xxx", "function", func1);
+		var delta1 = new OpenAiApi.ChatCompletionMessage(null, OpenAiApi.ChatCompletionMessage.Role.ASSISTANT, null,
+				null, List.of(toolCall1), null, null, null, null);
+		var choice1 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta1, null);
+		var chunk1 = new OpenAiApi.ChatCompletionChunk("chatcmpl-1", List.of(choice1), 1L, "qwen", null, null, null,
+				null);
+
+		// Chunk 2: same ID, empty name, partial arguments
+		var func2 = new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction("", "{\"firstStep");
+		var toolCall2 = new OpenAiApi.ChatCompletionMessage.ToolCall(0, "call_xxx", "function", func2);
+		var delta2 = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall2), null, null, null,
+				null);
+		var choice2 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta2, null);
+		var chunk2 = new OpenAiApi.ChatCompletionChunk("chatcmpl-1", List.of(choice2), 1L, "qwen", null, null, null,
+				null);
+
+		// Chunk 3: empty ID, continuation
+		var func3 = new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction("", "\": \"value\"}");
+		var toolCall3 = new OpenAiApi.ChatCompletionMessage.ToolCall(0, "", "function", func3);
+		var delta3 = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall3), null, null, null,
+				null);
+		var choice3 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta3, null);
+		var chunk3 = new OpenAiApi.ChatCompletionChunk("chatcmpl-1", List.of(choice3), 1L, "qwen", null, null, null,
+				null);
+
+		// Simulate reduce: merge all chunks
+		var initial = new OpenAiApi.ChatCompletionChunk(null, null, null, null, null, null, null, null);
+		var result = this.helper.merge(this.helper.merge(this.helper.merge(initial, chunk1), chunk2), chunk3);
+
+		// Should have exactly 1 tool call with correct name and combined arguments
+		var mergedDelta = result.choices().get(0).delta();
+		assertThat(mergedDelta.toolCalls()).hasSize(1);
+		assertThat(mergedDelta.toolCalls().get(0).function().name()).isEqualTo("init_work_status");
+		assertThat(mergedDelta.toolCalls().get(0).function().arguments()).isEqualTo("{\"firstStep\": \"value\"}");
+	}
+
+	@Test
 	public void edgeCases_emptyStringFields() {
 		var chunk = new OpenAiApi.ChatCompletionChunk("", Collections.emptyList(), 0L, "", "", "", "", null);
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamToolCallMergeTest.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamToolCallMergeTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.api;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionChunk.ChunkChoice;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionFinishReason;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.ChatCompletionFunction;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.Role;
+import org.springframework.ai.openai.api.OpenAiApi.ChatCompletionMessage.ToolCall;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for streaming tool call merging with OpenAI-compatible APIs (Qwen, DeepSeek via
+ * vLLM/OpenRouter) that send the same tool call ID across multiple chunks.
+ *
+ * Reproduces the bug described in
+ * <a href="https://github.com/spring-projects/spring-ai/issues/4790">#4790</a>.
+ *
+ * @author ChoMinGi
+ */
+class OpenAiStreamToolCallMergeTest {
+
+	private final OpenAiStreamFunctionCallingHelper helper = new OpenAiStreamFunctionCallingHelper();
+
+	/**
+	 * Simulates the full OpenAiApi streaming pipeline (windowing + merging) with
+	 * Qwen-style chunks where the same tool call ID is repeated across multiple chunks.
+	 * Before the fix, this would produce multiple ToolCall objects with empty names,
+	 * causing "toolName cannot be null or empty" in DefaultToolCallingManager.
+	 */
+	@Test
+	void streamingPipeline_qwenSameIdToolCallChunks_shouldProduceSingleMergedToolCall() {
+		// Qwen streaming pattern from issue #4790:
+		// Chunk 1: id + name + empty args
+		// Chunk 2: same id + empty name + partial args
+		// Chunk 3-N: empty id + empty name + more args
+		// Finish: finish_reason=tool_calls
+
+		var chunk1 = createToolCallChunk("call_f7e76b4b", "init_work_status", "");
+		var chunk2 = createToolCallChunk("call_f7e76b4b", "", "{\"firstStep");
+		var chunk3 = createToolCallChunk("", "", "\": \"start\"}");
+		var finishChunk = createFinishChunk(ChatCompletionFinishReason.TOOL_CALLS);
+
+		Flux<ChatCompletionChunk> rawChunks = Flux.just(chunk1, chunk2, chunk3, finishChunk);
+
+		List<ChatCompletionChunk> result = applyStreamingPipeline(rawChunks).collectList().block();
+
+		// Find the chunk that contains tool calls
+		ChatCompletionChunk toolChunk = result.stream()
+			.filter(c -> !c.choices().isEmpty() && c.choices().get(0).delta() != null
+					&& c.choices().get(0).delta().toolCalls() != null
+					&& !c.choices().get(0).delta().toolCalls().isEmpty())
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No tool call chunk found"));
+
+		List<ToolCall> toolCalls = toolChunk.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("init_work_status");
+		assertThat(toolCalls.get(0).function().arguments()).isEqualTo("{\"firstStep\": \"start\"}");
+	}
+
+	/**
+	 * Simulates the Qwen streaming pattern where finish_reason is "stop" instead of
+	 * "tool_calls". The windowing still closes when the stream completes, and reduce()
+	 * merges all chunks correctly.
+	 */
+	@Test
+	void streamingPipeline_qwenStopFinishReason_shouldStillMergeToolCalls() {
+		var chunk1 = createToolCallChunk("call_abc123", "get_weather", "");
+		var chunk2 = createToolCallChunk("call_abc123", "", "{\"location\":");
+		var chunk3 = createToolCallChunk("", "", " \"Seoul\"}");
+		var finishChunk = createFinishChunk(ChatCompletionFinishReason.STOP);
+
+		Flux<ChatCompletionChunk> rawChunks = Flux.just(chunk1, chunk2, chunk3, finishChunk);
+
+		List<ChatCompletionChunk> result = applyStreamingPipeline(rawChunks).collectList().block();
+
+		// All chunks end up in one window (since finish_reason != TOOL_CALLS)
+		// but reduce still merges them when stream completes
+		boolean hasValidToolCall = result.stream().anyMatch(c -> {
+			if (c.choices().isEmpty() || c.choices().get(0).delta() == null
+					|| c.choices().get(0).delta().toolCalls() == null) {
+				return false;
+			}
+			var toolCalls = c.choices().get(0).delta().toolCalls();
+			return toolCalls.size() == 1 && "get_weather".equals(toolCalls.get(0).function().name())
+					&& toolCalls.get(0).function().arguments().contains("Seoul");
+		});
+
+		assertThat(hasValidToolCall).isTrue();
+	}
+
+	/**
+	 * Simulates the DeepSeek streaming pattern reported by wmaozhi where arguments are
+	 * null in the first chunk and the same ID is used across chunks.
+	 */
+	@Test
+	void streamingPipeline_deepSeekNullArguments_shouldMergeCorrectly() {
+		var func1 = new ChatCompletionFunction("todoList", null);
+		var toolCall1 = new ToolCall(0, "868f7f42", "function", func1);
+		var delta1 = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall1), null, null, null,
+				null);
+		var chunk1 = new ChatCompletionChunk("id", List.of(new ChunkChoice(null, 0, delta1, null)), 1L, "deepseek",
+				null, null, null, null);
+
+		var func2 = new ChatCompletionFunction(null, "{\"page");
+		var toolCall2 = new ToolCall(0, "868f7f42", "function", func2);
+		var delta2 = new ChatCompletionMessage(null, null, null, null, List.of(toolCall2), null, null, null, null);
+		var chunk2 = new ChatCompletionChunk("id", List.of(new ChunkChoice(null, 0, delta2, null)), 1L, "deepseek",
+				null, null, null, null);
+
+		var func3 = new ChatCompletionFunction(null, "No\":1}");
+		var toolCall3 = new ToolCall(0, "868f7f42", "function", func3);
+		var delta3 = new ChatCompletionMessage(null, null, null, null, List.of(toolCall3), null, null, null, null);
+		var chunk3 = new ChatCompletionChunk("id", List.of(new ChunkChoice(null, 0, delta3, null)), 1L, "deepseek",
+				null, null, null, null);
+
+		var finishChunk = createFinishChunk(ChatCompletionFinishReason.TOOL_CALLS);
+
+		Flux<ChatCompletionChunk> rawChunks = Flux.just(chunk1, chunk2, chunk3, finishChunk);
+
+		List<ChatCompletionChunk> result = applyStreamingPipeline(rawChunks).collectList().block();
+
+		ChatCompletionChunk toolChunk = result.stream()
+			.filter(c -> !c.choices().isEmpty() && c.choices().get(0).delta() != null
+					&& c.choices().get(0).delta().toolCalls() != null
+					&& !c.choices().get(0).delta().toolCalls().isEmpty())
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No tool call chunk found"));
+
+		List<ToolCall> toolCalls = toolChunk.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("todoList");
+		assertThat(toolCalls.get(0).function().arguments()).isEqualTo("{\"pageNo\":1}");
+	}
+
+	/**
+	 * Verifies that standard OpenAI streaming pattern (empty ID in continuation chunks)
+	 * still works correctly after the fix.
+	 */
+	@Test
+	void streamingPipeline_standardOpenAiPattern_shouldStillWork() {
+		// Standard OpenAI: first chunk has ID+name, continuations have empty ID
+		var chunk1 = createToolCallChunk("call_standard", "get_weather", "");
+		var chunk2 = createToolCallChunk("", "", "{\"location\":");
+		var chunk3 = createToolCallChunk("", "", " \"Tokyo\"}");
+		var finishChunk = createFinishChunk(ChatCompletionFinishReason.TOOL_CALLS);
+
+		Flux<ChatCompletionChunk> rawChunks = Flux.just(chunk1, chunk2, chunk3, finishChunk);
+
+		List<ChatCompletionChunk> result = applyStreamingPipeline(rawChunks).collectList().block();
+
+		ChatCompletionChunk toolChunk = result.stream()
+			.filter(c -> !c.choices().isEmpty() && c.choices().get(0).delta() != null
+					&& c.choices().get(0).delta().toolCalls() != null
+					&& !c.choices().get(0).delta().toolCalls().isEmpty())
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No tool call chunk found"));
+
+		List<ToolCall> toolCalls = toolChunk.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("get_weather");
+		assertThat(toolCalls.get(0).function().arguments()).isEqualTo("{\"location\": \"Tokyo\"}");
+	}
+
+	/**
+	 * Verifies that parallel tool calls with different IDs are kept separate and not
+	 * incorrectly merged.
+	 */
+	@Test
+	void streamingPipeline_parallelToolCallsWithDifferentIds_shouldRemainSeparate() {
+		var chunkA1 = createToolCallChunk("call_A", "get_weather", "{\"location\": \"Seoul\"}");
+		var chunkB1 = createToolCallChunk("call_B", "get_time", "{\"timezone\": \"KST\"}");
+		var finishChunk = createFinishChunk(ChatCompletionFinishReason.TOOL_CALLS);
+
+		Flux<ChatCompletionChunk> rawChunks = Flux.just(chunkA1, chunkB1, finishChunk);
+
+		List<ChatCompletionChunk> result = applyStreamingPipeline(rawChunks).collectList().block();
+
+		ChatCompletionChunk toolChunk = result.stream()
+			.filter(c -> !c.choices().isEmpty() && c.choices().get(0).delta() != null
+					&& c.choices().get(0).delta().toolCalls() != null
+					&& !c.choices().get(0).delta().toolCalls().isEmpty())
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No tool call chunk found"));
+
+		List<ToolCall> toolCalls = toolChunk.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(2);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("get_weather");
+		assertThat(toolCalls.get(1).function().name()).isEqualTo("get_time");
+	}
+
+	/**
+	 * Verifies the transition from merging same-ID chunks to starting a new tool call:
+	 * A(id=X) → A(id=X, continuation) → B(id=Y, new tool call).
+	 */
+	@Test
+	void streamingPipeline_sameIdThenDifferentId_shouldMergeThenSeparate() {
+		var chunkA1 = createToolCallChunk("call_A", "get_weather", "");
+		var chunkA2 = createToolCallChunk("call_A", "", "{\"location\": \"Seoul\"}");
+		var chunkB1 = createToolCallChunk("call_B", "get_time", "{\"timezone\": \"KST\"}");
+		var finishChunk = createFinishChunk(ChatCompletionFinishReason.TOOL_CALLS);
+
+		Flux<ChatCompletionChunk> rawChunks = Flux.just(chunkA1, chunkA2, chunkB1, finishChunk);
+
+		List<ChatCompletionChunk> result = applyStreamingPipeline(rawChunks).collectList().block();
+
+		ChatCompletionChunk toolChunk = result.stream()
+			.filter(c -> !c.choices().isEmpty() && c.choices().get(0).delta() != null
+					&& c.choices().get(0).delta().toolCalls() != null
+					&& !c.choices().get(0).delta().toolCalls().isEmpty())
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No tool call chunk found"));
+
+		List<ToolCall> toolCalls = toolChunk.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(2);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("get_weather");
+		assertThat(toolCalls.get(0).function().arguments()).isEqualTo("{\"location\": \"Seoul\"}");
+		assertThat(toolCalls.get(1).function().name()).isEqualTo("get_time");
+	}
+
+	/**
+	 * Verifies that null arguments in the first chunk are handled correctly during merge.
+	 */
+	@Test
+	void streamingPipeline_nullArgumentsInFirstChunk_shouldMergeCorrectly() {
+		var func1 = new ChatCompletionFunction("search", null);
+		var toolCall1 = new ToolCall(0, "call_null_args", "function", func1);
+		var delta1 = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall1), null, null, null,
+				null);
+		var chunk1 = new ChatCompletionChunk("chatcmpl-1", List.of(new ChunkChoice(null, 0, delta1, null)), 1L, "qwen",
+				null, null, null, null);
+
+		var chunk2 = createToolCallChunk("call_null_args", "", "{\"query\": \"spring ai\"}");
+		var finishChunk = createFinishChunk(ChatCompletionFinishReason.TOOL_CALLS);
+
+		Flux<ChatCompletionChunk> rawChunks = Flux.just(chunk1, chunk2, finishChunk);
+
+		List<ChatCompletionChunk> result = applyStreamingPipeline(rawChunks).collectList().block();
+
+		ChatCompletionChunk toolChunk = result.stream()
+			.filter(c -> !c.choices().isEmpty() && c.choices().get(0).delta() != null
+					&& c.choices().get(0).delta().toolCalls() != null
+					&& !c.choices().get(0).delta().toolCalls().isEmpty())
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No tool call chunk found"));
+
+		List<ToolCall> toolCalls = toolChunk.choices().get(0).delta().toolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).function().name()).isEqualTo("search");
+		assertThat(toolCalls.get(0).function().arguments()).isEqualTo("{\"query\": \"spring ai\"}");
+	}
+
+	/**
+	 * Applies the same streaming pipeline as OpenAiApi.chatCompletionStream(): windowing
+	 * by tool call boundaries and reducing each window via merge.
+	 */
+	private Flux<ChatCompletionChunk> applyStreamingPipeline(Flux<ChatCompletionChunk> rawChunks) {
+		AtomicBoolean isInsideTool = new AtomicBoolean(false);
+
+		return rawChunks.map(chunk -> {
+			if (this.helper.isStreamingToolFunctionCall(chunk)) {
+				isInsideTool.set(true);
+			}
+			return chunk;
+		}).windowUntil(chunk -> {
+			if (isInsideTool.get() && this.helper.isStreamingToolFunctionCallFinish(chunk)) {
+				isInsideTool.set(false);
+				return true;
+			}
+			return !isInsideTool.get();
+		}).concatMapIterable(window -> {
+			Mono<ChatCompletionChunk> monoChunk = window.reduce(
+					new ChatCompletionChunk(null, null, null, null, null, null, null, null),
+					(previous, current) -> this.helper.merge(previous, current));
+			return List.of(monoChunk);
+		}).flatMap(mono -> mono);
+	}
+
+	private ChatCompletionChunk createToolCallChunk(String toolCallId, String functionName, String arguments) {
+		var function = new ChatCompletionFunction(functionName, arguments);
+		var toolCall = new ToolCall(0, toolCallId, "function", function);
+		var delta = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall), null, null, null,
+				null);
+		var choice = new ChunkChoice(null, 0, delta, null);
+		return new ChatCompletionChunk("chatcmpl-1", List.of(choice), 1L, "qwen", null, null, null, null);
+	}
+
+	private ChatCompletionChunk createFinishChunk(ChatCompletionFinishReason finishReason) {
+		var delta = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, null, null, null, null, null);
+		var choice = new ChunkChoice(finishReason, 0, delta, null);
+		return new ChatCompletionChunk("chatcmpl-1", List.of(choice), 1L, "qwen", null, null, null, null);
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes #4790.

When OpenAI-compatible APIs (Qwen, DeepSeek via vLLM/OpenRouter) stream tool call chunks, they may reuse the **same tool call ID** across multiple chunks. The existing merge logic treated any chunk with a non-empty ID as a **new** tool call, producing multiple `ToolCall` objects where only the first has a valid `function.name`. This caused `IllegalArgumentException: toolName cannot be null or empty` in `DefaultToolCallingManager`.

## Root Cause

In the `merge(ChatCompletionMessage, ChatCompletionMessage)` method across streaming helpers, the condition only checked whether the ID was present — not whether it matched the previous tool call:

```java
if (StringUtils.hasText(currentToolCall.id())) {
    // Always treated as a new tool call — even when ID matches the previous one
    toolCalls.add(lastPreviousTooCall);
    toolCalls.add(currentToolCall);
}
```

## Fix

Align the merge condition with the pattern already used in `MiniMaxStreamFunctionCallingHelper`: merge when the tool call ID is absent **or** matches the previous tool call ID, otherwise treat as a new tool call.

```java
if (!StringUtils.hasText(currentToolCall.id())
        || (lastPreviousTooCall != null && currentToolCall.id().equals(lastPreviousTooCall.id()))) {
    toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
} else {
    if (lastPreviousTooCall != null) {
        toolCalls.add(lastPreviousTooCall);
    }
    toolCalls.add(currentToolCall);
}
```

## Scope

Applied to 3 affected helpers:

- `OpenAiStreamFunctionCallingHelper`
- `DeepSeekStreamFunctionCallingHelper`
- `MistralAiStreamFunctionCallingHelper`

`MiniMaxStreamFunctionCallingHelper` already had the correct logic — no changes needed.
`ZhiPuAiStreamFunctionCallingHelper` is excluded as the module is deprecated and scheduled for removal in 2.0.0-M5 (#5676).

No changes to `MessageAggregator` or other provider-neutral layers.

## Testing

- **Unit tests**: Reproduce Qwen and DeepSeek streaming patterns (same-ID chunks)
- **Pipeline tests** (`OpenAiStreamToolCallMergeTest`): Replicate the full `windowUntil()` + `reduce()` pipeline from `OpenAiApi` with 7 scenarios:
  - Qwen same-ID chunks with `finish_reason=tool_calls`
  - Qwen same-ID chunks with `finish_reason=stop`
  - DeepSeek pattern with `null` arguments
  - Standard OpenAI pattern regression (empty ID continuations)
  - Parallel tool calls with different IDs remain separate
  - Same-ID merge then transition to new tool call (A→A→B pattern)
  - Null arguments in first chunk
- All existing tests pass

## Related

- Aware of PR #4794 by @ultramancode — this PR takes a narrower approach, targeting only the streaming helper merge logic without changes to the provider-neutral `MessageAggregator`.