### PR TITLE
Use mvn package instead of mvn test in pr-check workflow.

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Run tests
         run: |
-          ./mvnw -ntp -B -U test
+          ./mvnw -ntp -B -U package


### PR DESCRIPTION
Previously, there could be a problematic edge case where the buildcache could cause a build failure.

Imagine the following scenario, starting from a clean state (no cache): Project has at least 2 modules, A and B, where B depends on A.

1. mvn clean test runs. Everything is fine and compiles fine. the buildcache is populated with the success of compilation and running tests (but not with an actual artifact).
2. mvn clean test again, without change: everything is fine, the buildcache is hit and the tests are skipped since nothing changed.
3. Slighlty change code in B
4. mvn clean test run again. When it comes time to compile/test B, there is no cache hit, and so B needs to be compiled again. Sadly, the reactor build did not build A again. So there is nothing to compile B against, and the build fails.

Using package instead of test makes sure something is saved in the cache and restored.

Auto-cherry-pick to 1.1.x

