### PR TITLE
Deprecate Vertex AI, OCI GenAI and Zhipu AI models

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCICohereChatModelProperties.java
@@ -24,7 +24,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * Configuration properties for OCI Cohere chat model.
  *
  * @author Anders Swanson
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(OCICohereChatModelProperties.CONFIG_PREFIX)
 public class OCICohereChatModelProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIConnectionProperties.java
@@ -25,7 +25,10 @@ import org.springframework.util.StringUtils;
  * Configuration properties for OCI connection.
  *
  * @author Anders Swanson
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(OCIConnectionProperties.CONFIG_PREFIX)
 public class OCIConnectionProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIEmbeddingModelProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIEmbeddingModelProperties.java
@@ -25,7 +25,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for OCI embedding model.
  *
  * @author Anders Swanson
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(OCIEmbeddingModelProperties.CONFIG_PREFIX)
 public class OCIEmbeddingModelProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiChatAutoConfiguration.java
@@ -38,7 +38,10 @@ import org.springframework.context.annotation.Bean;
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
  * @author Issam El-atif
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = OCIGenAiInferenceClientAutoConfiguration.class)
 @ConditionalOnClass(OCICohereChatModel.class)
 @EnableConfigurationProperties(OCICohereChatModelProperties.class)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiEmbeddingAutoConfiguration.java
@@ -35,7 +35,10 @@ import org.springframework.context.annotation.Bean;
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
  * @author Issam El-atif
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = OCIGenAiInferenceClientAutoConfiguration.class)
 @ConditionalOnClass(OCIEmbeddingModel.class)
 @EnableConfigurationProperties(OCIEmbeddingModelProperties.class)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiInferenceClientAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/OCIGenAiInferenceClientAutoConfiguration.java
@@ -42,7 +42,10 @@ import org.springframework.util.StringUtils;
  *
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration
 @ConditionalOnClass(GenerativeAiInferenceClient.class)
 @EnableConfigurationProperties(OCIConnectionProperties.class)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/ServingMode.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-oci-genai/src/main/java/org/springframework/ai/model/oci/genai/autoconfigure/ServingMode.java
@@ -20,7 +20,10 @@ package org.springframework.ai.model.oci.genai.autoconfigure;
  * OCI serving mode.
  *
  * @author Anders Swanson
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public enum ServingMode {
 
 	ON_DEMAND("on-demand"), DEDICATED("dedicated");

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiEmbeddingConnectionAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiEmbeddingConnectionAutoConfiguration.java
@@ -35,7 +35,9 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @author Nguyen Tran
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration
 @ConditionalOnClass(PredictionServiceSettings.class)
 @EnableConfigurationProperties(VertexAiEmbeddingConnectionProperties.class)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiEmbeddingConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiEmbeddingConnectionProperties.java
@@ -24,7 +24,9 @@ import org.springframework.core.io.Resource;
  *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(VertexAiEmbeddingConnectionProperties.CONFIG_PREFIX)
 public class VertexAiEmbeddingConnectionProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultiModalEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultiModalEmbeddingAutoConfiguration.java
@@ -39,7 +39,9 @@ import org.springframework.context.annotation.Bean;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = { SpringAiRetryAutoConfiguration.class, VertexAiEmbeddingConnectionAutoConfiguration.class })
 @ConditionalOnClass({ VertexAI.class, VertexAiMultimodalEmbeddingModel.class })
 @ConditionalOnProperty(name = SpringAIModelProperties.MULTI_MODAL_EMBEDDING_MODEL,

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultimodalEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiMultimodalEmbeddingProperties.java
@@ -25,7 +25,9 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(VertexAiMultimodalEmbeddingProperties.CONFIG_PREFIX)
 public class VertexAiMultimodalEmbeddingProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingAutoConfiguration.java
@@ -42,7 +42,9 @@ import org.springframework.core.retry.RetryTemplate;
  * @author Ilayaperumal Gopinathan
  * @author Yanming Zhou
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = { SpringAiRetryAutoConfiguration.class, VertexAiEmbeddingConnectionAutoConfiguration.class })
 @ConditionalOnClass(VertexAiTextEmbeddingModel.class)
 @ConditionalOnProperty(name = SpringAIModelProperties.TEXT_EMBEDDING_MODEL, havingValue = SpringAIModels.VERTEX_AI,

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/embedding/VertexAiTextEmbeddingProperties.java
@@ -25,7 +25,9 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(VertexAiTextEmbeddingProperties.CONFIG_PREFIX)
 public class VertexAiTextEmbeddingProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatAutoConfiguration.java
@@ -54,7 +54,9 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @author Yanming Zhou
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = { SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class })
 @ConditionalOnClass({ VertexAI.class, VertexAiGeminiChatModel.class })
 @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.VERTEX_AI,

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiChatProperties.java
@@ -27,7 +27,9 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * @author Christian Tzolov
  * @author Hyunsang Han
  * @since 0.8.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(VertexAiGeminiChatProperties.CONFIG_PREFIX)
 public class VertexAiGeminiChatProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/src/main/java/org/springframework/ai/model/vertexai/autoconfigure/gemini/VertexAiGeminiConnectionProperties.java
@@ -26,7 +26,9 @@ import org.springframework.core.io.Resource;
  *
  * @author Christian Tzolov
  * @since 0.8.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(VertexAiGeminiConnectionProperties.CONFIG_PREFIX)
 public class VertexAiGeminiConnectionProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatAutoConfiguration.java
@@ -51,7 +51,10 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Geng Rong
  * @author Ilayaperumal Gopinathan
  * @author Yanming Zhou
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class,
 		ToolCallingAutoConfiguration.class })
 @ConditionalOnClass(ZhiPuAiApi.class)

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiChatProperties.java
@@ -25,7 +25,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * Configuration properties for ZhiPuAI chat model.
  *
  * @author Geng Rong
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(ZhiPuAiChatProperties.CONFIG_PREFIX)
 public class ZhiPuAiChatProperties extends ZhiPuAiParentProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiConnectionProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiConnectionProperties.java
@@ -18,6 +18,11 @@ package org.springframework.ai.model.zhipuai.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
+ */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(ZhiPuAiConnectionProperties.CONFIG_PREFIX)
 public class ZhiPuAiConnectionProperties extends ZhiPuAiParentProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingAutoConfiguration.java
@@ -47,7 +47,10 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Geng Rong
  * @author Ilayaperumal Gopinathan
  * @author Yanming Zhou
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(ZhiPuAiApi.class)
 @ConditionalOnProperty(name = SpringAIModelProperties.EMBEDDING_MODEL, havingValue = SpringAIModels.ZHIPUAI,

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiEmbeddingProperties.java
@@ -26,7 +26,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * Configuration properties for ZhiPuAI embedding model.
  *
  * @author Geng Rong
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(ZhiPuAiEmbeddingProperties.CONFIG_PREFIX)
 public class ZhiPuAiEmbeddingProperties extends ZhiPuAiParentProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageAutoConfiguration.java
@@ -43,7 +43,10 @@ import org.springframework.web.client.RestClient;
  * @author Geng Rong
  * @author Ilayaperumal Gopinathan
  * @author Yanming Zhou
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @AutoConfiguration(after = { RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class })
 @ConditionalOnClass(ZhiPuAiApi.class)
 @ConditionalOnProperty(name = SpringAIModelProperties.IMAGE_MODEL, havingValue = SpringAIModels.ZHIPUAI,

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiImageProperties.java
@@ -24,7 +24,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  * Configuration properties for ZhiPuAI chat model.
  *
  * @author Geng Rong
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @ConfigurationProperties(ZhiPuAiImageProperties.CONFIG_PREFIX)
 public class ZhiPuAiImageProperties extends ZhiPuAiParentProperties {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiParentProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-zhipuai/src/main/java/org/springframework/ai/model/zhipuai/autoconfigure/ZhiPuAiParentProperties.java
@@ -18,7 +18,10 @@ package org.springframework.ai.model.zhipuai.autoconfigure;
 
 /**
  * @author Geng Rong
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 class ZhiPuAiParentProperties {
 
 	private String apiKey;

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingModel.java
@@ -51,7 +51,10 @@ import org.springframework.util.StringUtils;
  *
  * @author Anders Swanson
  * @since 1.0.0
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class OCIEmbeddingModel extends AbstractEmbeddingModel {
 
 	// The OCI GenAI API has a batch size of 96 for embed text requests.

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingOptions.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/OCIEmbeddingOptions.java
@@ -27,7 +27,10 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  *
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OCIEmbeddingOptions implements EmbeddingOptions {
 

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/ServingModeHelper.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/ServingModeHelper.java
@@ -25,7 +25,10 @@ import com.oracle.bmc.generativeaiinference.model.ServingMode;
  * {@link com.oracle.bmc.generativeaiinference.model.ServingMode}
  *
  * @author Anders Swanson
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public final class ServingModeHelper {
 
 	private ServingModeHelper() {

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatModel.java
@@ -63,7 +63,10 @@ import org.springframework.util.StringUtils;
  * @author Anders Swanson
  * @author Alexandros Pappas
  * @since 1.0.0
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class OCICohereChatModel implements ChatModel {
 
 	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();

--- a/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatOptions.java
+++ b/models/spring-ai-oci-genai/src/main/java/org/springframework/ai/oci/cohere/OCICohereChatOptions.java
@@ -32,7 +32,10 @@ import org.springframework.ai.chat.prompt.ChatOptions;
  * @author Anders Swanson
  * @author Ilayaperumal Gopinathan
  * @author Alexnadros Pappas
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OCICohereChatOptions implements ChatOptions {
 

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/VertexAiEmbeddingConnectionDetails.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/VertexAiEmbeddingConnectionDetails.java
@@ -32,7 +32,9 @@ import org.springframework.util.StringUtils;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class VertexAiEmbeddingConnectionDetails {
 
 	public static final String DEFAULT_ENDPOINT = "us-central1-aiplatform.googleapis.com:443";

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/VertexAiEmbeddingUtils.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/VertexAiEmbeddingUtils.java
@@ -34,7 +34,9 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public abstract class VertexAiEmbeddingUtils {
 
 	public static Value valueOf(boolean n) {

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
@@ -61,7 +61,9 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Mark Pollack
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class VertexAiMultimodalEmbeddingModel implements DocumentEmbeddingModel {
 
 	private static final Logger logger = LoggerFactory.getLogger(VertexAiMultimodalEmbeddingModel.class);

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModelName.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModelName.java
@@ -27,7 +27,9 @@ import org.springframework.ai.model.EmbeddingModelDescription;
  *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public enum VertexAiMultimodalEmbeddingModelName implements EmbeddingModelDescription {
 
 	/**

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingOptions.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingOptions.java
@@ -60,7 +60,9 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(Include.NON_NULL)
 public class VertexAiMultimodalEmbeddingOptions implements EmbeddingOptions {
 

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
@@ -62,7 +62,9 @@ import org.springframework.util.StringUtils;
  * @author Rodrigo Malara
  * @author Soby Chacko
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class VertexAiTextEmbeddingModel extends AbstractEmbeddingModel {
 
 	private static final EmbeddingModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultEmbeddingModelObservationConvention();

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModelName.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModelName.java
@@ -27,7 +27,9 @@ import org.springframework.ai.model.EmbeddingModelDescription;
  *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public enum VertexAiTextEmbeddingModelName implements EmbeddingModelDescription {
 
 	/**

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingOptions.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingOptions.java
@@ -29,7 +29,9 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(Include.NON_NULL)
 public class VertexAiTextEmbeddingOptions implements EmbeddingOptions {
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/MimeTypeDetector.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/MimeTypeDetector.java
@@ -49,7 +49,9 @@ import org.springframework.util.MimeTypeUtils;
  *
  * @author Christian Tzolov
  * @since 0.8.1
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public abstract class MimeTypeDetector {
 
 	/**

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatModel.java
@@ -143,7 +143,9 @@ import org.springframework.util.StringUtils;
  * @see VertexAiGeminiChatOptions
  * @see ToolCallingManager
  * @see ChatModel
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class VertexAiGeminiChatModel implements ChatModel, DisposableBean {
 
 	private static final ChatModelObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/VertexAiGeminiChatOptions.java
@@ -50,7 +50,9 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(Include.NON_NULL)
 public class VertexAiGeminiChatOptions implements ToolCallingChatOptions, StructuredOutputChatOptions {
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/aot/VertexAiGeminiRuntimeHints.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/aot/VertexAiGeminiRuntimeHints.java
@@ -28,7 +28,9 @@ import static org.springframework.ai.aot.AiRuntimeHints.findJsonAnnotatedClasses
  *
  * @author Christian Tzolov
  * @since 0.8.1
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class VertexAiGeminiRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/api/VertexAiGeminiApi.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/api/VertexAiGeminiApi.java
@@ -18,6 +18,10 @@ package org.springframework.ai.vertexai.gemini.api;
 
 import java.util.List;
 
+/**
+ * @deprecated use Google GenAI instead
+ */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class VertexAiGeminiApi {
 
 	public record LogProbs(Double avgLogprobs, List<TopContent> topCandidates,

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/common/VertexAiGeminiConstants.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/common/VertexAiGeminiConstants.java
@@ -22,7 +22,9 @@ import org.springframework.ai.observation.conventions.AiProvider;
  * Constants for Vertex AI Gemini.
  *
  * @author Soby Chacko
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public final class VertexAiGeminiConstants {
 
 	public static final String PROVIDER_NAME = AiProvider.VERTEX_AI.value();

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/common/VertexAiGeminiSafetyRating.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/common/VertexAiGeminiSafetyRating.java
@@ -24,7 +24,9 @@ package org.springframework.ai.vertexai.gemini.common;
  * @author Mark Pollack
  * @since 1.1.1
  * @see VertexAiGeminiSafetySetting
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public record VertexAiGeminiSafetyRating(HarmCategory category, HarmProbability probability, boolean blocked,
 		float probabilityScore, HarmSeverity severity, float severityScore) {
 

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/common/VertexAiGeminiSafetySetting.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/common/VertexAiGeminiSafetySetting.java
@@ -16,6 +16,10 @@
 
 package org.springframework.ai.vertexai.gemini.common;
 
+/**
+ * @deprecated use Google GenAI instead
+ */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public final class VertexAiGeminiSafetySetting {
 
 	public static Builder builder() {

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/schema/JsonSchemaConverter.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/schema/JsonSchemaConverter.java
@@ -33,7 +33,10 @@ import org.springframework.util.Assert;
 
 /**
  * Utility class for converting JSON Schema to OpenAPI schema format.
+ *
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public final class JsonSchemaConverter {
 
 	private JsonSchemaConverter() {

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/schema/VertexAiSchemaConverter.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/schema/VertexAiSchemaConverter.java
@@ -23,7 +23,9 @@ import com.google.protobuf.util.JsonFormat;
  * Utility class for converting OpenAPI schemas to Vertex AI Schema objects.
  *
  * @since 1.1.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public final class VertexAiSchemaConverter {
 
 	private VertexAiSchemaConverter() {

--- a/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/schema/VertexToolCallingManager.java
+++ b/models/spring-ai-vertex-ai-gemini/src/main/java/org/springframework/ai/vertexai/gemini/schema/VertexToolCallingManager.java
@@ -41,7 +41,9 @@ import org.springframework.util.Assert;
  *
  * @author Christian Tzolov
  * @since 1.0.0
+ * @deprecated use Google GenAI instead
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class VertexToolCallingManager implements ToolCallingManager {
 
 	/**

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiAssistantMessage.java
@@ -26,7 +26,10 @@ import org.springframework.ai.content.Media;
 /**
  * @author YunKui Lu
  * @author Sun Yuhan
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiAssistantMessage extends AssistantMessage {
 
 	/**

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatModel.java
@@ -87,7 +87,10 @@ import org.springframework.util.MimeType;
  * @see StreamingChatModel
  * @see ZhiPuAiApi
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiChatModel implements ChatModel {
 
 	private static final Logger logger = LoggerFactory.getLogger(ZhiPuAiChatModel.class);

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiChatOptions.java
@@ -47,7 +47,10 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  * @author YunKui Lu
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(Include.NON_NULL)
 public class ZhiPuAiChatOptions implements ToolCallingChatOptions {
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingModel.java
@@ -54,7 +54,10 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author YuJie Wan
  * @since 1.0.0
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiEmbeddingModel extends AbstractEmbeddingModel {
 
 	private static final Logger logger = LoggerFactory.getLogger(ZhiPuAiEmbeddingModel.class);

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiEmbeddingOptions.java
@@ -29,7 +29,10 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(Include.NON_NULL)
 public class ZhiPuAiEmbeddingOptions implements EmbeddingOptions {
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageModel.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageModel.java
@@ -40,7 +40,10 @@ import org.springframework.util.Assert;
  *
  * @author Geng Rong
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiImageModel implements ImageModel {
 
 	private static final Logger logger = LoggerFactory.getLogger(ZhiPuAiImageModel.class);

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageOptions.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/ZhiPuAiImageOptions.java
@@ -45,7 +45,10 @@ import org.springframework.ai.zhipuai.api.ZhiPuAiImageApi;
  * @author Geng Rong
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ZhiPuAiImageOptions implements ImageOptions {
 

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/aot/ZhiPuAiRuntimeHints.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/aot/ZhiPuAiRuntimeHints.java
@@ -30,7 +30,10 @@ import static org.springframework.ai.aot.AiRuntimeHints.findJsonAnnotatedClasses
  *
  * @author Geng Rong
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiApi.java
@@ -55,7 +55,10 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @author Thomas Vitale
  * @author YunKui Lu
  * @since 1.0.0
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiApi {
 
 	/**

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiImageApi.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiImageApi.java
@@ -34,7 +34,10 @@ import org.springframework.web.client.RestClient;
  * @see <a href= "https://open.bigmodel.cn/dev/howuse/cogview">CogView Images</a>
  * @author Geng Rong
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiImageApi {
 
 	public static final String DEFAULT_IMAGE_MODEL = ImageModel.CogView_3.getValue();

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuAiStreamFunctionCallingHelper.java
@@ -37,7 +37,10 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Geng Rong
  * @since 1.0.0 M1
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public class ZhiPuAiStreamFunctionCallingHelper {
 
 	/**

--- a/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuApiConstants.java
+++ b/models/spring-ai-zhipuai/src/main/java/org/springframework/ai/zhipuai/api/ZhiPuApiConstants.java
@@ -23,7 +23,10 @@ import org.springframework.ai.observation.conventions.AiProvider;
  *
  * @author Piotr Olaszewski
  * @since 1.0.0 M2
+ * @deprecated will be moved to <a href="https://github.com/spring-ai-community">Spring AI
+ * Community</a> with new package and dependency coordinates if a maintainer is found
  */
+@Deprecated(since = "2.0.0-M4", forRemoval = true)
 public final class ZhiPuApiConstants {
 
 	public static final String DEFAULT_BASE_URL = "https://open.bigmodel.cn/api/paas";


### PR DESCRIPTION
This PR deprecates 3 models before their removal from this codebase in `2.0.0-M5`:
 - Vertex AI is superseded by Google GenAI
 - OCI GenAI will be moved to https://github.com/spring-ai-community/
 - Zhipu AI will be moved to https://github.com/spring-ai-community/ if a maintainer is found, or else just removed.