### PR TITLE
Fix CosmosDB NIN filter operator from !IN to NOT IN

### DIFF
--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverter.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBFilterExpressionConverter.java
@@ -125,7 +125,7 @@ class CosmosDBFilterExpressionConverter extends AbstractFilterExpressionConverte
 			case GT -> " > ";
 			case GTE -> " >= ";
 			case IN -> " IN ";
-			case NIN -> " !IN ";
+			case NIN -> " NOT IN ";
 			default -> throw new RuntimeException("Not supported expression type:" + exp.type());
 		};
 	}


### PR DESCRIPTION
## Summary

Fixes #5665

## Problem

`CosmosDBFilterExpressionConverter` was generating `!IN` for `NIN` 
filter expressions, but CosmosDB NoSQL API does not recognize `!IN` 
as a valid operator.

## Root Cause

The `NIN` case in `CosmosDBFilterExpressionConverter` was producing 
the wrong operator string:
```java
// Before
case NIN -> " !IN ";

// After
case NIN -> " NOT IN ";
```

## Verification

The correct syntax can be verified in the 
[CosmosDB Data Explorer](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/keywords#not-in).
```sql
-- Invalid (before)
SELECT * FROM c WHERE c.category !IN ("tech", "science")

-- Valid (after)
SELECT * FROM c WHERE c.category NOT IN ("tech", "science")
```