### PR TITLE
Add built-in web search tool support for Anthropic

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicPropertiesTests.java
@@ -104,6 +104,35 @@ class AnthropicPropertiesTests {
 	}
 
 	@Test
+	void webSearchToolProperties() {
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.anthropic.api-key=API_KEY",
+					"spring.ai.anthropic.chat.options.web-search-tool.max-uses=5",
+					"spring.ai.anthropic.chat.options.web-search-tool.allowed-domains=docs.spring.io,github.com",
+					"spring.ai.anthropic.chat.options.web-search-tool.blocked-domains=example.com",
+					"spring.ai.anthropic.chat.options.web-search-tool.user-location.city=San Francisco",
+					"spring.ai.anthropic.chat.options.web-search-tool.user-location.country=US",
+					"spring.ai.anthropic.chat.options.web-search-tool.user-location.region=California",
+					"spring.ai.anthropic.chat.options.web-search-tool.user-location.timezone=America/Los_Angeles")
+			.withConfiguration(
+					AutoConfigurations.of(AnthropicChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var chatProperties = context.getBean(AnthropicChatProperties.class);
+				var webSearch = chatProperties.getOptions().getWebSearchTool();
+
+				assertThat(webSearch).isNotNull();
+				assertThat(webSearch.getMaxUses()).isEqualTo(5);
+				assertThat(webSearch.getAllowedDomains()).containsExactly("docs.spring.io", "github.com");
+				assertThat(webSearch.getBlockedDomains()).containsExactly("example.com");
+				assertThat(webSearch.getUserLocation()).isNotNull();
+				assertThat(webSearch.getUserLocation().city()).isEqualTo("San Francisco");
+				assertThat(webSearch.getUserLocation().country()).isEqualTo("US");
+				assertThat(webSearch.getUserLocation().region()).isEqualTo("California");
+				assertThat(webSearch.getUserLocation().timezone()).isEqualTo("America/Los_Angeles");
+			});
+	}
+
+	@Test
 	void chatCompletionDisabled() {
 		// Enabled by default
 		new ApplicationContextRunner().withPropertyValues("spring.ai.anthropic.api-key=API_KEY")

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -35,6 +35,7 @@ import com.anthropic.models.messages.CitationCharLocation;
 import com.anthropic.models.messages.CitationContentBlockLocation;
 import com.anthropic.models.messages.CitationPageLocation;
 import com.anthropic.models.messages.CitationsDelta;
+import com.anthropic.models.messages.CitationsWebSearchResultLocation;
 import com.anthropic.models.messages.CodeExecutionTool20260120;
 import com.anthropic.models.messages.ContentBlock;
 import com.anthropic.models.messages.ContentBlockParam;
@@ -57,6 +58,10 @@ import com.anthropic.models.messages.ToolUseBlock;
 import com.anthropic.models.messages.ToolUseBlockParam;
 import com.anthropic.models.messages.UrlImageSource;
 import com.anthropic.models.messages.UrlPdfSource;
+import com.anthropic.models.messages.UserLocation;
+import com.anthropic.models.messages.WebSearchResultBlock;
+import com.anthropic.models.messages.WebSearchTool20260209;
+import com.anthropic.models.messages.WebSearchToolResultBlock;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -402,6 +407,16 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				AssistantMessage assistantMessage = AssistantMessage.builder().properties(redactedProperties).build();
 				return new ChatResponse(List.of(new Generation(assistantMessage)));
 			}
+			else if (contentBlock.isWebSearchToolResult()) {
+				// Accumulate web search results for final response metadata
+				WebSearchToolResultBlock wsBlock = contentBlock.asWebSearchToolResult();
+				if (wsBlock.content().isResultBlocks()) {
+					for (WebSearchResultBlock r : wsBlock.content().asResultBlocks()) {
+						streamingState.addWebSearchResult(
+								new AnthropicWebSearchResult(r.title(), r.url(), r.pageAge().orElse(null)));
+					}
+				}
+			}
 			return null;
 		}
 
@@ -502,6 +517,11 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				metadataBuilder.keyValue("citations", citations).keyValue("citationCount", citations.size());
 			}
 
+			List<AnthropicWebSearchResult> webSearchResults = streamingState.getWebSearchResults();
+			if (!webSearchResults.isEmpty()) {
+				metadataBuilder.keyValue("web-search-results", webSearchResults);
+			}
+
 			return new ChatResponse(List.of(generation), metadataBuilder.build());
 		});
 
@@ -542,7 +562,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				}
 
 				List<Citation> citations = new ArrayList<>();
-				List<Generation> generations = buildGenerations(message, citations);
+				List<AnthropicWebSearchResult> webSearchResults = new ArrayList<>();
+				List<Generation> generations = buildGenerations(message, citations, webSearchResults);
 
 				// Current usage
 				com.anthropic.models.messages.Usage sdkUsage = message.usage();
@@ -551,7 +572,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 						? UsageCalculator.getCumulativeUsage(currentChatResponseUsage, previousChatResponse)
 						: currentChatResponseUsage;
 
-				ChatResponse chatResponse = new ChatResponse(generations, from(message, accumulatedUsage, citations));
+				ChatResponse chatResponse = new ChatResponse(generations,
+						from(message, accumulatedUsage, citations, webSearchResults));
 
 				observationContext.setResponse(chatResponse);
 
@@ -633,6 +655,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				}
 				if (originalAnthropicOptions.getSkillContainer() != null) {
 					requestOptions.setSkillContainer(originalAnthropicOptions.getSkillContainer());
+				}
+				if (originalAnthropicOptions.getWebSearchTool() != null) {
+					requestOptions.setWebSearchTool(originalAnthropicOptions.getWebSearchTool());
 				}
 			}
 		}
@@ -854,7 +879,10 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			builder.outputConfig(requestOptions.getOutputConfig());
 		}
 
-		// Add tool definitions if any are configured
+		// Build combined tool list (user-defined tools + built-in tools)
+		List<ToolUnion> allTools = new ArrayList<>();
+
+		// Add user-defined tool definitions
 		List<ToolDefinition> toolDefinitions = this.toolCallingManager.resolveToolDefinitions(requestOptions);
 		if (!CollectionUtils.isEmpty(toolDefinitions)) {
 			List<Tool> tools = toolDefinitions.stream().map(this::toAnthropicTool).toList();
@@ -874,7 +902,16 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				tools = modifiedTools;
 			}
 
-			builder.tools(tools.stream().map(ToolUnion::ofTool).toList());
+			tools.stream().map(ToolUnion::ofTool).forEach(allTools::add);
+		}
+
+		// Add built-in web search tool if configured
+		if (requestOptions.getWebSearchTool() != null) {
+			allTools.add(ToolUnion.ofWebSearchTool20260209(toSdkWebSearchTool(requestOptions.getWebSearchTool())));
+		}
+
+		if (!allTools.isEmpty()) {
+			builder.tools(allTools);
 
 			// Set tool choice if specified, applying disableParallelToolUse if set
 			if (requestOptions.getToolChoice() != null) {
@@ -959,9 +996,11 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	 * thinking content, and citations from the response content blocks.
 	 * @param message the Anthropic message response
 	 * @param citationAccumulator collects citations found in text blocks
+	 * @param webSearchAccumulator collects web search results found in response
 	 * @return list of generations with text, tool calls, and/or thinking content
 	 */
-	private List<Generation> buildGenerations(Message message, List<Citation> citationAccumulator) {
+	private List<Generation> buildGenerations(Message message, List<Citation> citationAccumulator,
+			List<AnthropicWebSearchResult> webSearchAccumulator) {
 		List<Generation> generations = new ArrayList<>();
 
 		String finishReason = message.stopReason().map(r -> r.toString()).orElse("");
@@ -1013,6 +1052,15 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 				generations.add(new Generation(AssistantMessage.builder().properties(redactedProperties).build(),
 						generationMetadata));
 			}
+			else if (block.isWebSearchToolResult()) {
+				WebSearchToolResultBlock wsBlock = block.asWebSearchToolResult();
+				if (wsBlock.content().isResultBlocks()) {
+					for (WebSearchResultBlock r : wsBlock.content().asResultBlocks()) {
+						webSearchAccumulator
+							.add(new AnthropicWebSearchResult(r.title(), r.url(), r.pageAge().orElse(null)));
+					}
+				}
+			}
 			else if (block.isContainerUpload() || block.isServerToolUse() || block.isBashCodeExecutionToolResult()
 					|| block.isTextEditorCodeExecutionToolResult() || block.isCodeExecutionToolResult()) {
 				logger.warn("Unsupported content block type: {}", block);
@@ -1036,7 +1084,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	 * @param usage the usage information
 	 * @return the chat response metadata
 	 */
-	private ChatResponseMetadata from(Message message, Usage usage, List<Citation> citations) {
+	private ChatResponseMetadata from(Message message, Usage usage, List<Citation> citations,
+			List<AnthropicWebSearchResult> webSearchResults) {
 		Assert.notNull(message, "Anthropic Message must not be null");
 		ChatResponseMetadata.Builder metadataBuilder = ChatResponseMetadata.builder()
 			.id(message.id())
@@ -1045,6 +1094,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			.keyValue("anthropic-response", message);
 		if (!citations.isEmpty()) {
 			metadataBuilder.keyValue("citations", citations).keyValue("citationCount", citations.size());
+		}
+		if (!webSearchResults.isEmpty()) {
+			metadataBuilder.keyValue("web-search-results", webSearchResults);
 		}
 		return metadataBuilder.build();
 	}
@@ -1074,6 +1126,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		else if (textCitation.isContentBlockLocation()) {
 			return fromContentBlockLocation(textCitation.asContentBlockLocation());
 		}
+		else if (textCitation.isWebSearchResultLocation()) {
+			return fromWebSearchResultLocation(textCitation.asWebSearchResultLocation());
+		}
 		return null;
 	}
 
@@ -1086,6 +1141,9 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		}
 		else if (citation.isContentBlockLocation()) {
 			return fromContentBlockLocation(citation.asContentBlockLocation());
+		}
+		else if (citation.isWebSearchResultLocation()) {
+			return fromWebSearchResultLocation(citation.asWebSearchResultLocation());
 		}
 		return null;
 	}
@@ -1103,6 +1161,10 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	private Citation fromContentBlockLocation(CitationContentBlockLocation loc) {
 		return Citation.ofContentBlockLocation(loc.citedText(), (int) loc.documentIndex(),
 				loc.documentTitle().orElse(null), (int) loc.startBlockIndex(), (int) loc.endBlockIndex());
+	}
+
+	private Citation fromWebSearchResultLocation(CitationsWebSearchResultLocation loc) {
+		return Citation.ofWebSearchResultLocation(loc.citedText(), loc.url(), loc.title().orElse(null));
 	}
 
 	/**
@@ -1255,6 +1317,45 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		catch (Exception e) {
 			throw new RuntimeException("Failed to parse tool input schema: " + toolDefinition.inputSchema(), e);
 		}
+	}
+
+	/**
+	 * Converts a Spring AI {@link AnthropicWebSearchTool} to the Anthropic SDK's
+	 * {@link WebSearchTool20260209}.
+	 * @param webSearchTool the web search configuration
+	 * @return the SDK web search tool
+	 */
+	private WebSearchTool20260209 toSdkWebSearchTool(AnthropicWebSearchTool webSearchTool) {
+		WebSearchTool20260209.Builder sdkBuilder = WebSearchTool20260209.builder();
+
+		if (webSearchTool.getAllowedDomains() != null) {
+			sdkBuilder.allowedDomains(webSearchTool.getAllowedDomains());
+		}
+		if (webSearchTool.getBlockedDomains() != null) {
+			sdkBuilder.blockedDomains(webSearchTool.getBlockedDomains());
+		}
+		if (webSearchTool.getMaxUses() != null) {
+			sdkBuilder.maxUses(webSearchTool.getMaxUses());
+		}
+		if (webSearchTool.getUserLocation() != null) {
+			AnthropicWebSearchTool.UserLocation loc = webSearchTool.getUserLocation();
+			UserLocation.Builder locBuilder = UserLocation.builder();
+			if (loc.city() != null) {
+				locBuilder.city(loc.city());
+			}
+			if (loc.country() != null) {
+				locBuilder.country(loc.country());
+			}
+			if (loc.region() != null) {
+				locBuilder.region(loc.region());
+			}
+			if (loc.timezone() != null) {
+				locBuilder.timezone(loc.timezone());
+			}
+			sdkBuilder.userLocation(locBuilder.build());
+		}
+
+		return sdkBuilder.build();
 	}
 
 	/**
@@ -1422,6 +1523,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 		private final List<Citation> accumulatedCitations = new ArrayList<>();
 
+		private final List<AnthropicWebSearchResult> accumulatedWebSearchResults = new ArrayList<>();
+
 		void setMessageInfo(String id, String modelName, long tokens) {
 			this.messageId.set(id);
 			this.model.set(modelName);
@@ -1495,6 +1598,14 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 		List<Citation> getCitations() {
 			return new ArrayList<>(this.accumulatedCitations);
+		}
+
+		void addWebSearchResult(AnthropicWebSearchResult result) {
+			this.accumulatedWebSearchResults.add(result);
+		}
+
+		List<AnthropicWebSearchResult> getWebSearchResults() {
+			return new ArrayList<>(this.accumulatedWebSearchResults);
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatOptions.java
@@ -193,6 +193,13 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 	 */
 	private @Nullable String inferenceGeo;
 
+	/**
+	 * Configuration for Anthropic's built-in web search tool. When set, Claude can search
+	 * the web during the conversation.
+	 */
+	@JsonIgnore
+	private @Nullable AnthropicWebSearchTool webSearchTool;
+
 	private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
 
 	/**
@@ -398,6 +405,14 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		this.inferenceGeo = inferenceGeo;
 	}
 
+	public @Nullable AnthropicWebSearchTool getWebSearchTool() {
+		return this.webSearchTool;
+	}
+
+	public void setWebSearchTool(@Nullable AnthropicWebSearchTool webSearchTool) {
+		this.webSearchTool = webSearchTool;
+	}
+
 	@Override
 	@JsonIgnore
 	public @Nullable String getOutputSchema() {
@@ -533,7 +548,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			.outputConfig(this.outputConfig)
 			.httpHeaders(this.getHttpHeaders())
 			.skillContainer(this.getSkillContainer())
-			.inferenceGeo(this.inferenceGeo);
+			.inferenceGeo(this.inferenceGeo)
+			.webSearchTool(this.webSearchTool);
 	}
 
 	@Override
@@ -560,7 +576,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				&& Objects.equals(this.outputConfig, that.outputConfig)
 				&& Objects.equals(this.httpHeaders, that.httpHeaders)
 				&& Objects.equals(this.skillContainer, that.skillContainer)
-				&& Objects.equals(this.inferenceGeo, that.inferenceGeo);
+				&& Objects.equals(this.inferenceGeo, that.inferenceGeo)
+				&& Objects.equals(this.webSearchTool, that.webSearchTool);
 	}
 
 	@Override
@@ -568,7 +585,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		return Objects.hash(this.getModel(), this.maxTokens, this.metadata, this.stopSequences, this.temperature,
 				this.topP, this.topK, this.toolChoice, this.thinking, this.disableParallelToolUse, this.toolCallbacks,
 				this.toolNames, this.internalToolExecutionEnabled, this.toolContext, this.citationDocuments,
-				this.cacheOptions, this.outputConfig, this.httpHeaders, this.skillContainer, this.inferenceGeo);
+				this.cacheOptions, this.outputConfig, this.httpHeaders, this.skillContainer, this.inferenceGeo,
+				this.webSearchTool);
 	}
 
 	@Override
@@ -581,7 +599,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				+ ", internalToolExecutionEnabled=" + this.internalToolExecutionEnabled + ", toolContext="
 				+ this.toolContext + ", citationDocuments=" + this.citationDocuments + ", cacheOptions="
 				+ this.cacheOptions + ", outputConfig=" + this.outputConfig + ", httpHeaders=" + this.httpHeaders
-				+ ", skillContainer=" + this.skillContainer + ", inferenceGeo=" + this.inferenceGeo + '}';
+				+ ", skillContainer=" + this.skillContainer + ", inferenceGeo=" + this.inferenceGeo + ", webSearchTool="
+				+ this.webSearchTool + '}';
 	}
 
 	/**
@@ -629,6 +648,8 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 		private @Nullable AnthropicSkillContainer skillContainer;
 
 		private @Nullable String inferenceGeo;
+
+		private @Nullable AnthropicWebSearchTool webSearchTool;
 
 		@Override
 		public B outputSchema(@Nullable String outputSchema) {
@@ -794,6 +815,16 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			return self();
 		}
 
+		/**
+		 * Enables Anthropic's built-in web search tool with the given configuration.
+		 * @param webSearchTool the web search configuration
+		 * @return this builder
+		 */
+		public B webSearchTool(@Nullable AnthropicWebSearchTool webSearchTool) {
+			this.webSearchTool = webSearchTool;
+			return self();
+		}
+
 		public B skill(String skillIdOrName) {
 			Assert.hasText(skillIdOrName, "Skill ID or name cannot be empty");
 			AnthropicSkill prebuilt = AnthropicSkill.fromId(skillIdOrName);
@@ -913,6 +944,9 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 				if (options.inferenceGeo != null) {
 					this.inferenceGeo = options.inferenceGeo;
 				}
+				if (options.webSearchTool != null) {
+					this.webSearchTool = options.webSearchTool;
+				}
 			}
 			return self();
 		}
@@ -951,6 +985,7 @@ public class AnthropicChatOptions extends AbstractAnthropicOptions
 			options.httpHeaders = this.httpHeaders;
 			options.skillContainer = this.skillContainer;
 			options.inferenceGeo = this.inferenceGeo;
+			options.webSearchTool = this.webSearchTool;
 			options.validateCitationConsistency();
 			return options;
 		}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicWebSearchResult.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicWebSearchResult.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents an individual web search result returned by Anthropic's built-in web search
+ * tool. Accessible via {@code chatResponse.getMetadata().get("web-search-results")}.
+ *
+ * @param title the page title
+ * @param url the source URL
+ * @param pageAge how old the page is, or null if not available
+ * @author Soby Chacko
+ * @since 1.0.0
+ */
+public record AnthropicWebSearchResult(String title, String url, @Nullable String pageAge) {
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicWebSearchTool.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicWebSearchTool.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Configuration for Anthropic's built-in web search tool. When enabled, Claude can search
+ * the web during a conversation and use the results to generate cited responses.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * var webSearch = AnthropicWebSearchTool.builder()
+ *     .allowedDomains(List.of("docs.spring.io", "github.com"))
+ *     .maxUses(5)
+ *     .build();
+ *
+ * var options = AnthropicChatOptions.builder()
+ *     .webSearchTool(webSearch)
+ *     .build();
+ * }</pre>
+ *
+ * @author Soby Chacko
+ * @since 1.0.0
+ * @see <a href=
+ * "https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search">Anthropic Web
+ * Search</a>
+ */
+public class AnthropicWebSearchTool {
+
+	private @Nullable List<String> allowedDomains;
+
+	private @Nullable List<String> blockedDomains;
+
+	private @Nullable Long maxUses;
+
+	private @Nullable UserLocation userLocation;
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public @Nullable List<String> getAllowedDomains() {
+		return this.allowedDomains;
+	}
+
+	public void setAllowedDomains(@Nullable List<String> allowedDomains) {
+		this.allowedDomains = allowedDomains;
+	}
+
+	public @Nullable List<String> getBlockedDomains() {
+		return this.blockedDomains;
+	}
+
+	public void setBlockedDomains(@Nullable List<String> blockedDomains) {
+		this.blockedDomains = blockedDomains;
+	}
+
+	public @Nullable Long getMaxUses() {
+		return this.maxUses;
+	}
+
+	public void setMaxUses(@Nullable Long maxUses) {
+		this.maxUses = maxUses;
+	}
+
+	public @Nullable UserLocation getUserLocation() {
+		return this.userLocation;
+	}
+
+	public void setUserLocation(@Nullable UserLocation userLocation) {
+		this.userLocation = userLocation;
+	}
+
+	/**
+	 * Approximate user location for localizing web search results.
+	 *
+	 * @param city the city name
+	 * @param country the ISO 3166-1 alpha-2 country code
+	 * @param region the region or state
+	 * @param timezone the IANA timezone identifier
+	 */
+	public record UserLocation(@Nullable String city, @Nullable String country, @Nullable String region,
+			@Nullable String timezone) {
+	}
+
+	public static class Builder {
+
+		private @Nullable List<String> allowedDomains;
+
+		private @Nullable List<String> blockedDomains;
+
+		private @Nullable Long maxUses;
+
+		private @Nullable UserLocation userLocation;
+
+		public Builder allowedDomains(List<String> allowedDomains) {
+			this.allowedDomains = new ArrayList<>(allowedDomains);
+			return this;
+		}
+
+		public Builder blockedDomains(List<String> blockedDomains) {
+			this.blockedDomains = new ArrayList<>(blockedDomains);
+			return this;
+		}
+
+		public Builder maxUses(long maxUses) {
+			this.maxUses = maxUses;
+			return this;
+		}
+
+		public Builder userLocation(@Nullable String city, @Nullable String country, @Nullable String region,
+				@Nullable String timezone) {
+			this.userLocation = new UserLocation(city, country, region, timezone);
+			return this;
+		}
+
+		public AnthropicWebSearchTool build() {
+			AnthropicWebSearchTool tool = new AnthropicWebSearchTool();
+			tool.allowedDomains = this.allowedDomains;
+			tool.blockedDomains = this.blockedDomains;
+			tool.maxUses = this.maxUses;
+			tool.userLocation = this.userLocation;
+			return tool;
+		}
+
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/Citation.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/Citation.java
@@ -61,7 +61,10 @@ public final class Citation {
 		PAGE_LOCATION,
 
 		/** Block-based location for custom content documents */
-		CONTENT_BLOCK_LOCATION
+		CONTENT_BLOCK_LOCATION,
+
+		/** URL-based location for web search results */
+		WEB_SEARCH_RESULT_LOCATION
 
 	}
 
@@ -85,6 +88,8 @@ public final class Citation {
 	private @Nullable Integer startBlockIndex;
 
 	private @Nullable Integer endBlockIndex;
+
+	private @Nullable String url;
 
 	// Private constructor
 	private Citation(LocationType type, String citedText, int documentIndex, @Nullable String documentTitle) {
@@ -145,6 +150,21 @@ public final class Citation {
 		return citation;
 	}
 
+	/**
+	 * Create a web search result location citation. For this type,
+	 * {@link #getDocumentIndex()} returns 0 and is not meaningful — use {@link #getUrl()}
+	 * instead.
+	 * @param citedText the text that was cited from the search result
+	 * @param url the URL of the search result
+	 * @param documentTitle the title of the web page
+	 * @return a new Citation with WEB_SEARCH_RESULT_LOCATION type
+	 */
+	public static Citation ofWebSearchResultLocation(String citedText, String url, @Nullable String documentTitle) {
+		Citation citation = new Citation(LocationType.WEB_SEARCH_RESULT_LOCATION, citedText, 0, documentTitle);
+		citation.url = url;
+		return citation;
+	}
+
 	public LocationType getType() {
 		return this.type;
 	}
@@ -185,6 +205,10 @@ public final class Citation {
 		return this.endBlockIndex;
 	}
 
+	public @Nullable String getUrl() {
+		return this.url;
+	}
+
 	/**
 	 * Get a human-readable location description.
 	 */
@@ -204,6 +228,10 @@ public final class Citation {
 				yield this.startBlockIndex.equals(this.endBlockIndex - 1)
 						? String.format("Block %d", this.startBlockIndex)
 						: String.format("Blocks %d-%d", this.startBlockIndex, this.endBlockIndex - 1);
+			}
+			case WEB_SEARCH_RESULT_LOCATION -> {
+				Assert.state(this.url != null, "url must be defined with web search result location");
+				yield this.url;
 			}
 		};
 	}

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatOptionsTests.java
@@ -568,4 +568,51 @@ class AnthropicChatOptionsTests extends AbstractChatOptionsTests<AnthropicChatOp
 		assertThat(merged2.getInferenceGeo()).isEqualTo("us");
 	}
 
+	@Test
+	void testWebSearchToolBuilder() {
+		AnthropicWebSearchTool webSearch = AnthropicWebSearchTool.builder()
+			.allowedDomains(List.of("docs.spring.io"))
+			.blockedDomains(List.of("example.com"))
+			.maxUses(5)
+			.userLocation("San Francisco", "US", "California", "America/Los_Angeles")
+			.build();
+
+		AnthropicChatOptions options = AnthropicChatOptions.builder().webSearchTool(webSearch).build();
+
+		assertThat(options.getWebSearchTool()).isNotNull();
+		assertThat(options.getWebSearchTool().getAllowedDomains()).containsExactly("docs.spring.io");
+		assertThat(options.getWebSearchTool().getBlockedDomains()).containsExactly("example.com");
+		assertThat(options.getWebSearchTool().getMaxUses()).isEqualTo(5);
+		assertThat(options.getWebSearchTool().getUserLocation()).isNotNull();
+		assertThat(options.getWebSearchTool().getUserLocation().city()).isEqualTo("San Francisco");
+		assertThat(options.getWebSearchTool().getUserLocation().country()).isEqualTo("US");
+	}
+
+	@Test
+	void testWebSearchToolPreservedInMutate() {
+		AnthropicWebSearchTool webSearch = AnthropicWebSearchTool.builder().maxUses(3).build();
+		AnthropicChatOptions original = AnthropicChatOptions.builder().webSearchTool(webSearch).build();
+		AnthropicChatOptions copied = original.mutate().build();
+
+		assertThat(copied.getWebSearchTool()).isNotNull();
+		assertThat(copied.getWebSearchTool().getMaxUses()).isEqualTo(3);
+	}
+
+	@Test
+	void testWebSearchToolCombineWith() {
+		AnthropicWebSearchTool base = AnthropicWebSearchTool.builder().maxUses(3).build();
+		AnthropicWebSearchTool override = AnthropicWebSearchTool.builder().maxUses(10).build();
+
+		AnthropicChatOptions baseOpts = AnthropicChatOptions.builder().webSearchTool(base).build();
+		AnthropicChatOptions overrideOpts = AnthropicChatOptions.builder().webSearchTool(override).build();
+
+		AnthropicChatOptions merged = baseOpts.mutate().combineWith(overrideOpts.mutate()).build();
+		assertThat(merged.getWebSearchTool().getMaxUses()).isEqualTo(10);
+
+		// Null doesn't override
+		AnthropicChatOptions noOverride = AnthropicChatOptions.builder().build();
+		AnthropicChatOptions merged2 = baseOpts.mutate().combineWith(noOverride.mutate()).build();
+		assertThat(merged2.getWebSearchTool().getMaxUses()).isEqualTo(3);
+	}
+
 }

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelIT.java
@@ -41,6 +41,8 @@ import org.springframework.ai.anthropic.AnthropicChatModel;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.anthropic.AnthropicCitationDocument;
 import org.springframework.ai.anthropic.AnthropicTestConfiguration;
+import org.springframework.ai.anthropic.AnthropicWebSearchResult;
+import org.springframework.ai.anthropic.AnthropicWebSearchTool;
 import org.springframework.ai.anthropic.Citation;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -871,6 +873,38 @@ class AnthropicChatModelIT {
 		assertThat(text).isNotEmpty();
 		logger.info("Structured output with effort response: {}", text);
 		assertThat(text).contains("answer");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void webSearchTest() {
+		var webSearch = AnthropicWebSearchTool.builder().maxUses(3).build();
+
+		var options = AnthropicChatOptions.builder().model(Model.CLAUDE_SONNET_4_6).webSearchTool(webSearch).build();
+
+		ChatResponse response = this.chatModel
+			.call(new Prompt("What is the latest released version of Spring AI?", options));
+
+		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+		logger.info("Web search response: {}", response.getResult().getOutput().getText());
+
+		// Verify web search results are surfaced in metadata
+		List<AnthropicWebSearchResult> results = (List<AnthropicWebSearchResult>) response.getMetadata()
+			.get("web-search-results");
+		assertThat(results).isNotNull().isNotEmpty();
+		assertThat(results.get(0).url()).isNotEmpty();
+		assertThat(results.get(0).title()).isNotEmpty();
+
+		// Verify web search citations if present
+		List<Citation> citations = (List<Citation>) response.getMetadata().get("citations");
+		if (citations != null && !citations.isEmpty()) {
+			logger.info("Web search citations received: {}", citations.size());
+			citations.stream()
+				.filter(c -> c.getType() == Citation.LocationType.WEB_SEARCH_RESULT_LOCATION)
+				.forEach(c -> logger.info("Web search citation: url={}, title={}", c.getUrl(), c.getDocumentTitle()));
+			assertThat(citations).anyMatch(c -> c.getType() == Citation.LocationType.WEB_SEARCH_RESULT_LOCATION
+					&& c.getUrl() != null && !c.getUrl().isEmpty());
+		}
 	}
 
 	record ActorsFilmsRecord(String actor, List<String> movies) {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -60,6 +60,13 @@ Use the `spring.ai.anthropic.*` properties to configure the Anthropic connection
 | `spring.ai.anthropic.chat.options.temperature` | Sampling temperature | -
 | `spring.ai.anthropic.chat.options.top-p` | Top-p sampling | -
 | `spring.ai.anthropic.chat.options.top-k` | Top-k sampling | -
+| `spring.ai.anthropic.chat.options.web-search-tool.max-uses` | Maximum number of web searches per request | -
+| `spring.ai.anthropic.chat.options.web-search-tool.allowed-domains` | Comma-separated list of domains to restrict search results to | -
+| `spring.ai.anthropic.chat.options.web-search-tool.blocked-domains` | Comma-separated list of domains to exclude from search results | -
+| `spring.ai.anthropic.chat.options.web-search-tool.user-location.city` | City for localizing search results | -
+| `spring.ai.anthropic.chat.options.web-search-tool.user-location.country` | ISO 3166-1 alpha-2 country code | -
+| `spring.ai.anthropic.chat.options.web-search-tool.user-location.region` | Region or state | -
+| `spring.ai.anthropic.chat.options.web-search-tool.user-location.timezone` | IANA timezone identifier | -
 |====
 
 == Manual Configuration
@@ -1398,6 +1405,123 @@ try {
 } catch (IOException e) {
     log.error("Failed to download file: {}", e.getMessage());
 }
+----
+
+== Web Search
+
+Anthropic's https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search[Web Search] tool allows Claude to search the web during a conversation and use the results to generate cited responses.
+
+[NOTE]
+====
+* Web search is a built-in server-side tool — no external tool callbacks are needed
+* Web search results automatically include citations with URLs
+* You can combine web search with other tools (function calling, code execution, skills) in the same request
+====
+
+=== Basic Usage
+
+Enable web search by adding an `AnthropicWebSearchTool` to your chat options:
+
+[source,java]
+----
+var webSearch = AnthropicWebSearchTool.builder().build();
+
+ChatResponse response = chatModel.call(
+    new Prompt("What is the latest released version of Spring AI?",
+        AnthropicChatOptions.builder()
+            .webSearchTool(webSearch)
+            .build()));
+
+String answer = response.getResult().getOutput().getText();
+----
+
+=== Configuration Options
+
+[cols="3,5,1", stripes=even]
+|====
+| Option | Description | Default
+
+| maxUses | Maximum number of web searches Claude can perform per request | -
+| allowedDomains | Restrict search results to these domains only | -
+| blockedDomains | Exclude these domains from search results | -
+| userLocation | Approximate user location for localizing results (city, country, region, timezone) | -
+|====
+
+=== Domain Filtering
+
+Restrict or exclude specific domains from search results:
+
+[source,java]
+----
+var webSearch = AnthropicWebSearchTool.builder()
+    .allowedDomains(List.of("docs.spring.io", "github.com"))
+    .blockedDomains(List.of("example.com"))
+    .maxUses(5)
+    .build();
+----
+
+=== User Location
+
+Provide approximate location to localize search results:
+
+[source,java]
+----
+var webSearch = AnthropicWebSearchTool.builder()
+    .userLocation("San Francisco", "US", "California", "America/Los_Angeles")
+    .build();
+----
+
+=== Accessing Web Search Results
+
+Web search results and citations are available in the response metadata:
+
+[source,java]
+----
+ChatResponse response = chatModel.call(
+    new Prompt("What happened in tech news today?",
+        AnthropicChatOptions.builder()
+            .webSearchTool(AnthropicWebSearchTool.builder().build())
+            .build()));
+
+// Get web search results
+@SuppressWarnings("unchecked")
+List<AnthropicWebSearchResult> results =
+    (List<AnthropicWebSearchResult>) response.getMetadata().get("web-search-results");
+
+if (results != null) {
+    for (AnthropicWebSearchResult result : results) {
+        System.out.println("Title: " + result.title());
+        System.out.println("URL: " + result.url());
+        System.out.println("Page age: " + result.pageAge());
+    }
+}
+
+// Get web search citations
+@SuppressWarnings("unchecked")
+List<Citation> citations =
+    (List<Citation>) response.getMetadata().get("citations");
+
+if (citations != null) {
+    for (Citation citation : citations) {
+        if (citation.getType() == Citation.LocationType.WEB_SEARCH_RESULT_LOCATION) {
+            System.out.println("Source: " + citation.getUrl());
+            System.out.println("Title: " + citation.getDocumentTitle());
+            System.out.println("Cited text: " + citation.getCitedText());
+        }
+    }
+}
+----
+
+=== Spring Boot Configuration
+
+Configure web search via `application.properties` or `application.yml`:
+
+[source,properties]
+----
+spring.ai.anthropic.chat.options.web-search-tool.max-uses=5
+spring.ai.anthropic.chat.options.web-search-tool.allowed-domains=docs.spring.io,github.com
+spring.ai.anthropic.chat.options.web-search-tool.user-location.city=San Francisco
+spring.ai.anthropic.chat.options.web-search-tool.user-location.country=US
 ----
 
 == Observability


### PR DESCRIPTION
Enable Claude to search the web during conversations via AnthropicWebSearchTool configuration on chat options. Web search results and URL-based citations are surfaced in ChatResponse metadata. Includes auto-configuration property binding and reference documentation.