### PR TITLE
Fix `AssistantMessage.ToolCall.id` handling with Ollama

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -258,7 +258,8 @@ public class OllamaChatModel implements ChatModel {
 						: ollamaResponse.message()
 							.toolCalls()
 							.stream()
-							.map(toolCall -> new AssistantMessage.ToolCall("", "function", toolCall.function().name(),
+							.map(toolCall -> new AssistantMessage.ToolCall(toolCall.id(), "function",
+									toolCall.function().name(),
 									ModelOptionsUtils.toJsonString(toolCall.function().arguments())))
 							.toList();
 
@@ -344,7 +345,8 @@ public class OllamaChatModel implements ChatModel {
 					toolCalls = chunk.message()
 						.toolCalls()
 						.stream()
-						.map(toolCall -> new AssistantMessage.ToolCall("", "function", toolCall.function().name(),
+						.map(toolCall -> new AssistantMessage.ToolCall(toolCall.id(), "function",
+								toolCall.function().name(),
 								ModelOptionsUtils.toJsonString(toolCall.function().arguments())))
 						.toList();
 				}
@@ -499,7 +501,7 @@ public class OllamaChatModel implements ChatModel {
 						var function = new ToolCallFunction(toolCall.name(),
 								JsonParser.fromJson(toolCall.arguments(), new TypeReference<>() {
 								}));
-						return new ToolCall(function);
+						return new ToolCall(toolCall.id(), function);
 					}).toList();
 				}
 				return List.of(OllamaApi.Message.builder(Role.ASSISTANT)

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaApi.java
@@ -310,10 +310,12 @@ public final class OllamaApi {
 		/**
 		 * The relevant tool call.
 		 *
+		 * @param id The id of the tool call.
 		 * @param function The function definition.
 		 */
 		@JsonInclude(Include.NON_NULL)
 		public record ToolCall(
+			@JsonProperty("id") String id,
 			@JsonProperty("function") ToolCallFunction function) {
 		}
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelFunctionCallingIT.java
@@ -79,6 +79,27 @@ class OllamaChatModelFunctionCallingIT extends BaseOllamaIT {
 	}
 
 	@Test
+	void toolCallIdIsPopulated() {
+		UserMessage userMessage = new UserMessage("What are the weather conditions in San Francisco?");
+
+		var promptOptions = OllamaChatOptions.builder()
+			.model(MODEL)
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.description(
+						"Find the weather conditions, forecasts, and temperatures for a location, like a city or state.")
+				.inputType(MockWeatherService.Request.class)
+				.build()))
+			.internalToolExecutionEnabled(false)
+			.build();
+
+		ChatResponse response = this.chatModel.call(new Prompt(List.of(userMessage), promptOptions));
+
+		AssistantMessage assistantMessage = response.getResult().getOutput();
+		assertThat(assistantMessage.getToolCalls()).isNotNull().hasSize(1);
+		assertThat(assistantMessage.getToolCalls().get(0).id()).isNotBlank();
+	}
+
+	@Test
 	void streamFunctionCallTest() {
 		UserMessage userMessage = new UserMessage(
 				"What are the weather conditions in San Francisco, Tokyo, and Paris? Find the temperature in Celsius for each of the three locations.");


### PR DESCRIPTION
Update the `OllamaApi.ToolCall` record to deserialize the `id` property and map it correctly to `AssistantMessage.ToolCall`, replacing the previously hardcoded empty string.

I plan to backport it to `1.1.x` (manually due to conflicts).

Fixes #5694