### PR TITLE
feat: add spring.ai.mcp.server.immediate-execution property for WebMVC Sampling support

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
@@ -215,12 +215,22 @@ public class McpServerAutoConfiguration {
 		return serverBuilder.build();
 	}
 
+	/**
+	 * Registers a {@link McpSyncServerCustomizer} for servlet-based (WebMVC) deployments
+	 * that applies the configured {@code immediateExecution} setting.
+	 * <p>
+	 * By default, {@code immediateExecution} is {@code true} to preserve backwards
+	 * compatibility. Set {@code spring.ai.mcp.server.immediate-execution=false} when
+	 * your MCP tools issue server-initiated requests to the client (MCP Sampling or
+	 * Elicitation), to avoid exhausting the servlet container's thread pool while
+	 * handlers block waiting for the client's response.
+	 */
 	@Bean
 	@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
-	McpSyncServerCustomizer servletMcpSyncServerCustomizer() {
-		return serverBuilder -> serverBuilder.immediateExecution(true);
+	McpSyncServerCustomizer servletMcpSyncServerCustomizer(McpServerProperties serverProperties) {
+		return serverBuilder -> serverBuilder.immediateExecution(serverProperties.isImmediateExecution());
 	}
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
@@ -100,6 +100,27 @@ public class McpServerProperties {
 	private ServerProtocol protocol = ServerProtocol.SSE;
 
 	/**
+	 * Whether to execute tool/handler requests on the servlet container thread
+	 * (immediate execution) or dispatch them to a separate thread pool.
+	 * <p>
+	 * When {@code true} (default), the request handler runs synchronously on the
+	 * incoming HTTP request thread. This is the standard behaviour for Spring WebMVC
+	 * servlet applications that do not use MCP Sampling or Elicitation.
+	 * <p>
+	 * When {@code false}, the request handler is dispatched to a bounded elastic
+	 * scheduler thread before execution. This is required when using MCP Sampling
+	 * ({@code sampling/createMessage}) or Elicitation, because those features block
+	 * the handler thread while waiting for the client's response. Running on the
+	 * servlet container thread would exhaust its thread pool under load, as each
+	 * in-flight sampling request holds a Tomcat worker thread for the full duration
+	 * of the LLM call.
+	 * <p>
+	 * Set to {@code false} when your MCP tools issue server-initiated requests to
+	 * the client (sampling, elicitation).
+	 */
+	private boolean immediateExecution = true;
+
+	/**
 	 * Sets the duration to wait for server responses before timing out requests. This
 	 * timeout applies to all requests made through the client, including tool calls,
 	 * resource access, and prompt operations.
@@ -209,6 +230,14 @@ public class McpServerProperties {
 	public void setProtocol(ServerProtocol serverMode) {
 		Assert.notNull(serverMode, "Server mode must not be null");
 		this.protocol = serverMode;
+	}
+
+	public boolean isImmediateExecution() {
+		return this.immediateExecution;
+	}
+
+	public void setImmediateExecution(boolean immediateExecution) {
+		this.immediateExecution = immediateExecution;
 	}
 
 	public static class Capabilities {


### PR DESCRIPTION
Added configurable property to support MCP Sampling without thread pool exhaustion. When tools use MCP Sampling, they block the handler thread. Setting spring.ai.mcp.server.immediate-execution=false dispatches handlers to a bounded-elastic scheduler.