### PR TITLE
Add Amazon Bedrock AgentCore ChatMemoryRepository

### DIFF
--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../../../../../pom.xml</relativePath>
+    </parent>
+    <artifactId>spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Bedrock AgentCore Chat Memory Auto Configuration</name>
+    <description>Spring AI Bedrock AgentCore Chat Memory Repository Auto Configuration</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-model-chat-memory-repository-bedrock-agentcore</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-bedrock-ai</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-test</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/BedrockAgentCoreChatMemoryRepositoryAutoConfiguration.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/BedrockAgentCoreChatMemoryRepositoryAutoConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.chat.memory.repository.bedrock.agentcore.autoconfigure;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
+
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.repository.bedrock.agentcore.BedrockAgentCoreChatMemoryConfig;
+import org.springframework.ai.chat.memory.repository.bedrock.agentcore.BedrockAgentCoreChatMemoryRepository;
+import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionConfiguration;
+import org.springframework.ai.model.chat.memory.autoconfigure.ChatMemoryAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.util.Assert;
+
+/**
+ * {@link AutoConfiguration} for {@link BedrockAgentCoreChatMemoryRepository}.
+ *
+ * <p>
+ * Requires {@code spring.ai.chat.memory.repository.bedrock.agent-core.memory.memory-id}
+ * to be set. AWS credentials and region are resolved via the shared
+ * {@link BedrockAwsConnectionConfiguration} (configured via
+ * {@code spring.ai.bedrock.aws.*} properties).
+ * </p>
+ *
+ * @author Chaemin Lee
+ */
+@AutoConfiguration(before = ChatMemoryAutoConfiguration.class)
+@ConditionalOnClass({ BedrockAgentCoreChatMemoryRepository.class, BedrockAgentCoreClient.class })
+@EnableConfigurationProperties(BedrockAgentCoreChatMemoryRepositoryProperties.class)
+@Import(BedrockAwsConnectionConfiguration.class)
+public class BedrockAgentCoreChatMemoryRepositoryAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(ChatMemoryRepository.class)
+	@ConditionalOnBean({ AwsCredentialsProvider.class, AwsRegionProvider.class })
+	public BedrockAgentCoreChatMemoryRepository chatMemoryRepository(AwsCredentialsProvider credentialsProvider,
+			AwsRegionProvider regionProvider, BedrockAgentCoreChatMemoryRepositoryProperties props) {
+		Assert.hasText(props.getMemoryId(),
+				"spring.ai.chat.memory.repository.bedrock.agent-core.memory.memory-id must be set");
+
+		BedrockAgentCoreClient client = BedrockAgentCoreClient.builder()
+			.credentialsProvider(credentialsProvider)
+			.region(regionProvider.getRegion())
+			.build();
+
+		BedrockAgentCoreChatMemoryConfig config = BedrockAgentCoreChatMemoryConfig.builder()
+			.bedrockAgentCoreClient(client)
+			.memoryId(props.getMemoryId())
+			.actorId(props.getActorId())
+			.build();
+
+		return new BedrockAgentCoreChatMemoryRepository(config);
+	}
+
+}

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/BedrockAgentCoreChatMemoryRepositoryProperties.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/BedrockAgentCoreChatMemoryRepositoryProperties.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.chat.memory.repository.bedrock.agentcore.autoconfigure;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.memory.repository.bedrock.agentcore.BedrockAgentCoreChatMemoryConfig;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for
+ * {@link BedrockAgentCoreChatMemoryRepositoryAutoConfiguration}.
+ *
+ * @author Chaemin Lee
+ */
+@ConfigurationProperties(BedrockAgentCoreChatMemoryRepositoryProperties.CONFIG_PREFIX)
+public class BedrockAgentCoreChatMemoryRepositoryProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.chat.memory.repository.bedrock.agent-core.memory";
+
+	/**
+	 * The Bedrock AgentCore Memory Store ID (must be pre-created in AWS).
+	 */
+	private @Nullable String memoryId;
+
+	/**
+	 * The actor ID representing this application in Bedrock AgentCore.
+	 */
+	private String actorId = BedrockAgentCoreChatMemoryConfig.DEFAULT_ACTOR_ID;
+
+	public @Nullable String getMemoryId() {
+		return this.memoryId;
+	}
+
+	public void setMemoryId(@Nullable String memoryId) {
+		this.memoryId = memoryId;
+	}
+
+	public String getActorId() {
+		return this.actorId;
+	}
+
+	public void setActorId(String actorId) {
+		this.actorId = actorId;
+	}
+
+}

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/package-info.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.model.chat.memory.repository.bedrock.agentcore.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2023-present the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.springframework.ai.model.chat.memory.repository.bedrock.agentcore.autoconfigure.BedrockAgentCoreChatMemoryRepositoryAutoConfiguration

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/BedrockAgentCoreChatMemoryRepositoryAutoConfigurationIT.java
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/model/chat/memory/repository/bedrock/agentcore/autoconfigure/BedrockAgentCoreChatMemoryRepositoryAutoConfigurationIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.chat.memory.repository.bedrock.agentcore.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.repository.bedrock.agentcore.BedrockAgentCoreChatMemoryRepository;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link BedrockAgentCoreChatMemoryRepositoryAutoConfiguration}.
+ *
+ * @author Chaemin Lee
+ */
+class BedrockAgentCoreChatMemoryRepositoryAutoConfigurationIT {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(BedrockAgentCoreChatMemoryRepositoryAutoConfiguration.class))
+		.withUserConfiguration(MockAwsConfig.class)
+		.withPropertyValues("spring.ai.chat.memory.repository.bedrock.agent-core.memory.memory-id=test-store");
+
+	@Test
+	void autoConfiguresBedrockRepository() {
+		this.contextRunner.run(ctx -> {
+			assertThat(ctx).hasSingleBean(BedrockAgentCoreChatMemoryRepository.class);
+			assertThat(ctx).hasSingleBean(ChatMemoryRepository.class);
+		});
+	}
+
+	@Test
+	void backsOffWhenChatMemoryRepositoryAlreadyDefined() {
+		this.contextRunner.withUserConfiguration(UserDefinedRepositoryConfig.class).run(ctx -> {
+			assertThat(ctx).hasSingleBean(ChatMemoryRepository.class);
+			assertThat(ctx).doesNotHaveBean(BedrockAgentCoreChatMemoryRepository.class);
+		});
+	}
+
+	@Test
+	void defaultActorIdIsSpringAi() {
+		this.contextRunner.run(ctx -> {
+			BedrockAgentCoreChatMemoryRepositoryProperties props = ctx
+				.getBean(BedrockAgentCoreChatMemoryRepositoryProperties.class);
+			assertThat(props.getActorId()).isEqualTo("spring-ai");
+		});
+	}
+
+	@Test
+	void customActorIdIsApplied() {
+		this.contextRunner
+			.withPropertyValues("spring.ai.chat.memory.repository.bedrock.agent-core.memory.actor-id=my-agent")
+			.run(ctx -> {
+				BedrockAgentCoreChatMemoryRepositoryProperties props = ctx
+					.getBean(BedrockAgentCoreChatMemoryRepositoryProperties.class);
+				assertThat(props.getActorId()).isEqualTo("my-agent");
+			});
+	}
+
+	@Configuration
+	static class MockAwsConfig {
+
+		@Bean
+		AwsCredentialsProvider credentialsProvider() {
+			return Mockito.mock(AwsCredentialsProvider.class);
+		}
+
+		@Bean
+		AwsRegionProvider regionProvider() {
+			AwsRegionProvider mock = Mockito.mock(AwsRegionProvider.class);
+			Mockito.when(mock.getRegion()).thenReturn(Region.US_EAST_1);
+			return mock;
+		}
+
+	}
+
+	@Configuration
+	static class UserDefinedRepositoryConfig {
+
+		@Bean
+		ChatMemoryRepository customRepository() {
+			return Mockito.mock(ChatMemoryRepository.class);
+		}
+
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/pom.xml
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-ai-model-chat-memory-repository-bedrock-agentcore</artifactId>
+    <name>Spring AI Bedrock AgentCore Chat Memory Repository</name>
+    <description>Spring AI ChatMemoryRepository implementation backed by Amazon Bedrock AgentCore Memory</description>
+
+    <url>https://github.com/spring-projects/spring-ai</url>
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-client-chat</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>bedrockagentcore</artifactId>
+            <version>${bedrockagentcore.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/AdvancedBedrockAgentCoreChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/AdvancedBedrockAgentCoreChatMemoryRepository.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.bedrock.agentcore;
+
+import java.util.List;
+
+import software.amazon.awssdk.services.bedrockagentcore.model.MemoryRecordSummary;
+
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.messages.Message;
+
+/**
+ * Bedrock AgentCore-specific extended interface for {@link ChatMemoryRepository} that
+ * provides access to <strong>long-term memory</strong> operations.
+ *
+ * <p>
+ * Bedrock AgentCore separates memory into two layers:
+ * <ul>
+ * <li><strong>Short-term (Events API)</strong>: raw conversation events stored per
+ * session. The base {@link ChatMemoryRepository} operations ({@code saveAll},
+ * {@code findByConversationId}, {@code deleteByConversationId}) map to this layer.</li>
+ * <li><strong>Long-term (MemoryRecords API)</strong>: structured memories extracted from
+ * conversations by Bedrock's memory strategies. This interface adds operations for
+ * semantic retrieval, listing, and deletion of these records.</li>
+ * </ul>
+ *
+ * <p>
+ * The {@code memoryId} is always taken from the underlying
+ * {@link BedrockAgentCoreChatMemoryConfig} and does not need to be supplied by the
+ * caller.
+ *
+ * <p>
+ * For multi-actor (e.g. per-user) scenarios, use the overloads that take an explicit
+ * {@code actorId}. The {@link ChatMemoryRepository} methods delegate to those overloads
+ * using {@link BedrockAgentCoreChatMemoryConfig#getActorId()}.
+ *
+ * @author Chaemin Lee
+ * @see BedrockAgentCoreChatMemoryRepository
+ * @see BedrockAgentCoreChatMemoryConfig
+ */
+public interface AdvancedBedrockAgentCoreChatMemoryRepository extends ChatMemoryRepository {
+
+	/**
+	 * Lists conversation ids (Bedrock session ids) for the given actor.
+	 *
+	 * <p>
+	 * Uses the Bedrock SDK paginator ({@code listSessionsPaginator}) to automatically
+	 * traverse all pages. The SDK fetches pages of up to 20 items by default, but all
+	 * pages are consumed transparently and the full result set is returned.
+	 * @param actorId the Bedrock AgentCore actor identifier
+	 * @return session ids, never {@code null}
+	 */
+	List<String> findConversationIds(String actorId);
+
+	/**
+	 * Loads all messages for a conversation scoped to the given actor.
+	 *
+	 * <p>
+	 * Uses the Bedrock SDK paginator ({@code listEventsPaginator}) to automatically
+	 * traverse all pages. The SDK fetches pages of up to 20 items by default, but all
+	 * pages are consumed transparently and the full result set is returned.
+	 * @param actorId the Bedrock AgentCore actor identifier
+	 * @param conversationId the conversation id (Bedrock session id)
+	 * @return messages in chronological order, never {@code null}
+	 */
+	List<Message> findByConversationId(String actorId, String conversationId);
+
+	/**
+	 * Replaces all messages for a conversation scoped to the given actor.
+	 * @param actorId the Bedrock AgentCore actor identifier
+	 * @param conversationId the conversation id (Bedrock session id)
+	 * @param messages the messages to store
+	 */
+	void saveAll(String actorId, String conversationId, List<Message> messages);
+
+	/**
+	 * Deletes all messages for a conversation scoped to the given actor.
+	 * @param actorId the Bedrock AgentCore actor identifier
+	 * @param conversationId the conversation id (Bedrock session id)
+	 */
+	void deleteByConversationId(String actorId, String conversationId);
+
+	/**
+	 * Semantically searches long-term memory records under the namespace.
+	 *
+	 * <p>
+	 * Uses the Bedrock SDK paginator ({@code retrieveMemoryRecordsPaginator}) to
+	 * automatically traverse all pages. The SDK fetches pages of up to 20 items by
+	 * default, but all pages are consumed transparently and the full result set is
+	 * returned.
+	 * @param namespace namespace prefix for stored records
+	 * @param searchQuery natural-language query (up to 10,000 characters)
+	 * @return matching summaries ordered by relevance, never {@code null}
+	 */
+	List<MemoryRecordSummary> retrieveMemoryRecords(String namespace, String searchQuery);
+
+	/**
+	 * Lists long-term memory records under the namespace without semantic search.
+	 *
+	 * <p>
+	 * Uses the Bedrock SDK paginator ({@code listMemoryRecordsPaginator}) to
+	 * automatically traverse all pages. The SDK fetches pages of up to 20 items by
+	 * default, but all pages are consumed transparently and the full result set is
+	 * returned.
+	 * @param namespace namespace prefix
+	 * @return summaries, never {@code null}
+	 */
+	List<MemoryRecordSummary> listMemoryRecords(String namespace);
+
+	/**
+	 * Deletes a specific long-term memory record by its ID.
+	 * @param memoryRecordId the memory record identifier
+	 */
+	void deleteMemoryRecord(String memoryRecordId);
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryConfig.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryConfig.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.bedrock.agentcore;
+
+import org.jspecify.annotations.Nullable;
+import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
+
+import org.springframework.util.Assert;
+
+/**
+ * Configuration class for {@link BedrockAgentCoreChatMemoryRepository}.
+ *
+ * @author Chaemin Lee
+ * @see BedrockAgentCoreChatMemoryRepository
+ */
+public final class BedrockAgentCoreChatMemoryConfig {
+
+	/**
+	 * Default actor ID used when no explicit actor is configured.
+	 */
+	public static final String DEFAULT_ACTOR_ID = "spring-ai";
+
+	private final BedrockAgentCoreClient bedrockAgentCoreClient;
+
+	private final String memoryId;
+
+	private final String actorId;
+
+	private BedrockAgentCoreChatMemoryConfig(Builder builder) {
+		Assert.notNull(builder.bedrockAgentCoreClient, "bedrockAgentCoreClient must not be null");
+		Assert.hasText(builder.memoryId, "memoryId must not be empty");
+		Assert.hasText(builder.actorId, "actorId must not be empty");
+
+		this.bedrockAgentCoreClient = builder.bedrockAgentCoreClient;
+		this.memoryId = builder.memoryId;
+		this.actorId = builder.actorId;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public BedrockAgentCoreClient getBedrockAgentCoreClient() {
+		return this.bedrockAgentCoreClient;
+	}
+
+	public String getMemoryId() {
+		return this.memoryId;
+	}
+
+	public String getActorId() {
+		return this.actorId;
+	}
+
+	/**
+	 * Builder for {@link BedrockAgentCoreChatMemoryConfig}.
+	 */
+	public static final class Builder {
+
+		private @Nullable BedrockAgentCoreClient bedrockAgentCoreClient;
+
+		private @Nullable String memoryId;
+
+		private String actorId = DEFAULT_ACTOR_ID;
+
+		private Builder() {
+		}
+
+		public Builder bedrockAgentCoreClient(BedrockAgentCoreClient bedrockAgentCoreClient) {
+			this.bedrockAgentCoreClient = bedrockAgentCoreClient;
+			return this;
+		}
+
+		public Builder memoryId(String memoryId) {
+			this.memoryId = memoryId;
+			return this;
+		}
+
+		public Builder actorId(String actorId) {
+			this.actorId = actorId;
+			return this;
+		}
+
+		public BedrockAgentCoreChatMemoryConfig build() {
+			return new BedrockAgentCoreChatMemoryConfig(this);
+		}
+
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryRepository.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.bedrock.agentcore;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
+import software.amazon.awssdk.services.bedrockagentcore.model.Content;
+import software.amazon.awssdk.services.bedrockagentcore.model.Conversational;
+import software.amazon.awssdk.services.bedrockagentcore.model.CreateEventRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.DeleteEventRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.DeleteMemoryRecordRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.Event;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListEventsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListMemoryRecordsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListSessionsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.MemoryRecordSummary;
+import software.amazon.awssdk.services.bedrockagentcore.model.PayloadType;
+import software.amazon.awssdk.services.bedrockagentcore.model.RetrieveMemoryRecordsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.Role;
+import software.amazon.awssdk.services.bedrockagentcore.model.SearchCriteria;
+import software.amazon.awssdk.services.bedrockagentcore.model.SessionSummary;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.util.Assert;
+
+/**
+ * An implementation of {@link AdvancedBedrockAgentCoreChatMemoryRepository} backed by
+ * Amazon Bedrock AgentCore Memory.
+ *
+ * <p>
+ * Maps Spring AI {@link Message} objects to Bedrock AgentCore Events. The
+ * {@code conversationId} maps to the Bedrock AgentCore {@code sessionId}. Message roles
+ * are stored using the native {@link Role} enum in the {@code Conversational} payload.
+ * </p>
+ *
+ * <p>
+ * Use {@link #builder()} or construct directly with a
+ * {@link BedrockAgentCoreChatMemoryConfig}.
+ * </p>
+ *
+ * @author Chaemin Lee
+ * @see AdvancedBedrockAgentCoreChatMemoryRepository
+ * @see BedrockAgentCoreChatMemoryConfig
+ */
+public final class BedrockAgentCoreChatMemoryRepository implements AdvancedBedrockAgentCoreChatMemoryRepository {
+
+	private static final Logger logger = LoggerFactory.getLogger(BedrockAgentCoreChatMemoryRepository.class);
+
+	static final String METADATA_KEY_EVENT_ID = "bedrockEventId";
+
+	private final BedrockAgentCoreChatMemoryConfig config;
+
+	private final BedrockAgentCoreClient bedrockAgentCoreClient;
+
+	public BedrockAgentCoreChatMemoryRepository(BedrockAgentCoreChatMemoryConfig config) {
+		Assert.notNull(config, "config must not be null");
+
+		this.config = config;
+		this.bedrockAgentCoreClient = config.getBedrockAgentCoreClient();
+	}
+
+	@Override
+	public List<String> findConversationIds() {
+		return findConversationIds(this.config.getActorId());
+	}
+
+	@Override
+	public List<String> findConversationIds(String actorId) {
+		Assert.hasText(actorId, "actorId must not be empty");
+
+		ListSessionsRequest request = ListSessionsRequest.builder()
+			.memoryId(this.config.getMemoryId())
+			.actorId(actorId)
+			.build();
+
+		try {
+			return this.bedrockAgentCoreClient.listSessionsPaginator(request)
+				.sessionSummaries()
+				.stream()
+				.map(SessionSummary::sessionId)
+				.toList();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to list conversation ids", e);
+		}
+	}
+
+	@Override
+	public List<Message> findByConversationId(String conversationId) {
+		return findByConversationId(this.config.getActorId(), conversationId);
+	}
+
+	@Override
+	public List<Message> findByConversationId(String actorId, String conversationId) {
+		Assert.hasText(actorId, "actorId must not be empty");
+		Assert.hasText(conversationId, "conversationId must not be empty");
+
+		return findEventsByConversationId(actorId, conversationId,
+				Comparator.comparing(Event::eventTimestamp, Comparator.nullsLast(Comparator.naturalOrder())))
+			.stream()
+			.map(BedrockAgentCoreChatMemoryRepository::toMessage)
+			.toList();
+	}
+
+	@Override
+	public void saveAll(String conversationId, List<Message> messages) {
+		saveAll(this.config.getActorId(), conversationId, messages);
+	}
+
+	@Override
+	public void saveAll(String actorId, String conversationId, List<Message> messages) {
+		Assert.hasText(actorId, "actorId must not be empty");
+		Assert.hasText(conversationId, "conversationId must not be empty");
+		Assert.notNull(messages, "messages must not be null");
+		Assert.noNullElements(messages, "messages cannot contain null elements");
+
+		deleteByConversationId(actorId, conversationId);
+		for (Message message : messages) {
+			CreateEventRequest request = CreateEventRequest.builder()
+				.memoryId(this.config.getMemoryId())
+				.actorId(actorId)
+				.sessionId(conversationId)
+				.eventTimestamp(Instant.now())
+				.payload(toPayload(message))
+				.build();
+			try {
+				this.bedrockAgentCoreClient.createEvent(request);
+			}
+			catch (Exception e) {
+				throw new IllegalStateException(
+						"Failed to save event for actorId=" + actorId + ", conversationId=" + conversationId, e);
+			}
+		}
+	}
+
+	@Override
+	public void deleteByConversationId(String conversationId) {
+		deleteByConversationId(this.config.getActorId(), conversationId);
+	}
+
+	@Override
+	public void deleteByConversationId(String actorId, String conversationId) {
+		Assert.hasText(actorId, "actorId must not be empty");
+		Assert.hasText(conversationId, "conversationId must not be empty");
+
+		List<Event> events = findEventsByConversationId(actorId, conversationId, null);
+		for (Event event : events) {
+			DeleteEventRequest request = DeleteEventRequest.builder()
+				.memoryId(this.config.getMemoryId())
+				.actorId(actorId)
+				.sessionId(conversationId)
+				.eventId(event.eventId())
+				.build();
+			try {
+				this.bedrockAgentCoreClient.deleteEvent(request);
+			}
+			catch (Exception e) {
+				throw new IllegalStateException(
+						"Failed to delete event for actorId=" + actorId + ", conversationId=" + conversationId, e);
+			}
+		}
+	}
+
+	private List<Event> findEventsByConversationId(String actorId, String conversationId,
+			@Nullable Comparator<Event> comparator) {
+		ListEventsRequest request = ListEventsRequest.builder()
+			.memoryId(this.config.getMemoryId())
+			.actorId(actorId)
+			.sessionId(conversationId)
+			.includePayloads(true)
+			.build();
+
+		try {
+			Stream<Event> stream = this.bedrockAgentCoreClient.listEventsPaginator(request).events().stream();
+			if (comparator != null) {
+				stream = stream.sorted(comparator);
+			}
+			return stream.toList();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException(
+					"Failed to list events for actorId=" + actorId + ", conversationId=" + conversationId, e);
+		}
+	}
+
+	private static PayloadType toPayload(Message message) {
+		Role role = switch (message.getMessageType()) {
+			case ASSISTANT -> Role.ASSISTANT;
+			case TOOL -> Role.TOOL;
+			case SYSTEM -> Role.OTHER;
+			default -> Role.USER;
+		};
+		// ToolResponseMessage stores its data in getResponses(), not getText().
+		// Bedrock AgentCore's Conversational payload is text-only, so ToolResponse
+		// entries (id, name, responseData) cannot be persisted and are intentionally
+		// discarded here (see toMessage for read-back behavior).
+		return PayloadType.fromConversational(
+				Conversational.builder().role(role).content(Content.builder().text(message.getText()).build()).build());
+	}
+
+	private static Message toMessage(Event event) {
+		String text = "";
+		Role role = Role.USER;
+		if (event.hasPayload()) {
+			for (PayloadType payload : event.payload()) {
+				Conversational conv = payload.conversational();
+				if (conv != null) {
+					Content content = conv.content();
+					if (content != null && content.text() != null) {
+						text = content.text();
+					}
+					if (conv.role() != null) {
+						role = conv.role();
+					}
+					break;
+				}
+			}
+		}
+		Map<String, Object> metadata = new HashMap<>();
+		metadata.put(METADATA_KEY_EVENT_ID, event.eventId());
+		return switch (role) {
+			case ASSISTANT -> AssistantMessage.builder().content(text).properties(metadata).build();
+			case USER -> UserMessage.builder().text(text).metadata(metadata).build();
+			// Conversational events do not carry ToolResponse entries; use an empty list
+			// because
+			// ToolResponseMessage data lives in getResponses(), which was not persisted
+			// (toPayload).
+			case TOOL -> ToolResponseMessage.builder().responses(List.of()).metadata(metadata).build();
+			case OTHER -> SystemMessage.builder().text(text).metadata(metadata).build();
+			default -> {
+				logger.warn("Unknown role '{}', defaulting to UserMessage", role);
+				yield UserMessage.builder().text(text).metadata(metadata).build();
+			}
+		};
+	}
+
+	@Override
+	public List<MemoryRecordSummary> retrieveMemoryRecords(String namespace, String searchQuery) {
+		Assert.hasText(namespace, "namespace must not be empty");
+		Assert.hasText(searchQuery, "searchQuery must not be empty");
+
+		RetrieveMemoryRecordsRequest request = RetrieveMemoryRecordsRequest.builder()
+			.memoryId(this.config.getMemoryId())
+			.namespace(namespace)
+			.searchCriteria(SearchCriteria.builder().searchQuery(searchQuery).build())
+			.build();
+
+		try {
+			return this.bedrockAgentCoreClient.retrieveMemoryRecordsPaginator(request)
+				.memoryRecordSummaries()
+				.stream()
+				.toList();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to retrieve memory records for namespace=" + namespace, e);
+		}
+	}
+
+	@Override
+	public List<MemoryRecordSummary> listMemoryRecords(String namespace) {
+		Assert.hasText(namespace, "namespace must not be empty");
+
+		ListMemoryRecordsRequest request = ListMemoryRecordsRequest.builder()
+			.memoryId(this.config.getMemoryId())
+			.namespace(namespace)
+			.build();
+
+		try {
+			return this.bedrockAgentCoreClient.listMemoryRecordsPaginator(request)
+				.memoryRecordSummaries()
+				.stream()
+				.toList();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to list memory records for namespace=" + namespace, e);
+		}
+	}
+
+	@Override
+	public void deleteMemoryRecord(String memoryRecordId) {
+		Assert.hasText(memoryRecordId, "memoryRecordId must not be empty");
+
+		DeleteMemoryRecordRequest request = DeleteMemoryRecordRequest.builder()
+			.memoryId(this.config.getMemoryId())
+			.memoryRecordId(memoryRecordId)
+			.build();
+		try {
+			this.bedrockAgentCoreClient.deleteMemoryRecord(request);
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to delete memory record: " + memoryRecordId, e);
+		}
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link BedrockAgentCoreChatMemoryRepository}.
+	 */
+	public static final class Builder {
+
+		private @Nullable BedrockAgentCoreClient bedrockAgentCoreClient;
+
+		private @Nullable String memoryId;
+
+		private String actorId = BedrockAgentCoreChatMemoryConfig.DEFAULT_ACTOR_ID;
+
+		private Builder() {
+		}
+
+		public Builder bedrockAgentCoreClient(BedrockAgentCoreClient bedrockAgentCoreClient) {
+			this.bedrockAgentCoreClient = bedrockAgentCoreClient;
+			return this;
+		}
+
+		public Builder memoryId(String memoryId) {
+			this.memoryId = memoryId;
+			return this;
+		}
+
+		public Builder actorId(String actorId) {
+			this.actorId = actorId;
+			return this;
+		}
+
+		public BedrockAgentCoreChatMemoryRepository build() {
+			Assert.notNull(this.bedrockAgentCoreClient, "bedrockAgentCoreClient must not be null");
+			Assert.hasText(this.memoryId, "memoryId must not be empty");
+			Assert.hasText(this.actorId, "actorId must not be empty");
+
+			BedrockAgentCoreChatMemoryConfig config = BedrockAgentCoreChatMemoryConfig.builder()
+				.bedrockAgentCoreClient(this.bedrockAgentCoreClient)
+				.memoryId(this.memoryId)
+				.actorId(this.actorId)
+				.build();
+			return new BedrockAgentCoreChatMemoryRepository(config);
+		}
+
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/package-info.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/main/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.chat.memory.repository.bedrock.agentcore;
+
+import org.jspecify.annotations.NullMarked;

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryRepositoryIT.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryRepositoryIT.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.bedrock.agentcore;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
+import software.amazon.awssdk.services.bedrockagentcore.model.BatchCreateMemoryRecordsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.BatchCreateMemoryRecordsResponse;
+import software.amazon.awssdk.services.bedrockagentcore.model.MemoryContent;
+import software.amazon.awssdk.services.bedrockagentcore.model.MemoryRecordCreateInput;
+import software.amazon.awssdk.services.bedrockagentcore.model.MemoryRecordSummary;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Integration tests for {@link BedrockAgentCoreChatMemoryRepository}.
+ *
+ * <p>
+ * Requires the following environment variables:
+ * <ul>
+ * <li>{@code BEDROCK_AGENTCORE_MEMORY_ID} — the Bedrock AgentCore memory store ID
+ * (required for all tests)</li>
+ * <li>{@code BEDROCK_AGENTCORE_MEMORY_STRATEGY_ID} — the memory strategy ID used for
+ * long-term memory tests; tests requiring this are skipped if not set</li>
+ * </ul>
+ *
+ * @author Chaemin Lee
+ */
+@RequiresAwsCredentials
+class BedrockAgentCoreChatMemoryRepositoryIT {
+
+	private static final String MEMORY_ID_PROPERTY = "BEDROCK_AGENTCORE_MEMORY_ID";
+
+	private static final String MEMORY_STRATEGY_ID_PROPERTY = "BEDROCK_AGENTCORE_MEMORY_STRATEGY_ID";
+
+	private BedrockAgentCoreClient awsClient;
+
+	private BedrockAgentCoreChatMemoryRepository repository;
+
+	private String memoryId;
+
+	private String memoryStrategyId;
+
+	private String conversationId;
+
+	private String testNamespace;
+
+	private final List<String> createdRecordIds = new ArrayList<>();
+
+	@BeforeEach
+	void setUp() {
+		this.memoryId = System.getenv(MEMORY_ID_PROPERTY);
+		if (this.memoryId == null) {
+			this.memoryId = System.getProperty(MEMORY_ID_PROPERTY);
+		}
+		Assumptions.assumeThat(this.memoryId)
+			.as(MEMORY_ID_PROPERTY + " environment variable must be set")
+			.isNotNull()
+			.isNotBlank();
+
+		this.memoryStrategyId = System.getenv(MEMORY_STRATEGY_ID_PROPERTY);
+		if (this.memoryStrategyId == null) {
+			this.memoryStrategyId = System.getProperty(MEMORY_STRATEGY_ID_PROPERTY);
+		}
+
+		this.awsClient = BedrockAgentCoreClient.builder()
+			.credentialsProvider(DefaultCredentialsProvider.builder().build())
+			.region(Region.US_EAST_1)
+			.build();
+
+		BedrockAgentCoreChatMemoryConfig config = BedrockAgentCoreChatMemoryConfig.builder()
+			.bedrockAgentCoreClient(this.awsClient)
+			.memoryId(this.memoryId)
+			.build();
+
+		this.repository = new BedrockAgentCoreChatMemoryRepository(config);
+		this.conversationId = "springai-test-" + UUID.randomUUID();
+		this.testNamespace = "springai-test-" + UUID.randomUUID();
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.repository.deleteByConversationId(this.conversationId);
+		for (String recordId : this.createdRecordIds) {
+			try {
+				this.repository.deleteMemoryRecord(recordId);
+			}
+			catch (Exception ignored) {
+			}
+		}
+	}
+
+	@Test
+	void saveAllAndFindByConversationId() {
+		List<Message> messages = List.of(UserMessage.builder().text("Hello from Spring AI").build(),
+				AssistantMessage.builder().content("Hi! How can I help?").build());
+
+		this.repository.saveAll(this.conversationId, messages);
+
+		List<Message> found = this.repository.findByConversationId(this.conversationId);
+		assertThat(found).hasSize(2);
+		assertThat(found.get(0).getText()).isEqualTo("Hello from Spring AI");
+		assertThat(found.get(1).getText()).isEqualTo("Hi! How can I help?");
+	}
+
+	@Test
+	void saveAllReplacesExistingMessages() {
+		this.repository.saveAll(this.conversationId, List.of(UserMessage.builder().text("First message").build()));
+		this.repository.saveAll(this.conversationId, List.of(UserMessage.builder().text("Replaced message").build()));
+
+		List<Message> found = this.repository.findByConversationId(this.conversationId);
+		assertThat(found).hasSize(1);
+		assertThat(found.get(0).getText()).isEqualTo("Replaced message");
+	}
+
+	@Test
+	void deleteByConversationIdRemovesAllMessages() {
+		this.repository.saveAll(this.conversationId, List.of(UserMessage.builder().text("To be deleted").build()));
+
+		this.repository.deleteByConversationId(this.conversationId);
+
+		List<Message> found = this.repository.findByConversationId(this.conversationId);
+		assertThat(found).isEmpty();
+	}
+
+	@Test
+	void findConversationIdsContainsSavedConversation() {
+		this.repository.saveAll(this.conversationId, List.of(UserMessage.builder().text("Hello").build()));
+
+		List<String> ids = this.repository.findConversationIds();
+		assertThat(ids).contains(this.conversationId);
+	}
+
+	@Test
+	void findByConversationIdReturnsEmptyForNonExistentConversation() {
+		List<Message> found = this.repository.findByConversationId("non-existent-" + UUID.randomUUID());
+		assertThat(found).isEmpty();
+	}
+
+	@Test
+	void deleteByConversationIdDoesNotThrowForNonExistentConversation() {
+		assertThatCode(() -> this.repository.deleteByConversationId("non-existent-" + UUID.randomUUID()))
+			.doesNotThrowAnyException();
+	}
+
+	@Test
+	void saveAllPreservesMessageTypes() {
+		List<Message> messages = List.of(UserMessage.builder().text("User message").build(),
+				AssistantMessage.builder().content("Assistant message").build(),
+				SystemMessage.builder().text("System message").build());
+
+		this.repository.saveAll(this.conversationId, messages);
+
+		List<Message> found = this.repository.findByConversationId(this.conversationId);
+		assertThat(found).hasSize(3);
+		assertThat(found.get(0).getMessageType()).isEqualTo(MessageType.USER);
+		assertThat(found.get(1).getMessageType()).isEqualTo(MessageType.ASSISTANT);
+		assertThat(found.get(2).getMessageType()).isEqualTo(MessageType.SYSTEM);
+	}
+
+	@Test
+	void listMemoryRecordsDoesNotThrow() {
+		// listMemoryRecords relies on async backend indexing after record creation,
+		// so we cannot assert on specific results. We verify only that the API call
+		// succeeds and returns a non-null list.
+		List<MemoryRecordSummary> records = this.repository.listMemoryRecords(this.testNamespace);
+
+		assertThat(records).isNotNull();
+	}
+
+	@Test
+	void listMemoryRecordsIsEmptyForUnknownNamespace() {
+		List<MemoryRecordSummary> records = this.repository
+			.listMemoryRecords("springai-nonexistent-" + UUID.randomUUID());
+
+		assertThat(records).isEmpty();
+	}
+
+	@Test
+	void deleteMemoryRecordDoesNotThrow() {
+		String recordId = createTestMemoryRecord("some fact to be deleted");
+		this.createdRecordIds.remove(recordId);
+
+		assertThatCode(() -> this.repository.deleteMemoryRecord(recordId)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void retrieveMemoryRecordsDoesNotThrow() {
+		// retrieveMemoryRecords relies on async semantic indexing after record creation,
+		// so we cannot assert on specific results. We verify only that the API call
+		// succeeds and returns a non-null list.
+		List<MemoryRecordSummary> records = this.repository.retrieveMemoryRecords(this.testNamespace,
+				"user preferences");
+
+		assertThat(records).isNotNull();
+	}
+
+	/**
+	 * Creates a long-term memory record directly via the AWS SDK (bypassing the
+	 * repository) and registers it for cleanup in {@link #tearDown()}.
+	 * <p>
+	 * Skips the calling test if {@code BEDROCK_AGENTCORE_MEMORY_STRATEGY_ID} is not set.
+	 */
+	private String createTestMemoryRecord(String text) {
+		Assumptions.assumeThat(this.memoryStrategyId)
+			.as(MEMORY_STRATEGY_ID_PROPERTY + " must be set for long-term memory tests")
+			.isNotNull()
+			.isNotBlank();
+
+		String requestIdentifier = UUID.randomUUID().toString();
+		BatchCreateMemoryRecordsResponse response = this.awsClient
+			.batchCreateMemoryRecords(BatchCreateMemoryRecordsRequest.builder()
+				.memoryId(this.memoryId)
+				.records(List.of(MemoryRecordCreateInput.builder()
+					.requestIdentifier(requestIdentifier)
+					.content(MemoryContent.fromText(text))
+					.namespaces(List.of(this.testNamespace))
+					.memoryStrategyId(this.memoryStrategyId)
+					.timestamp(Instant.now())
+					.build()))
+				.build());
+
+		assertThat(response.successfulRecords()).as("test setup: batchCreateMemoryRecords should succeed").hasSize(1);
+
+		String recordId = response.successfulRecords().get(0).memoryRecordId();
+		this.createdRecordIds.add(recordId);
+		return recordId;
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryRepositoryTests.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/BedrockAgentCoreChatMemoryRepositoryTests.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.bedrock.agentcore;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
+import software.amazon.awssdk.services.bedrockagentcore.model.Content;
+import software.amazon.awssdk.services.bedrockagentcore.model.Conversational;
+import software.amazon.awssdk.services.bedrockagentcore.model.CreateEventRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.CreateEventResponse;
+import software.amazon.awssdk.services.bedrockagentcore.model.DeleteEventRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.DeleteEventResponse;
+import software.amazon.awssdk.services.bedrockagentcore.model.DeleteMemoryRecordRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.DeleteMemoryRecordResponse;
+import software.amazon.awssdk.services.bedrockagentcore.model.Event;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListEventsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListMemoryRecordsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.ListSessionsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.MemoryContent;
+import software.amazon.awssdk.services.bedrockagentcore.model.MemoryRecordSummary;
+import software.amazon.awssdk.services.bedrockagentcore.model.PayloadType;
+import software.amazon.awssdk.services.bedrockagentcore.model.RetrieveMemoryRecordsRequest;
+import software.amazon.awssdk.services.bedrockagentcore.model.Role;
+import software.amazon.awssdk.services.bedrockagentcore.model.SessionSummary;
+import software.amazon.awssdk.services.bedrockagentcore.paginators.ListEventsIterable;
+import software.amazon.awssdk.services.bedrockagentcore.paginators.ListMemoryRecordsIterable;
+import software.amazon.awssdk.services.bedrockagentcore.paginators.ListSessionsIterable;
+import software.amazon.awssdk.services.bedrockagentcore.paginators.RetrieveMemoryRecordsIterable;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link BedrockAgentCoreChatMemoryRepository}.
+ *
+ * @author Chaemin Lee
+ */
+@ExtendWith(MockitoExtension.class)
+class BedrockAgentCoreChatMemoryRepositoryTests {
+
+	@Mock
+	BedrockAgentCoreClient client;
+
+	BedrockAgentCoreChatMemoryRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		this.repository = BedrockAgentCoreChatMemoryRepository.builder()
+			.bedrockAgentCoreClient(this.client)
+			.memoryId("test-store")
+			.build();
+	}
+
+	@Test
+	void builderRejectsNullClient() {
+		assertThatThrownBy(() -> BedrockAgentCoreChatMemoryRepository.builder().memoryId("test-store").build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("bedrockAgentCoreClient");
+	}
+
+	@Test
+	void builderRejectsBlankMemoryId() {
+		assertThatThrownBy(() -> BedrockAgentCoreChatMemoryRepository.builder()
+			.bedrockAgentCoreClient(this.client)
+			.memoryId("")
+			.build()).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("memoryId");
+	}
+
+	@Test
+	void saveAllRejectsNullMessages() {
+		assertThatThrownBy(() -> this.repository.saveAll("conv-1", null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages");
+	}
+
+	@Test
+	void saveAllRejectsNullMessageElement() {
+		assertThatThrownBy(() -> this.repository.saveAll("conv-1", java.util.Arrays.asList(null, null)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("messages");
+	}
+
+	@Test
+	void saveAllAndFindByConversationIdRoundTrip() {
+		UserMessage userMsg = UserMessage.builder().text("Hello").build();
+		AssistantMessage assistantMsg = AssistantMessage.builder().content("Hi there").build();
+
+		Event event1 = Event.builder()
+			.eventId("evt-1")
+			.sessionId("conv-1")
+			.payload(PayloadType.fromConversational(
+					Conversational.builder().role(Role.USER).content(Content.builder().text("Hello").build()).build()))
+			.build();
+		Event event2 = Event.builder()
+			.eventId("evt-2")
+			.sessionId("conv-1")
+			.payload(PayloadType.fromConversational(Conversational.builder()
+				.role(Role.ASSISTANT)
+				.content(Content.builder().text("Hi there").build())
+				.build()))
+			.build();
+
+		// First call: empty (inside deleteByConversationId within saveAll)
+		// Second call: returns the two saved events (findByConversationId)
+		ListEventsIterable emptyPage = mockEventsPaginator(List.of());
+		ListEventsIterable eventsPage = mockEventsPaginator(List.of(event1, event2));
+		when(this.client.listEventsPaginator(any(ListEventsRequest.class))).thenReturn(emptyPage)
+			.thenReturn(eventsPage);
+		when(this.client.createEvent(any(CreateEventRequest.class))).thenReturn(CreateEventResponse.builder().build());
+
+		this.repository.saveAll("conv-1", List.of(userMsg, assistantMsg));
+		List<Message> result = this.repository.findByConversationId("conv-1");
+
+		assertThat(result).hasSize(2);
+		ArgumentCaptor<ListEventsRequest> listCaptor = ArgumentCaptor.forClass(ListEventsRequest.class);
+		verify(this.client, times(2)).listEventsPaginator(listCaptor.capture());
+		assertThat(listCaptor.getAllValues())
+			.allMatch(r -> BedrockAgentCoreChatMemoryConfig.DEFAULT_ACTOR_ID.equals(r.actorId()));
+		assertThat(result.get(0).getText()).isEqualTo("Hello");
+		assertThat(result.get(1).getText()).isEqualTo("Hi there");
+		verify(this.client, times(2)).createEvent(any(CreateEventRequest.class));
+	}
+
+	@Test
+	void findByConversationIdWithActorIdUsesActorInListEventsRequest() {
+		ListEventsIterable emptyPage = mockEventsPaginator(List.of());
+		when(this.client.listEventsPaginator(any(ListEventsRequest.class))).thenReturn(emptyPage);
+
+		this.repository.findByConversationId("actor-z", "conv-9");
+
+		ArgumentCaptor<ListEventsRequest> captor = ArgumentCaptor.forClass(ListEventsRequest.class);
+		verify(this.client).listEventsPaginator(captor.capture());
+		assertThat(captor.getValue().actorId()).isEqualTo("actor-z");
+		assertThat(captor.getValue().sessionId()).isEqualTo("conv-9");
+	}
+
+	@Test
+	void saveAllWithActorIdUsesActorInCreateEvent() {
+		UserMessage userMsg = UserMessage.builder().text("Hi").build();
+		ListEventsIterable emptyPage = mockEventsPaginator(List.of());
+		when(this.client.listEventsPaginator(any(ListEventsRequest.class))).thenReturn(emptyPage);
+		when(this.client.createEvent(any(CreateEventRequest.class))).thenReturn(CreateEventResponse.builder().build());
+
+		this.repository.saveAll("actor-x", "conv-7", List.of(userMsg));
+
+		ArgumentCaptor<CreateEventRequest> captor = ArgumentCaptor.forClass(CreateEventRequest.class);
+		verify(this.client).createEvent(captor.capture());
+		assertThat(captor.getValue().actorId()).isEqualTo("actor-x");
+		assertThat(captor.getValue().sessionId()).isEqualTo("conv-7");
+	}
+
+	@Test
+	void saveAllWithEmptyListDeletesExistingMessages() {
+		Event event1 = Event.builder().eventId("evt-1").sessionId("conv-1").build();
+		ListEventsIterable page = mockEventsPaginator(List.of(event1));
+		when(this.client.listEventsPaginator(any(ListEventsRequest.class))).thenReturn(page);
+		when(this.client.deleteEvent(any(DeleteEventRequest.class))).thenReturn(DeleteEventResponse.builder().build());
+
+		this.repository.saveAll("conv-1", List.of());
+
+		verify(this.client).listEventsPaginator(any(ListEventsRequest.class));
+		verify(this.client).deleteEvent(any(DeleteEventRequest.class));
+		verify(this.client, never()).createEvent(any(CreateEventRequest.class));
+	}
+
+	@Test
+	void deleteByConversationIdDeletesEachEvent() {
+		Event event1 = Event.builder().eventId("evt-1").sessionId("conv-1").build();
+		Event event2 = Event.builder().eventId("evt-2").sessionId("conv-1").build();
+
+		ListEventsIterable page = mockEventsPaginator(List.of(event1, event2));
+		when(this.client.listEventsPaginator(any(ListEventsRequest.class))).thenReturn(page);
+		when(this.client.deleteEvent(any(DeleteEventRequest.class))).thenReturn(DeleteEventResponse.builder().build());
+
+		this.repository.deleteByConversationId("conv-1");
+
+		verify(this.client, times(2)).deleteEvent(any(DeleteEventRequest.class));
+	}
+
+	@Test
+	void deleteByConversationIdWithActorIdUsesActorInDeleteEvent() {
+		Event event1 = Event.builder().eventId("evt-1").sessionId("conv-1").build();
+		ListEventsIterable page = mockEventsPaginator(List.of(event1));
+		when(this.client.listEventsPaginator(any(ListEventsRequest.class))).thenReturn(page);
+		when(this.client.deleteEvent(any(DeleteEventRequest.class))).thenReturn(DeleteEventResponse.builder().build());
+
+		this.repository.deleteByConversationId("actor-y", "conv-1");
+
+		ArgumentCaptor<DeleteEventRequest> captor = ArgumentCaptor.forClass(DeleteEventRequest.class);
+		verify(this.client).deleteEvent(captor.capture());
+		assertThat(captor.getValue().actorId()).isEqualTo("actor-y");
+	}
+
+	@Test
+	void deleteByConversationIdIsNoOpWhenNoEvents() {
+		ListEventsIterable emptyPage = mockEventsPaginator(List.of());
+		when(this.client.listEventsPaginator(any(ListEventsRequest.class))).thenReturn(emptyPage);
+
+		this.repository.deleteByConversationId("conv-does-not-exist");
+
+		verify(this.client, never()).deleteEvent(any(DeleteEventRequest.class));
+	}
+
+	@Test
+	void retrieveMemoryRecordsReturnsResults() {
+		MemoryRecordSummary summary = MemoryRecordSummary.builder()
+			.memoryRecordId("mem-001")
+			.content(MemoryContent.fromText("the user prefers dark mode"))
+			.score(Double.valueOf(0.95))
+			.build();
+		RetrieveMemoryRecordsIterable paginator = mockRetrieveMemoryRecordsPaginator(List.of(summary));
+		when(this.client.retrieveMemoryRecordsPaginator(any(RetrieveMemoryRecordsRequest.class))).thenReturn(paginator);
+
+		List<MemoryRecordSummary> result = this.repository.retrieveMemoryRecords("user123", "UI preferences");
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).memoryRecordId()).isEqualTo("mem-001");
+		assertThat(result.get(0).score()).isEqualTo(0.95);
+		verify(this.client).retrieveMemoryRecordsPaginator(any(RetrieveMemoryRecordsRequest.class));
+	}
+
+	@Test
+	void retrieveMemoryRecordsWithPaginationCollectsAllPages() {
+		MemoryRecordSummary summary1 = MemoryRecordSummary.builder()
+			.memoryRecordId("mem-001")
+			.score(Double.valueOf(0.9))
+			.build();
+		MemoryRecordSummary summary2 = MemoryRecordSummary.builder()
+			.memoryRecordId("mem-002")
+			.score(Double.valueOf(0.8))
+			.build();
+		RetrieveMemoryRecordsIterable paginator = mockRetrieveMemoryRecordsPaginator(List.of(summary1, summary2));
+		when(this.client.retrieveMemoryRecordsPaginator(any(RetrieveMemoryRecordsRequest.class))).thenReturn(paginator);
+
+		List<MemoryRecordSummary> result = this.repository.retrieveMemoryRecords("user123", "preferences");
+
+		assertThat(result).hasSize(2);
+		assertThat(result).extracting(MemoryRecordSummary::memoryRecordId).containsExactly("mem-001", "mem-002");
+		verify(this.client).retrieveMemoryRecordsPaginator(any(RetrieveMemoryRecordsRequest.class));
+	}
+
+	@Test
+	void retrieveMemoryRecordsRejectsBlankNamespace() {
+		assertThatThrownBy(() -> this.repository.retrieveMemoryRecords("", "query"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("namespace");
+	}
+
+	@Test
+	void retrieveMemoryRecordsRejectsBlankSearchQuery() {
+		assertThatThrownBy(() -> this.repository.retrieveMemoryRecords("user123", ""))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("searchQuery");
+	}
+
+	@Test
+	void listMemoryRecordsReturnsResults() {
+		MemoryRecordSummary summary = MemoryRecordSummary.builder()
+			.memoryRecordId("mem-010")
+			.content(MemoryContent.fromText("user lives in Seoul"))
+			.build();
+		ListMemoryRecordsIterable paginator = mockListMemoryRecordsPaginator(List.of(summary));
+		when(this.client.listMemoryRecordsPaginator(any(ListMemoryRecordsRequest.class))).thenReturn(paginator);
+
+		List<MemoryRecordSummary> result = this.repository.listMemoryRecords("user123");
+
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).memoryRecordId()).isEqualTo("mem-010");
+		verify(this.client).listMemoryRecordsPaginator(any(ListMemoryRecordsRequest.class));
+	}
+
+	@Test
+	void listMemoryRecordsWithPaginationCollectsAllPages() {
+		MemoryRecordSummary s1 = MemoryRecordSummary.builder().memoryRecordId("mem-010").build();
+		MemoryRecordSummary s2 = MemoryRecordSummary.builder().memoryRecordId("mem-011").build();
+		ListMemoryRecordsIterable paginator = mockListMemoryRecordsPaginator(List.of(s1, s2));
+		when(this.client.listMemoryRecordsPaginator(any(ListMemoryRecordsRequest.class))).thenReturn(paginator);
+
+		List<MemoryRecordSummary> result = this.repository.listMemoryRecords("user123");
+
+		assertThat(result).hasSize(2);
+		assertThat(result).extracting(MemoryRecordSummary::memoryRecordId).containsExactly("mem-010", "mem-011");
+		verify(this.client).listMemoryRecordsPaginator(any(ListMemoryRecordsRequest.class));
+	}
+
+	@Test
+	void listMemoryRecordsRejectsBlankNamespace() {
+		assertThatThrownBy(() -> this.repository.listMemoryRecords("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("namespace");
+	}
+
+	@Test
+	void deleteMemoryRecordCallsClient() {
+		when(this.client.deleteMemoryRecord(any(DeleteMemoryRecordRequest.class)))
+			.thenReturn(DeleteMemoryRecordResponse.builder().memoryRecordId("mem-999").build());
+
+		this.repository.deleteMemoryRecord("mem-999");
+
+		verify(this.client).deleteMemoryRecord(any(DeleteMemoryRecordRequest.class));
+	}
+
+	@Test
+	void deleteMemoryRecordWrapsExceptionAsRuntimeException() {
+		when(this.client.deleteMemoryRecord(any(DeleteMemoryRecordRequest.class)))
+			.thenThrow(new RuntimeException("AWS error"));
+
+		assertThatThrownBy(() -> this.repository.deleteMemoryRecord("mem-999")).isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("mem-999");
+	}
+
+	@Test
+	void deleteMemoryRecordRejectsBlankId() {
+		assertThatThrownBy(() -> this.repository.deleteMemoryRecord("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("memoryRecordId");
+	}
+
+	@Test
+	void findConversationIdsReturnsSessionIds() {
+		SessionSummary session1 = SessionSummary.builder().sessionId("conv-1").build();
+		SessionSummary session2 = SessionSummary.builder().sessionId("conv-2").build();
+		ListSessionsIterable paginator = mockSessionsPaginator(List.of(session1, session2));
+		when(this.client.listSessionsPaginator(any(ListSessionsRequest.class))).thenReturn(paginator);
+
+		List<String> ids = this.repository.findConversationIds();
+
+		assertThat(ids).containsExactly("conv-1", "conv-2");
+		ArgumentCaptor<ListSessionsRequest> captor = ArgumentCaptor.forClass(ListSessionsRequest.class);
+		verify(this.client).listSessionsPaginator(captor.capture());
+		assertThat(captor.getValue().actorId()).isEqualTo(BedrockAgentCoreChatMemoryConfig.DEFAULT_ACTOR_ID);
+	}
+
+	@Test
+	void findConversationIdsWithActorIdUsesActorInRequest() {
+		ListSessionsIterable paginator = mockSessionsPaginator(List.of());
+		when(this.client.listSessionsPaginator(any(ListSessionsRequest.class))).thenReturn(paginator);
+
+		this.repository.findConversationIds("user-42");
+
+		ArgumentCaptor<ListSessionsRequest> captor = ArgumentCaptor.forClass(ListSessionsRequest.class);
+		verify(this.client).listSessionsPaginator(captor.capture());
+		assertThat(captor.getValue().actorId()).isEqualTo("user-42");
+	}
+
+	@Test
+	void findConversationIdsWithActorIdRejectsBlankActorId() {
+		assertThatThrownBy(() -> this.repository.findConversationIds("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("actorId");
+	}
+
+	@Test
+	void findConversationIdsReturnsEmptyWhenNoSessions() {
+		ListSessionsIterable paginator = mockSessionsPaginator(List.of());
+		when(this.client.listSessionsPaginator(any(ListSessionsRequest.class))).thenReturn(paginator);
+
+		List<String> ids = this.repository.findConversationIds();
+
+		assertThat(ids).isEmpty();
+	}
+
+	private ListSessionsIterable mockSessionsPaginator(List<SessionSummary> sessions) {
+		ListSessionsIterable paginator = mock(ListSessionsIterable.class);
+		SdkIterable<SessionSummary> sdkSessions = sessions::iterator;
+		when(paginator.sessionSummaries()).thenReturn(sdkSessions);
+		return paginator;
+	}
+
+	private ListEventsIterable mockEventsPaginator(List<Event> events) {
+		ListEventsIterable paginator = mock(ListEventsIterable.class);
+		SdkIterable<Event> sdkEvents = events::iterator;
+		when(paginator.events()).thenReturn(sdkEvents);
+		return paginator;
+	}
+
+	private RetrieveMemoryRecordsIterable mockRetrieveMemoryRecordsPaginator(List<MemoryRecordSummary> summaries) {
+		RetrieveMemoryRecordsIterable paginator = mock(RetrieveMemoryRecordsIterable.class);
+		SdkIterable<MemoryRecordSummary> sdkSummaries = summaries::iterator;
+		when(paginator.memoryRecordSummaries()).thenReturn(sdkSummaries);
+		return paginator;
+	}
+
+	private ListMemoryRecordsIterable mockListMemoryRecordsPaginator(List<MemoryRecordSummary> summaries) {
+		ListMemoryRecordsIterable paginator = mock(ListMemoryRecordsIterable.class);
+		SdkIterable<MemoryRecordSummary> sdkSummaries = summaries::iterator;
+		when(paginator.memoryRecordSummaries()).thenReturn(sdkSummaries);
+		return paginator;
+	}
+
+}

--- a/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/RequiresAwsCredentials.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore/src/test/java/org/springframework/ai/chat/memory/repository/bedrock/agentcore/RequiresAwsCredentials.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.memory.repository.bedrock.agentcore;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIfEnvironmentVariable(named = "AWS_ACCESS_KEY_ID", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AWS_SECRET_ACCESS_KEY", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AWS_SESSION_TOKEN", matches = ".+")
+public @interface RequiresAwsCredentials {
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
 		<module>memory/repository/spring-ai-model-chat-memory-repository-mongodb</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-neo4j</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-redis</module>
+		<module>memory/repository/spring-ai-model-chat-memory-repository-bedrock-agentcore</module>
 
 
 
@@ -98,6 +99,7 @@
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc</module>
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb</module>
 		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-neo4j</module>
+		<module>auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore</module>
 		<module>auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis</module>
 
 		<module>auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation</module>
@@ -229,6 +231,7 @@
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-mongodb</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-neo4j</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-redis</module>
+		<module>spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-bedrock-agentcore</module>
 
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-mcp-client</module>
 		<module>spring-ai-spring-boot-starters/spring-ai-starter-mcp-server</module>
@@ -296,9 +299,10 @@
 		<jtokkit.version>1.1.0</jtokkit.version>
 		<kotlin.version>2.2.21</kotlin.version>
 
-		<!-- NOTE: keep bedrockruntime and awssdk versions aligned -->
+		<!-- NOTE: keep bedrockruntime, awssdk, and bedrockagentcore versions aligned -->
 		<bedrockruntime.version>2.41.22</bedrockruntime.version>
 		<awssdk.version>2.41.22</awssdk.version>
+		<bedrockagentcore.version>2.41.22</bedrockagentcore.version>
 
 		<djl.version>0.32.0</djl.version>
 		<onnxruntime.version>1.19.2</onnxruntime.version>

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -239,6 +239,24 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-model-chat-memory-repository-bedrock-agentcore</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-starter-model-chat-memory-repository-bedrock-agentcore</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
 			<!-- Spring AI Models -->
 
 			<dependency>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-bedrock-agentcore/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-chat-memory-repository-bedrock-agentcore/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>spring-ai-starter-model-chat-memory-repository-bedrock-agentcore</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Starter - Bedrock AgentCore Chat Memory Repository</name>
+    <description>Spring AI Bedrock AgentCore Chat Memory Repository Starter</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-chat-memory-repository-bedrock-agentcore</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-model-chat-memory-repository-bedrock-agentcore</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Implements ChatMemoryRepository using Bedrock AgentCore Events API for short-term memory (conversationId → sessionId). Introduces AdvancedBedrockAgentCoreChatMemoryRepository with long-term memory operations (retrieveMemoryRecords, listMemoryRecords, deleteMemoryRecord) and actor-scoped overloads for short-term operations so multi-actor callers can pass an explicit actorId; default ChatMemoryRepository methods use the configured actor id.

Includes auto-configuration and Spring Boot starter.

Fixes: #5662