### PR TITLE
Fix Javadoc documentation and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ To update the year on license headers using the [license-maven-plugin](https://o
 
 To check javadocs using the [javadoc:javadoc](https://maven.apache.org/plugins/maven-javadoc-plugin/)
 ```shell
-./mvnw javadoc:javadoc -Pjavadoc
+./mvnw javadoc:javadoc
 ```
 
 #### Source Code Style

--- a/pom.xml
+++ b/pom.xml
@@ -607,24 +607,21 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin.version}</version>
-				<configuration>
-					<overview>
-						${maven.multiModuleProjectDirectory}/spring-ai-docs/src/main/javadoc/overview.html</overview>
-					<detectJavaApiLink>false</detectJavaApiLink>
-					<doclint>none</doclint>
-				</configuration>
-				<executions>
-					<execution>
-						<id>package-javadocs</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<configuration>
-							<failOnError>false</failOnError>
-						</configuration>
-					</execution>
-				</executions>
+			<configuration>
+				<overview>
+					${maven.multiModuleProjectDirectory}/spring-ai-docs/src/main/javadoc/overview.html</overview>
+				<detectJavaApiLink>false</detectJavaApiLink>
+				<doclint>none</doclint>
+			</configuration>
+			<executions>
+				<execution>
+					<id>package-javadocs</id>
+					<phase>package</phase>
+					<goals>
+						<goal>jar</goal>
+					</goals>
+				</execution>
+			</executions>
 			</plugin>
 
 		</plugins>

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -369,4 +369,16 @@
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
Before this PR, the documented javadoc generation command was broken.

This PR updates it, and refines the javadoc configuration to just skip the javadoc generation in `spring-ai-spring-boot-testcontainers` (which contains no public class) instead of disabling `failOnError`.