### PR TITLE
Add ModerationAdvisor for ChatClient

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ModerationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ModerationAdvisor.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.moderation.ModerationModel;
+import org.springframework.ai.moderation.ModerationPrompt;
+import org.springframework.ai.moderation.ModerationResponse;
+import org.springframework.ai.moderation.ModerationResult;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * An advisor that uses a {@link ModerationModel} to decide whether a request should be
+ * blocked before invoking the next advisor in the chain.
+ *
+ * @author Kim Taewoong
+ * @since 2.0.0
+ */
+public final class ModerationAdvisor implements CallAdvisor, StreamAdvisor {
+
+	public static final String MODERATION_RESPONSE_CONTEXT_KEY = "moderation.response";
+
+	public static final String MODERATION_BLOCKED_CONTEXT_KEY = "moderation.blocked";
+
+	private static final String DEFAULT_FAILURE_RESPONSE = "I'm unable to respond to that due to safety policy.";
+
+	private static final int DEFAULT_ORDER = 0;
+
+	private final ModerationModel moderationModel;
+
+	private final String failureResponse;
+
+	private final int order;
+
+	private final Scheduler scheduler;
+
+	private final boolean failOpen;
+
+	private ModerationAdvisor(ModerationModel moderationModel, String failureResponse, int order, Scheduler scheduler,
+			boolean failOpen) {
+		Assert.notNull(moderationModel, "moderationModel must not be null");
+		Assert.notNull(failureResponse, "failureResponse must not be null");
+		Assert.notNull(scheduler, "scheduler must not be null");
+		this.moderationModel = moderationModel;
+		this.failureResponse = failureResponse;
+		this.order = order;
+		this.scheduler = scheduler;
+		this.failOpen = failOpen;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public ChatClientResponse adviseCall(ChatClientRequest chatClientRequest, CallAdvisorChain callAdvisorChain) {
+		Assert.notNull(chatClientRequest, "chatClientRequest must not be null");
+		Assert.notNull(callAdvisorChain, "callAdvisorChain must not be null");
+
+		ModerationResponse moderationResponse;
+		try {
+			moderationResponse = moderate(chatClientRequest);
+		}
+		catch (RuntimeException exception) {
+			if (this.failOpen) {
+				return callAdvisorChain.nextCall(chatClientRequest);
+			}
+			throw new IllegalStateException("Moderation processing failed", exception);
+		}
+
+		if (isFlagged(moderationResponse)) {
+			return createFailureResponse(chatClientRequest, moderationResponse);
+		}
+		return callAdvisorChain.nextCall(addModerationContext(chatClientRequest, moderationResponse, false));
+	}
+
+	@Override
+	public Flux<ChatClientResponse> adviseStream(ChatClientRequest chatClientRequest,
+			StreamAdvisorChain streamAdvisorChain) {
+		Assert.notNull(chatClientRequest, "chatClientRequest must not be null");
+		Assert.notNull(streamAdvisorChain, "streamAdvisorChain must not be null");
+
+		Mono<ModerationResponse> moderationResponseMono = Mono.fromCallable(() -> moderate(chatClientRequest))
+			.publishOn(this.scheduler);
+
+		if (this.failOpen) {
+			moderationResponseMono = moderationResponseMono.onErrorResume(error -> Mono.empty());
+		}
+		else {
+			moderationResponseMono = moderationResponseMono
+				.onErrorMap(error -> new IllegalStateException("Moderation processing failed", error));
+		}
+
+		return moderationResponseMono.flatMapMany(moderationResponse -> {
+			if (isFlagged(moderationResponse)) {
+				return Flux.just(createFailureResponse(chatClientRequest, moderationResponse));
+			}
+			return streamAdvisorChain.nextStream(addModerationContext(chatClientRequest, moderationResponse, false));
+		}).switchIfEmpty(Flux.defer(() -> streamAdvisorChain.nextStream(chatClientRequest)));
+	}
+
+	private ModerationResponse moderate(ChatClientRequest chatClientRequest) {
+		return this.moderationModel.call(new ModerationPrompt(chatClientRequest.prompt().getContents()));
+	}
+
+	private static boolean isFlagged(ModerationResponse moderationResponse) {
+		if (moderationResponse.getResult() == null || moderationResponse.getResult().getOutput() == null
+				|| CollectionUtils.isEmpty(moderationResponse.getResult().getOutput().getResults())) {
+			return false;
+		}
+		return moderationResponse.getResult().getOutput().getResults().stream().anyMatch(ModerationResult::isFlagged);
+	}
+
+	private static ChatClientRequest addModerationContext(ChatClientRequest chatClientRequest,
+			ModerationResponse moderationResponse, boolean blocked) {
+		return chatClientRequest.mutate()
+			.context(MODERATION_RESPONSE_CONTEXT_KEY, moderationResponse)
+			.context(MODERATION_BLOCKED_CONTEXT_KEY, blocked)
+			.build();
+	}
+
+	private ChatClientResponse createFailureResponse(ChatClientRequest chatClientRequest,
+			ModerationResponse moderationResponse) {
+		return ChatClientResponse.builder()
+			.chatResponse(ChatResponse.builder()
+				.generations(List.of(new Generation(new AssistantMessage(this.failureResponse))))
+				.build())
+			.context(chatClientRequest.context())
+			.context(MODERATION_RESPONSE_CONTEXT_KEY, moderationResponse)
+			.context(MODERATION_BLOCKED_CONTEXT_KEY, true)
+			.build();
+	}
+
+	@Override
+	public String getName() {
+		return this.getClass().getSimpleName();
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static final class Builder {
+
+		private @Nullable ModerationModel moderationModel;
+
+		private String failureResponse = DEFAULT_FAILURE_RESPONSE;
+
+		private int order = DEFAULT_ORDER;
+
+		private Scheduler scheduler = BaseAdvisor.DEFAULT_SCHEDULER;
+
+		private boolean failOpen = true;
+
+		private Builder() {
+		}
+
+		public Builder moderationModel(ModerationModel moderationModel) {
+			Assert.notNull(moderationModel, "moderationModel must not be null");
+			this.moderationModel = moderationModel;
+			return this;
+		}
+
+		public Builder failureResponse(String failureResponse) {
+			Assert.notNull(failureResponse, "failureResponse must not be null");
+			this.failureResponse = failureResponse;
+			return this;
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder scheduler(Scheduler scheduler) {
+			Assert.notNull(scheduler, "scheduler must not be null");
+			this.scheduler = scheduler;
+			return this;
+		}
+
+		public Builder failOpen(boolean failOpen) {
+			this.failOpen = failOpen;
+			return this;
+		}
+
+		public ModerationAdvisor build() {
+			Assert.state(this.moderationModel != null, "moderationModel must not be null");
+			return new ModerationAdvisor(this.moderationModel, this.failureResponse, this.order, this.scheduler,
+					this.failOpen);
+		}
+
+	}
+
+}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ModerationAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ModerationAdvisorTests.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.moderation.Moderation;
+import org.springframework.ai.moderation.ModerationModel;
+import org.springframework.ai.moderation.ModerationResponse;
+import org.springframework.ai.moderation.ModerationResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link ModerationAdvisor}.
+ *
+ * @author Kim Taewoong
+ */
+@ExtendWith(MockitoExtension.class)
+class ModerationAdvisorTests {
+
+	@Mock
+	private ModerationModel moderationModel;
+
+	@Mock
+	private CallAdvisorChain callAdvisorChain;
+
+	@Mock
+	private StreamAdvisorChain streamAdvisorChain;
+
+	@Test
+	void whenModerationModelIsNullThenThrow() {
+		assertThatThrownBy(() -> ModerationAdvisor.builder().moderationModel(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("moderationModel must not be null");
+	}
+
+	@Test
+	void whenModerationFlagsRequestThenBlockCall() {
+		ModerationAdvisor advisor = advisor(true);
+		ChatClientRequest request = request("harmful content");
+		ModerationResponse moderationResponse = moderationResponse(true);
+		given(this.moderationModel.call(any())).willReturn(moderationResponse);
+
+		ChatClientResponse response = advisor.adviseCall(request, this.callAdvisorChain);
+
+		verify(this.callAdvisorChain, never()).nextCall(any());
+		assertThat(response.context().get(ModerationAdvisor.MODERATION_BLOCKED_CONTEXT_KEY)).isEqualTo(true);
+		assertThat(response.context().get(ModerationAdvisor.MODERATION_RESPONSE_CONTEXT_KEY))
+			.isEqualTo(moderationResponse);
+		assertThat(response.chatResponse()).isNotNull();
+		assertThat(response.chatResponse().getResult()).isNotNull();
+		assertThat(response.chatResponse().getResult().getOutput().getText())
+			.isEqualTo("I'm unable to respond to that due to safety policy.");
+	}
+
+	@Test
+	void whenModerationAllowsRequestThenContinueCallChain() {
+		ModerationAdvisor advisor = advisor(true);
+		ChatClientRequest request = request("safe content");
+		ModerationResponse moderationResponse = moderationResponse(false);
+		ChatClientResponse expected = chatClientResponse("allowed");
+
+		given(this.moderationModel.call(any())).willReturn(moderationResponse);
+		given(this.callAdvisorChain.nextCall(any())).willReturn(expected);
+
+		ChatClientResponse response = advisor.adviseCall(request, this.callAdvisorChain);
+
+		ArgumentCaptor<ChatClientRequest> requestCaptor = ArgumentCaptor.forClass(ChatClientRequest.class);
+		verify(this.callAdvisorChain).nextCall(requestCaptor.capture());
+		assertThat(requestCaptor.getValue().context().get(ModerationAdvisor.MODERATION_BLOCKED_CONTEXT_KEY))
+			.isEqualTo(false);
+		assertThat(requestCaptor.getValue().context().get(ModerationAdvisor.MODERATION_RESPONSE_CONTEXT_KEY))
+			.isEqualTo(moderationResponse);
+		assertThat(response).isEqualTo(expected);
+	}
+
+	@Test
+	void whenModerationFailsAndFailOpenThenContinueCallChain() {
+		ModerationAdvisor advisor = advisor(true);
+		ChatClientRequest request = request("safe content");
+		ChatClientResponse expected = chatClientResponse("allowed");
+
+		given(this.moderationModel.call(any())).willThrow(new RuntimeException("moderation down"));
+		given(this.callAdvisorChain.nextCall(request)).willReturn(expected);
+
+		ChatClientResponse response = advisor.adviseCall(request, this.callAdvisorChain);
+
+		verify(this.callAdvisorChain).nextCall(request);
+		assertThat(response).isEqualTo(expected);
+	}
+
+	@Test
+	void whenModerationFailsAndFailOpenIsDisabledThenThrow() {
+		ModerationAdvisor advisor = advisor(false);
+		ChatClientRequest request = request("safe content");
+
+		given(this.moderationModel.call(any())).willThrow(new RuntimeException("moderation down"));
+
+		assertThatThrownBy(() -> advisor.adviseCall(request, this.callAdvisorChain))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Moderation processing failed");
+		verify(this.callAdvisorChain, never()).nextCall(any());
+	}
+
+	@Test
+	void whenModerationFlagsRequestThenBlockStream() {
+		ModerationAdvisor advisor = advisor(true);
+		ChatClientRequest request = request("harmful content");
+		ModerationResponse moderationResponse = moderationResponse(true);
+		given(this.moderationModel.call(any())).willReturn(moderationResponse);
+
+		ChatClientResponse response = advisor.adviseStream(request, this.streamAdvisorChain).blockFirst();
+
+		verify(this.streamAdvisorChain, never()).nextStream(any());
+		assertThat(response).isNotNull();
+		assertThat(response.context().get(ModerationAdvisor.MODERATION_BLOCKED_CONTEXT_KEY)).isEqualTo(true);
+		assertThat(response.context().get(ModerationAdvisor.MODERATION_RESPONSE_CONTEXT_KEY))
+			.isEqualTo(moderationResponse);
+	}
+
+	@Test
+	void whenModerationAllowsRequestThenContinueStreamChain() {
+		ModerationAdvisor advisor = advisor(true);
+		ChatClientRequest request = request("safe content");
+		ModerationResponse moderationResponse = moderationResponse(false);
+		ChatClientResponse expected = chatClientResponse("stream allowed");
+
+		given(this.moderationModel.call(any())).willReturn(moderationResponse);
+		given(this.streamAdvisorChain.nextStream(any())).willReturn(Flux.just(expected));
+
+		ChatClientResponse response = advisor.adviseStream(request, this.streamAdvisorChain).blockFirst();
+
+		ArgumentCaptor<ChatClientRequest> requestCaptor = ArgumentCaptor.forClass(ChatClientRequest.class);
+		verify(this.streamAdvisorChain).nextStream(requestCaptor.capture());
+		assertThat(requestCaptor.getValue().context().get(ModerationAdvisor.MODERATION_BLOCKED_CONTEXT_KEY))
+			.isEqualTo(false);
+		assertThat(requestCaptor.getValue().context().get(ModerationAdvisor.MODERATION_RESPONSE_CONTEXT_KEY))
+			.isEqualTo(moderationResponse);
+		assertThat(response).isEqualTo(expected);
+	}
+
+	@Test
+	void whenModerationFailsAndFailOpenThenContinueStreamChain() {
+		ModerationAdvisor advisor = advisor(true);
+		ChatClientRequest request = request("safe content");
+		ChatClientResponse expected = chatClientResponse("stream fallback");
+
+		given(this.moderationModel.call(any())).willThrow(new RuntimeException("moderation down"));
+		given(this.streamAdvisorChain.nextStream(request)).willReturn(Flux.just(expected));
+
+		ChatClientResponse response = advisor.adviseStream(request, this.streamAdvisorChain).blockFirst();
+
+		verify(this.streamAdvisorChain).nextStream(request);
+		assertThat(response).isEqualTo(expected);
+	}
+
+	@Test
+	void whenModerationFailsAndFailOpenDisabledThenStreamErrors() {
+		ModerationAdvisor advisor = advisor(false);
+		ChatClientRequest request = request("safe content");
+		given(this.moderationModel.call(any())).willThrow(new RuntimeException("moderation down"));
+
+		assertThatThrownBy(() -> advisor.adviseStream(request, this.streamAdvisorChain).blockFirst())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("Moderation processing failed");
+		verify(this.streamAdvisorChain, never()).nextStream(any());
+	}
+
+	private ModerationAdvisor advisor(boolean failOpen) {
+		return ModerationAdvisor.builder()
+			.moderationModel(this.moderationModel)
+			.scheduler(Schedulers.immediate())
+			.failOpen(failOpen)
+			.build();
+	}
+
+	private ChatClientRequest request(String text) {
+		return ChatClientRequest.builder().prompt(new Prompt(text)).build();
+	}
+
+	private ChatClientResponse chatClientResponse(String text) {
+		return ChatClientResponse.builder()
+			.chatResponse(
+					ChatResponse.builder().generations(List.of(new Generation(new AssistantMessage(text)))).build())
+			.build();
+	}
+
+	private ModerationResponse moderationResponse(boolean flagged) {
+		ModerationResult result = ModerationResult.builder().flagged(flagged).build();
+		Moderation moderation = Moderation.builder()
+			.id("mod-1")
+			.model("moderation-model")
+			.results(List.of(result))
+			.build();
+		ModerationResponse moderationResponse = mock(ModerationResponse.class, RETURNS_DEEP_STUBS);
+		given(moderationResponse.getResult().getOutput()).willReturn(moderation);
+		return moderationResponse;
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors.adoc
@@ -385,6 +385,10 @@ Based on the article: [Re-Reading Improves Reasoning in LLMs](https://arxiv.org/
 +
 A simple advisor designed to prevent the model from generating harmful or inappropriate content.
 
+* `ModerationAdvisor`
++
+An advisor that uses a configured `ModerationModel` to evaluate the prompt content before model invocation, blocking flagged requests and allowing safe requests to continue through the advisor chain.
+
 
 === Streaming vs Non-Streaming
 


### PR DESCRIPTION
## Add ModerationAdvisor for ChatClient
Closes: #5717 

## Summary
This PR adds a built-in `ModerationAdvisor` for `ChatClient` using `ModerationModel`.
It supports both non-streaming and streaming advisor flows.


## Motivation
`SafeGuardAdvisor` covers rule/keyword-based checks.
This PR adds model-based moderation gating in the advisor chain via existing `ModerationModel` implementations.

## Behavior
- Evaluate user input before invoking the next advisor
- If moderation is flagged, return a fallback response and mark context as blocked
- If moderation is not flagged, continue advisor chain execution
- Support failure policy with `failOpen`
  - `failOpen=true`: continue chain when moderation call fails
  - `failOpen=false`: fail request when moderation call fails
- Configurable via builder options (`order`, `failureResponse`, `failOpen`)


### Manual Validation (separate demo app)
Validated with provider-backed moderation for both non-stream and stream paths.

---
#### A. Flagged Input -> Blocked Response (`blocked=true`)
---
#### OpenAI Stream and Non Stream
<!-- Attach screenshot -->
<img width="937" height="413" alt="openai_non_stream" src="https://github.com/user-attachments/assets/5bccfb70-9ccb-43ca-a851-e0f033bd725b" />

<img width="931" height="475" alt="openai_stream" src="https://github.com/user-attachments/assets/9eea69c3-2cee-4801-83c4-a71a553bed94" />


#### Mistral Stream and Non Stream

<!-- Attach screenshot -->

<img width="934" height="423" alt="mistral_non_stream" src="https://github.com/user-attachments/assets/b2c4b2de-1741-4a96-9f15-bc0340837be3" />

<img width="937" height="476" alt="mistral_stream" src="https://github.com/user-attachments/assets/865642c8-cfd0-4173-b569-6e25d6441279" />

---
#### B. Failure Policy (`failOpen`) with invalid moderation endpoint
---
#### `failOpen=true` -> request continues to chat model
<!-- Attach screenshot -->

<img width="927" height="433" alt="openai_fail_open_true" src="https://github.com/user-attachments/assets/2cfe34b9-07f6-4466-9999-8fdda0436b81" />

#### `failOpen=false` -> request fails with moderation processing error
<!-- Attach screenshot -->
<img width="931" height="458" alt="openai_fail_open_false" src="https://github.com/user-attachments/assets/f5e69ae3-997f-4c82-9430-f2d419d4d253" />

