### PR TITLE
Upgrade GH actions to latest versions

### DIFF
--- a/.github/workflows/artifactory-milestone-release.yml
+++ b/.github/workflows/artifactory-milestone-release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -31,7 +31,7 @@ jobs:
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)
         if: ${{ github.event_name != 'schedule' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/build-cache
           # See pr-check.yml for an explanation of the key format
@@ -45,7 +45,7 @@ jobs:
           ./mvnw --batch-mode -ntp --update-snapshots clean install
 
       - name: Upload Spring-AI Built Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-artifacts
           path: ~/.m2/repository/org/springframework/ai

--- a/.github/workflows/dependency-ci-dashboard.yml
+++ b/.github/workflows/dependency-ci-dashboard.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.repository == 'spring-projects/spring-ai' }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load configuration
         id: config

--- a/.github/workflows/documentation-upload.yml
+++ b/.github/workflows/documentation-upload.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
       - name: Check out sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 25

--- a/.github/workflows/mcp-integration-tests.yml
+++ b/.github/workflows/mcp-integration-tests.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -36,17 +36,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,17 +10,17 @@ jobs:
     if: ${{ github.repository_owner == 'spring-projects' }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/build-cache
           # See https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache


### PR DESCRIPTION
Github runners will soon only support Node 24, so
actions need to be upgraded to versions that support it.
