### PR TITLE
Deprecate Pixtral models

### DIFF
--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/api/MistralAiApi.java
@@ -258,6 +258,7 @@ public class MistralAiApi {
 		CODESTRAL("codestral-latest"),
 		DEVSTRAL_MEDIUM("devstral-medium-latest"),
 		MISTRAL_LARGE("mistral-large-latest"),
+		@Deprecated(forRemoval = true) // Retirement planed the 31st of May 2026
 		PIXTRAL_LARGE("pixtral-large-latest"),
 		// Free Models
 		MINISTRAL_3B("ministral-3b-latest"),
@@ -266,7 +267,6 @@ public class MistralAiApi {
 		MAGISTRAL_SMALL("magistral-small-latest"),
 		DEVSTRAL_SMALL("devstral-small-latest"),
 		MISTRAL_SMALL("mistral-small-latest"),
-		PIXTRAL_12B("pixtral-12b-latest"),
 		// Free Models - Research
 		OPEN_MISTRAL_NEMO("open-mistral-nemo");
 		// @formatter:on

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatClientIT.java
@@ -30,6 +30,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.ListOutputConverter;
@@ -53,7 +54,7 @@ class MistralAiChatClientIT {
 	private static final Logger logger = LoggerFactory.getLogger(MistralAiChatClientIT.class);
 
 	@Autowired
-	MistralAiChatModel chatModel;
+	private ChatModel chatModel;
 
 	@Value("classpath:/prompts/system-message.st")
 	private Resource systemTextResource;
@@ -70,7 +71,8 @@ class MistralAiChatClientIT {
 				.chatResponse();
 		// @formatter:on
 
-		logger.info("" + response);
+		assertThat(response).isNotNull();
+		logger.info(response.toString());
 		assertThat(response.getResults()).hasSize(1);
 		assertThat(response.getResults().get(0).getOutput().getText()).contains("Blackbeard");
 	}
@@ -87,6 +89,8 @@ class MistralAiChatClientIT {
 				.call()
 				.chatResponse();
 		// @formatter:on
+		assertThat(response).isNotNull();
+		assertThat(response.getResult()).isNotNull();
 		assertThat(response.getResult().getOutput().getText()).containsAnyOf("Blackbeard");
 
 		// @formatter:off
@@ -97,7 +101,10 @@ class MistralAiChatClientIT {
 				.chatResponse();
 		// @formatter:on
 
-		logger.info("" + response);
+		assertThat(response).isNotNull();
+		logger.info(response.toString());
+		assertThat(response.getResult()).isNotNull();
+		assertThat(response.getResult().getOutput().getText()).isNotNull();
 		assertThat(response.getResult().getOutput().getText().toLowerCase()).containsAnyOf("blackbeard",
 				"bartholomew roberts");
 	}
@@ -112,6 +119,7 @@ class MistralAiChatClientIT {
 				.entity(new ParameterizedTypeReference<>() { });
 		// @formatter:on
 
+		assertThat(collection).isNotNull();
 		logger.info(collection.toString());
 		assertThat(collection).hasSize(5);
 	}
@@ -127,7 +135,8 @@ class MistralAiChatClientIT {
 				});
 		// @formatter:on
 
-		logger.info("" + actorsFilms);
+		assertThat(actorsFilms).isNotNull();
+		logger.info(actorsFilms.toString());
 		assertThat(actorsFilms).hasSize(2);
 	}
 
@@ -160,6 +169,7 @@ class MistralAiChatClientIT {
 				});
 		// @formatter:on
 
+		assertThat(result).isNotNull();
 		assertThat(result.get("numbers")).isEqualTo(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
 	}
 
@@ -173,7 +183,8 @@ class MistralAiChatClientIT {
 				.entity(ActorsFilms.class);
 		// @formatter:on
 
-		logger.info("" + actorsFilms);
+		assertThat(actorsFilms).isNotNull();
+		logger.info(actorsFilms.toString());
 		assertThat(actorsFilms.actor()).isNotBlank();
 	}
 
@@ -187,7 +198,8 @@ class MistralAiChatClientIT {
 				.entity(ActorsFilms.class);
 		// @formatter:on
 
-		logger.info("" + actorsFilms);
+		assertThat(actorsFilms).isNotNull();
+		logger.info(actorsFilms.toString());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -209,14 +221,15 @@ class MistralAiChatClientIT {
 				.content();
 
 		String generationTextFromStream = chatResponse.collectList()
-				.block()
+				.blockOptional()
 				.stream()
+				.flatMap(List::stream)
 				.collect(Collectors.joining());
 		// @formatter:on
 
 		ActorsFilms actorsFilms = outputConverter.convert(generationTextFromStream);
 
-		logger.info("" + actorsFilms);
+		logger.info(actorsFilms.toString());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -278,9 +291,14 @@ class MistralAiChatClientIT {
 					.build())
 				.stream()
 				.content();
+
+		String content = response.collectList()
+				.blockOptional()
+				.stream()
+				.flatMap(List::stream)
+				.collect(Collectors.joining());
 		// @formatter:on
 
-		String content = response.collectList().block().stream().collect(Collectors.joining());
 		logger.info("Response: {}", content);
 
 		assertThat(content).containsAnyOf("30.0", "30");
@@ -290,9 +308,7 @@ class MistralAiChatClientIT {
 
 	@Test
 	void validateCallResponseMetadata() {
-		// String model = MistralAiApi.ChatModel.OPEN_MISTRAL_7B.getName();
-		String model = MistralAiApi.ChatModel.PIXTRAL_12B.getName();
-		// String model = MistralAiApi.ChatModel.PIXTRAL_LARGE.getName();
+		String model = MistralAiApi.ChatModel.MINISTRAL_14B.getName();
 		// @formatter:off
 		ChatResponse response = ChatClient.create(this.chatModel).prompt()
 				.options(MistralAiChatOptions.builder().model(model).build())
@@ -301,6 +317,7 @@ class MistralAiChatClientIT {
 				.chatResponse();
 		// @formatter:on
 
+		assertThat(response).isNotNull();
 		logger.info(response.toString());
 		assertThat(response.getMetadata().getId()).isNotEmpty();
 		assertThat(response.getMetadata().getModel()).containsIgnoringCase(model);

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelIT.java
@@ -170,7 +170,7 @@ class MistralAiChatModelIT {
 		Generation generation = this.chatModel.call(prompt).getResult();
 
 		ActorsFilmsRecord actorsFilms = outputConverter.convert(generation.getOutput().getText());
-		logger.info("" + actorsFilms);
+		logger.info(actorsFilms.toString());
 		assertThat(actorsFilms.actor()).isEqualTo("Tom Hanks");
 		assertThat(actorsFilms.movies()).hasSize(5);
 	}
@@ -274,7 +274,7 @@ class MistralAiChatModelIT {
 			.media(List.of(new Media(MimeTypeUtils.IMAGE_PNG, imageData)))
 			.build();
 
-		var chatOptions = ChatOptions.builder().model(MistralAiApi.ChatModel.PIXTRAL_LARGE.getValue()).build();
+		var chatOptions = ChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_LARGE.getValue()).build();
 
 		var response = this.chatModel.call(new Prompt(List.of(userMessage), chatOptions));
 
@@ -293,7 +293,7 @@ class MistralAiChatModelIT {
 				.build()))
 			.build();
 
-		var chatOptions = ChatOptions.builder().model(MistralAiApi.ChatModel.PIXTRAL_LARGE.getValue()).build();
+		var chatOptions = ChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_LARGE.getValue()).build();
 
 		ChatResponse response = this.chatModel.call(new Prompt(List.of(userMessage), chatOptions));
 
@@ -313,7 +313,7 @@ class MistralAiChatModelIT {
 			.build();
 
 		Flux<ChatResponse> response = this.streamingChatModel.stream(new Prompt(List.of(userMessage),
-				ChatOptions.builder().model(MistralAiApi.ChatModel.PIXTRAL_LARGE.getValue()).build()));
+				ChatOptions.builder().model(MistralAiApi.ChatModel.MISTRAL_LARGE.getValue()).build()));
 
 		String content = response.collectList()
 			.blockOptional()


### PR DESCRIPTION
## Description

- Remove deprecated Pixtral 12B model,
- Deprecate Pixtral Large model,
- Update integration tests to use recommended models,
- Polish integration tests.

## Explanations

According to [Mistral AI's documentation](https://docs.mistral.ai/getting-started/models#legacy-models), Pixtral models have been deprecated. Pixtral 12B model is already retired while Pixtral Large model will be retired the 31st of May 2026.

## Proposed milestones

- **2.0.0-M5**,
- **1.1.5**,
- **1.0.6**.