### PR TITLE
Avoid repeated context injection in RetrievalAugmentationAdvisor

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -16,9 +16,12 @@
 
 package org.springframework.ai.chat.client.advisor;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
@@ -125,6 +128,8 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 
 		ChatClientResponse chatClientResponse = null;
 
+		Map<String, @Nullable Object> context = new HashMap<>(chatClientRequest.context());
+
 		boolean isToolCall = false;
 
 		do {
@@ -132,7 +137,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 			// Before Call
 			var processedChatClientRequest = ChatClientRequest.builder()
 				.prompt(new Prompt(instructions, optionsCopy))
-				.context(chatClientRequest.context())
+				.context(context)
 				.build();
 
 			// Next Call
@@ -173,6 +178,10 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 
 				instructions = this.doGetNextInstructionsForToolCall(processedChatClientRequest, chatClientResponse,
 						toolExecutionResult);
+
+				// Preserve context from advisors for the next iteration
+				context = new HashMap<>(chatClientResponse.context());
+
 			}
 
 		}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
@@ -16,11 +16,14 @@
 
 package org.springframework.ai.chat.client.advisor;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -32,6 +35,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
@@ -709,6 +713,54 @@ public class ToolCallAdvisorTests {
 	}
 
 	@Test
+	void testAdviseCallPreservesContextAcrossToolCallIterations() {
+		ToolCallAdvisor advisor = ToolCallAdvisor.builder().toolCallingManager(this.toolCallingManager).build();
+
+		ChatClientRequest request = createMockRequest(true);
+
+		// Track how many times the context-setting advisor actually processes
+		AtomicInteger processingCount = new AtomicInteger(0);
+
+		ContextSettingAdvisor contextAdvisor = new ContextSettingAdvisor(processingCount);
+
+		// Terminal advisor that propagates request context to response
+		// (mimicking real ChatModelCallAdvisor behavior)
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			callCount[0]++;
+			ChatClientResponse mockResponse = callCount[0] == 1 ? createMockResponse(true) : createMockResponse(false);
+			return ChatClientResponse.builder()
+				.chatResponse(mockResponse.chatResponse())
+				.context(req.context())
+				.build();
+		});
+
+		// Chain: ToolCallAdvisor -> ContextSettingAdvisor -> TerminalAdvisor
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, contextAdvisor, terminalAdvisor))
+			.build();
+
+		// Mock tool execution result
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		advisor.adviseCall(request, realChain);
+
+		// The terminal advisor was called twice (two iterations of the tool call loop)
+		assertThat(callCount[0]).isEqualTo(2);
+
+		// The context-setting advisor should have processed only once,
+		// because on the second iteration the context key from the first iteration
+		// is preserved, causing it to skip processing.
+		assertThat(processingCount.get()).isEqualTo(1);
+	}
+
+	@Test
 	void testExtendedAdvisorWithCustomHooks() {
 		int[] hookCallCounts = { 0, 0, 0 }; // initializeLoop, beforeCall, afterCall
 
@@ -970,6 +1022,54 @@ public class ToolCallAdvisorTests {
 		@Override
 		public Flux<ChatClientResponse> adviseStream(ChatClientRequest req, StreamAdvisorChain chain) {
 			return this.responseFunction.apply(req, chain);
+		}
+
+	}
+
+	/**
+	 * A BaseAdvisor that sets a context key on first processing and skips if the key
+	 * already exists. Used to verify that context is preserved across tool call loop
+	 * iterations.
+	 */
+	private static class ContextSettingAdvisor implements BaseAdvisor {
+
+		private static final String CONTEXT_KEY = "test_context";
+
+		private final AtomicInteger processingCount;
+
+		ContextSettingAdvisor(AtomicInteger processingCount) {
+			this.processingCount = processingCount;
+		}
+
+		@Override
+		public ChatClientRequest before(ChatClientRequest chatClientRequest, @Nullable AdvisorChain advisorChain) {
+			Map<String, @Nullable Object> context = new HashMap<>(chatClientRequest.context());
+
+			// Skip processing if context key already exists (like RAG's DOCUMENT_CONTEXT
+			// check)
+			if (context.containsKey(CONTEXT_KEY)) {
+				return chatClientRequest;
+			}
+
+			this.processingCount.incrementAndGet();
+			context.put(CONTEXT_KEY, "injected-value");
+
+			return chatClientRequest.mutate().context(context).build();
+		}
+
+		@Override
+		public ChatClientResponse after(ChatClientResponse chatClientResponse, @Nullable AdvisorChain advisorChain) {
+			return chatClientResponse;
+		}
+
+		@Override
+		public String getName() {
+			return "context-setting";
+		}
+
+		@Override
+		public int getOrder() {
+			return 0;
 		}
 
 	}

--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/advisor/RetrievalAugmentationAdvisor.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/advisor/RetrievalAugmentationAdvisor.java
@@ -107,6 +107,11 @@ public final class RetrievalAugmentationAdvisor implements BaseAdvisor {
 	public ChatClientRequest before(ChatClientRequest chatClientRequest, @Nullable AdvisorChain advisorChain) {
 		Map<String, Object> context = new HashMap<>(chatClientRequest.context());
 
+		// Skip RAG processing if document context has already been injected
+		if (context.containsKey(DOCUMENT_CONTEXT)) {
+			return chatClientRequest;
+		}
+
 		// 0. Create a query from the user text, parameters, and conversation history.
 		String text = chatClientRequest.prompt().getUserMessage().getText();
 		Query originalQuery = Query.builder()

--- a/spring-ai-rag/src/test/java/org/springframework/ai/rag/advisor/RetrievalAugmentationAdvisorTests.java
+++ b/spring-ai-rag/src/test/java/org/springframework/ai/rag/advisor/RetrievalAugmentationAdvisorTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.rag.advisor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.retrieval.search.DocumentRetriever;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RetrievalAugmentationAdvisor}.
+ */
+class RetrievalAugmentationAdvisorTests {
+
+	@Test
+	void whenDocumentContextAlreadyExistsThenSkipRagProcessing() {
+		DocumentRetriever documentRetriever = mock(DocumentRetriever.class);
+
+		RetrievalAugmentationAdvisor advisor = RetrievalAugmentationAdvisor.builder()
+			.documentRetriever(documentRetriever)
+			.build();
+
+		// Simulate a request that already has DOCUMENT_CONTEXT in context
+		// (e.g. from a previous iteration in a tool call loop)
+		List<Document> existingDocuments = List.of(new Document("existing context"));
+		Map<String, Object> context = new HashMap<>();
+		context.put(RetrievalAugmentationAdvisor.DOCUMENT_CONTEXT, existingDocuments);
+
+		Prompt prompt = new Prompt(new UserMessage("test query"));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).context(context).build();
+
+		ChatClientRequest result = advisor.before(request, null);
+
+		// Should return the original request unchanged
+		assertThat(result).isSameAs(request);
+
+		// Document retriever should NOT have been called
+		verify(documentRetriever, never()).retrieve(any());
+	}
+
+	@Test
+	void whenDocumentContextDoesNotExistThenExecuteRagProcessing() {
+		DocumentRetriever documentRetriever = mock(DocumentRetriever.class);
+		List<Document> retrievedDocuments = List.of(new Document("retrieved doc"));
+		when(documentRetriever.retrieve(any())).thenReturn(retrievedDocuments);
+
+		RetrievalAugmentationAdvisor advisor = RetrievalAugmentationAdvisor.builder()
+			.documentRetriever(documentRetriever)
+			.build();
+
+		Prompt prompt = new Prompt(new UserMessage("test query"));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).build();
+
+		ChatClientRequest result = advisor.before(request, null);
+
+		// Document retriever should have been called
+		verify(documentRetriever).retrieve(any());
+
+		// The result should be different from the original request (augmented)
+		assertThat(result).isNotSameAs(request);
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/spring-projects/spring-ai/issues/5722

During tool call loops in `ToolCallAdvisor`, the advisor chain is re-executed on each iteration. Previously, the original request context was used every time, causing `RetrievalAugmentationAdvisor` to redundantly run the full RAG pipeline (query transformation, vector retrieval, document post-processing) on every tool call. This leads to unnecessary API costs and latency in agent scenarios.

## Changes

- **`ToolCallAdvisor`**: Propagate response context across tool call loop iterations so that state set by advisors in earlier iterations is preserved for subsequent ones.
- **`RetrievalAugmentationAdvisor`**: Skip RAG processing when `DOCUMENT_CONTEXT` already exists in the request context.

## Test plan

- Added `ToolCallAdvisorTests.testAdviseCallPreservesContextAcrossToolCallIterations` — verifies context is preserved across tool call loop iterations and that a context-setting advisor processes only once.
- Added `RetrievalAugmentationAdvisorTests` — verifies RAG pipeline is skipped when `DOCUMENT_CONTEXT` already exists, and executed normally when it doesn't.