### PR TITLE
MCP Server: filter tools with spring.ai.mcp.server.expose-mcp-client-tools

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/StatelessToolCallbackConverterAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/StatelessToolCallbackConverterAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +32,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
 
 /**
@@ -53,9 +51,8 @@ public class StatelessToolCallbackConverterAutoConfiguration {
 			ObjectProvider<List<ToolCallback>> toolCalls, List<ToolCallback> toolCallbackList,
 			ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
 			ObjectProvider<ToolCallbackProvider> tcbProviders, McpServerProperties serverProperties) {
-
-		List<ToolCallback> tools = this.aggregateToolCallbacks(toolCalls, toolCallbackList, tcbProviderList,
-				tcbProviders);
+		List<ToolCallback> tools = ToolCallbackUtils.aggregateToolCallbacks(toolCalls, toolCallbackList,
+				tcbProviderList, tcbProviders, serverProperties.isExposeMcpClientTools());
 
 		return this.toSyncToolSpecifications(tools, serverProperties);
 	}
@@ -85,9 +82,8 @@ public class StatelessToolCallbackConverterAutoConfiguration {
 			ObjectProvider<List<ToolCallback>> toolCalls, List<ToolCallback> toolCallbackList,
 			ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
 			ObjectProvider<ToolCallbackProvider> tcbProviders, McpServerProperties serverProperties) {
-
-		List<ToolCallback> tools = this.aggregateToolCallbacks(toolCalls, toolCallbackList, tcbProviderList,
-				tcbProviders);
+		List<ToolCallback> tools = ToolCallbackUtils.aggregateToolCallbacks(toolCalls, toolCallbackList,
+				tcbProviderList, tcbProviders, serverProperties.isExposeMcpClientTools());
 
 		return this.toAsyncToolSpecification(tools, serverProperties);
 	}
@@ -108,35 +104,6 @@ public class StatelessToolCallbackConverterAutoConfiguration {
 				return McpToolUtils.toStatelessAsyncToolSpecification(tool, mimeType);
 			})
 			.toList();
-	}
-
-	private List<ToolCallback> aggregateToolCallbacks(ObjectProvider<List<ToolCallback>> toolCalls,
-			List<ToolCallback> toolCallbackList, ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
-			ObjectProvider<ToolCallbackProvider> tcbProviders) {
-
-		// Merge ToolCallbackProviders from both ObjectProviders.
-		List<ToolCallbackProvider> totalToolCallbackProviders = new ArrayList<>(
-				tcbProviderList.stream().flatMap(List::stream).toList());
-		totalToolCallbackProviders.addAll(tcbProviders.stream().toList());
-
-		// De-duplicate ToolCallbackProviders
-		totalToolCallbackProviders = totalToolCallbackProviders.stream().distinct().toList();
-
-		List<ToolCallback> tools = new ArrayList<>(toolCalls.stream().flatMap(List::stream).toList());
-
-		if (!CollectionUtils.isEmpty(toolCallbackList)) {
-			tools.addAll(toolCallbackList);
-		}
-
-		List<ToolCallback> providerToolCallbacks = totalToolCallbackProviders.stream()
-			.map(pr -> List.of(pr.getToolCallbacks()))
-			.flatMap(List::stream)
-			.filter(fc -> fc instanceof ToolCallback)
-			.map(fc -> (ToolCallback) fc)
-			.toList();
-
-		tools.addAll(providerToolCallbacks);
-		return tools;
 	}
 
 	public static class ToolCallbackConverterCondition extends AllNestedConditions {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackConverterAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackConverterAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +32,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeType;
 
 /**
@@ -52,8 +50,8 @@ public class ToolCallbackConverterAutoConfiguration {
 			List<ToolCallback> toolCallbackList, ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
 			ObjectProvider<ToolCallbackProvider> tcbProviders, McpServerProperties serverProperties) {
 
-		List<ToolCallback> tools = this.aggregateToolCallbacks(toolCalls, toolCallbackList, tcbProviderList,
-				tcbProviders);
+		List<ToolCallback> tools = ToolCallbackUtils.aggregateToolCallbacks(toolCalls, toolCallbackList,
+				tcbProviderList, tcbProviders, serverProperties.isExposeMcpClientTools());
 
 		return this.toSyncToolSpecifications(tools, serverProperties);
 	}
@@ -81,11 +79,10 @@ public class ToolCallbackConverterAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	public List<McpServerFeatures.AsyncToolSpecification> asyncTools(ObjectProvider<List<ToolCallback>> toolCalls,
-			List<ToolCallback> toolCallbacksList, ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
+			List<ToolCallback> toolCallbackList, ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
 			ObjectProvider<ToolCallbackProvider> tcbProviders, McpServerProperties serverProperties) {
-
-		List<ToolCallback> tools = this.aggregateToolCallbacks(toolCalls, toolCallbacksList, tcbProviderList,
-				tcbProviders);
+		List<ToolCallback> tools = ToolCallbackUtils.aggregateToolCallbacks(toolCalls, toolCallbackList,
+				tcbProviderList, tcbProviders, serverProperties.isExposeMcpClientTools());
 
 		return this.toAsyncToolSpecification(tools, serverProperties);
 	}
@@ -95,12 +92,10 @@ public class ToolCallbackConverterAutoConfiguration {
 		// De-duplicate tools by their name, keeping the first occurrence of each tool
 		// name
 		return tools.stream() // Key: tool name
-			.collect(Collectors.toMap(tool -> tool.getToolDefinition().name(), tool -> tool, // Value:
-																								// the
-																								// tool
-																								// itself
+			.collect(Collectors.toMap(tool -> tool.getToolDefinition().name(), tool -> tool,
+					// Value: the tool itself
 					(existing, replacement) -> existing)) // On duplicate key, keep the
-															// existing tool
+			// existing tool
 			.values()
 			.stream()
 			.map(tool -> {
@@ -112,33 +107,9 @@ public class ToolCallbackConverterAutoConfiguration {
 			.toList();
 	}
 
-	private List<ToolCallback> aggregateToolCallbacks(ObjectProvider<List<ToolCallback>> toolCalls,
-			List<ToolCallback> toolCallbackList, ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
-			ObjectProvider<ToolCallbackProvider> tcbProviders) {
-
-		// Merge ToolCallbackProviders from both ObjectProviders.
-		List<ToolCallbackProvider> totalToolCallbackProviders = new ArrayList<>(
-				tcbProviderList.stream().flatMap(List::stream).toList());
-		totalToolCallbackProviders.addAll(tcbProviders.stream().toList());
-
-		// De-duplicate ToolCallbackProviders
-		totalToolCallbackProviders = totalToolCallbackProviders.stream().distinct().toList();
-
-		List<ToolCallback> tools = new ArrayList<>(toolCalls.stream().flatMap(List::stream).toList());
-
-		if (!CollectionUtils.isEmpty(toolCallbackList)) {
-			tools.addAll(toolCallbackList);
-		}
-
-		List<ToolCallback> providerToolCallbacks = totalToolCallbackProviders.stream()
-			.map(pr -> List.of(pr.getToolCallbacks()))
-			.flatMap(List::stream)
-			.filter(fc -> fc instanceof ToolCallback)
-			.map(fc -> (ToolCallback) fc)
-			.toList();
-
-		tools.addAll(providerToolCallbacks);
-		return tools;
+	private static boolean isMcpToolProvider(ToolCallbackProvider tcbp) {
+		return !(tcbp instanceof org.springframework.ai.mcp.SyncMcpToolCallbackProvider)
+				&& !(tcbp instanceof org.springframework.ai.mcp.AsyncMcpToolCallbackProvider);
 	}
 
 	public static class ToolCallbackConverterCondition extends AllNestedConditions {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackUtils.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.mcp.AsyncMcpToolCallback;
+import org.springframework.ai.mcp.SyncMcpToolCallback;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * @author Daniel Garnier-Moiroux
+ */
+final class ToolCallbackUtils {
+
+	private static final Logger log = LoggerFactory.getLogger(ToolCallbackUtils.class);
+
+	private ToolCallbackUtils() {
+	}
+
+	static List<ToolCallback> aggregateToolCallbacks(ObjectProvider<List<ToolCallback>> toolCalls,
+			List<ToolCallback> toolCallbackList, ObjectProvider<List<ToolCallbackProvider>> tcbProviderList,
+			ObjectProvider<ToolCallbackProvider> tcbProviders, boolean includeMcpTools) {
+		var allToolCallbacks = Stream.concat(toolCalls.stream().flatMap(List::stream), toolCallbackList.stream())
+			.filter(toolCallback -> includeMcpTools || !isMcpToolCallback(toolCallback));
+
+		var allCallbackProviders = Stream.concat(tcbProviderList.stream().flatMap(List::stream), tcbProviders.stream());
+		AtomicBoolean hasExcludedToolProvider = new AtomicBoolean(false);
+		var filteredProviders = allCallbackProviders.filter(provider -> {
+			var includeProvider = includeMcpTools || !isMcpToolProvider(provider);
+			if (!includeProvider) {
+				hasExcludedToolProvider.set(true);
+			}
+			return includeProvider;
+		}).distinct();
+		var toolCallbacksFromProviders = filteredProviders.map(pr -> List.of(pr.getToolCallbacks()))
+			.flatMap(List::stream)
+			.filter(Objects::nonNull);
+
+		var toolCallbacks = Stream.concat(allToolCallbacks, toolCallbacksFromProviders).toList();
+
+		// After consuming all the streams, log if we have excluded MCP tools
+		if (hasExcludedToolProvider.get()) {
+			log.warn(
+					"Found MCP Clients. The MCP Client tools will not be exposed by the MCP Server. If you would like to expose the tools, set {}.expose-mcp-client-tools=true.",
+					McpServerProperties.CONFIG_PREFIX);
+		}
+		return toolCallbacks;
+	}
+
+	static boolean isMcpToolCallback(ToolCallback toolCallback) {
+		return (toolCallback instanceof SyncMcpToolCallback) || (toolCallback instanceof AsyncMcpToolCallback);
+	}
+
+	static boolean isMcpToolProvider(ToolCallbackProvider tcbp) {
+		return (tcbp instanceof org.springframework.ai.mcp.SyncMcpToolCallbackProvider)
+				|| (tcbp instanceof org.springframework.ai.mcp.AsyncMcpToolCallbackProvider);
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
@@ -100,6 +100,12 @@ public class McpServerProperties {
 	private ServerProtocol protocol = ServerProtocol.SSE;
 
 	/**
+	 * Whether to re-expose downstream MCP tools (provided by MCP clients) as tools in
+	 * this MCP server. Defaults to false.
+	 */
+	private boolean exposeMcpClientTools = false;
+
+	/**
 	 * Sets the duration to wait for server responses before timing out requests. This
 	 * timeout applies to all requests made through the client, including tool calls,
 	 * resource access, and prompt operations.
@@ -108,6 +114,14 @@ public class McpServerProperties {
 
 	public Duration getRequestTimeout() {
 		return this.requestTimeout;
+	}
+
+	public boolean isExposeMcpClientTools() {
+		return this.exposeMcpClientTools;
+	}
+
+	public void setExposeMcpClientTools(boolean exposeMcpClientTools) {
+		this.exposeMcpClientTools = exposeMcpClientTools;
 	}
 
 	public void setRequestTimeout(Duration requestTimeout) {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/StatelessToolCallbackConverterAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/StatelessToolCallbackConverterAutoConfigurationIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.function.Function;
 
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification;
@@ -29,6 +30,7 @@ import org.springframework.ai.mcp.SyncMcpToolCallback;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -47,11 +49,12 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(StatelessToolCallbackConverterAutoConfiguration.class))
-		.withPropertyValues("spring.ai.mcp.server.enabled=true", "spring.ai.mcp.server.protocol=STATELESS");
+		.withPropertyValues("spring.ai.mcp.server.enabled=true", "spring.ai.mcp.server.protocol=STATELESS",
+				"spring.ai.mcp.server.expose-mcp-client-tools=true");
 
 	@Test
 	void defaultSyncToolsConfiguration() {
-		this.contextRunner.withUserConfiguration(TestToolConfiguration.class).run(context -> {
+		this.contextRunner.withUserConfiguration(TestMcpToolConfiguration.class).run(context -> {
 			assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
 			assertThat(context).hasBean("syncTools");
 
@@ -65,7 +68,7 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 	@Test
 	void asyncToolsConfiguration() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.server.type=ASYNC")
-			.withUserConfiguration(TestToolConfiguration.class)
+			.withUserConfiguration(TestMcpToolConfiguration.class)
 			.run(context -> {
 				assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
 				assertThat(context).hasBean("asyncTools");
@@ -105,7 +108,7 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 	@Test
 	void toolResponseMimeTypeConfiguration() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.server.tool-response-mime-type.test-tool=application/json")
-			.withUserConfiguration(TestToolConfiguration.class)
+			.withUserConfiguration(TestMcpToolConfiguration.class)
 			.run(context -> {
 				assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
 				assertThat(context).hasBean("syncTools");
@@ -136,7 +139,7 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 	@Test
 	void conditionDisabledWhenServerDisabled() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.server.enabled=false")
-			.withUserConfiguration(TestToolConfiguration.class)
+			.withUserConfiguration(TestMcpToolConfiguration.class)
 			.run(context -> {
 				assertThat(context).doesNotHaveBean(StatelessToolCallbackConverterAutoConfiguration.class);
 				assertThat(context).doesNotHaveBean("syncTools");
@@ -147,7 +150,7 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 	@Test
 	void conditionDisabledWhenToolCallbackConvertDisabled() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.server.tool-callback-converter=false")
-			.withUserConfiguration(TestToolConfiguration.class)
+			.withUserConfiguration(TestMcpToolConfiguration.class)
 			.run(context -> {
 				assertThat(context).doesNotHaveBean(StatelessToolCallbackConverterAutoConfiguration.class);
 				assertThat(context).doesNotHaveBean("syncTools");
@@ -157,7 +160,7 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 
 	@Test
 	void conditionEnabledByDefault() {
-		this.contextRunner.withUserConfiguration(TestToolConfiguration.class).run(context -> {
+		this.contextRunner.withUserConfiguration(TestMcpToolConfiguration.class).run(context -> {
 			assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
 			assertThat(context).hasBean("syncTools");
 		});
@@ -168,7 +171,7 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 		this.contextRunner
 			.withPropertyValues("spring.ai.mcp.server.enabled=true",
 					"spring.ai.mcp.server.tool-callback-converter=true")
-			.withUserConfiguration(TestToolConfiguration.class)
+			.withUserConfiguration(TestMcpToolConfiguration.class)
 			.run(context -> {
 				assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
 				assertThat(context).hasBean("syncTools");
@@ -190,7 +193,7 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 	@Test
 	void mixedToolCallbacksAndProvidersConfiguration() {
 		this.contextRunner
-			.withUserConfiguration(TestToolConfiguration.class, TestToolCallbackProviderConfiguration.class)
+			.withUserConfiguration(TestMcpToolConfiguration.class, TestToolCallbackProviderConfiguration.class)
 			.run(context -> {
 				assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
 				assertThat(context).hasBean("syncTools");
@@ -198,12 +201,44 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 				@SuppressWarnings("unchecked")
 				List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
 				assertThat(syncTools).hasSize(2); // One from direct callback, one from
-													// provider
+				// provider
+			});
+	}
+
+	@Test
+	void mcpClientToolsNotExposedByDefault() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(StatelessToolCallbackConverterAutoConfiguration.class))
+			.withPropertyValues("spring.ai.mcp.server.enabled=true", "spring.ai.mcp.server.protocol=STATELESS")
+			.withUserConfiguration(TestMcpToolCallbackProviderConfiguration.class, TestMcpToolConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
+				assertThat(context).hasBean("syncTools");
+
+				@SuppressWarnings("unchecked")
+				List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
+				assertThat(syncTools).isEmpty();
+			});
+	}
+
+	@Test
+	void regularToolsExportedByDefault() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(StatelessToolCallbackConverterAutoConfiguration.class))
+			.withPropertyValues("spring.ai.mcp.server.enabled=true", "spring.ai.mcp.server.protocol=STATELESS")
+			.withUserConfiguration(TestRegularToolConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasSingleBean(StatelessToolCallbackConverterAutoConfiguration.class);
+				assertThat(context).hasBean("syncTools");
+
+				@SuppressWarnings("unchecked")
+				List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
+				assertThat(syncTools).hasSize(1);
 			});
 	}
 
 	@Configuration
-	static class TestToolConfiguration {
+	static class TestMcpToolConfiguration {
 
 		@Bean
 		List<ToolCallback> testToolCallbacks() {
@@ -217,6 +252,20 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 			when(mockClient.getClientInfo()).thenReturn(new McpSchema.Implementation("testClient", "1.0.0"));
 
 			return List.of(SyncMcpToolCallback.builder().mcpClient(mockClient).tool(mockTool).build());
+		}
+
+	}
+
+	@Configuration
+	static class TestRegularToolConfiguration {
+
+		@Bean
+		List<ToolCallback> testRegularToolCallbacks() {
+			var regularToolCallback = FunctionToolCallback.builder("regular-tool", Function.identity())
+				.description("Regular Tool")
+				.inputType(String.class)
+				.build();
+			return List.of(regularToolCallback);
 		}
 
 	}
@@ -297,6 +346,31 @@ public class StatelessToolCallbackConverterAutoConfigurationIT {
 				return new ToolCallback[] {
 						SyncMcpToolCallback.builder().mcpClient(mockClient).tool(mockTool).build() };
 			};
+		}
+
+	}
+
+	@Configuration
+	static class TestMcpToolCallbackProviderConfiguration {
+
+		@Bean
+		ToolCallbackProvider testMcpToolCallbackProvider() {
+			McpSyncClient mockClient = Mockito.mock(McpSyncClient.class);
+			McpSchema.Tool mockTool = Mockito.mock(McpSchema.Tool.class);
+			McpSchema.CallToolResult mockResult = Mockito.mock(McpSchema.CallToolResult.class);
+
+			Mockito.when(mockTool.name()).thenReturn("mcp-provider-tool");
+			Mockito.when(mockTool.description()).thenReturn("MCP Provider Tool");
+			Mockito.when(mockClient.callTool(Mockito.any(McpSchema.CallToolRequest.class))).thenReturn(mockResult);
+			when(mockClient.getClientInfo()).thenReturn(new McpSchema.Implementation("testClient", "1.0.0"));
+			when(mockClient.getClientCapabilities()).thenReturn(McpSchema.ClientCapabilities.builder().build());
+
+			McpSchema.ListToolsResult listToolsResult = new McpSchema.ListToolsResult(List.of(mockTool), null);
+			Mockito.when(mockClient.listTools()).thenReturn(listToolsResult);
+
+			return org.springframework.ai.mcp.SyncMcpToolCallbackProvider.builder()
+				.mcpClients(List.of(mockClient))
+				.build();
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackConverterAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/ToolCallbackConverterAutoConfigurationIT.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.function.Function;
 
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
@@ -29,6 +30,7 @@ import org.springframework.ai.mcp.SyncMcpToolCallback;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -47,7 +49,7 @@ public class ToolCallbackConverterAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(ToolCallbackConverterAutoConfiguration.class))
-		.withPropertyValues("spring.ai.mcp.server.enabled=true");
+		.withPropertyValues("spring.ai.mcp.server.enabled=true", "spring.ai.mcp.server.expose-mcp-client-tools=true");
 
 	@Test
 	void defaultSyncToolsConfiguration() {
@@ -80,7 +82,7 @@ public class ToolCallbackConverterAutoConfigurationIT {
 
 	@Test
 	void toolCallbackProviderConfiguration() {
-		this.contextRunner.withUserConfiguration(TestToolCallbackProviderConfiguration.class).run(context -> {
+		this.contextRunner.withUserConfiguration(TestMcpToolCallbackProviderConfiguration.class).run(context -> {
 			assertThat(context).hasSingleBean(ToolCallbackConverterAutoConfiguration.class);
 			assertThat(context).hasBean("syncTools");
 
@@ -190,7 +192,7 @@ public class ToolCallbackConverterAutoConfigurationIT {
 	@Test
 	void mixedToolCallbacksAndProvidersConfiguration() {
 		this.contextRunner
-			.withUserConfiguration(TestToolConfiguration.class, TestToolCallbackProviderConfiguration.class)
+			.withUserConfiguration(TestToolConfiguration.class, TestMcpToolCallbackProviderConfiguration.class)
 			.run(context -> {
 				assertThat(context).hasSingleBean(ToolCallbackConverterAutoConfiguration.class);
 				assertThat(context).hasBean("syncTools");
@@ -198,7 +200,39 @@ public class ToolCallbackConverterAutoConfigurationIT {
 				@SuppressWarnings("unchecked")
 				List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
 				assertThat(syncTools).hasSize(2); // One from direct callback, one from
-													// provider
+				// provider
+			});
+	}
+
+	@Test
+	void mcpClientToolsNotExposedByDefault() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ToolCallbackConverterAutoConfiguration.class))
+			.withPropertyValues("spring.ai.mcp.server.enabled=true")
+			.withUserConfiguration(TestMcpToolCallbackProviderConfiguration.class, TestMcpToolConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasSingleBean(ToolCallbackConverterAutoConfiguration.class);
+				assertThat(context).hasBean("syncTools");
+
+				@SuppressWarnings("unchecked")
+				List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
+				assertThat(syncTools).isEmpty();
+			});
+	}
+
+	@Test
+	void regularToolsExportedByDefault() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ToolCallbackConverterAutoConfiguration.class))
+			.withPropertyValues("spring.ai.mcp.server.enabled=true")
+			.withUserConfiguration(TestRegularToolConfiguration.class)
+			.run(context -> {
+				assertThat(context).hasSingleBean(ToolCallbackConverterAutoConfiguration.class);
+				assertThat(context).hasBean("syncTools");
+
+				@SuppressWarnings("unchecked")
+				List<SyncToolSpecification> syncTools = (List<SyncToolSpecification>) context.getBean("syncTools");
+				assertThat(syncTools).hasSize(1);
 			});
 	}
 
@@ -217,6 +251,20 @@ public class ToolCallbackConverterAutoConfigurationIT {
 			when(mockClient.getClientInfo()).thenReturn(new McpSchema.Implementation("testClient", "1.0.0"));
 
 			return List.of(SyncMcpToolCallback.builder().mcpClient(mockClient).tool(mockTool).build());
+		}
+
+	}
+
+	@Configuration
+	static class TestRegularToolConfiguration {
+
+		@Bean
+		List<ToolCallback> testRegularToolCallbacks() {
+			var regularToolCallback = FunctionToolCallback.builder("regular-tool", Function.identity())
+				.description("Regular Tool")
+				.inputType(String.class)
+				.build();
+			return List.of(regularToolCallback);
 		}
 
 	}
@@ -280,23 +328,45 @@ public class ToolCallbackConverterAutoConfigurationIT {
 	}
 
 	@Configuration
-	static class TestToolCallbackProviderConfiguration {
+	static class TestMcpToolConfiguration {
 
 		@Bean
-		ToolCallbackProvider testToolCallbackProvider() {
-			return () -> {
-				McpSyncClient mockClient = Mockito.mock(McpSyncClient.class);
-				McpSchema.Tool mockTool = Mockito.mock(McpSchema.Tool.class);
-				McpSchema.CallToolResult mockResult = Mockito.mock(McpSchema.CallToolResult.class);
+		List<ToolCallback> testToolCallbacks() {
+			McpSyncClient mockClient = Mockito.mock(McpSyncClient.class);
+			McpSchema.Tool mockTool = Mockito.mock(McpSchema.Tool.class);
+			McpSchema.CallToolResult mockResult = Mockito.mock(McpSchema.CallToolResult.class);
 
-				Mockito.when(mockTool.name()).thenReturn("provider-tool");
-				Mockito.when(mockTool.description()).thenReturn("Provider Tool");
-				Mockito.when(mockClient.callTool(Mockito.any(McpSchema.CallToolRequest.class))).thenReturn(mockResult);
-				when(mockClient.getClientInfo()).thenReturn(new McpSchema.Implementation("testClient", "1.0.0"));
+			Mockito.when(mockTool.name()).thenReturn("test-tool");
+			Mockito.when(mockTool.description()).thenReturn("Test Tool");
+			Mockito.when(mockClient.callTool(Mockito.any(McpSchema.CallToolRequest.class))).thenReturn(mockResult);
+			when(mockClient.getClientInfo()).thenReturn(new McpSchema.Implementation("testClient", "1.0.0"));
 
-				return new ToolCallback[] {
-						SyncMcpToolCallback.builder().mcpClient(mockClient).tool(mockTool).build() };
-			};
+			return List.of(SyncMcpToolCallback.builder().mcpClient(mockClient).tool(mockTool).build());
+		}
+
+	}
+
+	@Configuration
+	static class TestMcpToolCallbackProviderConfiguration {
+
+		@Bean
+		ToolCallbackProvider testMcpToolCallbackProvider() {
+			McpSyncClient mockClient = Mockito.mock(McpSyncClient.class);
+			McpSchema.Tool mockTool = Mockito.mock(McpSchema.Tool.class);
+			McpSchema.CallToolResult mockResult = Mockito.mock(McpSchema.CallToolResult.class);
+
+			Mockito.when(mockTool.name()).thenReturn("mcp-provider-tool");
+			Mockito.when(mockTool.description()).thenReturn("MCP Provider Tool");
+			Mockito.when(mockClient.callTool(Mockito.any(McpSchema.CallToolRequest.class))).thenReturn(mockResult);
+			when(mockClient.getClientInfo()).thenReturn(new McpSchema.Implementation("testClient", "1.0.0"));
+			when(mockClient.getClientCapabilities()).thenReturn(McpSchema.ClientCapabilities.builder().build());
+
+			McpSchema.ListToolsResult listToolsResult = new McpSchema.ListToolsResult(List.of(mockTool), null);
+			Mockito.when(mockClient.listTools()).thenReturn(listToolsResult);
+
+			return org.springframework.ai.mcp.SyncMcpToolCallbackProvider.builder()
+				.mcpClients(List.of(mockClient))
+				.build();
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
@@ -72,6 +72,7 @@ All Common properties are prefixed with `spring.ai.mcp.server`:
 |`capabilities.tool` |Enable/disable tool capabilities |`true`
 |`capabilities.prompt` |Enable/disable prompt capabilities |`true`
 |`capabilities.completion` |Enable/disable completion capabilities |`true`
+|`expose-mcp-client-tools` |Whether to re-expose downstream MCP tools (provided by MCP clients) as tools in this MCP server |`false`
 |`tool-response-mime-type` |Response MIME type per tool name |`-`
 |`request-timeout` |Request timeout duration |`20 seconds`
 |===

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
@@ -88,6 +88,7 @@ All Common properties are prefixed with `spring.ai.mcp.server`:
 |`resource-change-notification` |Enable resource change notifications |`true`
 |`prompt-change-notification` |Enable prompt change notifications |`true`
 |`tool-change-notification` |Enable tool change notifications |`true`
+|`expose-mcp-client-tools` |Whether to re-expose downstream MCP tools (provided by MCP clients) as tools in this MCP server |`false`
 |`tool-response-mime-type` |Optional response MIME type per tool name. For example, `spring.ai.mcp.server.tool-response-mime-type.generateImage=image/png` will associate the `image/png` MIME type with the `generateImage()` tool name |`-`
 |`request-timeout` |Duration to wait for server responses before timing out requests. Applies to all requests made through the client, including tool calls, resource access, and prompt operations |`20 seconds`
 |===

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
@@ -68,6 +68,7 @@ All common properties are prefixed with `spring.ai.mcp.server`:
 |`resource-change-notification` |Enable resource change notifications |`true`
 |`prompt-change-notification` |Enable prompt change notifications |`true`
 |`tool-change-notification` |Enable tool change notifications |`true`
+|`expose-mcp-client-tools` |Whether to re-expose downstream MCP tools (provided by MCP clients) as tools in this MCP server |`false`
 |`tool-response-mime-type` |Response MIME type per tool name |`-`
 |`request-timeout` |Request timeout duration |`20 seconds`
 |===


### PR DESCRIPTION
Add configuration property to toggle exposing MCP client tools in MCP servers, `spring.ai.mcp.server.expose-mcp-client-tools`. Defaults to false.

Centralize the aggregation of all toolcallback sources into a single utils class.

## Breaking change

By default, tools from MCP clients are **not** exposed in MCP servers anymore.


Originally reported by @christos-spearbit