### PR TITLE
Fix tracing observation handlers not registered due to auto-configuration ordering

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
@@ -58,7 +58,8 @@ import org.springframework.context.annotation.Scope;
  * @author Jonatan Ivanov
  * @since 1.0.0
  */
-@AutoConfiguration
+@AutoConfiguration(
+		afterName = "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration")
 @ConditionalOnClass(ChatClient.class)
 @EnableConfigurationProperties(ChatClientBuilderProperties.class)
 @ConditionalOnProperty(prefix = ChatClientBuilderProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",

--- a/auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation/src/main/java/org/springframework/ai/model/chat/observation/autoconfigure/ChatObservationAutoConfiguration.java
+++ b/auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation/src/main/java/org/springframework/ai/model/chat/observation/autoconfigure/ChatObservationAutoConfiguration.java
@@ -53,9 +53,11 @@ import org.springframework.context.annotation.Configuration;
  * @since 1.0.0
  */
 // afterName: CompositeMeterRegistryAutoConfiguration declares a MeterRegistry bean that
-// some beans here are conditional on
-@AutoConfiguration(
-		afterName = "org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration")
+// some beans here are conditional on. MicrometerTracingAutoConfiguration depends on a
+// Tracer bean, ensuring @ConditionalOnBean(Tracer.class) in nested configurations works
+@AutoConfiguration(afterName = {
+		"org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration",
+		"org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration" })
 @ConditionalOnClass(ChatModel.class)
 @EnableConfigurationProperties(ChatObservationProperties.class)
 public class ChatObservationAutoConfiguration {

--- a/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/src/main/java/org/springframework/ai/model/image/observation/autoconfigure/ImageObservationAutoConfiguration.java
+++ b/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/src/main/java/org/springframework/ai/model/image/observation/autoconfigure/ImageObservationAutoConfiguration.java
@@ -41,7 +41,8 @@ import org.springframework.context.annotation.Configuration;
  * @author Jonatan Ivanov
  * @since 1.0.0
  */
-@AutoConfiguration
+@AutoConfiguration(
+		afterName = "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration")
 @ConditionalOnClass(ImageModel.class)
 @EnableConfigurationProperties(ImageObservationProperties.class)
 public class ImageObservationAutoConfiguration {

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreObservationAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreObservationAutoConfiguration.java
@@ -42,7 +42,8 @@ import org.springframework.context.annotation.Configuration;
  * @author Jonatan Ivanov
  * @since 1.0.0
  */
-@AutoConfiguration
+@AutoConfiguration(
+		afterName = "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration")
 @ConditionalOnClass(VectorStore.class)
 @EnableConfigurationProperties(VectorStoreObservationProperties.class)
 public class VectorStoreObservationAutoConfiguration {


### PR DESCRIPTION
## Summary

Fixes #5641

Spring AI observation auto-configurations use `@ConditionalOnBean(Tracer.class)` to determine whether to register tracing-aware observation handlers. However, without explicit ordering constraints, these configurations can be processed before `BraveAutoConfiguration` or `OpenTelemetryAutoConfiguration` creates the `Tracer` bean.

When this happens, both `TracerPresentObservationConfiguration` and `TracerNotPresentObservationConfiguration` are skipped — no observation handlers are registered at all.

## Changes

Added `afterName = "...MicrometerTracingAutoConfiguration"` to the following auto-configurations:

- `ChatClientAutoConfiguration`
- `ChatObservationAutoConfiguration`
- `ImageObservationAutoConfiguration`
- `VectorStoreObservationAutoConfiguration`

`MicrometerTracingAutoConfiguration` is used rather than individual implementations (e.g. `BraveAutoConfiguration`) to cover both Brave and OpenTelemetry.