### PR TITLE
fix: skip OpenAiApi chat bean when no chat API key is configured

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
@@ -61,6 +61,8 @@ public class OpenAiChatAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = "spring.ai.openai", name = { "api-key", "chat.api-key" },
+			matchIfMissing = false)
 	public OpenAiApi openAiApi(OpenAiConnectionProperties commonProperties, OpenAiChatProperties chatProperties,
 			ObjectProvider<RestClient.Builder> restClientBuilderProvider,
 			ObjectProvider<WebClient.Builder> webClientBuilderProvider,

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiModelConfigurationTests.java
@@ -386,4 +386,24 @@ public class OpenAiModelConfigurationTests {
 			});
 	}
 
+	@Test
+	void imageOnlyApiKeyDoesNotFailChatAutoConfiguration() {
+		// Regression test for https://github.com/spring-projects/spring-ai/issues/1818
+		// When only spring.ai.openai.image.api-key is set (no chat or common api-key),
+		// OpenAiChatAutoConfiguration must not throw an IllegalArgumentException.
+		// The OpenAiApi bean for chat should simply not be created.
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.openai.image.api-key=IMAGE_API_KEY",
+					"spring.ai.openai.base-url=TEST_BASE_URL")
+			.withConfiguration(AutoConfigurations.of(OpenAiChatAutoConfiguration.class,
+					OpenAiImageAutoConfiguration.class, RestClientAutoConfiguration.class,
+					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class,
+					WebClientAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context.getBeansOfType(OpenAiChatModel.class)).isEmpty();
+				assertThat(context.getBeansOfType(OpenAiImageModel.class)).isNotEmpty();
+			});
+	}
+
 }


### PR DESCRIPTION
## Problem

Fixes #1818

When a user configures **only** `spring.ai.openai.image.api-key` (without setting `spring.ai.openai.api-key` or `spring.ai.openai.chat.api-key`), the application fails to start with:

```
java.lang.IllegalArgumentException: OpenAI API key must be set
```

This happens because `OpenAiChatAutoConfiguration` is annotated with `matchIfMissing = true` at class level (so it always loads), but the `openAiApi` bean inside it calls `resolveConnectionProperties(commonProperties, chatProperties, "chat")` which throws when neither a common nor a chat-specific API key is present.

## Fix

Add `@ConditionalOnProperty` on the `openAiApi` bean inside `OpenAiChatAutoConfiguration`:

```java
@Bean
@ConditionalOnMissingBean
@ConditionalOnProperty(prefix = "spring.ai.openai", name = { "api-key", "chat.api-key" },
        matchIfMissing = false)
public OpenAiApi openAiApi(...) {
```

This ensures the chat `OpenAiApi` bean is only created when the user has set at least one of the two relevant API key properties. Users who only need image (or embedding, or audio) but not chat will no longer get a startup failure.

## Test

Added `imageOnlyApiKeyDoesNotFailChatAutoConfiguration` in `OpenAiModelConfigurationTests`:
- Loads context with `spring.ai.openai.image.api-key=IMAGE_API_KEY` only
- Includes both `OpenAiChatAutoConfiguration` and `OpenAiImageAutoConfiguration`
- Asserts context starts without errors (`hasNotFailed()`)
- Asserts `OpenAiImageModel` is present and `OpenAiChatModel` is absent

Signed-off-by: anuragg-saxenaa <anuragg.saxenaa@gmail.com>