### PR TITLE
fix: Allow overriding the MCP endpoint for non-supported MediaTypes

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
@@ -49,6 +49,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -189,8 +190,8 @@ public final class WebFluxSseServerTransportProvider implements McpServerTranspo
 		this.contextExtractor = contextExtractor;
 		this.securityValidator = securityValidator;
 		this.routerFunction = RouterFunctions.route()
-			.GET(this.sseEndpoint, this::handleSseConnection)
-			.POST(this.messageEndpoint, this::handleMessage)
+			.GET(this.sseEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM), this::handleSseConnection)
+			.POST(this.messageEndpoint, RequestPredicates.accept(MediaType.APPLICATION_JSON), this::handleMessage)
 			.build();
 
 		if (keepAliveInterval != null) {

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStatelessServerTransport.java
@@ -39,6 +39,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -83,8 +84,8 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 		this.contextExtractor = contextExtractor;
 		this.securityValidator = securityValidator;
 		this.routerFunction = RouterFunctions.route()
-			.GET(this.mcpEndpoint, this::handleGet)
-			.POST(this.mcpEndpoint, this::handlePost)
+			.POST(this.mcpEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM, MediaType.APPLICATION_JSON),
+					this::handlePost)
 			.build();
 	}
 
@@ -114,10 +115,6 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 		return this.routerFunction;
 	}
 
-	private Mono<ServerResponse> handleGet(ServerRequest request) {
-		return ServerResponse.status(HttpStatus.METHOD_NOT_ALLOWED).build();
-	}
-
 	private Mono<ServerResponse> handlePost(ServerRequest request) {
 		if (this.isClosing) {
 			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("Server is shutting down");
@@ -133,12 +130,6 @@ public final class WebFluxStatelessServerTransport implements McpStatelessServer
 		}
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
-
-		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
-				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
-			return ServerResponse.badRequest().build();
-		}
 
 		return request.bodyToMono(String.class).<ServerResponse>flatMap(body -> {
 			try {

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxStreamableServerTransportProvider.java
@@ -50,6 +50,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -104,8 +105,9 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		this.disallowDelete = disallowDelete;
 		this.securityValidator = securityValidator;
 		this.routerFunction = RouterFunctions.route()
-			.GET(this.mcpEndpoint, this::handleGet)
-			.POST(this.mcpEndpoint, this::handlePost)
+			.GET(this.mcpEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM), this::handleGet)
+			.POST(this.mcpEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM, MediaType.APPLICATION_JSON),
+					this::handlePost)
 			.DELETE(this.mcpEndpoint, this::handleDelete)
 			.build();
 
@@ -216,11 +218,6 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
 		return Mono.defer(() -> {
-			List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-			if (!acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM)) {
-				return ServerResponse.badRequest().build();
-			}
-
 			if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
 				return ServerResponse.badRequest().build(); // TODO: say we need a session
 															// id
@@ -278,12 +275,6 @@ public final class WebFluxStreamableServerTransportProvider implements McpStream
 		}
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
-
-		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
-				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
-			return ServerResponse.badRequest().build();
-		}
 
 		return request.bodyToMono(String.class).<ServerResponse>flatMap(body -> {
 			try {

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
@@ -44,6 +44,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RequestPredicates;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerRequest;
@@ -175,8 +177,8 @@ public final class WebMvcSseServerTransportProvider implements McpServerTranspor
 		this.contextExtractor = contextExtractor;
 		this.securityValidator = securityValidator;
 		this.routerFunction = RouterFunctions.route()
-			.GET(this.sseEndpoint, this::handleSseConnection)
-			.POST(this.messageEndpoint, this::handleMessage)
+			.GET(this.sseEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM), this::handleSseConnection)
+			.POST(this.messageEndpoint, RequestPredicates.accept(MediaType.APPLICATION_JSON), this::handleMessage)
 			.build();
 
 		if (keepAliveInterval != null) {

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStatelessServerTransport.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.mcp.server.webmvc.transport;
 
 import java.io.IOException;
-import java.util.List;
 
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.json.McpJsonDefaults;
@@ -37,6 +36,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RequestPredicates;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerRequest;
@@ -85,8 +85,8 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 		this.contextExtractor = contextExtractor;
 		this.securityValidator = securityValidator;
 		this.routerFunction = RouterFunctions.route()
-			.GET(this.mcpEndpoint, this::handleGet)
-			.POST(this.mcpEndpoint, this::handlePost)
+			.POST(this.mcpEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM, MediaType.APPLICATION_JSON),
+					this::handlePost)
 			.build();
 	}
 
@@ -116,10 +116,6 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 		return this.routerFunction;
 	}
 
-	private ServerResponse handleGet(ServerRequest request) {
-		return ServerResponse.status(HttpStatus.METHOD_NOT_ALLOWED).build();
-	}
-
 	private ServerResponse handlePost(ServerRequest request) {
 		if (this.isClosing) {
 			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
@@ -135,12 +131,6 @@ public final class WebMvcStatelessServerTransport implements McpStatelessServerT
 		}
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
-
-		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-		if (!(acceptHeaders.contains(MediaType.APPLICATION_JSON)
-				&& acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM))) {
-			return ServerResponse.badRequest().build();
-		}
 
 		var handler = this.mcpHandler;
 		if (handler == null) {

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcStreamableServerTransportProvider.java
@@ -47,6 +47,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RequestPredicates;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.ServerRequest;
@@ -151,8 +152,9 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		this.contextExtractor = contextExtractor;
 		this.securityValidator = securityValidator;
 		this.routerFunction = RouterFunctions.route()
-			.GET(this.mcpEndpoint, this::handleGet)
-			.POST(this.mcpEndpoint, this::handlePost)
+			.GET(this.mcpEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM), this::handleGet)
+			.POST(this.mcpEndpoint, RequestPredicates.accept(MediaType.TEXT_EVENT_STREAM, MediaType.APPLICATION_JSON),
+					this::handlePost)
 			.DELETE(this.mcpEndpoint, this::handleDelete)
 			.build();
 
@@ -280,11 +282,6 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 			return ServerResponse.status(e.getStatusCode()).body(message);
 		}
 
-		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-		if (!acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM)) {
-			return ServerResponse.badRequest().body("Invalid Accept header. Expected TEXT_EVENT_STREAM");
-		}
-
 		McpTransportContext transportContext = this.contextExtractor.extract(request);
 
 		if (request.headers().header(HttpHeaders.MCP_SESSION_ID).isEmpty()) {
@@ -367,15 +364,6 @@ public final class WebMvcStreamableServerTransportProvider implements McpStreama
 		catch (ServerTransportSecurityException e) {
 			var message = e.getMessage() != null ? e.getMessage() : "";
 			return ServerResponse.status(e.getStatusCode()).body(message);
-		}
-
-		List<MediaType> acceptHeaders = request.headers().asHttpHeaders().getAccept();
-		if (!acceptHeaders.contains(MediaType.TEXT_EVENT_STREAM)
-				|| !acceptHeaders.contains(MediaType.APPLICATION_JSON)) {
-			return ServerResponse.badRequest()
-				.body(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND)
-					.message("Invalid Accept headers. Expected TEXT_EVENT_STREAM and APPLICATION_JSON")
-					.build());
 		}
 
 		McpTransportContext transportContext = this.contextExtractor.extract(request);


### PR DESCRIPTION
The Routing to the mcp endpoint was hardcoded to route everything to the provided methods.
In the code of those methods then was checked if the right content-type could be provided for what the client could accept.

The effect is that implementing an HTML page to a user who accidentally opened the mcp endpoint was much harder than needed.

This change moves the accepted content type checks to the routing function and removes the needless GET handlers where GET is not implemented.

The advantage of this change is that now you can simply provide a meaningful explanation by simply implementing something like `@GetMapping(value = "/mcp", produces = MediaType.TEXT_HTML_VALUE)`

The downside of this change is that now doing a GET that is not allowed returns a 404 (Not Found) instead of the current 405 (Method Not Allowed).

I'm looking forward to your feedback on this proposal.