### PR TITLE
GH-5765: Fix content length issue with Open AI Azure endpoint

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAIAutoConfigurationUtil.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAIAutoConfigurationUtil.java
@@ -16,15 +16,48 @@
 
 package org.springframework.ai.model.openai.autoconfigure;
 
+import java.net.URI;
+import java.util.Locale;
+
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.lang.NonNull;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
 
 public final class OpenAIAutoConfigurationUtil {
 
 	private OpenAIAutoConfigurationUtil() {
 		// Avoids instantiation
+	}
+
+	public static RestClient.Builder prepareRestClientBuilderForOpenAi(@NonNull RestClient.Builder restClientBuilder,
+			String baseUrl) {
+		if (!isAzureOpenAiEndpoint(baseUrl)) {
+			return restClientBuilder;
+		}
+		return restClientBuilder.clone()
+			.requestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
+	}
+
+	public static boolean isAzureOpenAiEndpoint(String baseUrl) {
+		if (!StringUtils.hasText(baseUrl)) {
+			return false;
+		}
+		try {
+			URI uri = URI.create(baseUrl.trim());
+			String host = uri.getHost();
+			if (host == null) {
+				return false;
+			}
+			String lower = host.toLowerCase(Locale.ROOT);
+			return lower.endsWith("openai.azure.com");
+		}
+		catch (IllegalArgumentException ex) {
+			return false;
+		}
 	}
 
 	public static @NonNull ResolvedConnectionProperties resolveConnectionProperties(

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/main/java/org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfigurationUtil.prepareRestClientBuilderForOpenAi;
 import static org.springframework.ai.model.openai.autoconfigure.OpenAIAutoConfigurationUtil.resolveConnectionProperties;
 
 /**
@@ -75,7 +76,8 @@ public class OpenAiChatAutoConfiguration {
 			.headers(resolved.headers())
 			.completionsPath(chatProperties.getCompletionsPath())
 			.embeddingsPath(OpenAiEmbeddingProperties.DEFAULT_EMBEDDINGS_PATH)
-			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
+			.restClientBuilder(prepareRestClientBuilderForOpenAi(
+					restClientBuilderProvider.getIfAvailable(RestClient::builder), resolved.baseUrl()))
 			.webClientBuilder(webClientBuilderProvider.getIfAvailable(WebClient::builder))
 			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
 			.build();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAzureChatHttpTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/src/test/java/org/springframework/ai/model/openai/autoconfigure/OpenAiAzureChatHttpTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.openai.autoconfigure;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OpenAiAzureChatHttpTests {
+
+	@Test
+	public void isAzureOpenAiEndpointRecognizesAzureHosts() {
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint("https://my-resource.openai.azure.com")).isTrue();
+		assertThat(OpenAIAutoConfigurationUtil
+			.isAzureOpenAiEndpoint("https://my-resource.openai.azure.com/openai/deployments/x")).isTrue();
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint("  https://Ab.openai.azure.com  ")).isTrue();
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint("https://openai.azure.com")).isTrue();
+	}
+
+	@Test
+	public void isAzureOpenAiEndpointRejectsNonAzureHosts() {
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint("https://api.openai.com")).isFalse();
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint("https://localhost:8080")).isFalse();
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint("")).isFalse();
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint(null)).isFalse();
+		assertThat(OpenAIAutoConfigurationUtil.isAzureOpenAiEndpoint("not-a-uri")).isFalse();
+	}
+
+	@Test
+	public void prepareRestClientBuilderForOpenAiSendsContentLengthOnPostToLocalServer() throws Exception {
+		AtomicReference<String> contentLength = new AtomicReference<>();
+		AtomicReference<String> transferEncoding = new AtomicReference<>();
+		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/v1/chat/completions", exchange -> {
+			contentLength.set(exchange.getRequestHeaders().getFirst("Content-Length"));
+			transferEncoding.set(exchange.getRequestHeaders().getFirst("Transfer-Encoding"));
+			String response = """
+					{"id":"1","object":"chat.completion","created":0,"model":"gpt","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}
+					""";
+			byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(200, bytes.length);
+			try (OutputStream os = exchange.getResponseBody()) {
+				os.write(bytes);
+			}
+		});
+		server.start();
+		int port = server.getAddress().getPort();
+		try {
+			RestClient client = OpenAIAutoConfigurationUtil
+				.prepareRestClientBuilderForOpenAi(RestClient.builder(), "https://resource.openai.azure.com")
+				.baseUrl("http://127.0.0.1:" + port)
+				.build();
+			String body = client.post()
+				.uri("/v1/chat/completions")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body("{\"model\":\"gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}")
+				.retrieve()
+				.body(String.class);
+			assertThat(body).contains("chat.completion");
+			assertThat(contentLength.get()).isNotNull().isNotBlank();
+			assertThat(transferEncoding.get()).isNull();
+		}
+		finally {
+			server.stop(0);
+		}
+	}
+
+}


### PR DESCRIPTION
Solves GH-5765 assuming Azure Open AI endpoint is azure.openai.com by overriding the Rest client when encountering azure endpoint.