### PR TITLE
Add pluggable exception handler for MCP tool method invocations

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerAnnotationScannerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerAnnotationScannerAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.ai.mcp.annotation.McpComplete;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolCallExceptionHandler;
 import org.springframework.ai.mcp.annotation.spring.scan.AbstractAnnotatedMethodBeanFactoryInitializationAotProcessor;
 import org.springframework.ai.mcp.annotation.spring.scan.AbstractAnnotatedMethodBeanPostProcessor;
 import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBeans;
@@ -53,6 +54,12 @@ public class McpServerAnnotationScannerAutoConfiguration {
 
 	private static final Set<Class<? extends Annotation>> SERVER_MCP_ANNOTATIONS = Set.of(McpTool.class,
 			McpResource.class, McpPrompt.class, McpComplete.class);
+
+	@Bean
+	@ConditionalOnMissingBean
+	public McpToolCallExceptionHandler mcpToolCallExceptionHandler() {
+		return McpToolCallExceptionHandler.defaultHandler();
+	}
 
 	@Bean
 	@ConditionalOnMissingBean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerSpecificationFactoryAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.ai.mcp.annotation.McpComplete;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolCallExceptionHandler;
 import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerAutoConfiguration;
@@ -85,9 +86,9 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.SyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, McpToolCallExceptionHandler exceptionHandler) {
 			List<Object> beansByAnnotation = beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class);
-			return SyncMcpAnnotationProviders.toolSpecifications(beansByAnnotation);
+			return SyncMcpAnnotationProviders.toolSpecifications(beansByAnnotation, exceptionHandler);
 		}
 
 	}
@@ -127,9 +128,9 @@ public class McpServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpServerFeatures.AsyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
-			return AsyncMcpAnnotationProviders
-				.toolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, McpToolCallExceptionHandler exceptionHandler) {
+			return AsyncMcpAnnotationProviders.toolSpecifications(
+					beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class), exceptionHandler);
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/StatelessServerSpecificationFactoryAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.ai.mcp.annotation.McpComplete;
 import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolCallExceptionHandler;
 import org.springframework.ai.mcp.annotation.spring.AsyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.annotation.spring.SyncMcpAnnotationProviders;
 import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStatelessAutoConfiguration;
@@ -83,11 +84,9 @@ public class StatelessServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, McpToolCallExceptionHandler exceptionHandler) {
 			List<Object> beansByAnnotation = beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class);
-			List<McpStatelessServerFeatures.SyncToolSpecification> syncToolSpecifications = SyncMcpAnnotationProviders
-				.statelessToolSpecifications(beansByAnnotation);
-			return syncToolSpecifications;
+			return SyncMcpAnnotationProviders.statelessToolSpecifications(beansByAnnotation, exceptionHandler);
 		}
 
 	}
@@ -126,9 +125,9 @@ public class StatelessServerSpecificationFactoryAutoConfiguration {
 
 		@Bean
 		public List<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecs(
-				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations) {
-			return AsyncMcpAnnotationProviders
-				.statelessToolSpecifications(beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class));
+				ServerMcpAnnotatedBeans beansWithMcpMethodAnnotations, McpToolCallExceptionHandler exceptionHandler) {
+			return AsyncMcpAnnotationProviders.statelessToolSpecifications(
+					beansWithMcpMethodAnnotations.getBeansByAnnotation(McpTool.class), exceptionHandler);
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
@@ -54,6 +54,7 @@ import org.springframework.ai.mcp.annotation.McpPrompt;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolCallExceptionHandler;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerChangeNotificationProperties;
@@ -365,6 +366,28 @@ public class McpServerAutoConfigurationIT {
 	void toolCallbackProviderConfiguration() {
 		this.contextRunner.withUserConfiguration(TestToolCallbackProviderConfiguration.class)
 			.run(context -> assertThat(context).hasSingleBean(ToolCallbackProvider.class));
+	}
+
+	@Test
+	void defaultMcpToolCallExceptionHandlerBeanIsRegistered() {
+		this.contextRunner.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class)
+			.run(context -> assertThat(context).hasSingleBean(McpToolCallExceptionHandler.class));
+	}
+
+	@Test
+	void customMcpToolCallExceptionHandlerOverridesDefault() {
+		McpToolCallExceptionHandler customHandler = (toolName,
+				ex) -> io.modelcontextprotocol.spec.McpSchema.CallToolResult.builder()
+					.isError(true)
+					.addTextContent("custom: " + ex.getMessage())
+					.build();
+
+		this.contextRunner.withUserConfiguration(McpServerAnnotationScannerAutoConfiguration.class)
+			.withBean(McpToolCallExceptionHandler.class, () -> customHandler)
+			.run(context -> {
+				assertThat(context).hasSingleBean(McpToolCallExceptionHandler.class);
+				assertThat(context.getBean(McpToolCallExceptionHandler.class)).isSameAs(customHandler);
+			});
 	}
 
 	@SuppressWarnings("unchecked")

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractAsyncMcpToolMethodCallback.java
@@ -44,10 +44,18 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 
 	protected final Class<? extends Throwable> toolCallExceptionClass;
 
+	protected final McpToolCallExceptionHandler toolCallExceptionHandler;
+
 	protected AbstractAsyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject,
 			Class<? extends Throwable> toolCallExceptionClass) {
+		this(returnMode, toolMethod, toolObject, toolCallExceptionClass, McpToolCallExceptionHandler.defaultHandler());
+	}
+
+	protected AbstractAsyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject,
+			Class<? extends Throwable> toolCallExceptionClass, McpToolCallExceptionHandler toolCallExceptionHandler) {
 		super(returnMode, toolMethod, toolObject);
 		this.toolCallExceptionClass = toolCallExceptionClass;
+		this.toolCallExceptionHandler = toolCallExceptionHandler;
 	}
 
 	/**
@@ -73,11 +81,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			}
 
 			// Handle other Mono types - map the emitted value to CallToolResult
-			return monoResult.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return monoResult.map(this::mapValueToCallToolResult).onErrorResume(this::handleReactiveError);
 		}
 
 		// Handle Flux by taking the first element
@@ -96,12 +100,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			}
 
 			// Handle other Flux types by taking the first element and mapping
-			return fluxResult.next()
-				.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return fluxResult.next().map(this::mapValueToCallToolResult).onErrorResume(this::handleReactiveError);
 		}
 
 		// Handle other Publisher types
@@ -121,11 +120,7 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 			}
 
 			// Handle other Publisher types by mapping the emitted value
-			return monoFromPublisher.map(this::mapValueToCallToolResult)
-				.onErrorResume(e -> Mono.just(CallToolResult.builder()
-					.isError(true)
-					.addTextContent("Error invoking method: %s".formatted(e.getMessage()))
-					.build()));
+			return monoFromPublisher.map(this::mapValueToCallToolResult).onErrorResume(this::handleReactiveError);
 		}
 
 		// This should not happen in async context, but handle as fallback
@@ -149,11 +144,18 @@ public abstract class AbstractAsyncMcpToolMethodCallback<T, RC extends McpReques
 	 * @return A Mono<CallToolResult> representing the error
 	 */
 	protected Mono<CallToolResult> createAsyncErrorResult(Exception e) {
-		Throwable rootCause = findCauseUsingPlainJava(e);
-		return Mono.just(CallToolResult.builder()
-			.isError(true)
-			.addTextContent(e.getMessage() + System.lineSeparator() + rootCause.getMessage())
-			.build());
+		return handleReactiveError(e);
+	}
+
+	/**
+	 * Adapts a reactive-pipeline {@link Throwable} into a {@link CallToolResult} error by
+	 * delegating to the configured {@link McpToolCallExceptionHandler}.
+	 * @param t the throwable emitted by the reactive pipeline
+	 * @return a {@code Mono<CallToolResult>} representing the error
+	 */
+	private Mono<CallToolResult> handleReactiveError(Throwable t) {
+		Exception ex = (t instanceof Exception e) ? e : new RuntimeException(t);
+		return Mono.just(this.toolCallExceptionHandler.process(this.mcpToolName, ex));
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractMcpToolMethodCallback.java
@@ -54,10 +54,15 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 
 	protected final ReturnMode returnMode;
 
+	protected final String mcpToolName;
+
 	protected AbstractMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject) {
 		this.toolMethod = toolMethod;
 		this.toolObject = toolObject;
 		this.returnMode = returnMode;
+		McpTool annotation = toolMethod.getAnnotation(McpTool.class);
+		this.mcpToolName = (annotation != null && annotation.name() != null && !annotation.name().isEmpty())
+				? annotation.name() : toolMethod.getName();
 	}
 
 	/**
@@ -78,7 +83,14 @@ public abstract class AbstractMcpToolMethodCallback<T, RC extends McpRequestCont
 			throw new RuntimeException("Failed to access tool method", ex);
 		}
 		catch (InvocationTargetException ex) {
-			throw new RuntimeException("Error invoking method: " + this.toolMethod.getName(), ex.getCause());
+			Throwable cause = ex.getCause();
+			if (cause instanceof RuntimeException re) {
+				throw re;
+			}
+			if (cause instanceof Error error) {
+				throw error;
+			}
+			throw new RuntimeException(cause);
 		}
 		return result;
 	}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AbstractSyncMcpToolMethodCallback.java
@@ -43,6 +43,11 @@ public abstract class AbstractSyncMcpToolMethodCallback<T, RC extends McpRequest
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
 	}
 
+	protected AbstractSyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject,
+			Class<? extends Throwable> toolCallExceptionClass, McpToolCallExceptionHandler toolCallExceptionHandler) {
+		super(returnMode, toolMethod, toolObject, toolCallExceptionClass, toolCallExceptionHandler);
+	}
+
 	/**
 	 * Processes the result of the method invocation and converts it to a CallToolResult.
 	 * This is a synchronous wrapper around the parent class's reactive result processing.
@@ -60,11 +65,7 @@ public abstract class AbstractSyncMcpToolMethodCallback<T, RC extends McpRequest
 	 * @return A CallToolResult representing the error
 	 */
 	protected CallToolResult createSyncErrorResult(Exception e) {
-		Throwable rootCause = findCauseUsingPlainJava(e);
-		return CallToolResult.builder()
-			.isError(true)
-			.addTextContent(e.getMessage() + System.lineSeparator() + rootCause.getMessage())
-			.build();
+		return this.toolCallExceptionHandler.process(this.mcpToolName, e);
 	}
 
 	/**

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallback.java
@@ -50,6 +50,11 @@ public final class AsyncMcpToolMethodCallback
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
 	}
 
+	public AsyncMcpToolMethodCallback(ReturnMode returnMode, Method toolMethod, Object toolObject,
+			Class<? extends Throwable> toolCallExceptionClass, McpToolCallExceptionHandler toolCallExceptionHandler) {
+		super(returnMode, toolMethod, toolObject, toolCallExceptionClass, toolCallExceptionHandler);
+	}
+
 	@Override
 	protected boolean isExchangeOrContextType(Class<?> paramType) {
 		return McpAsyncServerExchange.class.isAssignableFrom(paramType)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallback.java
@@ -49,6 +49,12 @@ public final class AsyncStatelessMcpToolMethodCallback
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
 	}
 
+	public AsyncStatelessMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod,
+			Object toolObject, Class<? extends Throwable> toolCallExceptionClass,
+			McpToolCallExceptionHandler toolCallExceptionHandler) {
+		super(returnMode, toolMethod, toolObject, toolCallExceptionClass, toolCallExceptionHandler);
+	}
+
 	@Override
 	protected boolean isExchangeOrContextType(Class<?> paramType) {
 		return McpTransportContext.class.isAssignableFrom(paramType)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/McpToolCallExceptionHandler.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/McpToolCallExceptionHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.method.tool;
+
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+
+/**
+ * Interface for handling exceptions that occur during MCP tool method invocation.
+ * Implementations can be provided to customize how exceptions are converted into
+ * {@link CallToolResult} error responses.
+ *
+ * <p>
+ * A default implementation is available via {@link #defaultHandler()}.
+ *
+ * @since 2.0.0
+ */
+@FunctionalInterface
+public interface McpToolCallExceptionHandler {
+
+	/**
+	 * Processes an exception that occurred during the invocation of an MCP tool method
+	 * and returns an appropriate {@link CallToolResult} error response.
+	 * @param toolName the name of the tool method that raised the exception
+	 * @param exception the exception that was caught
+	 * @return a {@link CallToolResult} representing the error
+	 */
+	CallToolResult process(String toolName, Exception exception);
+
+	/**
+	 * Returns a default handler that marks the result as an error and includes the error
+	 * message in the response content.
+	 * @return the default {@link McpToolCallExceptionHandler}
+	 */
+	static McpToolCallExceptionHandler defaultHandler() {
+		return (toolName, exception) -> CallToolResult.builder()
+			.isError(true)
+			.addTextContent("Error invoking tool '%s': %s".formatted(toolName, exception.getMessage()))
+			.build();
+	}
+
+}

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallback.java
@@ -48,6 +48,11 @@ public final class SyncMcpToolMethodCallback
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
 	}
 
+	public SyncMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod, Object toolObject,
+			Class<? extends Throwable> toolCallExceptionClass, McpToolCallExceptionHandler toolCallExceptionHandler) {
+		super(returnMode, toolMethod, toolObject, toolCallExceptionClass, toolCallExceptionHandler);
+	}
+
 	@Override
 	protected boolean isExchangeOrContextType(Class<?> paramType) {
 		return McpSyncServerExchange.class.isAssignableFrom(paramType)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncStatelessMcpToolMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/SyncStatelessMcpToolMethodCallback.java
@@ -48,6 +48,12 @@ public final class SyncStatelessMcpToolMethodCallback
 		super(returnMode, toolMethod, toolObject, toolCallExceptionClass);
 	}
 
+	public SyncStatelessMcpToolMethodCallback(ReturnMode returnMode, java.lang.reflect.Method toolMethod,
+			Object toolObject, Class<? extends Throwable> toolCallExceptionClass,
+			McpToolCallExceptionHandler toolCallExceptionHandler) {
+		super(returnMode, toolMethod, toolObject, toolCallExceptionClass, toolCallExceptionHandler);
+	}
+
 	@Override
 	protected boolean isExchangeOrContextType(Class<?> paramType) {
 		return McpTransportContext.class.isAssignableFrom(paramType)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
@@ -24,6 +24,7 @@ import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.util.Assert;
 
 import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolCallExceptionHandler;
 
 /**
  * @author Christian Tzolov
@@ -36,6 +37,8 @@ public abstract class AbstractMcpToolProvider {
 	protected final List<Object> toolObjects;
 
 	protected McpJsonMapper jsonMapper = McpJsonDefaults.getMapper();
+
+	private McpToolCallExceptionHandler toolCallExceptionHandler = McpToolCallExceptionHandler.defaultHandler();
 
 	public AbstractMcpToolProvider(List<Object> toolObjects) {
 		Assert.notNull(toolObjects, "toolObjects cannot be null");
@@ -52,6 +55,15 @@ public abstract class AbstractMcpToolProvider {
 
 	protected Class<? extends Throwable> doGetToolCallException() {
 		return Exception.class;
+	}
+
+	protected McpToolCallExceptionHandler doGetToolCallExceptionHandler() {
+		return this.toolCallExceptionHandler;
+	}
+
+	public void setExceptionHandler(McpToolCallExceptionHandler exceptionHandler) {
+		Assert.notNull(exceptionHandler, "exceptionHandler cannot be null");
+		this.toolCallExceptionHandler = exceptionHandler;
 	}
 
 	public void setJsonMapper(McpJsonMapper jsonMapper) {

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -141,7 +141,8 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT;
 
 					BiFunction<McpAsyncServerExchange, CallToolRequest, Mono<CallToolResult>> methodCallback = new AsyncMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException(),
+							this.doGetToolCallExceptionHandler());
 
 					AsyncToolSpecification toolSpec = AsyncToolSpecification.builder()
 						.tool(tool)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -146,7 +146,8 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT;
 
 					BiFunction<McpTransportContext, CallToolRequest, Mono<CallToolResult>> methodCallback = new AsyncStatelessMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException(),
+							this.doGetToolCallExceptionHandler());
 
 					AsyncToolSpecification toolSpec = AsyncToolSpecification.builder()
 						.tool(tool)

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -137,7 +137,8 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT);
 
 					BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> methodCallback = new SyncMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException(),
+							this.doGetToolCallExceptionHandler());
 
 					var toolSpec = SyncToolSpecification.builder().tool(tool).callHandler(methodCallback).build();
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -141,7 +141,8 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 									: ReturnMode.TEXT);
 
 					BiFunction<McpTransportContext, CallToolRequest, CallToolResult> methodCallback = new SyncStatelessMcpToolMethodCallback(
-							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException());
+							returnMode, mcpToolMethod, toolObject, this.doGetToolCallException(),
+							this.doGetToolCallExceptionHandler());
 
 					var toolSpec = SyncToolSpecification.builder().tool(tool).callHandler(methodCallback).build();
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/AsyncMcpAnnotationProviders.java
@@ -33,6 +33,7 @@ import org.springframework.ai.mcp.annotation.method.elicitation.AsyncElicitation
 import org.springframework.ai.mcp.annotation.method.logging.AsyncLoggingSpecification;
 import org.springframework.ai.mcp.annotation.method.progress.AsyncProgressSpecification;
 import org.springframework.ai.mcp.annotation.method.sampling.AsyncSamplingSpecification;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolCallExceptionHandler;
 import org.springframework.ai.mcp.annotation.provider.changed.prompt.AsyncMcpPromptListChangedProvider;
 import org.springframework.ai.mcp.annotation.provider.changed.resource.AsyncMcpResourceListChangedProvider;
 import org.springframework.ai.mcp.annotation.provider.changed.tool.AsyncMcpToolListChangedProvider;
@@ -86,9 +87,23 @@ public final class AsyncMcpAnnotationProviders {
 		return new SpringAiAsyncMcpToolProvider(toolObjects).getToolSpecifications();
 	}
 
+	public static List<AsyncToolSpecification> toolSpecifications(List<Object> toolObjects,
+			McpToolCallExceptionHandler exceptionHandler) {
+		SpringAiAsyncMcpToolProvider provider = new SpringAiAsyncMcpToolProvider(toolObjects);
+		provider.setExceptionHandler(exceptionHandler);
+		return provider.getToolSpecifications();
+	}
+
 	public static List<McpStatelessServerFeatures.AsyncToolSpecification> statelessToolSpecifications(
 			List<Object> toolObjects) {
 		return new SpringAiAsyncStatelessMcpToolProvider(toolObjects).getToolSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.AsyncToolSpecification> statelessToolSpecifications(
+			List<Object> toolObjects, McpToolCallExceptionHandler exceptionHandler) {
+		SpringAiAsyncStatelessMcpToolProvider provider = new SpringAiAsyncStatelessMcpToolProvider(toolObjects);
+		provider.setExceptionHandler(exceptionHandler);
+		return provider.getToolSpecifications();
 	}
 
 	// COMPLETE

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/spring/SyncMcpAnnotationProviders.java
@@ -33,6 +33,7 @@ import org.springframework.ai.mcp.annotation.method.elicitation.SyncElicitationS
 import org.springframework.ai.mcp.annotation.method.logging.SyncLoggingSpecification;
 import org.springframework.ai.mcp.annotation.method.progress.SyncProgressSpecification;
 import org.springframework.ai.mcp.annotation.method.sampling.SyncSamplingSpecification;
+import org.springframework.ai.mcp.annotation.method.tool.McpToolCallExceptionHandler;
 import org.springframework.ai.mcp.annotation.provider.changed.prompt.SyncMcpPromptListChangedProvider;
 import org.springframework.ai.mcp.annotation.provider.changed.resource.SyncMcpResourceListChangedProvider;
 import org.springframework.ai.mcp.annotation.provider.changed.tool.SyncMcpToolListChangedProvider;
@@ -66,9 +67,23 @@ public final class SyncMcpAnnotationProviders {
 		return new SpringAiSyncToolProvider(toolObjects).getToolSpecifications();
 	}
 
+	public static List<SyncToolSpecification> toolSpecifications(List<Object> toolObjects,
+			McpToolCallExceptionHandler exceptionHandler) {
+		SpringAiSyncToolProvider provider = new SpringAiSyncToolProvider(toolObjects);
+		provider.setExceptionHandler(exceptionHandler);
+		return provider.getToolSpecifications();
+	}
+
 	public static List<McpStatelessServerFeatures.SyncToolSpecification> statelessToolSpecifications(
 			List<Object> toolObjects) {
 		return new SpringAiSyncStatelessToolProvider(toolObjects).getToolSpecifications();
+	}
+
+	public static List<McpStatelessServerFeatures.SyncToolSpecification> statelessToolSpecifications(
+			List<Object> toolObjects, McpToolCallExceptionHandler exceptionHandler) {
+		SpringAiSyncStatelessToolProvider provider = new SpringAiSyncStatelessToolProvider(toolObjects);
+		provider.setExceptionHandler(exceptionHandler);
+		return provider.getToolSpecifications();
 	}
 
 	// COMPLETE

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncMcpToolMethodCallbackTests.java
@@ -133,7 +133,31 @@ public class AsyncMcpToolMethodCallbackTests {
 			assertThat(result.isError()).isTrue();
 			assertThat(result.content()).hasSize(1);
 			assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
-			assertThat(((TextContent) result.content().get(0)).text()).contains("Error invoking method");
+			assertThat(((TextContent) result.content().get(0)).text())
+				.contains("Error invoking tool 'exception-mono-tool'");
+		}).verifyComplete();
+	}
+
+	@Test
+	public void testCustomExceptionHandler_IsInvokedOnReactiveError() throws Exception {
+		TestAsyncToolProvider provider = new TestAsyncToolProvider();
+		Method method = TestAsyncToolProvider.class.getMethod("exceptionMonoTool", String.class);
+
+		McpToolCallExceptionHandler customHandler = (toolName, ex) -> CallToolResult.builder()
+			.isError(true)
+			.addTextContent("CUSTOM[" + toolName + "]: " + ex.getMessage())
+			.build();
+
+		AsyncMcpToolMethodCallback callback = new AsyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
+				Exception.class, customHandler);
+
+		McpAsyncServerExchange exchange = mock(McpAsyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("exception-mono-tool", Map.of("input", "test"));
+
+		StepVerifier.create(callback.apply(exchange, request)).assertNext(result -> {
+			assertThat(result.isError()).isTrue();
+			assertThat(((TextContent) result.content().get(0)).text())
+				.isEqualTo("CUSTOM[exception-mono-tool]: Tool execution failed: test");
 		}).verifyComplete();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/AsyncStatelessMcpToolMethodCallbackTests.java
@@ -136,7 +136,8 @@ public class AsyncStatelessMcpToolMethodCallbackTests {
 			assertThat(result.isError()).isTrue();
 			assertThat(result.content()).hasSize(1);
 			assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
-			assertThat(((TextContent) result.content().get(0)).text()).contains("Error invoking method");
+			assertThat(((TextContent) result.content().get(0)).text())
+				.contains("Error invoking tool 'exception-mono-tool'");
 		}).verifyComplete();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackExceptionHandlingTests.java
@@ -97,10 +97,10 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
 		CallToolRequest request = new CallToolRequest("runtime-exception-tool", Map.of("input", "test"));
 
-		// The RuntimeException from callMethod should NOT be caught (not an
-		// IllegalArgumentException)
+		// The RuntimeException from the tool method should NOT be caught (not an
+		// IllegalArgumentException) and propagates with its original message
 		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(RuntimeException.class)
-			.hasMessageContaining("Error invoking method");
+			.hasMessageContaining("Runtime error: test");
 	}
 
 	@Test
@@ -138,9 +138,10 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
 		CallToolRequest request = new CallToolRequest("checked-exception-tool", Map.of("input", "test"));
 
-		// The RuntimeException wrapper should NOT be caught
+		// The checked exception wrapped in RuntimeException should NOT be caught and
+		// propagates with the original cause accessible
 		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(RuntimeException.class)
-			.hasMessageContaining("Error invoking method")
+			.hasMessageContaining("Business error: test")
 			.hasCauseInstanceOf(BusinessException.class);
 	}
 
@@ -271,6 +272,55 @@ public class SyncMcpToolMethodCallbackExceptionHandlingTests {
 		CallToolResult result = callback.apply(exchange, request);
 		assertThat(result).isNotNull();
 		assertThat(result.isError()).isTrue();
+	}
+
+	@Test
+	public void testCustomExceptionHandler_ReplacesDefaultFormatting() throws Exception {
+		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
+		Method method = ExceptionTestToolProvider.class.getMethod("runtimeExceptionTool", String.class);
+
+		McpToolCallExceptionHandler customHandler = (toolName, ex) -> CallToolResult.builder()
+			.isError(true)
+			.addTextContent("CUSTOM[" + toolName + "]: " + ex.getMessage())
+			.build();
+
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
+				Exception.class, customHandler);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("runtime-exception-tool", Map.of("input", "test"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text())
+			.isEqualTo("CUSTOM[runtime-exception-tool]: Runtime error: test");
+	}
+
+	@Test
+	public void testCustomExceptionHandler_ReceivesAnnotationToolName() throws Exception {
+		// Verify that the handler receives the @McpTool annotation name, not the Java
+		// method name
+		ExceptionTestToolProvider provider = new ExceptionTestToolProvider();
+		Method method = ExceptionTestToolProvider.class.getMethod("runtimeExceptionTool", String.class);
+
+		String[] capturedToolName = new String[1];
+		McpToolCallExceptionHandler capturingHandler = (toolName, ex) -> {
+			capturedToolName[0] = toolName;
+			return CallToolResult.builder().isError(true).addTextContent(ex.getMessage()).build();
+		};
+
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider,
+				Exception.class, capturingHandler);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("runtime-exception-tool", Map.of("input", "test"));
+
+		callback.apply(exchange, request);
+
+		// "runtimeExceptionTool" is the Java method name; "runtime-exception-tool" is the
+		// @McpTool annotation name — the handler must receive the latter
+		assertThat(capturedToolName[0]).isEqualTo("runtime-exception-tool");
 	}
 
 	// Custom exception classes for testing

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
@@ -1026,4 +1026,34 @@ public class AsyncMcpToolProviderTests {
 		assertThat(toolSpec.tool().outputSchema()).isNotNull();
 	}
 
+	@Test
+	void testSetExceptionHandler_customHandlerIsInvoked() {
+		class FailingTool {
+
+			@McpTool(name = "failing-tool", description = "Tool that always fails")
+			public Mono<String> failingTool(String input) {
+				return Mono.error(new RuntimeException("tool failure: " + input));
+			}
+
+		}
+
+		AsyncMcpToolProvider provider = new AsyncMcpToolProvider(List.of(new FailingTool()));
+		provider.setExceptionHandler((toolName, ex) -> CallToolResult.builder()
+			.isError(true)
+			.addTextContent("CUSTOM[" + toolName + "]: " + ex.getMessage())
+			.build());
+
+		Mono<CallToolResult> result = provider.getToolSpecifications()
+			.get(0)
+			.callHandler()
+			.apply(mock(McpAsyncServerExchange.class), new CallToolRequest("failing-tool", Map.of("input", "test")));
+
+		StepVerifier.create(result).assertNext(callToolResult -> {
+			assertThat(callToolResult.isError()).isTrue();
+			assertThat(callToolResult.content().get(0)).isInstanceOf(TextContent.class);
+			assertThat(((TextContent) callToolResult.content().get(0)).text())
+				.isEqualTo("CUSTOM[failing-tool]: tool failure: test");
+		}).verifyComplete();
+	}
+
 }

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProviderTests.java
@@ -917,6 +917,33 @@ public class SyncMcpToolProviderTests {
 		assertThat(toolSpec.tool().inputSchema()).isNotNull();
 	}
 
+	@Test
+	void testSetExceptionHandler_customHandlerIsInvoked() {
+		class FailingTool {
+
+			@McpTool(name = "failing-tool", description = "Tool that always fails")
+			public String failingTool(String input) {
+				throw new RuntimeException("tool failure: " + input);
+			}
+
+		}
+
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(new FailingTool()));
+		provider.setExceptionHandler((toolName, ex) -> CallToolResult.builder()
+			.isError(true)
+			.addTextContent("CUSTOM[" + toolName + "]: " + ex.getMessage())
+			.build());
+
+		CallToolResult result = provider.getToolSpecifications()
+			.get(0)
+			.callHandler()
+			.apply(mock(McpSyncServerExchange.class), new CallToolRequest("failing-tool", Map.of("input", "test")));
+
+		assertThat(result.isError()).isTrue();
+		assertThat(((TextContent) result.content().get(0)).text())
+			.isEqualTo("CUSTOM[failing-tool]: tool failure: test");
+	}
+
 	public static class UiMetaProvider implements MetaProvider {
 
 		@Override


### PR DESCRIPTION
Introduces `McpToolCallExceptionHandler`, an interface for customizing how exceptions thrown during MCP tool method invocations are converted into `CallToolResult` error responses. The MCP annotation framework silently swallows all exceptions from tool method calls and returns a generic error result. There's no hook to intercept those exceptions to customize or control the error message format.

This feature should help with:
* https://github.com/spring-projects/spring-ai/issues/4488
* https://github.com/spring-projects/spring-ai/issues/4691

**Summary of the changes:**
* `McpToolCallExceptionHandler` - New functional interface with a `defaultHandler()` factory method
* `AbstractMcpToolProvider.setExceptionHandler()` to configure the handler at the provider level
* `SyncMcpAnnotationProviders` / `AsyncMcpAnnotationProviders` utility overloads accepting a handler
* Auto-configuration registers a `@ConditionalOnMissingBean` `McpToolCallExceptionHandler` bean for Spring Boot override support