### PR TITLE
Remove MCP JSON dependency from spring-ai-client-chat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,7 @@
 		<okhttp3.version>4.12.0</okhttp3.version>
 		<rest-assured-bom.version>5.5.6</rest-assured-bom.version>
 		<json-unit-assertj.version>5.1.0</json-unit-assertj.version>
+		<json-schema-validator.version>3.0.1</json-schema-validator.version>
 
 		<!-- MCP-->
 		<mcp.sdk.version>1.1.0</mcp.sdk.version>
@@ -1071,6 +1072,11 @@
 				<version>${mcp.sdk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.networknt</groupId>
+				<artifactId>json-schema-validator</artifactId>
+				<version>${json-schema-validator.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-ai-client-chat/pom.xml
+++ b/spring-ai-client-chat/pom.xml
@@ -44,11 +44,9 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- TODO Require merging https://github.com/modelcontextprotocol/java-sdk/pull/742 -->
 		<dependency>
-			<groupId>io.modelcontextprotocol.sdk</groupId>
-			<artifactId>mcp-json-jackson3</artifactId>
-			<version>${mcp.sdk.version}</version>
+			<groupId>com.networknt</groupId>
+			<artifactId>json-schema-validator</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -17,18 +17,20 @@
 package org.springframework.ai.chat.client.advisor;
 
 import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import io.modelcontextprotocol.json.TypeRef;
-import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
-import io.modelcontextprotocol.json.schema.JsonSchemaValidator.ValidationResponse;
-import io.modelcontextprotocol.json.schema.jackson3.DefaultJsonSchemaValidator;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.chat.client.ChatClientRequest;
@@ -61,9 +63,6 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 
 	private static final Logger logger = LoggerFactory.getLogger(StructuredOutputValidationAdvisor.class);
 
-	private static final TypeRef<HashMap<String, Object>> MAP_TYPE_REF = new TypeRef<>() {
-	};
-
 	/**
 	 * Set the order close to {@link Ordered#LOWEST_PRECEDENCE} to ensure an advisor is
 	 * executed toward the last (but before the model call) in the chain (last for request
@@ -73,15 +72,9 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 	 */
 	private final int advisorOrder;
 
-	/**
-	 * The JSON schema used for validation.
-	 */
-	private final Map<String, Object> jsonSchema;
+	private final Schema jsonSchema;
 
-	/**
-	 * The JSON schema validator.
-	 */
-	private final DefaultJsonSchemaValidator jsonvalidator;
+	private final JsonMapper jsonMapper;
 
 	private final int maxRepeatAttempts;
 
@@ -95,21 +88,22 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		Assert.notNull(jsonMapper, "jsonMapper must not be null");
 
 		this.advisorOrder = advisorOrder;
-
-		this.jsonvalidator = new DefaultJsonSchemaValidator(jsonMapper);
+		this.jsonMapper = jsonMapper;
 
 		String jsonSchemaText = JsonSchemaGenerator.generateForType(outputType);
 
 		logger.info("Generated JSON Schema:\n{}", jsonSchemaText);
 
-		var mcpJsonMapper = new JacksonMcpJsonMapper(jsonMapper);
-
+		JsonNode schemaNode;
 		try {
-			this.jsonSchema = mcpJsonMapper.readValue(jsonSchemaText, MAP_TYPE_REF);
+			schemaNode = jsonMapper.readTree(jsonSchemaText);
 		}
 		catch (Exception e) {
 			throw new IllegalArgumentException("Failed to parse JSON schema", e);
 		}
+
+		SchemaRegistry schemaRegistry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
+		this.jsonSchema = schemaRegistry.getSchema(schemaNode);
 
 		this.maxRepeatAttempts = maxRepeatAttempts;
 	}
@@ -152,9 +146,9 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 			// response.
 			if (chatClientResponse.chatResponse() == null || !chatClientResponse.chatResponse().hasToolCalls()) {
 
-				ValidationResponse validationResponse = this.validateOutputSchema(chatClientResponse);
+				SchemaValidation validationResponse = validateOutputSchema(chatClientResponse);
 
-				isValidationSuccess = validationResponse.valid();
+				isValidationSuccess = validationResponse.success();
 
 				if (!isValidationSuccess) {
 
@@ -184,14 +178,14 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 	}
 
 	@SuppressWarnings("null")
-	private ValidationResponse validateOutputSchema(ChatClientResponse chatClientResponse) {
+	private SchemaValidation validateOutputSchema(ChatClientResponse chatClientResponse) {
 
 		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResult() == null
 				|| chatClientResponse.chatResponse().getResult().getOutput() == null
 				|| chatClientResponse.chatResponse().getResult().getOutput().getText() == null) {
 
 			logger.warn("ChatClientResponse is missing required json output for validation.");
-			return ValidationResponse.asInvalid("Missing required json output for validation.");
+			return SchemaValidation.failed("Missing required json output for validation.");
 		}
 
 		// TODO: should we consider validation for multiple results?
@@ -199,7 +193,25 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 
 		logger.debug("Validating JSON output against schema. Attempts left: {}", this.maxRepeatAttempts);
 
-		return this.jsonvalidator.validate(this.jsonSchema, json);
+		return validateJsonText(json);
+	}
+
+	private SchemaValidation validateJsonText(String json) {
+		if (json.isBlank()) {
+			return SchemaValidation.failed("Empty JSON output for validation.");
+		}
+		try {
+			JsonNode instance = this.jsonMapper.readTree(json);
+			List<Error> errors = this.jsonSchema.validate(instance);
+			if (errors.isEmpty()) {
+				return SchemaValidation.passed();
+			}
+			String message = errors.stream().map(Error::getMessage).collect(Collectors.joining("; "));
+			return SchemaValidation.failed(message);
+		}
+		catch (JacksonException e) {
+			return SchemaValidation.failed("Invalid JSON: " + e.getOriginalMessage());
+		}
 	}
 
 	@SuppressWarnings("null")
@@ -263,17 +275,6 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 		}
 
 		/**
-		 * Sets the output type using a TypeRef.
-		 * @param <T> the type parameter
-		 * @param outputType the output type
-		 * @return this builder
-		 */
-		public <T> Builder outputType(TypeRef<T> outputType) {
-			this.outputType = outputType.getType();
-			return this;
-		}
-
-		/**
 		 * Sets the output type using a TypeReference.
 		 * @param <T> the type parameter
 		 * @param outputType the output type
@@ -326,6 +327,18 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 			}
 			return new StructuredOutputValidationAdvisor(this.advisorOrder, this.outputType, this.maxRepeatAttempts,
 					this.jsonMapper);
+		}
+
+	}
+
+	private record SchemaValidation(boolean success, String errorMessage) {
+
+		private static SchemaValidation passed() {
+			return new SchemaValidation(true, "");
+		}
+
+		private static SchemaValidation failed(String errorMessage) {
+			return new SchemaValidation(false, errorMessage);
 		}
 
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
@@ -19,7 +19,6 @@ package org.springframework.ai.chat.client.advisor;
 import java.util.List;
 
 import io.micrometer.observation.ObservationRegistry;
-import io.modelcontextprotocol.json.TypeRef;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -68,25 +67,25 @@ public class StructuredOutputValidationAdvisorTests {
 
 	@Test
 	void whenAdvisorOrderIsOutOfRangeThenThrow() {
-		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().outputType(new TypeRef<Person>() {
+		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().outputType(new TypeReference<Person>() {
 		}).advisorOrder(Ordered.HIGHEST_PRECEDENCE).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("advisorOrder must be between HIGHEST_PRECEDENCE and LOWEST_PRECEDENCE");
 
-		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().outputType(new TypeRef<Person>() {
+		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().outputType(new TypeReference<Person>() {
 		}).advisorOrder(Ordered.LOWEST_PRECEDENCE).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("advisorOrder must be between HIGHEST_PRECEDENCE and LOWEST_PRECEDENCE");
 	}
 
 	@Test
 	void whenRepeatAttemptsIsNegativeThenThrow() {
-		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().outputType(new TypeRef<Person>() {
+		assertThatThrownBy(() -> StructuredOutputValidationAdvisor.builder().outputType(new TypeReference<Person>() {
 		}).maxRepeatAttempts(-1).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("repeatAttempts must be greater than or equal to 0");
 	}
 
 	@Test
-	void testBuilderMethodChainingWithTypeRef() {
-		TypeRef<Person> typeRef = new TypeRef<>() {
+	void testBuilderMethodChainingWithJacksonTypeReference() {
+		TypeReference<Person> typeRef = new TypeReference<>() {
 		};
 		int customOrder = Ordered.HIGHEST_PRECEDENCE + 500;
 		int customAttempts = 5;
@@ -137,7 +136,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testDefaultValues() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.build();
 
@@ -149,7 +148,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void whenChatClientRequestIsNullThenThrow() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.build();
 
@@ -161,7 +160,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void whenCallAdvisorChainIsNullThenThrow() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.build();
 		ChatClientRequest request = createMockRequest();
@@ -173,7 +172,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseCallWithValidJsonOnFirstAttempt() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(3)
 			.build();
@@ -215,7 +214,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseCallWithInvalidJsonRetries() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(2)
 			.build();
@@ -259,7 +258,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseCallExhaustsAllRetries() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(2)
 			.build();
@@ -302,7 +301,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseCallWithZeroRetries() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(0)
 			.build();
@@ -345,7 +344,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseCallWithNullChatResponse() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -390,7 +389,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseCallWithNullResult() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -437,7 +436,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseCallWithComplexType() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Address>() {
+			.outputType(new TypeReference<Address>() {
 			})
 			.maxRepeatAttempts(2)
 			.build();
@@ -476,7 +475,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testAdviseStreamThrowsUnsupportedOperationException() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.build();
 		ChatClientRequest request = createMockRequest();
@@ -490,7 +489,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testGetName() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.build();
 		assertThat(advisor.getName()).isEqualTo("Structured Output Validation Advisor");
@@ -500,7 +499,7 @@ public class StructuredOutputValidationAdvisorTests {
 	void testGetOrder() {
 		int customOrder = Ordered.HIGHEST_PRECEDENCE + 1500;
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.advisorOrder(customOrder)
 			.build();
@@ -511,7 +510,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testMultipleRetriesWithDifferentInvalidResponses() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(3)
 			.build();
@@ -565,7 +564,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testPromptAugmentationWithValidationError() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -623,7 +622,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithEmptyJsonString() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -667,7 +666,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithMalformedJson() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -712,7 +711,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithExtraFields() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(0)
 			.build();
@@ -752,7 +751,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithNestedObject() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<PersonWithAddress>() {
+			.outputType(new TypeReference<PersonWithAddress>() {
 			})
 			.maxRepeatAttempts(2)
 			.build();
@@ -790,7 +789,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithInvalidNestedObject() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<PersonWithAddress>() {
+			.outputType(new TypeReference<PersonWithAddress>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -835,7 +834,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithListType() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<List<Person>>() {
+			.outputType(new TypeReference<List<Person>>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -873,7 +872,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithInvalidListType() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<List<Person>>() {
+			.outputType(new TypeReference<List<Person>>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -918,7 +917,7 @@ public class StructuredOutputValidationAdvisorTests {
 	@Test
 	void testValidationWithWrongTypeInField() {
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.maxRepeatAttempts(1)
 			.build();
@@ -964,7 +963,7 @@ public class StructuredOutputValidationAdvisorTests {
 	void testAdvisorOrderingInChain() {
 		int customOrder = Ordered.HIGHEST_PRECEDENCE + 1000;
 		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
-			.outputType(new TypeRef<Person>() {
+			.outputType(new TypeReference<Person>() {
 			})
 			.advisorOrder(customOrder)
 			.build();


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-ai/issues/5760

`spring-ai-client-chat` depended on `io.modelcontextprotocol.sdk:mcp-json-jackson3` only so `StructuredOutputValidationAdvisor` could validate model output against a JSON schema. That pulled the MCP JSON stack and its transitives for everyone using the chat client, even when MCP is unused (e.g. gh-5760).

Declare `com.networknt:json-schema-validator` directly and validate with `SchemaRegistry`, Draft 2020-12, and the advisor's `JsonMapper`, aligned with the draft already emitted in the schema text. Schema text still comes from `JsonSchemaGenerator` in `spring-ai-model` (converting the expected Java type into JSON Schema). Only the validation path changed, not schema generation.

Remove the builder overload `outputType(io.modelcontextprotocol.json.TypeRef<T>)` with the MCP dependency. Callers should use `outputType(Type)`, `outputType(TypeReference<T>)` from `tools.jackson.core.type.TypeReference`, or `outputType(ParameterizedTypeReference<T>)` instead—same way to capture generic types at runtime, without MCP on the API.

These changes only affect parent `pom.xml`, `spring-ai-client-chat/pom.xml`, `StructuredOutputValidationAdvisor`, and its tests only.