### PR TITLE
Fix Bedrock Vector store autoconfig to use creds provider

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/autoconfigure/BedrockKnowledgeBaseVectorStoreAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/src/main/java/org/springframework/ai/vectorstore/bedrockknowledgebase/autoconfigure/BedrockKnowledgeBaseVectorStoreAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.ai.vectorstore.bedrockknowledgebase.autoconfigure;
 
 import java.util.Objects;
 
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClient;
 import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeClientBuilder;
@@ -86,16 +87,19 @@ public class BedrockKnowledgeBaseVectorStoreAutoConfiguration {
 	 * Creates a BedrockAgentRuntimeClient using default AWS credentials. This bean is
 	 * only created if no other BedrockAgentRuntimeClient is defined.
 	 * @param properties the configuration properties
+	 * @param credentialsProvider AWS credentials provider bean
 	 * @return the BedrockAgentRuntimeClient
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	BedrockAgentRuntimeClient bedrockAgentRuntimeClient(BedrockKnowledgeBaseVectorStoreProperties properties) {
+	BedrockAgentRuntimeClient bedrockAgentRuntimeClient(BedrockKnowledgeBaseVectorStoreProperties properties,
+			AwsCredentialsProvider credentialsProvider) {
 		BedrockAgentRuntimeClientBuilder builder = BedrockAgentRuntimeClient.builder();
 
 		if (StringUtils.hasText(properties.getRegion())) {
 			builder.region(Region.of(properties.getRegion()));
 		}
+		builder.credentialsProvider(credentialsProvider);
 
 		return builder.build();
 	}


### PR DESCRIPTION
Fix `BedrockKnowledgeBaseVectorStoreAutoConfiguration` to use AWSCredentialsProvider when creating `BedrockAgentRuntimeClient`.

Approach Taken
- Add `AWSCredentialsProvider` parameter when creating `BedrockAgentRuntimeClient`.
- When creating `BedrockAgentRuntimeClient` pass credentials provider to builder.

I could not find any tests for this but please feel free to point me in correct direction if I have missed.

Fixes https://github.com/spring-projects/spring-ai/issues/5768

