### PR TITLE
fix: treat omitted SSE event type as default 'message' in WebClientStreamableHttpTransport

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransport.java
@@ -502,7 +502,8 @@ public final class WebClientStreamableHttpTransport implements McpClientTranspor
 	}
 
 	private Tuple2<Optional<String>, Iterable<McpSchema.JSONRPCMessage>> parse(ServerSentEvent<String> event) {
-		if (MESSAGE_EVENT_TYPE.equals(event.event())) {
+		String eventType = event.event();
+		if (eventType == null || eventType.isEmpty() || MESSAGE_EVENT_TYPE.equals(eventType)) {
 			try {
 				// We don't support batching ATM and probably won't since the next version
 				// considers removing it.

--- a/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportErrorHandlingIT.java
+++ b/mcp/transport/mcp-spring-webflux/src/test/java/org/springframework/ai/mcp/client/webflux/transport/WebClientStreamableHttpTransportErrorHandlingIT.java
@@ -396,6 +396,62 @@ public class WebClientStreamableHttpTransportErrorHandlingIT {
 		StepVerifier.create(transport.closeGracefully()).verifyComplete();
 	}
 
+	/**
+	 * Test that SSE frames with omitted {@code event:} field are treated as default
+	 * {@code message} events per the SSE specification. An SSE frame containing only a
+	 * {@code data:} line (no {@code event:} line) must not be silently dropped.
+	 */
+	@Test
+	void testSseFrameWithoutEventTypeIsAccepted() throws InterruptedException {
+		CountDownLatch sseLatch = new CountDownLatch(1);
+		CountDownLatch messageLatch = new CountDownLatch(1);
+
+		// Use a fresh server endpoint for this test
+		this.server.createContext("/mcp-no-event", exchange -> {
+			String method = exchange.getRequestMethod();
+			if ("POST".equals(method)) {
+				// Respond with text/event-stream SSE stream that has NO event: line
+				String sessionId = "sse-no-event-session";
+				exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+				exchange.getResponseHeaders().set(HttpHeaders.MCP_SESSION_ID, sessionId);
+				exchange.sendResponseHeaders(200, 0);
+				// SSE frame with only data: — event type intentionally omitted
+				String sseData = "data: {\"jsonrpc\":\"2.0\",\"result\":{\"protocolVersion\":\"2025-03-26\","
+						+ "\"capabilities\":{},\"serverInfo\":{\"name\":\"test\",\"version\":\"1.0\"}},\"id\":\"test-id\"}\n\n";
+				try {
+					exchange.getResponseBody().write(sseData.getBytes());
+					exchange.getResponseBody().flush();
+				}
+				catch (IOException ex) {
+					// stream already closed
+				}
+				sseLatch.countDown();
+			}
+			else {
+				exchange.sendResponseHeaders(405, 0);
+			}
+			exchange.close();
+		});
+
+		var transport = WebClientStreamableHttpTransport.builder(WebClient.builder().baseUrl(this.host))
+			.endpoint("/mcp-no-event")
+			.build();
+
+		StepVerifier.create(transport.connect(msg -> {
+			messageLatch.countDown();
+			return Mono.empty();
+		})).verifyComplete();
+
+		var testMessage = createTestMessage();
+		transport.sendMessage(testMessage).subscribe();
+
+		// SSE frame must have been received and dispatched to the message handler
+		assertThat(sseLatch.await(5, TimeUnit.SECONDS)).isTrue();
+		assertThat(messageLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+		StepVerifier.create(transport.closeGracefully()).verifyComplete();
+	}
+
 	private McpSchema.JSONRPCRequest createTestMessage() {
 		var initializeRequest = new McpSchema.InitializeRequest(ProtocolVersions.MCP_2025_03_26,
 				McpSchema.ClientCapabilities.builder().roots(true).build(),


### PR DESCRIPTION
## Problem

`WebClientStreamableHttpTransport.parse()` only processes SSE frames where `event.event()` equals `"message"`. Per the [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), omitting the `event:` field means the event type defaults to `"message"`. When Spring/WebFlux decodes such a frame, `ServerSentEvent.event()` returns `null` — so the frame was silently dropped.

This caused MCP clients to miss valid JSON-RPC responses from servers that emit bare `data:`-only SSE frames, resulting in initialization timeouts like:
- `Client failed to initialize by explicit API call`
- `Did not observe any item or terminal signal within ...`

This is the Spring AI counterpart of `modelcontextprotocol/java-sdk#885` / PR `#913`, which fixed the `HttpClient` variant but explicitly noted the `WebClient` variant needed a separate fix here.

## Fix

Accept all three equivalent event types for SSE message frames:
- `event == null` (field omitted)
- `event == ""` (field present but empty)
- `event == "message"` (explicit)

```java
String eventType = event.event();
if (eventType == null || eventType.isEmpty() || MESSAGE_EVENT_TYPE.equals(eventType)) {
```

## Testing

Added `testSseFrameWithoutEventTypeIsAccepted()` to `WebClientStreamableHttpTransportErrorHandlingIT` — spins up a local HTTP server that returns an SSE stream with only a `data:` line (no `event:` line) and verifies the message handler receives the parsed JSON-RPC message.

Closes #5780