### PR TITLE
Remove ModelOptionsUtils.merge calls

### DIFF
--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageModel.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageModel.java
@@ -125,20 +125,15 @@ public class AzureOpenAiImageModel implements ImageModel {
 	private String getDeploymentName(ImagePrompt prompt) {
 		var runtimeImageOptions = prompt.getOptions();
 
-		if (this.defaultOptions != null) {
-			// Merge options fixed in beta7
-			// https://github.com/Azure/azure-sdk-for-java/issues/38183
-			runtimeImageOptions = ModelOptionsUtils.merge(runtimeImageOptions, this.defaultOptions,
-					AzureOpenAiImageOptions.class);
-		}
+		// Merge options fixed in beta7
+		// https://github.com/Azure/azure-sdk-for-java/issues/38183
+		runtimeImageOptions = ModelOptionsUtils.merge(runtimeImageOptions, this.defaultOptions,
+				AzureOpenAiImageOptions.class);
 
-		if (runtimeImageOptions != null) {
-			if (runtimeImageOptions instanceof AzureOpenAiImageOptions runtimeAzureOpenAiImageOptions) {
-				if (runtimeAzureOpenAiImageOptions.getDeploymentName() != null) {
-					return runtimeAzureOpenAiImageOptions.getDeploymentName();
-				}
+		if (runtimeImageOptions instanceof AzureOpenAiImageOptions runtimeAzureOpenAiImageOptions) {
+			if (runtimeAzureOpenAiImageOptions.getDeploymentName() != null) {
+				return runtimeAzureOpenAiImageOptions.getDeploymentName();
 			}
-
 		}
 
 		// By default the one provided in the image prompt

--- a/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageOptions.java
+++ b/models/spring-ai-azure-openai/src/main/java/org/springframework/ai/azure/openai/AzureOpenAiImageOptions.java
@@ -18,9 +18,6 @@ package org.springframework.ai.azure.openai;
 
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.image.ImageOptions;
 
 /**
@@ -31,7 +28,6 @@ import org.springframework.ai.image.ImageOptions;
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0 M1
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AzureOpenAiImageOptions implements ImageOptions {
 
 	public static final String DEFAULT_IMAGE_MODEL = ImageModel.GPT_IMAGE_1_MINI.getValue();
@@ -40,32 +36,27 @@ public class AzureOpenAiImageOptions implements ImageOptions {
 	 * The number of images to generate. Must be between 1 and 10. For dall-e-3, only n=1
 	 * is supported.
 	 */
-	@JsonProperty("n")
 	private Integer n;
 
 	/**
 	 * The model dall-e-3 or dall-e-2 By default dall-e-3
 	 */
-	@JsonProperty("model")
 	private String model = ImageModel.GPT_IMAGE_1_MINI.value;
 
 	/**
 	 * The deployment name as defined in Azure Open AI Studio when creating a deployment
 	 * backed by an Azure OpenAI base model.
 	 */
-	@JsonProperty("deployment_name")
 	private String deploymentName;
 
 	/**
 	 * The width of the generated images. Must be one of 256, 512, or 1024 for dall-e-2.
 	 */
-	@JsonProperty("size_width")
 	private Integer width;
 
 	/**
 	 * The height of the generated images. Must be one of 256, 512, or 1024 for dall-e-2.
 	 */
-	@JsonProperty("size_height")
 	private Integer height;
 
 	/**
@@ -73,21 +64,18 @@ public class AzureOpenAiImageOptions implements ImageOptions {
 	 * details and greater consistency across the image. This param is only supported for
 	 * dall-e-3. standard or hd
 	 */
-	@JsonProperty("quality")
 	private String quality;
 
 	/**
 	 * The format in which the generated images are returned. Must be one of url or
 	 * b64_json.
 	 */
-	@JsonProperty("response_format")
 	private String responseFormat;
 
 	/**
 	 * The size of the generated images. Must be one of 256x256, 512x512, or 1024x1024 for
 	 * dall-e-2. Must be one of 1024x1024, 1792x1024, or 1024x1792 for dall-e-3 models.
 	 */
-	@JsonProperty("size")
 	private String size;
 
 	/**
@@ -96,14 +84,12 @@ public class AzureOpenAiImageOptions implements ImageOptions {
 	 * the model to produce more natural, less hyper-real looking images. This param is
 	 * only supported for dall-e-3. natural or vivid
 	 */
-	@JsonProperty("style")
 	private String style;
 
 	/**
 	 * A unique identifier representing your end-user, which can help OpenAI to monitor
 	 * and detect abuse.
 	 */
-	@JsonProperty("user")
 	private String user;
 
 	public static Builder builder() {

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
@@ -124,16 +124,15 @@ public class BedrockCohereEmbeddingModel extends AbstractEmbeddingModel {
 	 */
 	BedrockCohereEmbeddingOptions mergeOptions(EmbeddingOptions requestOptions) {
 
-		BedrockCohereEmbeddingOptions options = (this.defaultOptions != null) ? this.defaultOptions
-				: BedrockCohereEmbeddingOptions.builder()
-					.inputType(CohereEmbeddingRequest.InputType.SEARCH_DOCUMENT)
-					.truncate(CohereEmbeddingRequest.Truncate.NONE)
-					.build();
-
-		if (requestOptions != null) {
-			options = ModelOptionsUtils.merge(requestOptions, options, BedrockCohereEmbeddingOptions.class);
+		BedrockCohereEmbeddingOptions options = this.defaultOptions;
+		// BedrockCohereEmbeddingOptions disregards options from EmbeddingOptions, so only
+		// specific options make sense here
+		if (requestOptions instanceof BedrockCohereEmbeddingOptions ro) {
+			options = BedrockCohereEmbeddingOptions.builder()
+				.inputType(ModelOptionsUtils.mergeOption(ro.getInputType(), options.getInputType()))
+				.truncate(ModelOptionsUtils.mergeOption(ro.getTruncate(), options.getTruncate()))
+				.build();
 		}
-
 		return options;
 	}
 

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingOptions.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingOptions.java
@@ -16,11 +16,6 @@
 
 package org.springframework.ai.bedrock.cohere;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest.InputType;
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingRequest.Truncate;
 import org.springframework.ai.embedding.EmbeddingOptions;
@@ -32,7 +27,6 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  */
-@JsonInclude(Include.NON_NULL)
 public class BedrockCohereEmbeddingOptions implements EmbeddingOptions {
 
 	// @formatter:off
@@ -42,14 +36,14 @@ public class BedrockCohereEmbeddingOptions implements EmbeddingOptions {
 	 * In this case, embed your corpus with the search_document type and embedded queries with
 	 * type search_query type.
 	 */
-	private @JsonProperty("input_type") InputType inputType;
+	private InputType inputType;
 
 	/**
 	 * Specifies how the API handles inputs longer than the maximum token length. If you specify LEFT or
 	 * RIGHT, the model discards the input until the remaining input is exactly the maximum input token length for the
 	 * model.
 	 */
-	private @JsonProperty("truncate") Truncate truncate;
+	private Truncate truncate;
 	// @formatter:on
 
 	public static Builder builder() {
@@ -73,13 +67,11 @@ public class BedrockCohereEmbeddingOptions implements EmbeddingOptions {
 	}
 
 	@Override
-	@JsonIgnore
 	public String getModel() {
 		return null;
 	}
 
 	@Override
-	@JsonIgnore
 	public Integer getDimensions() {
 		return null;
 	}

--- a/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
+++ b/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
@@ -226,23 +226,37 @@ public class GoogleGenAiTextEmbeddingModel extends AbstractEmbeddingModel {
 	}
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
-		// Process runtime options
-		GoogleGenAiTextEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					GoogleGenAiTextEmbeddingOptions.class);
+		EmbeddingOptions requestOptions = embeddingRequest.getOptions();
+		GoogleGenAiTextEmbeddingOptions mergedOptions = this.defaultOptions;
+
+		if (requestOptions != null) {
+			GoogleGenAiTextEmbeddingOptions.Builder builder = GoogleGenAiTextEmbeddingOptions.builder()
+				.model(ModelOptionsUtils.mergeOption(requestOptions.getModel(), this.defaultOptions.getModel()))
+				.dimensions(ModelOptionsUtils.mergeOption(requestOptions.getDimensions(),
+						this.defaultOptions.getDimensions()));
+
+			if (requestOptions instanceof GoogleGenAiTextEmbeddingOptions googleOptions) {
+				builder
+					.taskType(ModelOptionsUtils.mergeOption(googleOptions.getTaskType(),
+							this.defaultOptions.getTaskType()))
+					.title(ModelOptionsUtils.mergeOption(googleOptions.getTitle(), this.defaultOptions.getTitle()))
+					.autoTruncate(ModelOptionsUtils.mergeOption(googleOptions.getAutoTruncate(),
+							this.defaultOptions.getAutoTruncate()));
+			}
+			else {
+				builder.taskType(this.defaultOptions.getTaskType())
+					.title(this.defaultOptions.getTitle())
+					.autoTruncate(this.defaultOptions.getAutoTruncate());
+			}
+			mergedOptions = builder.build();
 		}
 
-		// Define request options by merging runtime options and default options
-		GoogleGenAiTextEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,
-				GoogleGenAiTextEmbeddingOptions.class);
-
 		// Validate request options
-		if (!StringUtils.hasText(requestOptions.getModel())) {
+		if (!StringUtils.hasText(mergedOptions.getModel())) {
 			throw new IllegalArgumentException("model cannot be null or empty");
 		}
 
-		return new EmbeddingRequest(embeddingRequest.getInstructions(), requestOptions);
+		return new EmbeddingRequest(embeddingRequest.getInstructions(), mergedOptions);
 	}
 
 	private EmbeddingResponseMetadata generateResponseMetadata(String model, Integer totalTokens) {

--- a/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingOptions.java
+++ b/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingOptions.java
@@ -16,10 +16,6 @@
 
 package org.springframework.ai.google.genai.text;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.util.StringUtils;
 
@@ -31,7 +27,6 @@ import org.springframework.util.StringUtils;
  * @author Dan Dobrin
  * @since 1.0.0
  */
-@JsonInclude(Include.NON_NULL)
 public class GoogleGenAiTextEmbeddingOptions implements EmbeddingOptions {
 
 	public static final String DEFAULT_MODEL_NAME = GoogleGenAiTextEmbeddingModelName.GEMINI_EMBEDDING_001.getName();
@@ -41,7 +36,7 @@ public class GoogleGenAiTextEmbeddingOptions implements EmbeddingOptions {
 	 * (recommended for Gemini API), text-embedding-004, text-multilingual-embedding-002
 	 * and multimodalembedding@001.
 	 */
-	private @JsonProperty("model") String model;
+	private String model;
 
 	// @formatter:off
 
@@ -49,25 +44,25 @@ public class GoogleGenAiTextEmbeddingOptions implements EmbeddingOptions {
 	 * The intended downstream application to help the model produce better quality embeddings.
 	 * Not all model versions support all task types.
 	 */
-	private @JsonProperty("task") TaskType taskType;
+	private TaskType taskType;
 
 	/**
 	 * The number of dimensions the resulting output embeddings should have.
 	 * Supported for model version 004 and later. You can use this parameter to reduce the
 	 * embedding size, for example, for storage optimization.
 	 */
-	private @JsonProperty("dimensions") Integer dimensions;
+	private Integer dimensions;
 
 	/**
 	 * Optional title, only valid with task_type=RETRIEVAL_DOCUMENT.
 	 */
-	private @JsonProperty("title") String title;
+	private String title;
 
 	/**
 	 * When set to true, input text will be truncated. When set to false, an error is returned
 	 * if the input text is longer than the maximum length supported by the model. Defaults to true.
 	 */
-	private @JsonProperty("autoTruncate") Boolean autoTruncate;
+	private Boolean autoTruncate;
 
 	public static Builder builder() {
 		return new Builder();

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingModel.java
@@ -28,7 +28,6 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.AbstractEmbeddingModel;
 import org.springframework.ai.embedding.Embedding;
-import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.embedding.EmbeddingResponseMetadata;
@@ -197,23 +196,21 @@ public class MiniMaxEmbeddingModel extends AbstractEmbeddingModel {
 	}
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
-		// Process runtime options
-		MiniMaxEmbeddingOptions runtimeOptions = null;
+		MiniMaxEmbeddingOptions options = this.defaultOptions;
+
 		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					MiniMaxEmbeddingOptions.class);
+			options = MiniMaxEmbeddingOptions.builder()
+				.model(ModelOptionsUtils.mergeOption(embeddingRequest.getOptions().getModel(),
+						this.defaultOptions.getModel()))
+				.build();
 		}
 
-		// Define request options by merging runtime options and default options
-		MiniMaxEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,
-				MiniMaxEmbeddingOptions.class);
-
 		// Validate request options
-		if (!StringUtils.hasText(requestOptions.getModel())) {
+		if (!StringUtils.hasText(options.getModel())) {
 			throw new IllegalArgumentException("model cannot be null or empty");
 		}
 
-		return new EmbeddingRequest(embeddingRequest.getInstructions(), requestOptions);
+		return new EmbeddingRequest(embeddingRequest.getInstructions(), options);
 	}
 
 	public void setObservationConvention(EmbeddingModelObservationConvention observationConvention) {

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxEmbeddingOptions.java
@@ -16,11 +16,6 @@
 
 package org.springframework.ai.minimax;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.embedding.EmbeddingOptions;
 
 /**
@@ -30,14 +25,13 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  * @author Thomas Vitale
  * @since 1.0.0 M1
  */
-@JsonInclude(Include.NON_NULL)
 public class MiniMaxEmbeddingOptions implements EmbeddingOptions {
 
 	// @formatter:off
 	/**
 	 * ID of the model to use.
 	 */
-	private @JsonProperty("model") String model;
+	private String model;
 	// @formatter:on
 
 	public static Builder builder() {
@@ -54,7 +48,6 @@ public class MiniMaxEmbeddingOptions implements EmbeddingOptions {
 	}
 
 	@Override
-	@JsonIgnore
 	public Integer getDimensions() {
 		return null;
 	}

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingModel.java
@@ -145,18 +145,24 @@ public class MistralAiEmbeddingModel extends AbstractEmbeddingModel {
 	}
 
 	private EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
-		// Process runtime options
-		MistralAiEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					MistralAiEmbeddingOptions.class);
+		EmbeddingOptions requestOptions = embeddingRequest.getOptions();
+		MistralAiEmbeddingOptions mergedOptions = this.defaultOptions;
+
+		if (requestOptions != null) {
+			MistralAiEmbeddingOptions.Builder builder = MistralAiEmbeddingOptions.builder()
+				.withModel(ModelOptionsUtils.mergeOption(requestOptions.getModel(), this.defaultOptions.getModel()));
+
+			if (requestOptions instanceof MistralAiEmbeddingOptions mistralOptions) {
+				builder.withEncodingFormat(ModelOptionsUtils.mergeOption(mistralOptions.getEncodingFormat(),
+						this.defaultOptions.getEncodingFormat()));
+			}
+			else {
+				builder.withEncodingFormat(this.defaultOptions.getEncodingFormat());
+			}
+			mergedOptions = builder.build();
 		}
 
-		// Define request options by merging runtime options and default options
-		MistralAiEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,
-				MistralAiEmbeddingOptions.class);
-
-		return new EmbeddingRequest(embeddingRequest.getInstructions(), requestOptions);
+		return new EmbeddingRequest(embeddingRequest.getInstructions(), mergedOptions);
 	}
 
 	private DefaultUsage getDefaultUsage(MistralAiApi.Usage usage) {

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiEmbeddingOptions.java
@@ -16,10 +16,6 @@
 
 package org.springframework.ai.mistralai;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.embedding.EmbeddingOptions;
@@ -32,20 +28,19 @@ import org.springframework.ai.embedding.EmbeddingOptions;
  * @author Jason Smith
  * @since 0.8.1
  */
-@JsonInclude(Include.NON_NULL)
 public class MistralAiEmbeddingOptions implements EmbeddingOptions {
 
 	/**
 	 * ID of the model to use.
 	 */
 	@SuppressWarnings("NullAway.Init")
-	private @JsonProperty("model") String model;
+	private String model;
 
 	/**
 	 * The format to return the embeddings in. Can be either float or base64.
 	 */
 	@SuppressWarnings("NullAway.Init")
-	private @JsonProperty("encoding_format") String encodingFormat;
+	private String encodingFormat;
 
 	public static Builder builder() {
 		return new Builder();
@@ -69,7 +64,6 @@ public class MistralAiEmbeddingOptions implements EmbeddingOptions {
 	}
 
 	@Override
-	@JsonIgnore
 	public @Nullable Integer getDimensions() {
 		return null;
 	}

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationModel.java
@@ -74,19 +74,14 @@ public class MistralAiModerationModel implements ModerationModel {
 
 			var instructions = moderationPrompt.getInstructions().getText();
 
-			var moderationRequest = new MistralAiModerationRequest(instructions);
+			ModerationOptions requestOptions = moderationPrompt.getOptions();
+			String model = this.defaultOptions.getModel();
 
-			if (this.defaultOptions != null) {
-				moderationRequest = ModelOptionsUtils.merge(this.defaultOptions, moderationRequest,
-						MistralAiModerationRequest.class);
+			if (requestOptions != null) {
+				model = ModelOptionsUtils.mergeOption(requestOptions.getModel(), this.defaultOptions.getModel());
 			}
-			else {
-				// moderationPrompt.getOptions() never null but model can be empty,
-				// cause
-				// by ModerationPrompt constructor
-				moderationRequest = ModelOptionsUtils.merge(toMistralAiModerationOptions(moderationPrompt.getOptions()),
-						moderationRequest, MistralAiModerationRequest.class);
-			}
+
+			var moderationRequest = new MistralAiModerationRequest(instructions, model);
 
 			var moderationResponseEntity = this.mistralAiModerationApi.moderate(moderationRequest);
 
@@ -151,14 +146,6 @@ public class MistralAiModerationModel implements ModerationModel {
 			.build();
 
 		return new ModerationResponse(new Generation(moderation));
-	}
-
-	private MistralAiModerationOptions toMistralAiModerationOptions(ModerationOptions runtimeModerationOptions) {
-		var mistralAiModerationOptionsBuilder = MistralAiModerationOptions.builder();
-		if (runtimeModerationOptions != null && runtimeModerationOptions.getModel() != null) {
-			mistralAiModerationOptionsBuilder.model(runtimeModerationOptions.getModel());
-		}
-		return mistralAiModerationOptionsBuilder.build();
 	}
 
 	public static Builder builder() {

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationOptions.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/moderation/MistralAiModerationOptions.java
@@ -16,16 +16,12 @@
 
 package org.springframework.ai.mistralai.moderation;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.mistralai.api.MistralAiModerationApi;
 import org.springframework.ai.moderation.ModerationOptions;
 
 /**
  * @author Ricken Bazolo
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MistralAiModerationOptions implements ModerationOptions {
 
 	private static final String DEFAULT_MODEL = MistralAiModerationApi.Model.MISTRAL_MODERATION.getValue();
@@ -33,7 +29,6 @@ public class MistralAiModerationOptions implements ModerationOptions {
 	/**
 	 * The model to use for moderation generation.
 	 */
-	@JsonProperty("model")
 	private String model = DEFAULT_MODEL;
 
 	public static Builder builder() {

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/aot/MistralAiRuntimeHintsTests.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/aot/MistralAiRuntimeHintsTests.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.ai.mistralai.MistralAiEmbeddingOptions;
 import org.springframework.ai.mistralai.api.MistralAiApi;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeReference;
@@ -52,7 +51,6 @@ class MistralAiRuntimeHintsTests {
 		assertThat(registeredTypes.contains(TypeReference.of(MistralAiApi.ChatCompletionChunk.class))).isTrue();
 		assertThat(registeredTypes.contains(TypeReference.of(MistralAiApi.LogProbs.class))).isTrue();
 		assertThat(registeredTypes.contains(TypeReference.of(MistralAiApi.ChatCompletionFinishReason.class))).isTrue();
-		assertThat(registeredTypes.contains(TypeReference.of(MistralAiEmbeddingOptions.class))).isTrue();
 	}
 
 	@Test

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaEmbeddingModel.java
@@ -147,16 +147,7 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 	}
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
-		// Process runtime options
-		OllamaEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					OllamaEmbeddingOptions.class);
-		}
-
-		// Define request options by merging runtime options and default options
-		OllamaEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,
-				OllamaEmbeddingOptions.class);
+		OllamaEmbeddingOptions requestOptions = mergeOptions(embeddingRequest.getOptions());
 
 		// Validate request options
 		if (!StringUtils.hasText(requestOptions.getModel())) {
@@ -164,6 +155,34 @@ public class OllamaEmbeddingModel extends AbstractEmbeddingModel {
 		}
 
 		return new EmbeddingRequest(embeddingRequest.getInstructions(), requestOptions);
+	}
+
+	private OllamaEmbeddingOptions mergeOptions(@Nullable EmbeddingOptions requestOptions) {
+		OllamaEmbeddingOptions options = this.defaultOptions;
+
+		if (requestOptions == null) {
+			return options;
+		}
+
+		OllamaEmbeddingOptions.Builder builder = OllamaEmbeddingOptions.builder()
+			.model(ModelOptionsUtils.mergeOption(requestOptions.getModel(), options.getModel()))
+			.dimensions(ModelOptionsUtils.mergeOption(requestOptions.getDimensions(), options.getDimensions()));
+
+		if (requestOptions instanceof OllamaEmbeddingOptions ro) {
+			builder.keepAlive(ModelOptionsUtils.mergeOption(ro.getKeepAlive(), options.getKeepAlive()))
+				.truncate(ModelOptionsUtils.mergeOption(ro.getTruncate(), options.getTruncate()))
+				.useNUMA(ModelOptionsUtils.mergeOption(ro.getUseNUMA(), options.getUseNUMA()))
+				.numBatch(ModelOptionsUtils.mergeOption(ro.getNumBatch(), options.getNumBatch()))
+				.numGPU(ModelOptionsUtils.mergeOption(ro.getNumGPU(), options.getNumGPU()))
+				.mainGPU(ModelOptionsUtils.mergeOption(ro.getMainGPU(), options.getMainGPU()))
+				.lowVRAM(ModelOptionsUtils.mergeOption(ro.getLowVRAM(), options.getLowVRAM()))
+				.vocabOnly(ModelOptionsUtils.mergeOption(ro.getVocabOnly(), options.getVocabOnly()))
+				.useMMap(ModelOptionsUtils.mergeOption(ro.getUseMMap(), options.getUseMMap()))
+				.useMLock(ModelOptionsUtils.mergeOption(ro.getUseMLock(), options.getUseMLock()))
+				.numThread(ModelOptionsUtils.mergeOption(ro.getNumThread(), options.getNumThread()));
+		}
+
+		return builder.build();
 	}
 
 	/**

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaEmbeddingOptions.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/api/OllamaEmbeddingOptions.java
@@ -21,13 +21,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.embedding.EmbeddingOptions;
-import org.springframework.ai.model.ModelOptionsUtils;
 
 /**
  * Helper class for creating strongly-typed Ollama options.
@@ -41,7 +37,6 @@ import org.springframework.ai.model.ModelOptionsUtils;
  * Valid Parameters and Values</a>
  * @see <a href="https://github.com/ollama/ollama/blob/main/api/types.go">Ollama Types</a>
  */
-@JsonInclude(Include.NON_NULL)
 public class OllamaEmbeddingOptions implements EmbeddingOptions {
 
 	private static final List<String> NON_SUPPORTED_FIELDS = List.of("model", "keep_alive", "truncate", "dimensions");
@@ -60,7 +55,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * Used to allow overriding the model name with prompt options.
 	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">parameters</a>.
 	 */
-	@JsonProperty("model")
 	private @Nullable String model;
 
 	/**
@@ -68,7 +62,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * setting are parsed by <a href="https://pkg.go.dev/time#ParseDuration">ParseDuration in Go</a>.
 	 * Part of Chat completion <a href="https://github.com/ollama/ollama/blob/main/docs/api.md#parameters-1">advanced parameters</a>.
 	 */
-	@JsonProperty("keep_alive")
 	private @Nullable String keepAlive;
 
 
@@ -76,7 +69,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * The dimensions of the embedding output. This allows you to specify the size of the embedding vector
 	 * that should be returned by the model. Not all models support this parameter.
 	 */
-	@JsonProperty("dimensions")
 	private @Nullable Integer dimensions;
 
 
@@ -84,7 +76,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * Truncates the end of each input to fit within context length. Returns error if false and context length is exceeded.
 	 * Defaults to true.
 	 */
-	@JsonProperty("truncate")
 	private @Nullable Boolean truncate;
 
 	// @formatter:off
@@ -92,13 +83,11 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	/**
 	 * Whether to use NUMA. (Default: false)
 	 */
-	@JsonProperty("numa")
 	private @Nullable Boolean useNUMA;
 
 	/**
 	 * Prompt processing maximum batch size. (Default: 512)
 	 */
-	@JsonProperty("num_batch")
 	private @Nullable Integer numBatch;
 
 	/**
@@ -106,7 +95,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * to enable metal support, 0 to disable.
 	 * (Default: -1, which indicates that numGPU should be set dynamically)
 	 */
-	@JsonProperty("num_gpu")
 	private @Nullable Integer numGPU;
 
 	/**
@@ -116,19 +104,16 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * more VRAM to store a scratch buffer for temporary results.
 	 * By default, GPU 0 is used.
 	 */
-	@JsonProperty("main_gpu")
 	private @Nullable Integer mainGPU;
 
 	/**
 	 * (Default: false)
 	 */
-	@JsonProperty("low_vram")
 	private @Nullable Boolean lowVRAM;
 
 	/**
 	 * Load only the vocabulary, not the weights.
 	 */
-	@JsonProperty("vocab_only")
 	private @Nullable Boolean vocabOnly;
 
 	/**
@@ -140,7 +125,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * the model from loading at all.
 	 * (Default: null)
 	 */
-	@JsonProperty("use_mmap")
 	private @Nullable Boolean useMMap;
 
 	/**
@@ -149,7 +133,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * by requiring more RAM to run and potentially slowing down load times as the model loads into RAM.
 	 * (Default: false)
 	 */
-	@JsonProperty("use_mlock")
 	private @Nullable Boolean useMLock;
 
 	/**
@@ -158,7 +141,6 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * Using the correct number of threads can greatly improve performance.
 	 * By default, Ollama will detect this value for optimal performance.
 	 */
-	@JsonProperty("num_thread")
 	private @Nullable Integer numThread;
 
 
@@ -308,7 +290,47 @@ public class OllamaEmbeddingOptions implements EmbeddingOptions {
 	 * @return The {@link Map} of key/value pairs.
 	 */
 	public Map<String, Object> toMap() {
-		return ModelOptionsUtils.objectToMap(this);
+		Map<String, Object> map = new java.util.HashMap<>();
+		if (this.model != null) {
+			map.put("model", this.model);
+		}
+		if (this.keepAlive != null) {
+			map.put("keep_alive", this.keepAlive);
+		}
+		if (this.dimensions != null) {
+			map.put("dimensions", this.dimensions);
+		}
+		if (this.truncate != null) {
+			map.put("truncate", this.truncate);
+		}
+		if (this.useNUMA != null) {
+			map.put("numa", this.useNUMA);
+		}
+		if (this.numBatch != null) {
+			map.put("num_batch", this.numBatch);
+		}
+		if (this.numGPU != null) {
+			map.put("num_gpu", this.numGPU);
+		}
+		if (this.mainGPU != null) {
+			map.put("main_gpu", this.mainGPU);
+		}
+		if (this.lowVRAM != null) {
+			map.put("low_vram", this.lowVRAM);
+		}
+		if (this.vocabOnly != null) {
+			map.put("vocab_only", this.vocabOnly);
+		}
+		if (this.useMMap != null) {
+			map.put("use_mmap", this.useMMap);
+		}
+		if (this.useMLock != null) {
+			map.put("use_mlock", this.useMLock);
+		}
+		if (this.numThread != null) {
+			map.put("num_thread", this.numThread);
+		}
+		return map;
 	}
 
 	public OllamaEmbeddingOptions copy() {

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/aot/OllamaRuntimeHintsTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/aot/OllamaRuntimeHintsTests.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.ollama.api.OllamaApi;
-import org.springframework.ai.ollama.api.OllamaEmbeddingOptions;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeReference;
 
@@ -50,7 +49,6 @@ class OllamaRuntimeHintsTests {
 		assertThat(registeredTypes.contains(TypeReference.of(OllamaApi.ChatRequest.class))).isTrue();
 		assertThat(registeredTypes.contains(TypeReference.of(OllamaApi.ChatRequest.Tool.class))).isTrue();
 		assertThat(registeredTypes.contains(TypeReference.of(OllamaApi.Message.class))).isTrue();
-		assertThat(registeredTypes.contains(TypeReference.of(OllamaEmbeddingOptions.class))).isTrue();
 	}
 
 	@Test

--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingModel.java
@@ -155,13 +155,31 @@ public class PostgresMlEmbeddingModel extends AbstractEmbeddingModel implements 
 	 */
 	PostgresMlEmbeddingOptions mergeOptions(@Nullable EmbeddingOptions requestOptions) {
 
-		PostgresMlEmbeddingOptions options = this.defaultOptions;
-
-		if (requestOptions != null) {
-			options = ModelOptionsUtils.merge(requestOptions, options, PostgresMlEmbeddingOptions.class);
+		if (requestOptions == null) {
+			return this.defaultOptions;
 		}
 
-		return options;
+		PostgresMlEmbeddingOptions.Builder builder = PostgresMlEmbeddingOptions.builder();
+
+		// PostgresMlEmbeddingOptions disregards base EmbeddingOptions properties
+		if (requestOptions instanceof PostgresMlEmbeddingOptions pgOptions) {
+			builder
+				.transformer(
+						ModelOptionsUtils.mergeOption(pgOptions.getTransformer(), this.defaultOptions.getTransformer()))
+				.vectorType(
+						ModelOptionsUtils.mergeOption(pgOptions.getVectorType(), this.defaultOptions.getVectorType()))
+				.kwargs(ModelOptionsUtils.mergeOption(pgOptions.getKwargs(), this.defaultOptions.getKwargs()))
+				.metadataMode(ModelOptionsUtils.mergeOption(pgOptions.getMetadataMode(),
+						this.defaultOptions.getMetadataMode()));
+		}
+		else {
+			builder.transformer(this.defaultOptions.getTransformer())
+				.vectorType(this.defaultOptions.getVectorType())
+				.kwargs(this.defaultOptions.getKwargs())
+				.metadataMode(this.defaultOptions.getMetadataMode());
+		}
+
+		return builder.build();
 	}
 
 	@Override

--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptions.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptions.java
@@ -18,10 +18,6 @@ package org.springframework.ai.postgresml;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.document.MetadataMode;
@@ -36,30 +32,29 @@ import org.springframework.ai.postgresml.PostgresMlEmbeddingModel.VectorType;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  */
-@JsonInclude(Include.NON_NULL)
 public class PostgresMlEmbeddingOptions implements EmbeddingOptions {
 
 	// @formatter:off
 	/**
 	 * The Huggingface transformer model to use for the embedding.
 	 */
-	private @JsonProperty("transformer") String transformer = PostgresMlEmbeddingModel.DEFAULT_TRANSFORMER_MODEL;
+	private String transformer = PostgresMlEmbeddingModel.DEFAULT_TRANSFORMER_MODEL;
 
 	/**
 	 * PostgresML vector type to use for the embedding.
 	 * Two options are supported: PG_ARRAY and PG_VECTOR.
 	 */
-	private @JsonProperty("vectorType") VectorType vectorType = VectorType.PG_ARRAY;
+	private VectorType vectorType = VectorType.PG_ARRAY;
 
 	/**
 	 * Additional transformer specific options.
 	 */
-	private @JsonProperty("kwargs") Map<String, Object> kwargs = Map.of();
+	private Map<String, Object> kwargs = Map.of();
 
 	/**
 	 * The Document metadata aggregation mode.
 	 */
-	private @JsonProperty("metadataMode") MetadataMode metadataMode = MetadataMode.EMBED;
+	private MetadataMode metadataMode = MetadataMode.EMBED;
 	// @formatter:on
 
 	public static Builder builder() {
@@ -99,13 +94,11 @@ public class PostgresMlEmbeddingOptions implements EmbeddingOptions {
 	}
 
 	@Override
-	@JsonIgnore
 	public @Nullable String getModel() {
 		return null;
 	}
 
 	@Override
-	@JsonIgnore
 	public @Nullable Integer getDimensions() {
 		return null;
 	}

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingModel.java
@@ -39,6 +39,7 @@ import org.springframework.ai.document.Document;
 import org.springframework.ai.embedding.DocumentEmbeddingModel;
 import org.springframework.ai.embedding.DocumentEmbeddingRequest;
 import org.springframework.ai.embedding.Embedding;
+import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.embedding.EmbeddingResponseMetadata;
 import org.springframework.ai.embedding.EmbeddingResultMetadata;
@@ -97,13 +98,30 @@ public class VertexAiMultimodalEmbeddingModel implements DocumentEmbeddingModel 
 
 		EmbeddingResponse finalResponse = new EmbeddingResponse(List.of());
 
-		// merge the runtime and default vertex ai options.
+		EmbeddingOptions requestOptions = request.getOptions();
 		VertexAiMultimodalEmbeddingOptions mergedOptions = this.defaultOptions;
 
-		if (request.getOptions() != null) {
-			var defaultOptionsCopy = VertexAiMultimodalEmbeddingOptions.builder().from(this.defaultOptions).build();
-			mergedOptions = ModelOptionsUtils.merge(request.getOptions(), defaultOptionsCopy,
-					VertexAiMultimodalEmbeddingOptions.class);
+		if (requestOptions != null) {
+			VertexAiMultimodalEmbeddingOptions.Builder builder = VertexAiMultimodalEmbeddingOptions.builder()
+				.model(ModelOptionsUtils.mergeOption(requestOptions.getModel(), this.defaultOptions.getModel()))
+				.dimensions(ModelOptionsUtils.mergeOption(requestOptions.getDimensions(),
+						this.defaultOptions.getDimensions()));
+
+			if (requestOptions instanceof VertexAiMultimodalEmbeddingOptions vertexOptions) {
+				builder
+					.videoStartOffsetSec(ModelOptionsUtils.mergeOption(vertexOptions.getVideoStartOffsetSec(),
+							this.defaultOptions.getVideoStartOffsetSec()))
+					.videoEndOffsetSec(ModelOptionsUtils.mergeOption(vertexOptions.getVideoEndOffsetSec(),
+							this.defaultOptions.getVideoEndOffsetSec()))
+					.videoIntervalSec(ModelOptionsUtils.mergeOption(vertexOptions.getVideoIntervalSec(),
+							this.defaultOptions.getVideoIntervalSec()));
+			}
+			else {
+				builder.videoStartOffsetSec(this.defaultOptions.getVideoStartOffsetSec())
+					.videoEndOffsetSec(this.defaultOptions.getVideoEndOffsetSec())
+					.videoIntervalSec(this.defaultOptions.getVideoIntervalSec());
+			}
+			mergedOptions = builder.build();
 		}
 
 		// Create the Vertex AI Prediction Service client.

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingOptions.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/multimodal/VertexAiMultimodalEmbeddingOptions.java
@@ -16,10 +16,6 @@
 
 package org.springframework.ai.vertexai.embedding.multimodal;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.util.StringUtils;
 
@@ -61,7 +57,6 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
-@JsonInclude(Include.NON_NULL)
 public class VertexAiMultimodalEmbeddingOptions implements EmbeddingOptions {
 
 	public static final String DEFAULT_MODEL_NAME = VertexAiMultimodalEmbeddingModelName.MULTIMODAL_EMBEDDING_001
@@ -72,25 +67,25 @@ public class VertexAiMultimodalEmbeddingOptions implements EmbeddingOptions {
 	 * The embedding model name to use. Supported models are:
 	 * text-embedding-004, text-multilingual-embedding-002 and multimodalembedding@001.
 	 */
-	private @JsonProperty("model") String model;
+	private String model;
 
 	/**
 	 * The number of dimensions the resulting output embeddings should have.
 	 * Supported for model version 004 and later. You can use this parameter to reduce the
 	 * embedding size, for example, for storage optimization.
 	 */
-	private @JsonProperty("dimensions") Integer dimensions;
+	private Integer dimensions;
 
 	/**
 	 * The start offset of the video segment in seconds. If not specified, it's calculated with max(0, endOffsetSec - 120).
 	 */
-	private @JsonProperty("videoStartOffsetSec") Integer videoStartOffsetSec;
+	private Integer videoStartOffsetSec;
 
 	/**
 	 * The end offset of the video segment in seconds. If not specified, it's calculated with min(video length, startOffSec + 120).
 	 * If both startOffSec and endOffSec are specified, endOffsetSec is adjusted to min(startOffsetSec+120, endOffsetSec).
 	 */
-	private @JsonProperty("videoEndOffsetSec") Integer videoEndOffsetSec;
+	private Integer videoEndOffsetSec;
 
 	/**
 	 * The interval of the video the embedding will be generated. The minimum value for interval_sec is 4.
@@ -98,7 +93,7 @@ public class VertexAiMultimodalEmbeddingOptions implements EmbeddingOptions {
 	 * of the interval. However, if the interval is larger than min(video length, 120s), it impacts the quality of the
 	 * generated embeddings. Default value: 16.
 	 */
-	private @JsonProperty("videoIntervalSec") Integer videoIntervalSec;
+	private Integer videoIntervalSec;
 
 
 	// @formatter:on

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingModel.java
@@ -167,23 +167,37 @@ public class VertexAiTextEmbeddingModel extends AbstractEmbeddingModel {
 	}
 
 	EmbeddingRequest buildEmbeddingRequest(EmbeddingRequest embeddingRequest) {
-		// Process runtime options
-		VertexAiTextEmbeddingOptions runtimeOptions = null;
-		if (embeddingRequest.getOptions() != null) {
-			runtimeOptions = ModelOptionsUtils.copyToTarget(embeddingRequest.getOptions(), EmbeddingOptions.class,
-					VertexAiTextEmbeddingOptions.class);
+		EmbeddingOptions requestOptions = embeddingRequest.getOptions();
+		VertexAiTextEmbeddingOptions options = this.defaultOptions;
+
+		if (requestOptions != null) {
+			VertexAiTextEmbeddingOptions.Builder builder = VertexAiTextEmbeddingOptions.builder()
+				.model(ModelOptionsUtils.mergeOption(requestOptions.getModel(), this.defaultOptions.getModel()))
+				.dimensions(ModelOptionsUtils.mergeOption(requestOptions.getDimensions(),
+						this.defaultOptions.getDimensions()));
+
+			if (requestOptions instanceof VertexAiTextEmbeddingOptions vertexOptions) {
+				builder
+					.taskType(ModelOptionsUtils.mergeOption(vertexOptions.getTaskType(),
+							this.defaultOptions.getTaskType()))
+					.title(ModelOptionsUtils.mergeOption(vertexOptions.getTitle(), this.defaultOptions.getTitle()))
+					.autoTruncate(ModelOptionsUtils.mergeOption(vertexOptions.getAutoTruncate(),
+							this.defaultOptions.getAutoTruncate()));
+			}
+			else {
+				builder.taskType(this.defaultOptions.getTaskType())
+					.title(this.defaultOptions.getTitle())
+					.autoTruncate(this.defaultOptions.getAutoTruncate());
+			}
+			options = builder.build();
 		}
 
-		// Define request options by merging runtime options and default options
-		VertexAiTextEmbeddingOptions requestOptions = ModelOptionsUtils.merge(runtimeOptions, this.defaultOptions,
-				VertexAiTextEmbeddingOptions.class);
-
 		// Validate request options
-		if (!StringUtils.hasText(requestOptions.getModel())) {
+		if (!StringUtils.hasText(options.getModel())) {
 			throw new IllegalArgumentException("model cannot be null or empty");
 		}
 
-		return new EmbeddingRequest(embeddingRequest.getInstructions(), requestOptions);
+		return new EmbeddingRequest(embeddingRequest.getInstructions(), options);
 	}
 
 	protected PredictRequest.Builder getPredictRequestBuilder(EmbeddingRequest request, EndpointName endpointName,

--- a/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingOptions.java
+++ b/models/spring-ai-vertex-ai-embedding/src/main/java/org/springframework/ai/vertexai/embedding/text/VertexAiTextEmbeddingOptions.java
@@ -16,10 +16,6 @@
 
 package org.springframework.ai.vertexai.embedding.text;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.springframework.ai.embedding.EmbeddingOptions;
 import org.springframework.util.StringUtils;
 
@@ -30,7 +26,6 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @since 1.0.0
  */
-@JsonInclude(Include.NON_NULL)
 public class VertexAiTextEmbeddingOptions implements EmbeddingOptions {
 
 	public static final String DEFAULT_MODEL_NAME = VertexAiTextEmbeddingModelName.TEXT_EMBEDDING_004.getName();
@@ -39,7 +34,7 @@ public class VertexAiTextEmbeddingOptions implements EmbeddingOptions {
 	 * The embedding model name to use. Supported models are: text-embedding-004,
 	 * text-multilingual-embedding-002 and multimodalembedding@001.
 	 */
-	private @JsonProperty("model") String model;
+	private String model;
 
 	// @formatter:off
 
@@ -47,25 +42,25 @@ public class VertexAiTextEmbeddingOptions implements EmbeddingOptions {
 	 * The intended downstream application to help the model produce better quality embeddings.
 	 * Not all model versions support all task types.
 	 */
-	private @JsonProperty("task") TaskType taskType;
+	private TaskType taskType;
 
 	/**
 	 * The number of dimensions the resulting output embeddings should have.
 	 * Supported for model version 004 and later. You can use this parameter to reduce the
 	 * embedding size, for example, for storage optimization.
 	 */
-	private @JsonProperty("dimensions") Integer dimensions;
+	private Integer dimensions;
 
 	/**
 	 * Optional title, only valid with task_type=RETRIEVAL_DOCUMENT.
 	 */
-	private @JsonProperty("title") String title;
+	private String title;
 
 	/**
 	 * When set to true, input text will be truncated. When set to false, an error is returned
 	 * if the input text is longer than the maximum length supported by the model. Defaults to true.
 	 */
-	private @JsonProperty("autoTruncate") Boolean autoTruncate;
+	private Boolean autoTruncate;
 
 	public static Builder builder() {
 		return new Builder();


### PR DESCRIPTION
This PR removes remaining usages of MOU.merge() and removes Jackson annotations from options classes.