### PR TITLE
Add RESPECT_JSONPROPERTY_ORDER to JsonSchemaGenerator  

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -90,7 +90,8 @@ public final class JsonSchemaGenerator {
 	 * Initialize JSON Schema generators.
 	 */
 	static {
-		Module jacksonModule = new JacksonSchemaModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED);
+		Module jacksonModule = new JacksonSchemaModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+				JacksonOption.RESPECT_JSONPROPERTY_ORDER);
 		Module openApiModule = new Swagger2Module();
 		Module springAiSchemaModule = PROPERTY_REQUIRED_BY_DEFAULT ? new SpringAiSchemaModule()
 				: new SpringAiSchemaModule(SpringAiSchemaModule.Option.PROPERTY_REQUIRED_FALSE_BY_DEFAULT);

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -705,25 +705,25 @@ class JsonSchemaGeneratorTests {
 	void generateSchemaForTypeWithJsonPropertyOrder() {
 		String schema = JsonSchemaGenerator.generateForType(OrderedPerson.class);
 		String expectedJsonSchema = """
-              {
-                  "$schema": "https://json-schema.org/draft/2020-12/schema",
-                  "type": "object",
-                  "properties": {
-                      "name": {
-                          "type": "string"
-                      },
-                      "email": {
-                          "type": "string"
-                      },
-                      "id": {
-                          "type": "integer",
-                          "format": "int32"
-                      }
-                  },
-                  "required": [ "name", "email", "id" ],
-                  "additionalProperties": false
-              }
-              """;
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "name": {
+				            "type": "string"
+				        },
+				        "email": {
+				            "type": "string"
+				        },
+				        "id": {
+				            "type": "integer",
+				            "format": "int32"
+				        }
+				    },
+				    "required": [ "name", "email", "id" ],
+				    "additionalProperties": false
+				}
+				""";
 
 		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
 	}
@@ -846,17 +846,29 @@ class JsonSchemaGeneratorTests {
 
 		private String email;
 
-		public int getId() { return this.id; }
+		public int getId() {
+			return this.id;
+		}
 
-		public void setId(int id) { this.id = id; }
+		public void setId(int id) {
+			this.id = id;
+		}
 
-		public String getName() { return this.name; }
+		public String getName() {
+			return this.name;
+		}
 
-		public void setName(String name) { this.name = name; }
+		public void setName(String name) {
+			this.name = name;
+		}
 
-		public String getEmail() { return this.email; }
+		public String getEmail() {
+			return this.email;
+		}
 
-		public void setEmail(String email) { this.email = email; }
+		public void setEmail(String email) {
+			this.email = email;
+		}
 
 	}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -700,6 +701,33 @@ class JsonSchemaGeneratorTests {
 			.hasMessage("type cannot be null");
 	}
 
+	@Test
+	void generateSchemaForTypeWithJsonPropertyOrder() {
+		String schema = JsonSchemaGenerator.generateForType(OrderedPerson.class);
+		String expectedJsonSchema = """
+              {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                      "name": {
+                          "type": "string"
+                      },
+                      "email": {
+                          "type": "string"
+                      },
+                      "id": {
+                          "type": "integer",
+                          "format": "int32"
+                      }
+                  },
+                  "required": [ "name", "email", "id" ],
+                  "additionalProperties": false
+              }
+              """;
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
 	static class TestMethods {
 
 		public void simpleMethod(String name, int age) {
@@ -806,6 +834,29 @@ class JsonSchemaGeneratorTests {
 		public void setEmail(String email) {
 			this.email = email;
 		}
+
+	}
+
+	@JsonPropertyOrder({ "name", "email", "id" })
+	static class OrderedPerson {
+
+		private int id;
+
+		private String name;
+
+		private String email;
+
+		public int getId() { return this.id; }
+
+		public void setId(int id) { this.id = id; }
+
+		public String getName() { return this.name; }
+
+		public void setName(String name) { this.name = name; }
+
+		public String getEmail() { return this.email; }
+
+		public void setEmail(String email) { this.email = email; }
 
 	}
 


### PR DESCRIPTION
 ## Problem                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                   
  `JsonSchemaGenerator` was missing `JacksonOption.RESPECT_JSONPROPERTY_ORDER`                                                                                                                                                                                                                                     
  in its `JacksonSchemaModule` configuration, while `BeanOutputConverter`                                                                                                                                                                                                                                          
  already includes it. As a result, `@JsonPropertyOrder` annotations were                                                                                                                                                                                                                                          
  ignored when generating JSON schemas via `ResponseFormat.jsonSchema()`.                                                                                                                                                                                                                                          
                                               
  ## Changes                                                                                                                                                                                                                                                                                                       
                                                                      
  - Add `JacksonOption.RESPECT_JSONPROPERTY_ORDER` to `JsonSchemaGenerator`                                                                                                                                                                                                                                        
  - Add test to verify `@JsonPropertyOrder` is respected in schema generation
                                                                                                                                                                                                                                                                                                                   
  See gh-5797      