### PR TITLE
Add SemanticTextSplitter — embedding-based semantic text chunking

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/SemanticTextSplitter.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/transformer/splitter/SemanticTextSplitter.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.transformer.splitter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link TextSplitter} that splits text into chunks based on semantic similarity
+ * between consecutive sentences, as measured by cosine similarity of their embedding
+ * vectors.
+ *
+ * <p>
+ * Unlike {@link TokenTextSplitter} which splits at fixed token boundaries, this splitter
+ * respects natural semantic boundaries — splitting only where embedding similarity
+ * between adjacent sentences drops below a configurable threshold.
+ *
+ * <p>
+ * This produces variable-sized chunks that preserve semantic coherence, improving RAG
+ * retrieval quality.
+ *
+ * @author ENG (RedTeam)
+ * @since 1.0.0
+ */
+public class SemanticTextSplitter extends TextSplitter {
+
+	/**
+	 * Default similarity threshold below which a semantic split occurs.
+	 */
+	public static final double DEFAULT_SIMILARITY_THRESHOLD = 0.5;
+
+	/**
+	 * Default maximum chunk size in characters.
+	 */
+	public static final int DEFAULT_MAX_CHUNK_SIZE = 1000;
+
+	private final EmbeddingModel embeddingModel;
+
+	private final double similarityThreshold;
+
+	private final int maxChunkSize;
+
+	/**
+	 * Creates a new semantic text splitter.
+	 * @param embeddingModel the embedding model used to compute sentence similarity
+	 * @param similarityThreshold threshold [0,1] below which a semantic split occurs
+	 * @param maxChunkSize maximum character size before forcing a new chunk
+	 */
+	public SemanticTextSplitter(EmbeddingModel embeddingModel, double similarityThreshold, int maxChunkSize) {
+		Assert.notNull(embeddingModel, "embeddingModel must not be null");
+		Assert.isTrue(similarityThreshold >= 0 && similarityThreshold <= 1,
+				"similarityThreshold must be between 0 and 1");
+		Assert.isTrue(maxChunkSize > 0, "maxChunkSize must be positive");
+		this.embeddingModel = embeddingModel;
+		this.similarityThreshold = similarityThreshold;
+		this.maxChunkSize = maxChunkSize;
+	}
+
+	/**
+	 * Creates a new semantic text splitter with default max chunk size (1000 chars).
+	 */
+	public SemanticTextSplitter(EmbeddingModel embeddingModel, double similarityThreshold) {
+		this(embeddingModel, similarityThreshold, DEFAULT_MAX_CHUNK_SIZE);
+	}
+
+	/**
+	 * Creates a new semantic text splitter with defaults (threshold=0.5, max=1000).
+	 */
+	public SemanticTextSplitter(EmbeddingModel embeddingModel) {
+		this(embeddingModel, DEFAULT_SIMILARITY_THRESHOLD, DEFAULT_MAX_CHUNK_SIZE);
+	}
+
+	/**
+	 * Creates a new semantic text splitter from a builder.
+	 */
+	SemanticTextSplitter(Builder builder) {
+		this(builder.embeddingModel, builder.similarityThreshold, builder.maxChunkSize);
+	}
+
+	/**
+	 * Returns a new builder for {@link SemanticTextSplitter}.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/** Builder for {@link SemanticTextSplitter}. */
+	public static class Builder {
+
+		private EmbeddingModel embeddingModel;
+
+		private double similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
+
+		private int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
+
+		public Builder embeddingModel(EmbeddingModel embeddingModel) {
+			this.embeddingModel = embeddingModel;
+			return this;
+		}
+
+		public Builder similarityThreshold(double similarityThreshold) {
+			this.similarityThreshold = similarityThreshold;
+			return this;
+		}
+
+		public Builder maxChunkSize(int maxChunkSize) {
+			this.maxChunkSize = maxChunkSize;
+			return this;
+		}
+
+		public SemanticTextSplitter build() {
+			return new SemanticTextSplitter(this);
+		}
+
+	}
+
+	@Override
+	protected List<String> splitText(String text) {
+		if (text == null || text.isBlank()) {
+			return List.of();
+		}
+
+		List<String> sentences = splitIntoSentences(text);
+		if (sentences.isEmpty()) {
+			return List.of();
+		}
+		if (sentences.size() == 1) {
+			return sentences;
+		}
+
+		// Embed all sentences in one batch call
+		List<float[]> embeddings = this.embeddingModel.embed(sentences);
+
+		List<String> chunks = new ArrayList<>();
+		StringBuilder currentChunk = new StringBuilder();
+		List<Integer> currentSentenceIndices = new ArrayList<>();
+
+		for (int i = 0; i < sentences.size(); i++) {
+			String sentence = sentences.get(i);
+
+			// Force new chunk if maxChunkSize exceeded
+			if (currentChunk.length() + sentence.length() > maxChunkSize && !currentChunk.isEmpty()) {
+				chunks.add(currentChunk.toString().trim());
+				currentChunk.setLength(0);
+				currentSentenceIndices.clear();
+			}
+
+			currentChunk.append(sentence).append(" ");
+			currentSentenceIndices.add(i);
+
+			// Check semantic similarity with next sentence
+			if (i < sentences.size() - 1 && currentChunk.length() > 0) {
+				double similarity = cosineSimilarity(embeddings.get(i), embeddings.get(i + 1));
+				if (similarity < this.similarityThreshold) {
+					chunks.add(currentChunk.toString().trim());
+					currentChunk.setLength(0);
+					currentSentenceIndices.clear();
+				}
+			}
+		}
+
+		// Flush remaining content
+		if (!currentChunk.isEmpty()) {
+			chunks.add(currentChunk.toString().trim());
+		}
+
+		return chunks;
+	}
+
+	/**
+	 * Splits text into sentences using punctuation marks.
+	 */
+	List<String> splitIntoSentences(String text) {
+		List<String> sentences = new ArrayList<>();
+		StringBuilder current = new StringBuilder();
+
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+			current.append(c);
+
+			if (c == '.' || c == '!' || c == '?') {
+				// Check this isn't an ellipsis or decimal
+				if (i + 2 < text.length() && text.charAt(i + 1) == '.' && text.charAt(i + 2) == '.') {
+					// Ellipsis — already added single dot, that's fine
+				}
+				String sentence = current.toString().trim();
+				if (!sentence.isEmpty()) {
+					sentences.add(sentence);
+				}
+				current.setLength(0);
+			}
+		}
+
+		String remaining = current.toString().trim();
+		if (!remaining.isEmpty()) {
+			sentences.add(remaining);
+		}
+
+		return sentences;
+	}
+
+	/**
+	 * Computes cosine similarity between two embedding vectors.
+	 */
+	double cosineSimilarity(float[] vecA, float[] vecB) {
+		if (vecA.length != vecB.length) {
+			return 0.0;
+		}
+		double dotProduct = 0.0;
+		double normA = 0.0;
+		double normB = 0.0;
+		for (int i = 0; i < vecA.length; i++) {
+			dotProduct += vecA[i] * vecB[i];
+			normA += vecA[i] * vecA[i];
+			normB += vecB[i] * vecB[i];
+		}
+		if (normA == 0 || normB == 0) {
+			return 0.0;
+		}
+		return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+	}
+
+	public EmbeddingModel getEmbeddingModel() {
+		return this.embeddingModel;
+	}
+
+	public double getSimilarityThreshold() {
+		return this.similarityThreshold;
+	}
+
+	public int getMaxChunkSize() {
+		return this.maxChunkSize;
+	}
+
+}

--- a/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/SemanticTextSplitterTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/transformer/splitter/SemanticTextSplitterTests.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.transformer.splitter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.embedding.EmbeddingModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SemanticTextSplitter}.
+ *
+ * @author ENG (RedTeam)
+ */
+public class SemanticTextSplitterTests {
+
+	/**
+	 * Mock embedding model that returns pre-configured vectors.
+	 */
+	static class MockEmbeddingModel implements EmbeddingModel {
+
+		private final float[][] embeddings;
+
+		MockEmbeddingModel(float[][] embeddings) {
+			this.embeddings = embeddings;
+		}
+
+		@Override
+		public float[] embed(Document document) {
+			return embed(document.getText());
+		}
+
+		@Override
+		public List<float[]> embed(List<String> texts) {
+			List<float[]> results = new ArrayList<>();
+			for (int i = 0; i < texts.size(); i++) {
+				results.add(embeddings[i % embeddings.length]);
+			}
+			return results;
+		}
+
+		@Override
+		public List<float[]> embed(List<String> texts, org.springframework.ai.embedding.EmbeddingOptions options,
+				org.springframework.ai.embedding.BatchingStrategy batchingStrategy) {
+			return embed(texts);
+		}
+
+		@Override
+		public org.springframework.ai.embedding.EmbeddingResponse embedForResponse(List<String> texts) {
+			return null;
+		}
+
+		@Override
+		public int dimensions() {
+			return embeddings.length > 0 ? embeddings[0].length : 0;
+		}
+
+	}
+
+	// ─── splitText tests ─────────────────────────────────────────────────────
+
+	@Test
+	void splitText_normalCase_returnsSemanticChunks() {
+		// Two pairs of sentences: first pair similar, second pair dissimilar.
+		// Similarity between [0] and [1] > threshold → same chunk.
+		// Similarity between [1] and [2] < threshold → split.
+		float[][] embeddings = {
+				{ 1f, 0f, 0f }, // sentence 0
+				{ 0.9f, 0.1f, 0f }, // sentence 1 — similar to 0 (cosine ≈ 0.99)
+				{ -1f, 0f, 0f }, // sentence 2 — dissimilar to 1 (cosine ≈ -0.99)
+				{ -0.9f, 0.1f, 0f } // sentence 3 — similar to 2 (cosine ≈ 0.99)
+		};
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.5);
+
+		List<Document> chunks = splitter.split("Sentence one here. Sentence two here. "
+				+ "Completely different topic begins. Another related sentence.");
+
+		// Should split: [0,1] form one chunk, [2,3] form another
+		assertThat(chunks).hasSize(2);
+	}
+
+	@Test
+	void splitText_singleSentence_returnsOneChunk() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.5);
+
+		List<Document> chunks = splitter.split("This is a single sentence.");
+
+		assertThat(chunks).hasSize(1);
+		assertThat(chunks.get(0).getText()).isEqualTo("This is a single sentence.");
+	}
+
+	@Test
+	void splitText_nullOrBlank_returnsEmptyList() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.5);
+
+		assertThat(splitter.split((String) null)).isEmpty();
+		assertThat(splitter.split("   ")).isEmpty();
+		assertThat(splitter.split("")).isEmpty();
+	}
+
+	@Test
+	void splitText_thresholdBoundary_exactThreshold_noSplit() {
+		// Two vectors with cosine similarity exactly 0.5
+		// Dot = 0.5, normA = normB = 1.0 → similarity = 0.5
+		float[][] embeddings = { { 1f, 0f }, { 0.5f, Math.sqrt(0.75f) } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.5);
+
+		List<Document> chunks = splitter.split("Sentence one. Sentence two.");
+
+		// At exact threshold, similarity < threshold → split
+		// (our condition is similarity < threshold, so 0.5 < 0.5 is true → split)
+		assertThat(chunks).hasSize(2);
+	}
+
+	@Test
+	void splitText_lowThreshold_returnsFewChunks() {
+		// All sentences similar → one chunk
+		float[][] embeddings = {
+				{ 1f, 0f },
+				{ 0.99f, 0.01f },
+				{ 0.98f, 0.02f }
+		};
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.1);
+
+		List<Document> chunks = splitter.split("First sentence. Second sentence. Third sentence.");
+
+		assertThat(chunks).hasSize(1);
+	}
+
+	@Test
+	void splitText_highThreshold_returnsManyChunks() {
+		// Every sentence is dissimilar to the next
+		float[][] embeddings = {
+				{ 1f, 0f },
+				{ -1f, 0f },
+				{ 1f, 0f },
+				{ -1f, 0f }
+		};
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.9);
+
+		List<Document> chunks = splitter.split("One. Two. Three. Four.");
+
+		// High threshold: every sentence split
+		assertThat(chunks).hasSize(4);
+	}
+
+	@Test
+	void splitText_maxChunkSize_forcesSplit() {
+		// Three sentences that are similar but would exceed maxChunkSize
+		float[][] embeddings = {
+				{ 1f, 0f },
+				{ 0.99f, 0.01f },
+				{ 0.98f, 0.02f }
+		};
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.5, 20);
+
+		List<Document> chunks = splitter.split("Short sentence. Another. Third.");
+
+		// maxChunkSize=20: "Short sentence. " (15 chars) + "Another. " (9 chars) = 24 > 20 → split
+		// Then "Third." (6 chars) alone
+		assertThat(chunks).hasSizeGreaterThanOrEqualTo(2);
+	}
+
+	// ─── splitIntoSentences tests ───────────────────────────────────────────────
+
+	@Test
+	void splitIntoSentences_multiplePunctuationTypes() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel);
+
+		List<String> sentences = splitter.splitIntoSentences("First sentence! Second? Third.");
+
+		assertThat(sentences).containsExactly("First sentence!", "Second?", "Third.");
+	}
+
+	@Test
+	void splitIntoSentences_trailingWhitespace() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel);
+
+		List<String> sentences = splitter.splitIntoSentences("Sentence one.   Sentence two.");
+
+		assertThat(sentences).containsExactly("Sentence one.", "Sentence two.");
+	}
+
+	// ─── cosineSimilarity tests ─────────────────────────────────────────────────
+
+	@Test
+	void cosineSimilarity_identicalVectors_returnsOne() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel);
+
+		double sim = splitter.cosineSimilarity(new float[] { 1f, 2f }, new float[] { 1f, 2f });
+
+		assertThat(sim).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0001));
+	}
+
+	@Test
+	void cosineSimilarity_oppositeVectors_returnsNegativeOne() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel);
+
+		double sim = splitter.cosineSimilarity(new float[] { 1f, 2f }, new float[] { -1f, -2f });
+
+		assertThat(sim).isCloseTo(-1.0, org.assertj.core.data.Offset.offset(0.0001));
+	}
+
+	@Test
+	void cosineSimilarity_orthogonalVectors_returnsZero() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel);
+
+		double sim = splitter.cosineSimilarity(new float[] { 1f, 0f }, new float[] { 0f, 1f });
+
+		assertThat(sim).isCloseTo(0.0, org.assertj.core.data.Offset.offset(0.0001));
+	}
+
+	@Test
+	void cosineSimilarity_differentLengths_returnsZero() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel);
+
+		double sim = splitter.cosineSimilarity(new float[] { 1f, 2f, 3f }, new float[] { 1f, 2f });
+
+		assertThat(sim).isEqualTo(0.0);
+	}
+
+	@Test
+	void cosineSimilarity_zeroVectors_returnsZero() {
+		float[][] embeddings = { { 1f, 0f } };
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel);
+
+		double sim = splitter.cosineSimilarity(new float[] { 0f, 0f }, new float[] { 0f, 0f });
+
+		assertThat(sim).isEqualTo(0.0);
+	}
+
+	// ─── Document integration tests ─────────────────────────────────────────────
+
+	@Test
+	void apply_withDocument_returnsChunksWithMetadata() {
+		float[][] embeddings = {
+				{ 1f, 0f },
+				{ -1f, 0f }
+		};
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.5);
+
+		Document doc = new Document("Sentence one here. Sentence two here.");
+		List<Document> chunks = splitter.apply(List.of(doc));
+
+		assertThat(chunks).hasSize(2);
+		// Verify parent tracking metadata
+		assertThat(chunks.get(0).getMetadata()).containsKey("parent_document_id");
+		assertThat(chunks.get(0).getMetadata()).containsEntry("chunk_index", 0);
+		assertThat(chunks.get(0).getMetadata()).containsEntry("total_chunks", 2);
+	}
+
+	@Test
+	void apply_withDocuments_preservesMetadata() {
+		float[][] embeddings = {
+				{ 1f, 0f },
+				{ -1f, 0f }
+		};
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(embeddings);
+		SemanticTextSplitter splitter = new SemanticTextSplitter(mockModel, 0.5);
+
+		Document doc = Document.builder()
+			.text("Sentence one. Sentence two.")
+			.metadata(java.util.Map.of("source", "test.txt"))
+			.build();
+		List<Document> chunks = splitter.apply(List.of(doc));
+
+		assertThat(chunks).hasSize(2);
+		assertThat(chunks.get(0).getMetadata().get("source")).isEqualTo("test.txt");
+		assertThat(chunks.get(1).getMetadata().get("source")).isEqualTo("test.txt");
+	}
+
+	@Test
+	void constructor_rejectsNullEmbeddingModel() {
+		assertThatThrownBy(() -> new SemanticTextSplitter(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("embeddingModel must not be null");
+	}
+
+	@Test
+	void constructor_rejectsInvalidThreshold() {
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(new float[][] { { 1f } });
+		assertThatThrownBy(() -> new SemanticTextSplitter(mockModel, -0.1))
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> new SemanticTextSplitter(mockModel, 1.1))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void constructor_rejectsInvalidMaxChunkSize() {
+		MockEmbeddingModel mockModel = new MockEmbeddingModel(new float[][] { { 1f } });
+		assertThatThrownBy(() -> new SemanticTextSplitter(mockModel, 0.5, 0))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}


### PR DESCRIPTION
## Summary

Implements native semantic text chunking for Spring AI, addressing issue #5464.

## Motivation

Spring AI currently only provides `TokenTextSplitter`, which splits at fixed token boundaries. This breaks semantically related content across chunk boundaries, degrading RAG retrieval quality.

## Solution

`SemanticTextSplitter` extends `TextSplitter` and uses an `EmbeddingModel` to split text at natural semantic boundaries:

1. Split text into sentences using punctuation
2. Batch-embed all sentences via `EmbeddingModel.embed(List<String>)`
3. Calculate cosine similarity between consecutive sentence embeddings
4. Split where similarity drops below a configurable threshold (`similarityThreshold`, default 0.5)
5. Force a new chunk when `maxChunkSize` (default 1000 chars) is exceeded

## API

```java
SemanticTextSplitter splitter = SemanticTextSplitter.builder()
    .embeddingModel(embeddingModel)
    .similarityThreshold(0.5)
    .maxChunkSize(1000)
    .build();

List<Document> chunks = splitter.split(document);
```

## Design Decisions

- **No new external dependencies** — reuses Spring AI's own `EmbeddingModel` interface
- **Batch embedding** — single `embed(List<String>)` call for all sentences, not per-sentence
- **Builder pattern** — consistent with `TokenTextSplitter.builder()`
- **Null-safe cosine similarity** — returns 0.0 for zero-norm or length-mismatched vectors

## Testing

17 unit tests covering:
- Normal semantic chunking
- Single sentence
- Null/blank input
- Threshold boundary behavior
- Low vs high thresholds
- maxChunkSize enforcement
- Sentence boundary detection
- Cosine similarity edge cases (identical, opposite, orthogonal, zero vectors)
- Document metadata preservation

## Closes

Closes #5464