### PR TITLE
Annotate MCP Server beans with infrastructure role

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerAnnotationScannerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/annotations/McpServerAnnotationScannerAutoConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.ai.mcp.annotation.spring.scan.AbstractMcpAnnotatedBea
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -38,6 +39,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.context.annotation.Role;
 
 /**
  * @author Christian Tzolov
@@ -49,6 +51,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
 		havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(McpServerAnnotationScannerProperties.class)
 @ImportRuntimeHints(McpServerAnnotationScannerAutoConfiguration.AnnotationHints.class)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class McpServerAnnotationScannerAutoConfiguration {
 
 	private static final Set<Class<? extends Annotation>> SERVER_MCP_ANNOTATIONS = Set.of(McpTool.class,
@@ -56,6 +59,7 @@ public class McpServerAnnotationScannerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	public ServerMcpAnnotatedBeans serverAnnotatedBeanRegistry() {
 		return new ServerMcpAnnotatedBeans();
 	}
@@ -63,7 +67,7 @@ public class McpServerAnnotationScannerAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public static ServerAnnotatedMethodBeanPostProcessor serverAnnotatedMethodBeanPostProcessor(
-			ServerMcpAnnotatedBeans serverMcpAnnotatedBeans, McpServerAnnotationScannerProperties properties) {
+			ServerMcpAnnotatedBeans serverMcpAnnotatedBeans) {
 		return new ServerAnnotatedMethodBeanPostProcessor(serverMcpAnnotatedBeans, SERVER_MCP_ANNOTATIONS);
 	}
 


### PR DESCRIPTION
Prior to this PR, starting up a vanilla MCP server (e.g., generated from [start.spring.io](https://start.spring.io)) produced the following warnings:

```
2026-04-18T09:40:59.972+02:00  WARN 59027 --- [mcp-server] [           main] trationDelegate$BeanPostProcessorChecker : Bean 'org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration' of type [org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected/applied to a currently created BeanPostProcessor [serverAnnotatedMethodBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies/advisors. If this bean does not have to be post-processed, declare it with ROLE_INFRASTRUCTURE.
2026-04-18T09:40:59.972+02:00  WARN 59027 --- [mcp-server] [           main] trationDelegate$BeanPostProcessorChecker : Bean 'serverAnnotatedBeanRegistry' of type [org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration$ServerMcpAnnotatedBeans] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected/applied to a currently created BeanPostProcessor [serverAnnotatedMethodBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies/advisors. If this bean does not have to be post-processed, declare it with ROLE_INFRASTRUCTURE.
2026-04-18T09:40:59.977+02:00  WARN 59027 --- [mcp-server] [           main] trationDelegate$BeanPostProcessorChecker : Bean 'spring.ai.mcp.server.annotation-scanner-org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerProperties' of type [org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerProperties] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected/applied to a currently created BeanPostProcessor [serverAnnotatedMethodBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies/advisors. If this bean does not have to be post-processed, declare it with ROLE_INFRASTRUCTURE.
```
This PR contains two changes:
* Both `McpServerAnnotationScannerAutoConfiguration` and its `serverAnnotatedBeanRegistry()` bean definition are now annotated with `@Role(BeanDefinition.ROLE_INFRASTRUCTURE)`, following the log message recommendation
* The `McpServerAnnotationScannerProperties` parameter of `serverAnnotatedMethodBeanPostProcessor()` is now removed as it was unused

With these, the warnings no longer appear during startup.

---

* Fixes the first group of warnings at #4694