### PR TITLE
Emit tool execution result in streaming Flux when streamToolCallResponses is enabled

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/TOOLCALLADVISOR_STREAMING_DESIGN.md
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/TOOLCALLADVISOR_STREAMING_DESIGN.md
@@ -131,10 +131,23 @@ ToolCallAdvisor advisor = ToolCallAdvisor.builder()
     .build();
 ```
 
-| Configuration | Intermediate Tool Calls | Final Answer |
-|--------------|------------------------|--------------|
-| `streamToolCallResponses(false)` (default) | Filtered out | Streamed |
-| `streamToolCallResponses(true)` | Streamed | Streamed |
+| Configuration | Assistant Tool-Call Chunk | Tool Execution Result Chunk | Final Answer |
+|--------------|---------------------------|-----------------------------|--------------|
+| `streamToolCallResponses(false)` (default) | Filtered out | Not emitted | Streamed |
+| `streamToolCallResponses(true)` | Streamed | Synthetic chunk emitted between iterations | Streamed |
+
+When enabled, the flow for a single tool-call round-trip is:
+
+```
+[assistant chunks + tool_calls] → [synthetic tool-response chunk] → [assistant final-answer chunks]
+```
+
+The synthetic tool-response chunk is built from the `ToolExecutionResult` via
+`ToolExecutionResult.buildGenerations(...)`, matching the shape used by the
+`returnDirect` path. Each generation carries the tool result text as the
+`AssistantMessage` content and the tool's id/name plus a `returnDirect` finish
+reason in `ChatGenerationMetadata`, so downstream consumers can distinguish a
+tool-response chunk from a normal model chunk.
 
 The filtering is implemented as a terminal filter on the stream:
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -341,7 +341,26 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 				// Recursive call with updated conversation history
 				List<Message> nextInstructions = this.doGetNextInstructionsForToolCallStream(finalRequest,
 						finalAggregatedResponse, toolExecutionResult);
-				return this.internalStream(streamAdvisorChain, originalRequest, optionsCopy, nextInstructions);
+				Flux<ChatClientResponse> recursiveStream = this.internalStream(streamAdvisorChain, originalRequest,
+						optionsCopy, nextInstructions);
+
+				// When tool-call streaming is enabled, emit the tool execution result as
+				// an intermediate chunk before the recursive stream of the model's
+				// follow-up answer. This closes the gap in the streamed Flux between
+				// the assistant's tool-call request and the next model turn, giving
+				// downstream consumers visibility into the tool's response data.
+				if (this.streamToolCallResponses) {
+					ChatResponse toolResponseChatResponse = ChatResponse.builder()
+						.from(chatResponse)
+						.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
+						.build();
+					ChatClientResponse toolResponseChatClientResponse = finalAggregatedResponse.mutate()
+						.chatResponse(toolResponseChatResponse)
+						.build();
+					return Flux.just(toolResponseChatClientResponse).concatWith(recursiveStream);
+				}
+
+				return recursiveStream;
 			}
 		});
 		return toolCallFlux.subscribeOn(Schedulers.boundedElastic());

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
@@ -645,8 +645,13 @@ public class ToolCallAdvisorTests {
 			.build();
 
 		// Mock tool execution result
+		ToolResponseMessage.ToolResponse toolResponse = new ToolResponseMessage.ToolResponse("tool-call-1", "testTool",
+				"Tool result data");
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(toolResponse))
+			.build();
 		List<Message> conversationHistory = List.of(new UserMessage("test"),
-				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+				AssistantMessage.builder().content("").build(), toolResponseMessage);
 		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
 			.conversationHistory(conversationHistory)
 			.build();
@@ -655,10 +660,69 @@ public class ToolCallAdvisorTests {
 
 		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
 
-		// With streamToolCallResponses(true), we get both the intermediate tool call
-		// response (streamed in real-time) and the final response from recursive call
-		assertThat(results).isNotNull().hasSize(2);
-		assertThat(callCount[0]).isEqualTo(2); // Both iterations still happen
+		// With streamToolCallResponses(true), we get three emissions: the assistant
+		// chunk requesting the tool call, the synthetic tool response chunk, and the
+		// final response from the recursive call.
+		assertThat(results).isNotNull().hasSize(3);
+		assertThat(callCount[0]).isEqualTo(2); // Both model iterations still happen
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+
+		ChatResponse toolResponseChunk = results.get(1).chatResponse();
+		assertThat(toolResponseChunk).isNotNull();
+		assertThat(toolResponseChunk.getResults()).hasSize(1);
+		assertThat(toolResponseChunk.getResults().get(0).getOutput().getText()).isEqualTo("Tool result data");
+		assertThat(toolResponseChunk.getResults().get(0).getMetadata().getFinishReason())
+			.isEqualTo(ToolExecutionResult.FINISH_REASON);
+		assertThat(
+				toolResponseChunk.getResults().get(0).getMetadata().<String>get(ToolExecutionResult.METADATA_TOOL_ID))
+			.isEqualTo("tool-call-1");
+		assertThat(
+				toolResponseChunk.getResults().get(0).getMetadata().<String>get(ToolExecutionResult.METADATA_TOOL_NAME))
+			.isEqualTo("testTool");
+	}
+
+	@Test
+	void testAdviseStreamWithToolCallResponsesDisabledDoesNotEmitToolResponse() {
+		// Explicitly disable tool call response streaming. The synthetic tool response
+		// chunk must NOT be emitted and only the final response should be visible.
+		ToolCallAdvisor advisor = ToolCallAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.streamToolCallResponses(false)
+			.build();
+
+		ChatClientRequest request = createMockRequest(true);
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+		ChatClientResponse finalResponse = createMockResponse(false);
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			return Flux.just(callCount[0] == 1 ? responseWithToolCall : finalResponse);
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		ToolResponseMessage.ToolResponse toolResponse = new ToolResponseMessage.ToolResponse("tool-call-1", "testTool",
+				"Tool result data");
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(toolResponse))
+			.build();
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), toolResponseMessage);
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		// Only the final model response is emitted; the tool call request chunk and
+		// the synthetic tool response chunk are both suppressed.
+		assertThat(results).isNotNull().hasSize(1);
+		assertThat(callCount[0]).isEqualTo(2);
 		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/advisors-recursive.adoc
@@ -86,6 +86,58 @@ var chatClient = ChatClient.builder(chatModel)
     .build();
 ----
 
+==== Streaming Tool Call Responses
+
+When the `ToolCallAdvisor` runs through the streaming API (`ChatClient ... .stream()`), it aggregates the model's chunks, executes any requested tool calls, and then recurses to stream the follow-up turn. By default the intermediate chunks that carry the tool-call request (the ones where `ChatResponse.hasToolCalls()` is `true`) are *filtered out* of the downstream `Flux`, so consumers only observe the final assistant answer.
+
+To see the complete tool-call round-trip in the stream, enable `streamToolCallResponses(true)` on the builder:
+
+[source,java]
+----
+var toolCallAdvisor = ToolCallAdvisor.builder()
+    .toolCallingManager(toolCallingManager)
+    .streamToolCallResponses(true)
+    .build();
+----
+
+With the flag enabled, for each tool-call iteration the `Flux<ChatClientResponse>` now emits, in order:
+
+1. The streamed assistant chunks that contain the model's tool-call request (`ChatResponse.hasToolCalls()` is `true`).
+2. A *synthetic* `ChatClientResponse` carrying the tool execution result. This chunk is built via `ToolExecutionResult.buildGenerations(...)`, so each `Generation` carries:
+   * the tool's raw output as the `AssistantMessage` content,
+   * `finishReason == ToolExecutionResult.FINISH_REASON` (the string `"returnDirect"`),
+   * `ChatGenerationMetadata` entries under the keys `ToolExecutionResult.METADATA_TOOL_ID` and `ToolExecutionResult.METADATA_TOOL_NAME`.
+3. The streamed assistant chunks of the model's follow-up answer.
+
+Consumers that want to react to each phase should subscribe via `stream().chatClientResponse()` and branch on `finishReason` / the tool metadata keys to distinguish the synthetic tool-response chunk from normal model chunks. Example:
+
+[source,java]
+----
+chatClient.prompt()
+    .advisors(ToolCallAdvisor.builder().streamToolCallResponses(true).build())
+    .user("What's the weather in Tokyo?")
+    .toolCallbacks(weatherTool)
+    .stream()
+    .chatClientResponse()
+    .subscribe(event -> {
+        var generation = event.chatResponse().getResult();
+        var metadata = generation.getMetadata();
+        if (ToolExecutionResult.FINISH_REASON.equals(metadata.getFinishReason())) {
+            String toolName = metadata.get(ToolExecutionResult.METADATA_TOOL_NAME);
+            String toolOutput = generation.getOutput().getText();
+            // render tool result in UI, log it, etc.
+        }
+        else if (event.chatResponse().hasToolCalls()) {
+            // model is requesting a tool call
+        }
+        else {
+            // normal assistant chunk of the final answer
+        }
+    });
+----
+
+When `streamToolCallResponses` is left at its default (`false`), both the assistant tool-call chunks and the synthetic tool-response chunk are suppressed and only the model's final answer is streamed — preserving the simplest consumer contract.
+
 ==== Return Direct Functionality
 
 The "return direct" feature allows tools to bypass the LLM and return their results directly to the client application. This is useful when:

--- a/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorIT.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorIT.java
@@ -27,10 +27,14 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.ai.tool.metadata.ToolMetadata;
@@ -272,6 +276,42 @@ public abstract class AbstractToolCallAdvisorIT {
 			// With returnDirect=true, the raw tool result is returned without LLM
 			// processing
 			assertThat(content).contains("temp");
+		}
+
+		@Test
+		void streamEmitsToolResponseChunkWhenEnabled() {
+			// With streamToolCallResponses(true), the Flux must contain an intermediate
+			// ChatClientResponse that carries the tool execution result, distinguishable
+			// by finishReason == FINISH_REASON and the tool id/name metadata keys.
+			List<ChatClientResponse> events = ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(ToolCallAdvisor.builder().streamToolCallResponses(true).build())
+				.user("What's the weather like in Tokyo in Celsius?")
+				.toolCallbacks(createWeatherToolCallback())
+				.stream()
+				.chatClientResponse()
+				.collectList()
+				.block();
+
+			assertThat(events).isNotNull().isNotEmpty();
+
+			List<Generation> toolResponseGenerations = Objects.requireNonNull(events)
+				.stream()
+				.map(ChatClientResponse::chatResponse)
+				.filter(Objects::nonNull)
+				.map(ChatResponse::getResult)
+				.filter(Objects::nonNull)
+				.filter(generation -> ToolExecutionResult.FINISH_REASON
+					.equals(generation.getMetadata().getFinishReason()))
+				.collect(Collectors.toList());
+
+			assertThat(toolResponseGenerations).as("expected at least one synthetic tool-response chunk in the stream")
+				.isNotEmpty();
+			assertThat(toolResponseGenerations).allSatisfy(generation -> {
+				var metadata = generation.getMetadata();
+				assertThat(metadata.<String>get(ToolExecutionResult.METADATA_TOOL_NAME)).isEqualTo("getCurrentWeather");
+				assertThat(metadata.<String>get(ToolExecutionResult.METADATA_TOOL_ID)).isNotBlank();
+			});
 		}
 
 	}


### PR DESCRIPTION
**Summary**
- Closes the emission gap in `ToolCallAdvisor`'s streaming path so that, when `streamToolCallResponses(true)` is set, the downstream `Flux<ChatClientResponse>` now includes a synthetic chunk carrying the tool execution result between the model's tool-call request and its follow-up answer.
- Opt-in and additive: default behavior (`streamToolCallResponses=false`) is unchanged, and no existing advisor implementation is touched. The fix is confined to `ToolCallAdvisor.handleToolCallRecursion`.

**Context**
Reported in #5792: consumers of `ChatClient ... .stream()` observe that `ChatResponse.toolCalls` is "always empty". The underlying cause is the default filter in `ToolCallAdvisor` that drops any chunk where `hasToolCalls()` is `true`. Setting `streamToolCallResponses(true)` restores those chunks — but even with the flag on, the tool *execution result* was never emitted into the `Flux` for the non-`returnDirect` path, so the full round-trip was not observable downstream.

This PR is intentionally scoped as **short-term**: a narrow, zero-breakage fix that reuses the existing flag to make the round-trip fully visible. #5820(@cijaaimee) remains the long-term direction as a follow-up.

**Behavior**
With `streamToolCallResponses(true)`, per tool-call iteration the `Flux` now emits, in order:
1. Streamed assistant chunks that carry the model's tool-call request (`ChatResponse.hasToolCalls() == true`).
2. **New:** a synthetic `ChatClientResponse` whose `ChatResponse` is built via `ToolExecutionResult.buildGenerations(...)` — same shape the `returnDirect` path already uses. Each `Generation`:
   - has the tool's raw output as the `AssistantMessage` content,
   - has `finishReason == ToolExecutionResult.FINISH_REASON` (`"returnDirect"`),
   - carries `ToolExecutionResult.METADATA_TOOL_ID` and `METADATA_TOOL_NAME` in `ChatGenerationMetadata`.
3. Streamed assistant chunks of the model's final answer.

With `streamToolCallResponses(false)` (default) the synthetic chunk is **not** emitted and the existing filter continues to suppress the assistant tool-call chunk, so downstream consumers on the default path observe only the final answer — no behavior change.

**What this does not do**
- It does not flip the `streamToolCallResponses` default. Consumers who want visibility still need to opt in explicitly.
- It does not introduce a typed advisor-chain event model — that is #5820.

closes : #5792 
