### PR TITLE
Prevent OutOfMemoryError in ForkPDFLayoutTextStripper for zero-height whitespace

### DIFF
--- a/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/layout/ForkPDFLayoutTextStripper.java
+++ b/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/layout/ForkPDFLayoutTextStripper.java
@@ -48,10 +48,13 @@ public class ForkPDFLayoutTextStripper extends PDFTextStripper {
 
 	/**
 	 * Defensive upper bound on the number of empty lines that may be inserted between two
-	 * consecutive {@link TextPosition}s. Any real PDF layout produces a value well below
-	 * this; anything higher indicates a malformed document (see gh-5829).
+	 * consecutive {@link TextPosition}s. Chosen well below the threshold where
+	 * {@code ExtractedTextFormatter.trimAdjacentBlankLines} becomes unstable on long
+	 * blank-line runs (gh-2247), so the stripper's output can always be safely fed
+	 * through the default reader pipeline. Covers any realistic paragraph or section
+	 * break; anything higher indicates a malformed document (see gh-5829).
 	 */
-	static final int MAX_NEW_LINES_PER_POSITION_GAP = 500;
+	static final int MAX_NEW_LINES_PER_POSITION_GAP = 20;
 
 	private double currentPageWidth;
 

--- a/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/layout/ForkPDFLayoutTextStripper.java
+++ b/document-readers/pdf-reader/src/main/java/org/springframework/ai/reader/pdf/layout/ForkPDFLayoutTextStripper.java
@@ -46,6 +46,13 @@ public class ForkPDFLayoutTextStripper extends PDFTextStripper {
 
 	public static final int OUTPUT_SPACE_CHARACTER_WIDTH_IN_PT = 4;
 
+	/**
+	 * Defensive upper bound on the number of empty lines that may be inserted between two
+	 * consecutive {@link TextPosition}s. Any real PDF layout produces a value well below
+	 * this; anything higher indicates a malformed document (see gh-5829).
+	 */
+	static final int MAX_NEW_LINES_PER_POSITION_GAP = 500;
+
 	private double currentPageWidth;
 
 	private @Nullable TextPosition previousTextPosition;
@@ -169,8 +176,17 @@ public class ForkPDFLayoutTextStripper extends PDFTextStripper {
 
 		if (textYPosition > previousTextYPosition && (textYPosition - previousTextYPosition > 5.5)) {
 			double height = textPosition.getHeight();
+			// gh-5829: degenerate TextPositions (e.g. zero-height whitespace with a
+			// y-offset greater than 5.5) would otherwise compute
+			// Math.floor(delta) / 0.0 == POSITIVE_INFINITY, cast to Integer.MAX_VALUE,
+			// and trigger a multi-hundred-GB allocation in createNewEmptyNewLines.
+			// Fall back to the existing minimum (1) when we cannot compute a
+			// meaningful line count.
+			if (!Double.isFinite(height) || height <= 0.0) {
+				return 1;
+			}
 			int numberOfLines = (int) (Math.floor(textYPosition - previousTextYPosition) / height);
-			numberOfLines = Math.max(1, numberOfLines - 1); // exclude current new line
+			numberOfLines = Math.max(1, Math.min(numberOfLines - 1, MAX_NEW_LINES_PER_POSITION_GAP));
 			if (DEBUG) {
 				System.out.println(height + " " + numberOfLines);
 			}

--- a/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderOomTests.java
+++ b/document-readers/pdf-reader/src/test/java/org/springframework/ai/reader/pdf/PagePdfDocumentReaderOomTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.reader.pdf;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.pdfbox.util.Matrix;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.springframework.core.io.FileSystemResource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression test for gh-5829. Consecutive whitespace {@code TextPosition}s with
+ * {@code height == 0.0} separated by more than 5.5 points along the Y axis used to cause
+ * a division by zero inside
+ * {@code ForkPDFLayoutTextStripper.getNumberOfNewLinesFromPreviousTextPosition}, which
+ * yielded {@code Double.POSITIVE_INFINITY}, cast to {@code Integer.MAX_VALUE} and
+ * triggered an allocation of up to ~400 GiB worth of line buffers.
+ *
+ * @author Bapuji Koraganti
+ */
+class PagePdfDocumentReaderOomTests {
+
+	@TempDir(cleanup = CleanupMode.ON_SUCCESS)
+	Path workingDir;
+
+	@Test
+	void readsPdfWithOffsetZeroHeightWhitespaceWithoutOom() throws IOException {
+		Path pdf = this.workingDir.resolve("offset-whitespace.pdf");
+		generateOffsetWhitespacePdf(pdf);
+
+		PagePdfDocumentReader reader = new PagePdfDocumentReader(new FileSystemResource(pdf));
+		assertThatCode(reader::get).doesNotThrowAnyException();
+	}
+
+	/**
+	 * Minimal reproducer distilled from the original report: two consecutive whitespace
+	 * glyphs rendered with a zero-size font and separated by more than 5.5 points along
+	 * the Y axis. Matches the pattern the reporter found on the authors section of
+	 * https://www.clinical-lung-cancer.com/article/S1525-7304(22)00115-2/fulltext.
+	 */
+	static void generateOffsetWhitespacePdf(Path path) throws IOException {
+		try (PDDocument doc = new PDDocument()) {
+			PDPage page = new PDPage();
+			doc.addPage(page);
+
+			PDType1Font mainFont = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
+			PDType1Font boldFont = new PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD);
+			PDType1Font italicFont = new PDType1Font(Standard14Fonts.FontName.HELVETICA_OBLIQUE);
+
+			try (PDPageContentStream contents = new PDPageContentStream(doc, page)) {
+				contents.beginText();
+				contents.setFont(boldFont, 22);
+				contents.newLineAtOffset(50, 750);
+				contents.showText("A Study on AI-Driven PDF Parsing");
+				contents.endText();
+
+				contents.beginText();
+				contents.setFont(mainFont, 12);
+				contents.newLineAtOffset(50, 720);
+				contents.showText("John Doe");
+
+				contents.setTextMatrix(Matrix.getTranslateInstance(110, 728));
+				contents.showText("1");
+
+				// Trigger: first whitespace at superscript baseline, height == 0.0.
+				contents.setFont(mainFont, 0);
+				contents.showText(" ");
+				contents.endText();
+
+				// Trigger: second whitespace, > 5.5 points above the previous Y.
+				contents.beginText();
+				contents.setFont(mainFont, 0);
+				contents.setTextMatrix(Matrix.getTranslateInstance(120, 740));
+				contents.showText(" ");
+				contents.endText();
+
+				contents.beginText();
+				contents.setFont(mainFont, 12);
+				contents.setTextMatrix(Matrix.getTranslateInstance(135, 720));
+				contents.showText("Jane Smith");
+
+				contents.setTextMatrix(Matrix.getTranslateInstance(200, 728));
+				contents.showText("2");
+				contents.endText();
+
+				contents.beginText();
+				contents.setFont(mainFont, 0);
+				contents.showText(" ");
+				contents.endText();
+
+				contents.beginText();
+				contents.setFont(italicFont, 9);
+				contents.newLineAtOffset(50, 150);
+				contents.showText("1. Department of Large Integers, Spring AI University");
+				contents.endText();
+
+				contents.beginText();
+				contents.setFont(italicFont, 9);
+				contents.newLineAtOffset(50, 135);
+				contents.showText("2. Division of Divide-by-Zero, Overflow Institute");
+				contents.endText();
+
+				contents.beginText();
+				contents.setFont(mainFont, 8);
+				contents.newLineAtOffset(50, 110);
+				contents.showText("Correspondence: test@test.edu");
+				contents.endText();
+
+				contents.beginText();
+				contents.setFont(mainFont, 8);
+				contents.newLineAtOffset(240, 30);
+				contents.showText("Document generated for Spring AI Bug Report");
+				contents.endText();
+			}
+
+			doc.save(path.toFile());
+		}
+	}
+
+}


### PR DESCRIPTION
**Fixes**: #5829

**Summary**

- `ForkPDFLayoutTextStripper.getNumberOfNewLinesFromPreviousTextPosition` now guards against non-positive and non-finite `TextPosition.getHeight()`, and caps the resulting line count at 500. Removes a division-by-zero path that produced `Double.POSITIVE_INFINITY → Integer.MAX_VALUE → ~400 GiB` of `TextLine` allocations.
- Narrow in scope: one method in one file + a regression test. Default behavior on well-formed input is unchanged.

**Root cause**
Two consecutive whitespace `TextPosition`s with `height == 0.0`, separated by more than 5.5 points along the Y axis, hit the division-by-zero branch in `getNumberOfNewLinesFromPreviousTextPosition`:
1. `Math.floor(delta) / 0.0` → `Double.POSITIVE_INFINITY`
2. `(int) POSITIVE_INFINITY` → `Integer.MAX_VALUE`
3. `createNewEmptyNewLines(~2.1B)` allocates a `TextLine` per iteration, each with a `char[]` sized by the page width — hundreds of GB of attempted allocation → heap OOM.

The pattern occurs naturally in published PDFs (the reporter hit it on the authors section of an open-access journal article). That makes this reachable from untrusted PDF input — DoS-flavored..

**Fix**
- Primary guard: if `!Double.isFinite(height) || height <= 0.0`, return `1` (matches the existing `Math.max(1, ...)` floor — a Y-delta > 5.5 points still warrants at least one line break; we just can't compute an exact count without a valid height).
- Defensive cap: clamp `numberOfLines` at `MAX_NEW_LINES_PER_POSITION_GAP = 500`, covering legitimate-but-tiny positive heights (e.g. 0.001) that would otherwise produce thousands of spurious blank lines.. Any real PDF layout is well below 500.

No API change, no autoconfig change. Well-formed input path is unchanged.

**Validation**

Added `PagePdfDocumentReaderOomTests` with a deterministic PDF reproducer (adapted from the reporter's minimal example).
**Before the fix** on `main`, with a 512 MB heap cap:
java.lang.OutOfMemoryError: Java heap space
at TextLine.<init>(TextLine.java:41)
at ForkPDFLayoutTextStripper.addNewLine(ForkPDFLayoutTextStripper.java:185)
at ForkPDFLayoutTextStripper.createNewEmptyNewLines(ForkPDFLayoutTextStripper.java:157)
BUILD FAILURE (21.9 s)

**After the fix**, normal heap:
Tests run: 1, Failures: 0, Errors: 0 — 0.194 s


**Test plan**
- [x] `./mvnw -pl document-readers/pdf-reader -Dtest=PagePdfDocumentReaderOomTests test` — passes in 194 ms; reproduces OOM on `main` under `-Xmx512m`.
- [x] `./mvnw -pl document-readers/pdf-reader -am verify` — spring-javaformat:validate, checkstyle clean..
- [ ] Cross-check against the reporter's original PDF (https://www.clinical-lung-cancer.com/action/showPdf?pii=S1525-7304%2822%2900115-2) — not run locally; the synthesized reproducer test exercises the same code path.

**Backport candidates**
Happy to open backport PRs as required for previous versions - once this lands on `main`.