### PR TITLE
GH-5832: Fix StructuredOutputValidationAdvisor to validate all results

### DIFF
--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
@@ -250,9 +250,23 @@ public final class WebFluxSseServerTransportProvider implements McpServerTranspo
 			.then();
 	}
 
-	// FIXME: This javadoc makes claims about using isClosing flag but it's not
-	// actually
-	// doing that.
+	/**
+	 * Sends a JSON-RPC notification to a specific client session through its SSE
+	 * connection.
+	 *
+	 * <p>
+	 * The method:
+	 * <ul>
+	 * <li>Looks up the session by the given session ID</li>
+	 * <li>Returns an empty Mono if the session is not found</li>
+	 * <li>Sends the notification to the specific session if found</li>
+	 * </ul>
+	 * @param sessionId The ID of the target client session
+	 * @param method The JSON-RPC method to send to the client
+	 * @param params The method parameters to send to the client
+	 * @return A Mono that completes when the notification has been sent, or empty if the
+	 * session is not found
+	 */
 
 	@Override
 	public Mono<Void> notifyClient(String sessionId, String method, Object params) {

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -180,20 +180,28 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 	@SuppressWarnings("null")
 	private SchemaValidation validateOutputSchema(ChatClientResponse chatClientResponse) {
 
-		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResult() == null
-				|| chatClientResponse.chatResponse().getResult().getOutput() == null
-				|| chatClientResponse.chatResponse().getResult().getOutput().getText() == null) {
+		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResults() == null
+				|| chatClientResponse.chatResponse().getResults().isEmpty()) {
 
 			logger.warn("ChatClientResponse is missing required json output for validation.");
 			return SchemaValidation.failed("Missing required json output for validation.");
 		}
 
-		// TODO: should we consider validation for multiple results?
-		String json = chatClientResponse.chatResponse().getResult().getOutput().getText();
+		for (var result : chatClientResponse.chatResponse().getResults()) {
+			if (result == null || result.getOutput() == null || result.getOutput().getText() == null) {
+				logger.warn("ChatClientResponse result is missing required json output for validation.");
+				return SchemaValidation.failed("Missing required json output for validation.");
+			}
 
-		logger.debug("Validating JSON output against schema. Attempts left: {}", this.maxRepeatAttempts);
+			logger.debug("Validating JSON output against schema. Attempts left: {}", this.maxRepeatAttempts);
 
-		return validateJsonText(json);
+			SchemaValidation validation = validateJsonText(result.getOutput().getText());
+			if (!validation.success()) {
+				return validation;
+			}
+		}
+
+		return SchemaValidation.passed();
 	}
 
 	private SchemaValidation validateJsonText(String json) {


### PR DESCRIPTION
## What
Fixes **`validateOutputSchema()`** to validate all results in a **`ChatResponse`** 
instead of only the first one.

## Why
**`ChatResponse.getResult()`** returns only the first result. When multiple results 
exist, the remaining ones were silently skipped invalid JSON could pass 
validation undetected.

Addresses the TODO comment on line 191:
**`// TODO: should we consider validation for multiple results?`**

## How
Replaced **`getResult()`** with **`getResults()`** and added a loop to validate each 
result individually. Returns the first validation failure encountered.

Closes #5832