### PR TITLE
JsonParser: handle raw strings for jsr310 types

### DIFF
--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/SyncMcpToolMethodCallbackTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp.annotation.method.tool;
 
 import java.lang.reflect.Method;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -28,6 +29,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.mcp.annotation.McpTool;
@@ -535,6 +537,25 @@ public class SyncMcpToolMethodCallbackTests {
 				["test", "42"]"""));
 	}
 
+	@Test
+	@Disabled("Disabled for CI until the spring-ai-model SNAPSHOT has been published")
+	public void testToolWithDateParameter() throws Exception {
+		TestToolProvider provider = new TestToolProvider();
+		Method method = TestToolProvider.class.getMethod("dateTool", LocalDate.class);
+		SyncMcpToolMethodCallback callback = new SyncMcpToolMethodCallback(ReturnMode.TEXT, method, provider);
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		CallToolRequest request = new CallToolRequest("date-tool", Map.of("date", "2026-04-22"));
+
+		CallToolResult result = callback.apply(exchange, request);
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("Date: 2026-04-22");
+	}
+
 	private static class TestToolProvider {
 
 		@McpTool(name = "simple-tool", description = "A simple tool")
@@ -632,6 +653,11 @@ public class SyncMcpToolMethodCallbackTests {
 		@McpTool(name = "return-list-string-tool", description = "Tool that returns a list of complex objects")
 		public List<String> returnListStringTool(String name, int value) {
 			return List.of(name, String.valueOf(value));
+		}
+
+		@McpTool(name = "local-date-tool", description = "Tool with date input")
+		public String dateTool(@McpToolParam LocalDate date) {
+			return "Date: " + date.toString();
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/JsonParser.java
@@ -176,8 +176,11 @@ public final class JsonParser {
 			try {
 				result = JsonParser.fromJson(jsonString, javaType);
 			}
-			catch (JacksonException e) {
-				// ignore
+			catch (IllegalStateException e) {
+				// If the type is a raw string that should read as JSON String,
+				// parsing will fail but pass the following toJson -> fromJson cycle.
+				// Example: LocalDate, with jsonString = "2026-04-22", which is not valid
+				// JSON. Instead, it should be "\"2026-04-22\"".
 			}
 		}
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.util.json;
 
 import java.lang.reflect.Type;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.type.TypeReference;
@@ -276,6 +277,13 @@ class JsonParserTests {
 		String input = "[1,2,3]";
 		String result = JsonParser.toJson(input);
 		assertThat(input).isEqualTo(result);
+	}
+
+	@Test
+	void localDateTime() {
+		String input = "2026-04-19T07:12:00";
+		LocalDateTime result = (LocalDateTime) JsonParser.toTypedObject(input, LocalDateTime.class);
+		assertThat(result.getYear()).isEqualTo(2026);
 	}
 
 	record TestRecord(String name, Integer age) {


### PR DESCRIPTION
MCP tool objects don't work with JSR310 types. E.g.

```java
@McpTool(name = "local-date-tool", description = "Tool with date input")
public String dateTool(@McpToolParam LocalDate date) {
	return "Date: " + date.toString();
}
```

when called with `{ "date": "2026-04-20" }` will produce the following error:

```
Conversion from JSON to java.time.LocalDate failed
Unexpected character ('-' (code 45)): Expected space separating root-level values
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); byte offset: #UNKNOWN]
```

This is a hotfix rather than a deep investigation into the intricacies of our JSON parsing setup.