### PR TITLE
Fix NPE in ChatClientRequest when context contains null values

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientRequest.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientRequest.java
@@ -37,6 +37,11 @@ public record ChatClientRequest(Prompt prompt, Map<String, Object> context) {
 		Assert.notNull(prompt, "prompt cannot be null");
 		Assert.notNull(context, "context cannot be null");
 		Assert.noNullElements(context.keySet(), "context keys cannot be null");
+		for (Map.Entry<String, @Nullable Object> entry : context.entrySet()) {
+			if (entry.getValue() == null) {
+				throw new IllegalArgumentException("context value for key '" + entry.getKey() + "' cannot be null");
+			}
+		}
 	}
 
 	public ChatClientRequest copy() {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientRequestNullContextTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientRequestNullContextTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ChatClientRequest} null context value validation.
+ *
+ * @author Research Agent
+ * @since 1.0.0
+ */
+class ChatClientRequestNullContextTests {
+
+	@Test
+	void whenContextHasNullValueViaConstructorThenThrow() {
+		Map<String, Object> context = new HashMap<>();
+		context.put("tenantId", null);
+		context.put("otherKey", "value");
+
+		assertThatThrownBy(() -> new ChatClientRequest(new Prompt(), context))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("context value for key 'tenantId' cannot be null");
+	}
+
+	@Test
+	void whenContextHasNullValueViaBuilderContextMethodThenThrow() {
+		// Build will fail because the record constructor validates null values
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context("tenantId", null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("context value for key 'tenantId' cannot be null");
+	}
+
+	@Test
+	void whenContextHasNullValueViaBuilderMapThenThrow() {
+		Map<String, Object> contextWithNull = new HashMap<>();
+		contextWithNull.put("tenantId", null);
+		contextWithNull.put("userId", "user123");
+
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context(contextWithNull).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("context value for key 'tenantId' cannot be null");
+	}
+
+	@Test
+	void whenContextHasMultipleNullValuesThenReportFirst() {
+		Map<String, Object> context = new HashMap<>();
+		context.put("firstNull", null);
+		context.put("secondNull", null);
+
+		// The order depends on the map iteration order
+		assertThatThrownBy(() -> new ChatClientRequest(new Prompt(), context))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("context value for key")
+			.hasMessageContaining("cannot be null");
+	}
+
+	@Test
+	void whenContextHasNoNullValuesThenSuccess() {
+		Map<String, Object> context = Map.of("key1", "value1", "key2", "value2");
+
+		// Should succeed without throwing
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt()).context(context).build();
+
+		org.assertj.core.api.Assertions.assertThat(request.context()).hasSize(2);
+	}
+
+}


### PR DESCRIPTION
## Summary
Fixes #4952 - ChatClient advisors throw NullPointerException when context contains null values.

## Problem
ChatClientRequest only validates that context keys are not null, but not the values. When advisors like ChatModelStreamAdvisor, ChatModelCallAdvisor, and SafeGuardAdvisor call Map.copyOf(request.context()), it throws NPE if any value is null. The call/stream fails before the model is even invoked.

## Solution
Add validation in ChatClientRequest record constructor to check for null context values and throw IllegalArgumentException with a clear message identifying the offending key.

## Changes
- ChatClientRequest.java: Added validation loop in the canonical constructor to check for null values and throw a descriptive IllegalArgumentException
- ChatClientRequestNullContextTests.java: Added regression tests covering:
  - Constructor throws when context has null values
  - Builder context(String, Object) throws when value is null
  - Builder context(Map) throws when map contains null values
  - Multiple null values are detected (first one reported)
  - Normal non-null contexts still work correctly

## Test Results
All new tests pass: ChatClientRequestNullContextTests

## Alternative Approaches Considered
Option B (update advisors to use Collections.unmodifiableMap() with null-safe handling) was rejected because:
1. It would require changes in multiple advisor classes
2. The fix would be scattered rather than centralized
3. Fail-fast validation in the request object is the proper place to catch invalid inputs

---
**Related issue**: spring-projects/spring-ai#4952