### PR TITLE
Define default buildRequestPrompt method in ChatModel interface

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -93,7 +93,6 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -599,15 +598,6 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		}
 
 		return response;
-	}
-
-	Prompt buildRequestPrompt(Prompt prompt) {
-		var requestOptions = (AnthropicChatOptions) prompt.getOptions();
-		requestOptions = requestOptions == null ? this.options : requestOptions;
-
-		ToolCallingChatOptions.validateToolCallbacks(requestOptions.getToolCallbacks());
-
-		return prompt.mutate().chatOptions(requestOptions).build();
 	}
 
 	/**

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -105,7 +105,6 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -287,20 +286,6 @@ public class BedrockProxyChatModel implements ChatModel {
 	@Override
 	public ChatOptions getDefaultOptions() {
 		return this.defaultOptions;
-	}
-
-	Prompt buildRequestPrompt(Prompt prompt) {
-		BedrockChatOptions.Builder requestBuilder = this.defaultOptions.mutate();
-
-		if (prompt.getOptions() != null) {
-			requestBuilder.combineWith(prompt.getOptions().mutate());
-		}
-
-		BedrockChatOptions requestOptions = requestBuilder.build();
-
-		ToolCallingChatOptions.validateToolCallbacks(requestOptions.getToolCallbacks());
-
-		return prompt.mutate().chatOptions(requestOptions).build();
 	}
 
 	ConverseRequest createRequest(Prompt prompt) {

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -59,7 +59,6 @@ import org.springframework.ai.deepseek.api.DeepSeekApi.ChatCompletionRequest;
 import org.springframework.ai.deepseek.api.common.DeepSeekConstants;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -393,14 +392,6 @@ public class DeepSeekChatModel implements ChatModel {
 
 	private DefaultUsage getDefaultUsage(DeepSeekApi.Usage usage) {
 		return new DefaultUsage(usage.promptTokens(), usage.completionTokens(), usage.totalTokens(), usage);
-	}
-
-	Prompt buildRequestPrompt(Prompt prompt) {
-		DeepSeekChatOptions runtimeOptions = (DeepSeekChatOptions) prompt.getOptions();
-		runtimeOptions = runtimeOptions == null ? this.defaultOptions : runtimeOptions;
-		ToolCallingChatOptions.validateToolCallbacks(runtimeOptions.getToolCallbacks());
-
-		return prompt.mutate().chatOptions(runtimeOptions).build();
 	}
 
 	/**

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -85,7 +85,6 @@ import org.springframework.ai.google.genai.schema.GoogleGenAiToolCallingManager;
 import org.springframework.ai.model.ChatModelDescription;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -489,16 +488,6 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 		return response;
 
-	}
-
-	Prompt buildRequestPrompt(Prompt prompt) {
-		// Process runtime options
-		GoogleGenAiChatOptions runtimeOptions = (GoogleGenAiChatOptions) prompt.getOptions();
-		runtimeOptions = runtimeOptions == null ? this.defaultOptions : runtimeOptions;
-
-		ToolCallingChatOptions.validateToolCallbacks(runtimeOptions.getToolCallbacks());
-
-		return prompt.mutate().chatOptions(runtimeOptions).build();
 	}
 
 	@Override

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -626,7 +626,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 			.googleSearchRetrieval(this.googleSearchRetrieval)
 			.includeServerSideToolInvocations(this.includeServerSideToolInvocations)
 			.safetySettings(this.safetySettings)
-			.labels(this.labels);
+			.labels(this.labels)
+			.responseMimeType(this.responseMimeType);
 	}
 
 	public enum TransportType {

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -63,7 +63,6 @@ import org.springframework.ai.minimax.api.MiniMaxApi.ChatCompletionRequest;
 import org.springframework.ai.minimax.api.MiniMaxApiConstants;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -472,16 +471,6 @@ public class MiniMaxChatModel implements ChatModel {
 
 		return new ChatCompletion(chunk.id(), choices, chunk.created(), chunk.model(), chunk.systemFingerprint(),
 				"chat.completion", null, null);
-	}
-
-	Prompt buildRequestPrompt(Prompt prompt) {
-		// Process runtime options
-		MiniMaxChatOptions runtimeOptions = (MiniMaxChatOptions) prompt.getOptions();
-		runtimeOptions = runtimeOptions == null ? this.defaultOptions : runtimeOptions;
-
-		ToolCallingChatOptions.validateToolCallbacks(runtimeOptions.getToolCallbacks());
-
-		return prompt.mutate().chatOptions(runtimeOptions).build();
 	}
 
 	/**

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -63,7 +63,6 @@ import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionMessage.T
 import org.springframework.ai.mistralai.api.MistralAiApi.ChatCompletionRequest;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -385,20 +384,6 @@ public class MistralAiChatModel implements ChatModel {
 
 		return new ChatCompletion(chunk.id(), "chat.completion", Objects.requireNonNull(chunk.created()), chunk.model(),
 				choices, chunk.usage());
-	}
-
-	Prompt buildRequestPrompt(Prompt prompt) {
-		MistralAiChatOptions.Builder requestBuilder = this.defaultOptions.mutate();
-
-		if (prompt.getOptions() != null) {
-			requestBuilder.combineWith(prompt.getOptions().mutate());
-		}
-
-		MistralAiChatOptions requestOptions = requestBuilder.build();
-
-		ToolCallingChatOptions.validateToolCallbacks(requestOptions.getToolCallbacks());
-
-		return new Prompt(prompt.getInstructions(), requestOptions);
 	}
 
 	/**

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -52,7 +52,6 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -234,6 +233,7 @@ public class OllamaChatModel implements ChatModel {
 		// Before moving any further, build the final request Prompt,
 		// merging runtime and default options.
 		Prompt requestPrompt = buildRequestPrompt(prompt);
+		verifyPromptChatOptions(requestPrompt);
 		return this.internalCall(requestPrompt, null);
 	}
 
@@ -314,6 +314,7 @@ public class OllamaChatModel implements ChatModel {
 		// Before moving any further, build the final request Prompt,
 		// merging runtime and default options.
 		Prompt requestPrompt = buildRequestPrompt(prompt);
+		verifyPromptChatOptions(requestPrompt);
 		return this.internalStream(requestPrompt, null);
 	}
 
@@ -418,19 +419,12 @@ public class OllamaChatModel implements ChatModel {
 		});
 	}
 
-	Prompt buildRequestPrompt(Prompt prompt) {
+	private void verifyPromptChatOptions(Prompt prompt) {
+		var chatOptions = prompt.getOptions();
 
-		var requestOptions = (OllamaChatOptions) prompt.getOptions();
-		requestOptions = requestOptions == null ? this.defaultOptions : requestOptions;
-
-		// Validate request options
-		if (!StringUtils.hasText(requestOptions.getModel())) {
+		if (chatOptions != null && !StringUtils.hasText(chatOptions.getModel())) {
 			throw new IllegalArgumentException("model cannot be null or empty");
 		}
-
-		ToolCallingChatOptions.validateToolCallbacks(requestOptions.getToolCallbacks());
-
-		return prompt.mutate().chatOptions(requestOptions).build();
 	}
 
 	/**

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelIT.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
@@ -51,6 +50,7 @@ import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.converter.ListOutputConverter;
 import org.springframework.ai.converter.MapOutputConverter;
 import org.springframework.ai.model.tool.DefaultToolCallingManager;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.ollama.api.OllamaApi;
@@ -66,6 +66,7 @@ import org.springframework.ai.util.ResourceUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.json.JsonContent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.convert.support.DefaultConversionService;
 
@@ -111,10 +112,18 @@ class OllamaChatModelIT extends BaseOllamaIT {
 
 		UserMessage userMessage = new UserMessage("Tell me about 5 famous pirates from the Golden Age of Piracy.");
 
-		// ollama specific options
-		var ollamaOptions = OllamaChatOptions.builder().model(MODEL).lowVRAM(true).build();
+		// portable/generic options
+		var portableOptions = ChatOptions.builder().temperature(0.7).build();
 
-		ChatResponse response = this.chatModel.call(new Prompt(List.of(systemMessage, userMessage), ollamaOptions));
+		Prompt prompt = new Prompt(List.of(systemMessage, userMessage), portableOptions);
+
+		ChatResponse response = this.chatModel.call(prompt);
+		verifyMostFamousPiratePresence(response);
+
+		// ollama specific options
+		var ollamaOptions = OllamaChatOptions.builder().lowVRAM(true).build();
+
+		response = this.chatModel.call(new Prompt(List.of(systemMessage, userMessage), ollamaOptions));
 		verifyMostFamousPiratePresence(response);
 	}
 
@@ -266,7 +275,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 				""");
 		Map<String, Object> model = Map.of("country", "denmark");
 		var prompt = userPromptTemplate.create(model,
-				OllamaChatOptions.builder().model(MODEL).format(outputConverter.getJsonSchemaMap()).build());
+				OllamaChatOptions.builder().format(outputConverter.getJsonSchemaMap()).build());
 
 		var chatResponse = this.chatModel.call(prompt);
 
@@ -281,17 +290,26 @@ class OllamaChatModelIT extends BaseOllamaIT {
 	@Test
 	void jsonStructuredOutputWithOutputSchemaOption() {
 		var jsonSchemaAsText = ResourceUtils.getText("classpath:country-json-schema.json");
-		var chatOptions = OllamaChatOptions.builder().model(MODEL).outputSchema(jsonSchemaAsText).build();
+		var chatOptions = OllamaChatOptions.builder().outputSchema(jsonSchemaAsText).build();
 		var prompt = new Prompt("Tell me about Canada.", chatOptions);
 
 		var chatResponse = this.chatModel.call(prompt);
 
-		var outputText = chatResponse.getResult().getOutput().getText();
-		Map<String, Object> map = JsonMapper.builder().build().readValue(outputText, Map.class);
-		assertThat(map).containsOnlyKeys("name", "capital", "languages")
-			.containsEntry("name", "Canada")
-			.containsEntry("capital", "Ottawa");
-		assertThat(map.get("languages")).asInstanceOf(InstanceOfAssertFactories.LIST).contains("English", "French");
+		var result = chatResponse.getResult();
+		assertThat(result).isNotNull();
+		var outputText = result.getOutput().getText();
+		assertThat(outputText).isNotNull();
+
+		// @formatter:off
+		assertThat(new JsonContent<>(getClass(), null, outputText))
+				.extractingJsonPathMapValue("$")
+				.containsOnlyKeys("name", "capital", "languages")
+				.containsEntry("name", "Canada")
+				.containsEntry("capital", "Ottawa")
+				.extracting("languages")
+				.asInstanceOf(InstanceOfAssertFactories.LIST)
+				.contains("English", "French");
+		// @formatter:on
 	}
 
 	@Test
@@ -377,8 +395,7 @@ class OllamaChatModelIT extends BaseOllamaIT {
 		ChatMemory chatMemory = MessageWindowChatMemory.builder().build();
 		String conversationId = UUID.randomUUID().toString();
 
-		ChatOptions chatOptions = OllamaChatOptions.builder()
-			.model(MODEL)
+		ChatOptions chatOptions = ToolCallingChatOptions.builder()
 			.toolCallbacks(ToolCallbacks.from(new MathTools()))
 			.internalToolExecutionEnabled(false)
 			.build();

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatRequestTests.java
@@ -31,9 +31,6 @@ import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
 import org.springframework.ai.ollama.api.OllamaModel;
 import org.springframework.ai.retry.RetryUtils;
-import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.definition.DefaultToolDefinition;
-import org.springframework.ai.tool.definition.ToolDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,10 +58,10 @@ class OllamaChatRequestTests {
 		assertThat(request.stream()).isFalse();
 
 		assertThat(request.model()).isEqualTo("MODEL_NAME");
-		assertThat(request.options().get("temperature")).isEqualTo(66.6);
-		assertThat(request.options().get("top_k")).isEqualTo(99);
-		assertThat(request.options().get("num_gpu")).isEqualTo(1);
-		assertThat(request.options().get("top_p")).isNull();
+		assertThat(request.options()).containsEntry("temperature", 66.6);
+		assertThat(request.options()).containsEntry("top_k", 99);
+		assertThat(request.options()).containsEntry("num_gpu", 1);
+		assertThat(request.options()).doesNotContainKey("top_p");
 	}
 
 	@Test
@@ -84,10 +81,10 @@ class OllamaChatRequestTests {
 		assertThat(request.stream()).isTrue();
 
 		assertThat(request.model()).isEqualTo(OllamaModel.QWEN_2_5_3B.id());
-		assertThat(request.options().get("temperature")).isEqualTo(0.8);
-		assertThat(request.options()).doesNotContainKey("top_k");
-		assertThat(request.options().get("num_gpu")).isEqualTo(2);
-		assertThat(request.options().get("top_p")).isEqualTo(0.5);
+		assertThat(request.options()).containsEntry("temperature", 0.8);
+		assertThat(request.options()).containsEntry("top_k", 99);
+		assertThat(request.options()).containsEntry("num_gpu", 2);
+		assertThat(request.options()).containsEntry("top_p", 0.5);
 	}
 
 	@Test
@@ -192,26 +189,6 @@ class OllamaChatRequestTests {
 		var assistantMessage = new AssistantMessage("Test assistant message");
 
 		return List.of(systemMessage, userMessage, toolResponseMessage, assistantMessage);
-	}
-
-	static class TestToolCallback implements ToolCallback {
-
-		private final ToolDefinition toolDefinition;
-
-		TestToolCallback(String name) {
-			this.toolDefinition = DefaultToolDefinition.builder().name(name).inputSchema("{}").build();
-		}
-
-		@Override
-		public ToolDefinition getToolDefinition() {
-			return this.toolDefinition;
-		}
-
-		@Override
-		public String call(String toolInput) {
-			return "Mission accomplished!";
-		}
-
 	}
 
 }

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -86,7 +86,6 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate;
-import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate;
 import org.springframework.ai.model.tool.ToolExecutionResult;
@@ -182,6 +181,7 @@ public final class OpenAiChatModel implements ChatModel {
 	@Override
 	public ChatResponse call(Prompt prompt) {
 		Prompt requestPrompt = buildRequestPrompt(prompt);
+		verifyPromptChatOptions(requestPrompt);
 		return this.internalCall(requestPrompt, null);
 	}
 
@@ -263,6 +263,7 @@ public final class OpenAiChatModel implements ChatModel {
 	@Override
 	public Flux<ChatResponse> stream(Prompt prompt) {
 		Prompt requestPrompt = buildRequestPrompt(prompt);
+		verifyPromptChatOptions(requestPrompt);
 		return internalStream(requestPrompt, null);
 	}
 
@@ -626,26 +627,12 @@ public final class OpenAiChatModel implements ChatModel {
 				Math.toIntExact(usage.totalTokens()), usage, cacheRead, null);
 	}
 
-	/**
-	 * Builds the request prompt by merging runtime options with default options.
-	 * @param prompt the original prompt
-	 * @return the prompt with merged options
-	 */
-	Prompt buildRequestPrompt(Prompt prompt) {
-		OpenAiChatOptions.Builder requestBuilder = this.options.mutate();
+	private void verifyPromptChatOptions(Prompt prompt) {
+		var chatOptions = prompt.getOptions();
 
-		if (prompt.getOptions() != null) {
-			if (prompt.getOptions().getTopK() != null) {
-				logger.warn("The topK option is not supported by OpenAI chat models. Ignoring.");
-			}
-			requestBuilder.combineWith(prompt.getOptions().mutate());
+		if (chatOptions != null && chatOptions.getTopK() != null) {
+			logger.warn("The topK option is not supported by OpenAI chat models. Ignoring.");
 		}
-
-		OpenAiChatOptions requestOptions = requestBuilder.build();
-
-		ToolCallingChatOptions.validateToolCallbacks(requestOptions.getToolCallbacks());
-
-		return new Prompt(prompt.getInstructions(), requestOptions);
 	}
 
 	/**

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ChatModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/ChatModel.java
@@ -26,6 +26,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.Model;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 
 public interface ChatModel extends Model<Prompt, ChatResponse>, StreamingChatModel {
 
@@ -50,6 +51,24 @@ public interface ChatModel extends Model<Prompt, ChatResponse>, StreamingChatMod
 
 	default Flux<ChatResponse> stream(Prompt prompt) {
 		throw new UnsupportedOperationException("streaming is not supported");
+	}
+
+	default Prompt buildRequestPrompt(Prompt prompt) {
+		var chatOptionsBuilder = getDefaultOptions().mutate();
+		var chatOptions = prompt.getOptions();
+
+		if (chatOptions != null) {
+			chatOptionsBuilder.combineWith(chatOptions.mutate());
+		}
+
+		chatOptions = chatOptionsBuilder.build();
+
+		if (chatOptions instanceof ToolCallingChatOptions toolCallingChatOptions) {
+			ToolCallingChatOptions.validateToolCallbacks(toolCallingChatOptions.getToolCallbacks());
+		}
+
+		return new Prompt(prompt.getInstructions(), chatOptions);
+
 	}
 
 }


### PR DESCRIPTION
## Description

- Remove existing implementation when possible,
- Verify built `ChatOptions` when required by the vendor,
- Add missing `GoogleGenAiChatOptions.responseMimeType` mutation,
- Use different `ChatOptions` types in `OllamaChatModelIT`,
- Polish `OllamaChatRequestTests` unit tests.

## Explanations

The goal is to align the behavior of `ChatModel.buildRequestPrompt()` across vendors where possible, and to avoid casting `ChatOptions` to vendor-specific types.

## Related work

e3e8cca: fix `MistralAiChatModel.buildRequestPrompt()`

## Testing scope

**Warning**: Integration tests were run locally for **Mistral AI** and **Ollama** vendors only.