### PR TITLE
Pin spring-framework to 7.0.7 to fix flushing regression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1051,6 +1051,13 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>7.0.7</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${spring-boot.version}</version>


### PR DESCRIPTION
In 7.0.6 of spring-framework a regression was introduced that caused SSE events to not be delivered.
7.0.7 addresses this via https://github.com/spring-projects/spring-framework/issues/36537 and MCP-related integration tests pass again.
As soon as Spring Boot 4.1.0-RC1 is out, we can remove the manual dependency from pom.xml.