### PR TITLE
GH-5832: Validate all results in StructuredOutputValidationAdvisor

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisor.java
@@ -40,6 +40,7 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.util.json.JsonParser;
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
@@ -180,20 +181,31 @@ public final class StructuredOutputValidationAdvisor implements CallAdvisor, Str
 	@SuppressWarnings("null")
 	private SchemaValidation validateOutputSchema(ChatClientResponse chatClientResponse) {
 
-		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResult() == null
-				|| chatClientResponse.chatResponse().getResult().getOutput() == null
-				|| chatClientResponse.chatResponse().getResult().getOutput().getText() == null) {
-
+		if (chatClientResponse.chatResponse() == null) {
 			logger.warn("ChatClientResponse is missing required json output for validation.");
 			return SchemaValidation.failed("Missing required json output for validation.");
 		}
 
-		// TODO: should we consider validation for multiple results?
-		String json = chatClientResponse.chatResponse().getResult().getOutput().getText();
+		List<Generation> results = chatClientResponse.chatResponse().getResults();
+		if (results == null || results.isEmpty()) {
+			logger.warn("ChatClientResponse is missing required json output for validation.");
+			return SchemaValidation.failed("Missing required json output for validation.");
+		}
 
-		logger.debug("Validating JSON output against schema. Attempts left: {}", this.maxRepeatAttempts);
+		logger.debug("Validating {} result(s) against schema. Attempts left: {}", results.size(),
+				this.maxRepeatAttempts);
 
-		return validateJsonText(json);
+		for (Generation result : results) {
+			if (result == null || result.getOutput() == null || result.getOutput().getText() == null) {
+				return SchemaValidation.failed("Missing required json output for validation.");
+			}
+			SchemaValidation validation = validateJsonText(result.getOutput().getText());
+			if (!validation.success()) {
+				return validation;
+			}
+		}
+
+		return SchemaValidation.passed();
 	}
 
 	private SchemaValidation validateJsonText(String json) {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/StructuredOutputValidationAdvisorTests.java
@@ -396,7 +396,7 @@ public class StructuredOutputValidationAdvisorTests {
 
 		ChatClientRequest request = createMockRequest();
 		ChatResponse chatResponse = mock(ChatResponse.class);
-		when(chatResponse.getResult()).thenReturn(null);
+		when(chatResponse.getResults()).thenReturn(List.of());
 		ChatClientResponse nullResultResponse = mock(ChatClientResponse.class);
 		when(nullResultResponse.chatResponse()).thenReturn(chatResponse);
 
@@ -1027,6 +1027,89 @@ public class StructuredOutputValidationAdvisorTests {
 		assertThat(advisor.getName()).isEqualTo("Structured Output Validation Advisor");
 	}
 
+	@Test
+	void testValidationWithMultipleResultsAllValid() {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(new TypeReference<Person>() {
+			})
+			.maxRepeatAttempts(0)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		ChatClientResponse multiResultResponse = createMockResponseWithMultipleResults(
+				"{\"name\":\"Alice\",\"age\":25}", "{\"name\":\"Bob\",\"age\":30}");
+
+		CallAdvisor terminalAdvisor = new CallAdvisor() {
+			@Override
+			public String getName() {
+				return "terminal";
+			}
+
+			@Override
+			public int getOrder() {
+				return Ordered.LOWEST_PRECEDENCE;
+			}
+
+			@Override
+			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
+				return multiResultResponse;
+			}
+		};
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		ChatClientResponse result = realChain.nextCall(request);
+
+		assertThat(result).isEqualTo(multiResultResponse);
+	}
+
+	@Test
+	void testValidationWithMultipleResultsSecondInvalid() {
+		StructuredOutputValidationAdvisor advisor = StructuredOutputValidationAdvisor.builder()
+			.outputType(new TypeReference<Person>() {
+			})
+			.maxRepeatAttempts(1)
+			.build();
+
+		ChatClientRequest request = createMockRequest();
+		// First result valid, second missing required 'age'
+		ChatClientResponse invalidMultiResponse = createMockResponseWithMultipleResults(
+				"{\"name\":\"Alice\",\"age\":25}", "{\"name\":\"Bob\"}");
+		String validJson = "{\"name\":\"Alice\",\"age\":25}";
+		ChatClientResponse validResponse = createMockResponse(validJson);
+
+		int[] callCount = { 0 };
+		CallAdvisor terminalAdvisor = new CallAdvisor() {
+			@Override
+			public String getName() {
+				return "terminal";
+			}
+
+			@Override
+			public int getOrder() {
+				return Ordered.LOWEST_PRECEDENCE;
+			}
+
+			@Override
+			public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
+				callCount[0]++;
+				return callCount[0] == 1 ? invalidMultiResponse : validResponse;
+			}
+		};
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		ChatClientResponse result = realChain.nextCall(request);
+
+		// Should retry because second result was invalid
+		assertThat(result).isEqualTo(validResponse);
+		assertThat(callCount[0]).isEqualTo(2);
+	}
+
 	// Helper methods
 
 	private ChatClientRequest createMockRequest() {
@@ -1038,6 +1121,18 @@ public class StructuredOutputValidationAdvisorTests {
 		AssistantMessage assistantMessage = new AssistantMessage(jsonOutput);
 		Generation generation = new Generation(assistantMessage);
 		ChatResponse chatResponse = new ChatResponse(List.of(generation));
+
+		ChatClientResponse response = mock(ChatClientResponse.class);
+		when(response.chatResponse()).thenReturn(chatResponse);
+
+		return response;
+	}
+
+	private ChatClientResponse createMockResponseWithMultipleResults(String... jsonOutputs) {
+		List<Generation> generations = java.util.Arrays.stream(jsonOutputs)
+			.map(json -> new Generation(new AssistantMessage(json)))
+			.toList();
+		ChatResponse chatResponse = new ChatResponse(generations);
 
 		ChatClientResponse response = mock(ChatClientResponse.class);
 		when(response.chatResponse()).thenReturn(chatResponse);


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!

## Problem

`StructuredOutputValidationAdvisor.validateOutputSchema()` called `chatResponse.getResult()`, which only retrieves the **first** result. When a `ChatResponse` contains multiple results, all subsequent results were silently skipped, allowing invalid JSON in later generations to bypass schema validation entirely.

This was tracked as a TODO comment in the source:
```java
// TODO: should we consider validation for multiple results?
String json = chatClientResponse.chatResponse().getResult().getOutput().getText();
```

## Solution

Replace the single-result check with `getResults()` iteration. The first failing result short-circuits the loop and triggers a retry with an augmented prompt. All results must pass for the response to be accepted.

## Changes

- `StructuredOutputValidationAdvisor.java` — replaced `getResult()` with `getResults()` iteration in `validateOutputSchema()`; null/empty results check updated accordingly
- `StructuredOutputValidationAdvisorTests.java` — updated existing `testAdviseCallWithNullResult` to stub `getResults()` (the old `getResult()` stub became unused); added two new tests:
  - `testValidationWithMultipleResultsAllValid` — response with 2 valid results passes without retry
  - `testValidationWithMultipleResultsSecondInvalid` — response where second result is invalid triggers retry

## Checklist

- [x] Added `Signed-off-by` line to commit (DCO)
- [x] Rebased on latest `main`
- [x] Unit tests added/updated
- [x] Build passes (`mvn package -pl spring-ai-client-chat`)

Fixes #5832