### PR TITLE
GH-5797: Add RESPECT_JSONPROPERTY_ORDER to JsonSchemaGenerator

### DIFF
--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -886,6 +887,17 @@ class JsonSchemaGeneratorTests {
 			.hasMessage("type cannot be null");
 	}
 
+	@Test
+	void generateSchemaForTypeRespectsJsonPropertyOrder() throws Exception {
+		String schema = JsonSchemaGenerator.generateForType(OrderedPerson.class);
+		JsonNode schemaNode = JsonParser.getJsonMapper().readTree(schema);
+		JsonNode properties = schemaNode.get("properties");
+
+		assertThat(properties).isNotNull();
+		List<String> fieldNames = new java.util.ArrayList<>(properties.propertyNames());
+		assertThat(fieldNames).containsExactly("name", "email", "id");
+	}
+
 	static class TestMethods {
 
 		public void simpleMethod(String name, int age) {
@@ -1023,6 +1035,41 @@ class JsonSchemaGeneratorTests {
 	}
 
 	record WithMapField(String name, Map<String, Integer> scores) {
+
+	}
+
+	@JsonPropertyOrder({ "name", "email", "id" })
+	static class OrderedPerson {
+
+		private int id;
+
+		private String name;
+
+		private String email;
+
+		public int getId() {
+			return this.id;
+		}
+
+		public void setId(int id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return this.name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getEmail() {
+			return this.email;
+		}
+
+		public void setEmail(String email) {
+			this.email = email;
+		}
 
 	}
 


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!

## Problem

`BeanOutputConverter` configures its `JacksonSchemaModule` with both `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` and `JacksonOption.RESPECT_JSONPROPERTY_ORDER`, but `JsonSchemaGenerator` only includes `RESPECT_JSONPROPERTY_REQUIRED`.

This inconsistency means `@JsonPropertyOrder` annotations are silently ignored when generating schemas through `JsonSchemaGenerator` (e.g. via `ResponseFormat.jsonSchema(MyClass.class)`), even though they work correctly via `BeanOutputConverter`.

## Solution

Add the missing `JacksonOption.RESPECT_JSONPROPERTY_ORDER` option to the `JacksonSchemaModule` configuration in `JsonSchemaGenerator`, aligning it with `BeanOutputConverter`.

## Changes

- `JsonSchemaGenerator.java` — added `JacksonOption.RESPECT_JSONPROPERTY_ORDER` to `JacksonSchemaModule` constructor
- `JsonSchemaGeneratorTests.java` — added `generateSchemaForTypeRespectsJsonPropertyOrder` test using an `@JsonPropertyOrder`-annotated class; verified the schema properties are emitted in the declared order

## Checklist

- [x] Added `Signed-off-by` line to commit (DCO)
- [x] Rebased on latest `main`
- [x] Unit tests added
- [x] Build passes (`mvn package -pl spring-ai-model`)

Fixes #5797