### PR TITLE
GH-5803: Apply @Schema constraint attributes to @Tool method parameters

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -162,6 +162,7 @@ public final class JsonSchemaGenerator {
 			if (StringUtils.hasText(parameterDescription)) {
 				parameterNode.put("description", parameterDescription);
 			}
+			applySchemaConstraints(method.getParameters()[i], parameterNode);
 			properties.set(parameterName, parameterNode);
 		}
 
@@ -298,6 +299,61 @@ public final class JsonSchemaGenerator {
 				});
 			}
 		});
+	}
+
+	/**
+	 * Applies constraint attributes from a parameter-level {@code @Schema} annotation
+	 * (e.g. minimum, maximum, pattern, example, allowableValues) to the generated schema
+	 * node. Description and required/requiredMode are handled separately and are not
+	 * re-applied here.
+	 */
+	private static void applySchemaConstraints(Parameter parameter, ObjectNode parameterNode) {
+		var schemaAnnotation = parameter.getAnnotation(Schema.class);
+		if (schemaAnnotation == null) {
+			return;
+		}
+		if (StringUtils.hasText(schemaAnnotation.minimum())) {
+			tryParseDouble(schemaAnnotation.minimum(), parameterNode, "minimum");
+		}
+		if (StringUtils.hasText(schemaAnnotation.maximum())) {
+			tryParseDouble(schemaAnnotation.maximum(), parameterNode, "maximum");
+		}
+		if (schemaAnnotation.exclusiveMinimum()) {
+			parameterNode.put("exclusiveMinimum", true);
+		}
+		if (schemaAnnotation.exclusiveMaximum()) {
+			parameterNode.put("exclusiveMaximum", true);
+		}
+		if (schemaAnnotation.minLength() > 0) {
+			parameterNode.put("minLength", schemaAnnotation.minLength());
+		}
+		if (schemaAnnotation.maxLength() < Integer.MAX_VALUE) {
+			parameterNode.put("maxLength", schemaAnnotation.maxLength());
+		}
+		if (StringUtils.hasText(schemaAnnotation.pattern())) {
+			parameterNode.put("pattern", schemaAnnotation.pattern());
+		}
+		if (StringUtils.hasText(schemaAnnotation.example())) {
+			parameterNode.put("example", schemaAnnotation.example());
+		}
+		if (schemaAnnotation.allowableValues().length > 0) {
+			var enumArray = parameterNode.putArray("enum");
+			for (String value : schemaAnnotation.allowableValues()) {
+				enumArray.add(value);
+			}
+		}
+		if (schemaAnnotation.multipleOf() > 0) {
+			parameterNode.put("multipleOf", schemaAnnotation.multipleOf());
+		}
+	}
+
+	private static void tryParseDouble(String value, ObjectNode node, String fieldName) {
+		try {
+			node.put(fieldName, Double.parseDouble(value));
+		}
+		catch (NumberFormatException ignored) {
+			// If the value isn't a valid number, skip it.
+		}
 	}
 
 	// Based on the method in ModelOptionsUtils.

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -162,6 +162,32 @@ class JsonSchemaGeneratorTests {
 	}
 
 	@Test
+	void generateSchemaForMethodWithOpenApiSchemaConstraints() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("schemaConstraintsMethod", int.class, String.class,
+				String.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.getJsonMapper().readTree(schema);
+		JsonNode properties = schemaNode.get("properties");
+
+		JsonNode chanceNode = properties.get("chance");
+		assertThat(chanceNode.get("description").asText()).isEqualTo("Chance percentage");
+		assertThat(chanceNode.get("minimum").asDouble()).isEqualTo(0.0);
+		assertThat(chanceNode.get("maximum").asDouble()).isEqualTo(100.0);
+
+		JsonNode codeNode = properties.get("code");
+		assertThat(codeNode.get("minLength").asInt()).isEqualTo(3);
+		assertThat(codeNode.get("maxLength").asInt()).isEqualTo(10);
+		assertThat(codeNode.get("pattern").asText()).isEqualTo("[A-Z]+");
+
+		JsonNode statusNode = properties.get("status");
+		assertThat(statusNode.get("enum")).isNotNull();
+		List<String> enumValues = new java.util.ArrayList<>();
+		statusNode.get("enum").forEach(n -> enumValues.add(n.asText()));
+		assertThat(enumValues).containsExactly("ACTIVE", "INACTIVE", "PENDING");
+	}
+
+	@Test
 	void generateSchemaForMethodWithObjectParam() throws Exception {
 		Method method = TestMethods.class.getDeclaredMethod("objectParamMethod", Object.class);
 
@@ -914,6 +940,12 @@ class JsonSchemaGeneratorTests {
 		}
 
 		public void nullableMethod(@Nullable String username, String password) {
+		}
+
+		public void schemaConstraintsMethod(
+				@Schema(description = "Chance percentage", minimum = "0", maximum = "100") int chance,
+				@Schema(minLength = 3, maxLength = 10, pattern = "[A-Z]+") String code,
+				@Schema(allowableValues = { "ACTIVE", "INACTIVE", "PENDING" }) String status) {
 		}
 
 		public void complexMethod(List<String> items, TestData data, MoreTestData moreData) {


### PR DESCRIPTION
Thank you for taking time to contribute this pull request!

## Problem

`JsonSchemaGenerator.generateForMethodInput()` manually reads `@Schema` on method parameters for `description` and `requiredMode`, but silently drops all constraint attributes:

- `minimum` / `maximum`
- `exclusiveMinimum` / `exclusiveMaximum`
- `minLength` / `maxLength`
- `pattern`
- `example`
- `allowableValues` (mapped to `enum`)
- `multipleOf`

For example, this tool parameter produces no `minimum`/`maximum` in the generated schema:
```java
@Tool(name = "set_chance", description = "Set the chance value")
public String setChance(
    @Schema(description = "Chance percentage", minimum = "0", maximum = "100")
    int chance
) { ... }
```

## Solution

Add a private `applySchemaConstraints(Parameter, ObjectNode)` method that reads the `@Schema` annotation on a method parameter and applies its constraint attributes to the generated `ObjectNode`. This is called once per parameter in the existing `generateForMethodInput` loop, after the base schema and description have been set.

Numeric constraints (`minimum`, `maximum`, `multipleOf`) are parsed via a helper `tryParseDouble()` that silently skips non-numeric values to match the lenient nature of the Swagger `@Schema` annotation.

## Changes

- `JsonSchemaGenerator.java` — added `applySchemaConstraints()` + `tryParseDouble()` helpers; called from the parameter loop in `generateForMethodInput()`
- `JsonSchemaGeneratorTests.java` — added `generateSchemaForMethodWithOpenApiSchemaConstraints` test covering `minimum`/`maximum`, `minLength`/`maxLength`/`pattern`, and `allowableValues`; added `schemaConstraintsMethod` to `TestMethods`

## Checklist

- [x] Added `Signed-off-by` line to commit (DCO)
- [x] Rebased on latest `main`
- [x] Unit tests added
- [x] Build passes (`mvn package -pl spring-ai-model`)

Fixes #5803