### PR TITLE
Updated README for CPU arch note

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ To clone it you have to either:
 The project targets and build artifacts compatible with Java 17+, but requires JDK 21
 to build. This is enforced by the maven enforcer plugin.
 
+**NOTE:** Building Spring AI requires components that depend on your specific CPU architecture (PyTorch for example). MacOS has the ability to hide that detail for normal Java applications that will not work for building this project (this is not an issue for consuming the libraries). If you are unsure if you have the correct JDK distribution for your CPU, run the command `java -XshowSettings:properties -version 2>&1 | grep os.arch` from a fresh terminal to validate that it matches your machine.
+
 To build with running unit tests
 
 ```shell


### PR DESCRIPTION
When building Spring AI, there is a dependecy on PyTorch which is dependent upon the CPU architecture of the machine it is running on. In MacOS, an x86 built JVM can run on an ARM processor due to Rosetta. However, this arrangement will result in the project attempting to get the x86 distribution of PyTorch which will not run on an ARM processor. This note is to clarify how to validate if your JDK is reporting the correct CPU architecture your machine is actually running.

Signed-off-by: Michael Minella <michael.minella@broadcom.com>