### PR TITLE
GH-5806: Merge streaming tool call chunks in MessageAggregator

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/model/MessageAggregator.java
@@ -116,7 +116,9 @@ public class MessageAggregator {
 				}
 				AssistantMessage outputMessage = chatResponse.getResult().getOutput();
 				if (!CollectionUtils.isEmpty(outputMessage.getToolCalls())) {
-					toolCallsRef.get().addAll(outputMessage.getToolCalls());
+					for (ToolCall chunk : outputMessage.getToolCalls()) {
+						mergeToolCallChunk(toolCallsRef.get(), chunk);
+					}
 				}
 
 			}
@@ -205,6 +207,23 @@ public class MessageAggregator {
 			metadataRateLimitRef.set(new EmptyRateLimit());
 
 		}).doOnError(e -> logger.error("Aggregation Error", e));
+	}
+
+	/**
+	 * Merges a streaming tool call chunk into the accumulated tool call list. If the
+	 * chunk has a non-empty {@code id}, it starts a new tool call entry. Otherwise, its
+	 * {@code arguments} are appended to the most recently added tool call.
+	 */
+	private static void mergeToolCallChunk(List<ToolCall> toolCalls, ToolCall chunk) {
+		if (StringUtils.hasText(chunk.id())) {
+			toolCalls.add(chunk);
+		}
+		else if (!toolCalls.isEmpty()) {
+			ToolCall last = toolCalls.remove(toolCalls.size() - 1);
+			String merged = (last.arguments() != null ? last.arguments() : "")
+					+ (chunk.arguments() != null ? chunk.arguments() : "");
+			toolCalls.add(new ToolCall(last.id(), last.type(), last.name(), merged));
+		}
 	}
 
 	public record DefaultUsage(Integer promptTokens, Integer completionTokens, Integer totalTokens) implements Usage {

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/model/MessageAggregatorTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.model;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MessageAggregator} streaming tool call merging.
+ */
+class MessageAggregatorTests {
+
+	private final MessageAggregator aggregator = new MessageAggregator();
+
+	@Test
+	void should_merge_tool_call_chunks_into_single_complete_tool_call() {
+		// Streaming chunks: first has id+name, rest have empty id and append arguments
+		List<ChatResponse> chunks = List.of(
+				chatResponseWithToolCall(new ToolCall("call_123", "function", "queryCourse", "")),
+				chatResponseWithToolCall(new ToolCall("", "", "", "{\"query\":\"edu\"")),
+				chatResponseWithToolCall(new ToolCall("", "", "", ",\"page\":4")),
+				chatResponseWithToolCall(new ToolCall("", "", "", "}")));
+
+		ChatResponse aggregated = aggregateChunks(chunks);
+
+		List<ToolCall> toolCalls = aggregated.getResult().getOutput().getToolCalls();
+		assertThat(toolCalls).hasSize(1);
+		ToolCall merged = toolCalls.get(0);
+		assertThat(merged.id()).isEqualTo("call_123");
+		assertThat(merged.name()).isEqualTo("queryCourse");
+		assertThat(merged.arguments()).isEqualTo("{\"query\":\"edu\",\"page\":4}");
+	}
+
+	@Test
+	void should_pass_through_complete_tool_call_unchanged() {
+		List<ChatResponse> chunks = List
+			.of(chatResponseWithToolCall(new ToolCall("call_abc", "function", "myTool", "{\"key\":\"value\"}")));
+
+		ChatResponse aggregated = aggregateChunks(chunks);
+
+		List<ToolCall> toolCalls = aggregated.getResult().getOutput().getToolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).id()).isEqualTo("call_abc");
+		assertThat(toolCalls.get(0).arguments()).isEqualTo("{\"key\":\"value\"}");
+	}
+
+	@Test
+	void should_merge_multiple_parallel_tool_calls() {
+		// Two tool calls streamed in sequence, each with their own chunks
+		List<ChatResponse> chunks = List.of(
+				chatResponseWithToolCall(new ToolCall("call_1", "function", "toolA", "{\"a\":")),
+				chatResponseWithToolCall(new ToolCall("", "", "", "1}")),
+				chatResponseWithToolCall(new ToolCall("call_2", "function", "toolB", "{\"b\":")),
+				chatResponseWithToolCall(new ToolCall("", "", "", "2}")));
+
+		ChatResponse aggregated = aggregateChunks(chunks);
+
+		List<ToolCall> toolCalls = aggregated.getResult().getOutput().getToolCalls();
+		assertThat(toolCalls).hasSize(2);
+
+		assertThat(toolCalls.get(0).id()).isEqualTo("call_1");
+		assertThat(toolCalls.get(0).name()).isEqualTo("toolA");
+		assertThat(toolCalls.get(0).arguments()).isEqualTo("{\"a\":1}");
+
+		assertThat(toolCalls.get(1).id()).isEqualTo("call_2");
+		assertThat(toolCalls.get(1).name()).isEqualTo("toolB");
+		assertThat(toolCalls.get(1).arguments()).isEqualTo("{\"b\":2}");
+	}
+
+	@Test
+	void should_handle_chunk_with_null_arguments() {
+		List<ChatResponse> chunks = List.of(
+				chatResponseWithToolCall(new ToolCall("call_x", "function", "myTool", null)),
+				chatResponseWithToolCall(new ToolCall("", "", "", "{\"k\":\"v\"}")));
+
+		ChatResponse aggregated = aggregateChunks(chunks);
+
+		List<ToolCall> toolCalls = aggregated.getResult().getOutput().getToolCalls();
+		assertThat(toolCalls).hasSize(1);
+		assertThat(toolCalls.get(0).arguments()).isEqualTo("{\"k\":\"v\"}");
+	}
+
+	private ChatResponse chatResponseWithToolCall(ToolCall toolCall) {
+		AssistantMessage message = AssistantMessage.builder().toolCalls(List.of(toolCall)).build();
+		return new ChatResponse(List.of(new Generation(message)));
+	}
+
+	private ChatResponse aggregateChunks(List<ChatResponse> chunks) {
+		AtomicReference<ChatResponse> result = new AtomicReference<>();
+		this.aggregator.aggregate(Flux.fromIterable(chunks), result::set).blockLast();
+		return result.get();
+	}
+
+}


### PR DESCRIPTION
## Summary

- Streaming tool calls arrive in multiple chunks: first chunk carries `id` and `name`, subsequent chunks carry partial `arguments` with an empty `id`
- `MessageAggregator` was calling `addAll()` on every chunk, producing a list of incomplete `ToolCall` entries with empty `arguments`, ultimately causing `IllegalArgumentException: toolInput cannot be null or empty` during execution
- Added `mergeToolCallChunk()` helper: chunks with a non-empty `id` start a new entry; chunks with an empty `id` append their `arguments` to the most recently started call
- Handles single tool calls split across N chunks and multiple sequential tool calls streamed one after another

## How to test locally

```bash
./mvnw test -pl spring-ai-model -Dtest=MessageAggregatorTests
```

- `should_merge_tool_call_chunks_into_single_complete_tool_call` — replicates the exact streaming pattern from the issue report
- `should_pass_through_complete_tool_call_unchanged` — single complete tool call (no merging needed) still works
- `should_merge_multiple_parallel_tool_calls` — two sequential tool calls each split across two chunks
- `should_handle_chunk_with_null_arguments` — null arguments handled without NPE

Fixes GH-5806 (https://github.com/spring-projects/spring-ai/issues/5806)