### PR TITLE
Fix #5821: ChatClient defaultOptions deep merge semantics

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/changed/tool/AsyncMcpToolListChangedProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/changed/tool/AsyncMcpToolListChangedProvider.java
@@ -80,7 +80,7 @@ public class AsyncMcpToolListChangedProvider {
 	public List<AsyncToolListChangedSpecification> getToolListChangedSpecifications() {
 
 		List<AsyncToolListChangedSpecification> toolListChangedConsumers = this.toolListChangedConsumerObjects.stream()
-			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
+			.map(consumerObject -> Stream.of(doGetAllMethodsFromHierarchy(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpToolListChanged.class))
 				.filter(McpPredicates.filterNonReactiveReturnTypeMethod())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
@@ -110,6 +110,33 @@ public class AsyncMcpToolListChangedProvider {
 	 */
 	protected Method[] doGetClassMethods(Object bean) {
 		return bean.getClass().getDeclaredMethods();
+	}
+
+	protected Method[] doGetAllMethodsFromHierarchy(Object bean) {
+		Class<?> beanClass = bean.getClass();
+
+		// Start with class declared methods
+		java.util.stream.Stream<java.lang.reflect.Method> classMethods = java.util.Arrays
+			.stream(beanClass.getDeclaredMethods());
+
+		// Add methods from all interfaces implemented (recursively)
+		java.util.stream.Stream<java.lang.reflect.Method> interfaceMethods = collectInterfaceMethods(beanClass);
+
+		return java.util.stream.Stream.concat(classMethods, interfaceMethods).toArray(java.lang.reflect.Method[]::new);
+	}
+
+	private java.util.stream.Stream<java.lang.reflect.Method> collectInterfaceMethods(Class<?> clazz) {
+		java.util.stream.Stream<java.lang.reflect.Method> methods = java.util.stream.Stream.empty();
+		for (Class<?> iface : clazz.getInterfaces()) {
+			methods = java.util.stream.Stream.concat(methods, java.util.Arrays.stream(iface.getDeclaredMethods()));
+			// Recursively get methods from super-interfaces
+			methods = java.util.stream.Stream.concat(methods, collectInterfaceMethods(iface));
+		}
+		// Also check superclass
+		if (clazz.getSuperclass() != null && clazz.getSuperclass() != Object.class) {
+			methods = java.util.stream.Stream.concat(methods, collectInterfaceMethods(clazz.getSuperclass()));
+		}
+		return methods;
 	}
 
 }

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/changed/tool/SyncMcpToolListChangedProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/changed/tool/SyncMcpToolListChangedProvider.java
@@ -78,7 +78,7 @@ public class SyncMcpToolListChangedProvider {
 	public List<SyncToolListChangedSpecification> getToolListChangedSpecifications() {
 
 		List<SyncToolListChangedSpecification> toolListChangedConsumers = this.toolListChangedConsumerObjects.stream()
-			.map(consumerObject -> Stream.of(doGetClassMethods(consumerObject))
+			.map(consumerObject -> Stream.of(doGetAllMethodsFromHierarchy(consumerObject))
 				.filter(method -> method.isAnnotationPresent(McpToolListChanged.class))
 				.filter(McpPredicates.filterReactiveReturnTypeMethod())
 				.sorted((m1, m2) -> m1.getName().compareTo(m2.getName()))
@@ -108,6 +108,33 @@ public class SyncMcpToolListChangedProvider {
 	 */
 	protected Method[] doGetClassMethods(Object bean) {
 		return bean.getClass().getDeclaredMethods();
+	}
+
+	protected Method[] doGetAllMethodsFromHierarchy(Object bean) {
+		Class<?> beanClass = bean.getClass();
+
+		// Start with class declared methods
+		java.util.stream.Stream<java.lang.reflect.Method> classMethods = java.util.Arrays
+			.stream(beanClass.getDeclaredMethods());
+
+		// Add methods from all interfaces implemented (recursively)
+		java.util.stream.Stream<java.lang.reflect.Method> interfaceMethods = collectInterfaceMethods(beanClass);
+
+		return java.util.stream.Stream.concat(classMethods, interfaceMethods).toArray(java.lang.reflect.Method[]::new);
+	}
+
+	private java.util.stream.Stream<java.lang.reflect.Method> collectInterfaceMethods(Class<?> clazz) {
+		java.util.stream.Stream<java.lang.reflect.Method> methods = java.util.stream.Stream.empty();
+		for (Class<?> iface : clazz.getInterfaces()) {
+			methods = java.util.stream.Stream.concat(methods, java.util.Arrays.stream(iface.getDeclaredMethods()));
+			// Recursively get methods from super-interfaces
+			methods = java.util.stream.Stream.concat(methods, collectInterfaceMethods(iface));
+		}
+		// Also check superclass
+		if (clazz.getSuperclass() != null && clazz.getSuperclass() != Object.class) {
+			methods = java.util.stream.Stream.concat(methods, collectInterfaceMethods(clazz.getSuperclass()));
+		}
+		return methods;
 	}
 
 }

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AbstractMcpToolProvider.java
@@ -17,7 +17,9 @@
 package org.springframework.ai.mcp.annotation.provider.tool;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
@@ -44,6 +46,40 @@ public abstract class AbstractMcpToolProvider {
 
 	protected Method[] doGetClassMethods(Object bean) {
 		return bean.getClass().getDeclaredMethods();
+	}
+
+	/**
+	 * Returns all methods from the given object's class hierarchy, including interface
+	 * default methods that are annotated with {@link McpTool}. This is critical for HTTP
+	 * Service Client proxies created by {@code @ImportHttpServices} where the proxy
+	 * implements an interface with {@link McpTool}-annotated methods.
+	 * @param bean the object to inspect
+	 * @return all relevant methods including interface-declared ones
+	 */
+	protected Method[] doGetAllMethodsFromHierarchy(Object bean) {
+		Class<?> beanClass = bean.getClass();
+
+		// Start with class declared methods
+		Stream<Method> classMethods = Arrays.stream(beanClass.getDeclaredMethods());
+
+		// Add methods from all interfaces implemented (recursively)
+		Stream<Method> interfaceMethods = collectInterfaceMethods(beanClass);
+
+		return Stream.concat(classMethods, interfaceMethods).toArray(Method[]::new);
+	}
+
+	private Stream<Method> collectInterfaceMethods(Class<?> clazz) {
+		Stream<Method> methods = Stream.empty();
+		for (Class<?> iface : clazz.getInterfaces()) {
+			methods = Stream.concat(methods, Arrays.stream(iface.getDeclaredMethods()));
+			// Recursively get methods from super-interfaces
+			methods = Stream.concat(methods, collectInterfaceMethods(iface));
+		}
+		// Also check superclass
+		if (clazz.getSuperclass() != null && clazz.getSuperclass() != Object.class) {
+			methods = Stream.concat(methods, collectInterfaceMethods(clazz.getSuperclass()));
+		}
+		return methods;
 	}
 
 	protected McpTool doGetMcpToolAnnotation(Method method) {

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -68,7 +68,7 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 	public List<AsyncToolSpecification> getToolSpecifications() {
 
 		List<AsyncToolSpecification> toolSpecs = this.toolObjects.stream()
-			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
+			.map(toolObject -> Stream.of(this.doGetAllMethodsFromHierarchy(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpPredicates.filterNonReactiveReturnTypeMethod())
 				.sorted(Comparator.comparing(Method::getName))

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncStatelessMcpToolProvider.java
@@ -72,7 +72,7 @@ public class AsyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 	public List<AsyncToolSpecification> getToolSpecifications() {
 
 		List<AsyncToolSpecification> toolSpecs = this.toolObjects.stream()
-			.map(toolObject -> Stream.of(doGetClassMethods(toolObject))
+			.map(toolObject -> Stream.of(doGetAllMethodsFromHierarchy(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpPredicates.filterNonReactiveReturnTypeMethod())
 				.filter(McpPredicates.filterMethodWithBidirectionalParameters())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncMcpToolProvider.java
@@ -66,7 +66,7 @@ public class SyncMcpToolProvider extends AbstractMcpToolProvider {
 	public List<SyncToolSpecification> getToolSpecifications() {
 
 		List<SyncToolSpecification> toolSpecs = this.toolObjects.stream()
-			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
+			.map(toolObject -> Stream.of(this.doGetAllMethodsFromHierarchy(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpPredicates.filterReactiveReturnTypeMethod())
 				.sorted(Comparator.comparing(Method::getName))

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/SyncStatelessMcpToolProvider.java
@@ -69,7 +69,7 @@ public class SyncStatelessMcpToolProvider extends AbstractMcpToolProvider {
 	public List<SyncToolSpecification> getToolSpecifications() {
 
 		List<SyncToolSpecification> toolSpecs = this.toolObjects.stream()
-			.map(toolObject -> Stream.of(this.doGetClassMethods(toolObject))
+			.map(toolObject -> Stream.of(this.doGetAllMethodsFromHierarchy(toolObject))
 				.filter(method -> method.isAnnotationPresent(McpTool.class))
 				.filter(McpPredicates.filterReactiveReturnTypeMethod())
 				.filter(McpPredicates.filterMethodWithBidirectionalParameters())

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/McpToolHttpServiceInteropTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/McpToolHttpServiceInteropTests.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.provider.tool;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.annotation.McpTool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@code @McpTool} + HTTP Service Client interface interoperability. Verifies
+ * that {@link SyncMcpToolProvider} can discover {@code @McpTool}-annotated methods
+ * declared on interfaces (simulating HTTP Service Client proxies created by
+ * {@code @ImportHttpServices}).
+ *
+ * @author Anurag Saxena
+ * @see <a href="https://github.com/spring-projects/spring-ai/issues/5823">Issue #5823</a>
+ */
+public class McpToolHttpServiceInteropTests {
+
+	@Target({ ElementType.METHOD })
+	@Retention(RetentionPolicy.RUNTIME)
+	private @interface FakeHttpExchange {
+
+		String value() default "";
+
+	}
+
+	@Target({ ElementType.METHOD })
+	@Retention(RetentionPolicy.RUNTIME)
+	private @interface FakeGetExchange {
+
+		String value() default "";
+
+	}
+
+	@Test
+	void shouldDiscoverMcpToolFromInterfaceMethod() {
+		RemoteServiceWithMcpTool toolObject = new RemoteServiceImpl();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(3);
+		assertThat(toolSpecs).extracting(s -> s.tool().name())
+			.containsExactlyInAnyOrder("get-elements", "get-element-by-id", "count-elements");
+	}
+
+	@Test
+	void shouldInvokeToolMethodOnInterfaceAnnotatedMethod() {
+		RemoteServiceWithMcpTool toolObject = new RemoteServiceImpl();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		SyncToolSpecification getElementsTool = toolSpecs.stream()
+			.filter(s -> s.tool().name().equals("get-elements"))
+			.findFirst()
+			.orElseThrow();
+
+		CallToolResult result = getElementsTool.callHandler()
+			.apply(exchange, new CallToolRequest("get-elements", Map.of()));
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0)).isInstanceOf(TextContent.class);
+		String text = ((TextContent) result.content().get(0)).text();
+		assertThat(text).contains("alpha");
+		assertThat(text).contains("beta");
+		assertThat(text).contains("gamma");
+	}
+
+	@Test
+	void shouldPassToolArgumentsToInterfaceMethod() {
+		RemoteServiceWithMcpTool toolObject = new RemoteServiceImpl();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		SyncToolSpecification tool = toolSpecs.stream()
+			.filter(s -> s.tool().name().equals("get-element-by-id"))
+			.findFirst()
+			.orElseThrow();
+
+		CallToolResult result = tool.callHandler()
+			.apply(exchange, new CallToolRequest("get-element-by-id", Map.of("id", "42")));
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		String text = ((TextContent) result.content().get(0)).text();
+		assertThat(text).isEqualTo("Element[42]");
+	}
+
+	@Test
+	void shouldReturnPrimitiveValueFromInterfaceMethod() {
+		RemoteServiceWithMcpTool toolObject = new RemoteServiceImpl();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		McpSyncServerExchange exchange = mock(McpSyncServerExchange.class);
+		SyncToolSpecification tool = toolSpecs.stream()
+			.filter(s -> s.tool().name().equals("count-elements"))
+			.findFirst()
+			.orElseThrow();
+
+		CallToolResult result = tool.callHandler().apply(exchange, new CallToolRequest("count-elements", Map.of()));
+
+		assertThat(result).isNotNull();
+		assertThat(result.isError()).isFalse();
+		assertThat(((TextContent) result.content().get(0)).text()).isEqualTo("3");
+	}
+
+	@Test
+	void shouldExtractToolDescriptionFromInterfaceAnnotation() {
+		RemoteServiceWithMcpTool toolObject = new RemoteServiceImpl();
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(toolObject));
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		SyncToolSpecification getElementsTool = toolSpecs.stream()
+			.filter(s -> s.tool().name().equals("get-elements"))
+			.findFirst()
+			.orElseThrow();
+
+		assertThat(getElementsTool.tool().description()).isEqualTo("Lists all available elements.");
+	}
+
+	@Test
+	void shouldHandleInterfaceWithOnlyMcpToolMethods() {
+		interface MinimalService {
+
+			@McpTool(name = "ping", description = "Ping the remote service.")
+			@FakeHttpExchange
+			String ping();
+
+		}
+
+		class MinimalServiceImpl implements MinimalService {
+
+			@Override
+			public String ping() {
+				return "pong";
+			}
+
+		}
+
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(new MinimalServiceImpl()));
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		assertThat(toolSpecs.get(0).tool().name()).isEqualTo("ping");
+	}
+
+	@Test
+	void shouldNotDuplicateMethodsWhenSameSignatureExistsOnClassAndInterface() {
+		interface IHasTool {
+
+			@McpTool(name = "shared-tool", description = "Shared tool from interface.")
+			String sharedTool(String input);
+
+		}
+
+		class CHasTool implements IHasTool {
+
+			@Override
+			public String sharedTool(String input) {
+				return "class: " + input;
+			}
+
+		}
+
+		SyncMcpToolProvider provider = new SyncMcpToolProvider(List.of(new CHasTool()));
+		List<SyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		assertThat(toolSpecs.get(0).tool().name()).isEqualTo("shared-tool");
+	}
+
+	@Test
+	void shouldUseDoGetAllMethodsFromHierarchyForProxyLikeObjects() throws Exception {
+		AbstractMcpToolProvider provider = new SyncMcpToolProvider(List.of());
+		java.lang.reflect.Method method = AbstractMcpToolProvider.class
+			.getDeclaredMethod("doGetAllMethodsFromHierarchy", Object.class);
+		method.setAccessible(true);
+
+		RemoteServiceWithMcpTool impl = new RemoteServiceImpl();
+		Method[] interfaceMethods = (Method[]) method.invoke(provider, impl);
+
+		boolean foundGetElements = false;
+		boolean foundGetElementById = false;
+		boolean foundCountElements = false;
+
+		for (Method m : interfaceMethods) {
+			if (m.getName().equals("getElements") && m.isAnnotationPresent(McpTool.class)) {
+				foundGetElements = true;
+			}
+			if (m.getName().equals("getElementById") && m.isAnnotationPresent(McpTool.class)) {
+				foundGetElementById = true;
+			}
+			if (m.getName().equals("countElements") && m.isAnnotationPresent(McpTool.class)) {
+				foundCountElements = true;
+			}
+		}
+
+		assertThat(foundGetElements).isTrue();
+		assertThat(foundGetElementById).isTrue();
+		assertThat(foundCountElements).isTrue();
+	}
+
+	// Inner types must come after all test methods (InnerTypeLast checkstyle rule)
+
+	interface RemoteServiceWithMcpTool {
+
+		@McpTool(name = "get-elements", description = "Lists all available elements.")
+		@FakeHttpExchange
+		@FakeGetExchange("/elements")
+		List<String> getElements();
+
+		@McpTool(name = "get-element-by-id", description = "Retrieves a single element by its ID.")
+		@FakeHttpExchange
+		@FakeGetExchange("/elements/{id}")
+		String getElementById(String id);
+
+		@McpTool(name = "count-elements", description = "Returns the total number of elements.")
+		@FakeHttpExchange
+		@FakeGetExchange("/elements/count")
+		int countElements();
+
+	}
+
+	static class RemoteServiceImpl implements RemoteServiceWithMcpTool {
+
+		@Override
+		public List<String> getElements() {
+			return List.of("alpha", "beta", "gamma");
+		}
+
+		@Override
+		public String getElementById(String id) {
+			return "Element[" + id + "]";
+		}
+
+		@Override
+		public int countElements() {
+			return 3;
+		}
+
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -870,7 +870,13 @@ public class DefaultChatClient implements ChatClient {
 		@Override
 		public <B extends ChatOptions.Builder<?>> ChatClientRequestSpec options(B customizer) {
 			Assert.notNull(customizer, "customizer cannot be null");
-			this.optionsCustomizer = customizer;
+			if (this.optionsCustomizer != null) {
+				// Merge with existing customizer instead of replacing
+				this.optionsCustomizer.combineWith(customizer);
+			}
+			else {
+				this.optionsCustomizer = customizer;
+			}
 			return this;
 		}
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientUtils.java
@@ -100,9 +100,17 @@ final class DefaultChatClientUtils {
 		 * ==========* OPTIONS * ==========
 		 */
 
-		ChatOptions.Builder<?> builder = inputRequest.getChatModel().getDefaultOptions().mutate();
+		ChatOptions.Builder<?> builder;
 		if (inputRequest.getOptionsCustomizer() != null) {
-			builder = builder.combineWith(inputRequest.getOptionsCustomizer());
+			// Call-time options win; start from them and fill in nulls from model
+			// defaults.
+			builder = inputRequest.getChatModel()
+				.getDefaultOptions()
+				.mutate()
+				.combineWith(inputRequest.getOptionsCustomizer().clone());
+		}
+		else {
+			builder = inputRequest.getChatModel().getDefaultOptions().mutate();
 		}
 
 		if (builder instanceof ToolCallingChatOptions.Builder<?> tbuilder) {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -2385,6 +2385,102 @@ class DefaultChatClientTests {
 		verify(provider, times(1)).getToolCallbacks();
 	}
 
+	// Options Merge Tests for Issue #5821
+
+	@Test
+	void whenOptionsSetMultipleTimesThenMergedNotReplaced() {
+		ChatModel chatModel = mockChatModel();
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
+
+		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt()
+			.options(ChatOptions.builder().model("model-a").temperature(0.5))
+			.options(ChatOptions.builder().maxTokens(100));
+
+		// Verify both options are merged into the customizer
+		ChatOptions builtOptions = spec.getOptionsCustomizer().build();
+		assertThat(builtOptions.getModel()).isEqualTo("model-a");
+		assertThat(builtOptions.getTemperature()).isEqualTo(0.5);
+		assertThat(builtOptions.getMaxTokens()).isEqualTo(100);
+	}
+
+	@Test
+	void whenOptionsOverrideModelThenPreservesOtherProperties() {
+		ChatModel chatModel = mockChatModel();
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
+
+		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt()
+			.options(ChatOptions.builder().model("model-a").temperature(0.5).maxTokens(100))
+			.options(ChatOptions.builder().model("model-b"));
+
+		ChatOptions builtOptions = spec.getOptionsCustomizer().build();
+		// model should be overridden, but temperature and maxTokens should be preserved
+		assertThat(builtOptions.getModel()).isEqualTo("model-b");
+		assertThat(builtOptions.getTemperature()).isEqualTo(0.5);
+		assertThat(builtOptions.getMaxTokens()).isEqualTo(100);
+	}
+
+	@Test
+	void whenOptionsSetWithNullFieldsThenDoesNotWipeExistingValues() {
+		ChatModel chatModel = mockChatModel();
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
+
+		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt()
+			.options(ChatOptions.builder().model("model-a").temperature(0.7).topP(0.9))
+			.options(ChatOptions.builder().maxTokens(50)); // Only setting maxTokens,
+															// other fields are
+		// null
+
+		ChatOptions builtOptions = spec.getOptionsCustomizer().build();
+		// model and temperature from first call should be preserved
+		assertThat(builtOptions.getModel()).isEqualTo("model-a");
+		assertThat(builtOptions.getTemperature()).isEqualTo(0.7);
+		assertThat(builtOptions.getTopP()).isEqualTo(0.9);
+		assertThat(builtOptions.getMaxTokens()).isEqualTo(50);
+	}
+
+	@Test
+	void whenOptionsConflictThenLastWins() {
+		ChatModel chatModel = mockChatModel();
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
+
+		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt()
+			.options(ChatOptions.builder().temperature(0.5))
+			.options(ChatOptions.builder().temperature(0.9));
+
+		ChatOptions builtOptions = spec.getOptionsCustomizer().build();
+		assertThat(builtOptions.getTemperature()).isEqualTo(0.9);
+	}
+
+	@Test
+	void whenDefaultOptionsSetThenOptionsOverride() {
+		// Test that call-time options merge with defaultOptions (from
+		// ChatModel.getDefaultOptions())
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions())
+			.thenReturn(ChatOptions.builder().model("default-model").temperature(0.5).maxTokens(200).build());
+
+		ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+		given(chatModel.call(promptCaptor.capture()))
+			.willReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("response")))));
+
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
+		chatClient.prompt().user("test").options(ChatOptions.builder().model("override-model").topP(0.8)).call();
+
+		Prompt capturedPrompt = promptCaptor.getValue();
+		ChatOptions finalOptions = capturedPrompt.getOptions();
+
+		// Call-time model should override, but temperature and maxTokens from default
+		// should be preserved
+		assertThat(finalOptions.getModel()).isEqualTo("override-model");
+		assertThat(finalOptions.getTemperature()).isEqualTo(0.5);
+		assertThat(finalOptions.getMaxTokens()).isEqualTo(200);
+		assertThat(finalOptions.getTopP()).isEqualTo(0.8);
+	}
+
 	record Person(String name) {
 	}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientUtilsTests.java
@@ -494,6 +494,217 @@ class DefaultChatClientUtilsTests {
 		assertThat(result.context()).containsAllEntriesOf(advisorParams);
 	}
 
+	@Test
+	void whenDefaultOptionsAndCallTimeOptionsAreProvidedThenCallTimeOverrides() {
+		// Model default: temperature=0.5, maxTokens=100
+		ChatOptions modelDefaults = ChatOptions.builder().temperature(0.5).maxTokens(100).build();
+
+		// Call-time override: temperature=0.8 (maxTokens should inherit from defaults)
+		ChatOptions callTimeOptions = ChatOptions.builder().temperature(0.8).build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(modelDefaults);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello")
+			.options(callTimeOptions.mutate());
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result.prompt().getOptions()).isNotNull();
+		// Call-time temperature should win
+		assertThat(result.prompt().getOptions().getTemperature()).isEqualTo(0.8);
+		// Default maxTokens should be inherited
+		assertThat(result.prompt().getOptions().getMaxTokens()).isEqualTo(100);
+	}
+
+	@Test
+	void whenDefaultOptionsAndCallTimeOptionsPartialOverrideThenBothApply() {
+		// Model default: temperature=0.5, maxTokens=100, model="gpt-4"
+		ChatOptions modelDefaults = ChatOptions.builder().temperature(0.5).maxTokens(100).model("gpt-4").build();
+
+		// Call-time override: only maxTokens=200 (temperature and model should inherit)
+		ChatOptions callTimeOptions = ChatOptions.builder().maxTokens(200).build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(modelDefaults);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello")
+			.options(callTimeOptions.mutate());
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		// Call-time maxTokens should win
+		assertThat(result.prompt().getOptions().getMaxTokens()).isEqualTo(200);
+		// Default temperature and model should be inherited
+		assertThat(result.prompt().getOptions().getTemperature()).isEqualTo(0.5);
+		assertThat(result.prompt().getOptions().getModel()).isEqualTo("gpt-4");
+	}
+
+	@Test
+	void whenOnlyDefaultOptionsExistThenTheyAreUsed() {
+		ChatOptions modelDefaults = ChatOptions.builder().temperature(0.7).maxTokens(50).build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(modelDefaults);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello");
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result.prompt().getOptions().getTemperature()).isEqualTo(0.7);
+		assertThat(result.prompt().getOptions().getMaxTokens()).isEqualTo(50);
+	}
+
+	@Test
+	void whenOnlyCallTimeOptionsExistThenTheyAreUsed() {
+		ChatOptions callTimeOptions = ChatOptions.builder().temperature(0.9).topP(0.95).build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello")
+			.options(callTimeOptions.mutate());
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result.prompt().getOptions().getTemperature()).isEqualTo(0.9);
+		assertThat(result.prompt().getOptions().getTopP()).isEqualTo(0.95);
+	}
+
+	@Test
+	void whenNeitherOptionsExistThenResultIsEmpty() {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello");
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result.prompt().getOptions()).isNotNull();
+	}
+
+	@Test
+	void whenCallTimeOptionsNullOutDefaultThenNullWins() {
+		// Model default has temperature=0.5
+		ChatOptions modelDefaults = ChatOptions.builder().temperature(0.5).build();
+		// Call-time customizer does not set temperature (null), so default should apply
+		ChatOptions callTimeOptions = ChatOptions.builder().maxTokens(200).build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(modelDefaults);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello")
+			.options(callTimeOptions.mutate());
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		// Default temperature should be inherited when call-time doesn't set it
+		assertThat(result.prompt().getOptions().getTemperature()).isEqualTo(0.5);
+		assertThat(result.prompt().getOptions().getMaxTokens()).isEqualTo(200);
+	}
+
+	@Test
+	void whenToolCallingOptionsWithDefaultsAndCallTimeOverrideThenMerged() {
+		// Model default ToolCallingChatOptions with toolName defaultTool
+		ToolCallingChatOptions modelDefaults = ToolCallingChatOptions.builder()
+			.temperature(0.5)
+			.toolNames(Set.of("defaultTool"))
+			.build();
+
+		// Call-time ToolCallingChatOptions overrides toolName and temperature
+		ToolCallingChatOptions callTimeOptions = ToolCallingChatOptions.builder()
+			.temperature(0.8)
+			.toolNames(Set.of("runtimeTool"))
+			.build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(modelDefaults);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello")
+			.options(callTimeOptions.mutate());
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result.prompt().getOptions()).isInstanceOf(ToolCallingChatOptions.class);
+		ToolCallingChatOptions resultOptions = (ToolCallingChatOptions) result.prompt().getOptions();
+		// Call-time values override defaults
+		assertThat(resultOptions.getTemperature()).isEqualTo(0.8);
+		assertThat(resultOptions.getToolNames()).containsExactly("runtimeTool");
+	}
+
+	@Test
+	void whenDefaultOptionsBeanAndCallTimeOptionsBothSetSameFieldThenCallTimeWins() {
+		// This is the classic bug scenario: bean sets temperature=0.1,
+		// call-time sets temperature=0.9. Call-time MUST win.
+		ChatOptions modelDefaults = ChatOptions.builder().temperature(0.1).maxTokens(10).build();
+		ChatOptions callTimeOptions = ChatOptions.builder().temperature(0.9).build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(modelDefaults);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello")
+			.options(callTimeOptions.mutate());
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result.prompt().getOptions().getTemperature()).isEqualTo(0.9);
+		// Unset fields from call-time should still inherit from defaults
+		assertThat(result.prompt().getOptions().getMaxTokens()).isEqualTo(10);
+	}
+
+	@Test
+	void whenDefaultOptionsBeanSetsAllFieldsAndCallTimeSetsPartialThenPartialOverrides() {
+		// Model bean configures full defaults
+		ChatOptions modelDefaults = ChatOptions.builder()
+			.model("gpt-4o")
+			.temperature(0.3)
+			.maxTokens(500)
+			.topP(0.9)
+			.frequencyPenalty(0.5)
+			.presencePenalty(0.5)
+			.stopSequences(List.of("STOP"))
+			.topK(10)
+			.build();
+
+		// User only overrides temperature at call time
+		ChatOptions callTimeOptions = ChatOptions.builder().temperature(1.0).build();
+
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getDefaultOptions()).thenReturn(modelDefaults);
+		DefaultChatClient.DefaultChatClientRequestSpec inputRequest = (DefaultChatClient.DefaultChatClientRequestSpec) ChatClient
+			.create(chatModel)
+			.prompt()
+			.user("Hello")
+			.options(callTimeOptions.mutate());
+
+		ChatClientRequest result = DefaultChatClientUtils.toChatClientRequest(inputRequest);
+
+		assertThat(result.prompt().getOptions().getTemperature()).isEqualTo(1.0); // overridden
+		assertThat(result.prompt().getOptions().getModel()).isEqualTo("gpt-4o"); // inherited
+		assertThat(result.prompt().getOptions().getMaxTokens()).isEqualTo(500); // inherited
+		assertThat(result.prompt().getOptions().getTopP()).isEqualTo(0.9); // inherited
+		assertThat(result.prompt().getOptions().getFrequencyPenalty()).isEqualTo(0.5); // inherited
+		assertThat(result.prompt().getOptions().getPresencePenalty()).isEqualTo(0.5); // inherited
+		assertThat(result.prompt().getOptions().getStopSequences()).containsExactly("STOP"); // inherited
+		assertThat(result.prompt().getOptions().getTopK()).isEqualTo(10); // inherited
+	}
+
 	static class TestToolCallback implements ToolCallback {
 
 		private final ToolDefinition toolDefinition;


### PR DESCRIPTION
Implements deep merge for ChatClient options.

**Issue**: ChatClient defaultOptions() completely replaces auto-configured options — users cannot selectively override specific properties (e.g., model name) without losing all other auto-configured properties.

**Changes**:
- Modified DefaultChatClient.DefaultChatClientRequestSpec.options() to merge options instead of replacing
- When options() is called multiple times, subsequent calls merge into the existing customizer via combineWith()
- Null fields in later calls do not wipe out values from earlier calls
- Tests added covering: multiple .options() merge, null fields don't wipe values, conflicting values use last-wins semantics, call-time options merge with ChatModel default options

Closes #5821