### PR TITLE
Fix ChatClientRequest to reject null values in context Map, preventing NPE in advisors

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientRequest.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientRequest.java
@@ -82,6 +82,11 @@ public record ChatClientRequest(Prompt prompt, Map<String, @Nullable Object> con
 
 		public ChatClientRequest build() {
 			Assert.state(this.prompt != null, "prompt cannot be null");
+			for (Map.Entry<String, @Nullable Object> entry : this.context.entrySet()) {
+				if (entry.getValue() == null) {
+					throw new IllegalArgumentException("context values must not be null");
+				}
+			}
 			return new ChatClientRequest(this.prompt, this.context);
 		}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientRequestNullContextTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientRequestNullContextTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for {@link ChatClientRequest} null-value handling in context.
+ *
+ * @see <a href="https://github.com/spring-projects/spring-ai/issues/4952">Issue #4952</a>
+ */
+class ChatClientRequestNullContextTests {
+
+	@Test
+	void whenContextHasNullValueThenThrowViaBuilder() {
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context("tenantId", null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values must not be null");
+	}
+
+	@Test
+	void whenContextMapHasNullValueThenThrowViaBuilder() {
+		Map<String, Object> contextWithNull = new HashMap<>();
+		contextWithNull.put("tenantId", null);
+		contextWithNull.put("userId", "user-123");
+
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context(contextWithNull).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values must not be null");
+	}
+
+	@Test
+	void whenContextHasNullKeyAlreadyThrows() {
+		Map<String, Object> contextWithNullKey = new HashMap<>();
+		contextWithNullKey.put(null, "value");
+
+		assertThatThrownBy(() -> ChatClientRequest.builder().prompt(new Prompt()).context(contextWithNullKey).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context keys cannot be null");
+	}
+
+	@Test
+	void whenContextHasOnlyValidEntriesThenBuildSucceeds() {
+		Prompt prompt = new Prompt("test");
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.context("key1", "value1")
+			.context("key2", 42)
+			.build();
+
+		assertThat(request.context()).hasSize(2);
+		assertThat(request.context().get("key1")).isEqualTo("value1");
+		assertThat(request.context().get("key2")).isEqualTo(42);
+	}
+
+	@Test
+	void whenContextMapHasOnlyValidEntriesThenBuildSucceeds() {
+		Prompt prompt = new Prompt("test");
+		Map<String, Object> context = Map.of("key1", "value1", "key2", 42);
+
+		ChatClientRequest request = ChatClientRequest.builder().prompt(prompt).context(context).build();
+
+		assertThat(request.context()).hasSize(2);
+		assertThat(request.context().get("key1")).isEqualTo("value1");
+		assertThat(request.context().get("key2")).isEqualTo(42);
+	}
+
+	@Test
+	void whenMutateAddsNullValueThenBuildThrows() {
+		ChatClientRequest original = ChatClientRequest.builder()
+			.prompt(new Prompt())
+			.context("existing", "value")
+			.build();
+
+		assertThatThrownBy(() -> original.mutate().context("newKey", null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values must not be null");
+	}
+
+	@Test
+	void whenMutateMergesMapWithNullValueThenBuildThrows() {
+		ChatClientRequest original = ChatClientRequest.builder()
+			.prompt(new Prompt())
+			.context("existing", "value")
+			.build();
+
+		Map<String, Object> badMap = new HashMap<>();
+		badMap.put("goodKey", "goodValue");
+		badMap.put("badKey", null);
+
+		assertThatThrownBy(() -> original.mutate().context(badMap).build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values must not be null");
+	}
+
+}


### PR DESCRIPTION
## Fix: ChatClientRequest null-value validation in context Map

**See:** https://github.com/spring-projects/spring-ai/issues/4952

### Problem

`ChatClientRequest` only validated null keys in its context `Map`, not null values. When advisors (`ChatModelStreamAdvisor`, `ChatModelCallAdvisor`, `SafeGuardAdvisor`) call `Map.copyOf(request.context())`, it throws `NullPointerException` on null values — crashing before the model is ever invoked.

### Solution

Tightened `ChatClientRequest.Builder.build()` to iterate context entries and throw `IllegalArgumentException` with message `"context values must not be null"` if any value is null.

### Changes

**Modified:** `spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClientRequest.java`
- Added null-value check in `Builder.build()`: iterates context entries and throws `IllegalArgumentException` if any value is null

**Added:** `spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientRequestNullContextTests.java`
- 7 test cases covering: null value via `context(key, null)`, null value via `context(map)`, null key already handled, valid entries pass, mutate with null value throws

### Testing

`mvn test -pl spring-ai-client-chat -Dtest=ChatClientRequestNullContextTests -P '!checkstyle-check'` — all 7 tests pass.