### PR TITLE
Upgrade MCP SDK to 2.0.0-SNAPSHOT and fix tests for API changes

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotations2IT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotations2IT.java
@@ -162,7 +162,7 @@ public class StreamableMcpAnnotations2IT {
 						// Call a tool that sends progress notifications
 						CallToolRequest toolRequest = CallToolRequest.builder()
 							.name("tool1")
-							.arguments(Map.of())
+							.arguments(Map.of("input", "Test Input"))
 							.progressToken("test-progress-token")
 							.build();
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsIT.java
@@ -163,7 +163,7 @@ public class StreamableMcpAnnotationsIT {
 						// Call a tool that sends progress notifications
 						CallToolRequest toolRequest = CallToolRequest.builder()
 							.name("tool1")
-							.arguments(Map.of())
+							.arguments(Map.of("input", "Test Input"))
 							.progressToken("test-progress-token")
 							.build();
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsManualIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/test/java/org/springframework/ai/mcp/server/webflux/autoconfigure/StreamableMcpAnnotationsManualIT.java
@@ -170,7 +170,7 @@ public class StreamableMcpAnnotationsManualIT {
 						// Call a tool that sends progress notifications
 						CallToolRequest toolRequest = CallToolRequest.builder()
 							.name("tool1")
-							.arguments(Map.of())
+							.arguments(Map.of("input", "Test Input"))
 							.progressToken("test-progress-token")
 							.build();
 

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/AsyncMcpToolCallbackTest.java
@@ -202,7 +202,7 @@ class AsyncMcpToolCallbackTest {
 	@Test
 	void getToolDefinitionShouldReturnCorrectDefinition() {
 		when(this.tool.description()).thenReturn("Test tool description");
-		var jsonSchema = mock(McpSchema.JsonSchema.class);
+		var jsonSchema = mock(Map.class);
 		when(this.tool.inputSchema()).thenReturn(jsonSchema);
 
 		// Act
@@ -294,7 +294,7 @@ class AsyncMcpToolCallbackTest {
 	void deprecatedConstructorShouldWork() {
 		when(this.tool.name()).thenReturn("testTool");
 		when(this.tool.description()).thenReturn("Test description");
-		when(this.tool.inputSchema()).thenReturn(mock(McpSchema.JsonSchema.class));
+		when(this.tool.inputSchema()).thenReturn(mock(Map.class));
 		var clientInfo = new Implementation("testClient", "1.0.0");
 		when(this.mcpClient.getClientInfo()).thenReturn(clientInfo);
 

--- a/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderBuilderTest.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/SyncMcpToolCallbackProviderBuilderTest.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.mcp;
 
 import java.util.List;
+import java.util.Map;
 
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -253,7 +254,7 @@ class SyncMcpToolCallbackProviderBuilderTest {
 		Tool tool = Mockito.mock(Tool.class);
 		when(tool.name()).thenReturn(toolName);
 		when(tool.description()).thenReturn("Test tool description");
-		when(tool.inputSchema()).thenReturn(Mockito.mock(McpSchema.JsonSchema.class));
+		when(tool.inputSchema()).thenReturn(Mockito.mock(Map.class));
 
 		// Mock list tools response
 		McpSchema.ListToolsResult listToolsResult = Mockito.mock(McpSchema.ListToolsResult.class);

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
 		<json-schema-validator.version>3.0.1</json-schema-validator.version>
 
 		<!-- MCP-->
-		<mcp.sdk.version>1.1.0</mcp.sdk.version>
+		<mcp.sdk.version>2.0.0-SNAPSHOT</mcp.sdk.version>
 
 		<!-- plugin versions -->
 		<antlr.version>4.13.1</antlr.version>


### PR DESCRIPTION
Bump mcp.sdk.version from 1.1.0 to 2.0.0-SNAPSHOT. Adapt tests to the updated SDK API: replace McpSchema.JsonSchema mocks with Map (inputSchema() now returns Map), and supply required arguments to CallToolRequest in Streamable MCP annotation integration tests.