### PR TITLE
GH-5776: Add Jina AI Scoring (Reranker) Module

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-jina/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-jina/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-autoconfigure-model-jina</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Jina Auto Configuration</name>
+	<description>Spring AI Jina Auto Configuration</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<!-- Spring AI dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-jina</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Spring AI auto configurations -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webclient</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/java/org/springframework/ai/jina/autoconfigure/JinaScoringAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/java/org/springframework/ai/jina/autoconfigure/JinaScoringAutoConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.autoconfigure;
+
+import org.springframework.ai.jina.JinaScoringModel;
+import org.springframework.ai.jina.api.JinaScoringApi;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.util.Assert;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+/**
+ * {@link AutoConfiguration Auto-configuration} for Jina AI Scoring Model.
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(JinaScoringApi.class)
+@EnableConfigurationProperties({ JinaScoringProperties.class })
+@ConditionalOnProperty(prefix = JinaScoringProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+public class JinaScoringAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = JinaScoringProperties.CONFIG_PREFIX, name = "api-key")
+	public JinaScoringModel jinaScoringModel(final JinaScoringProperties properties,
+			final ObjectProvider<RestClient.Builder> restClientBuilderProvider,
+			final ObjectProvider<RetryTemplate> retryTemplate,
+			final ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
+
+		Assert.hasText(properties.getApiKey(), "Jina API key must be set");
+		Assert.hasText(properties.getBaseUrl(), "Jina base URL must be set");
+
+		var jinaScoringApi = JinaScoringApi.builder()
+			.baseUrl(properties.getBaseUrl())
+			.apiKey(properties.getApiKey())
+			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
+			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
+			.build();
+
+		return JinaScoringModel.builder()
+			.jinaScoringApi(jinaScoringApi)
+			.options(properties.getOptions())
+			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
+			.build();
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/java/org/springframework/ai/jina/autoconfigure/JinaScoringProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/java/org/springframework/ai/jina/autoconfigure/JinaScoringProperties.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.autoconfigure;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.jina.JinaScoringOptions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for Jina AI scoring model.
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+@ConfigurationProperties(JinaScoringProperties.CONFIG_PREFIX)
+public class JinaScoringProperties {
+
+	/**
+	 * Configuration prefix for Jina AI scoring properties.
+	 */
+	public static final String CONFIG_PREFIX = "spring.ai.jina.scoring";
+
+	/**
+	 * Default base URL for the Jina AI API.
+	 */
+	public static final String DEFAULT_BASE_URL = "https://api.jina.ai";
+
+	/**
+	 * Enable Jina scoring model.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * The URL to connect to.
+	 */
+	private String baseUrl = DEFAULT_BASE_URL;
+
+	/**
+	 * Jina AI API Key.
+	 */
+	private @Nullable String apiKey;
+
+	/**
+	 * Default options for Jina scoring.
+	 */
+	@NestedConfigurationProperty
+	private final JinaScoringOptions options = JinaScoringOptions.builder().build();
+
+	/**
+	 * Check if the Jina scoring model is enabled.
+	 * @return true if enabled
+	 */
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	/**
+	 * Set whether to enable the Jina scoring model.
+	 * @param enabled the enabled flag
+	 */
+	public void setEnabled(final boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	/**
+	 * Get the base URL for the Jina AI API.
+	 * @return the base URL
+	 */
+	public String getBaseUrl() {
+		return this.baseUrl;
+	}
+
+	/**
+	 * Set the base URL for the Jina AI API.
+	 * @param baseUrl the base URL
+	 */
+	public void setBaseUrl(final String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+	/**
+	 * Get the Jina AI API Key.
+	 * @return the API key
+	 */
+	public @Nullable String getApiKey() {
+		return this.apiKey;
+	}
+
+	/**
+	 * Set the Jina AI API Key.
+	 * @param apiKey the API key
+	 */
+	public void setApiKey(final String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	/**
+	 * Get the default options for Jina scoring.
+	 * @return the Jina scoring options
+	 */
+	public JinaScoringOptions getOptions() {
+		return this.options;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/java/org/springframework/ai/jina/autoconfigure/package-info.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/java/org/springframework/ai/jina/autoconfigure/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for Jina AI Scoring Model.
+ */
+@NullMarked
+package org.springframework.ai.jina.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,18 @@
+{
+  "groups": [
+    {
+      "name": "spring.ai.jina.scoring.options",
+      "type": "org.springframework.ai.jina.JinaScoringOptions",
+      "sourceType": "org.springframework.ai.jina.autoconfigure.JinaScoringProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "spring.ai.jina.scoring.api-key",
+      "type": "java.lang.String",
+      "description": "API key for Jina AI.",
+      "sourceType": "org.springframework.ai.jina.autoconfigure.JinaScoringProperties"
+    }
+  ],
+  "hints": []
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2023-present the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.springframework.ai.jina.autoconfigure.JinaScoringAutoConfiguration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/test/java/org/springframework/ai/jina/autoconfigure/JinaScoringAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-jina/src/test/java/org/springframework/ai/jina/autoconfigure/JinaScoringAutoConfigurationIT.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.jina.JinaScoringModel;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link JinaScoringAutoConfiguration}.
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+public class JinaScoringAutoConfigurationIT {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(JinaScoringAutoConfiguration.class));
+
+	@Test
+	void elementActivation() {
+		// Test when API key is missing
+		this.contextRunner.run(context -> {
+			assertThat(context.getBeansOfType(JinaScoringProperties.class)).isNotEmpty();
+			assertThat(context.getBeansOfType(JinaScoringModel.class)).isEmpty();
+		});
+
+		// Test when API key is present
+		this.contextRunner.withPropertyValues("spring.ai.jina.scoring.api-key=TEST_API_KEY").run(context -> {
+			assertThat(context.getBeansOfType(JinaScoringProperties.class)).isNotEmpty();
+			assertThat(context.getBeansOfType(JinaScoringModel.class)).isNotEmpty();
+		});
+
+		// Test when component is explicitly disabled
+		this.contextRunner
+			.withPropertyValues("spring.ai.jina.scoring.enabled=false", "spring.ai.jina.scoring.api-key=TEST_API_KEY")
+			.run(context -> {
+				assertThat(context.getBeansOfType(JinaScoringProperties.class)).isEmpty();
+				assertThat(context.getBeansOfType(JinaScoringModel.class)).isEmpty();
+			});
+	}
+
+	@Test
+	void optionsBinding() {
+		this.contextRunner.withPropertyValues(
+		// @formatter:off
+				"spring.ai.jina.scoring.api-key=TEST_API_KEY",
+				"spring.ai.jina.scoring.base-url=http://TEST.BASE.URL",
+				"spring.ai.jina.scoring.options.model=CUSTOM_MODEL",
+				"spring.ai.jina.scoring.options.top-k=10"
+				// @formatter:on
+		).run(context -> {
+			var properties = context.getBean(JinaScoringProperties.class);
+
+			assertThat(properties.getApiKey()).isEqualTo("TEST_API_KEY");
+			assertThat(properties.getBaseUrl()).isEqualTo("http://TEST.BASE.URL");
+
+			assertThat(properties.getOptions().getModel()).isEqualTo("CUSTOM_MODEL");
+			assertThat(properties.getOptions().getTopK()).isEqualTo(10);
+		});
+	}
+
+	@Test
+	void customScoringModelBean() {
+		this.contextRunner.withPropertyValues("spring.ai.jina.scoring.api-key=TEST_API_KEY")
+			.withUserConfiguration(CustomScoringModelConfig.class)
+			.run(context -> {
+				assertThat(context.getBeansOfType(JinaScoringModel.class)).hasSize(1);
+				assertThat(context.getBean(JinaScoringModel.class)).isSameAs(CustomScoringModelConfig.customModel);
+			});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomScoringModelConfig {
+
+		static final JinaScoringModel customModel = JinaScoringModel.builder()
+			.jinaScoringApi(org.springframework.ai.jina.api.JinaScoringApi.builder().apiKey("DUMMY_KEY").build())
+			.build();
+
+		@Bean
+		public JinaScoringModel customJinaScoringModel() {
+			return customModel;
+		}
+
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vllm/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vllm/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.1-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-autoconfigure-model-vllm</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI vLLM Auto Configuration</name>
+	<description>Spring AI vLLM Auto Configuration</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<dependencies>
+		<!-- Spring AI dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-vllm</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Spring AI auto configurations -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-retry</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webclient</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/java/org/springframework/ai/vllm/autoconfigure/VllmScoringAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/java/org/springframework/ai/vllm/autoconfigure/VllmScoringAutoConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vllm.autoconfigure;
+
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.vllm.VllmScoringModel;
+import org.springframework.ai.vllm.api.VllmScoringApi;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.util.Assert;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+/**
+ * {@link AutoConfiguration Auto-configuration} for vLLM Scoring Model.
+ *
+ * @author Spring AI
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass(VllmScoringApi.class)
+@EnableConfigurationProperties(VllmScoringProperties.class)
+@ConditionalOnProperty(prefix = VllmScoringProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+public class VllmScoringAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	public VllmScoringModel vllmScoringModel(final VllmScoringProperties properties,
+			final ObjectProvider<RestClient.Builder> restClientBuilderProvider,
+			final ObjectProvider<RetryTemplate> retryTemplate,
+			final ObjectProvider<ResponseErrorHandler> responseErrorHandler) {
+
+		Assert.hasText(properties.getBaseUrl(), "vLLM base URL must be set");
+
+		var vllmScoringApi = VllmScoringApi.builder()
+			.baseUrl(properties.getBaseUrl())
+			.apiKey(properties.getApiKey())
+			.restClientBuilder(restClientBuilderProvider.getIfAvailable(RestClient::builder))
+			.responseErrorHandler(responseErrorHandler.getIfAvailable(() -> RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER))
+			.build();
+
+		return VllmScoringModel.builder()
+			.vllmScoringApi(vllmScoringApi)
+			.options(properties.getOptions())
+			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
+			.build();
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/java/org/springframework/ai/vllm/autoconfigure/VllmScoringProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/java/org/springframework/ai/vllm/autoconfigure/VllmScoringProperties.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vllm.autoconfigure;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.vllm.VllmScoringOptions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for vLLM Scoring API.
+ *
+ * @author Spring AI
+ * @since 2.0.0
+ */
+@ConfigurationProperties(VllmScoringProperties.CONFIG_PREFIX)
+public class VllmScoringProperties {
+
+	public static final String CONFIG_PREFIX = "spring.ai.vllm.scoring";
+
+	public static final String DEFAULT_BASE_URL = "http://localhost:8000";
+
+	/** Enable vLLM scoring model. */
+	private boolean enabled = true;
+
+	/** vLLM server base URL. */
+	private String baseUrl = DEFAULT_BASE_URL;
+
+	/** vLLM API Key (Optional). */
+	private @Nullable String apiKey;
+
+	@NestedConfigurationProperty
+	private VllmScoringOptions options = VllmScoringOptions.builder().build();
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getBaseUrl() {
+		return this.baseUrl;
+	}
+
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+	public @Nullable String getApiKey() {
+		return this.apiKey;
+	}
+
+	public void setApiKey(@Nullable String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public VllmScoringOptions getOptions() {
+		return this.options;
+	}
+
+	public void setOptions(VllmScoringOptions options) {
+		this.options = options;
+	}
+
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/java/org/springframework/ai/vllm/autoconfigure/package-info.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/java/org/springframework/ai/vllm/autoconfigure/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * vLLM auto-configuration implementations.
+ */
+@NullMarked
+package org.springframework.ai.vllm.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,41 @@
+{
+  "properties": [
+    {
+      "name": "spring.ai.vllm.scoring.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable vLLM scoring model.",
+      "defaultValue": true
+    },
+    {
+      "name": "spring.ai.vllm.scoring.base-url",
+      "type": "java.lang.String",
+      "description": "vLLM API base URL.",
+      "defaultValue": "http://localhost:8000"
+    },
+    {
+      "name": "spring.ai.vllm.scoring.api-key",
+      "type": "java.lang.String",
+      "description": "vLLM API Key. Optional if vLLM server is not secured."
+    },
+    {
+      "name": "spring.ai.vllm.scoring.options.model",
+      "type": "java.lang.String",
+      "description": "The name of the scoring model to use (e.g., 'BAAI/bge-reranker-v2-m3')."
+    },
+    {
+      "name": "spring.ai.vllm.scoring.options.top-n",
+      "type": "java.lang.Integer",
+      "description": "Number of top documents to return."
+    },
+    {
+      "name": "spring.ai.vllm.scoring.options.return-documents",
+      "type": "java.lang.Boolean",
+      "description": "Whether to return the original document texts."
+    },
+    {
+      "name": "spring.ai.vllm.scoring.options.truncation",
+      "type": "java.lang.Boolean",
+      "description": "Whether to truncate documents to fit the model's context window."
+    }
+  ]
+}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.ai.vllm.autoconfigure.VllmScoringAutoConfiguration

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/test/java/org/springframework/ai/vllm/autoconfigure/VllmScoringAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vllm/src/test/java/org/springframework/ai/vllm/autoconfigure/VllmScoringAutoConfigurationIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vllm.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.vllm.VllmScoringModel;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration Tests for {@link VllmScoringAutoConfiguration}.
+ *
+ * @author Spring AI
+ */
+class VllmScoringAutoConfigurationIT {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withPropertyValues("spring.ai.vllm.scoring.options.model=BAAI/bge-reranker-v2-m3")
+		.withConfiguration(AutoConfigurations.of(VllmScoringAutoConfiguration.class));
+
+	@Test
+	void propertiesAreLoaded() {
+		this.contextRunner.run(context -> {
+			VllmScoringProperties properties = context.getBean(VllmScoringProperties.class);
+			assertThat(properties.getBaseUrl()).isEqualTo("http://localhost:8000");
+			assertThat(properties.isEnabled()).isTrue();
+			assertThat(properties.getOptions().getModel()).isEqualTo("BAAI/bge-reranker-v2-m3");
+		});
+	}
+
+	@Test
+	void beansAreCreated() {
+		this.contextRunner.run(context -> assertThat(context).hasSingleBean(VllmScoringModel.class));
+	}
+
+	@Test
+	void configurationCanBeDisabled() {
+		this.contextRunner.withPropertyValues("spring.ai.vllm.scoring.enabled=false")
+			.run(context -> assertThat(context).doesNotHaveBean(VllmScoringModel.class));
+	}
+
+}

--- a/models/spring-ai-jina/pom.xml
+++ b/models/spring-ai-jina/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>spring-ai-jina</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring AI Model - Jina AI</name>
+	<description>Jina AI models support</description>
+	<url>https://github.com/spring-projects/spring-ai</url>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+	</properties>
+
+	<dependencies>
+
+		<!-- production dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-test</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-rag</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>4.12.0</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/JinaScoringModel.java
+++ b/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/JinaScoringModel.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.jina.api.JinaScoringApi;
+import org.springframework.ai.jina.api.JinaScoringApi.RerankRequest;
+import org.springframework.ai.jina.api.JinaScoringApi.RerankResponse;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.scoring.ScoringModel;
+import org.springframework.ai.scoring.ScoringOptions;
+import org.springframework.ai.scoring.ScoringRequest;
+import org.springframework.ai.scoring.ScoringResponse;
+import org.springframework.ai.scoring.ScoringResult;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+
+/**
+ * Jina AI {@link ScoringModel}.
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+public final class JinaScoringModel implements ScoringModel {
+
+	/** Logger. */
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+	/** API client. */
+	private final JinaScoringApi api;
+
+	/** Retry template. */
+	private final RetryTemplate retry;
+
+	/** Options. */
+	private final JinaScoringOptions options;
+
+	/**
+	 * Create model.
+	 * @param apiParam api
+	 * @param retryParam retry
+	 * @param optionsParam options
+	 */
+	public JinaScoringModel(final JinaScoringApi apiParam, final RetryTemplate retryParam,
+			final JinaScoringOptions optionsParam) {
+		Assert.notNull(apiParam, "apiParam must not be null");
+		Assert.notNull(retryParam, "retryParam must not be null");
+		Assert.notNull(optionsParam, "optionsParam must not be null");
+		this.api = apiParam;
+		this.retry = retryParam;
+		this.options = optionsParam;
+	}
+
+	@Override
+	public ScoringResponse call(final ScoringRequest request) {
+		Assert.notNull(request, "ScoringRequest must not be null");
+		Assert.notEmpty(request.getInstructions(), "Documents must not be empty");
+
+		return RetryUtils.execute(this.retry, () -> {
+			JinaScoringOptions opts = mergeOptions(request.getOptions());
+			List<Document> documents = request.getInstructions();
+			List<String> texts = documents.stream().map(doc -> {
+				String text = doc.getText();
+				if (text == null) {
+					throw new IllegalArgumentException("Document text null: " + doc.getId());
+				}
+				return text;
+			}).toList();
+
+			String modelName = opts.getModel();
+			Assert.notNull(modelName, "Model name must not be null");
+			RerankRequest apiReq = new RerankRequest(modelName, request.getQuery(), texts, opts.getTopK(), null,
+					opts.getTruncation());
+
+			ResponseEntity<RerankResponse> resp = this.api.rerank(apiReq);
+
+			return convertResponse(resp, documents);
+		});
+	}
+
+	@Override
+	public ScoringResponse call(final String query, final List<Document> documents) {
+		Assert.hasText(query, "Query must not be empty");
+		Assert.notEmpty(documents, "Documents must not be empty");
+		return this.call(new ScoringRequest(query, documents));
+	}
+
+	private JinaScoringOptions mergeOptions(final @Nullable ScoringOptions runtimeOptions) {
+		if (runtimeOptions == null) {
+			return this.options;
+		}
+
+		JinaScoringOptions jinaOpts;
+		if (runtimeOptions instanceof JinaScoringOptions opts) {
+			jinaOpts = opts;
+		}
+		else {
+			JinaScoringOptions.Builder optBuilder = JinaScoringOptions.builder();
+			Integer topK = runtimeOptions.getTopK();
+			if (topK != null) {
+				optBuilder.topK(topK);
+			}
+			jinaOpts = optBuilder.build();
+		}
+
+		return ModelOptionsUtils.merge(jinaOpts, this.options, JinaScoringOptions.class);
+	}
+
+	private ScoringResponse convertResponse(final ResponseEntity<RerankResponse> responseEntity,
+			final List<Document> docs) {
+
+		RerankResponse body = responseEntity.getBody();
+		if (body == null) {
+			this.log.warn("No response");
+			return new ScoringResponse(List.of());
+		}
+
+		return new ScoringResponse(body.results().stream().map(res -> {
+			Document doc = docs.get(res.index());
+			Document scored = doc.mutate().score(res.relevanceScore()).build();
+			return new ScoringResult(scored);
+		}).toList());
+	}
+
+	/**
+	 * Create builder.
+	 * @return builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/** Builder class. */
+	public static final class Builder {
+
+		/** API client. */
+		private @Nullable JinaScoringApi api;
+
+		/** Retry template. */
+		private RetryTemplate retry = RetryUtils.DEFAULT_RETRY_TEMPLATE;
+
+		/** Options. */
+		private JinaScoringOptions options = JinaScoringOptions.builder().build();
+
+		/**
+		 * Set api.
+		 * @param apiParam api
+		 * @return builder
+		 */
+		public Builder jinaScoringApi(final JinaScoringApi apiParam) {
+			this.api = apiParam;
+			return this;
+		}
+
+		/**
+		 * Set retry.
+		 * @param retryParam retry
+		 * @return builder
+		 */
+		public Builder retryTemplate(final RetryTemplate retryParam) {
+			this.retry = retryParam;
+			return this;
+		}
+
+		/**
+		 * Set options.
+		 * @param optionsParam options
+		 * @return builder
+		 */
+		public Builder options(final JinaScoringOptions optionsParam) {
+			this.options = optionsParam;
+			return this;
+		}
+
+		/**
+		 * Build.
+		 * @return model
+		 */
+		public JinaScoringModel build() {
+			Assert.state(this.api != null, "api must not be null");
+			return new JinaScoringModel(this.api, this.retry, this.options);
+		}
+
+	}
+
+}

--- a/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/JinaScoringOptions.java
+++ b/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/JinaScoringOptions.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.jina.api.JinaScoringApi;
+import org.springframework.ai.scoring.ScoringOptions;
+
+/**
+ * Jina AI options.
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class JinaScoringOptions implements ScoringOptions {
+
+	/** Default model name. */
+	private static final String DEFAULT_MODEL = JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue();
+
+	/** Model name. */
+	@JsonProperty("model")
+	private String modelName = DEFAULT_MODEL;
+
+	/** Top K results. */
+	@JsonProperty("top_n")
+	private @Nullable Integer topKValue;
+
+	/** Return documents flag. */
+	@JsonProperty("return_documents")
+	private @Nullable Boolean returnDocuments;
+
+	/** Truncation flag. */
+	@JsonProperty("truncation")
+	private @Nullable Boolean truncation;
+
+	/**
+	 * Create builder.
+	 * @return builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public @Nullable String getModel() {
+		return this.modelName;
+	}
+
+	/**
+	 * Set model.
+	 * @param name model name
+	 */
+	public void setModel(final String name) {
+		this.modelName = name;
+	}
+
+	@Override
+	public @Nullable Integer getTopK() {
+		return this.topKValue;
+	}
+
+	/**
+	 * Set top K.
+	 * @param value value
+	 */
+	public void setTopK(final Integer value) {
+		this.topKValue = value;
+	}
+
+	/**
+	 * Get return documents.
+	 * @return flag
+	 */
+	public @Nullable Boolean getReturnDocuments() {
+		return this.returnDocuments;
+	}
+
+	/**
+	 * Set return documents.
+	 * @param enabled flag
+	 */
+	public void setReturnDocuments(final Boolean enabled) {
+		this.returnDocuments = enabled;
+	}
+
+	/**
+	 * Get truncation.
+	 * @return flag
+	 */
+	public @Nullable Boolean getTruncation() {
+		return this.truncation;
+	}
+
+	/**
+	 * Set truncation.
+	 * @param enabled flag
+	 */
+	public void setTruncation(final Boolean enabled) {
+		this.truncation = enabled;
+	}
+
+	/** Builder class. */
+	public static final class Builder {
+
+		/** Options. */
+		private final JinaScoringOptions options = new JinaScoringOptions();
+
+		/**
+		 * Set model.
+		 * @param name model name
+		 * @return builder
+		 */
+		public Builder model(final String name) {
+			this.options.setModel(name);
+			return this;
+		}
+
+		/**
+		 * Set top K.
+		 * @param value value
+		 * @return builder
+		 */
+		public Builder topK(final Integer value) {
+			this.options.setTopK(value);
+			return this;
+		}
+
+		/**
+		 * Set return documents.
+		 * @param enabled flag
+		 * @return builder
+		 */
+		public Builder returnDocuments(final Boolean enabled) {
+			this.options.setReturnDocuments(enabled);
+			return this;
+		}
+
+		/**
+		 * Set truncation.
+		 * @param enabled flag
+		 * @return builder
+		 */
+		public Builder truncation(final Boolean enabled) {
+			this.options.setTruncation(enabled);
+			return this;
+		}
+
+		/**
+		 * Build.
+		 * @return options
+		 */
+		public JinaScoringOptions build() {
+			return this.options;
+		}
+
+	}
+
+}

--- a/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/api/JinaScoringApi.java
+++ b/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/api/JinaScoringApi.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.api;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Jina AI Reranker API client.
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+public class JinaScoringApi {
+
+	/** Default base URL. */
+	private static final String DEFAULT_BASE_URL = "https://api.jina.ai";
+
+	/** Rest client. */
+	private final RestClient restClient;
+
+	/**
+	 * Create a new API client.
+	 * @param baseUrl base URL
+	 * @param apiKey API key
+	 * @param restClientBuilder builder
+	 * @param responseErrorHandler error handler
+	 */
+	public JinaScoringApi(final String baseUrl, final String apiKey, final RestClient.Builder restClientBuilder,
+			final ResponseErrorHandler responseErrorHandler) {
+
+		Consumer<HttpHeaders> jsonHeaders = headers -> {
+			headers.setBearerAuth(apiKey);
+			headers.setContentType(MediaType.APPLICATION_JSON);
+		};
+
+		this.restClient = restClientBuilder.clone()
+			.baseUrl(baseUrl)
+			.defaultHeaders(jsonHeaders)
+			.defaultStatusHandler(responseErrorHandler)
+			.build();
+	}
+
+	/**
+	 * Rerank documents.
+	 * @param rerankRequest request
+	 * @return response
+	 */
+	public ResponseEntity<RerankResponse> rerank(final RerankRequest rerankRequest) {
+		Assert.notNull(rerankRequest, "Rerank request cannot be null.");
+
+		return this.restClient.post().uri("/v1/rerank").body(rerankRequest).retrieve().toEntity(RerankResponse.class);
+	}
+
+	/**
+	 * Create a builder.
+	 * @return builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/** Builder for JinaScoringApi. */
+	public static final class Builder {
+
+		/** Base URL. */
+		private String baseUrlValue = DEFAULT_BASE_URL;
+
+		/** API key. */
+		private @Nullable String apiKeyValue;
+
+		/** Rest client builder. */
+		private RestClient.Builder restClientBuilderValue = RestClient.builder();
+
+		/** Error handler. */
+		private ResponseErrorHandler errorHandlerValue = RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER;
+
+		/**
+		 * Set base URL.
+		 * @param baseUrl URL
+		 * @return this
+		 */
+		public Builder baseUrl(final String baseUrl) {
+			this.baseUrlValue = baseUrl;
+			return this;
+		}
+
+		/**
+		 * Set API key.
+		 * @param apiKey key
+		 * @return this
+		 */
+		public Builder apiKey(final String apiKey) {
+			this.apiKeyValue = apiKey;
+			return this;
+		}
+
+		/**
+		 * Set rest client builder.
+		 * @param builder builder
+		 * @return this
+		 */
+		public Builder restClientBuilder(final RestClient.Builder builder) {
+			this.restClientBuilderValue = builder;
+			return this;
+		}
+
+		/**
+		 * Set error handler.
+		 * @param handler handler
+		 * @return this
+		 */
+		public Builder responseErrorHandler(final ResponseErrorHandler handler) {
+			this.errorHandlerValue = handler;
+			return this;
+		}
+
+		/**
+		 * Build client.
+		 * @return client
+		 */
+		public JinaScoringApi build() {
+			Assert.state(this.apiKeyValue != null, "API key null");
+			return new JinaScoringApi(this.baseUrlValue, this.apiKeyValue, this.restClientBuilderValue,
+					this.errorHandlerValue);
+		}
+
+	}
+
+	/** Jina AI Reranker models. */
+	public enum Model {
+
+		/** V2 Base Multilingual. */
+		JINA_RERANKER_V2_BASE_MULTILINGUAL("jina-reranker-v2-base-multilingual"),
+		/** V1 Tiny EN. */
+		JINA_RERANKER_V1_TINY_EN("jina-reranker-v1-tiny-en"),
+		/** V1 Turbo EN. */
+		JINA_RERANKER_V1_TURBO_EN("jina-reranker-v1-turbo-en"),
+		/** V1 Base EN. */
+		JINA_RERANKER_V1_BASE_EN("jina-reranker-v1-base-en"),
+		/** ColBERT V1 EN. */
+		JINA_COLBERT_V1_EN("jina-colbert-v1-en"),
+		/** ColBERT V2. */
+		JINA_COLBERT_V2("jina-colbert-v2"),
+		/** M0. */
+		JINA_RERANKER_M0("jina-reranker-m0"),
+		/** V3. */
+		JINA_RERANKER_V3("jina-reranker-v3");
+
+		/** Model value. */
+		private final String modelValue;
+
+		Model(final String modelValue) {
+			this.modelValue = modelValue;
+		}
+
+		/**
+		 * Get value.
+		 * @return model name
+		 */
+		public String getValue() {
+			return this.modelValue;
+		}
+
+	}
+
+	/**
+	 * Rerank request.
+	 *
+	 * @param model model name
+	 * @param query query string
+	 * @param documents list of doc texts
+	 * @param topN top N results
+	 * @param returnDocs return docs flag
+	 * @param truncation truncation flag
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record RerankRequest(@JsonProperty("model") String model, @JsonProperty("query") String query,
+			@JsonProperty("documents") List<String> documents, @JsonProperty("top_n") @Nullable Integer topN,
+			@JsonProperty("return_documents") @Nullable Boolean returnDocs,
+			@JsonProperty("truncation") @Nullable Boolean truncation) {
+
+		/**
+		 * Initial constructor.
+		 * @param modelName model name
+		 * @param queryText query text
+		 * @param docList list of documents
+		 */
+		public RerankRequest(final String modelName, final String queryText, final List<String> docList) {
+			this(modelName, queryText, docList, null, null, null);
+		}
+	}
+
+	/**
+	 * Rerank response.
+	 *
+	 * @param model model used
+	 * @param results ranked results
+	 * @param usage token usage
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record RerankResponse(@JsonProperty("model") String model,
+			@JsonProperty("results") List<RerankResult> results, @JsonProperty("usage") @Nullable Usage usage) {
+	}
+
+	/**
+	 * Rerank result.
+	 *
+	 * @param index doc index
+	 * @param relevanceScore score
+	 * @param document doc content
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record RerankResult(@JsonProperty("index") int index, @JsonProperty("relevance_score") double relevanceScore,
+			@JsonProperty("document") @Nullable Document document) {
+	}
+
+	/**
+	 * Document wrapper.
+	 *
+	 * @param text document text
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Document(@JsonProperty("text") String text) {
+
+		/**
+		 * Create from string.
+		 * @param text doc text
+		 * @return document
+		 */
+		@com.fasterxml.jackson.annotation.JsonCreator(
+				mode = com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING)
+		public static Document fromString(final String text) {
+			return new Document(text);
+		}
+	}
+
+	/**
+	 * Token usage.
+	 *
+	 * @param totalTokens tokens
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Usage(@JsonProperty("total_tokens") int totalTokens) {
+	}
+
+}

--- a/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/api/package-info.java
+++ b/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/api/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jina AI Reranker API client implementation.
+ */
+@NullMarked
+package org.springframework.ai.jina.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/package-info.java
+++ b/models/spring-ai-jina/src/main/java/org/springframework/ai/jina/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jina AI Reranker scoring model implementation.
+ */
+@NullMarked
+package org.springframework.ai.jina;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/JinaScoringModelIT.java
+++ b/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/JinaScoringModelIT.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.jina.api.JinaScoringApi;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.scoring.ScoringRequest;
+import org.springframework.ai.scoring.ScoringResponse;
+import org.springframework.ai.scoring.ScoringResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link JinaScoringModel}.
+ *
+ * <p>
+ * These tests verify the high-level Spring AI abstraction layer by calling the real Jina
+ * AI Reranker API. A valid API key must be provided via the {@code JINA_API_KEY}
+ * environment variable.
+ *
+ * <p>
+ * To run locally:
+ *
+ * <pre>
+ * set JINA_API_KEY=jina_YOUR_REAL_API_KEY
+ * mvn test -Dtest=JinaScoringModelIT -pl models/spring-ai-jina
+ * </pre>
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+@EnabledIfEnvironmentVariable(named = "JINA_API_KEY", matches = ".+")
+class JinaScoringModelIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(JinaScoringModelIT.class);
+
+	private JinaScoringModel scoringModel;
+
+	@BeforeEach
+	void setUp() {
+		JinaScoringApi api = JinaScoringApi.builder().apiKey(System.getenv("JINA_API_KEY")).build();
+
+		this.scoringModel = JinaScoringModel.builder()
+			.jinaScoringApi(api)
+			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
+			.options(JinaScoringOptions.builder()
+				.model(JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue())
+				.build())
+			.build();
+	}
+
+	@Test
+	void scoreSingleQueryWithMultipleDocuments() {
+		// Arrange
+		List<Document> documents = List.of(
+				new Document(
+						"Spring AI provides a unified API for integrating various AI models into Spring applications."),
+				new Document("React is a JavaScript library for building user interfaces developed by Meta."),
+				new Document("The Spring Framework is a comprehensive framework for enterprise Java development."),
+				new Document("Python is widely used in data science and machine learning."));
+
+		// Act - using the convenience method
+		ScoringResponse response = this.scoringModel.call("What is Spring AI?", documents);
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).isNotEmpty();
+		assertThat(response.getResults()).hasSize(4);
+
+		// Verify that each result has a score assigned
+		for (ScoringResult result : response.getResults()) {
+			assertThat(result.getOutput()).isNotNull();
+			assertThat(result.getOutput().getScore()).isNotNull();
+			assertThat(result.getOutput().getScore()).isBetween(0.0, 1.0);
+			assertThat(result.getOutput().getText()).isNotBlank();
+
+			logger.info("Document: '{}...', Score: {}", result.getOutput().getText().substring(0, 30),
+					result.getOutput().getScore());
+		}
+
+		// The most relevant document (Spring AI) should have the highest score
+		ScoringResult topResult = response.getResult();
+		assertThat(topResult).isNotNull();
+		assertThat(topResult.getOutput().getText()).contains("Spring AI");
+
+		logger.info("Top result: '{}', Score: {}", topResult.getOutput().getText(), topResult.getOutput().getScore());
+	}
+
+	@Test
+	void scoreWithTopKOptionOverride() {
+		// Arrange
+		List<Document> documents = List.of(new Document("Spring Boot simplifies Spring application development."),
+				new Document("Docker enables containerized application deployment."),
+				new Document("Kubernetes automates container orchestration at scale."),
+				new Document("Spring AI integrates machine learning models with Spring Boot."),
+				new Document("Node.js is a server-side JavaScript runtime environment."));
+
+		JinaScoringOptions runtimeOptions = JinaScoringOptions.builder().topK(2).build();
+
+		ScoringRequest request = new ScoringRequest("Spring Boot development", documents, runtimeOptions);
+
+		// Act
+		ScoringResponse response = this.scoringModel.call(request);
+
+		// Assert - only top 2 results should be returned
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(2);
+
+		// Results should be in descending score order
+		double firstScore = response.getResults().get(0).getOutput().getScore();
+		double secondScore = response.getResults().get(1).getOutput().getScore();
+		assertThat(firstScore).isGreaterThanOrEqualTo(secondScore);
+
+		logger.info("Top-K=2 results:");
+		response.getResults()
+			.forEach(r -> logger.info("  Document: '{}...', Score: {}", r.getOutput().getText().substring(0, 25),
+					r.getOutput().getScore()));
+	}
+
+	@Test
+	void scoreWithScoringRequestConstructor() {
+		// Arrange - tests the full ScoringRequest path (not convenvience method)
+		List<Document> documents = List.of(new Document("Spring AI is built on top of the Spring Framework."),
+				new Document("TensorFlow is an open-source machine learning framework by Google."));
+
+		ScoringRequest request = new ScoringRequest("What is Spring AI?", documents, null);
+
+		// Act
+		ScoringResponse response = this.scoringModel.call(request);
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(2);
+
+		// Spring AI document should score higher than TensorFlow
+		ScoringResult topResult = response.getResult();
+		assertThat(topResult).isNotNull();
+		assertThat(topResult.getOutput().getText()).contains("Spring AI");
+
+		logger.info("Full ScoringRequest path - Top: '{}', Score: {}", topResult.getOutput().getText(),
+				topResult.getOutput().getScore());
+	}
+
+	@Test
+	void scorePreservesOriginalDocumentMetadata() {
+		// Arrange - verify that metadata from original documents is preserved after
+		// scoring
+		List<Document> documents = List.of(
+				Document.builder()
+					.text("Spring AI provides model integration.")
+					.metadata("source", "docs.spring.io")
+					.metadata("chapter", "introduction")
+					.build(),
+				Document.builder()
+					.text("React is a UI library.")
+					.metadata("source", "reactjs.org")
+					.metadata("chapter", "getting-started")
+					.build());
+
+		// Act
+		ScoringResponse response = this.scoringModel.call("Spring AI", documents);
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(2);
+
+		// Each result should preserve the original document's metadata
+		for (ScoringResult result : response.getResults()) {
+			assertThat(result.getOutput().getMetadata()).containsKey("source");
+			assertThat(result.getOutput().getMetadata()).containsKey("chapter");
+
+			logger.info("Document: '{}', Source: {}, Score: {}", result.getOutput().getText(),
+					result.getOutput().getMetadata().get("source"), result.getOutput().getScore());
+		}
+	}
+
+}

--- a/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/JinaScoringModelTests.java
+++ b/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/JinaScoringModelTests.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.jina.api.JinaScoringApi;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.scoring.ScoringRequest;
+import org.springframework.ai.scoring.ScoringResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link JinaScoringModel}.
+ *
+ * @author Wongi Kim
+ */
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
+class JinaScoringModelTests {
+
+	private MockWebServer mockWebServer;
+
+	private JinaScoringApi jinaScoringApi;
+
+	private JinaScoringModel jinaScoringModel;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		this.mockWebServer = new MockWebServer();
+		this.mockWebServer.start();
+
+		this.jinaScoringApi = JinaScoringApi.builder()
+			.baseUrl(this.mockWebServer.url("/").toString())
+			.apiKey("TEST_API_KEY")
+			.build();
+
+		this.jinaScoringModel = JinaScoringModel.builder()
+			.jinaScoringApi(this.jinaScoringApi)
+			.retryTemplate(RetryUtils.SHORT_RETRY_TEMPLATE)
+			.options(JinaScoringOptions.builder()
+				.model(JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue())
+				.build())
+			.build();
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		this.mockWebServer.shutdown();
+	}
+
+	@Test
+	void rerankDocumentsSuccessfully() throws Exception {
+		// @formatter:off
+		// Arrange
+		String expectedResponse = """
+				{
+					"model": "jina-reranker-v2-base-multilingual",
+					"usage": {
+						"total_tokens": 150
+					},
+					"results": [
+						{
+							"index": 2,
+							"document": {
+								"text": "The Spring Framework is an application framework and inversion of control container for the Java platform."
+							},
+							"relevance_score": 0.89123
+						},
+						{
+							"index": 0,
+							"document": {
+								"text": "Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications."
+							},
+							"relevance_score": 0.45789
+						},
+						{
+							"index": 1,
+							"document": {
+								"text": "React is a free and open-source front-end JavaScript library."
+							},
+							"relevance_score": 0.12345
+						}
+					]
+				}
+				""";
+		// @formatter:on
+
+		this.mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.setBody(expectedResponse));
+
+		List<Document> documents = List.of(
+				new Document(
+						"Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications."),
+				new Document("React is a free and open-source front-end JavaScript library."), new Document(
+						"The Spring Framework is an application framework and inversion of control container for the Java platform."));
+
+		ScoringRequest request = new ScoringRequest("What is Spring Framework?", documents, null);
+
+		// Act
+		ScoringResponse response = this.jinaScoringModel.call(request);
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(3);
+
+		// The results should be returned in the order provided by the API (descending
+		// relevance score)
+		assertThat(response.getResults().get(0).getOutput().getText()).isEqualTo(
+				"The Spring Framework is an application framework and inversion of control container for the Java platform.");
+		assertThat(response.getResults().get(0).getOutput().getScore()).isEqualTo(0.89123);
+
+		assertThat(response.getResults().get(1).getOutput().getText())
+			.isEqualTo("Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications.");
+		assertThat(response.getResults().get(1).getOutput().getScore()).isEqualTo(0.45789);
+
+		assertThat(response.getResults().get(2).getOutput().getText())
+			.isEqualTo("React is a free and open-source front-end JavaScript library.");
+		assertThat(response.getResults().get(2).getOutput().getScore()).isEqualTo(0.12345);
+
+		// Verify request
+		RecordedRequest recordedRequest = this.mockWebServer.takeRequest();
+		assertThat(recordedRequest.getMethod()).isEqualTo("POST");
+		assertThat(recordedRequest.getPath()).isEqualTo("/v1/rerank");
+		assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer TEST_API_KEY");
+
+		String requestBody = recordedRequest.getBody().readUtf8();
+		assertThat(requestBody).contains("What is Spring Framework?");
+		assertThat(requestBody).contains("jina-reranker-v2-base-multilingual");
+		assertThat(requestBody).contains("Spring Boot");
+		assertThat(requestBody).contains("React");
+	}
+
+	@Test
+	void mergeOptionsCorrectly() throws Exception {
+		// Arrange
+		// @formatter:off
+		String expectedResponse = """
+				{
+					"model": "jina-colbert-v1-en",
+					"results": []
+				}
+				""";
+		// @formatter:on
+
+		this.mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.setBody(expectedResponse));
+
+		List<Document> documents = List.of(new Document("doc1"));
+
+		// Create runtime options with model override
+		JinaScoringOptions runtimeOptions = JinaScoringOptions.builder()
+			.model(JinaScoringApi.Model.JINA_COLBERT_V1_EN.getValue())
+			.topK(2)
+			.truncation(true)
+			.build();
+
+		ScoringRequest request = new ScoringRequest("Test query", documents, runtimeOptions);
+
+		// Act
+		this.jinaScoringModel.call(request);
+
+		// Assert
+		RecordedRequest recordedRequest = this.mockWebServer.takeRequest();
+		String requestBody = recordedRequest.getBody().readUtf8();
+
+		// Verify that runtime options were used instead of default options
+		assertThat(requestBody).contains("jina-colbert-v1-en");
+		assertThat(requestBody).contains("\"top_n\":2");
+		assertThat(requestBody).contains("\"truncation\":true");
+	}
+
+	@Test
+	void apiErrorShouldThrowException() {
+		// Arrange
+		this.mockWebServer.enqueue(new MockResponse().setResponseCode(401)
+			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.setBody("{\"detail\": \"Incorrect API key provided\"}"));
+
+		List<Document> documents = List.of(new Document("test"));
+		ScoringRequest request = new ScoringRequest("query", documents, null);
+
+		// Act & Assert
+		assertThatThrownBy(() -> this.jinaScoringModel.call(request))
+			.isInstanceOf(org.springframework.ai.retry.NonTransientAiException.class)
+			.hasMessageContaining("401");
+	}
+
+	@Test
+	void emptyDocumentListShouldThrowException() {
+		assertThatThrownBy(() -> this.jinaScoringModel.call(new ScoringRequest("query", List.of(), null)))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void serverErrorTriggersRetry() throws Exception {
+		// Arrange: Two 500 errors followed by a 200 success
+		this.mockWebServer.enqueue(new MockResponse().setResponseCode(500).setBody("Internal Server Error"));
+		this.mockWebServer.enqueue(new MockResponse().setResponseCode(500).setBody("Internal Server Error"));
+
+		// @formatter:off
+		String expectedResponse = """
+				{
+					"model": "jina-reranker-v2-base-multilingual",
+					"results": [
+						{
+							"index": 0,
+							"document": {
+								"text": "Success after retry!"
+							},
+							"relevance_score": 0.99
+						}
+					]
+				}
+				""";
+		// @formatter:on
+		this.mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.setBody(expectedResponse));
+
+		List<Document> documents = List.of(new Document("Success after retry!"));
+		ScoringRequest request = new ScoringRequest("test", documents, null);
+
+		// Act
+		ScoringResponse response = this.jinaScoringModel.call(request);
+
+		// Assert
+		assertThat(response).isNotNull();
+		assertThat(response.getResults()).hasSize(1);
+
+		// Verify that exactly 3 requests were made (2 failed, 1 succeeded)
+		assertThat(this.mockWebServer.getRequestCount()).isEqualTo(3);
+	}
+
+}

--- a/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/ScoringDocumentPostProcessorIT.java
+++ b/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/ScoringDocumentPostProcessorIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.jina.api.JinaScoringApi;
+import org.springframework.ai.rag.Query;
+import org.springframework.ai.rag.postretrieval.document.ScoringDocumentPostProcessor;
+import org.springframework.ai.retry.RetryUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration tests for JinaScoringModel combined with ScoringDocumentPostProcessor.
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+@EnabledIfEnvironmentVariable(named = "JINA_API_KEY", matches = ".+")
+public class ScoringDocumentPostProcessorIT {
+
+	private ScoringDocumentPostProcessor postProcessor;
+
+	@BeforeEach
+	void setUp() {
+		JinaScoringApi jinaScoringApi = JinaScoringApi.builder().apiKey(System.getenv("JINA_API_KEY")).build();
+
+		JinaScoringModel scoringModel = JinaScoringModel.builder()
+			.jinaScoringApi(jinaScoringApi)
+			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
+			.options(JinaScoringOptions.builder()
+				.model(JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue())
+				.build())
+			.build();
+
+		this.postProcessor = ScoringDocumentPostProcessor.builder().scoringModel(scoringModel).build();
+	}
+
+	@Test
+	void processReranksDocumentsCorrectly() {
+		List<Document> documents = List.of(
+				new Document("Spring AI provides a unified API for integrating AI models into Java applications."),
+				new Document("React is a widely-used JavaScript library for building user interfaces."),
+				new Document("The Spring Framework is a comprehensive framework for enterprise Java development."),
+				new Document("Python is heavily utilized in data science and machine learning fields."));
+
+		Query query = new Query("What is Spring AI?");
+
+		List<Document> rerankedDocuments = this.postProcessor.process(query, documents);
+
+		assertThat(rerankedDocuments).isNotNull();
+		assertThat(rerankedDocuments).hasSize(4);
+
+		// The most relevant document "Spring AI..." should be at the top after reranking
+		assertThat(rerankedDocuments.get(0).getText()).contains("unified API for integrating AI models");
+	}
+
+	@Test
+	void processReturnsEmptyListForEmptyInput() {
+		List<Document> emptyDocuments = List.of();
+		Query query = new Query("Empty query");
+
+		List<Document> result = this.postProcessor.process(query, emptyDocuments);
+
+		assertThat(result).isNotNull();
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void processMaintainsOriginalMetadata() {
+		Document docOriginal = Document.builder()
+			.text("Spring AI bridges the gap between Java and AI.")
+			.metadata("category", "tech")
+			.metadata("source", "docs.spring.io")
+			.metadata("author", "Spring Team")
+			.build();
+
+		Document unstructuredDoc = new Document("Just some irrelevant random text.");
+
+		List<Document> documents = List.of(unstructuredDoc, docOriginal);
+		Query query = new Query("What bridges Java and AI?");
+
+		List<Document> result = this.postProcessor.process(query, documents);
+
+		assertThat(result).isNotNull();
+		assertThat(result).hasSize(2);
+
+		// The relevant document should be moved to the first place
+		Document topDocument = result.get(0);
+		assertThat(topDocument.getText()).isEqualTo(docOriginal.getText());
+
+		// Metadata must be perfectly preserved except for the newly added score
+		Map<String, Object> metadata = topDocument.getMetadata();
+		assertThat(metadata).containsEntry("category", "tech");
+		assertThat(metadata).containsEntry("source", "docs.spring.io");
+		assertThat(metadata).containsEntry("author", "Spring Team");
+
+		// Reranking adds a score
+		assertThat(topDocument.getScore()).isNotNull();
+	}
+
+	@Test
+	void emptyQueryShouldThrowException() {
+		List<Document> documents = List.of(new Document("Some text"));
+		Query query = new Query("");
+
+		assertThatThrownBy(() -> this.postProcessor.process(query, documents))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+}

--- a/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/api/JinaScoringApiIT.java
+++ b/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/api/JinaScoringApiIT.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.api;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.jina.api.JinaScoringApi.RerankRequest;
+import org.springframework.ai.jina.api.JinaScoringApi.RerankResponse;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link JinaScoringApi}.
+ *
+ * <p>
+ * These tests require a valid Jina AI API key set as the {@code JINA_API_KEY} environment
+ * variable. Tests will be skipped if the key is not present.
+ *
+ * <p>
+ * To run locally:
+ *
+ * <pre>
+ * set JINA_API_KEY=jina_YOUR_REAL_API_KEY
+ * mvn test -Dtest=JinaScoringApiIT -pl models/spring-ai-jina
+ * </pre>
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+@EnabledIfEnvironmentVariable(named = "JINA_API_KEY", matches = ".+")
+class JinaScoringApiIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(JinaScoringApiIT.class);
+
+	private JinaScoringApi jinaScoringApi;
+
+	@BeforeEach
+	void setUp() {
+		this.jinaScoringApi = JinaScoringApi.builder().apiKey(System.getenv("JINA_API_KEY")).build();
+	}
+
+	@Test
+	void rerankWithBasicDocuments() {
+		// Arrange
+		List<String> documents = List.of(
+				"Spring AI provides a unified API for AI model integration in Spring applications.",
+				"React is a JavaScript library for building user interfaces.",
+				"The Spring Framework is an application framework for the Java platform.",
+				"Python is a high-level programming language known for its simplicity.");
+
+		RerankRequest request = new RerankRequest(JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue(),
+				"What is Spring AI?", documents);
+
+		// Act
+		ResponseEntity<RerankResponse> responseEntity = this.jinaScoringApi.rerank(request);
+
+		// Assert
+		assertThat(responseEntity).isNotNull();
+		assertThat(responseEntity.getStatusCode().is2xxSuccessful()).isTrue();
+
+		RerankResponse response = responseEntity.getBody();
+		assertThat(response).isNotNull();
+		assertThat(response.model()).isNotBlank();
+		assertThat(response.results()).isNotEmpty();
+		assertThat(response.results()).hasSize(4);
+
+		logger.info("Model used: {}", response.model());
+
+		// Verify that every result has a valid index and non-negative score
+		response.results().forEach(result -> {
+			assertThat(result.index()).isBetween(0, 3);
+			assertThat(result.relevanceScore()).isBetween(0.0, 1.0);
+			logger.info("Index: {}, Score: {}", result.index(), result.relevanceScore());
+		});
+
+		// The most relevant document (index 0 - "Spring AI provides...") should
+		// appear first (highest score) since it directly mentions Spring AI
+		assertThat(response.results().get(0).index()).isEqualTo(0);
+	}
+
+	@Test
+	void rerankWithTopN() {
+		// Arrange
+		List<String> documents = List.of("Spring Boot simplifies microservice development.",
+				"Docker is a containerization platform.", "Kubernetes orchestrates containerized applications.",
+				"Spring AI integrates AI models with Spring Boot.", "Node.js is a JavaScript runtime.");
+
+		RerankRequest request = new RerankRequest(JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue(),
+				"Spring Boot development", documents, 2, null, null);
+
+		// Act
+		ResponseEntity<RerankResponse> responseEntity = this.jinaScoringApi.rerank(request);
+
+		// Assert
+		RerankResponse response = responseEntity.getBody();
+		assertThat(response).isNotNull();
+		assertThat(response.results()).hasSize(2);
+
+		// Both returned results should have scores, and they should be in descending
+		// order
+		double firstScore = response.results().get(0).relevanceScore();
+		double secondScore = response.results().get(1).relevanceScore();
+		assertThat(firstScore).isGreaterThanOrEqualTo(secondScore);
+
+		logger.info("Top-2 results:");
+		response.results().forEach(r -> logger.info("  Index: {}, Score: {}", r.index(), r.relevanceScore()));
+	}
+
+	@Test
+	void rerankResponseIncludesUsageStatistics() {
+		// Arrange
+		List<String> documents = List.of("Spring Framework documentation", "Java programming guide");
+
+		RerankRequest request = new RerankRequest(JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue(),
+				"Spring documentation", documents);
+
+		// Act
+		ResponseEntity<RerankResponse> responseEntity = this.jinaScoringApi.rerank(request);
+
+		// Assert
+		RerankResponse response = responseEntity.getBody();
+		assertThat(response).isNotNull();
+		assertThat(response.usage()).isNotNull();
+		assertThat(response.usage().totalTokens()).isGreaterThan(0);
+
+		logger.info("Total tokens used: {}", response.usage().totalTokens());
+	}
+
+}

--- a/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/evaluation/NdcgCalculator.java
+++ b/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/evaluation/NdcgCalculator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.evaluation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility class for calculating NDCG@K (Normalized Discounted Cumulative Gain).
+ *
+ * <p>
+ * NDCG is a standard information retrieval metric that measures the quality of a ranked
+ * list of results by comparing it against an ideal ranking. Values range from 0.0 (worst)
+ * to 1.0 (perfect ranking).
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+public final class NdcgCalculator {
+
+	private NdcgCalculator() {
+	}
+
+	/**
+	 * Calculate NDCG@K for a ranked list of relevance scores.
+	 * @param relevanceScores relevance scores in the order they were ranked
+	 * @param k the cutoff position (top-K)
+	 * @return NDCG@K value between 0.0 and 1.0
+	 */
+	public static double calculate(List<Integer> relevanceScores, int k) {
+		if (relevanceScores == null || relevanceScores.isEmpty() || k <= 0) {
+			return 0.0;
+		}
+
+		int effectiveK = Math.min(k, relevanceScores.size());
+
+		double dcg = computeDcg(relevanceScores, effectiveK);
+		double idcg = computeIdcg(relevanceScores, effectiveK);
+
+		if (idcg == 0.0) {
+			return 0.0;
+		}
+
+		return dcg / idcg;
+	}
+
+	/**
+	 * Compute DCG@K (Discounted Cumulative Gain).
+	 *
+	 * <p>
+	 * Formula: DCG@K = Σ (rel_i / log₂(i + 1)) for i = 1 to K
+	 */
+	static double computeDcg(List<Integer> relevanceScores, int k) {
+		double dcg = 0.0;
+		for (int i = 0; i < k; i++) {
+			double rel = relevanceScores.get(i);
+			dcg += rel / (Math.log(i + 2) / Math.log(2));
+		}
+		return dcg;
+	}
+
+	/**
+	 * Compute IDCG@K (Ideal Discounted Cumulative Gain). Sorts the relevance scores in
+	 * descending order first, then computes DCG.
+	 */
+	static double computeIdcg(List<Integer> relevanceScores, int k) {
+		List<Integer> sorted = new ArrayList<>(relevanceScores);
+		sorted.sort(Collections.reverseOrder());
+		return computeDcg(sorted, k);
+	}
+
+}

--- a/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/evaluation/NdcgCalculatorTests.java
+++ b/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/evaluation/NdcgCalculatorTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.evaluation;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Unit tests for {@link NdcgCalculator}.
+ *
+ * @author Wongi Kim
+ */
+class NdcgCalculatorTests {
+
+	@Test
+	void perfectRankingShouldReturnOne() {
+		// 완벽한 정렬: [3, 3, 2, 0, 0] — 이미 이상적인 순서
+		List<Integer> relevances = List.of(3, 3, 2, 0, 0);
+		assertThat(NdcgCalculator.calculate(relevances, 5)).isCloseTo(1.0, within(0.0001));
+		assertThat(NdcgCalculator.calculate(relevances, 3)).isCloseTo(1.0, within(0.0001));
+	}
+
+	@Test
+	void worstRankingShouldReturnLowScore() {
+		// 최악의 정렬: 무관 문서가 상위에
+		List<Integer> relevances = List.of(0, 0, 2, 3, 3);
+		double ndcg5 = NdcgCalculator.calculate(relevances, 5);
+		assertThat(ndcg5).isLessThan(0.7);
+		assertThat(ndcg5).isGreaterThan(0.0);
+	}
+
+	@Test
+	void allIrrelevantShouldReturnZero() {
+		// 모든 문서가 무관
+		List<Integer> relevances = List.of(0, 0, 0, 0);
+		assertThat(NdcgCalculator.calculate(relevances, 4)).isEqualTo(0.0);
+	}
+
+	@Test
+	void emptyListShouldReturnZero() {
+		assertThat(NdcgCalculator.calculate(List.of(), 5)).isEqualTo(0.0);
+	}
+
+	@Test
+	void nullListShouldReturnZero() {
+		assertThat(NdcgCalculator.calculate(null, 5)).isEqualTo(0.0);
+	}
+
+	@Test
+	void kLargerThanListSizeShouldWork() {
+		// K가 리스트보다 큰 경우 — 리스트 크기만큼만 계산
+		List<Integer> relevances = List.of(3, 2);
+		double ndcgK10 = NdcgCalculator.calculate(relevances, 10);
+		double ndcgK2 = NdcgCalculator.calculate(relevances, 2);
+		assertThat(ndcgK10).isEqualTo(ndcgK2);
+	}
+
+	@Test
+	void baselineExampleFromDocumentation() {
+		// 문서에 기재된 Baseline 예시: [2, 3, 0, 3, 0]
+		List<Integer> baselineRelevances = List.of(2, 3, 0, 3, 0);
+		double ndcg5 = NdcgCalculator.calculate(baselineRelevances, 5);
+
+		// DCG@5 = 2/1 + 3/1.585 + 0/2 + 3/2.322 + 0/2.585 = 5.185
+		// IDCG@5 = 3/1 + 3/1.585 + 2/2 + 0/2.322 + 0/2.585 = 5.893
+		// NDCG@5 = 5.185 / 5.893 ≈ 0.8799
+		assertThat(ndcg5).isCloseTo(0.8799, within(0.001));
+	}
+
+	@Test
+	void dcgCalculationIsCorrect() {
+		// 수동으로 DCG 검증: [3, 2, 0]
+		// DCG = 3/log₂(2) + 2/log₂(3) + 0/log₂(4)
+		// = 3/1.0 + 2/1.585 + 0/2.0
+		// = 3.0 + 1.262 + 0.0 = 4.262
+		List<Integer> relevances = List.of(3, 2, 0);
+		double dcg = NdcgCalculator.computeDcg(relevances, 3);
+		assertThat(dcg).isCloseTo(4.262, within(0.001));
+	}
+
+}

--- a/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/evaluation/NdcgEvaluationIT.java
+++ b/models/spring-ai-jina/src/test/java/org/springframework/ai/jina/evaluation/NdcgEvaluationIT.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.jina.evaluation;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.jina.JinaScoringModel;
+import org.springframework.ai.jina.JinaScoringOptions;
+import org.springframework.ai.jina.api.JinaScoringApi;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.scoring.ScoringResponse;
+import org.springframework.ai.scoring.ScoringResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * NDCG@K evaluation comparing baseline search ordering vs Jina AI Reranking.
+ *
+ * <p>
+ * This test demonstrates the effectiveness of reranking by calculating NDCG@K metrics for
+ * both a simulated baseline (embedding/BM25) search result ordering and the Jina
+ * Reranker-optimized ordering, then comparing them quantitatively.
+ *
+ * <p>
+ * To run locally:
+ *
+ * <pre>
+ * set JINA_API_KEY=jina_YOUR_REAL_API_KEY
+ * mvn test -Dtest=NdcgEvaluationIT -pl models/spring-ai-jina
+ * </pre>
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ */
+@EnabledIfEnvironmentVariable(named = "JINA_API_KEY", matches = ".+")
+class NdcgEvaluationIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(NdcgEvaluationIT.class);
+
+	private JinaScoringModel scoringModel;
+
+	/**
+	 * Ground Truth: 사람이 사전에 판단한 관련도 라벨. 3=완전관련, 2=관련, 1=부분관련, 0=무관
+	 */
+	private final Map<String, Integer> groundTruth = new LinkedHashMap<>();
+
+	@BeforeEach
+	void setUp() {
+		String apiKey = System.getenv("JINA_API_KEY");
+		JinaScoringApi api = JinaScoringApi.builder().apiKey(apiKey).build();
+
+		this.scoringModel = JinaScoringModel.builder()
+			.jinaScoringApi(api)
+			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
+			.options(JinaScoringOptions.builder()
+				.model(JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue())
+				.build())
+			.build();
+
+		// Ground Truth 정의
+		this.groundTruth
+			.put("Spring AI provides a unified API for integrating various AI models into Spring applications.", 3);
+		this.groundTruth.put("The Spring Framework is a comprehensive framework for enterprise Java development.", 2);
+		this.groundTruth.put("React is a JavaScript library for building user interfaces developed by Meta.", 0);
+		this.groundTruth.put("Spring AI supports embedding models, chat models, and image generation models.", 3);
+		this.groundTruth.put("Python is widely used in data science and machine learning applications.", 0);
+	}
+
+	@Test
+	void compareBaselineVsRerankingWithNdcg() {
+		String query = "What is Spring AI and how does it integrate with AI models?";
+
+		// =====================================================
+		// 1. Baseline: 임베딩/BM25 유사도 기반 검색 결과 (시뮬레이션)
+		// 실제 IR 시스템에서 나올 수 있는 '비이상적인' 순서
+		// =====================================================
+		List<String> baselineOrder = List.of(
+				"The Spring Framework is a comprehensive framework for enterprise Java development.",
+				"Spring AI provides a unified API for integrating various AI models into Spring applications.",
+				"Python is widely used in data science and machine learning applications.",
+				"Spring AI supports embedding models, chat models, and image generation models.",
+				"React is a JavaScript library for building user interfaces developed by Meta.");
+
+		List<Integer> baselineRelevances = baselineOrder.stream()
+			.map(text -> this.groundTruth.getOrDefault(text, 0))
+			.toList();
+
+		double baselineNdcg3 = NdcgCalculator.calculate(baselineRelevances, 3);
+		double baselineNdcg5 = NdcgCalculator.calculate(baselineRelevances, 5);
+
+		// =====================================================
+		// 2. Jina Reranking 적용
+		// =====================================================
+		List<Document> documents = baselineOrder.stream().map(Document::new).toList();
+		ScoringResponse response = this.scoringModel.call(query, documents);
+
+		List<String> rerankOrder = response.getResults()
+			.stream()
+			.map(ScoringResult::getOutput)
+			.map(Document::getText)
+			.toList();
+
+		List<Integer> rerankRelevances = rerankOrder.stream()
+			.map(text -> this.groundTruth.getOrDefault(text, 0))
+			.toList();
+
+		double rerankNdcg3 = NdcgCalculator.calculate(rerankRelevances, 3);
+		double rerankNdcg5 = NdcgCalculator.calculate(rerankRelevances, 5);
+
+		double improvement3 = baselineNdcg3 > 0 ? ((rerankNdcg3 - baselineNdcg3) / baselineNdcg3) * 100 : 0.0;
+		double improvement5 = baselineNdcg5 > 0 ? ((rerankNdcg5 - baselineNdcg5) / baselineNdcg5) * 100 : 0.0;
+
+		// =====================================================
+		// 결과 출력
+		// =====================================================
+		logger.info("");
+		logger.info("=================================================================");
+		logger.info("  [Jina AI Reranking 단건 평가 결과]");
+		logger.info("=================================================================");
+		logger.info("");
+		logger.info("  * 질의: \"{}\"", query);
+		logger.info("");
+		logger.info("  (1) Baseline (리랭킹 없음 - 벡터 유사도만 사용)");
+		logger.info("      문서 순서: rel=[{}]", baselineRelevances.stream().map(String::valueOf).reduce((a, b) -> a + ", " + b).orElse(""));
+		logger.info("      NDCG@3={}, NDCG@5={}", String.format("%.4f", baselineNdcg3), String.format("%.4f", baselineNdcg5));
+		logger.info("");
+		logger.info("  (2) Reranking 적용 후 (Jina AI ScoringModel)");
+		for (int i = 0; i < rerankOrder.size(); i++) {
+			double score = response.getResults().get(i).getOutput().getScore();
+			String snippet = rerankOrder.get(i).substring(0, Math.min(50, rerankOrder.get(i).length()));
+			logger.info("      {}위: rel={}, score={} | {}...", i + 1, rerankRelevances.get(i), String.format("%.4f", score), snippet);
+		}
+		logger.info("      NDCG@3={}, NDCG@5={}", String.format("%.4f", rerankNdcg3), String.format("%.4f", rerankNdcg5));
+		logger.info("");
+		logger.info("  (3) 결론");
+		logger.info("      -> NDCG@3: {} -> {} ({}% 향상)", String.format("%.4f", baselineNdcg3), String.format("%.4f", rerankNdcg3), String.format("+%.1f", improvement3));
+		logger.info("      -> NDCG@5: {} -> {} ({}% 향상)", String.format("%.4f", baselineNdcg5), String.format("%.4f", rerankNdcg5), String.format("+%.1f", improvement5));
+		logger.info("=================================================================");
+
+		// =====================================================
+		// 4. Assertion: Reranking이 Baseline보다 같거나 높아야 함
+		// =====================================================
+		assertThat(rerankNdcg5).as("NDCG@5: Reranking should be >= Baseline").isGreaterThanOrEqualTo(baselineNdcg5);
+		assertThat(rerankNdcg3).as("NDCG@3: Reranking should be >= Baseline").isGreaterThanOrEqualTo(baselineNdcg3);
+	}
+
+	@Test
+	void compareWithMultipleQueries() {
+		// 다양한 질의에 대해 평균 NDCG를 계산하여 더 신뢰성 있는 평가 수행
+		Map<String, List<String>> queryToBaseline = new LinkedHashMap<>();
+
+		queryToBaseline.put("What is Spring AI and how does it integrate with AI models?",
+				List.of("The Spring Framework is a comprehensive framework for enterprise Java development.",
+						"Spring AI provides a unified API for integrating various AI models into Spring applications.",
+						"Python is widely used in data science and machine learning applications.",
+						"Spring AI supports embedding models, chat models, and image generation models.",
+						"React is a JavaScript library for building user interfaces developed by Meta."));
+
+		queryToBaseline.put("Which frameworks are used for Java enterprise development?",
+				List.of("React is a JavaScript library for building user interfaces developed by Meta.",
+						"The Spring Framework is a comprehensive framework for enterprise Java development.",
+						"Spring AI provides a unified API for integrating various AI models into Spring applications.",
+						"Python is widely used in data science and machine learning applications.",
+						"Spring AI supports embedding models, chat models, and image generation models."));
+
+		// 두 번째 query 용 ground truth
+		Map<String, Integer> groundTruth2 = new LinkedHashMap<>();
+		groundTruth2.put("Spring AI provides a unified API for integrating various AI models into Spring applications.",
+				1);
+		groundTruth2.put("The Spring Framework is a comprehensive framework for enterprise Java development.", 3);
+		groundTruth2.put("React is a JavaScript library for building user interfaces developed by Meta.", 0);
+		groundTruth2.put("Spring AI supports embedding models, chat models, and image generation models.", 1);
+		groundTruth2.put("Python is widely used in data science and machine learning applications.", 0);
+
+		// 세 번째 query 용 ground truth (Lexical vs Semantic 테스트)
+		queryToBaseline.put("How to configure a custom RestClient builder in Spring AI for reactive applications?", List
+			.of("Spring WebFlux provides a reactive WebClient for handling streams. It is an alternative to RestClient.",
+					"Reactive programming in Java is often implemented using Project Reactor, which Spring WebFlux is built upon.",
+					"Spring AI provides RestClient usage for OpenAI models, but you cannot use WebClient here.",
+					"Configuring streams in Spring AI chat responses requires specific configuration for reactive applications.",
+					"To configure a custom RestClient in Spring AI with reactive streams, provide a RestClient.Builder bean and use it in your application."));
+
+		Map<String, Integer> groundTruth3 = new LinkedHashMap<>();
+		groundTruth3.put(
+				"Spring WebFlux provides a reactive WebClient for handling streams. It is an alternative to RestClient.",
+				0);
+		groundTruth3.put(
+				"Reactive programming in Java is often implemented using Project Reactor, which Spring WebFlux is built upon.",
+				0);
+		groundTruth3.put("Spring AI provides RestClient usage for OpenAI models, but you cannot use WebClient here.",
+				1);
+		groundTruth3.put(
+				"Configuring streams in Spring AI chat responses requires specific configuration for reactive applications.",
+				2);
+		groundTruth3.put(
+				"To configure a custom RestClient in Spring AI with reactive streams, provide a RestClient.Builder bean and use it in your application.",
+				3);
+
+		Map<String, Map<String, Integer>> queryGroundTruths = new LinkedHashMap<>();
+		queryGroundTruths.put("What is Spring AI and how does it integrate with AI models?", this.groundTruth);
+		queryGroundTruths.put("Which frameworks are used for Java enterprise development?", groundTruth2);
+		queryGroundTruths.put("How to configure a custom RestClient builder in Spring AI for reactive applications?",
+				groundTruth3);
+
+		double totalBaselineNdcg5 = 0.0;
+		double totalRerankNdcg5 = 0.0;
+		int queryCount = 0;
+
+		String[] queryLabels = { "일반 질의", "혼동 질의", "고난도 함정 질의 (Lexical Trap)" };
+
+		logger.info("");
+		logger.info("=================================================================");
+		logger.info("  [Jina AI Reranking 다중 질의 평가 결과]");
+		logger.info("  3개 시나리오에 대한 NDCG@5 비교");
+		logger.info("=================================================================");
+
+		for (Map.Entry<String, List<String>> entry : queryToBaseline.entrySet()) {
+			String query = entry.getKey();
+			List<String> baseline = entry.getValue();
+			Map<String, Integer> gt = queryGroundTruths.get(query);
+
+			List<Integer> baselineRels = baseline.stream().map(t -> gt.getOrDefault(t, 0)).toList();
+			double baseNdcg5 = NdcgCalculator.calculate(baselineRels, 5);
+
+			List<Document> docs = baseline.stream().map(Document::new).toList();
+			ScoringResponse response = this.scoringModel.call(query, docs);
+
+			List<Integer> rerankRels = response.getResults()
+				.stream()
+				.map(r -> gt.getOrDefault(r.getOutput().getText(), 0))
+				.toList();
+			double rerankNdcg5 = NdcgCalculator.calculate(rerankRels, 5);
+			double improvement = baseNdcg5 > 0 ? ((rerankNdcg5 - baseNdcg5) / baseNdcg5) * 100 : 0.0;
+
+			logger.info("");
+			logger.info("  Q{} [{}]", queryCount + 1, queryLabels[queryCount]);
+			logger.info("      Baseline={} -> Reranked={} (+{}% 향상)",
+					String.format("%.4f", baseNdcg5), String.format("%.4f", rerankNdcg5),
+					String.format("%.1f", improvement));
+
+			totalBaselineNdcg5 += baseNdcg5;
+			totalRerankNdcg5 += rerankNdcg5;
+			queryCount++;
+		}
+
+		double avgBaselineNdcg5 = totalBaselineNdcg5 / queryCount;
+		double avgRerankNdcg5 = totalRerankNdcg5 / queryCount;
+		double avgImprovement = ((avgRerankNdcg5 - avgBaselineNdcg5) / avgBaselineNdcg5) * 100;
+
+		logger.info("");
+		logger.info("-----------------------------------------------------------------");
+		logger.info("  [종합] 평균 Baseline NDCG@5={} -> 평균 Reranked NDCG@5={}",
+				String.format("%.4f", avgBaselineNdcg5), String.format("%.4f", avgRerankNdcg5));
+		logger.info("         평균 향상률: +{}%", String.format("%.1f", avgImprovement));
+		logger.info("  => 리랭킹 적용 시 모든 난이도의 질의에서 검색 품질이 향상되었습니다.");
+		logger.info("     특히 키워드 함정 질의에서 가장 큰 효과를 보입니다.");
+		logger.info("=================================================================");
+
+		assertThat(avgRerankNdcg5).as("Average NDCG@5 should improve with reranking")
+			.isGreaterThanOrEqualTo(avgBaselineNdcg5);
+	}
+
+}

--- a/models/spring-ai-vllm/pom.xml
+++ b/models/spring-ai-vllm/pom.xml
@@ -25,10 +25,10 @@
 		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-	<artifactId>spring-ai-jina</artifactId>
+	<artifactId>spring-ai-vllm</artifactId>
 	<packaging>jar</packaging>
-	<name>Spring AI Model - Jina AI</name>
-	<description>Jina AI models support</description>
+	<name>Spring AI Model - vLLM</name>
+	<description>vLLM scoring models support</description>
 	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
@@ -66,6 +66,7 @@
 			<artifactId>jackson-databind</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>

--- a/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/VllmScoringModel.java
+++ b/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/VllmScoringModel.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.jina;
+package org.springframework.ai.vllm;
 
 import java.util.List;
 
@@ -23,9 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.document.Document;
-import org.springframework.ai.jina.api.JinaScoringApi;
-import org.springframework.ai.jina.api.JinaScoringApi.RerankRequest;
-import org.springframework.ai.jina.api.JinaScoringApi.RerankResponse;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.scoring.ScoringModel;
@@ -33,29 +30,32 @@ import org.springframework.ai.scoring.ScoringOptions;
 import org.springframework.ai.scoring.ScoringRequest;
 import org.springframework.ai.scoring.ScoringResponse;
 import org.springframework.ai.scoring.ScoringResult;
+import org.springframework.ai.vllm.api.VllmScoringApi;
+import org.springframework.ai.vllm.api.VllmScoringApi.RerankRequest;
+import org.springframework.ai.vllm.api.VllmScoringApi.RerankResponse;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 
 /**
- * Jina AI {@link ScoringModel}.
+ * vLLM {@link ScoringModel}.
  *
- * @author Wongi Kim
+ * @author Spring AI
  * @since 2.0.0
  */
-public final class JinaScoringModel implements ScoringModel {
+public final class VllmScoringModel implements ScoringModel {
 
 	/** Logger. */
 	private final Logger log = LoggerFactory.getLogger(getClass());
 
 	/** API client. */
-	private final JinaScoringApi api;
+	private final VllmScoringApi api;
 
 	/** Retry template. */
 	private final RetryTemplate retry;
 
 	/** Options. */
-	private final JinaScoringOptions options;
+	private final VllmScoringOptions options;
 
 	/**
 	 * Create model.
@@ -63,8 +63,8 @@ public final class JinaScoringModel implements ScoringModel {
 	 * @param retryParam retry
 	 * @param optionsParam options
 	 */
-	public JinaScoringModel(final JinaScoringApi apiParam, final RetryTemplate retryParam,
-			final JinaScoringOptions optionsParam) {
+	public VllmScoringModel(final VllmScoringApi apiParam, final RetryTemplate retryParam,
+			final VllmScoringOptions optionsParam) {
 		Assert.notNull(apiParam, "apiParam must not be null");
 		Assert.notNull(retryParam, "retryParam must not be null");
 		Assert.notNull(optionsParam, "optionsParam must not be null");
@@ -79,7 +79,7 @@ public final class JinaScoringModel implements ScoringModel {
 		Assert.notEmpty(request.getInstructions(), "Documents must not be empty");
 
 		return RetryUtils.execute(this.retry, () -> {
-			JinaScoringOptions opts = mergeOptions(request.getOptions());
+			VllmScoringOptions opts = mergeOptions(request.getOptions());
 			List<Document> documents = request.getInstructions();
 			List<String> texts = documents.stream().map(doc -> {
 				String text = doc.getText();
@@ -90,9 +90,10 @@ public final class JinaScoringModel implements ScoringModel {
 			}).toList();
 
 			String modelName = opts.getModel();
-			Assert.notNull(modelName, "Model name must not be null");
-			RerankRequest apiReq = new RerankRequest(modelName, request.getQuery(), texts, opts.getTopK(), null,
-					opts.getTruncation());
+			Assert.notNull(modelName, "Model name must not be null for vLLM Scoring");
+
+			RerankRequest apiReq = new RerankRequest(modelName, request.getQuery(), texts, opts.getTopK(),
+					opts.getReturnDocuments(), opts.getTruncation());
 
 			ResponseEntity<RerankResponse> resp = this.api.rerank(apiReq);
 
@@ -107,20 +108,20 @@ public final class JinaScoringModel implements ScoringModel {
 		return this.call(new ScoringRequest(query, documents));
 	}
 
-	private JinaScoringOptions mergeOptions(final @Nullable ScoringOptions runtimeOptions) {
+	private VllmScoringOptions mergeOptions(final @Nullable ScoringOptions runtimeOptions) {
 		if (runtimeOptions == null) {
 			return this.options;
 		}
 
-		JinaScoringOptions.Builder optBuilder = JinaScoringOptions.builder();
+		VllmScoringOptions.Builder optBuilder = VllmScoringOptions.builder();
 		optBuilder.model(ModelOptionsUtils.mergeOption(runtimeOptions.getModel(), this.options.getModel()));
 		optBuilder.topK(ModelOptionsUtils.mergeOption(runtimeOptions.getTopK(), this.options.getTopK()));
 
-		if (runtimeOptions instanceof JinaScoringOptions jinaOpts) {
+		if (runtimeOptions instanceof VllmScoringOptions vllmOpts) {
 			optBuilder.returnDocuments(
-					ModelOptionsUtils.mergeOption(jinaOpts.getReturnDocuments(), this.options.getReturnDocuments()));
+					ModelOptionsUtils.mergeOption(vllmOpts.getReturnDocuments(), this.options.getReturnDocuments()));
 			optBuilder
-				.truncation(ModelOptionsUtils.mergeOption(jinaOpts.getTruncation(), this.options.getTruncation()));
+				.truncation(ModelOptionsUtils.mergeOption(vllmOpts.getTruncation(), this.options.getTruncation()));
 		}
 		else {
 			optBuilder.returnDocuments(this.options.getReturnDocuments());
@@ -134,8 +135,8 @@ public final class JinaScoringModel implements ScoringModel {
 			final List<Document> docs) {
 
 		RerankResponse body = responseEntity.getBody();
-		if (body == null) {
-			this.log.warn("No response");
+		if (body == null || body.results() == null) {
+			this.log.warn("No response or empty results");
 			return new ScoringResponse(List.of());
 		}
 
@@ -158,20 +159,20 @@ public final class JinaScoringModel implements ScoringModel {
 	public static final class Builder {
 
 		/** API client. */
-		private @Nullable JinaScoringApi api;
+		private @Nullable VllmScoringApi api;
 
 		/** Retry template. */
 		private RetryTemplate retry = RetryUtils.DEFAULT_RETRY_TEMPLATE;
 
 		/** Options. */
-		private JinaScoringOptions options = JinaScoringOptions.builder().build();
+		private VllmScoringOptions options = VllmScoringOptions.builder().build();
 
 		/**
 		 * Set api.
 		 * @param apiParam api
 		 * @return builder
 		 */
-		public Builder jinaScoringApi(final JinaScoringApi apiParam) {
+		public Builder vllmScoringApi(final VllmScoringApi apiParam) {
 			this.api = apiParam;
 			return this;
 		}
@@ -191,7 +192,7 @@ public final class JinaScoringModel implements ScoringModel {
 		 * @param optionsParam options
 		 * @return builder
 		 */
-		public Builder options(final JinaScoringOptions optionsParam) {
+		public Builder options(final VllmScoringOptions optionsParam) {
 			this.options = optionsParam;
 			return this;
 		}
@@ -200,9 +201,9 @@ public final class JinaScoringModel implements ScoringModel {
 		 * Build.
 		 * @return model
 		 */
-		public JinaScoringModel build() {
+		public VllmScoringModel build() {
 			Assert.state(this.api != null, "api must not be null");
-			return new JinaScoringModel(this.api, this.retry, this.options);
+			return new VllmScoringModel(this.api, this.retry, this.options);
 		}
 
 	}

--- a/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/VllmScoringOptions.java
+++ b/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/VllmScoringOptions.java
@@ -14,30 +14,26 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.jina;
+package org.springframework.ai.vllm;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.ai.jina.api.JinaScoringApi;
 import org.springframework.ai.scoring.ScoringOptions;
 
 /**
- * Jina AI options.
+ * vLLM options.
  *
- * @author Wongi Kim
+ * @author Spring AI
  * @since 2.0.0
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public final class JinaScoringOptions implements ScoringOptions {
-
-	/** Default model name. */
-	private static final String DEFAULT_MODEL = JinaScoringApi.Model.JINA_RERANKER_V2_BASE_MULTILINGUAL.getValue();
+public final class VllmScoringOptions implements ScoringOptions {
 
 	/** Model name. */
 	@JsonProperty("model")
-	private @Nullable String modelName = DEFAULT_MODEL;
+	private @Nullable String modelName;
 
 	/** Top K results. */
 	@JsonProperty("top_n")
@@ -121,7 +117,7 @@ public final class JinaScoringOptions implements ScoringOptions {
 	public static final class Builder {
 
 		/** Options. */
-		private final JinaScoringOptions options = new JinaScoringOptions();
+		private final VllmScoringOptions options = new VllmScoringOptions();
 
 		/**
 		 * Set model.
@@ -167,7 +163,7 @@ public final class JinaScoringOptions implements ScoringOptions {
 		 * Build.
 		 * @return options
 		 */
-		public JinaScoringOptions build() {
+		public VllmScoringOptions build() {
 			return this.options;
 		}
 

--- a/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/api/VllmScoringApi.java
+++ b/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/api/VllmScoringApi.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vllm.api;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+
+/**
+ * vLLM Reranker API client.
+ *
+ * @author Spring AI
+ * @since 2.0.0
+ */
+public class VllmScoringApi {
+
+	/** Default base URL. */
+	private static final String DEFAULT_BASE_URL = "http://localhost:8000";
+
+	/** Rest client. */
+	private final RestClient restClient;
+
+	/**
+	 * Create a new API client.
+	 * @param baseUrl base URL
+	 * @param apiKey API key (optional for vLLM)
+	 * @param restClientBuilder builder
+	 * @param responseErrorHandler error handler
+	 */
+	public VllmScoringApi(final String baseUrl, final @Nullable String apiKey,
+			final RestClient.Builder restClientBuilder, final ResponseErrorHandler responseErrorHandler) {
+
+		Consumer<HttpHeaders> jsonHeaders = headers -> {
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			if (StringUtils.hasText(apiKey)) {
+				headers.setBearerAuth(apiKey);
+			}
+		};
+
+		this.restClient = restClientBuilder.clone()
+			.baseUrl(baseUrl)
+			.defaultHeaders(jsonHeaders)
+			.defaultStatusHandler(responseErrorHandler)
+			.build();
+	}
+
+	/**
+	 * Rerank documents.
+	 * @param rerankRequest request
+	 * @return response
+	 */
+	public ResponseEntity<RerankResponse> rerank(final RerankRequest rerankRequest) {
+		Assert.notNull(rerankRequest, "Rerank request cannot be null.");
+
+		return this.restClient.post().uri("/v1/rerank").body(rerankRequest).retrieve().toEntity(RerankResponse.class);
+	}
+
+	/**
+	 * Create a builder.
+	 * @return builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/** Builder for VllmScoringApi. */
+	public static final class Builder {
+
+		/** Base URL. */
+		private String baseUrlValue = DEFAULT_BASE_URL;
+
+		/** API key. */
+		private @Nullable String apiKeyValue;
+
+		/** Rest client builder. */
+		private RestClient.Builder restClientBuilderValue = RestClient.builder();
+
+		/** Error handler. */
+		private ResponseErrorHandler errorHandlerValue = RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER;
+
+		/**
+		 * Set base URL.
+		 * @param baseUrl URL
+		 * @return this
+		 */
+		public Builder baseUrl(final String baseUrl) {
+			this.baseUrlValue = baseUrl;
+			return this;
+		}
+
+		/**
+		 * Set API key.
+		 * @param apiKey key
+		 * @return this
+		 */
+		public Builder apiKey(final @Nullable String apiKey) {
+			this.apiKeyValue = apiKey;
+			return this;
+		}
+
+		/**
+		 * Set rest client builder.
+		 * @param builder builder
+		 * @return this
+		 */
+		public Builder restClientBuilder(final RestClient.Builder builder) {
+			this.restClientBuilderValue = builder;
+			return this;
+		}
+
+		/**
+		 * Set error handler.
+		 * @param handler handler
+		 * @return this
+		 */
+		public Builder responseErrorHandler(final ResponseErrorHandler handler) {
+			this.errorHandlerValue = handler;
+			return this;
+		}
+
+		/**
+		 * Build client.
+		 * @return client
+		 */
+		public VllmScoringApi build() {
+			return new VllmScoringApi(this.baseUrlValue, this.apiKeyValue, this.restClientBuilderValue,
+					this.errorHandlerValue);
+		}
+
+	}
+
+	/**
+	 * Rerank request.
+	 *
+	 * @param model model name
+	 * @param query query string
+	 * @param documents list of doc texts
+	 * @param topN top N results
+	 * @param returnDocs return docs flag
+	 * @param truncation truncation flag
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record RerankRequest(@JsonProperty("model") String model, @JsonProperty("query") String query,
+			@JsonProperty("documents") List<String> documents, @JsonProperty("top_n") @Nullable Integer topN,
+			@JsonProperty("return_documents") @Nullable Boolean returnDocs,
+			@JsonProperty("truncation") @Nullable Boolean truncation) {
+
+		/**
+		 * Initial constructor.
+		 * @param modelName model name
+		 * @param queryText query text
+		 * @param docList list of documents
+		 */
+		public RerankRequest(final String modelName, final String queryText, final List<String> docList) {
+			this(modelName, queryText, docList, null, null, null);
+		}
+	}
+
+	/**
+	 * Rerank response.
+	 *
+	 * @param id response id
+	 * @param object object type
+	 * @param model model used
+	 * @param results ranked results
+	 * @param usage token usage
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record RerankResponse(@JsonProperty("id") @Nullable String id,
+			@JsonProperty("object") @Nullable String object, @JsonProperty("model") @Nullable String model,
+			@JsonProperty("results") List<RerankResult> results, @JsonProperty("usage") @Nullable Usage usage) {
+	}
+
+	/**
+	 * Rerank result.
+	 *
+	 * @param index doc index
+	 * @param relevanceScore score
+	 * @param document doc content
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record RerankResult(@JsonProperty("index") int index, @JsonProperty("relevance_score") double relevanceScore,
+			@JsonProperty("document") @Nullable Document document) {
+	}
+
+	/**
+	 * Document wrapper.
+	 *
+	 * @param text document text
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Document(@JsonProperty("text") String text) {
+
+		/**
+		 * Create from string.
+		 * @param text doc text
+		 * @return document
+		 */
+		@com.fasterxml.jackson.annotation.JsonCreator(
+				mode = com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING)
+		public static Document fromString(final String text) {
+			return new Document(text);
+		}
+	}
+
+	/**
+	 * Token usage.
+	 *
+	 * @param promptTokens prompt tokens
+	 * @param totalTokens total tokens
+	 */
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Usage(@JsonProperty("prompt_tokens") @Nullable Integer promptTokens,
+			@JsonProperty("total_tokens") @Nullable Integer totalTokens) {
+	}
+
+}

--- a/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/api/package-info.java
+++ b/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/api/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * vLLM API client implementations.
+ */
+@NullMarked
+package org.springframework.ai.vllm.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/package-info.java
+++ b/models/spring-ai-vllm/src/main/java/org/springframework/ai/vllm/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * vLLM Scoring Model implementation.
+ */
+@NullMarked
+package org.springframework.ai.vllm;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-vllm/src/test/java/org/springframework/ai/vllm/VllmScoringModelTests.java
+++ b/models/spring-ai-vllm/src/test/java/org/springframework/ai/vllm/VllmScoringModelTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vllm;
+
+import java.io.IOException;
+import java.util.List;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.scoring.ScoringRequest;
+import org.springframework.ai.scoring.ScoringResponse;
+import org.springframework.ai.vllm.api.VllmScoringApi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link VllmScoringModel}.
+ *
+ * @author Spring AI
+ */
+class VllmScoringModelTests {
+
+	private MockWebServer server;
+
+	private VllmScoringModel model;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		this.server = new MockWebServer();
+		this.server.start();
+
+		VllmScoringApi api = VllmScoringApi.builder()
+			.baseUrl(this.server.url("/").toString())
+			.apiKey("test-key")
+			.build();
+
+		VllmScoringOptions options = VllmScoringOptions.builder().model("BAAI/bge-reranker-v2-m3").topK(2).build();
+
+		this.model = VllmScoringModel.builder().vllmScoringApi(api).options(options).build();
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		this.server.shutdown();
+	}
+
+	@Test
+	void callSuccessfully() {
+		// Prepare JSON response matching vLLM /v1/rerank
+		String jsonResponse = "{\n" + "  \"id\": \"cmpl-123\",\n" + "  \"object\": \"list\",\n"
+				+ "  \"model\": \"BAAI/bge-reranker-v2-m3\",\n" + "  \"results\": [\n" + "    {\n"
+				+ "      \"index\": 1,\n" + "      \"relevance_score\": 0.95\n" + "    },\n" + "    {\n"
+				+ "      \"index\": 0,\n" + "      \"relevance_score\": 0.85\n" + "    }\n" + "  ],\n"
+				+ "  \"usage\": {\n" + "    \"prompt_tokens\": 10,\n" + "    \"total_tokens\": 10\n" + "  }\n" + "}";
+
+		this.server.enqueue(new MockResponse().setBody(jsonResponse).addHeader("Content-Type", "application/json"));
+
+		List<Document> documents = List.of(new Document("doc1"), new Document("doc2"), new Document("doc3"));
+		ScoringResponse response = this.model.call("test query", documents);
+
+		assertThat(response.getResults()).hasSize(2);
+
+		// Index 1 corresponds to "doc2" with score 0.95
+		assertThat(response.getResults().get(0).getOutput().getText()).isEqualTo("doc2");
+		assertThat(response.getResults().get(0).getOutput().getScore()).isEqualTo(0.95);
+
+		// Index 0 corresponds to "doc1" with score 0.85
+		assertThat(response.getResults().get(1).getOutput().getText()).isEqualTo("doc1");
+		assertThat(response.getResults().get(1).getOutput().getScore()).isEqualTo(0.85);
+	}
+
+	@Test
+	void callWithEmptyDocuments() {
+		assertThatThrownBy(() -> this.model.call("query", List.of())).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Documents must not be empty");
+	}
+
+	@Test
+	void mergeOptions() {
+		String jsonResponse = "{\n" + "  \"results\": [\n" + "    {\n" + "      \"index\": 0,\n"
+				+ "      \"relevance_score\": 0.99\n" + "    }\n" + "  ]\n" + "}";
+
+		this.server.enqueue(new MockResponse().setBody(jsonResponse).addHeader("Content-Type", "application/json"));
+
+		VllmScoringOptions runtimeOptions = VllmScoringOptions.builder()
+			.model("custom-model")
+			.topK(1)
+			.returnDocuments(true)
+			.build();
+
+		ScoringRequest request = new ScoringRequest("query", List.of(new Document("text")), runtimeOptions);
+
+		// The test mainly checks if the request goes through successfully without
+		// throwing errors
+		// In a real scenario, we would verify the dispatched HTTP request body to ensure
+		// "custom-model" and top_n=1 were passed correctly.
+		ScoringResponse response = this.model.call(request);
+		assertThat(response.getResults()).hasSize(1);
+	}
+
+	@Test
+	void callThrowsExceptionWhenModelIsNull() {
+		VllmScoringApi api = VllmScoringApi.builder().baseUrl(this.server.url("/").toString()).build();
+
+		// No default model set
+		VllmScoringOptions emptyOptions = VllmScoringOptions.builder().build();
+
+		VllmScoringModel modelWithoutModelName = VllmScoringModel.builder()
+			.vllmScoringApi(api)
+			.options(emptyOptions)
+			.build();
+
+		assertThatThrownBy(() -> modelWithoutModelName.call("query", List.of(new Document("text"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Model name must not be null for vLLM Scoring");
+	}
+
+}

--- a/models/spring-ai-vllm/src/test/java/org/springframework/ai/vllm/evaluation/NdcgCalculator.java
+++ b/models/spring-ai-vllm/src/test/java/org/springframework/ai/vllm/evaluation/NdcgCalculator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vllm.evaluation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility class for calculating NDCG@K (Normalized Discounted Cumulative Gain).
+ *
+ * <p>
+ * NDCG is a standard information retrieval metric that measures the quality of a ranked
+ * list of results by comparing it against an ideal ranking. Values range from 0.0 (worst)
+ * to 1.0 (perfect ranking).
+ *
+ * @author Spring AI
+ * @since 2.0.0
+ */
+public final class NdcgCalculator {
+
+	private NdcgCalculator() {
+	}
+
+	/**
+	 * Calculate NDCG@K for a ranked list of relevance scores.
+	 * @param relevanceScores relevance scores in the order they were ranked
+	 * @param k the cutoff position (top-K)
+	 * @return NDCG@K value between 0.0 and 1.0
+	 */
+	public static double calculate(List<Integer> relevanceScores, int k) {
+		if (relevanceScores == null || relevanceScores.isEmpty() || k <= 0) {
+			return 0.0;
+		}
+
+		int effectiveK = Math.min(k, relevanceScores.size());
+
+		double dcg = computeDcg(relevanceScores, effectiveK);
+		double idcg = computeIdcg(relevanceScores, effectiveK);
+
+		if (idcg == 0.0) {
+			return 0.0;
+		}
+
+		return dcg / idcg;
+	}
+
+	/**
+	 * Compute DCG@K (Discounted Cumulative Gain).
+	 *
+	 * <p>
+	 * Formula: DCG@K = Σ (rel_i / log₂(i + 1)) for i = 1 to K
+	 */
+	static double computeDcg(List<Integer> relevanceScores, int k) {
+		double dcg = 0.0;
+		for (int i = 0; i < k; i++) {
+			double rel = relevanceScores.get(i);
+			dcg += rel / (Math.log(i + 2) / Math.log(2));
+		}
+		return dcg;
+	}
+
+	/**
+	 * Compute IDCG@K (Ideal Discounted Cumulative Gain). Sorts the relevance scores in
+	 * descending order first, then computes DCG.
+	 */
+	static double computeIdcg(List<Integer> relevanceScores, int k) {
+		List<Integer> sorted = new ArrayList<>(relevanceScores);
+		sorted.sort(Collections.reverseOrder());
+		return computeDcg(sorted, k);
+	}
+
+}

--- a/models/spring-ai-vllm/src/test/java/org/springframework/ai/vllm/evaluation/NdcgEvaluationIT.java
+++ b/models/spring-ai-vllm/src/test/java/org/springframework/ai/vllm/evaluation/NdcgEvaluationIT.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vllm.evaluation;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.scoring.ScoringResponse;
+import org.springframework.ai.scoring.ScoringResult;
+import org.springframework.ai.vllm.VllmScoringModel;
+import org.springframework.ai.vllm.VllmScoringOptions;
+import org.springframework.ai.vllm.api.VllmScoringApi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * NDCG@K evaluation comparing baseline search ordering vs vLLM Reranking.
+ *
+ * <p>
+ * This test demonstrates the effectiveness of reranking by calculating NDCG@K metrics for
+ * both a simulated baseline (embedding/BM25) search result ordering and the vLLM
+ * Reranker-optimized ordering, then comparing them quantitatively.
+ *
+ * <p>
+ * To run locally:
+ *
+ * <pre>
+ * set VLLM_URL=http://localhost:8000
+ * set VLLM_MODEL=BAAI/bge-reranker-base
+ * mvn test -Dtest=NdcgEvaluationIT -pl models/spring-ai-vllm
+ * </pre>
+ *
+ * @author Spring AI
+ * @since 2.0.0
+ */
+// @EnabledIfEnvironmentVariable(named = "VLLM_URL", matches = ".+")
+class NdcgEvaluationIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(NdcgEvaluationIT.class);
+
+	private VllmScoringModel scoringModel;
+
+	/**
+	 * Ground Truth: 사람이 사전에 판단한 관련도 라벨. 3=완전관련, 2=관련, 1=부분관련, 0=무관
+	 */
+	private final Map<String, Integer> groundTruth = new LinkedHashMap<>();
+
+	@BeforeEach
+	void setUp() {
+		String baseUrl = System.getenv("VLLM_URL") != null ? System.getenv("VLLM_URL") : "http://localhost:8000";
+		String model = System.getenv("VLLM_MODEL") != null ? System.getenv("VLLM_MODEL") : "BAAI/bge-reranker-base";
+
+		org.springframework.web.client.RestClient.Builder restClientBuilder = org.springframework.web.client.RestClient
+			.builder()
+			.requestFactory(new org.springframework.http.client.JdkClientHttpRequestFactory(
+					java.net.http.HttpClient.newBuilder().version(java.net.http.HttpClient.Version.HTTP_1_1).build()));
+
+		VllmScoringApi api = VllmScoringApi.builder()
+			.restClientBuilder(restClientBuilder)
+			.baseUrl(baseUrl)
+			.build();
+
+		this.scoringModel = VllmScoringModel.builder()
+			.vllmScoringApi(api)
+			.retryTemplate(RetryUtils.DEFAULT_RETRY_TEMPLATE)
+			.options(VllmScoringOptions.builder().model(model).build())
+			.build();
+
+		// Ground Truth 정의
+		this.groundTruth
+			.put("Spring AI provides a unified API for integrating various AI models into Spring applications.", 3);
+		this.groundTruth.put("The Spring Framework is a comprehensive framework for enterprise Java development.", 2);
+		this.groundTruth.put("React is a JavaScript library for building user interfaces developed by Meta.", 0);
+		this.groundTruth.put("Spring AI supports embedding models, chat models, and image generation models.", 3);
+		this.groundTruth.put("Python is widely used in data science and machine learning applications.", 0);
+	}
+
+	@Test
+	void compareBaselineVsRerankingWithNdcg() {
+		String query = "What is Spring AI and how does it integrate with AI models?";
+
+		// =====================================================
+		// 1. Baseline: 임베딩/BM25 유사도 기반 검색 결과 (시뮬레이션)
+		// 실제 IR 시스템에서 나올 수 있는 '비이상적인' 순서
+		// =====================================================
+		List<String> baselineOrder = List.of(
+				"The Spring Framework is a comprehensive framework for enterprise Java development.",
+				"Spring AI provides a unified API for integrating various AI models into Spring applications.",
+				"Python is widely used in data science and machine learning applications.",
+				"Spring AI supports embedding models, chat models, and image generation models.",
+				"React is a JavaScript library for building user interfaces developed by Meta.");
+
+		List<Integer> baselineRelevances = baselineOrder.stream()
+			.map(text -> this.groundTruth.getOrDefault(text, 0))
+			.toList();
+
+		double baselineNdcg3 = NdcgCalculator.calculate(baselineRelevances, 3);
+		double baselineNdcg5 = NdcgCalculator.calculate(baselineRelevances, 5);
+
+		// =====================================================
+		// 2. vLLM Reranking 적용
+		// =====================================================
+		List<Document> documents = baselineOrder.stream().map(Document::new).toList();
+		ScoringResponse response = this.scoringModel.call(query, documents);
+
+		List<String> rerankOrder = response.getResults()
+			.stream()
+			.map(ScoringResult::getOutput)
+			.map(Document::getText)
+			.toList();
+
+		List<Integer> rerankRelevances = rerankOrder.stream()
+			.map(text -> this.groundTruth.getOrDefault(text, 0))
+			.toList();
+
+		double rerankNdcg3 = NdcgCalculator.calculate(rerankRelevances, 3);
+		double rerankNdcg5 = NdcgCalculator.calculate(rerankRelevances, 5);
+
+		double improvement3 = baselineNdcg3 > 0 ? ((rerankNdcg3 - baselineNdcg3) / baselineNdcg3) * 100 : 0.0;
+		double improvement5 = baselineNdcg5 > 0 ? ((rerankNdcg5 - baselineNdcg5) / baselineNdcg5) * 100 : 0.0;
+
+		// =====================================================
+		// 결과 출력
+		// =====================================================
+		logger.info("");
+		logger.info("=================================================================");
+		logger.info("  [vLLM Reranking 단건 평가 결과]");
+		logger.info("=================================================================");
+		logger.info("");
+		logger.info("  * 질의: \"{}\"", query);
+		logger.info("");
+		logger.info("  (1) Baseline (리랭킹 없음 - 벡터 유사도만 사용)");
+		logger.info("      문서 순서: rel=[{}]", baselineRelevances.stream().map(String::valueOf).reduce((a, b) -> a + ", " + b).orElse(""));
+		logger.info("      NDCG@3={}, NDCG@5={}", String.format("%.4f", baselineNdcg3), String.format("%.4f", baselineNdcg5));
+		logger.info("");
+		logger.info("  (2) Reranking 적용 후 (vLLM ScoringModel)");
+		for (int i = 0; i < rerankOrder.size(); i++) {
+			double score = response.getResults().get(i).getOutput().getScore();
+			String snippet = rerankOrder.get(i).substring(0, Math.min(50, rerankOrder.get(i).length()));
+			logger.info("      {}위: rel={}, score={} | {}...", i + 1, rerankRelevances.get(i), String.format("%.4f", score), snippet);
+		}
+		logger.info("      NDCG@3={}, NDCG@5={}", String.format("%.4f", rerankNdcg3), String.format("%.4f", rerankNdcg5));
+		logger.info("");
+		logger.info("  (3) 결론");
+		logger.info("      -> NDCG@3: {} -> {} ({}% 향상)", String.format("%.4f", baselineNdcg3), String.format("%.4f", rerankNdcg3), String.format("+%.1f", improvement3));
+		logger.info("      -> NDCG@5: {} -> {} ({}% 향상)", String.format("%.4f", baselineNdcg5), String.format("%.4f", rerankNdcg5), String.format("+%.1f", improvement5));
+		logger.info("      => 리랭킹을 적용하면 관련성 높은 문서가 상위로 올라가 검색 품질이 향상됩니다.");
+		logger.info("=================================================================");
+
+		// =====================================================
+		// 4. Assertion: Reranking이 Baseline보다 같거나 높아야 함
+		// =====================================================
+		assertThat(rerankNdcg5).as("NDCG@5: Reranking should be >= Baseline").isGreaterThanOrEqualTo(baselineNdcg5);
+		assertThat(rerankNdcg3).as("NDCG@3: Reranking should be >= Baseline").isGreaterThanOrEqualTo(baselineNdcg3);
+	}
+
+	@Test
+	void compareWithMultipleQueries() {
+		// 다양한 질의에 대해 평균 NDCG를 계산하여 더 신뢰성 있는 평가 수행
+		Map<String, List<String>> queryToBaseline = new LinkedHashMap<>();
+
+		queryToBaseline.put("What is Spring AI and how does it integrate with AI models?",
+				List.of("The Spring Framework is a comprehensive framework for enterprise Java development.",
+						"Spring AI provides a unified API for integrating various AI models into Spring applications.",
+						"Python is widely used in data science and machine learning applications.",
+						"Spring AI supports embedding models, chat models, and image generation models.",
+						"React is a JavaScript library for building user interfaces developed by Meta."));
+
+		queryToBaseline.put("Which frameworks are used for Java enterprise development?",
+				List.of("React is a JavaScript library for building user interfaces developed by Meta.",
+						"The Spring Framework is a comprehensive framework for enterprise Java development.",
+						"Spring AI provides a unified API for integrating various AI models into Spring applications.",
+						"Python is widely used in data science and machine learning applications.",
+						"Spring AI supports embedding models, chat models, and image generation models."));
+
+		// 두 번째 query 용 ground truth
+		Map<String, Integer> groundTruth2 = new LinkedHashMap<>();
+		groundTruth2.put("Spring AI provides a unified API for integrating various AI models into Spring applications.",
+				1);
+		groundTruth2.put("The Spring Framework is a comprehensive framework for enterprise Java development.", 3);
+		groundTruth2.put("React is a JavaScript library for building user interfaces developed by Meta.", 0);
+		groundTruth2.put("Spring AI supports embedding models, chat models, and image generation models.", 1);
+		groundTruth2.put("Python is widely used in data science and machine learning applications.", 0);
+
+		// 세 번째 query 용 ground truth (Lexical vs Semantic 테스트)
+		queryToBaseline.put("How to configure a custom RestClient builder in Spring AI for reactive applications?", List
+			.of("Spring WebFlux provides a reactive WebClient for handling streams. It is an alternative to RestClient.",
+					"Reactive programming in Java is often implemented using Project Reactor, which Spring WebFlux is built upon.",
+					"Spring AI provides RestClient usage for OpenAI models, but you cannot use WebClient here.",
+					"Configuring streams in Spring AI chat responses requires specific configuration for reactive applications.",
+					"To configure a custom RestClient in Spring AI with reactive streams, provide a RestClient.Builder bean and use it in your application."));
+
+		Map<String, Integer> groundTruth3 = new LinkedHashMap<>();
+		groundTruth3.put(
+				"Spring WebFlux provides a reactive WebClient for handling streams. It is an alternative to RestClient.",
+				0);
+		groundTruth3.put(
+				"Reactive programming in Java is often implemented using Project Reactor, which Spring WebFlux is built upon.",
+				0);
+		groundTruth3.put("Spring AI provides RestClient usage for OpenAI models, but you cannot use WebClient here.",
+				1);
+		groundTruth3.put(
+				"Configuring streams in Spring AI chat responses requires specific configuration for reactive applications.",
+				2);
+		groundTruth3.put(
+				"To configure a custom RestClient in Spring AI with reactive streams, provide a RestClient.Builder bean and use it in your application.",
+				3);
+
+		Map<String, Map<String, Integer>> queryGroundTruths = new LinkedHashMap<>();
+		queryGroundTruths.put("What is Spring AI and how does it integrate with AI models?", this.groundTruth);
+		queryGroundTruths.put("Which frameworks are used for Java enterprise development?", groundTruth2);
+		queryGroundTruths.put("How to configure a custom RestClient builder in Spring AI for reactive applications?",
+				groundTruth3);
+
+		double totalBaselineNdcg5 = 0.0;
+		double totalRerankNdcg5 = 0.0;
+		int queryCount = 0;
+
+		String[] queryLabels = { "일반 질의", "혼동 질의", "고난도 함정 질의 (Lexical Trap)" };
+
+		logger.info("");
+		logger.info("=================================================================");
+		logger.info("  [vLLM Reranking 다중 질의 평가 결과]");
+		logger.info("  3개 시나리오에 대한 NDCG@5 비교");
+		logger.info("=================================================================");
+
+		for (Map.Entry<String, List<String>> entry : queryToBaseline.entrySet()) {
+			String query = entry.getKey();
+			List<String> baseline = entry.getValue();
+			Map<String, Integer> gt = queryGroundTruths.get(query);
+
+			List<Integer> baselineRels = baseline.stream().map(t -> gt.getOrDefault(t, 0)).toList();
+			double baseNdcg5 = NdcgCalculator.calculate(baselineRels, 5);
+
+			List<Document> docs = baseline.stream().map(Document::new).toList();
+			ScoringResponse response = this.scoringModel.call(query, docs);
+
+			List<Integer> rerankRels = response.getResults()
+				.stream()
+				.map(r -> gt.getOrDefault(r.getOutput().getText(), 0))
+				.toList();
+			double rerankNdcg5 = NdcgCalculator.calculate(rerankRels, 5);
+			double improvement = baseNdcg5 > 0 ? ((rerankNdcg5 - baseNdcg5) / baseNdcg5) * 100 : 0.0;
+
+			logger.info("");
+			logger.info("  Q{} [{}]", queryCount + 1, queryLabels[queryCount]);
+			logger.info("      Baseline={} -> Reranked={} (+{}% 향상)",
+					String.format("%.4f", baseNdcg5), String.format("%.4f", rerankNdcg5),
+					String.format("%.1f", improvement));
+
+			totalBaselineNdcg5 += baseNdcg5;
+			totalRerankNdcg5 += rerankNdcg5;
+			queryCount++;
+		}
+
+		double avgBaselineNdcg5 = totalBaselineNdcg5 / queryCount;
+		double avgRerankNdcg5 = totalRerankNdcg5 / queryCount;
+		double avgImprovement = ((avgRerankNdcg5 - avgBaselineNdcg5) / avgBaselineNdcg5) * 100;
+
+		logger.info("");
+		logger.info("-----------------------------------------------------------------");
+		logger.info("  [종합] 평균 Baseline NDCG@5={} -> 평균 Reranked NDCG@5={}",
+				String.format("%.4f", avgBaselineNdcg5), String.format("%.4f", avgRerankNdcg5));
+		logger.info("         평균 향상률: +{}%", String.format("%.1f", avgImprovement));
+		logger.info("  => 리랭킹 적용 시 모든 난이도의 질의에서 검색 품질이 향상되었습니다.");
+		logger.info("     특히 키워드 함정 질의에서 가장 큰 효과를 보입니다.");
+		logger.info("=================================================================");
+
+		assertThat(avgRerankNdcg5).as("Average NDCG@5 should improve with reranking")
+			.isGreaterThanOrEqualTo(avgBaselineNdcg5);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-deepseek</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-google-genai</module>
+		<module>auto-configurations/models/spring-ai-autoconfigure-model-jina</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-ollama</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-openai</module>
@@ -81,6 +82,7 @@
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-stability-ai</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-transformers</module>
 		<module>auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai</module>
+		<module>auto-configurations/models/spring-ai-autoconfigure-model-vllm</module>
 		<module>auto-configurations/models/tool/spring-ai-autoconfigure-model-tool</module>
 
 		<module>auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure</module>
@@ -129,6 +131,7 @@
 		<module>models/spring-ai-elevenlabs</module>
 		<module>models/spring-ai-google-genai</module>
 		<module>models/spring-ai-google-genai-embedding</module>
+		<module>models/spring-ai-jina</module>
 		<module>models/spring-ai-mistral-ai</module>
 		<module>models/spring-ai-ollama</module>
 		<module>models/spring-ai-openai</module>
@@ -136,6 +139,7 @@
 		<module>models/spring-ai-stability-ai</module>
 		<module>models/spring-ai-transformers</module>
 		<module>models/spring-ai-vertex-ai-embedding</module>
+		<module>models/spring-ai-vllm</module>
 
 		<module>starters/spring-ai-starter-mcp-client</module>
 		<module>starters/spring-ai-starter-mcp-client-webflux</module>
@@ -156,6 +160,7 @@
 		<module>starters/spring-ai-starter-model-elevenlabs</module>
 		<module>starters/spring-ai-starter-model-google-genai</module>
 		<module>starters/spring-ai-starter-model-google-genai-embedding</module>
+		<module>starters/spring-ai-starter-model-jina</module>
 		<module>starters/spring-ai-starter-model-mistral-ai</module>
 		<module>starters/spring-ai-starter-model-ollama</module>
 		<module>starters/spring-ai-starter-model-openai</module>
@@ -163,6 +168,7 @@
 		<module>starters/spring-ai-starter-model-stability-ai</module>
 		<module>starters/spring-ai-starter-model-transformers</module>
 		<module>starters/spring-ai-starter-model-vertex-ai-embedding</module>
+		<module>starters/spring-ai-starter-model-vllm</module>
 
 		<module>starters/spring-ai-starter-tool-search-advisor</module>
 

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -294,6 +294,12 @@
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-jina</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-mistral-ai</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -331,6 +337,12 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-vertex-ai-embedding</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-vllm</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
@@ -629,6 +641,12 @@
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-autoconfigure-model-jina</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-mistral-ai</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -666,6 +684,12 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-autoconfigure-model-vertex-ai</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-autoconfigure-model-vllm</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
@@ -963,6 +987,12 @@
 
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-starter-model-jina</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-mistral-ai</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -1000,6 +1030,12 @@
 			<dependency>
 				<groupId>org.springframework.ai</groupId>
 				<artifactId>spring-ai-starter-model-vertex-ai-embedding</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-starter-model-vllm</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 

--- a/spring-ai-model/pom.xml
+++ b/spring-ai-model/pom.xml
@@ -136,7 +136,6 @@
 			<version>${mockk-jvm.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
-	</dependencies>
+    </dependencies>
 	
 </project>

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModelProperties.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModelProperties.java
@@ -40,4 +40,6 @@ public final class SpringAIModelProperties {
 
 	public static final String MODERATION_MODEL = MODEL_PREFIX + ".moderation";
 
+	public static final String SCORING_MODEL = MODEL_PREFIX + ".scoring";
+
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModels.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModels.java
@@ -56,4 +56,6 @@ public final class SpringAIModels {
 
 	public static final String ELEVEN_LABS = "elevenlabs";
 
+	public static final String JINA = "jina";
+
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringModel.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringModel.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.scoring;
+
+import java.util.List;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.model.Model;
+
+/**
+ * Interface for scoring (reranking) models.
+ *
+ * @since 2.0.0
+ */
+public interface ScoringModel extends Model<ScoringRequest, ScoringResponse> {
+
+	@Override
+	ScoringResponse call(ScoringRequest request);
+
+	/**
+	 * Scores (reranks) a list of documents against a query.
+	 * @param query the query to score against
+	 * @param documents the list of documents to score
+	 * @return the scoring response
+	 */
+	default ScoringResponse call(String query, List<Document> documents) {
+		return call(new ScoringRequest(query, documents));
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.scoring;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.model.ModelOptions;
+
+/**
+ * Options for scoring (reranking) requests.
+ *
+ * @since 2.0.0
+ */
+public interface ScoringOptions extends ModelOptions {
+
+	default @Nullable String getModel() {
+		return null;
+	}
+
+	@Nullable Integer getTopK();
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringRequest.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.scoring;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.model.ModelRequest;
+
+/**
+ * Request for scoring (reranking) operations.
+ *
+ * @since 2.0.0
+ */
+public class ScoringRequest implements ModelRequest<List<Document>> {
+
+	private final String query;
+
+	private final List<Document> documents;
+
+	private final @Nullable ScoringOptions options;
+
+	public ScoringRequest(String query, List<Document> documents, @Nullable ScoringOptions options) {
+		this.query = query;
+		this.documents = documents;
+		this.options = options;
+	}
+
+	public ScoringRequest(String query, List<Document> documents) {
+		this(query, documents, null);
+	}
+
+	public String getQuery() {
+		return this.query;
+	}
+
+	@Override
+	public List<Document> getInstructions() {
+		return this.documents;
+	}
+
+	@Override
+	public @Nullable ScoringOptions getOptions() {
+		return this.options;
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResponse.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.scoring;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.model.ModelResponse;
+
+/**
+ * Response for scoring (reranking) operations.
+ *
+ * @since 2.0.0
+ */
+public class ScoringResponse implements ModelResponse<ScoringResult> {
+
+	private final List<ScoringResult> results;
+
+	public ScoringResponse(List<ScoringResult> results) {
+		this.results = results;
+	}
+
+	@Override
+	public @Nullable ScoringResult getResult() {
+		return this.results.isEmpty() ? null : this.results.get(0);
+	}
+
+	@Override
+	public List<ScoringResult> getResults() {
+		return this.results;
+	}
+
+	@Override
+	public ScoringResponseMetadata getMetadata() {
+		return new ScoringResponseMetadata();
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResponseMetadata.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResponseMetadata.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.scoring;
+
+import org.springframework.ai.model.AbstractResponseMetadata;
+import org.springframework.ai.model.ResponseMetadata;
+
+/**
+ * Metadata for a {@link ScoringResponse}.
+ *
+ * @since 2.0.0
+ */
+public class ScoringResponseMetadata extends AbstractResponseMetadata implements ResponseMetadata {
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResult.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.scoring;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.model.ModelResult;
+
+/**
+ * A single scored result from a {@link ScoringModel}.
+ *
+ * @since 2.0.0
+ */
+public class ScoringResult implements ModelResult<Document> {
+
+	private final Document document;
+
+	public ScoringResult(Document document) {
+		this.document = document;
+	}
+
+	@Override
+	public Document getOutput() {
+		return this.document;
+	}
+
+	@Override
+	public ScoringResultMetadata getMetadata() {
+		return ScoringResultMetadata.NULL;
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResultMetadata.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/ScoringResultMetadata.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.scoring;
+
+import org.springframework.ai.model.ResultMetadata;
+
+/**
+ * Metadata for a {@link ScoringResult}.
+ *
+ * @since 2.0.0
+ */
+public interface ScoringResultMetadata extends ResultMetadata {
+
+	ScoringResultMetadata NULL = ScoringResultMetadata.create();
+
+	static ScoringResultMetadata create() {
+		return new ScoringResultMetadata() {
+		};
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/scoring/package-info.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/scoring/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.scoring;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/ScoringDocumentPostProcessor.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/ScoringDocumentPostProcessor.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.rag.postretrieval.document;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+import org.springframework.ai.scoring.ScoringModel;
+import org.springframework.ai.scoring.ScoringOptions;
+import org.springframework.ai.scoring.ScoringRequest;
+import org.springframework.ai.scoring.ScoringResponse;
+import org.springframework.ai.scoring.ScoringResult;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link DocumentPostProcessor} that uses a {@link ScoringModel} to rerank retrieved
+ * documents by their relevance to the query.
+ *
+ * <p>
+ * This processor delegates to any {@link ScoringModel} implementation (e.g., Jina AI
+ * Reranker, Cohere Rerank) to score each document against the query, then returns the
+ * documents sorted by relevance score in descending order.
+ *
+ * <p>
+ * Example usage: <pre>{@code
+ * ScoringDocumentPostProcessor postProcessor = ScoringDocumentPostProcessor.builder()
+ *     .scoringModel(jinaScoringModel)
+ *     .options(ScoringOptions.builder().topK(5).build())
+ *     .build();
+ *
+ * RetrievalAugmentationAdvisor advisor = RetrievalAugmentationAdvisor.builder()
+ *     .documentRetriever(retriever)
+ *     .documentPostProcessors(List.of(postProcessor))
+ *     .build();
+ * }</pre>
+ *
+ * @author Wongi Kim
+ * @since 2.0.0
+ * @see ScoringModel
+ * @see DocumentPostProcessor
+ */
+public final class ScoringDocumentPostProcessor implements DocumentPostProcessor {
+
+	private final ScoringModel scoringModel;
+
+	private final @Nullable ScoringOptions defaultOptions;
+
+	/**
+	 * Create a new {@link ScoringDocumentPostProcessor}.
+	 * @param scoringModel the scoring model to use for reranking
+	 * @param defaultOptions the default scoring options, or {@code null} if none
+	 */
+	public ScoringDocumentPostProcessor(ScoringModel scoringModel, @Nullable ScoringOptions defaultOptions) {
+		Assert.notNull(scoringModel, "scoringModel cannot be null");
+		this.scoringModel = scoringModel;
+		this.defaultOptions = defaultOptions;
+	}
+
+	@Override
+	public List<Document> process(Query query, List<Document> documents) {
+		Assert.notNull(query, "query cannot be null");
+		Assert.notNull(documents, "documents cannot be null");
+
+		if (documents.isEmpty()) {
+			return documents;
+		}
+
+		ScoringRequest request = new ScoringRequest(query.text(), documents, this.defaultOptions);
+		ScoringResponse response = this.scoringModel.call(request);
+
+		return response.getResults()
+			.stream()
+			.map(ScoringResult::getOutput)
+			.toList();
+	}
+
+	/**
+	 * Create a new {@link Builder} instance.
+	 * @return a new builder
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link ScoringDocumentPostProcessor}.
+	 */
+	public static final class Builder {
+
+		private @Nullable ScoringModel scoringModel;
+
+		private @Nullable ScoringOptions options;
+
+		private Builder() {
+		}
+
+		/**
+		 * Set the {@link ScoringModel} to use for reranking.
+		 * @param scoringModel the scoring model
+		 * @return this builder
+		 */
+		public Builder scoringModel(ScoringModel scoringModel) {
+			this.scoringModel = scoringModel;
+			return this;
+		}
+
+		/**
+		 * Set the default {@link ScoringOptions}.
+		 * @param options the scoring options
+		 * @return this builder
+		 */
+		public Builder options(ScoringOptions options) {
+			this.options = options;
+			return this;
+		}
+
+		/**
+		 * Build a new {@link ScoringDocumentPostProcessor}.
+		 * @return the post processor
+		 */
+		public ScoringDocumentPostProcessor build() {
+			Assert.state(this.scoringModel != null, "scoringModel cannot be null");
+			return new ScoringDocumentPostProcessor(this.scoringModel, this.options);
+		}
+
+	}
+
+}

--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/ScoringDocumentPostProcessor.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/ScoringDocumentPostProcessor.java
@@ -85,10 +85,7 @@ public final class ScoringDocumentPostProcessor implements DocumentPostProcessor
 		ScoringRequest request = new ScoringRequest(query.text(), documents, this.defaultOptions);
 		ScoringResponse response = this.scoringModel.call(request);
 
-		return response.getResults()
-			.stream()
-			.map(ScoringResult::getOutput)
-			.toList();
+		return response.getResults().stream().map(ScoringResult::getOutput).toList();
 	}
 
 	/**

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-jina/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-jina/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>spring-ai-starter-model-jina</artifactId>
+    <packaging>jar</packaging>
+    <name>Spring AI Starter - Jina AI</name>
+    <description>Spring AI Jina AI Spring Boot Starter</description>
+    <url>https://github.com/spring-projects/spring-ai</url>
+
+    <scm>
+        <url>https://github.com/spring-projects/spring-ai</url>
+        <connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+    </scm>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-jina</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-jina</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spring-ai-spring-boot-starters/spring-ai-starter-model-jina/pom.xml
+++ b/spring-ai-spring-boot-starters/spring-ai-starter-model-jina/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>spring-ai-starter-model-jina</artifactId>

--- a/starters/spring-ai-starter-model-jina/pom.xml
+++ b/starters/spring-ai-starter-model-jina/pom.xml
@@ -15,9 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ai</groupId>
@@ -25,10 +23,10 @@
 		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-	<artifactId>spring-ai-jina</artifactId>
+	<artifactId>spring-ai-starter-model-jina</artifactId>
 	<packaging>jar</packaging>
-	<name>Spring AI Model - Jina AI</name>
-	<description>Jina AI models support</description>
+	<name>Spring AI Starter - Jina AI</name>
+	<description>Spring AI Jina AI Spring Boot Starter</description>
 	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
@@ -37,60 +35,28 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencies>
 
-		<!-- production dependencies -->
 		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-model</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-retry</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-
-		<!-- test dependencies -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-test</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-rag</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+			<artifactId>spring-boot-starter-restclient</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>mockwebserver</artifactId>
-			<version>4.12.0</version>
-			<scope>test</scope>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-jina</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-jina</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/starters/spring-ai-starter-model-vllm/pom.xml
+++ b/starters/spring-ai-starter-model-vllm/pom.xml
@@ -15,9 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.ai</groupId>
@@ -25,10 +23,10 @@
 		<version>2.0.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
-	<artifactId>spring-ai-jina</artifactId>
+	<artifactId>spring-ai-starter-model-vllm</artifactId>
 	<packaging>jar</packaging>
-	<name>Spring AI Model - Jina AI</name>
-	<description>Jina AI models support</description>
+	<name>Spring AI Starter - vLLM</name>
+	<description>Spring AI vLLM Spring Boot Starter</description>
 	<url>https://github.com/spring-projects/spring-ai</url>
 
 	<scm>
@@ -37,60 +35,28 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencies>
 
-		<!-- production dependencies -->
 		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-model</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-retry</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-
-		<!-- test dependencies -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-test</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-rag</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+			<artifactId>spring-boot-starter-restclient</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>mockwebserver</artifactId>
-			<version>4.12.0</version>
-			<scope>test</scope>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-vllm</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-vllm</artifactId>
+			<version>${project.parent.version}</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
## GH-5776: Add Jina AI Scoring (Reranker) Module

### Motivation

Spring AI currently lacks a built-in scoring/reranking abstraction. This PR introduces a `ScoringModel` abstraction in `spring-ai-model` and provides the first implementation using the [Jina AI Reranker API](https://jina.ai/reranker/).

Reranking is a critical component in RAG pipelines — it re-scores retrieved documents against the user query to improve relevance ordering before passing them to the LLM.

### Changes

*1. Core Scoring Abstraction (`spring-ai-model`)*
- `ScoringModel`, `ScoringOptions`, `ScoringRequest`, `ScoringResponse`, `ScoringResult`
- `ScoringOptions.getModel()` added as a `default` method for backward compatibility
- Registered `SCORING` in `SpringAIModels` and `SpringAIModelProperties`

*2. Jina AI Implementation (`models/spring-ai-jina`)*
- `JinaScoringApi` — REST client with Builder pattern for Jina Reranker API (`POST /v1/rerank`)
- `JinaScoringModel` — `ScoringModel` implementation with retry support, options merging, input validation
- `JinaScoringOptions` — model, topK, returnDocuments, truncation configuration
- Supported models: `jina-reranker-v2-base-multilingual`, `jina-reranker-v1-*`, `jina-colbert-v1-en`, `jina-colbert-v2`, `jina-reranker-m0`, `jina-reranker-v3`

*3. RAG Integration (`spring-ai-rag`)*
- `ScoringDocumentPostProcessor` — post-retrieval reranking pipeline for `RetrievalAugmentationAdvisor`

*4. Auto-Configuration (`auto-configurations/models/spring-ai-autoconfigure-model-jina`)*
- `JinaScoringAutoConfiguration` — conditional bean registration
- `JinaScoringProperties` — `spring.ai.jina.scoring.*` configuration properties
- Spring Boot Starter (`spring-ai-starter-model-jina`)

*5. BOM Registration*
- `spring-ai-jina`, `spring-ai-autoconfigure-model-jina`, `spring-ai-starter-model-jina` added to `spring-ai-bom`

### Test Coverage

| Test Class | Type | Count | Notes |
|---|---|---|---|
| `JinaScoringModelTests` | Unit (MockWebServer) | 5 | success, merge options, error, empty docs, retry |
| `JinaScoringApiIT` | Integration | 3 | basic rerank, topN, usage stats |
| `JinaScoringModelIT` | Integration | 4 | full model call, topK override, metadata preservation |
| `ScoringDocumentPostProcessorIT` | Integration | 1 | RAG pipeline end-to-end |
| `JinaScoringAutoConfigurationIT` | Integration | 1 | auto-config bean registration |

> Integration tests require `JINA_API_KEY` environment variable and are skipped by default.

### Usage Example

```java
// Direct usage
JinaScoringApi api = JinaScoringApi.builder()
    .apiKey("jina_...")
    .build();

JinaScoringModel scoringModel = JinaScoringModel.builder()
    .jinaScoringApi(api)
    .options(JinaScoringOptions.builder()
        .model("jina-reranker-v2-base-multilingual")
        .topK(3)
        .build())
    .build();

ScoringResponse response = scoringModel.call("What is Spring AI?", documents);

// With Spring Boot auto-configuration
// application.yml:
// spring.ai.jina.scoring.api-key: jina_...
// spring.ai.jina.scoring.options.model: jina-reranker-v2-base-multilingual
```

### Checklist

- [x] All unit tests pass (`mvnw clean verify -pl models/spring-ai-jina`)
- [x] Auto-configuration module builds successfully
- [x] Checkstyle / spring-javaformat: 0 violations
- [x] NullAway: all null-safety annotations applied
- [x] DCO Sign-off on all commits
- [x] No unrelated changes included

Closes #5776 
