### PR TITLE
GH-5889: Fix CsvSource parsing in TikaDocumentReaderTests

### DIFF
--- a/document-readers/tika-reader/src/test/java/org/springframework/ai/reader/tika/TikaDocumentReaderTests.java
+++ b/document-readers/tika-reader/src/test/java/org/springframework/ai/reader/tika/TikaDocumentReaderTests.java
@@ -31,13 +31,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class TikaDocumentReaderTests {
 
 	@ParameterizedTest
-	@CsvSource({
-			"classpath:/word-sample.docx,word-sample.docx,Two kinds of links are possible, those that refer to an external website",
-			"classpath:/word-sample.doc,word-sample.doc,The limited permissions granted above are perpetual and will not be revoked by OASIS",
-			"classpath:/sample2.pdf,sample2.pdf,Consult doc/pdftex/manual.pdf from your tetex distribution for more",
-			"classpath:/sample.ppt,sample.ppt,Sed ipsum tortor, fringilla a consectetur eget, cursus posuere sem.",
-			"classpath:/sample.pptx,sample.pptx,Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-			"https://github.com/spring-projects/spring-ai/,https://github.com/spring-projects/spring-ai/,An Application Framework for AI Engineering" })
+	@CsvSource(value = {
+			"classpath:/word-sample.docx;word-sample.docx;Two kinds of links are possible, those that refer to an external website",
+			"classpath:/word-sample.doc;word-sample.doc;The limited permissions granted above are perpetual and will not be revoked by OASIS",
+			"classpath:/sample2.pdf;sample2.pdf;Consult doc/pdftex/manual.pdf from your tetex distribution for more",
+			"classpath:/sample.ppt;sample.ppt;Sed ipsum tortor, fringilla a consectetur eget, cursus posuere sem.",
+			"classpath:/sample.pptx;sample.pptx;Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			"https://github.com/spring-projects/spring-ai/;https://github.com/spring-projects/spring-ai/;An Application Framework for AI Engineering" },
+			delimiter = ';')
 	public void testDocx(String resourceUri, String resourceName, String contentSnipped) {
 
 		var docs = new TikaDocumentReader(resourceUri).get();
@@ -51,10 +52,12 @@ public class TikaDocumentReaderTests {
 	}
 
 	@ParameterizedTest
-	@CsvSource({
-			"classpath:/word-sample.docx,word-sample.docx,This document demonstrates the ability of the calibre DOCX Input plugin",
-			"classpath:/sample2.pdf,sample2.pdf,Robert Maron", "classpath:/sample.ppt,sample.ppt,Sample FILE",
-			"classpath:/sample.pptx,sample.pptx,Sample FILE" })
+	@CsvSource(value = {
+			"classpath:/word-sample.docx;word-sample.docx;This document demonstrates the ability of the calibre DOCX Input plugin",
+			"classpath:/sample2.pdf;sample2.pdf;Robert Maron",
+			"classpath:/sample.ppt;sample.ppt;Sample FILE",
+			"classpath:/sample.pptx;sample.pptx;Sample FILE" },
+			delimiter = ';')
 	public void testReaderWithFormatter(String resourceUri, String resourceName, String contentSnipped) {
 
 		ExtractedTextFormatter formatter = ExtractedTextFormatter.builder().withNumberOfTopTextLinesToDelete(5).build();


### PR DESCRIPTION
Fixes `TikaDocumentReaderTests` parameterized test data that included commas in `contentSnipped` values.

Previously, rows that relied on the default `@CsvSource` separator could misparse snippet values containing commas, causing the test to assert against truncated content.

This change updates the parameterized test input to use a non-comma delimiter so the full snippet text is preserved.

Affected file:
- `document-readers/tika-reader/src/test/java/org/springframework/ai/reader/tika/TikaDocumentReaderTests.java`

Closes #5889 