### PR TITLE
Wire mcpServerJsonMapper into stateless MCP server builders

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification;
@@ -37,9 +38,11 @@ import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -75,6 +78,7 @@ public class McpServerStatelessAutoConfiguration {
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
 	public McpStatelessSyncServer mcpStatelessSyncServer(McpStatelessServerTransport statelessTransport,
+			@Qualifier("mcpServerJsonMapper") JsonMapper mcpServerJsonMapper,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
 			ObjectProvider<List<SyncToolSpecification>> tools,
 			ObjectProvider<List<SyncResourceSpecification>> resources,
@@ -86,7 +90,9 @@ public class McpServerStatelessAutoConfiguration {
 				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
-		StatelessSyncSpecification serverBuilder = McpServer.sync(statelessTransport).serverInfo(serverInfo);
+		StatelessSyncSpecification serverBuilder = McpServer.sync(statelessTransport)
+			.jsonMapper(new JacksonMcpJsonMapper(mcpServerJsonMapper))
+			.serverInfo(serverInfo);
 
 		// Tools
 		if (serverProperties.getCapabilities().isTool()) {
@@ -165,6 +171,7 @@ public class McpServerStatelessAutoConfiguration {
 	@Bean
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	public McpStatelessAsyncServer mcpStatelessAsyncServer(McpStatelessServerTransport statelessTransport,
+			@Qualifier("mcpServerJsonMapper") JsonMapper mcpServerJsonMapper,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,
 			ObjectProvider<List<AsyncToolSpecification>> tools,
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
@@ -176,7 +183,9 @@ public class McpServerStatelessAutoConfiguration {
 				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
-		StatelessAsyncSpecification serverBuilder = McpServer.async(statelessTransport).serverInfo(serverInfo);
+		StatelessAsyncSpecification serverBuilder = McpServer.async(statelessTransport)
+			.jsonMapper(new JacksonMcpJsonMapper(mcpServerJsonMapper))
+			.serverInfo(serverInfo);
 
 		// Tools
 		if (serverProperties.getCapabilities().isTool()) {


### PR DESCRIPTION
`McpServerStatelessAutoConfiguration` builds the stateless sync and async `McpServer` without calling `.jsonMapper(...)`. This causes the handler stage (e.g. `convertValue(req, InitializeRequest.class)`) to fall back to `McpJsonMapper.getDefault()` - a strict vanilla ObjectMapper with `FAIL_ON_UNKNOWN_PROPERTIES=true`.

Meanwhile, the transport layer correctly uses the lenient `mcpServerJsonMapper` bean. So we end up with two different mappers at different stages:

- **Stage 1 (transport)** - JSON-RPC envelope -> `JSONRPCRequest`: lenient mapper ✅
- **Stage 2 (handler)** - `params` -> `InitializeRequest`: strict default ❌

Any MCP client implementing the 2025-11-25 spec (e.g. Codex) sends fields like `capabilities.elicitation.form` that the current SDK records don't model yet, so the strict mapper rejects them and the initialize handshake fails with:

```
Unrecognized field "form" (class ...ClientCapabilities$Elicitation),
not marked as ignorable
```

This change adds `@Qualifier("mcpServerJsonMapper") JsonMapper` to both `mcpStatelessSyncServer` and `mcpStatelessAsyncServer` bean methods and wires it via `.jsonMapper(new JacksonMcpJsonMapper(...))` on the builder - the same pattern already used by `McpServerAutoConfiguration` for the stdio transport.

Closes gh-5894