### PR TITLE
Restore OpenAI embedding encoding format option

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
@@ -36,11 +36,18 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 
 	public static final String DEFAULT_EMBEDDING_MODEL = EmbeddingModel.TEXT_EMBEDDING_ADA_002.asString();
 
+	public static final String DEFAULT_ENCODING_FORMAT = EmbeddingCreateParams.EncodingFormat.FLOAT.asString();
+
 	/**
 	 * An identifier for the caller or end user of the operation. This may be used for
 	 * tracking or rate-limiting purposes.
 	 */
 	private @Nullable String user;
+
+	/**
+	 * The format to return the embeddings in. Can be either float or base64.
+	 */
+	private @Nullable String encodingFormat = DEFAULT_ENCODING_FORMAT;
 
 	/*
 	 * The number of dimensions the resulting output embeddings should have. Only
@@ -60,6 +67,14 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 		this.user = user;
 	}
 
+	public @Nullable String getEncodingFormat() {
+		return this.encodingFormat;
+	}
+
+	public void setEncodingFormat(@Nullable String encodingFormat) {
+		this.encodingFormat = encodingFormat;
+	}
+
 	@Override
 	public @Nullable Integer getDimensions() {
 		return this.dimensions;
@@ -72,7 +87,8 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 	@Override
 	public String toString() {
 		return "OpenAiEmbeddingOptions{" + "user='" + this.user + '\'' + ", model='" + this.getModel() + '\''
-				+ ", deploymentName='" + this.getDeploymentName() + '\'' + ", dimensions=" + this.dimensions + '}';
+				+ ", deploymentName='" + this.getDeploymentName() + '\'' + ", encodingFormat='" + this.encodingFormat
+				+ '\'' + ", dimensions=" + this.dimensions + '}';
 	}
 
 	public EmbeddingCreateParams toOpenAiCreateParams(List<String> instructions) {
@@ -93,6 +109,9 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 		}
 		if (this.getUser() != null) {
 			builder.user(this.getUser());
+		}
+		if (this.getEncodingFormat() != null) {
+			builder.encodingFormat(EmbeddingCreateParams.EncodingFormat.of(this.getEncodingFormat()));
 		}
 		if (this.getDimensions() != null) {
 			builder.dimensions(this.getDimensions());
@@ -121,6 +140,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			this.options.setCustomHeaders(fromOptions.getCustomHeaders());
 			// Child class fields
 			this.options.setUser(fromOptions.getUser());
+			this.options.setEncodingFormat(fromOptions.getEncodingFormat());
 			this.options.setDimensions(fromOptions.getDimensions());
 			return this;
 		}
@@ -164,6 +184,9 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 				if (castFrom.getUser() != null) {
 					this.options.setUser(castFrom.getUser());
 				}
+				if (castFrom.getEncodingFormat() != null) {
+					this.options.setEncodingFormat(castFrom.getEncodingFormat());
+				}
 				if (castFrom.getDimensions() != null) {
 					this.options.setDimensions(castFrom.getDimensions());
 				}
@@ -176,6 +199,9 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			if (openAiCreateParams.user().isPresent()) {
 				this.options.setUser(openAiCreateParams.user().get());
 			}
+			if (openAiCreateParams.encodingFormat().isPresent()) {
+				this.options.setEncodingFormat(openAiCreateParams.encodingFormat().get().asString());
+			}
 			if (openAiCreateParams.dimensions().isPresent()) {
 				this.options.setDimensions(Math.toIntExact(openAiCreateParams.dimensions().get()));
 			}
@@ -184,6 +210,11 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 
 		public Builder user(String user) {
 			this.options.setUser(user);
+			return this;
+		}
+
+		public Builder encodingFormat(String encodingFormat) {
+			this.options.setEncodingFormat(encodingFormat);
 			return this;
 		}
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
@@ -49,6 +49,8 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 	 */
 	private @Nullable String encodingFormat = DEFAULT_ENCODING_FORMAT;
 
+	private boolean encodingFormatSet;
+
 	/*
 	 * The number of dimensions the resulting output embeddings should have. Only
 	 * supported in `text-embedding-3` and later models.
@@ -73,6 +75,16 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 
 	public void setEncodingFormat(@Nullable String encodingFormat) {
 		this.encodingFormat = encodingFormat;
+		this.encodingFormatSet = true;
+	}
+
+	private boolean isEncodingFormatSet() {
+		return this.encodingFormatSet;
+	}
+
+	private void copyEncodingFormatFrom(OpenAiEmbeddingOptions fromOptions) {
+		this.encodingFormat = fromOptions.getEncodingFormat();
+		this.encodingFormatSet = fromOptions.isEncodingFormatSet();
 	}
 
 	@Override
@@ -140,7 +152,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			this.options.setCustomHeaders(fromOptions.getCustomHeaders());
 			// Child class fields
 			this.options.setUser(fromOptions.getUser());
-			this.options.setEncodingFormat(fromOptions.getEncodingFormat());
+			this.options.copyEncodingFormatFrom(fromOptions);
 			this.options.setDimensions(fromOptions.getDimensions());
 			return this;
 		}
@@ -184,7 +196,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 				if (castFrom.getUser() != null) {
 					this.options.setUser(castFrom.getUser());
 				}
-				if (castFrom.getEncodingFormat() != null) {
+				if (castFrom.isEncodingFormatSet() && castFrom.getEncodingFormat() != null) {
 					this.options.setEncodingFormat(castFrom.getEncodingFormat());
 				}
 				if (castFrom.getDimensions() != null) {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
@@ -36,8 +36,6 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 
 	public static final String DEFAULT_EMBEDDING_MODEL = EmbeddingModel.TEXT_EMBEDDING_ADA_002.asString();
 
-	public static final String DEFAULT_ENCODING_FORMAT = EmbeddingCreateParams.EncodingFormat.FLOAT.asString();
-
 	/**
 	 * An identifier for the caller or end user of the operation. This may be used for
 	 * tracking or rate-limiting purposes.
@@ -47,9 +45,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 	/**
 	 * The format to return the embeddings in. Can be either float or base64.
 	 */
-	private @Nullable String encodingFormat = DEFAULT_ENCODING_FORMAT;
-
-	private boolean encodingFormatSet;
+	private EmbeddingCreateParams.@Nullable EncodingFormat encodingFormat;
 
 	/*
 	 * The number of dimensions the resulting output embeddings should have. Only
@@ -69,22 +65,12 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 		this.user = user;
 	}
 
-	public @Nullable String getEncodingFormat() {
+	public EmbeddingCreateParams.@Nullable EncodingFormat getEncodingFormat() {
 		return this.encodingFormat;
 	}
 
-	public void setEncodingFormat(@Nullable String encodingFormat) {
+	public void setEncodingFormat(EmbeddingCreateParams.@Nullable EncodingFormat encodingFormat) {
 		this.encodingFormat = encodingFormat;
-		this.encodingFormatSet = true;
-	}
-
-	private boolean isEncodingFormatSet() {
-		return this.encodingFormatSet;
-	}
-
-	private void copyEncodingFormatFrom(OpenAiEmbeddingOptions fromOptions) {
-		this.encodingFormat = fromOptions.getEncodingFormat();
-		this.encodingFormatSet = fromOptions.isEncodingFormatSet();
 	}
 
 	@Override
@@ -123,7 +109,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			builder.user(this.getUser());
 		}
 		if (this.getEncodingFormat() != null) {
-			builder.encodingFormat(EmbeddingCreateParams.EncodingFormat.of(this.getEncodingFormat()));
+			builder.encodingFormat(this.getEncodingFormat());
 		}
 		if (this.getDimensions() != null) {
 			builder.dimensions(this.getDimensions());
@@ -152,7 +138,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			this.options.setCustomHeaders(fromOptions.getCustomHeaders());
 			// Child class fields
 			this.options.setUser(fromOptions.getUser());
-			this.options.copyEncodingFormatFrom(fromOptions);
+			this.options.setEncodingFormat(fromOptions.getEncodingFormat());
 			this.options.setDimensions(fromOptions.getDimensions());
 			return this;
 		}
@@ -196,7 +182,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 				if (castFrom.getUser() != null) {
 					this.options.setUser(castFrom.getUser());
 				}
-				if (castFrom.isEncodingFormatSet() && castFrom.getEncodingFormat() != null) {
+				if (castFrom.getEncodingFormat() != null) {
 					this.options.setEncodingFormat(castFrom.getEncodingFormat());
 				}
 				if (castFrom.getDimensions() != null) {
@@ -212,7 +198,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 				this.options.setUser(openAiCreateParams.user().get());
 			}
 			if (openAiCreateParams.encodingFormat().isPresent()) {
-				this.options.setEncodingFormat(openAiCreateParams.encodingFormat().get().asString());
+				this.options.setEncodingFormat(openAiCreateParams.encodingFormat().get());
 			}
 			if (openAiCreateParams.dimensions().isPresent()) {
 				this.options.setDimensions(Math.toIntExact(openAiCreateParams.dimensions().get()));
@@ -225,7 +211,7 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			return this;
 		}
 
-		public Builder encodingFormat(String encodingFormat) {
+		public Builder encodingFormat(EmbeddingCreateParams.EncodingFormat encodingFormat) {
 			this.options.setEncodingFormat(encodingFormat);
 			return this;
 		}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiEmbeddingOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiEmbeddingOptionsTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai;
+
+import java.util.List;
+
+import com.openai.models.embeddings.EmbeddingCreateParams;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAiEmbeddingOptionsTests {
+
+	@Test
+	void defaultEncodingFormatIsFloat() {
+		OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder().model("test-model").build();
+
+		EmbeddingCreateParams createParams = options.toOpenAiCreateParams(List.of("test input"));
+
+		assertThat(options.getEncodingFormat()).isEqualTo(OpenAiEmbeddingOptions.DEFAULT_ENCODING_FORMAT);
+		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.FLOAT);
+	}
+
+	@Test
+	void encodingFormatCanBeConfigured() {
+		OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder()
+			.model("test-model")
+			.encodingFormat("base64")
+			.build();
+
+		EmbeddingCreateParams createParams = options.toOpenAiCreateParams(List.of("test input"));
+
+		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.BASE64);
+	}
+
+	@Test
+	void encodingFormatIsCopiedAndMerged() {
+		OpenAiEmbeddingOptions source = OpenAiEmbeddingOptions.builder()
+			.model("test-model")
+			.encodingFormat("base64")
+			.build();
+
+		OpenAiEmbeddingOptions copied = OpenAiEmbeddingOptions.builder().from(source).build();
+		OpenAiEmbeddingOptions merged = OpenAiEmbeddingOptions.builder().model("other-model").merge(source).build();
+
+		assertThat(copied.getEncodingFormat()).isEqualTo("base64");
+		assertThat(merged.getEncodingFormat()).isEqualTo("base64");
+	}
+
+}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiEmbeddingOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiEmbeddingOptionsTests.java
@@ -61,4 +61,22 @@ class OpenAiEmbeddingOptionsTests {
 		assertThat(merged.getEncodingFormat()).isEqualTo("base64");
 	}
 
+	@Test
+	void unspecifiedEncodingFormatDoesNotOverrideDefaultOptionsWhenMerged() {
+		OpenAiEmbeddingOptions defaultOptions = OpenAiEmbeddingOptions.builder()
+			.model("test-model")
+			.encodingFormat("base64")
+			.build();
+		OpenAiEmbeddingOptions runtimeOptions = OpenAiEmbeddingOptions.builder().model("other-model").build();
+
+		OpenAiEmbeddingOptions merged = OpenAiEmbeddingOptions.builder()
+			.from(defaultOptions)
+			.merge(runtimeOptions)
+			.build();
+		EmbeddingCreateParams createParams = merged.toOpenAiCreateParams(List.of("test input"));
+
+		assertThat(merged.getEncodingFormat()).isEqualTo("base64");
+		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.BASE64);
+	}
+
 }

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiEmbeddingOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiEmbeddingOptionsTests.java
@@ -26,57 +26,39 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OpenAiEmbeddingOptionsTests {
 
 	@Test
-	void defaultEncodingFormatIsFloat() {
+	void defaultEncodingFormatIsNull() {
 		OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder().model("test-model").build();
 
 		EmbeddingCreateParams createParams = options.toOpenAiCreateParams(List.of("test input"));
 
-		assertThat(options.getEncodingFormat()).isEqualTo(OpenAiEmbeddingOptions.DEFAULT_ENCODING_FORMAT);
-		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.FLOAT);
+		assertThat(options.getEncodingFormat()).isNull();
+		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.BASE64);
 	}
 
 	@Test
 	void encodingFormatCanBeConfigured() {
 		OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder()
 			.model("test-model")
-			.encodingFormat("base64")
+			.encodingFormat(EmbeddingCreateParams.EncodingFormat.FLOAT)
 			.build();
 
 		EmbeddingCreateParams createParams = options.toOpenAiCreateParams(List.of("test input"));
 
-		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.BASE64);
+		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.FLOAT);
 	}
 
 	@Test
 	void encodingFormatIsCopiedAndMerged() {
 		OpenAiEmbeddingOptions source = OpenAiEmbeddingOptions.builder()
 			.model("test-model")
-			.encodingFormat("base64")
+			.encodingFormat(EmbeddingCreateParams.EncodingFormat.FLOAT)
 			.build();
 
 		OpenAiEmbeddingOptions copied = OpenAiEmbeddingOptions.builder().from(source).build();
 		OpenAiEmbeddingOptions merged = OpenAiEmbeddingOptions.builder().model("other-model").merge(source).build();
 
-		assertThat(copied.getEncodingFormat()).isEqualTo("base64");
-		assertThat(merged.getEncodingFormat()).isEqualTo("base64");
-	}
-
-	@Test
-	void unspecifiedEncodingFormatDoesNotOverrideDefaultOptionsWhenMerged() {
-		OpenAiEmbeddingOptions defaultOptions = OpenAiEmbeddingOptions.builder()
-			.model("test-model")
-			.encodingFormat("base64")
-			.build();
-		OpenAiEmbeddingOptions runtimeOptions = OpenAiEmbeddingOptions.builder().model("other-model").build();
-
-		OpenAiEmbeddingOptions merged = OpenAiEmbeddingOptions.builder()
-			.from(defaultOptions)
-			.merge(runtimeOptions)
-			.build();
-		EmbeddingCreateParams createParams = merged.toOpenAiCreateParams(List.of("test input"));
-
-		assertThat(merged.getEncodingFormat()).isEqualTo("base64");
-		assertThat(createParams.encodingFormat()).contains(EmbeddingCreateParams.EncodingFormat.BASE64);
+		assertThat(copied.getEncodingFormat()).isEqualTo(EmbeddingCreateParams.EncodingFormat.FLOAT);
+		assertThat(merged.getEncodingFormat()).isEqualTo(EmbeddingCreateParams.EncodingFormat.FLOAT);
 	}
 
 }


### PR DESCRIPTION
## Summary

This restores the OpenAI embedding `encodingFormat` option and passes it through to `EmbeddingCreateParams`

In Spring AI 2.0.0-M5, the OpenAI model implementation migrated to the official OpenAI Java SDK. During that migration, the previous `encodingFormat` option from `OpenAiEmbeddingOptions` was dropped. The OpenAI Java SDK 4.28.0 defaults embedding requests to `base64`

As a result, even when users configure `spring.ai.openai.embedding.options.encoding-format=float`, the actual request is sent with `encoding_format: base64`. This breaks some OpenAI-compatible embedding APIs, such as IONOS bge-m3, where float array embeddings are expected

This change
- Restores `encodingFormat` on `OpenAiEmbeddingOptions`
- Defaults it to `float`
- Passes it to `EmbeddingCreateParams`
- Preserves it across builder `from(...)`, `merge(...)`, and `from(EmbeddingCreateParams)`
- Adds unit coverage for the default value, explicit `base64`, and copy/merge behavior

Fixes gh-5901

## Regression Cause

In `v2.0.0-M4`, `OpenAiEmbeddingOptions` exposed `encodingFormat` and mapped it to the `encoding_format` request field

Evidence
`OpenAiEmbeddingOptions` in `v2.0.0-M4` contains

```java
private @JsonProperty("encoding_format") String encodingFormat;

public String getEncodingFormat()
public void setEncodingFormat(String encodingFormat)

public Builder encodingFormat(String encodingFormat)
```

Source
https://raw.githubusercontent.com/spring-projects/spring-ai/v2.0.0-M4/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java

In `v2.0.0-M5`, after the migration to the official OpenAI Java SDK, that option is no longer present in `OpenAiEmbeddingOptions`, and `toOpenAiCreateParams(...)` does not call `builder.encodingFormat(...)`

Evidence
`OpenAiEmbeddingOptions` in `v2.0.0-M5` contains `user` and `dimensions`, but no `encodingFormat`, `getEncodingFormat`, `setEncodingFormat`, or builder `encodingFormat(...)`

Source
https://raw.githubusercontent.com/spring-projects/spring-ai/v2.0.0-M5/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java

Therefore, when Spring AI does not explicitly set the value, the SDK default `base64` is used. That is the regression introduced in M5

## Verification

### Internal Unit Test

```text
Command
.\mvnw.cmd -pl models/spring-ai-openai -Dtest=OpenAiEmbeddingOptionsTests test

Result
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Spring Boot Reproducer - Before Fix, 2.0.0-M5

```text
Dependency
org.springframework.ai:spring-ai-starter-model-openai:2.0.0-M5

Application property
spring.ai.openai.api-key=test-key
spring.ai.openai.embedding.options.model=bge-m3
spring.ai.openai.embedding.options.encoding-format=float

Result
AssertionError because the request body did not contain "encoding_format":"float".
```

<img width="594" height="246" alt="image" src="https://github.com/user-attachments/assets/67d12371-c703-4ccb-9100-9fe960d114ec" />

---

### Spring Boot Verification - After Fix, 2.0.0-SNAPSHOT

```text
Dependency
org.springframework.ai:spring-ai-starter-model-openai:2.0.0-SNAPSHOT

Application property
spring.ai.openai.api-key=test-key
spring.ai.openai.embedding.options.model=bge-m3
spring.ai.openai.embedding.options.encoding-format=float
```

<img width="395" height="186" alt="image" src="https://github.com/user-attachments/assets/7499a006-7709-40f6-ac4b-19ce9bbca131" />