### PR TITLE
Add reranking document post processor

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/retrieval-augmented-generation.adoc
@@ -428,6 +428,57 @@ A component for post-processing retrieved documents based on a query, addressing
 
 For example, it could rank documents based on their relevance to the query, remove irrelevant or redundant documents, or compress the content of each document to reduce noise and redundancy.
 
+===== RerankingDocumentPostProcessor
+
+A `RerankingDocumentPostProcessor` reranks retrieved documents before they are passed to the model.
+This is useful when you want to retrieve a larger candidate set from a vector store and then keep only the most relevant documents for generation.
+
+In a Spring Boot application, add the RAG module and the vector store starter you want to use.
+For example, with Gradle:
+
+[source,groovy]
+----
+dependencies {
+    implementation platform("org.springframework.ai:spring-ai-bom:2.0.0")
+    implementation "org.springframework.ai:spring-ai-rag"
+    implementation "org.springframework.ai:spring-ai-starter-vector-store-pgvector"
+
+    // Choose the chat model starter used by your application.
+    implementation "org.springframework.ai:spring-ai-starter-model-openai"
+}
+----
+
+Then implement a `DocumentReranker` using your preferred reranking provider.
+The reranker receives the user query and the retrieved documents, and returns the documents in relevance order.
+
+[source,java]
+----
+@Bean
+DocumentReranker documentReranker(MyRerankClient rerankClient) {
+    return (query, documents) -> rerankClient.rerank(query.text(), documents);
+}
+----
+
+Finally, configure the post-processor in the `RetrievalAugmentationAdvisor`.
+In this example, the vector store retrieves 20 candidates and the reranker keeps the best 5.
+
+[source,java]
+----
+@Bean
+Advisor retrievalAugmentationAdvisor(VectorStore vectorStore, DocumentReranker documentReranker) {
+    return RetrievalAugmentationAdvisor.builder()
+        .documentRetriever(VectorStoreDocumentRetriever.builder()
+            .vectorStore(vectorStore)
+            .topK(20)
+            .build())
+        .documentPostProcessors(RerankingDocumentPostProcessor.builder()
+            .documentReranker(documentReranker)
+            .topN(5)
+            .build())
+        .build();
+}
+----
+
 === Generation
 
 Generation modules are responsible for generating the final response based on the user query and retrieved documents.

--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/DocumentReranker.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/DocumentReranker.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.rag.postretrieval.document;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+
+/**
+ * Reranks retrieved documents according to their relevance to a query.
+ *
+ * @author KoreaNirsa
+ */
+public interface DocumentReranker extends BiFunction<Query, List<Document>, List<Document>> {
+
+	/**
+	 * Rerank the given documents for the query.
+	 * @param query the user query
+	 * @param documents the retrieved documents to rerank
+	 * @return the reranked documents
+	 */
+	List<Document> rerank(Query query, List<Document> documents);
+
+	@Override
+	default List<Document> apply(Query query, List<Document> documents) {
+		return rerank(query, documents);
+	}
+
+}

--- a/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/RerankingDocumentPostProcessor.java
+++ b/spring-ai-rag/src/main/java/org/springframework/ai/rag/postretrieval/document/RerankingDocumentPostProcessor.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.rag.postretrieval.document;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link DocumentPostProcessor} that reranks retrieved documents and optionally keeps
+ * only the highest-ranked documents.
+ *
+ * @author KoreaNirsa
+ */
+public final class RerankingDocumentPostProcessor implements DocumentPostProcessor {
+
+	private final DocumentReranker documentReranker;
+
+	private final @Nullable Integer topN;
+
+	private RerankingDocumentPostProcessor(DocumentReranker documentReranker, @Nullable Integer topN) {
+		Assert.notNull(documentReranker, "documentReranker cannot be null");
+		if (topN != null) {
+			Assert.isTrue(topN > 0, "topN must be greater than 0");
+		}
+		this.documentReranker = documentReranker;
+		this.topN = topN;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public List<Document> process(Query query, List<Document> documents) {
+		Assert.notNull(query, "query cannot be null");
+		Assert.notNull(documents, "documents cannot be null");
+		Assert.noNullElements(documents, "documents cannot contain null elements");
+
+		if (documents.isEmpty()) {
+			return List.of();
+		}
+
+		List<Document> rerankedDocuments = this.documentReranker.rerank(query, documents);
+		Assert.notNull(rerankedDocuments, "rerankedDocuments cannot be null");
+		Assert.noNullElements(rerankedDocuments, "rerankedDocuments cannot contain null elements");
+
+		if (this.topN == null || rerankedDocuments.size() <= this.topN) {
+			return List.copyOf(rerankedDocuments);
+		}
+
+		return List.copyOf(rerankedDocuments.subList(0, this.topN));
+	}
+
+	public static final class Builder {
+
+		private @Nullable DocumentReranker documentReranker;
+
+		private @Nullable Integer topN;
+
+		private Builder() {
+		}
+
+		/**
+		 * Configure the reranker used to reorder retrieved documents.
+		 * @param documentReranker the document reranker
+		 * @return this builder
+		 */
+		public Builder documentReranker(DocumentReranker documentReranker) {
+			this.documentReranker = documentReranker;
+			return this;
+		}
+
+		/**
+		 * Keep only the first {@code topN} reranked documents.
+		 * @param topN the maximum number of reranked documents to keep
+		 * @return this builder
+		 */
+		public Builder topN(int topN) {
+			this.topN = topN;
+			return this;
+		}
+
+		public RerankingDocumentPostProcessor build() {
+			Assert.notNull(this.documentReranker, "documentReranker cannot be null");
+			return new RerankingDocumentPostProcessor(this.documentReranker, this.topN);
+		}
+
+	}
+
+}

--- a/spring-ai-rag/src/test/java/org/springframework/ai/rag/postretrieval/document/RerankingDocumentPostProcessorTests.java
+++ b/spring-ai-rag/src/test/java/org/springframework/ai/rag/postretrieval/document/RerankingDocumentPostProcessorTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.rag.postretrieval.document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.rag.Query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link RerankingDocumentPostProcessor}.
+ *
+ * @author KoreaNirsa
+ */
+class RerankingDocumentPostProcessorTests {
+
+	@Test
+	void whenDocumentRerankerIsNullThenThrow() {
+		assertThatThrownBy(() -> RerankingDocumentPostProcessor.builder().documentReranker(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("documentReranker cannot be null");
+	}
+
+	@Test
+	void whenTopNIsLessThanOneThenThrow() {
+		assertThatThrownBy(() -> RerankingDocumentPostProcessor.builder()
+			.documentReranker((query, documents) -> documents)
+			.topN(0)
+			.build()).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("topN must be greater than 0");
+	}
+
+	@Test
+	void shouldRerankDocuments() {
+		Document first = Document.builder().id("1").text("The first document").score(0.60).build();
+		Document second = Document.builder().id("2").text("The second document").score(0.80).build();
+		Document third = Document.builder().id("3").text("The third document").score(0.70).build();
+
+		DocumentPostProcessor processor = RerankingDocumentPostProcessor.builder()
+			.documentReranker((query, documents) -> List.of(second, third, first))
+			.build();
+
+		List<Document> documents = processor.process(new Query("query"), List.of(first, second, third));
+
+		assertThat(documents).extracting(Document::getId).containsExactly("2", "3", "1");
+	}
+
+	@Test
+	void shouldKeepOnlyTopNDocuments() {
+		Document first = Document.builder().id("1").text("The first document").build();
+		Document second = Document.builder().id("2").text("The second document").build();
+		Document third = Document.builder().id("3").text("The third document").build();
+
+		DocumentPostProcessor processor = RerankingDocumentPostProcessor.builder()
+			.documentReranker((query, documents) -> List.of(second, third, first))
+			.topN(2)
+			.build();
+
+		List<Document> documents = processor.process(new Query("query"), List.of(first, second, third));
+
+		assertThat(documents).extracting(Document::getId).containsExactly("2", "3");
+	}
+
+	@Test
+	void whenRerankedDocumentsAreNullThenThrow() {
+		DocumentPostProcessor processor = RerankingDocumentPostProcessor.builder()
+			.documentReranker((query, documents) -> null)
+			.build();
+
+		assertThatThrownBy(() -> processor.process(new Query("query"), List.of(document("1"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("rerankedDocuments cannot be null");
+	}
+
+	@Test
+	void whenRerankedDocumentsContainNullElementsThenThrow() {
+		List<Document> rerankedDocuments = new ArrayList<>();
+		rerankedDocuments.add(document("1"));
+		rerankedDocuments.add(null);
+		DocumentPostProcessor processor = RerankingDocumentPostProcessor.builder()
+			.documentReranker((query, documents) -> rerankedDocuments)
+			.build();
+
+		assertThatThrownBy(() -> processor.process(new Query("query"), List.of(document("1"))))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("rerankedDocuments cannot contain null elements");
+	}
+
+	@Test
+	void shouldNotCallRerankerWhenDocumentsAreEmpty() {
+		DocumentPostProcessor processor = RerankingDocumentPostProcessor.builder()
+			.documentReranker((query, documents) -> {
+				throw new AssertionError("Reranker should not be called for empty documents");
+			})
+			.build();
+
+		assertThat(processor.process(new Query("query"), List.of())).isEmpty();
+	}
+
+	private static Document document(String id) {
+		return Document.builder().id(id).text("Document " + id).build();
+	}
+
+}


### PR DESCRIPTION
Closes #5903 

## Overview

This PR adds reusable document reranking support to the RAG module.

The new post-processor supports the common RAG pattern of retrieving a broader candidate set from a vector store, reranking those candidates with a more precise relevance strategy, and passing only the best-ranked documents to generation.

The implementation intentionally does not define the ranking strategy itself. Instead, applications provide a `DocumentReranker`, which can delegate to an external reranking model or service, use custom metadata-based scoring, apply rule-based ranking, or combine multiple relevance signals.

## Changes

- Adds `DocumentReranker` as a functional contract for reranking retrieved documents based on a `Query`
- Adds `RerankingDocumentPostProcessor` to apply a `DocumentReranker` after retrieval
- Adds optional `topN` support to keep only the highest-ranked reranked documents
- Adds unit tests for reranking, `topN` truncation, validation, and empty input behavior
- Updates the RAG documentation with an example using `RetrievalAugmentationAdvisor`
