### PR TITLE
Preserve reasoning_content on assistant tool-call message in DeepSeek…

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekAssistantMessage.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekAssistantMessage.java
@@ -32,6 +32,20 @@ import org.springframework.ai.content.Media;
  */
 public class DeepSeekAssistantMessage extends AssistantMessage {
 
+	/**
+	 * Metadata key under which {@link #reasoningContent} is mirrored. Mirroring is
+	 * required because {@code Prompt#mutate()} rebuilds assistant messages as plain
+	 * {@link AssistantMessage} (preserving only metadata), so any subclass-only field
+	 * would otherwise be lost on the next request.
+	 */
+	public static final String REASONING_CONTENT_METADATA_KEY = "reasoning_content";
+
+	/**
+	 * Metadata key under which {@link #prefix} is mirrored. See
+	 * {@link #REASONING_CONTENT_METADATA_KEY} for the rationale.
+	 */
+	public static final String PREFIX_METADATA_KEY = "prefix";
+
 	private @Nullable Boolean prefix;
 
 	private @Nullable String reasoningContent;
@@ -41,6 +55,12 @@ public class DeepSeekAssistantMessage extends AssistantMessage {
 		super(content, properties, toolCalls, media);
 		this.reasoningContent = reasoningContent;
 		this.prefix = prefix;
+		if (reasoningContent != null) {
+			getMetadata().put(REASONING_CONTENT_METADATA_KEY, reasoningContent);
+		}
+		if (prefix != null) {
+			getMetadata().put(PREFIX_METADATA_KEY, prefix);
+		}
 	}
 
 	public static DeepSeekAssistantMessage prefixAssistantMessage(@Nullable String content) {
@@ -58,6 +78,12 @@ public class DeepSeekAssistantMessage extends AssistantMessage {
 
 	public void setPrefix(Boolean prefix) {
 		this.prefix = prefix;
+		if (prefix != null) {
+			getMetadata().put(PREFIX_METADATA_KEY, prefix);
+		}
+		else {
+			getMetadata().remove(PREFIX_METADATA_KEY);
+		}
 	}
 
 	public @Nullable String getReasoningContent() {
@@ -66,6 +92,12 @@ public class DeepSeekAssistantMessage extends AssistantMessage {
 
 	public void setReasoningContent(@Nullable String reasoningContent) {
 		this.reasoningContent = reasoningContent;
+		if (reasoningContent != null) {
+			getMetadata().put(REASONING_CONTENT_METADATA_KEY, reasoningContent);
+		}
+		else {
+			getMetadata().remove(REASONING_CONTENT_METADATA_KEY);
+		}
 	}
 
 	@Override

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -16,9 +16,11 @@
 
 package org.springframework.ai.deepseek;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -244,6 +246,19 @@ public class DeepSeekChatModel implements ChatModel {
 			// The rest of the chunks with same ID share the same role.
 			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
 
+			// Cross-chunk accumulators for the streaming + tool-calling path.
+			// DeepSeekApi#chatCompletionStream emits each pre-tool-call chunk
+			// (reasoning_content delta, content delta) as its own one-element
+			// window for streaming UX, and only merges chunks within the
+			// tool-call window. As a result the chunk that triggers
+			// executeToolCalls only carries the tool_calls payload — its
+			// content/reasoning_content are null. Without this side-channel,
+			// the assistant message replayed to the API in the next round
+			// would have empty content and missing reasoning_content, which
+			// deepseek-reasoner rejects when thinking is enabled (gh-5898).
+			AtomicReference<String> accumulatedContent = new AtomicReference<>("");
+			AtomicReference<String> accumulatedReasoningContent = new AtomicReference<>("");
+
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(DeepSeekConstants.PROVIDER_NAME)
@@ -272,7 +287,19 @@ public class DeepSeekChatModel implements ChatModel {
 										"finishReason", choice.finishReason() != null ? choice.finishReason().name() : ""
 								);
   				// @formatter:on
-							return buildGeneration(choice, metadata);
+							Generation generation = buildGeneration(choice, metadata);
+							// Side-channel: accumulate content/reasoning_content across
+							// chunks so we can rebuild the full assistant message when
+							// a tool call is requested mid-stream.
+							String chunkContent = choice.message().content();
+							if (chunkContent != null && !chunkContent.isEmpty()) {
+								accumulatedContent.updateAndGet(prev -> prev + chunkContent);
+							}
+							String chunkReasoning = choice.message().reasoningContent();
+							if (chunkReasoning != null && !chunkReasoning.isEmpty()) {
+								accumulatedReasoningContent.updateAndGet(prev -> prev + chunkReasoning);
+							}
+							return generation;
 						}).toList();
 						DeepSeekApi.Usage usage = chatCompletion2.usage();
 						Usage currentUsage = (usage != null) ? getDefaultUsage(usage) : new EmptyUsage();
@@ -292,27 +319,33 @@ public class DeepSeekChatModel implements ChatModel {
 				ChatOptions options = prompt.getOptions();
 				Assert.state(options != null, "options must not be null");
 				if (this.toolExecutionEligibilityPredicate.isToolExecutionRequired(options, response)) {
+					// Snapshot the cross-chunk accumulators and merge them into the
+					// assistant message so that ToolCallingManager#executeToolCalls
+					// puts a complete assistant message (content + reasoning_content +
+					// tool_calls) into the next round's conversation history.
+					ChatResponse responseForToolCall = enrichResponseWithAccumulatedFields(response,
+							accumulatedContent.get(), accumulatedReasoningContent.get());
 					// FIXME: bounded elastic needs to be used since tool calling
 					//  is currently only synchronous
 					return Flux.deferContextual(ctx -> {
 						ToolExecutionResult toolExecutionResult;
 						try {
 							ToolCallReactiveContextHolder.setContext(ctx);
-							toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, response);
+							toolExecutionResult = this.toolCallingManager.executeToolCalls(prompt, responseForToolCall);
 						}
 						finally {
 							ToolCallReactiveContextHolder.clearContext();
 						}
 						if (toolExecutionResult.returnDirect()) {
 							// Return tool execution result directly to the client.
-							return Flux.just(ChatResponse.builder().from(response)
+							return Flux.just(ChatResponse.builder().from(responseForToolCall)
 									.generations(ToolExecutionResult.buildGenerations(toolExecutionResult))
 									.build());
 						}
 						else {
 							// Send the tool execution result back to the model.
 							return this.internalStream(new Prompt(toolExecutionResult.conversationHistory(), prompt.getOptions()),
-									response);
+									responseForToolCall);
 						}
 					}).subscribeOn(Schedulers.boundedElastic());
 				}
@@ -328,6 +361,39 @@ public class DeepSeekChatModel implements ChatModel {
 			return new MessageAggregator().aggregate(flux, observationContext::setResponse);
 
 		});
+	}
+
+	/**
+	 * Replace each {@link Generation}'s assistant message in {@code response} with a
+	 * {@link DeepSeekAssistantMessage} that includes the accumulated content and
+	 * {@code reasoning_content} from earlier stream chunks. Used right before
+	 * {@code executeToolCalls} so the message replayed to the API in the next round
+	 * carries the full pre-tool-call context. Package-private for testing.
+	 */
+	ChatResponse enrichResponseWithAccumulatedFields(ChatResponse response, String accumulatedContent,
+			String accumulatedReasoningContent) {
+		if (accumulatedContent.isEmpty() && accumulatedReasoningContent.isEmpty()) {
+			return response;
+		}
+		List<Generation> enrichedGenerations = new ArrayList<>(response.getResults().size());
+		for (Generation generation : response.getResults()) {
+			AssistantMessage existing = generation.getOutput();
+			String mergedContent = accumulatedContent;
+			if (existing.getText() != null && !existing.getText().isEmpty()) {
+				mergedContent = accumulatedContent + existing.getText();
+			}
+			String mergedReasoning = accumulatedReasoningContent.isEmpty() ? null : accumulatedReasoningContent;
+			Boolean prefix = (existing instanceof DeepSeekAssistantMessage dsm) ? dsm.getPrefix() : null;
+			DeepSeekAssistantMessage enriched = new DeepSeekAssistantMessage.Builder().content(mergedContent)
+				.reasoningContent(mergedReasoning)
+				.prefix(prefix)
+				.properties(existing.getMetadata())
+				.toolCalls(existing.getToolCalls())
+				.media(existing.getMedia())
+				.build();
+			enrichedGenerations.add(new Generation(enriched, generation.getMetadata()));
+		}
+		return ChatResponse.builder().from(response).generations(enrichedGenerations).build();
 	}
 
 	private Generation buildGeneration(Choice choice, Map<String, Object> metadata) {
@@ -423,15 +489,21 @@ public class DeepSeekChatModel implements ChatModel {
 						return new ToolCall(toolCall.id(), toolCall.type(), function);
 					}).toList();
 				}
+				// Read deepseek-specific fields from metadata so they survive
+				// Prompt#mutate(), which rebuilds assistant messages as plain
+				// AssistantMessage and would otherwise drop subclass fields.
+				Map<String, Object> metadata = assistantMessage.getMetadata();
 				Boolean isPrefixAssistantMessage = null;
-				if (message instanceof DeepSeekAssistantMessage
-						&& Boolean.TRUE.equals(((DeepSeekAssistantMessage) message).getPrefix())) {
+				Object prefixMetadata = metadata.get(DeepSeekAssistantMessage.PREFIX_METADATA_KEY);
+				if (Boolean.TRUE.equals(prefixMetadata)) {
 					isPrefixAssistantMessage = true;
 				}
+				Object reasoningMetadata = metadata.get(DeepSeekAssistantMessage.REASONING_CONTENT_METADATA_KEY);
+				String reasoningContent = (reasoningMetadata instanceof String s) ? s : null;
 				String text = assistantMessage.getText();
 				Assert.state(text != null, "text must not be null");
 				return List.of(new ChatCompletionMessage(text, ChatCompletionMessage.Role.ASSISTANT, null, null,
-						toolCalls, isPrefixAssistantMessage, null));
+						toolCalls, isPrefixAssistantMessage, reasoningContent));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
@@ -81,10 +81,14 @@ public class DeepSeekStreamFunctionCallingHelper {
 	private ChatCompletionMessage merge(@Nullable ChatCompletionMessage previous, ChatCompletionMessage current) {
 		String content = (previous != null && previous.content() != null)
 				? previous.content() + (current.content() != null ? current.content() : "") : current.content();
+		String reasoningContent = (previous != null && previous.reasoningContent() != null)
+				? previous.reasoningContent() + (current.reasoningContent() != null ? current.reasoningContent() : "")
+				: current.reasoningContent();
 		Role role = current.role();
 		String name = (current.name() != null ? current.name() : (previous != null ? previous.name() : null));
 		String toolCallId = (current.toolCallId() != null ? current.toolCallId()
 				: (previous != null ? previous.toolCallId() : null));
+		Boolean prefix = (current.prefix() != null ? current.prefix() : (previous != null ? previous.prefix() : null));
 
 		List<ToolCall> toolCalls = new ArrayList<>();
 		ToolCall lastPreviousTooCall = null;
@@ -114,7 +118,7 @@ public class DeepSeekStreamFunctionCallingHelper {
 				toolCalls.add(lastPreviousTooCall);
 			}
 		}
-		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls);
+		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, prefix, reasoningContent);
 	}
 
 	private ToolCall merge(@Nullable ToolCall previous, ToolCall current) {

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/DeepSeekChatCompletionRequestTests.java
@@ -16,8 +16,15 @@
 
 package org.springframework.ai.deepseek;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
 
@@ -52,6 +59,94 @@ public class DeepSeekChatCompletionRequestTests {
 
 		assertThat(request.model()).isEqualTo("PROMPT_MODEL");
 		assertThat(request.temperature()).isEqualTo(99.9D);
+	}
+
+	// gh-5898: when an assistant turn carrying tool_calls is replayed back to the API
+	// with thinking enabled, reasoning_content must be present on the assistant
+	// message or the API returns an "invalid_request_error".
+	@Test
+	public void createRequestPreservesReasoningContentOnAssistantToolCallMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var assistantToolCall = new AssistantMessage.ToolCall("call_1", "function", "getWeather",
+				"{\"city\":\"Beijing\"}");
+		var assistant = new DeepSeekAssistantMessage.Builder().content("")
+			.reasoningContent("I should check the weather first.")
+			.toolCalls(List.of(assistantToolCall))
+			.build();
+
+		var prompt = client.buildRequestPrompt(new Prompt(List.of(new UserMessage("hi"), assistant),
+				DeepSeekChatOptions.builder().model("deepseek-reasoner").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages()).hasSize(2);
+		var assistantParam = request.messages().get(1);
+		assertThat(assistantParam.role()).isEqualTo(DeepSeekApi.ChatCompletionMessage.Role.ASSISTANT);
+		assertThat(assistantParam.reasoningContent()).isEqualTo("I should check the weather first.");
+		assertThat(assistantParam.toolCalls()).hasSize(1);
+	}
+
+	@Test
+	public void createRequestLeavesReasoningContentNullForPlainAssistantMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var prompt = client.buildRequestPrompt(new Prompt(List.of(new UserMessage("hi"), new AssistantMessage("ok")),
+				DeepSeekChatOptions.builder().model("deepseek-chat").build()));
+
+		var request = client.createRequest(prompt, false);
+
+		assertThat(request.messages().get(1).reasoningContent()).isNull();
+	}
+
+	// gh-5898: in the streaming path, pre-tool-call reasoning_content and content
+	// chunks are emitted individually before tool_call chunks. The chunk that
+	// triggers tool execution carries only tool_calls, so the assistant message
+	// reaching the conversation history would be missing the accumulated context.
+	// enrichResponseWithAccumulatedFields stitches them back together.
+	@Test
+	public void enrichResponseWithAccumulatedFieldsMergesContentAndReasoningOntoToolCallMessage() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var toolCall = new AssistantMessage.ToolCall("call_1", "function", "getWeather", "{\"city\":\"Hangzhou\"}");
+		// Simulate the chunk that triggers tool execution: tool_calls present,
+		// content/reasoningContent empty/null because earlier chunks were already
+		// emitted as separate one-element windows.
+		var toolCallOnlyMessage = new DeepSeekAssistantMessage.Builder().content("")
+			.toolCalls(List.of(toolCall))
+			.build();
+		var response = ChatResponse.builder()
+			.generations(List.of(new Generation(toolCallOnlyMessage, ChatGenerationMetadata.builder().build())))
+			.build();
+
+		var enriched = client.enrichResponseWithAccumulatedFields(response,
+				"Sure, let me check the weather in Hangzhou.",
+				"The user wants the weather and whether to bring an umbrella; I should call getWeather.");
+
+		var enrichedMessage = (DeepSeekAssistantMessage) enriched.getResult().getOutput();
+		assertThat(enrichedMessage.getText()).isEqualTo("Sure, let me check the weather in Hangzhou.");
+		assertThat(enrichedMessage.getReasoningContent())
+			.isEqualTo("The user wants the weather and whether to bring an umbrella; I should call getWeather.");
+		assertThat(enrichedMessage.getToolCalls()).hasSize(1);
+		assertThat(enrichedMessage.getToolCalls().get(0).id()).isEqualTo("call_1");
+		// reasoning_content is mirrored into metadata so it survives Prompt#mutate()
+		assertThat(enrichedMessage.getMetadata()).containsEntry(DeepSeekAssistantMessage.REASONING_CONTENT_METADATA_KEY,
+				"The user wants the weather and whether to bring an umbrella; I should call getWeather.");
+	}
+
+	@Test
+	public void enrichResponseWithAccumulatedFieldsIsNoOpWhenAccumulatorsEmpty() {
+		var client = DeepSeekChatModel.builder().deepSeekApi(DeepSeekApi.builder().apiKey("TEST").build()).build();
+
+		var toolCall = new AssistantMessage.ToolCall("call_1", "function", "noop", "{}");
+		var existing = new DeepSeekAssistantMessage.Builder().content("").toolCalls(List.of(toolCall)).build();
+		var response = ChatResponse.builder()
+			.generations(List.of(new Generation(existing, ChatGenerationMetadata.builder().build())))
+			.build();
+
+		var result = client.enrichResponseWithAccumulatedFields(response, "", "");
+
+		assertThat(result).isSameAs(response);
 	}
 
 }

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
@@ -208,6 +208,76 @@ class DeepSeekStreamFunctionCallingHelperTest {
 	}
 
 	@Test
+	void mergeShouldAccumulateReasoningContentAcrossChunks() {
+		// Given: streamed deltas where reasoning_content is split across chunks and a
+		// tool call arrives only at the end (the failure mode reported in #5898).
+		ChatCompletionMessage previousMsg = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, null, null,
+				"Let me think ");
+		ChatCompletionMessage currentMsg = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, null, null,
+				"about this.");
+
+		ChatCompletionChunk previous = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, previousMsg, null)), 123L, "model", null, null,
+				null, null);
+
+		ChatCompletionChunk current = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, currentMsg, null)), 123L, "model", null, null,
+				null, null);
+
+		// When
+		ChatCompletionChunk result = this.helper.merge(previous, current);
+
+		// Then
+		assertThat(result.choices().get(0).delta().reasoningContent()).isEqualTo("Let me think about this.");
+	}
+
+	@Test
+	void mergeShouldHandleNullCurrentReasoningContent() {
+		// Given
+		ChatCompletionMessage previousMsg = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, null, null,
+				"partial reasoning");
+		ChatCompletionMessage currentMsg = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, null, null,
+				null);
+
+		ChatCompletionChunk previous = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, previousMsg, null)), 123L, "model", null, null,
+				null, null);
+
+		ChatCompletionChunk current = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, currentMsg, null)), 123L, "model", null, null,
+				null, null);
+
+		// When
+		ChatCompletionChunk result = this.helper.merge(previous, current);
+
+		// Then
+		assertThat(result.choices().get(0).delta().reasoningContent()).isEqualTo("partial reasoning");
+	}
+
+	@Test
+	void mergeShouldPreservePrefixFromPreviousWhenCurrentIsNull() {
+		// Given
+		ChatCompletionMessage previousMsg = new ChatCompletionMessage("hello", Role.ASSISTANT, null, null, null, true,
+				null);
+		ChatCompletionMessage currentMsg = new ChatCompletionMessage(" world", Role.ASSISTANT, null, null, null, null,
+				null);
+
+		ChatCompletionChunk previous = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, previousMsg, null)), 123L, "model", null, null,
+				null, null);
+
+		ChatCompletionChunk current = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, currentMsg, null)), 123L, "model", null, null,
+				null, null);
+
+		// When
+		ChatCompletionChunk result = this.helper.merge(previous, current);
+
+		// Then
+		assertThat(result.choices().get(0).delta().prefix()).isTrue();
+	}
+
+	@Test
 	void mergeWhenCurrentToolCallsIsEmptyListShouldNotThrowException() {
 		// Given
 		ToolCall toolCall = new ToolCall("call_1", "function", new ChatCompletionFunction("func1", "{}"));


### PR DESCRIPTION
… streaming

When deepseek-reasoner is used with streaming and tool calls, the API requires the assistant message replayed in subsequent rounds to include reasoning_content; otherwise it returns "thinking is enabled but reasoning_content is missing in assistant tool call message".

Spring AI dropped the field on three independent paths:

1. DeepSeekStreamFunctionCallingHelper#merge did not accumulate the reasoning_content delta nor forward the prefix flag across chunks.

2. DeepSeekChatModel#createRequest passed null for reasoning_content when re-serializing a DeepSeekAssistantMessage. Even after reading the typed field, Prompt#mutate() (called from buildRequestPrompt) downgrades AssistantMessage subclasses to the plain superclass via instructionsCopy, so subclass-only fields cannot survive a round trip; only metadata does.

3. DeepSeekApi#chatCompletionStream emits each pre-tool-call chunk (reasoning delta, content delta) as its own one-element window for streaming UX and only merges chunks once the tool-call window opens. The chunk that triggers ToolCallingManager#executeToolCalls therefore carries only tool_calls, and the assistant message stored in the next round's conversation history has empty content and no reasoning_content.

Fixes:

- Merge reasoning_content and forward prefix in the chunk-window merger.
- Mirror reasoningContent and prefix from DeepSeekAssistantMessage into the message metadata, and read them back from metadata in createRequest, so the round trip works whether the message is a DeepSeekAssistantMessage or a plain AssistantMessage created by Prompt#instructionsCopy.
- In DeepSeekChatModel#internalStream, maintain per-stream-call accumulators for content and reasoning_content. Before invoking executeToolCalls, enrich the assistant message with the accumulated values so the next round carries the full pre-tool-call context.

Adds regression tests covering chunk-merge accumulation, the AssistantMessage to ChatCompletionMessage round trip, and the streaming-path enrichment.

Fixes gh-5898

Thank you for taking time to contribute this pull request!
You might have already read the [contributor guide][1], but as a reminder, please make sure to:

* Add a Signed-off-by line to each commit (`git commit -s`) per the [DCO](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring#how-to-use-developer-certificate-of-origin)
* Rebase your changes on the latest `main` branch and squash your commits
* Add/Update unit tests as needed
* Run a build and make sure all tests pass prior to submission

For more details, please check the [contributor guide][1].
Thank you upfront!

[1]: https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.adoc