### PR TITLE
Add Tool Search Tool advisor for on-demand tool discovery

### DIFF
--- a/advisors/tool-search-tool/tool-indexes/tool-index-lucene/pom.xml
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-lucene/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-tool-index-lucene</artifactId>
+	<name>spring-ai-tool-index-lucene</name>
+	<description>Lucene-based tool index implementation</description>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+	</properties>
+
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-search-tool-api</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-core</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/advisors/tool-search-tool/tool-indexes/tool-index-lucene/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/lucene/LuceneToolIndex.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-lucene/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/lucene/LuceneToolIndex.java
@@ -1,0 +1,425 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.index.lucene;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.AlreadyClosedException;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.QueryBuilder;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse.SearchMetadata;
+
+/**
+ * Lucene-based tool searcher for indexing and searching tool descriptions.
+ * <p>
+ * This class provides full-text search capabilities for tool metadata using Apache
+ * Lucene's in-memory index. Entries are grouped by sessionId and retrieval is filtered by
+ * the provided sessionId.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public class LuceneToolIndex implements Closeable, ToolIndex {
+
+	private static final Logger logger = LoggerFactory.getLogger(LuceneToolIndex.class);
+
+	private static final String FIELD_ID = "id";
+
+	private static final String FIELD_SESSION_ID = "sessionId";
+
+	private static final String FIELD_TOOL_NAME = "toolName";
+
+	private static final String FIELD_TOOL_DESCRIPTION = "toolDescription";
+
+	private static final int DEFAULT_MAX_RESULTS = 10;
+
+	private final Analyzer analyzer;
+
+	private final float minScoreThreshold;
+
+	private final AtomicInteger counter = new AtomicInteger(0);
+
+	/**
+	 * Map of sessionId to their respective Lucene indexes.
+	 */
+	private final Map<String, SessionIndex> sessionIndexes = new ConcurrentHashMap<>();
+
+	/**
+	 * Creates a new LuceneToolIndex with default settings.
+	 */
+	public LuceneToolIndex() {
+		this(0.25f);
+	}
+
+	public LuceneToolIndex(float minScoreThreshold) {
+		this.minScoreThreshold = minScoreThreshold;
+		this.analyzer = new StandardAnalyzer();
+	}
+
+	/**
+	 * Gets or creates a SessionIndex for the given sessionId.
+	 * @param sessionId the session identifier
+	 * @return the SessionIndex for the session
+	 */
+	private SessionIndex getOrCreateSessionIndex(String sessionId) {
+		return this.sessionIndexes.computeIfAbsent(sessionId, key -> {
+			try {
+				return new SessionIndex(this.analyzer);
+			}
+			catch (IOException e) {
+				throw new RuntimeException("Failed to initialize Lucene index for session: " + sessionId, e);
+			}
+		});
+	}
+
+	@Override
+	public void clearIndex(String sessionId) {
+		SessionIndex sessionIndex = this.sessionIndexes.remove(sessionId);
+		if (sessionIndex != null) {
+			try {
+				sessionIndex.close();
+			}
+			catch (IOException e) {
+				throw new RuntimeException("Failed to clear the index for session: " + sessionId, e);
+			}
+		}
+	}
+
+	@Override
+	public void indexTool(String sessionId, ToolReference toolReference) {
+		this.add(sessionId, String.valueOf(this.counter.getAndIncrement()), toolReference.toolName(),
+				toolReference.summary());
+	}
+
+	@Override
+	public void indexTools(String sessionId, List<ToolReference> toolReferences) {
+		for (ToolReference ref : toolReferences) {
+			this.add(sessionId, String.valueOf(this.counter.getAndIncrement()), ref.toolName(), ref.summary());
+		}
+	}
+
+	@Override
+	public ToolSearchResponse search(ToolSearchRequest toolSearchRequest) {
+		String sessionId = toolSearchRequest.sessionId();
+		if (sessionId == null || sessionId.isBlank()) {
+			logger.warn("No sessionId provided in ToolSearchRequest, returning empty results");
+			return ToolSearchResponse.builder().build();
+		}
+
+		SessionIndex sessionIndex = this.sessionIndexes.get(sessionId);
+		if (sessionIndex == null) {
+			logger.debug("No index found for session: {}", sessionId);
+			return ToolSearchResponse.builder().build();
+		}
+
+		return this.doSearch(sessionIndex, toolSearchRequest.query(),
+				toolSearchRequest.maxResults() != null ? toolSearchRequest.maxResults() : DEFAULT_MAX_RESULTS,
+				this.minScoreThreshold);
+	}
+
+	/**
+	 * Adds a single tool to the index for the specified session.
+	 * <p>
+	 * <b>Thread-safety note:</b> a narrow write-after-close race exists when
+	 * {@link #clearIndex(String)} is called concurrently for the same session from a
+	 * different thread. The advisor's built-in flow prevents this via the atomic
+	 * fingerprint-check in {@code initializeSession()}. Direct callers must ensure that
+	 * no concurrent {@code clearIndex()} runs for the same session; if one does, the
+	 * document is silently dropped (the session was cleared anyway).
+	 * @param sessionId the session ID associated with the tool
+	 * @param id unique identifier for the tool
+	 * @param toolName name of the tool
+	 * @param toolDescription description of the tool (searchable)
+	 */
+	public void add(String sessionId, String id, String toolName, String toolDescription) {
+		try {
+			SessionIndex sessionIndex = getOrCreateSessionIndex(sessionId);
+			Document doc = this.createDocument(sessionId, id, toolName, toolDescription);
+			sessionIndex.writer.addDocument(doc);
+		}
+		catch (AlreadyClosedException ex) {
+			logger.warn("Skipping add for session '{}': index was concurrently cleared", sessionId);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to add document to index", e);
+		}
+	}
+
+	/**
+	 * Commits all pending changes to all session indexes. Call this after batch additions
+	 * for better performance.
+	 */
+	public void commit() {
+		for (Map.Entry<String, SessionIndex> entry : this.sessionIndexes.entrySet()) {
+			try {
+				SessionIndex sessionIndex = entry.getValue();
+				sessionIndex.writer.commit();
+				sessionIndex.refreshReader();
+			}
+			catch (IOException e) {
+				throw new RuntimeException("Failed to commit changes to index for session: " + entry.getKey(), e);
+			}
+		}
+	}
+
+	/**
+	 * Commits all pending changes to the index for the specified session. Call this after
+	 * batch additions for better performance.
+	 * @param sessionId the session ID to commit changes for
+	 */
+	public void commit(String sessionId) {
+		SessionIndex sessionIndex = this.sessionIndexes.get(sessionId);
+		if (sessionIndex != null) {
+			try {
+				sessionIndex.writer.commit();
+				sessionIndex.refreshReader();
+			}
+			catch (IOException e) {
+				throw new RuntimeException("Failed to commit changes to index for session: " + sessionId, e);
+			}
+		}
+	}
+
+	/**
+	 * Searches for tools matching the query string within the specified session's index.
+	 * @param sessionIndex the session index to search
+	 * @param queryString the search query
+	 * @param maxResults maximum number of results to return
+	 * @param minScore minimum score threshold for results
+	 * @return list of matching documents
+	 */
+	private ToolSearchResponse doSearch(SessionIndex sessionIndex, String queryString, int maxResults, float minScore) {
+		try {
+			IndexSearcher searcher = new IndexSearcher(sessionIndex.ensureAndGetReader());
+
+			Query query = buildQuery(queryString);
+			if (query == null) {
+				return ToolSearchResponse.builder().build();
+			}
+
+			TopDocs results = searcher.search(query, maxResults);
+			return this.extractToolReferences(queryString, searcher, results, minScore);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to search index", e);
+		}
+	}
+
+	private ToolSearchResponse extractToolReferences(String query, IndexSearcher searcher, TopDocs results,
+			float minScore) throws IOException {
+
+		List<ToolReference> foundToolReferences = new ArrayList<>(results.scoreDocs.length);
+		StoredFields storedFields = searcher.storedFields();
+		for (ScoreDoc scoreDoc : results.scoreDocs) {
+			logger.info("Score: {}, name: {}", scoreDoc.score,
+					storedFields.document(scoreDoc.doc).get(FIELD_TOOL_NAME));
+			if (scoreDoc.score >= minScore) {
+				var doc = storedFields.document(scoreDoc.doc);
+				foundToolReferences.add(ToolReference.builder()
+					.relevanceScore(scoreDoc.score)
+					.toolName(doc.get(FIELD_TOOL_NAME))
+					.summary(doc.get(FIELD_TOOL_DESCRIPTION))
+					.build());
+			}
+		}
+
+		return ToolSearchResponse.builder()
+			.toolReferences(foundToolReferences)
+			.totalMatches(foundToolReferences.size())
+			.searchMetadata(SearchMetadata.builder().searchType(this.getClass().getSimpleName()).query(query).build())
+			.build();
+	}
+
+	/**
+	 * Deletes a tool from the index for the specified session by its ID.
+	 * @param sessionId the session ID
+	 * @param id the tool ID to delete
+	 */
+	public void delete(String sessionId, String id) {
+		SessionIndex sessionIndex = this.sessionIndexes.get(sessionId);
+		if (sessionIndex != null) {
+			try {
+				sessionIndex.writer.deleteDocuments(new Term(FIELD_ID, id));
+			}
+			catch (IOException e) {
+				throw new RuntimeException("Failed to delete document from index", e);
+			}
+		}
+	}
+
+	/**
+	 * Returns the number of documents in the index for the specified session.
+	 * @param sessionId the session ID
+	 * @return document count, or 0 if session not found
+	 */
+	public int size(String sessionId) {
+		SessionIndex sessionIndex = this.sessionIndexes.get(sessionId);
+		if (sessionIndex == null) {
+			return 0;
+		}
+		try {
+			return sessionIndex.ensureAndGetReader().numDocs();
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Failed to get index size for session: " + sessionId, e);
+		}
+	}
+
+	/**
+	 * Returns the total number of documents across all session indexes.
+	 * @return total document count
+	 */
+	public int totalSize() {
+		int total = 0;
+		for (String sessionId : this.sessionIndexes.keySet()) {
+			total += size(sessionId);
+		}
+		return total;
+	}
+
+	@Override
+	public void close() throws IOException {
+		for (SessionIndex sessionIndex : this.sessionIndexes.values()) {
+			sessionIndex.close();
+		}
+		this.sessionIndexes.clear();
+		this.analyzer.close();
+	}
+
+	private Document createDocument(String sessionId, String id, String toolName, String toolDescription) {
+		Document doc = new Document();
+		doc.add(new StringField(FIELD_SESSION_ID, sessionId, Field.Store.YES));
+		doc.add(new StringField(FIELD_ID, id, Field.Store.YES));
+		doc.add(new TextField(FIELD_TOOL_NAME, toolName, Field.Store.YES));
+		doc.add(new TextField(FIELD_TOOL_DESCRIPTION, toolDescription, Field.Store.YES));
+		return doc;
+	}
+
+	private @Nullable Query buildQuery(String queryString) {
+		QueryBuilder builder = new QueryBuilder(this.analyzer);
+		BooleanQuery.Builder combined = new BooleanQuery.Builder();
+
+		Query descPhrase = builder.createPhraseQuery(FIELD_TOOL_DESCRIPTION, queryString);
+		Query descTerms = builder.createBooleanQuery(FIELD_TOOL_DESCRIPTION, queryString, BooleanClause.Occur.SHOULD);
+		if (descPhrase != null) {
+			combined.add(descPhrase, BooleanClause.Occur.SHOULD);
+		}
+		if (descTerms != null) {
+			combined.add(descTerms, BooleanClause.Occur.SHOULD);
+		}
+
+		// Tool name matches are boosted so direct name lookups rank above description
+		// hits.
+		Query namePhrase = builder.createPhraseQuery(FIELD_TOOL_NAME, queryString);
+		Query nameTerms = builder.createBooleanQuery(FIELD_TOOL_NAME, queryString, BooleanClause.Occur.SHOULD);
+		if (namePhrase != null) {
+			combined.add(new BoostQuery(namePhrase, 4.0f), BooleanClause.Occur.SHOULD);
+		}
+		if (nameTerms != null) {
+			combined.add(new BoostQuery(nameTerms, 2.0f), BooleanClause.Occur.SHOULD);
+		}
+
+		BooleanQuery result = combined.build();
+		return result.clauses().isEmpty() ? null : result;
+	}
+
+	/**
+	 * Holds the Lucene index components for a specific session.
+	 */
+	private static class SessionIndex {
+
+		final Directory directory;
+
+		final IndexWriter writer;
+
+		@Nullable DirectoryReader reader;
+
+		SessionIndex(Analyzer analyzer) throws IOException {
+			this.directory = new ByteBuffersDirectory();
+			IndexWriterConfig config = new IndexWriterConfig(analyzer);
+			this.writer = new IndexWriter(this.directory, config);
+		}
+
+		synchronized DirectoryReader ensureAndGetReader() throws IOException {
+			if (this.reader == null) {
+				this.writer.commit();
+				this.reader = DirectoryReader.open(this.directory);
+			}
+			else {
+				DirectoryReader newReader = DirectoryReader.openIfChanged(this.reader);
+				if (newReader != null) {
+					this.reader.close();
+					this.reader = newReader;
+				}
+			}
+			return this.reader;
+		}
+
+		synchronized void refreshReader() throws IOException {
+			if (this.reader != null) {
+				DirectoryReader newReader = DirectoryReader.openIfChanged(this.reader);
+				if (newReader != null) {
+					this.reader.close();
+					this.reader = newReader;
+				}
+			}
+		}
+
+		synchronized void close() throws IOException {
+			if (this.reader != null) {
+				this.reader.close();
+			}
+			this.writer.close();
+			this.directory.close();
+		}
+
+	}
+
+}

--- a/advisors/tool-search-tool/tool-indexes/tool-index-lucene/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/lucene/package-info.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-lucene/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/lucene/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.chat.client.advisor.tool.index.lucene;
+
+import org.jspecify.annotations.NullMarked;

--- a/advisors/tool-search-tool/tool-indexes/tool-index-lucene/src/test/java/org/springframework/ai/chat/client/advisor/tool/index/lucene/LuceneToolIndexTests.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-lucene/src/test/java/org/springframework/ai/chat/client/advisor/tool/index/lucene/LuceneToolIndexTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.index.lucene;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link LuceneToolIndex}.
+ *
+ * @author Christian Tzolov
+ */
+class LuceneToolIndexTests {
+
+	private static final String SESSION = "session-1";
+
+	private ToolReference ref(String name, String description) {
+		return ToolReference.builder().toolName(name).summary(description).build();
+	}
+
+	private ToolSearchResponse search(LuceneToolIndex searcher, String query) {
+		return searcher.search(new ToolSearchRequest(SESSION, query, null, null));
+	}
+
+	@Test
+	void matchesByDescription() throws Exception {
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			searcher.indexTool(SESSION, ref("weatherTool", "Returns current weather conditions"));
+			searcher.indexTool(SESSION, ref("calculatorTool", "Performs arithmetic calculations"));
+
+			ToolSearchResponse response = search(searcher, "weather conditions");
+
+			assertThat(response.toolReferences()).hasSize(1);
+			assertThat(response.toolReferences().get(0).toolName()).isEqualTo("weatherTool");
+		}
+	}
+
+	@Test
+	void matchesByToolName() throws Exception {
+		// StandardAnalyzer lowercases tokens; "getWeather" -> "getweather".
+		// Now it is a TextField so the QueryBuilder could match it.
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			searcher.indexTool(SESSION, ref("getWeather", "Retrieves meteorological data"));
+			searcher.indexTool(SESSION, ref("calculateTax", "Computes tax obligations"));
+
+			ToolSearchResponse response = search(searcher, "getWeather");
+
+			assertThat(response.toolReferences()).isNotEmpty();
+			assertThat(response.toolReferences().get(0).toolName()).isEqualTo("getWeather");
+		}
+	}
+
+	@Test
+	void nameMatchRanksAboveDescriptionMatch() throws Exception {
+		// "weather" appears as the full name of one tool and inside the description of
+		// another. The name field carries a 4x boost, so the name-exact-match must win.
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			searcher.indexTool(SESSION, ref("weather", "Current conditions provider"));
+			searcher.indexTool(SESSION, ref("forecast", "Provides detailed weather predictions daily"));
+
+			ToolSearchResponse response = search(searcher, "weather");
+
+			assertThat(response.toolReferences()).hasSizeGreaterThanOrEqualTo(1);
+			assertThat(response.toolReferences().get(0).toolName()).isEqualTo("weather");
+		}
+	}
+
+	@Test
+	void indexToolsBatchAddsAllTools() throws Exception {
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			searcher.indexTools(SESSION, List.of(ref("tool1", "First tool description"),
+					ref("tool2", "Second tool description"), ref("tool3", "Third tool description")));
+
+			assertThat(searcher.size(SESSION)).isEqualTo(3);
+		}
+	}
+
+	@Test
+	void noResultsForEmptySession() throws Exception {
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			ToolSearchResponse response = search(searcher, "weather");
+
+			assertThat(response.toolReferences()).isEmpty();
+		}
+	}
+
+	@Test
+	void clearIndexRemovesAllTools() throws Exception {
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			searcher.indexTools(SESSION, List.of(ref("tool1", "desc one"), ref("tool2", "desc two")));
+
+			searcher.clearIndex(SESSION);
+
+			assertThat(searcher.size(SESSION)).isEqualTo(0);
+			assertThat(search(searcher, "desc").toolReferences()).isEmpty();
+		}
+	}
+
+	@Test
+	void sessionIsolationPreventsLeakage() throws Exception {
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			searcher.indexTool(SESSION, ref("weatherTool", "Weather data source"));
+			searcher.indexTool("session-2", ref("calculatorTool", "Math operations tool"));
+
+			ToolSearchResponse response = searcher.search(new ToolSearchRequest("session-2", "weather", null, null));
+
+			assertThat(response.toolReferences()).isEmpty();
+		}
+	}
+
+	@Test
+	void maxResultsLimitsOutput() throws Exception {
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			for (int i = 0; i < 8; i++) {
+				searcher.indexTool(SESSION, ref("dataTool" + i, "Retrieves data from source " + i));
+			}
+
+			ToolSearchResponse response = searcher.search(new ToolSearchRequest(SESSION, "data", 3, null));
+
+			assertThat(response.toolReferences()).hasSizeLessThanOrEqualTo(3);
+		}
+	}
+
+	@Test
+	void lazyCommitMakesToolsVisibleAtSearchTime() throws Exception {
+		try (LuceneToolIndex searcher = new LuceneToolIndex()) {
+			// No explicit commit — tools are flushed inside the first search call
+			searcher.indexTool(SESSION, ref("stockTool", "Fetches live stock prices"));
+			searcher.indexTool(SESSION, ref("newsTool", "Returns latest news headlines"));
+
+			ToolSearchResponse response = search(searcher, "stock prices");
+
+			assertThat(response.toolReferences()).isNotEmpty();
+			assertThat(response.toolReferences().get(0).toolName()).isEqualTo("stockTool");
+		}
+	}
+
+	@Test
+	void concurrentSearchesAreThreadSafe() throws Exception {
+		// Concurrent calls to ensureAndGetReader() on the same
+		// session must not leak readers or throw due to unsynchronised reader assignment.
+		// minScore=0 avoids IDF collapse: with 10 identical-token documents the BM25
+		// score stays above zero but falls below the default 0.25 threshold.
+		try (LuceneToolIndex searcher = new LuceneToolIndex(0.0f)) {
+			for (int i = 0; i < 10; i++) {
+				searcher.indexTool(SESSION, ref("tool" + i, "Processes data stream number " + i));
+			}
+
+			int threadCount = 8;
+			ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+			List<Future<ToolSearchResponse>> futures = new ArrayList<>(threadCount);
+
+			for (int i = 0; i < threadCount; i++) {
+				futures.add(executor.submit(() -> search(searcher, "data")));
+			}
+
+			executor.shutdown();
+			assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+
+			for (Future<ToolSearchResponse> future : futures) {
+				assertThat(future.get().toolReferences()).isNotEmpty();
+			}
+		}
+	}
+
+}

--- a/advisors/tool-search-tool/tool-indexes/tool-index-regex/pom.xml
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-regex/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-tool-index-regex</artifactId>
+	<name>spring-ai-tool-index-regex</name>
+	<description>Regex-based tool index implementation</description>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-search-tool-api</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/advisors/tool-search-tool/tool-indexes/tool-index-regex/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/regex/RegexToolIndex.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-regex/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/regex/RegexToolIndex.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.index.regex;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse.SearchMetadata;
+
+/**
+ * Regex-based tool searcher that converts natural-language queries into case-insensitive
+ * OR patterns and matches them against tool names and descriptions.
+ * <p>
+ * Stop words are filtered out and remaining tokens are escaped and joined into a pattern
+ * of the form {@code (?i)(token1|token2|...)}. Generated patterns are capped at 200
+ * characters. Tool-name matches are weighted 2× higher than description matches.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public class RegexToolIndex implements Closeable, ToolIndex {
+
+	private static final Logger logger = LoggerFactory.getLogger(RegexToolIndex.class);
+
+	private static final int DEFAULT_MAX_RESULTS = 10;
+
+	private static final int MAX_PATTERN_LENGTH = 200;
+
+	private final AtomicInteger counter = new AtomicInteger(0);
+
+	/**
+	 * Map of sessionId to their respective tool indexes.
+	 */
+	private final Map<String, SessionIndex> sessionIndexes = new ConcurrentHashMap<>();
+
+	public RegexToolIndex() {
+	}
+
+	/**
+	 * Gets or creates a SessionIndex for the given sessionId.
+	 * @param sessionId the session identifier
+	 * @return the SessionIndex for the session
+	 */
+	private SessionIndex getOrCreateSessionIndex(String sessionId) {
+		return this.sessionIndexes.computeIfAbsent(sessionId, key -> new SessionIndex());
+	}
+
+	@Override
+	public void clearIndex(String sessionId) {
+		SessionIndex sessionIndex = this.sessionIndexes.remove(sessionId);
+		if (sessionIndex != null) {
+			sessionIndex.clear();
+			logger.debug("Cleared index for session: {}", sessionId);
+		}
+	}
+
+	@Override
+	public void indexTool(String sessionId, ToolReference toolReference) {
+		String id = String.valueOf(this.counter.getAndIncrement());
+		SessionIndex sessionIndex = getOrCreateSessionIndex(sessionId);
+		sessionIndex.addTool(new ToolEntry(id, toolReference.toolName(), toolReference.summary()));
+		logger.debug("Added tool '{}' to session '{}' with id '{}'", toolReference.toolName(), sessionId, id);
+	}
+
+	@Override
+	public void indexTools(String sessionId, List<ToolReference> toolReferences) {
+		SessionIndex sessionIndex = getOrCreateSessionIndex(sessionId);
+		for (ToolReference ref : toolReferences) {
+			String id = String.valueOf(this.counter.getAndIncrement());
+			sessionIndex.addTool(new ToolEntry(id, ref.toolName(), ref.summary()));
+		}
+		logger.debug("Added {} tools to session '{}'", toolReferences.size(), sessionId);
+	}
+
+	@Override
+	public ToolSearchResponse search(ToolSearchRequest toolSearchRequest) {
+		String sessionId = toolSearchRequest.sessionId();
+		if (sessionId == null || sessionId.isBlank()) {
+			logger.warn("No sessionId provided in ToolSearchRequest, returning empty results");
+			return ToolSearchResponse.builder().build();
+		}
+
+		SessionIndex sessionIndex = this.sessionIndexes.get(sessionId);
+		if (sessionIndex == null) {
+			logger.debug("No index found for session: {}", sessionId);
+			return ToolSearchResponse.builder().build();
+		}
+
+		String query = toolSearchRequest.query();
+		int maxResults = toolSearchRequest.maxResults() != null ? toolSearchRequest.maxResults() : DEFAULT_MAX_RESULTS;
+
+		// Convert natural language query to regex pattern
+		String regexPattern = convertQueryToRegexPattern(query);
+		logger.debug("Converted query '{}' to regex pattern '{}'", query, regexPattern);
+
+		return this.doSearch(sessionIndex, query, regexPattern, maxResults);
+	}
+
+	/**
+	 * Converts a natural-language query into a case-insensitive OR regex pattern.
+	 * <p>
+	 * Tokens are lowercased, stop words removed, special regex characters escaped, and
+	 * joined as {@code (?i)(token1|token2|...)}. The pattern is truncated if it would
+	 * exceed 200 characters. Subclasses may override to apply a different conversion
+	 * strategy.
+	 * @param query the natural-language query
+	 * @return a valid regex pattern string; never {@code null}
+	 */
+	protected String convertQueryToRegexPattern(String query) {
+		if (query == null || query.isBlank()) {
+			return ".*"; // Match everything if no query
+		}
+
+		// Common English stop words to filter out
+		Set<String> stopWords = Set.of("a", "an", "the", "is", "are", "was", "were", "be", "been", "being", "have",
+				"has", "had", "do", "does", "did", "will", "would", "could", "should", "may", "might", "must", "shall",
+				"can", "need", "dare", "ought", "used", "to", "of", "in", "for", "on", "with", "at", "by", "from", "as",
+				"into", "through", "during", "before", "after", "above", "below", "between", "and", "or", "but", "if",
+				"because", "until", "while", "although", "this", "that", "these", "those", "what", "which", "who",
+				"whom", "whose", "i", "me", "my", "we", "our", "you", "your", "he", "him", "his", "she", "her", "it",
+				"its", "they", "them", "their", "all", "any", "both", "each", "every", "some", "no", "not", "only",
+				"just", "also", "very", "too", "so");
+
+		// Tokenize: split by whitespace and common delimiters
+		String[] tokens = query.toLowerCase().split("[\\s,;:.!?()\\[\\]{}\"']+");
+
+		// Filter and process tokens
+		List<String> processedTokens = Arrays.stream(tokens)
+			.map(String::trim)
+			.filter(token -> !token.isEmpty())
+			.filter(token -> token.length() >= 2) // Filter out single characters
+			.filter(token -> !stopWords.contains(token))
+			.map(this::escapeRegexSpecialChars) // Escape special regex characters
+			.distinct()
+			.collect(Collectors.toList());
+
+		if (processedTokens.isEmpty()) {
+			// If all tokens were filtered, use original query words
+			processedTokens = Arrays.stream(tokens)
+				.map(String::trim)
+				.filter(token -> !token.isEmpty())
+				.map(this::escapeRegexSpecialChars)
+				.distinct()
+				.collect(Collectors.toList());
+		}
+
+		if (processedTokens.isEmpty()) {
+			return ".*"; // Match everything if no valid tokens
+		}
+
+		// Build the regex pattern: (?i)(token1|token2|token3)
+		String pattern = "(?i)(" + String.join("|", processedTokens) + ")";
+
+		// Enforce max pattern length
+		if (pattern.length() > MAX_PATTERN_LENGTH) {
+			// Truncate by removing tokens from the end until within limit
+			while (pattern.length() > MAX_PATTERN_LENGTH && processedTokens.size() > 1) {
+				processedTokens.remove(processedTokens.size() - 1);
+				pattern = "(?i)(" + String.join("|", processedTokens) + ")";
+			}
+			logger.debug("Pattern truncated to {} tokens to fit max length", processedTokens.size());
+		}
+
+		return pattern;
+	}
+
+	/**
+	 * Escapes special regex characters in a string.
+	 * @param input the input string
+	 * @return the escaped string safe for use in regex patterns
+	 */
+	private String escapeRegexSpecialChars(String input) {
+		// Characters that have special meaning in regex: . * + ? ^ $ { } [ ] \ | ( )
+		return input.replaceAll("([\\\\.*+?^${}\\[\\]|()])", "\\\\$1");
+	}
+
+	/**
+	 * Searches for tools matching the regex pattern.
+	 * @param sessionIndex the session index to search
+	 * @param originalQuery the original natural language query (for metadata)
+	 * @param regexPattern the regex pattern to match against tool names and descriptions
+	 * @param maxResults maximum number of results to return
+	 * @return the search response with matching tools
+	 */
+	private ToolSearchResponse doSearch(SessionIndex sessionIndex, String originalQuery, String regexPattern,
+			int maxResults) {
+		long startTime = System.currentTimeMillis();
+
+		Pattern pattern;
+		try {
+			// Pattern flags (like case-insensitivity) are controlled via inline flags in
+			// the pattern
+			// e.g., "(?i)weather" for case-insensitive matching
+			pattern = Pattern.compile(regexPattern);
+		}
+		catch (PatternSyntaxException e) {
+			logger.error("Invalid regex pattern: '{}'. Error: {}", regexPattern, e.getMessage());
+			return ToolSearchResponse.builder()
+				.searchMetadata(SearchMetadata.builder()
+					.searchType(this.getClass().getSimpleName())
+					.query(originalQuery)
+					.searchTimeMs(System.currentTimeMillis() - startTime)
+					.build())
+				.build();
+		}
+
+		List<MatchedTool> matchedTools = new ArrayList<>();
+
+		for (ToolEntry entry : sessionIndex.getTools()) {
+			double score = calculateMatchScore(pattern, entry);
+			if (score > 0) {
+				matchedTools.add(new MatchedTool(entry, score));
+			}
+		}
+
+		// Sort by score descending and limit results
+		matchedTools.sort((a, b) -> Double.compare(b.score(), a.score()));
+
+		List<ToolReference> toolReferences = matchedTools.stream()
+			.limit(maxResults)
+			.map(matched -> ToolReference.builder()
+				.toolName(matched.entry().toolName())
+				.relevanceScore(matched.score())
+				.summary(matched.entry().toolDescription())
+				.build())
+			.toList();
+
+		long searchTimeMs = System.currentTimeMillis() - startTime;
+
+		return ToolSearchResponse.builder()
+			.toolReferences(toolReferences)
+			.totalMatches(toolReferences.size())
+			.searchMetadata(SearchMetadata.builder()
+				.searchType(this.getClass().getSimpleName())
+				.query(originalQuery)
+				.searchTimeMs(searchTimeMs)
+				.build())
+			.build();
+	}
+
+	/**
+	 * Calculates a match score for a tool entry against the given pattern. The score is
+	 * based on:
+	 * <ul>
+	 * <li>Number of matches found in tool name and description</li>
+	 * <li>Higher weight for tool name matches (2x)</li>
+	 * <li>Match position (earlier matches score higher)</li>
+	 * </ul>
+	 * @param pattern the compiled regex pattern
+	 * @param entry the tool entry to match
+	 * @return the calculated score, or 0 if no match
+	 */
+	private double calculateMatchScore(Pattern pattern, ToolEntry entry) {
+		double score = 0.0;
+
+		// Match against tool name (higher weight)
+		Matcher nameMatcher = pattern.matcher(entry.toolName());
+		int nameMatchCount = 0;
+		int earliestNameMatchPos = Integer.MAX_VALUE;
+		while (nameMatcher.find()) {
+			nameMatchCount++;
+			if (nameMatcher.start() < earliestNameMatchPos) {
+				earliestNameMatchPos = nameMatcher.start();
+			}
+		}
+		if (nameMatchCount > 0) {
+			// Base score for name match + bonus for multiple matches + position bonus
+			double positionBonus = 1.0 / (1.0 + earliestNameMatchPos * 0.1);
+			score += 2.0 * nameMatchCount + positionBonus;
+		}
+
+		// Match against tool description (lower weight)
+		Matcher descMatcher = pattern.matcher(entry.toolDescription());
+		int descMatchCount = 0;
+		int earliestDescMatchPos = Integer.MAX_VALUE;
+		while (descMatcher.find()) {
+			descMatchCount++;
+			if (descMatcher.start() < earliestDescMatchPos) {
+				earliestDescMatchPos = descMatcher.start();
+			}
+		}
+		if (descMatchCount > 0) {
+			// Base score for description match + bonus for multiple matches + position
+			// bonus
+			double positionBonus = 1.0 / (1.0 + earliestDescMatchPos * 0.1);
+			score += 1.0 * descMatchCount + positionBonus * 0.5;
+		}
+
+		return score;
+	}
+
+	/**
+	 * Returns the number of tools in the index for the specified session.
+	 * @param sessionId the session ID
+	 * @return tool count, or 0 if session not found
+	 */
+	public int size(String sessionId) {
+		SessionIndex sessionIndex = this.sessionIndexes.get(sessionId);
+		if (sessionIndex == null) {
+			return 0;
+		}
+		return sessionIndex.size();
+	}
+
+	/**
+	 * Returns the total number of tools across all session indexes.
+	 * @return total tool count
+	 */
+	public int totalSize() {
+		int total = 0;
+		for (SessionIndex sessionIndex : this.sessionIndexes.values()) {
+			total += sessionIndex.size();
+		}
+		return total;
+	}
+
+	/**
+	 * Validates a regex pattern without performing a search.
+	 * @param regexPattern the pattern to validate
+	 * @return true if the pattern is valid, false otherwise
+	 */
+	public boolean isValidPattern(String regexPattern) {
+		if (regexPattern == null || regexPattern.isBlank()) {
+			return false;
+		}
+		if (regexPattern.length() > MAX_PATTERN_LENGTH) {
+			return false;
+		}
+		try {
+			Pattern.compile(regexPattern);
+			return true;
+		}
+		catch (PatternSyntaxException e) {
+			return false;
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		for (SessionIndex sessionIndex : this.sessionIndexes.values()) {
+			sessionIndex.clear();
+		}
+		this.sessionIndexes.clear();
+		logger.debug("Closed RegexToolIndex and cleared all session indexes");
+	}
+
+	/**
+	 * Represents a tool entry stored in the index.
+	 */
+	private record ToolEntry(String id, String toolName, String toolDescription) {
+	}
+
+	/**
+	 * Represents a matched tool with its match score.
+	 */
+	private record MatchedTool(ToolEntry entry, double score) {
+	}
+
+	/**
+	 * Holds the tool entries for a specific session.
+	 */
+	private static class SessionIndex {
+
+		final List<ToolEntry> tools = new CopyOnWriteArrayList<>();
+
+		void addTool(ToolEntry entry) {
+			this.tools.add(entry);
+		}
+
+		List<ToolEntry> getTools() {
+			return Collections.unmodifiableList(this.tools);
+		}
+
+		void clear() {
+			this.tools.clear();
+		}
+
+		int size() {
+			return this.tools.size();
+		}
+
+	}
+
+}

--- a/advisors/tool-search-tool/tool-indexes/tool-index-regex/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/regex/package-info.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-regex/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/regex/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.chat.client.advisor.tool.index.regex;
+
+import org.jspecify.annotations.NullMarked;

--- a/advisors/tool-search-tool/tool-indexes/tool-index-regex/src/test/java/org/springframework/ai/chat/client/advisor/tool/index/regex/RegexToolIndexTests.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-regex/src/test/java/org/springframework/ai/chat/client/advisor/tool/index/regex/RegexToolIndexTests.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.index.regex;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RegexToolIndex}.
+ *
+ * @author Christian Tzolov
+ */
+class RegexToolIndexTests {
+
+	private static final String SESSION = "session-1";
+
+	private ToolReference ref(String name, String description) {
+		return ToolReference.builder().toolName(name).summary(description).build();
+	}
+
+	private ToolSearchResponse search(RegexToolIndex searcher, String query) {
+		return searcher.search(new ToolSearchRequest(SESSION, query, null, null));
+	}
+
+	@Test
+	void searchTypeIsRegex() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			assertThat(searcher.getClass().getSimpleName()).isEqualTo("RegexToolIndex");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void matchesByToolName() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			searcher.indexTool(SESSION, ref("weatherTool", "Returns current weather conditions"));
+			searcher.indexTool(SESSION, ref("calculatorTool", "Performs arithmetic calculations"));
+
+			ToolSearchResponse response = search(searcher, "weather");
+
+			assertThat(response.toolReferences()).hasSize(1);
+			assertThat(response.toolReferences().get(0).toolName()).isEqualTo("weatherTool");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void matchesByDescription() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			searcher.indexTool(SESSION, ref("toolA", "Fetches stock price data"));
+			searcher.indexTool(SESSION, ref("toolB", "Converts temperature units"));
+
+			ToolSearchResponse response = search(searcher, "stock price");
+
+			assertThat(response.toolReferences()).hasSize(1);
+			assertThat(response.toolReferences().get(0).toolName()).isEqualTo("toolA");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void indexToolsBatchAddsAllTools() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			searcher.indexTools(SESSION, List.of(ref("tool1", "First tool description"),
+					ref("tool2", "Second tool description"), ref("tool3", "Third tool description")));
+
+			assertThat(searcher.size(SESSION)).isEqualTo(3);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void noResultsForEmptySession() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			ToolSearchResponse response = search(searcher, "weather");
+
+			assertThat(response.toolReferences()).isEmpty();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void clearIndexRemovesAllTools() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			searcher.indexTools(SESSION, List.of(ref("tool1", "desc1"), ref("tool2", "desc2")));
+			assertThat(searcher.size(SESSION)).isEqualTo(2);
+
+			searcher.clearIndex(SESSION);
+
+			assertThat(searcher.size(SESSION)).isEqualTo(0);
+			assertThat(search(searcher, "tool").toolReferences()).isEmpty();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void sessionIsolationPreventsLeakage() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			searcher.indexTool(SESSION, ref("weatherTool", "Weather data"));
+			searcher.indexTool("session-2", ref("calculatorTool", "Math operations"));
+
+			ToolSearchResponse response = searcher.search(new ToolSearchRequest("session-2", "weather", null, null));
+
+			assertThat(response.toolReferences()).isEmpty();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void nameMatchScoresHigherThanDescriptionMatch() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			searcher.indexTool(SESSION, ref("weatherTool", "General purpose tool"));
+			searcher.indexTool(SESSION, ref("genericTool", "Provides weather forecasts"));
+
+			ToolSearchResponse response = search(searcher, "weather");
+
+			assertThat(response.toolReferences()).hasSize(2);
+			assertThat(response.toolReferences().get(0).toolName()).isEqualTo("weatherTool");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void maxResultsLimitsOutput() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			for (int i = 0; i < 10; i++) {
+				searcher.indexTool(SESSION, ref("dataTool" + i, "Retrieves data from source " + i));
+			}
+
+			ToolSearchResponse response = searcher.search(new ToolSearchRequest(SESSION, "data", 3, null));
+
+			assertThat(response.toolReferences()).hasSize(3);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void convertQueryToRegexPattern() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			assertThat(searcher.convertQueryToRegexPattern("weather tools")).isEqualTo("(?i)(weather|tools)");
+			assertThat(searcher.convertQueryToRegexPattern("get user data")).isEqualTo("(?i)(get|user|data)");
+			assertThat(searcher.convertQueryToRegexPattern("")).isEqualTo(".*");
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	void isValidPatternAcceptsValidRegex() {
+		try (RegexToolIndex searcher = new RegexToolIndex()) {
+			assertThat(searcher.isValidPattern("(?i)(weather|tools)")).isTrue();
+			assertThat(searcher.isValidPattern("[invalid")).isFalse();
+			assertThat(searcher.isValidPattern(null)).isFalse();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/pom.xml
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-tool-index-vectorstore</artifactId>
+	<name>spring-ai-tool-index-vectorstore</name>
+	<description>Vector store-based tool index implementation</description>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-search-tool-api</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<!-- Spring AI Vector Store for semantic search -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-vector-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/vectorstore/VectorToolIndex.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/vectorstore/VectorToolIndex.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.index.vectorstore;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse.SearchMetadata;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder;
+
+/**
+ * Vector-based tool searcher for semantic search of tool descriptions.
+ * <p>
+ * This class provides semantic search capabilities using vector embeddings, allowing for
+ * more intelligent matching based on meaning rather than just keywords. Uses Spring AI's
+ * VectorStore for vector storage.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public class VectorToolIndex implements Closeable, ToolIndex {
+
+	private static final Logger logger = LoggerFactory.getLogger(VectorToolIndex.class);
+
+	private static final String METADATA_ID = "id";
+
+	private static final String METADATA_SESSION_ID = "sessionId";
+
+	public static final String METADATA_TOOL_NAME = "toolName";
+
+	public static final String METADATA_TOOL_DESCRIPTION = "toolDescription";
+
+	private static final int DEFAULT_MAX_RESULTS = 10;
+
+	private static final double DEFAULT_SIMILARITY_THRESHOLD = 0.2;
+
+	private final VectorStore vectorStore;
+
+	private final AtomicInteger counter = new AtomicInteger(0);
+
+	private final ConcurrentHashMap<String, List<String>> sessionToolIds = new ConcurrentHashMap<>();
+
+	@Override
+	public void clearIndex(String sessionId) {
+
+		List<String> toolIds = this.sessionToolIds.get(sessionId);
+
+		if (toolIds != null) {
+			this.vectorStore.delete(toolIds);
+			this.sessionToolIds.remove(sessionId);
+			logger.info("Cleared {} tools for sessionId={}", toolIds.size(), sessionId);
+		}
+		else {
+			logger.info("No tools found for sessionId={}", sessionId);
+		}
+	}
+
+	/**
+	 * Creates a new VectorToolIndex with the given vector store.
+	 * @param vectorStore the vector store to use for storing and searching tool
+	 * embeddings
+	 */
+	public VectorToolIndex(VectorStore vectorStore) {
+		this.vectorStore = vectorStore;
+	}
+
+	@Override
+	public void indexTool(String sessionId, ToolReference toolReference) {
+		String id = String.valueOf(this.counter.getAndIncrement());
+		this.add(sessionId, id, toolReference.toolName(), toolReference.summary());
+		this.sessionToolIds.compute(sessionId, (k, existing) -> {
+			List<String> list = existing != null ? new ArrayList<>(existing) : new ArrayList<>();
+			list.add(id);
+			return list;
+		});
+	}
+
+	@Override
+	public void indexTools(String sessionId, List<ToolReference> toolReferences) {
+		if (toolReferences.isEmpty()) {
+			return;
+		}
+
+		List<String> ids = toolReferences.stream().map(ref -> String.valueOf(this.counter.getAndIncrement())).toList();
+
+		List<Document> documents = new ArrayList<>(toolReferences.size());
+		for (int i = 0; i < toolReferences.size(); i++) {
+			ToolReference ref = toolReferences.get(i);
+			String id = ids.get(i);
+			documents.add(new Document(id, ref.summary(), Map.of(METADATA_SESSION_ID, sessionId, METADATA_ID, id,
+					METADATA_TOOL_NAME, ref.toolName(), METADATA_TOOL_DESCRIPTION, ref.summary())));
+		}
+
+		this.vectorStore.add(documents);
+		this.sessionToolIds.compute(sessionId, (k, existing) -> {
+			List<String> list = existing != null ? new ArrayList<>(existing) : new ArrayList<>(ids.size());
+			list.addAll(ids);
+			return list;
+		});
+		logger.info("Indexed {} tools for sessionId={}", documents.size(), sessionId);
+	}
+
+	@Override
+	public ToolSearchResponse search(ToolSearchRequest toolSearchRequest) {
+		int maxResults = toolSearchRequest.maxResults() != null ? toolSearchRequest.maxResults() : DEFAULT_MAX_RESULTS;
+
+		List<Document> docs = this.doSearch(toolSearchRequest.query(), toolSearchRequest.sessionId(), maxResults,
+				DEFAULT_SIMILARITY_THRESHOLD);
+
+		List<ToolReference> toolReferences = docs.stream()
+			.map(doc -> ToolReference.builder()
+				.toolName((String) Objects.requireNonNull(doc.getMetadata().get(METADATA_TOOL_NAME)))
+				.relevanceScore(Objects.requireNonNull(doc.getScore()))
+				.summary((String) Objects.requireNonNull(doc.getMetadata().get(METADATA_TOOL_DESCRIPTION)))
+				.build())
+			.toList();
+
+		return ToolSearchResponse.builder()
+			.toolReferences(toolReferences)
+			.totalMatches(toolReferences.size())
+			.searchMetadata(SearchMetadata.builder()
+				.searchType(this.getClass().getSimpleName())
+				.query(toolSearchRequest.query())
+				.build())
+			.build();
+	}
+
+	/**
+	 * Adds a single tool to the vector index.
+	 * @param sessionId the session ID associated with the tool
+	 * @param id unique identifier for the tool
+	 * @param toolName name of the tool
+	 * @param toolDescription description of the tool (used for embedding)
+	 */
+	public void add(String sessionId, String id, String toolName, String toolDescription) {
+		Document document = new Document(id, toolDescription, Map.of(METADATA_SESSION_ID, sessionId, METADATA_ID, id,
+				METADATA_TOOL_NAME, toolName, METADATA_TOOL_DESCRIPTION, toolDescription));
+		this.vectorStore.add(List.of(document));
+	}
+
+	/**
+	 * Searches for tools matching the query string using semantic similarity.
+	 * @param queryString the search query
+	 * @return list of matching documents sorted by similarity
+	 */
+	public List<Document> doSearch(String queryString) {
+		return doSearch(queryString, DEFAULT_MAX_RESULTS, DEFAULT_SIMILARITY_THRESHOLD);
+	}
+
+	/**
+	 * Searches for tools matching the query string with custom parameters.
+	 * @param queryString the search query
+	 * @param maxResults maximum number of results to return
+	 * @param similarityThreshold minimum similarity threshold (0.0 to 1.0)
+	 * @return list of matching documents sorted by similarity
+	 */
+	public List<Document> doSearch(String queryString, int maxResults, double similarityThreshold) {
+		return doSearch(queryString, null, maxResults, similarityThreshold);
+	}
+
+	/**
+	 * Searches the vector store with full control over parameters.
+	 * @param queryString the search query
+	 * @param sessionId if non-null, restricts results to this session's indexed tools
+	 * @param maxResults maximum number of results to return
+	 * @param similarityThreshold minimum similarity score (0.0–1.0)
+	 * @return matching documents sorted by descending similarity score
+	 */
+	public List<Document> doSearch(String queryString, @Nullable String sessionId, int maxResults,
+			double similarityThreshold) {
+		var b = new FilterExpressionBuilder();
+		SearchRequest searchRequest = SearchRequest.builder()
+			.query(queryString)
+			.topK(maxResults)
+			.similarityThreshold(similarityThreshold)
+			.filterExpression(sessionId != null ? b.eq(METADATA_SESSION_ID, sessionId).build() : null)
+			.build();
+
+		return this.vectorStore.similaritySearch(searchRequest);
+	}
+
+	/**
+	 * Deletes a tool from the index by its ID.
+	 * @param id the tool ID to delete
+	 */
+	public void delete(String id) {
+		this.vectorStore.delete(List.of(id));
+	}
+
+	/**
+	 * Deletes multiple tools from the index.
+	 * @param ids list of tool IDs to delete
+	 */
+	public void deleteAll(List<String> ids) {
+		this.vectorStore.delete(ids);
+	}
+
+	@Override
+	public void close() throws IOException {
+		// Vector store lifecycle is managed externally; no cleanup needed here.
+	}
+
+	/**
+	 * Gets the tool name from a search result document.
+	 * @param document the search result document
+	 * @return the tool name
+	 */
+	public static String getToolName(Document document) {
+		return (String) Objects.requireNonNull(document.getMetadata().get(METADATA_TOOL_NAME));
+	}
+
+	/**
+	 * Gets the tool ID from a search result document.
+	 * @param document the search result document
+	 * @return the tool ID
+	 */
+	public static String getToolId(Document document) {
+		return (String) Objects.requireNonNull(document.getMetadata().get(METADATA_ID));
+	}
+
+	/**
+	 * Gets the tool description (content) from a search result document.
+	 * @param document the search result document
+	 * @return the tool description
+	 */
+	public static String getToolDescription(Document document) {
+		return (String) Objects.requireNonNull(document.getMetadata().get(METADATA_TOOL_DESCRIPTION));
+	}
+
+}

--- a/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/vectorstore/package-info.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/src/main/java/org/springframework/ai/chat/client/advisor/tool/index/vectorstore/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.chat.client.advisor.tool.index.vectorstore;
+
+import org.jspecify.annotations.NullMarked;

--- a/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/src/test/java/org/springframework/ai/chat/client/advisor/tool/index/vectorstore/VectorToolIndexTests.java
+++ b/advisors/tool-search-tool/tool-indexes/tool-index-vectorstore/src/test/java/org/springframework/ai/chat/client/advisor/tool/index/vectorstore/VectorToolIndexTests.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.index.vectorstore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link VectorToolIndex}.
+ *
+ * @author Christian Tzolov
+ */
+@ExtendWith(MockitoExtension.class)
+class VectorToolIndexTests {
+
+	private static final String SESSION = "session-1";
+
+	@Mock
+	private VectorStore vectorStore;
+
+	private VectorToolIndex toolIndex;
+
+	@BeforeEach
+	void setUp() {
+		this.toolIndex = new VectorToolIndex(this.vectorStore);
+	}
+
+	private ToolReference ref(String name, String description) {
+		return ToolReference.builder().toolName(name).summary(description).build();
+	}
+
+	private ToolSearchResponse search(String query) {
+		return this.toolIndex.search(new ToolSearchRequest(SESSION, query, null, null));
+	}
+
+	// -------------------------------------------------------------------------
+	// searchType
+	// -------------------------------------------------------------------------
+
+	@Test
+	void searchTypeIsSemantic() {
+		assertThat(this.toolIndex.getClass().getSimpleName()).isEqualTo("VectorToolIndex");
+	}
+
+	// -------------------------------------------------------------------------
+	// indexTool
+	// -------------------------------------------------------------------------
+
+	@Test
+	void indexToolAddsOneDocumentToVectorStore() {
+		this.toolIndex.indexTool(SESSION, ref("weatherTool", "Returns current weather conditions"));
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<Document>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore).add(captor.capture());
+
+		List<Document> added = captor.getValue();
+		assertThat(added).hasSize(1);
+		assertThat(added.get(0).getMetadata().get(VectorToolIndex.METADATA_TOOL_NAME)).isEqualTo("weatherTool");
+		assertThat(added.get(0).getMetadata().get(VectorToolIndex.METADATA_TOOL_DESCRIPTION))
+			.isEqualTo("Returns current weather conditions");
+		assertThat(added.get(0).getMetadata().get("sessionId")).isEqualTo(SESSION);
+	}
+
+	@Test
+	void indexToolTracksIdSoThatClearIndexCanDeleteIt() {
+		this.toolIndex.indexTool(SESSION, ref("tool1", "desc1"));
+		this.toolIndex.indexTool(SESSION, ref("tool2", "desc2"));
+
+		this.toolIndex.clearIndex(SESSION);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<String>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore).delete(deleteCaptor.capture());
+		assertThat(deleteCaptor.getValue()).hasSize(2);
+	}
+
+	// -------------------------------------------------------------------------
+	// indexTools (batch)
+	// -------------------------------------------------------------------------
+
+	@Test
+	void indexToolsBatchAddsAllDocumentsInOneVectorStoreCall() {
+		this.toolIndex.indexTools(SESSION,
+				List.of(ref("tool1", "First tool"), ref("tool2", "Second tool"), ref("tool3", "Third tool")));
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<Document>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore, times(1)).add(captor.capture());
+
+		assertThat(captor.getValue()).hasSize(3);
+	}
+
+	@Test
+	void indexToolsBatchDocumentsCarryCorrectMetadata() {
+		this.toolIndex.indexTools(SESSION, List.of(ref("weatherTool", "Weather forecast service")));
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<Document>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore).add(captor.capture());
+
+		Document doc = captor.getValue().get(0);
+		assertThat(doc.getMetadata().get(VectorToolIndex.METADATA_TOOL_NAME)).isEqualTo("weatherTool");
+		assertThat(doc.getMetadata().get(VectorToolIndex.METADATA_TOOL_DESCRIPTION))
+			.isEqualTo("Weather forecast service");
+		assertThat(doc.getMetadata().get("sessionId")).isEqualTo(SESSION);
+		assertThat(doc.getText()).isEqualTo("Weather forecast service");
+	}
+
+	@Test
+	void indexToolsBatchTracksAllIdsForCleanup() {
+		this.toolIndex.indexTools(SESSION, List.of(ref("t1", "d1"), ref("t2", "d2"), ref("t3", "d3")));
+
+		this.toolIndex.clearIndex(SESSION);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<String>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore).delete(deleteCaptor.capture());
+		assertThat(deleteCaptor.getValue()).hasSize(3);
+	}
+
+	@Test
+	void indexToolsBatchIsNoopForEmptyList() {
+		this.toolIndex.indexTools(SESSION, List.of());
+
+		verify(this.vectorStore, never()).add(anyList());
+	}
+
+	// -------------------------------------------------------------------------
+	// clearIndex
+	// -------------------------------------------------------------------------
+
+	@Test
+	void clearIndexDeletesAllTrackedIds() {
+		this.toolIndex.indexTools(SESSION, List.of(ref("tool1", "desc1"), ref("tool2", "desc2")));
+
+		this.toolIndex.clearIndex(SESSION);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore).delete(captor.capture());
+		assertThat(captor.getValue()).hasSize(2);
+	}
+
+	@Test
+	void clearIndexIsNoopForUnknownSession() {
+		this.toolIndex.clearIndex("no-such-session");
+
+		verify(this.vectorStore, never()).delete(anyList());
+	}
+
+	@Test
+	void clearIndexAllowsReindexingAfterwards() {
+		this.toolIndex.indexTools(SESSION, List.of(ref("tool1", "desc1")));
+		this.toolIndex.clearIndex(SESSION);
+
+		this.toolIndex.indexTools(SESSION, List.of(ref("tool2", "desc2")));
+
+		this.toolIndex.clearIndex(SESSION);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore, times(2)).delete(captor.capture());
+		assertThat(captor.getAllValues().get(0)).hasSize(1);
+		assertThat(captor.getAllValues().get(1)).hasSize(1);
+	}
+
+	// -------------------------------------------------------------------------
+	// search
+	// -------------------------------------------------------------------------
+
+	@Test
+	void searchPassesQueryAndSessionFilterToVectorStore() {
+		when(this.vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
+
+		this.toolIndex.search(new ToolSearchRequest(SESSION, "weather forecast", 5, null));
+
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(this.vectorStore).similaritySearch(captor.capture());
+
+		SearchRequest req = captor.getValue();
+		assertThat(req.getQuery()).isEqualTo("weather forecast");
+		assertThat(req.getTopK()).isEqualTo(5);
+		assertThat(req.getFilterExpression()).isNotNull();
+		assertThat(req.getFilterExpression().toString()).contains(SESSION);
+	}
+
+	@Test
+	void searchMapsDocumentMetadataToToolReferences() {
+		Document doc = Document.builder()
+			.id("1")
+			.text("Provides weather data")
+			.metadata(
+					Map.of(VectorToolIndex.METADATA_TOOL_NAME, "weatherTool", VectorToolIndex.METADATA_TOOL_DESCRIPTION,
+							"Provides weather data", "sessionId", SESSION, "id", "1"))
+			.score(0.92)
+			.build();
+		when(this.vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of(doc));
+
+		ToolSearchResponse response = search("weather");
+
+		assertThat(response.toolReferences()).hasSize(1);
+		assertThat(response.toolReferences().get(0).toolName()).isEqualTo("weatherTool");
+		assertThat(response.toolReferences().get(0).summary()).isEqualTo("Provides weather data");
+		assertThat(response.toolReferences().get(0).relevanceScore()).isEqualTo(0.92);
+	}
+
+	@Test
+	void searchReturnsEmptyWhenVectorStoreReturnsNoResults() {
+		when(this.vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
+
+		ToolSearchResponse response = search("anything");
+
+		assertThat(response.toolReferences()).isEmpty();
+	}
+
+	@Test
+	void searchUsesDefaultMaxResultsWhenNotProvided() {
+		when(this.vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
+
+		this.toolIndex.search(new ToolSearchRequest(SESSION, "query", null, null));
+
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(this.vectorStore).similaritySearch(captor.capture());
+		assertThat(captor.getValue().getTopK()).isEqualTo(10);
+	}
+
+	@Test
+	void searchWithMultipleResultsReturnsAllMapped() {
+		List<Document> docs = List.of(
+				Document.builder()
+					.id("1")
+					.text("Weather data")
+					.metadata(Map.of(VectorToolIndex.METADATA_TOOL_NAME, "weatherTool",
+							VectorToolIndex.METADATA_TOOL_DESCRIPTION, "Weather data", "sessionId", SESSION, "id", "1"))
+					.score(0.9)
+					.build(),
+				Document.builder()
+					.id("2")
+					.text("Calculator")
+					.metadata(Map.of(VectorToolIndex.METADATA_TOOL_NAME, "calculatorTool",
+							VectorToolIndex.METADATA_TOOL_DESCRIPTION, "Calculator", "sessionId", SESSION, "id", "2"))
+					.score(0.7)
+					.build());
+		when(this.vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(docs);
+
+		ToolSearchResponse response = search("tools");
+
+		assertThat(response.toolReferences()).hasSize(2);
+		assertThat(response.toolReferences()).extracting(ToolReference::toolName)
+			.containsExactly("weatherTool", "calculatorTool");
+		assertThat(response.totalMatches()).isEqualTo(2);
+		assertThat(response.searchMetadata().searchType()).isEqualTo("VectorToolIndex");
+	}
+
+	// -------------------------------------------------------------------------
+	// Session isolation
+	// -------------------------------------------------------------------------
+
+	@Test
+	void sessionIsolationViaMetadataFilter() {
+		when(this.vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
+
+		this.toolIndex.search(new ToolSearchRequest("session-A", "query", null, null));
+		this.toolIndex.search(new ToolSearchRequest("session-B", "query", null, null));
+
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(this.vectorStore, times(2)).similaritySearch(captor.capture());
+
+		List<SearchRequest> requests = captor.getAllValues();
+		assertThat(requests.get(0).getFilterExpression().toString()).contains("session-A");
+		assertThat(requests.get(1).getFilterExpression().toString()).contains("session-B");
+	}
+
+	@Test
+	void clearIndexForOneSessionDoesNotAffectAnother() {
+		this.toolIndex.indexTools(SESSION, List.of(ref("tool1", "desc1")));
+		this.toolIndex.indexTools("session-2", List.of(ref("tool2", "desc2")));
+
+		this.toolIndex.clearIndex(SESSION);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore, times(1)).delete(captor.capture());
+		assertThat(captor.getValue()).hasSize(1);
+	}
+
+	// -------------------------------------------------------------------------
+	// Thread safety
+	// -------------------------------------------------------------------------
+
+	@Test
+	void concurrentIndexToolsDoesNotCorruptIdList() throws InterruptedException {
+		int threadCount = 10;
+		int toolsPerThread = 20;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch start = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(threadCount);
+
+		for (int t = 0; t < threadCount; t++) {
+			int threadIdx = t;
+			executor.submit(() -> {
+				try {
+					start.await();
+					List<ToolReference> refs = new ArrayList<>();
+					for (int i = 0; i < toolsPerThread; i++) {
+						refs.add(ref("tool-" + threadIdx + "-" + i, "desc " + threadIdx + " " + i));
+					}
+					this.toolIndex.indexTools(SESSION, refs);
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				finally {
+					done.countDown();
+				}
+			});
+		}
+
+		start.countDown();
+		assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+		executor.shutdown();
+
+		// Capture all IDs passed to delete — should be exactly threadCount *
+		// toolsPerThread
+		this.toolIndex.clearIndex(SESSION);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.vectorStore).delete(captor.capture());
+		assertThat(captor.getValue()).hasSize(threadCount * toolsPerThread);
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/pom.xml
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-tool-search-tool-advisor</artifactId>
+	<name>spring-ai-tool-search-tool-advisor</name>
+	<description>Advisor module for the tool search tool</description>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>java-compile</id>
+						<configuration>
+							<compilerArgs combine.children="append">
+								<arg>-parameters</arg>
+							</compilerArgs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-search-tool-api</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.12.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.21.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.21.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.27.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation</artifactId>
+			<version>1.16.2</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Local ONNX embedding model (all-MiniLM-L6-v2) for VectorToolIndex -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-transformers</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-vector-store</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Tool Index implementations -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-index-regex</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-index-lucene</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-tool-index-vectorstore</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-openai</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/ToolSearchToolCallingAdvisor.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/ToolSearchToolCallingAdvisor.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.type.TypeReference;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndexEvictionStrategy;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+import org.springframework.ai.chat.client.advisor.tool.search.eviction.CompositeEvictionStrategy;
+import org.springframework.ai.chat.client.advisor.tool.search.eviction.LruEvictionStrategy;
+import org.springframework.ai.chat.client.advisor.tool.search.eviction.TtlEvictionStrategy;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage.ToolResponse;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.ai.util.json.JsonParser;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+/**
+ * CallAdvisor that integrates a tool search mechanism into the tool calling workflow. It
+ * indexes available tools at the start of a conversation, exposes a "toolSearchTool" for
+ * searching tools based on natural language queries, and manages the selection and
+ * injection of discovered tools into the conversation flow.
+ * <p>
+ * Tool indexes are cached across turns of the same conversation: re-indexing only occurs
+ * when the tool set changes (detected via a fingerprint of tool names and descriptions).
+ * Stale session indexes are cleaned up according to the configured
+ * {@link ToolIndexEvictionStrategy}.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public class ToolSearchToolCallingAdvisor extends ToolCallAdvisor {
+
+	private static final String TOOL_SEARCH_TOOL_SESSION_ID_KEY = "toolSearchToolSessionId";
+
+	private static final String CACHED_TOOL_CALLBACKS_KEY = ToolSearchToolCallingAdvisor.class.getName()
+			+ ".cachedToolCallbacks";
+
+	/**
+	 * Internal Tool implementing the tool search functionality. It is registered,
+	 * automatically, under the name "toolSearchTool".
+	 */
+	private final ToolCallback toolSearchToolCallback;
+
+	/**
+	 * The ToolIndex used to find tools based on search queries.
+	 */
+	private final ToolIndex toolIndex;
+
+	/**
+	 * The Tool Search system message suffix augment to be added to the prompt during
+	 * initialization.
+	 */
+	private final String systemMessageSuffix;
+
+	/**
+	 * If enabled, accumulates all tool search tool responses to find tool references.
+	 * <p>
+	 * If disabled, only the last tool search tool response is used to find tool
+	 * references.
+	 */
+	private final boolean referenceToolNameAccumulation;
+
+	@Nullable private final Integer maxResults;
+
+	private final String sessionIdKeyName;
+
+	/**
+	 * Tracks the fingerprint (sorted name+description hash) of the tool set last indexed
+	 * for each session. A fingerprint match means the session's index is still valid and
+	 * re-indexing can be skipped.
+	 */
+	private final ConcurrentHashMap<String, String> indexedSessionFingerprints = new ConcurrentHashMap<>();
+
+	private final ToolIndexEvictionStrategy evictionStrategy;
+
+	protected ToolSearchToolCallingAdvisor(ToolCallingManager toolCallingManager, int advisorOrder,
+			boolean streamToolCallResponses, ToolIndex toolIndex, String systemMessageSuffix,
+			boolean referenceToolNameAccumulation, @Nullable Integer maxResults, boolean conversationHistoryEnabled,
+			String sessionIdKeyName, ToolIndexEvictionStrategy evictionStrategy) {
+
+		super(toolCallingManager, advisorOrder, conversationHistoryEnabled, streamToolCallResponses);
+		this.toolIndex = toolIndex;
+		this.systemMessageSuffix = systemMessageSuffix;
+		this.referenceToolNameAccumulation = referenceToolNameAccumulation;
+		this.maxResults = maxResults;
+		this.sessionIdKeyName = sessionIdKeyName;
+		this.evictionStrategy = evictionStrategy;
+		this.toolSearchToolCallback = MethodToolCallbackProvider.builder()
+			.toolObjects(new ToolSearchTool())
+			.build()
+			.getToolCallbacks()[0];
+	}
+
+	@Override
+	@SuppressWarnings("null")
+	public String getName() {
+		return "ToolSearchToolCallingAdvisor";
+	}
+
+	// -------------------------------------------------------------------------
+	// Sync hooks
+	// -------------------------------------------------------------------------
+
+	@Override
+	protected ChatClientRequest doInitializeLoop(ChatClientRequest chatClientRequest,
+			CallAdvisorChain callAdvisorChain) {
+		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions) {
+			return initializeSession(chatClientRequest);
+		}
+		return super.doInitializeLoop(chatClientRequest, callAdvisorChain);
+	}
+
+	@Override
+	protected ChatClientRequest doBeforeCall(ChatClientRequest chatClientRequest, CallAdvisorChain callAdvisorChain) {
+		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions) {
+			return prepareIteration(chatClientRequest);
+		}
+		return super.doBeforeCall(chatClientRequest, callAdvisorChain);
+	}
+
+	// -------------------------------------------------------------------------
+	// Stream hooks
+	// -------------------------------------------------------------------------
+
+	@Override
+	protected ChatClientRequest doInitializeLoopStream(ChatClientRequest chatClientRequest,
+			StreamAdvisorChain streamAdvisorChain) {
+		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions) {
+			return initializeSession(chatClientRequest);
+		}
+		return super.doInitializeLoopStream(chatClientRequest, streamAdvisorChain);
+	}
+
+	@Override
+	protected ChatClientRequest doBeforeStream(ChatClientRequest chatClientRequest,
+			StreamAdvisorChain streamAdvisorChain) {
+		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions) {
+			return prepareIteration(chatClientRequest);
+		}
+		return super.doBeforeStream(chatClientRequest, streamAdvisorChain);
+	}
+
+	// -------------------------------------------------------------------------
+	// Shared logic
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Indexes tools for the session (skipping re-indexing when the tool set is
+	 * unchanged), runs eviction, and augments the system message.
+	 */
+	@SuppressWarnings("null")
+	private ChatClientRequest initializeSession(ChatClientRequest chatClientRequest) {
+		ToolCallingChatOptions toolOptions = (ToolCallingChatOptions) chatClientRequest.prompt().getOptions();
+
+		String sessionId = this.getSessionId(chatClientRequest.context());
+
+		// Evict stale sessions before touching the current one.
+		this.evictionStrategy.onAccess(sessionId).forEach(this::doEvict);
+
+		// validation of tool options happens in the tool calling advisor, so we can
+		// assume that if tool options are present, they are valid and contain either tool
+		// callbacks or tool names to search for.
+		List<ToolReference> toolReferences = this.toolCallingManager
+			.resolveToolDefinitions(Objects.requireNonNull(toolOptions))
+			.stream()
+			.map(toolDef -> ToolReference.builder().toolName(toolDef.name()).summary(toolDef.description()).build())
+			.toList();
+
+		// Re-index only when the tool set has changed for this session.
+		// compute() serializes concurrent requests for the same session so that only one
+		// thread performs clear+reindex when the fingerprint changes.
+		String fingerprint = computeFingerprint(toolReferences);
+		this.indexedSessionFingerprints.compute(sessionId, (id, current) -> {
+			if (!fingerprint.equals(current)) {
+				this.toolIndex.clearIndex(id);
+				this.toolIndex.indexTools(id, toolReferences);
+			}
+			return fingerprint;
+		});
+
+		ConcurrentHashMap<String, ToolCallback> cachedResolvedToolCallbacks = new ConcurrentHashMap<>();
+		if (!CollectionUtils.isEmpty(toolOptions.getToolCallbacks())) {
+			toolOptions.getToolCallbacks()
+				.forEach(tc -> cachedResolvedToolCallbacks.putIfAbsent(tc.getToolDefinition().name(), tc));
+		}
+
+		chatClientRequest.context().put(CACHED_TOOL_CALLBACKS_KEY, cachedResolvedToolCallbacks);
+		chatClientRequest.context().put(TOOL_SEARCH_TOOL_SESSION_ID_KEY, sessionId);
+
+		return chatClientRequest.mutate()
+			.prompt(chatClientRequest.prompt()
+				.copy()
+				.augmentSystemMessage(systemMessage -> systemMessage.copy()
+					.mutate()
+					.text(systemMessage.getText() + this.systemMessageSuffix)
+					.build()))
+			.build();
+	}
+
+	// Selects tools discovered via previous toolSearchTool calls and injects them into
+	// options.
+	@SuppressWarnings({ "null", "unchecked" })
+	private ChatClientRequest prepareIteration(ChatClientRequest chatClientRequest) {
+		ToolCallingChatOptions toolOptions = Objects
+			.requireNonNull((ToolCallingChatOptions) chatClientRequest.prompt().getOptions());
+
+		Set<ToolCallback> selectedToolCallbacks = new HashSet<>(List.of(this.toolSearchToolCallback));
+		Set<String> selectedToolNames = new HashSet<>();
+
+		var cachedToolCallbacks = (Map<String, ToolCallback>) chatClientRequest.context()
+			.get(CACHED_TOOL_CALLBACKS_KEY);
+
+		if (cachedToolCallbacks != null) {
+			this.extractToolNameReferences(chatClientRequest.prompt().getInstructions()).forEach(toolName -> {
+				if (cachedToolCallbacks.containsKey(toolName)) {
+					selectedToolCallbacks.add(cachedToolCallbacks.get(toolName));
+				}
+				else {
+					selectedToolNames.add(toolName);
+				}
+			});
+		}
+
+		ToolCallingChatOptions toolOptionsCopy = ((ToolCallingChatOptions.Builder<?>) toolOptions.mutate())
+			.toolCallbacks(new ArrayList<>(selectedToolCallbacks))
+			.toolNames(selectedToolNames)
+			.toolContext(TOOL_SEARCH_TOOL_SESSION_ID_KEY,
+					Objects.requireNonNull(chatClientRequest.context().get(TOOL_SEARCH_TOOL_SESSION_ID_KEY)))
+			.build();
+
+		return chatClientRequest.mutate()
+			.prompt(chatClientRequest.prompt().mutate().chatOptions(toolOptionsCopy).build())
+			.build();
+	}
+
+	/**
+	 * Explicitly evicts a session's tool index and removes it from the advisor's cache.
+	 * <p>
+	 * Call this when a conversation is known to be over (e.g., on logout or session
+	 * expiry) to free resources held by the underlying {@link ToolIndex}.
+	 * @param sessionId the session to evict
+	 */
+	public void evictSession(String sessionId) {
+		doEvict(sessionId);
+	}
+
+	private void doEvict(String sessionId) {
+		this.toolIndex.clearIndex(sessionId);
+		this.indexedSessionFingerprints.remove(sessionId);
+		this.evictionStrategy.onRemoved(sessionId);
+	}
+
+	private List<String> extractToolNameReferences(List<Message> messages) {
+
+		List<ToolResponse> toolSearchToolResponses = messages.stream()
+			.filter(m -> m.getMessageType() == MessageType.TOOL)
+			.map(r -> ((ToolResponseMessage) r).getResponses())
+			.flatMap(List::stream)
+			.filter(r -> r.name().equalsIgnoreCase(this.toolSearchToolCallback.getToolDefinition().name()))
+			.toList();
+
+		if (CollectionUtils.isEmpty(toolSearchToolResponses)) {
+			return List.of();
+		}
+
+		toolSearchToolResponses = (this.referenceToolNameAccumulation) ? toolSearchToolResponses
+				: List.of(toolSearchToolResponses.get(toolSearchToolResponses.size() - 1));
+
+		return toolSearchToolResponses.stream()
+			.map(r -> JsonParser.fromJson(r.responseData(), new TypeReference<List<String>>() {
+			}))
+			.flatMap(List::stream)
+			.toList();
+	}
+
+	private String getSessionId(Map<String, @Nullable Object> context) {
+		Assert.notNull(context, "context cannot be null");
+		Assert.noNullElements(context.keySet().toArray(), "context cannot contain null keys");
+		Assert.notNull(context.get(this.sessionIdKeyName),
+				"context must contain a non-null value for '" + this.sessionIdKeyName + "'");
+
+		return context.get(this.sessionIdKeyName).toString();
+	}
+
+	/**
+	 * Computes a stable SHA-256 fingerprint for the given tool set. Tools are sorted by
+	 * name so that registration order does not affect equality. Hashing avoids false
+	 * cache hits that string-concatenation with delimiters can produce when names or
+	 * summaries contain those delimiter characters.
+	 */
+	private static String computeFingerprint(List<ToolReference> toolReferences) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			toolReferences.stream().sorted(Comparator.comparing(ToolReference::toolName)).forEachOrdered(tr -> {
+				digest.update(tr.toolName().getBytes(StandardCharsets.UTF_8));
+				digest.update((byte) 0); // field separator
+				digest.update(tr.summary().getBytes(StandardCharsets.UTF_8));
+				digest.update((byte) 1); // entry separator
+			});
+			return HexFormat.of().formatHex(digest.digest());
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("SHA-256 not available", e);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Builder
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Creates a new Builder instance for constructing a ToolSearchToolCallingAdvisor.
+	 * @return a new Builder instance
+	 */
+	public static Builder<?> builder() {
+		return new Builder<>();
+	}
+
+	private class ToolSearchTool {
+
+		// @formatter:off
+		@Tool(name = "toolSearchTool", description = """
+				Search for tools in the tool registry to discover capabilities for completing the current task.
+				Use this when you need functionality not provided by your currently available tools.
+				The search queries against tool names, descriptions, and parameter information to find the most relevant tools.
+				Returns references to matching tools which will be expanded into full definitions you can then invoke.
+				""")
+		public List<String> toolSearchTool(
+			@ToolParam(description = "A natural language search query describing the tool capability you need. Be specific and include relevant keywords.") String query,
+			@ToolParam(description = "Maximum number of tool references to return (1-10). Default is 5.", required = false) Integer maxResults,
+			@ToolParam(description = "Optional filter to narrow search to a specific tool category.", required = false) String categoryFilter,
+			ToolContext toolContext) { // @formatter:on
+
+			String sessionId = Objects.requireNonNull(toolContext.getContext().get(TOOL_SEARCH_TOOL_SESSION_ID_KEY))
+				.toString();
+
+			// Advisor-configured maxResults is the fallback when the LLM does not provide
+			// one.
+			maxResults = (maxResults != null) ? maxResults : ToolSearchToolCallingAdvisor.this.maxResults;
+
+			ToolSearchResponse toolSearchResponse = ToolSearchToolCallingAdvisor.this.toolIndex
+				.search(new ToolSearchRequest(sessionId, query, maxResults, categoryFilter));
+
+			return toolSearchResponse.toolReferences().stream().map(tr -> tr.toolName()).toList();
+		}
+
+	}
+
+	/**
+	 * Builder for creating instances of ToolSearchToolCallingAdvisor.
+	 * <p>
+	 * This builder extends {@link ToolCallAdvisor.Builder} and adds configuration options
+	 * specific to tool search functionality.
+	 *
+	 * @param <T> the builder type, used for self-referential generics to support method
+	 * chaining in subclasses
+	 */
+	public static class Builder<T extends Builder<T>> extends ToolCallAdvisor.Builder<T> {
+
+		@Nullable private ToolIndex toolIndex;
+
+		@Nullable private String systemMessageSuffix;
+
+		private boolean referenceToolNameAccumulation = true;
+
+		@Nullable private Integer maxResults;
+
+		private String sessionIdKeyName = ChatMemory.CONVERSATION_ID;
+
+		private ToolIndexEvictionStrategy evictionStrategy = new LruEvictionStrategy(1000);
+
+		protected Builder() {
+		}
+
+		public T referenceToolNameAccumulation(boolean referenceToolNameAccumulation) {
+			this.referenceToolNameAccumulation = referenceToolNameAccumulation;
+			return self();
+		}
+
+		public T systemMessageSuffix(String systemMessageSuffix) {
+			Assert.hasText(systemMessageSuffix, "systemMessageSuffix cannot be null or empty");
+			this.systemMessageSuffix = systemMessageSuffix;
+			return self();
+		}
+
+		/**
+		 * Sets the ToolIndex to be used for finding tools.
+		 * @param toolIndex the ToolIndex instance
+		 * @return this Builder instance for method chaining
+		 */
+		public T toolIndex(ToolIndex toolIndex) {
+			Assert.notNull(toolIndex, "toolIndex cannot be null");
+			this.toolIndex = toolIndex;
+			return self();
+		}
+
+		/**
+		 * Sets the maximum number of tool references to return in tool search results.
+		 * This is the human/user defined default value used when invoking the tool search
+		 * tool.
+		 * @param maxResults
+		 * @return
+		 */
+		public T maxResults(Integer maxResults) {
+			this.maxResults = maxResults;
+			return self();
+		}
+
+		/**
+		 * Sets the key name in the context where the conversation ID is stored. By
+		 * default, it is "conversationId", but it can be customized if the conversation
+		 * ID is stored under a different key in the context.
+		 * @param sessionIdKeyName
+		 * @return
+		 */
+		public T sessionIdKeyName(String sessionIdKeyName) {
+			Assert.hasText(sessionIdKeyName, "sessionIdKeyName cannot be null or empty");
+			this.sessionIdKeyName = sessionIdKeyName;
+			return self();
+		}
+
+		/**
+		 * Sets the eviction strategy that determines when session tool indexes are
+		 * cleared from the advisor's cache.
+		 * <p>
+		 * Defaults to {@code new LruEvictionStrategy(1000)}, which retains indexes for at
+		 * most 1 000 concurrently active sessions and silently evicts the
+		 * least-recently-used one when the cap is exceeded. Adjust the cap to match the
+		 * expected peak concurrency of your deployment — lower values reduce memory
+		 * pressure, higher values reduce unnecessary re-indexing for services with many
+		 * parallel conversations.
+		 * <p>
+		 * Combine with {@link TtlEvictionStrategy} via {@link CompositeEvictionStrategy}
+		 * to also release indexes for sessions that have been idle longer than a fixed
+		 * duration.
+		 * @param evictionStrategy the eviction strategy to use; must not be {@code null}
+		 * @return this Builder instance for method chaining
+		 * @see LruEvictionStrategy
+		 * @see TtlEvictionStrategy
+		 * @see CompositeEvictionStrategy
+		 */
+		public T evictionStrategy(ToolIndexEvictionStrategy evictionStrategy) {
+			Assert.notNull(evictionStrategy, "evictionStrategy must not be null");
+			this.evictionStrategy = evictionStrategy;
+			return self();
+		}
+
+		/**
+		 * Builds and returns a new ToolSearchToolCallingAdvisor instance with the
+		 * configured properties.
+		 * @return a new ToolSearchToolCallingAdvisor instance
+		 * @throws IllegalArgumentException if required parameters are null or invalid
+		 */
+		@Override
+		public ToolSearchToolCallingAdvisor build() {
+
+			if (!StringUtils.hasText(this.systemMessageSuffix)) {
+				try {
+					this.systemMessageSuffix = new DefaultResourceLoader()
+						.getResource("classpath:/DEFAULT_SYSTEM_PROMPT_SUFFIX.md")
+						.getContentAsString(StandardCharsets.UTF_8);
+				}
+				catch (Exception ex) {
+					throw new IllegalArgumentException(
+							"Failed to load default system message suffix from classpath resource", ex);
+				}
+			}
+
+			Assert.notNull(this.toolIndex, "toolIndex is required");
+			return new ToolSearchToolCallingAdvisor(getToolCallingManager(), getAdvisorOrder(),
+					isStreamToolCallResponses(), this.toolIndex, Objects.requireNonNull(this.systemMessageSuffix),
+					this.referenceToolNameAccumulation, this.maxResults, this.isConversationHistoryEnabled(),
+					this.sessionIdKeyName, this.evictionStrategy);
+		}
+
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/AlwaysEvictStrategy.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/AlwaysEvictStrategy.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.eviction;
+
+import java.util.Set;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndexEvictionStrategy;
+
+/**
+ * A {@link ToolIndexEvictionStrategy} that clears a session's tool index before every
+ * request, ensuring tools are always re-indexed on each conversation turn.
+ * <p>
+ * Use this strategy when the tool set may change between turns (e.g. dynamically
+ * generated tool descriptions) and you want to guarantee freshness at the cost of
+ * re-indexing on every request. For stable tool sets, {@link NeverEvictStrategy} is more
+ * efficient.
+ * <p>
+ * <b>Contract note:</b> {@link #onAccess} intentionally returns the currently-accessed
+ * session ID, which diverges from the general recommendation in
+ * {@link ToolIndexEvictionStrategy#onAccess}. This is safe because the advisor's
+ * {@code doEvict} + fingerprint-recheck sequence is idempotent: evicting the current
+ * session removes its cached fingerprint, so the subsequent fingerprint comparison always
+ * sees {@code null} and triggers a full re-index. When combined with other strategies in
+ * a {@link CompositeEvictionStrategy}, the always-evict behaviour is preserved (the more
+ * aggressive strategy wins).
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ * @see NeverEvictStrategy
+ * @see LruEvictionStrategy
+ * @see TtlEvictionStrategy
+ */
+public final class AlwaysEvictStrategy implements ToolIndexEvictionStrategy {
+
+	/**
+	 * Shared singleton instance.
+	 */
+	public static final AlwaysEvictStrategy INSTANCE = new AlwaysEvictStrategy();
+
+	private AlwaysEvictStrategy() {
+	}
+
+	/**
+	 * Returns a set containing {@code sessionId}, causing the advisor to clear the
+	 * session's index and remove its cached fingerprint before the fingerprint-comparison
+	 * step. The comparison then always sees a missing fingerprint and re-indexes the full
+	 * tool set.
+	 * @param sessionId the session being accessed
+	 * @return a singleton set containing {@code sessionId}
+	 */
+	@Override
+	public Set<String> onAccess(String sessionId) {
+		return Set.of(sessionId);
+	}
+
+	@Override
+	public void onRemoved(String sessionId) {
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/CompositeEvictionStrategy.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/CompositeEvictionStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.eviction;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndexEvictionStrategy;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link ToolIndexEvictionStrategy} that delegates to multiple strategies and unions
+ * their eviction decisions.
+ * <p>
+ * All delegates receive every {@link #onAccess} and {@link #onRemoved} call. A session is
+ * evicted if <em>any</em> delegate requests its eviction. Typical usage is to combine LRU
+ * capacity bounding with TTL-based idle cleanup.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public final class CompositeEvictionStrategy implements ToolIndexEvictionStrategy {
+
+	private final List<ToolIndexEvictionStrategy> delegates;
+
+	/**
+	 * Creates a composite strategy from the given delegates.
+	 * @param strategies one or more strategies to combine; must not be empty
+	 */
+	public CompositeEvictionStrategy(ToolIndexEvictionStrategy... strategies) {
+		Assert.notEmpty(strategies, "at least one strategy is required");
+		this.delegates = List.of(strategies);
+	}
+
+	@Override
+	public Set<String> onAccess(String sessionId) {
+		return this.delegates.stream().flatMap(s -> s.onAccess(sessionId).stream()).collect(Collectors.toSet());
+	}
+
+	@Override
+	public void onRemoved(String sessionId) {
+		this.delegates.forEach(s -> s.onRemoved(sessionId));
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/LruEvictionStrategy.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/LruEvictionStrategy.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.eviction;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndexEvictionStrategy;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link ToolIndexEvictionStrategy} that evicts the least-recently-used session when
+ * the number of concurrently active sessions exceeds a configured maximum.
+ * <p>
+ * Access order is updated on every {@link #onAccess} call, so a session that receives a
+ * new request is moved to the most-recently-used position and will not be a candidate for
+ * eviction until all other sessions have been accessed.
+ * <p>
+ * This strategy is suitable for remote vector databases and API-based embedding models,
+ * where the number of sessions whose embeddings are retained in the store must be
+ * bounded.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public final class LruEvictionStrategy implements ToolIndexEvictionStrategy {
+
+	private final int maxSessions;
+
+	// access-order LinkedHashMap; iteration order = LRU → MRU
+	private final Map<String, Boolean> accessOrder;
+
+	/**
+	 * Creates a new LruEvictionStrategy.
+	 * @param maxSessions maximum number of sessions whose indexes are retained; must be
+	 * positive
+	 */
+	public LruEvictionStrategy(int maxSessions) {
+		Assert.isTrue(maxSessions > 0, "maxSessions must be positive");
+		this.maxSessions = maxSessions;
+		this.accessOrder = Collections.synchronizedMap(new LinkedHashMap<>(maxSessions + 1, 0.75f, true));
+	}
+
+	@Override
+	public Set<String> onAccess(String sessionId) {
+		synchronized (this.accessOrder) {
+			this.accessOrder.put(sessionId, Boolean.TRUE);
+			if (this.accessOrder.size() <= this.maxSessions) {
+				return Set.of();
+			}
+			// First entry in iteration order is the LRU one.
+			String lru = this.accessOrder.entrySet().iterator().next().getKey();
+			this.accessOrder.remove(lru);
+			return Set.of(lru);
+		}
+	}
+
+	@Override
+	public void onRemoved(String sessionId) {
+		synchronized (this.accessOrder) {
+			this.accessOrder.remove(sessionId);
+		}
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/NeverEvictStrategy.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/NeverEvictStrategy.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.eviction;
+
+import java.util.Set;
+
+import org.springframework.ai.chat.client.advisor.tool.search.ToolSearchToolCallingAdvisor;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndexEvictionStrategy;
+
+/**
+ * A {@link ToolIndexEvictionStrategy} that never evicts sessions automatically.
+ * <p>
+ * Tool indexes persist across requests for the lifetime of the
+ * {@link ToolSearchToolCallingAdvisor} bean, or until explicitly released via
+ * {@link ToolSearchToolCallingAdvisor#evictSession(String)}.
+ * <p>
+ * <b>Memory warning:</b> this strategy accumulates one index entry per distinct session
+ * ID and never frees them. In a service that handles many short-lived conversations (e.g.
+ * HTTP sessions, anonymous users) the index map will grow without bound, eventually
+ * exhausting heap (Lucene {@code ByteBuffersDirectory} instances) or remote vector-store
+ * quota. For production deployments use {@link LruEvictionStrategy} to cap the number of
+ * concurrently retained indexes, {@link TtlEvictionStrategy} to expire idle sessions, or
+ * a {@link CompositeEvictionStrategy} combining both.
+ * <p>
+ * This strategy is appropriate only when the set of active sessions is small and stable
+ * (e.g. a single-user tool or a bounded pool of long-running agents), or when the
+ * application manages session lifecycle explicitly via
+ * {@link ToolSearchToolCallingAdvisor#evictSession(String)}.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public final class NeverEvictStrategy implements ToolIndexEvictionStrategy {
+
+	/**
+	 * Shared singleton instance.
+	 */
+	public static final NeverEvictStrategy INSTANCE = new NeverEvictStrategy();
+
+	private NeverEvictStrategy() {
+	}
+
+	@Override
+	public Set<String> onAccess(String sessionId) {
+		return Set.of();
+	}
+
+	@Override
+	public void onRemoved(String sessionId) {
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/TtlEvictionStrategy.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/TtlEvictionStrategy.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.eviction;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndexEvictionStrategy;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link ToolIndexEvictionStrategy} that evicts sessions whose last-access time is
+ * older than a configured time-to-live (TTL).
+ * <p>
+ * Expiry is evaluated lazily on each {@link #onAccess} call: all tracked sessions (other
+ * than the one currently being accessed) are checked against the TTL, and any that have
+ * exceeded it are returned for eviction. No background thread is used.
+ * <p>
+ * The TTL resets on every access, so a session that continues to receive requests will
+ * not be evicted as long as the gap between consecutive requests stays below the TTL.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public final class TtlEvictionStrategy implements ToolIndexEvictionStrategy {
+
+	private final Duration ttl;
+
+	private final ConcurrentHashMap<String, Instant> lastAccess = new ConcurrentHashMap<>();
+
+	/**
+	 * Creates a new TtlEvictionStrategy.
+	 * @param ttl maximum idle time before a session's index is evicted; must be positive
+	 */
+	public TtlEvictionStrategy(Duration ttl) {
+		Assert.notNull(ttl, "ttl must not be null");
+		Assert.isTrue(!ttl.isNegative() && !ttl.isZero(), "ttl must be positive");
+		this.ttl = ttl;
+	}
+
+	@Override
+	public Set<String> onAccess(String sessionId) {
+		Instant now = Instant.now();
+		this.lastAccess.put(sessionId, now);
+
+		Set<String> expired = new HashSet<>();
+		this.lastAccess.forEach((id, ts) -> {
+			if (!id.equals(sessionId) && Duration.between(ts, now).compareTo(this.ttl) >= 0) {
+				expired.add(id);
+			}
+		});
+		expired.forEach(this.lastAccess::remove);
+		return expired;
+	}
+
+	@Override
+	public void onRemoved(String sessionId) {
+		this.lastAccess.remove(sessionId);
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/package-info.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package for tool index eviction strategies.
+ */
+@NullMarked
+package org.springframework.ai.chat.client.advisor.tool.search.eviction;
+
+import org.jspecify.annotations.NullMarked;

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/package-info.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tool Search Tool Advisor package for dynamic tool discovery and search capabilities.
+ */
+@NullMarked
+package org.springframework.ai.chat.client.advisor.tool.search;
+
+import org.jspecify.annotations.NullMarked;

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/resources/DEFAULT_SYSTEM_PROMPT_SUFFIX.md
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/resources/DEFAULT_SYSTEM_PROMPT_SUFFIX.md
@@ -1,0 +1,2 @@
+
+You have access to a special tool called `toolSearchTool` that allows you to discover relevant tools on-demand. When you need to perform an action but don't see an appropriate tool in your current context, use `toolSearchTool` to search for it.

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/main/resources/DEFAULT_SYSTEM_PROMPT_SUFFIX_LARGE.md
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/main/resources/DEFAULT_SYSTEM_PROMPT_SUFFIX_LARGE.md
@@ -1,0 +1,26 @@
+You are an AI assistant with access to a large library of tools. However, not all tools are loaded into your context initially to conserve context window space and improve accuracy.
+
+### Tool Discovery Process
+
+You have access to a special tool called `toolSearchTool` that allows you to discover relevant tools on-demand. When you need to perform an action but don't see an appropriate tool in your current context, use `toolSearchTool` to search for it.
+
+**How tool search works:**
+1. When you receive a request that may require tools not currently visible to you, call `toolSearchTool` with a search query describing what capability you need
+2. The search will return references to matching tools (typically 3-5 most relevant)
+3. These tool references will be automatically expanded into full tool definitions that you can then use
+4. Select the most appropriate discovered tool and invoke it with the required parameters
+
+**When to use tool search:**
+- When you need a capability not provided by your currently available tools
+- When the user's request implies operations (database queries, API calls, file operations, etc.) that require specific tools
+- When you're unsure which tool to use for a complex task - search can help you discover the right one
+
+**Search query best practices:**
+- Use descriptive keywords related to the functionality you need
+- Include domain-specific terms (e.g., "github pull request", "slack message", "database query")
+- You can search by functionality ("send notification"), by service ("jira"), or by action type ("create ticket")
+
+**Available tool categories in this system:**
+[PLACEHOLDER: List your tool categories here, e.g., "Slack messaging, GitHub operations, database queries, file management, calendar scheduling"]
+
+Remember: After discovering tools via search, you must still invoke them using the standard tool calling mechanism. The search only makes tools visible to you - it doesn't execute them.

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/AbstractToolSearchToolCallingAdvisorIT.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/AbstractToolSearchToolCallingAdvisorIT.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.tool.index.lucene.LuceneToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.index.regex.RegexToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.index.vectorstore.VectorToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse.SearchMetadata;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.method.MethodToolCallback;
+import org.springframework.ai.tool.support.ToolDefinitions;
+import org.springframework.ai.transformers.TransformersEmbeddingModel;
+import org.springframework.ai.vectorstore.SimpleVectorStore;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Abstract base class for {@link ToolSearchToolCallingAdvisor} integration tests. Mirrors
+ * the structure of {@code AbstractToolCallAdvisorIT} but exercises the full tool-search
+ * flow: the LLM first calls {@code toolSearchTool} to discover tools, then invokes the
+ * resolved tool.
+ *
+ * <p>
+ * Each test is parameterized and runs against three {@link ToolIndex} implementations:
+ * {@link RegexToolIndex}, {@link LuceneToolIndex}, and a {@link VectorToolIndex} backed
+ * by a local ONNX embedding model ({@code all-MiniLM-L6-v2} via
+ * {@link TransformersEmbeddingModel}).
+ *
+ * @author Christian Tzolov
+ */
+public abstract class AbstractToolSearchToolCallingAdvisorIT {
+
+	protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+	protected abstract ChatModel getChatModel();
+
+	/**
+	 * Provides the three {@link ToolIndex} implementations used to parameterize every
+	 * test. The {@link VectorToolIndex} variant uses a local ONNX embedding model, which
+	 * is downloaded and cached on first run.
+	 */
+	static Stream<Arguments> toolIndexes() throws Exception {
+		TransformersEmbeddingModel embeddingModel = new TransformersEmbeddingModel();
+		embeddingModel.afterPropertiesSet();
+		VectorToolIndex vectorToolIndex = new VectorToolIndex(SimpleVectorStore.builder(embeddingModel).build());
+
+		return Stream.of(
+				// PassThroughToolIndex returns every indexed tool for any query —
+				// isolates the advisor lifecycle from search-quality variability.
+				Arguments.of(Named.named("PassThroughToolIndex", new PassThroughToolIndex())),
+				Arguments.of(Named.named("RegexToolIndex", new RegexToolIndex())),
+				// Score threshold 0.0f: Lucene BM25 scores are not normalized and drop
+				// very low in a 1-document corpus. IT tests exercise the advisor
+				// lifecycle,
+				// not search ranking, so any positive match is sufficient.
+				Arguments.of(Named.named("LuceneToolIndex", new LuceneToolIndex(0.0f))),
+				Arguments.of(Named.named("VectorToolIndex", vectorToolIndex)));
+	}
+
+	protected ToolSearchToolCallingAdvisor createToolSearchToolCallingAdvisor(ToolIndex toolIndex) {
+		return ToolSearchToolCallingAdvisor.builder().toolIndex(toolIndex).build();
+	}
+
+	protected ToolSearchToolCallingAdvisor createToolSearchToolCallingAdvisorWithExternalMemory(ToolIndex toolIndex) {
+		return ToolSearchToolCallingAdvisor.builder().toolIndex(toolIndex).disableInternalConversationHistory().build();
+	}
+
+	protected ToolCallback createWeatherToolCallback() {
+
+		Method method = ReflectionUtils.findMethod(WeatherTool.class, "currentWeather", String.class);
+		return MethodToolCallback.builder()
+			.toolDefinition(ToolDefinitions.builder(method).description("Get the weather in location").build())
+			.toolMethod(method)
+			.toolObject(new WeatherTool())
+			.build();
+	}
+
+	private static String join(Flux<String> flux) {
+		return Objects.requireNonNull(flux.collectList().block()).stream().collect(Collectors.joining());
+	}
+
+	@Nested
+	class CallTests {
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void callMultipleToolInvocations(ToolIndex toolIndex) {
+			String response = ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(createToolSearchToolCallingAdvisor(toolIndex))
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void callMultipleToolInvocationsWithExternalMemory(ToolIndex toolIndex) {
+			String response = ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(createToolSearchToolCallingAdvisorWithExternalMemory(toolIndex),
+						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
+							.build())
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void callDefaultAdvisorConfiguration(ToolIndex toolIndex) {
+			var chatClient = ChatClient.builder(getChatModel())
+				.defaultAdvisors(createToolSearchToolCallingAdvisor(toolIndex))
+				.build();
+
+			String response = chatClient.prompt()
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void callDefaultAdvisorConfigurationWithExternalMemory(ToolIndex toolIndex) {
+			var chatClient = ChatClient.builder(getChatModel())
+				.defaultAdvisors(createToolSearchToolCallingAdvisorWithExternalMemory(toolIndex),
+						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
+				.build();
+
+			String response = chatClient.prompt()
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+	}
+
+	@Nested
+	class StreamTests {
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void streamMultipleToolInvocations(ToolIndex toolIndex) {
+			Flux<String> response = ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(createToolSearchToolCallingAdvisor(toolIndex))
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.stream()
+				.content();
+
+			String content = join(response);
+			logger.info("Response: {}", content);
+			assertThat(content).contains("30", "10", "15");
+		}
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void streamMultipleToolInvocationsWithExternalMemory(ToolIndex toolIndex) {
+			Flux<String> response = ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(createToolSearchToolCallingAdvisorWithExternalMemory(toolIndex),
+						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
+							.build())
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.stream()
+				.content();
+
+			String content = join(response);
+			logger.info("Response: {}", content);
+			assertThat(content).contains("30", "10", "15");
+		}
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void streamDefaultAdvisorConfiguration(ToolIndex toolIndex) {
+			var chatClient = ChatClient.builder(getChatModel())
+				.defaultAdvisors(createToolSearchToolCallingAdvisor(toolIndex))
+				.build();
+
+			Flux<String> response = chatClient.prompt()
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.stream()
+				.content();
+
+			String content = join(response);
+			logger.info("Response: {}", content);
+			assertThat(content).contains("30", "10", "15");
+		}
+
+		@ParameterizedTest(name = "[{index}] {0}")
+		@MethodSource("org.springframework.ai.chat.client.advisor.tool.search.AbstractToolSearchToolCallingAdvisorIT#toolIndexes")
+		void streamDefaultAdvisorConfigurationWithExternalMemory(ToolIndex toolIndex) {
+			var chatClient = ChatClient.builder(getChatModel())
+				.defaultAdvisors(createToolSearchToolCallingAdvisorWithExternalMemory(toolIndex),
+						MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
+				.build();
+
+			Flux<String> response = chatClient.prompt()
+				.user("Use the weather tool to get the current temperature in San Francisco, Tokyo, and Paris. Report the exact readings in Celsius.")
+				.toolCallbacks(createWeatherToolCallback())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "chat_memory_conversation_id"))
+				.stream()
+				.content();
+
+			String content = join(response);
+			logger.info("Response: {}", content);
+			assertThat(content).contains("30", "10", "15");
+		}
+
+	}
+
+	/**
+	 * A ToolIndex that returns every indexed tool for any query. Suitable for integration
+	 * tests where search quality is irrelevant — all that matters is that the advisor
+	 * lifecycle (index → search → expand → invoke) works end-to-end.
+	 */
+	static class PassThroughToolIndex implements ToolIndex {
+
+		private final ConcurrentHashMap<String, List<ToolReference>> sessionTools = new ConcurrentHashMap<>();
+
+		@Override
+		public void indexTool(String sessionId, ToolReference toolReference) {
+			this.sessionTools.computeIfAbsent(sessionId, k -> new CopyOnWriteArrayList<>()).add(toolReference);
+		}
+
+		@Override
+		public void clearIndex(String sessionId) {
+			this.sessionTools.remove(sessionId);
+		}
+
+		@Override
+		public ToolSearchResponse search(ToolSearchRequest req) {
+			List<ToolReference> refs = this.sessionTools.getOrDefault(req.sessionId(), List.of());
+			return ToolSearchResponse.builder()
+				.toolReferences(refs)
+				.totalMatches(refs.size())
+				.searchMetadata(SearchMetadata.builder().searchType("PassThroughToolIndex").query(req.query()).build())
+				.build();
+		}
+
+	}
+
+	public static class WeatherTool {
+
+		@Tool(description = "Get the current temperature in Celsius for a location or comma-separated list of locations")
+		public String currentWeather(String location) {
+			String loc = location.toLowerCase();
+			StringBuilder result = new StringBuilder();
+			if (loc.contains("san francisco") || loc.contains("francisco")) {
+				result.append("San Francisco: 30°C");
+			}
+			if (loc.contains("tokyo")) {
+				if (!result.isEmpty()) {
+					result.append(", ");
+				}
+				result.append("Tokyo: 10°C");
+			}
+			if (loc.contains("paris")) {
+				if (!result.isEmpty()) {
+					result.append(", ");
+				}
+				result.append("Paris: 15°C");
+			}
+			// If the LLM passed an unrecognised location string, return all readings so
+			// the test can still verify the end-to-end flow.
+			return result.isEmpty() ? "San Francisco: 30°C, Tokyo: 10°C, Paris: 15°C" : result.toString();
+		}
+
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/OpenAiToolSearchToolCallingAdvisorIT.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/OpenAiToolSearchToolCallingAdvisorIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search;
+
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+/**
+ * OpenAI-backed integration tests for {@link ToolSearchToolCallingAdvisor}.
+ *
+ * <p>
+ * Requires the {@code OPENAI_API_KEY} environment variable to be set.
+ *
+ * @author Christian Tzolov
+ */
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+class OpenAiToolSearchToolCallingAdvisorIT extends AbstractToolSearchToolCallingAdvisorIT {
+
+	@Override
+	protected ChatModel getChatModel() {
+		return OpenAiChatModel.builder()
+			.options(OpenAiChatOptions.builder()
+				.apiKey(System.getenv("OPENAI_API_KEY"))
+				.model(OpenAiChatOptions.DEFAULT_CHAT_MODEL)
+				.build())
+			.build();
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/ToolSearchToolCallingAdvisorCallTests.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/ToolSearchToolCallingAdvisorCallTests.java
@@ -1,0 +1,882 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.DefaultAroundAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchRequest;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolSearchResponse;
+import org.springframework.ai.chat.client.advisor.tool.search.eviction.LruEvictionStrategy;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ToolSearchToolCallingAdvisor}.
+ *
+ * @author Christian Tzolov
+ */
+@ExtendWith(MockitoExtension.class)
+public class ToolSearchToolCallingAdvisorCallTests {
+
+	@Mock
+	private ToolCallingManager toolCallingManager;
+
+	@Mock
+	private ToolIndex toolIndex;
+
+	@Test
+	void whenToolIndexIsNullThenThrow() {
+		assertThatThrownBy(() -> ToolSearchToolCallingAdvisor.builder().build())
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void testBuilderMethodChaining() {
+		ToolIndex customSearcher = mock(ToolIndex.class);
+		ToolCallingManager customManager = mock(ToolCallingManager.class);
+		int customOrder = BaseAdvisor.HIGHEST_PRECEDENCE + 500;
+		String customSuffix = "\n\nCustom suffix";
+
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(customManager)
+			.advisorOrder(customOrder)
+			.toolIndex(customSearcher)
+			.systemMessageSuffix(customSuffix)
+			.referenceToolNameAccumulation(false)
+			.maxResults(10)
+			.evictionStrategy(new LruEvictionStrategy(50))
+			.build();
+
+		assertThat(advisor).isNotNull();
+		assertThat(advisor.getOrder()).isEqualTo(customOrder);
+		assertThat(advisor.getName()).isEqualTo("ToolSearchToolCallingAdvisor");
+	}
+
+	@Test
+	void testDefaultValues() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder().toolIndex(this.toolIndex).build();
+
+		assertThat(advisor).isNotNull();
+		assertThat(advisor.getOrder()).isEqualTo(BaseAdvisor.HIGHEST_PRECEDENCE + 300);
+		assertThat(advisor.getName()).isEqualTo("ToolSearchToolCallingAdvisor");
+	}
+
+	@Test
+	void testInitializeLoopIndexesTools() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.systemMessageSuffix("\n\nTest suffix")
+			.build();
+
+		// Create mock tool definitions
+		ToolDefinition toolDef1 = DefaultToolDefinition.builder()
+			.name("tool1")
+			.description("Description for tool1")
+			.inputSchema("{}")
+			.build();
+		ToolDefinition toolDef2 = DefaultToolDefinition.builder()
+			.name("tool2")
+			.description("Description for tool2")
+			.inputSchema("{}")
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(toolDef1, toolDef2));
+
+		ChatClientRequest request = createMockRequest(true);
+		ChatClientResponse response = createMockResponse(false);
+
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> response);
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		advisor.adviseCall(request, realChain);
+
+		// Verify that indexTools was called once with all tool definitions
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<ToolReference>> toolRefsCaptor = ArgumentCaptor.forClass(List.class);
+
+		verify(this.toolIndex).indexTools(anyString(), toolRefsCaptor.capture());
+
+		List<ToolReference> indexedTools = toolRefsCaptor.getValue();
+		assertThat(indexedTools).hasSize(2);
+		assertThat(indexedTools.get(0).toolName()).isEqualTo("tool1");
+		assertThat(indexedTools.get(1).toolName()).isEqualTo("tool2");
+	}
+
+	@Test
+	void testInitializeLoopAugmentsSystemMessage() {
+		String customSuffix = "\n\nCUSTOM SUFFIX FOR TESTING";
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.systemMessageSuffix(customSuffix)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		SystemMessage originalSystemMessage = new SystemMessage("Original system message");
+		UserMessage userMessage = new UserMessage("test");
+
+		ToolCallingChatOptions toolOptions = mock(ToolCallingChatOptions.class,
+				Mockito.withSettings().strictness(Strictness.LENIENT));
+		when(toolOptions.copy()).thenReturn(toolOptions);
+		when(toolOptions.getInternalToolExecutionEnabled()).thenReturn(false);
+		doReturn(ToolCallingChatOptions.builder()).when(toolOptions).mutate();
+
+		Prompt prompt = new Prompt(List.of(originalSystemMessage, userMessage), toolOptions);
+		Map<String, Object> augmentContext = new ConcurrentHashMap<>();
+		augmentContext.put(ChatMemory.CONVERSATION_ID, "test-session-id");
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.build()
+			.mutate()
+			.context(augmentContext)
+			.build();
+
+		ChatClientResponse response = createMockResponse(false);
+
+		// Capture the augmented request
+		ChatClientRequest[] capturedRequest = new ChatClientRequest[1];
+		CallAdvisor capturingAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			capturedRequest[0] = req;
+			return response;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, capturingAdvisor))
+			.build();
+
+		advisor.adviseCall(request, realChain);
+
+		// Verify system message was augmented
+		assertThat(capturedRequest[0]).isNotNull();
+		List<Message> messages = capturedRequest[0].prompt().getInstructions();
+		SystemMessage augmentedSystemMessage = (SystemMessage) messages.get(0);
+		assertThat(augmentedSystemMessage.getText()).contains("Original system message");
+		assertThat(augmentedSystemMessage.getText()).contains(customSuffix);
+	}
+
+	/**
+	 * First request for a new session: clearIndex + indexTools are called once
+	 * (fingerprint miss). No cleanup happens in doFinalizeLoop — the index stays alive
+	 * for the next turn.
+	 */
+	@Test
+	void testFirstRequest_indexesToolsOnce() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		ChatClientRequest request = createMockRequest(true);
+		ChatClientResponse response = createMockResponse(false);
+
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> response);
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		advisor.adviseCall(request, realChain);
+
+		// clearIndex once (fingerprint miss) + indexTools once
+		verify(this.toolIndex, times(1)).clearIndex(anyString());
+		verify(this.toolIndex, times(1)).indexTools(anyString(), any());
+	}
+
+	/**
+	 * Second request for the same session with the same tool set: clearIndex and
+	 * indexTools are NOT called again — the cached index is reused.
+	 */
+	@Test
+	void testSecondRequest_sameTools_skipsReindexing() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		ToolDefinition toolDef = DefaultToolDefinition.builder()
+			.name("weatherTool")
+			.description("Gets the weather")
+			.inputSchema("{}")
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(toolDef));
+
+		ChatClientRequest request = createMockRequest(true, "conv-1");
+		ChatClientResponse response = createMockResponse(false);
+		CallAdvisorChain chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+
+		// First request — indexes once
+		advisor.adviseCall(request, chain);
+		verify(this.toolIndex, times(1)).indexTools(anyString(), any());
+
+		// Second request — same session, same tools → no re-indexing
+		chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+		advisor.adviseCall(createMockRequest(true, "conv-1"), chain);
+
+		verify(this.toolIndex, times(1)).indexTools(anyString(), any()); // still only
+																			// 1
+		verify(this.toolIndex, times(1)).clearIndex(anyString()); // still only 1
+	}
+
+	/**
+	 * Second request for the same session with a changed tool set: clearIndex and
+	 * indexTools are called again to refresh the index.
+	 */
+	@Test
+	void testSecondRequest_differentTools_reindexes() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		ToolDefinition toolDef1 = DefaultToolDefinition.builder()
+			.name("weatherTool")
+			.description("Gets the weather")
+			.inputSchema("{}")
+			.build();
+		ToolDefinition toolDef2 = DefaultToolDefinition.builder()
+			.name("calculatorTool")
+			.description("Does math")
+			.inputSchema("{}")
+			.build();
+
+		// First request: only weatherTool
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(toolDef1));
+
+		ChatClientResponse response = createMockResponse(false);
+		CallAdvisorChain chain1 = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+		advisor.adviseCall(createMockRequest(true, "conv-1"), chain1);
+		verify(this.toolIndex, times(1)).indexTools(anyString(), any());
+
+		// Second request: different tool set → re-index
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(toolDef1, toolDef2));
+		CallAdvisorChain chain2 = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+		advisor.adviseCall(createMockRequest(true, "conv-1"), chain2);
+
+		verify(this.toolIndex, times(2)).indexTools(anyString(), any()); // re-indexed
+		verify(this.toolIndex, times(2)).clearIndex(anyString()); // clear before each
+																	// index
+	}
+
+	/**
+	 * With LruEvictionStrategy(1), accessing a second session evicts the first.
+	 */
+	@Test
+	void testLruEviction_evictsLruSessionWhenCapacityExceeded() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.evictionStrategy(new LruEvictionStrategy(1))
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		ChatClientResponse response = createMockResponse(false);
+
+		// Session A
+		CallAdvisorChain chainA = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+		advisor.adviseCall(createMockRequest(true, "session-A"), chainA);
+
+		// Verify session A was indexed (clearIndex + indexTools for fingerprint miss)
+		ArgumentCaptor<String> clearCaptor = ArgumentCaptor.forClass(String.class);
+		verify(this.toolIndex, times(1)).clearIndex(clearCaptor.capture());
+		assertThat(clearCaptor.getAllValues()).containsExactly("session-A");
+
+		// Session B — should evict session A (capacity = 1)
+		CallAdvisorChain chainB = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+		advisor.adviseCall(createMockRequest(true, "session-B"), chainB);
+
+		// clearIndex called twice: once for session-A eviction, once for session-B
+		// fingerprint miss
+		verify(this.toolIndex, times(3)).clearIndex(clearCaptor.capture());
+		List<String> allClears = clearCaptor.getAllValues();
+		assertThat(allClears).contains("session-A", "session-B");
+	}
+
+	/**
+	 * evictSession() clears the index and removes the fingerprint so the next request
+	 * re-indexes.
+	 */
+	@Test
+	void testEvictSession_forcesReindexOnNextRequest() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		ToolDefinition toolDef = DefaultToolDefinition.builder()
+			.name("tool1")
+			.description("desc")
+			.inputSchema("{}")
+			.build();
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(toolDef));
+
+		ChatClientResponse response = createMockResponse(false);
+
+		// First request — indexes
+		CallAdvisorChain chain1 = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+		advisor.adviseCall(createMockRequest(true, "conv-1"), chain1);
+		verify(this.toolIndex, times(1)).indexTools(anyString(), any());
+
+		// Explicit eviction
+		advisor.evictSession("conv-1");
+		verify(this.toolIndex, times(2)).clearIndex("conv-1");
+
+		// Next request must re-index (fingerprint was removed)
+		CallAdvisorChain chain2 = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+		advisor.adviseCall(createMockRequest(true, "conv-1"), chain2);
+		verify(this.toolIndex, times(2)).indexTools(anyString(), any());
+	}
+
+	@Test
+	void testBeforeCallExtractsToolReferences() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		// Create a request with tool response messages containing tool references
+		ToolResponseMessage.ToolResponse toolSearchResponse = new ToolResponseMessage.ToolResponse("id1",
+				"toolSearchTool", "[\"weatherTool\", \"calculatorTool\"]");
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(toolSearchResponse))
+			.build();
+
+		SystemMessage systemMessage = new SystemMessage("System message");
+		UserMessage userMessage = new UserMessage("test");
+		AssistantMessage assistantMessage = AssistantMessage.builder().content("Using tool search").build();
+
+		// Use real TestToolCallingChatOptions instead of mocking
+		TestToolCallingChatOptions toolOptions = new TestToolCallingChatOptions();
+
+		Prompt prompt = new Prompt(List.of(systemMessage, userMessage, assistantMessage, toolResponseMessage),
+				toolOptions);
+		Map<String, Object> extractContext = new ConcurrentHashMap<>();
+		extractContext.put(ChatMemory.CONVERSATION_ID, "test-session-id");
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.build()
+			.mutate()
+			.context(extractContext)
+			.build();
+
+		ChatClientResponse response = createMockResponse(false);
+
+		// Capture the request to verify tool names were extracted
+		ChatClientRequest[] capturedRequest = new ChatClientRequest[1];
+		CallAdvisor capturingAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			capturedRequest[0] = req;
+			return response;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, capturingAdvisor))
+			.build();
+
+		advisor.adviseCall(request, realChain);
+
+		// Verify tool names were extracted
+		assertThat(capturedRequest[0]).isNotNull();
+		ToolCallingChatOptions capturedOptions = (ToolCallingChatOptions) capturedRequest[0].prompt().getOptions();
+		// The tool search tool callback should be present
+		assertThat(capturedOptions.getToolCallbacks()).hasSize(1);
+		assertThat(capturedOptions.getToolCallbacks().get(0).getToolDefinition().name()).isEqualTo("toolSearchTool");
+		assertThat(capturedOptions.getToolNames()).contains("weatherTool", "calculatorTool");
+	}
+
+	@Test
+	void testConversationIdFromContext() {
+		String expectedConversationId = "test-conversation-123";
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		ChatClientResponse response = createMockResponse(false);
+		CallAdvisor terminalAdvisor = new TerminalCallAdvisor((req, chain) -> response);
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, terminalAdvisor))
+			.build();
+
+		advisor.adviseCall(createMockRequest(true, expectedConversationId), realChain);
+
+		// clearIndex is called exactly once for the fingerprint miss; doFinalizeLoop no
+		// longer clears the index.
+		ArgumentCaptor<String> sessionIdCaptor = ArgumentCaptor.forClass(String.class);
+		verify(this.toolIndex, times(1)).clearIndex(sessionIdCaptor.capture());
+		assertThat(sessionIdCaptor.getValue()).isEqualTo(expectedConversationId);
+	}
+
+	@Test
+	void testToolSearchToolCallbackIsRegistered() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		ChatClientRequest request = createMockRequest(true);
+		ChatClientResponse response = createMockResponse(false);
+
+		// Capture the request to verify toolSearchTool callback is present
+		ChatClientRequest[] capturedRequest = new ChatClientRequest[1];
+		CallAdvisor capturingAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			capturedRequest[0] = req;
+			return response;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, capturingAdvisor))
+			.build();
+
+		advisor.adviseCall(request, realChain);
+
+		assertThat(capturedRequest[0]).isNotNull();
+		ToolCallingChatOptions capturedOptions = (ToolCallingChatOptions) capturedRequest[0].prompt().getOptions();
+		assertThat(capturedOptions.getToolCallbacks()).isNotEmpty();
+
+		// Find the toolSearchTool callback
+		boolean foundToolSearchTool = capturedOptions.getToolCallbacks()
+			.stream()
+			.anyMatch(callback -> "toolSearchTool".equals(callback.getToolDefinition().name()));
+
+		assertThat(foundToolSearchTool).isTrue();
+	}
+
+	@Test
+	void testCachedToolCallbacksAreUsed() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		// Create a mock tool callback
+		ToolCallback mockToolCallback = mock(ToolCallback.class);
+		ToolDefinition mockToolDef = DefaultToolDefinition.builder()
+			.name("weatherTool")
+			.description("Gets weather")
+			.inputSchema("{}")
+			.build();
+		when(mockToolCallback.getToolDefinition()).thenReturn(mockToolDef);
+
+		// Use real TestToolCallingChatOptions with the tool callback configured
+		TestToolCallingChatOptions toolOptions = new TestToolCallingChatOptions();
+		toolOptions.setToolCallbacks(List.of(mockToolCallback));
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(mockToolDef));
+
+		// Create a request with tool response message referencing the weatherTool
+		ToolResponseMessage.ToolResponse toolSearchResponse = new ToolResponseMessage.ToolResponse("id1",
+				"toolSearchTool", "[\"weatherTool\"]");
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(toolSearchResponse))
+			.build();
+
+		UserMessage userMessage = new UserMessage("test");
+
+		Prompt prompt = new Prompt(List.of(userMessage, toolResponseMessage), toolOptions);
+		Map<String, Object> cachedContext = new ConcurrentHashMap<>();
+		cachedContext.put(ChatMemory.CONVERSATION_ID, "test-session-id");
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.build()
+			.mutate()
+			.context(cachedContext)
+			.build();
+
+		ChatClientResponse response = createMockResponse(false);
+
+		// Capture the request to verify both toolSearchTool and weatherTool are present
+		ChatClientRequest[] capturedRequest = new ChatClientRequest[1];
+		CallAdvisor capturingAdvisor = new TerminalCallAdvisor((req, chain) -> {
+			capturedRequest[0] = req;
+			return response;
+		});
+
+		CallAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, capturingAdvisor))
+			.build();
+
+		advisor.adviseCall(request, realChain);
+
+		// Verify the tool was indexed
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<ToolReference>> indexedToolsCaptor = ArgumentCaptor.forClass(List.class);
+		verify(this.toolIndex).indexTools(anyString(), indexedToolsCaptor.capture());
+		assertThat(indexedToolsCaptor.getValue()).extracting(ToolReference::toolName).containsExactly("weatherTool");
+
+		// Verify capturedOptions contains both toolSearchTool and weatherTool
+		assertThat(capturedRequest[0]).isNotNull();
+		ToolCallingChatOptions capturedOptions = (ToolCallingChatOptions) capturedRequest[0].prompt().getOptions();
+
+		assertThat(capturedOptions.getToolCallbacks()
+			.stream()
+			.anyMatch(cb -> "toolSearchTool".equals(cb.getToolDefinition().name()))).isTrue();
+
+		assertThat(capturedOptions.getToolCallbacks()
+			.stream()
+			.anyMatch(cb -> "weatherTool".equals(cb.getToolDefinition().name()))).isTrue();
+	}
+
+	@Test
+	void toolSearchToolUsesLlmMaxResultsOverAdvisorDefault() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.maxResults(3)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of());
+		when(this.toolIndex.search(any())).thenReturn(new ToolSearchResponse(List.of(), null, null));
+
+		ToolCallingChatOptions opts = captureToolOptions(advisor);
+		invokeToolSearchTool(opts, "{\"query\":\"weather\",\"maxResults\":7}");
+
+		ArgumentCaptor<ToolSearchRequest> captor = ArgumentCaptor.forClass(ToolSearchRequest.class);
+		verify(this.toolIndex).search(captor.capture());
+		assertThat(captor.getValue().maxResults()).isEqualTo(7);
+	}
+
+	@Test
+	void toolSearchToolFallsBackToAdvisorMaxResultsWhenLlmOmits() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.maxResults(3)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of());
+		when(this.toolIndex.search(any())).thenReturn(new ToolSearchResponse(List.of(), null, null));
+
+		ToolCallingChatOptions opts = captureToolOptions(advisor);
+		invokeToolSearchTool(opts, "{\"query\":\"weather\"}");
+
+		ArgumentCaptor<ToolSearchRequest> captor = ArgumentCaptor.forClass(ToolSearchRequest.class);
+		verify(this.toolIndex).search(captor.capture());
+		assertThat(captor.getValue().maxResults()).isEqualTo(3);
+	}
+
+	/**
+	 * doFinalizeLoop must NOT call clearIndex — the index persists for the next turn.
+	 */
+	@Test
+	void testFinalizeLoop_doesNotClearIndex() {
+		ToolSearchToolCallingAdvisor advisor = ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.build();
+
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class))).thenReturn(List.of());
+
+		ChatClientResponse response = createMockResponse(false);
+		CallAdvisorChain chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, c) -> response)))
+			.build();
+
+		advisor.adviseCall(createMockRequest(true), chain);
+
+		// Only the fingerprint-miss clearIndex at init; finalize does NOT add another.
+		verify(this.toolIndex, times(1)).clearIndex(anyString());
+	}
+
+	// Helper methods
+
+	private ToolCallingChatOptions captureToolOptions(ToolSearchToolCallingAdvisor advisor) {
+		ChatClientRequest[] captured = new ChatClientRequest[1];
+		CallAdvisorChain chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalCallAdvisor((req, ch) -> {
+				captured[0] = req;
+				return createMockResponse(false);
+			})))
+			.build();
+		advisor.adviseCall(createMockRequest(true), chain);
+		return (ToolCallingChatOptions) captured[0].prompt().getOptions();
+	}
+
+	private void invokeToolSearchTool(ToolCallingChatOptions opts, String toolInput) {
+		ToolCallback callback = opts.getToolCallbacks()
+			.stream()
+			.filter(cb -> "toolSearchTool".equals(cb.getToolDefinition().name()))
+			.findFirst()
+			.orElseThrow();
+		String sessionId = opts.getToolContext().get("toolSearchToolSessionId").toString();
+		callback.call(toolInput,
+				new org.springframework.ai.chat.model.ToolContext(Map.of("toolSearchToolSessionId", sessionId)));
+	}
+
+	private ChatClientRequest createMockRequest(boolean withToolCallingOptions) {
+		return createMockRequest(withToolCallingOptions, "test-session-id");
+	}
+
+	private ChatClientRequest createMockRequest(boolean withToolCallingOptions, String conversationId) {
+		List<Message> instructions = List.of(new SystemMessage("System message"), new UserMessage("test message"));
+
+		ChatOptions options = null;
+		if (withToolCallingOptions) {
+			// Use a real TestToolCallingChatOptions instead of mocking to avoid Byte
+			// Buddy issues on Java 25
+			options = new TestToolCallingChatOptions();
+		}
+
+		Prompt prompt = new Prompt(instructions, options);
+
+		Map<String, Object> context = new ConcurrentHashMap<>();
+		context.put(ChatMemory.CONVERSATION_ID, conversationId);
+
+		return ChatClientRequest.builder().prompt(prompt).build().mutate().context(context).build();
+	}
+
+	private ChatClientResponse createMockResponse(boolean hasToolCalls, Map<String, Object> context) {
+		// Create real objects instead of mocking to avoid Byte Buddy issues with Java 25
+		AssistantMessage assistantMessage;
+		if (hasToolCalls) {
+			// Create an assistant message with a tool call to make hasToolCalls() return
+			// true
+			assistantMessage = AssistantMessage.builder()
+				.content("response")
+				.toolCalls(List.of(new AssistantMessage.ToolCall("id1", "tool", "toolName", "{}")))
+				.build();
+		}
+		else {
+			assistantMessage = new AssistantMessage("response");
+		}
+		Generation generation = new Generation(assistantMessage);
+
+		// Create a real ChatResponse - hasToolCalls() is derived from generations' tool
+		// calls
+		ChatResponse chatResponse = ChatResponse.builder().generations(List.of(generation)).build();
+
+		// Create a real ChatClientResponse using the builder with context from request
+		return ChatClientResponse.builder()
+			.chatResponse(chatResponse)
+			.context(context != null ? context : new ConcurrentHashMap<>())
+			.build();
+	}
+
+	private ChatClientResponse createMockResponse(boolean hasToolCalls) {
+		return createMockResponse(hasToolCalls, new ConcurrentHashMap<>());
+	}
+
+	private static class TerminalCallAdvisor implements CallAdvisor {
+
+		private final BiFunction<ChatClientRequest, CallAdvisorChain, ChatClientResponse> responseFunction;
+
+		TerminalCallAdvisor(BiFunction<ChatClientRequest, CallAdvisorChain, ChatClientResponse> responseFunction) {
+			this.responseFunction = responseFunction;
+		}
+
+		@Override
+		public String getName() {
+			return "terminal";
+		}
+
+		@Override
+		public int getOrder() {
+			return 0;
+		}
+
+		@Override
+		public ChatClientResponse adviseCall(ChatClientRequest req, CallAdvisorChain chain) {
+			ChatClientResponse response = this.responseFunction.apply(req, chain);
+			// Ensure the response has the context from the request (including
+			// cachedToolCallbacks, etc.)
+			Map<String, Object> mergedContext = new ConcurrentHashMap<>(req.context());
+			mergedContext.putAll(response.context());
+			return response.mutate().context(mergedContext).build();
+		}
+
+	}
+
+	/**
+	 * Simple test implementation of ToolCallingChatOptions to avoid Mockito/ByteBuddy
+	 * issues on Java 25. Implements the required methods with sensible defaults.
+	 */
+	private static class TestToolCallingChatOptions implements ToolCallingChatOptions {
+
+		private boolean internalToolExecutionEnabled = true;
+
+		private List<ToolCallback> toolCallbacks = new ArrayList<>();
+
+		private java.util.Set<String> toolNames = new java.util.HashSet<>();
+
+		private Map<String, Object> toolContext = new java.util.HashMap<>();
+
+		@Override
+		public List<ToolCallback> getToolCallbacks() {
+			return this.toolCallbacks;
+		}
+
+		public void setToolCallbacks(List<ToolCallback> toolCallbacks) {
+			this.toolCallbacks = toolCallbacks != null ? toolCallbacks : new ArrayList<>();
+		}
+
+		@Override
+		public java.util.Set<String> getToolNames() {
+			return this.toolNames;
+		}
+
+		@Override
+		public Boolean getInternalToolExecutionEnabled() {
+			return this.internalToolExecutionEnabled;
+		}
+
+		@Override
+		public Map<String, Object> getToolContext() {
+			return this.toolContext;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public TestToolCallingChatOptions copy() {
+			TestToolCallingChatOptions copy = new TestToolCallingChatOptions();
+			copy.internalToolExecutionEnabled = this.internalToolExecutionEnabled;
+			copy.toolCallbacks = new ArrayList<>(this.toolCallbacks);
+			copy.toolNames = new java.util.HashSet<>(this.toolNames);
+			copy.toolContext = new java.util.HashMap<>(this.toolContext);
+			return copy;
+		}
+
+		@Override
+		public ToolCallingChatOptions.Builder<?> mutate() {
+			return ToolCallingChatOptions.builder()
+				.toolCallbacks(this.toolCallbacks)
+				.toolNames(this.toolNames)
+				.toolContext(this.toolContext)
+				.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
+		}
+
+		// ChatOptions methods - return null or defaults for unused options
+		@Override
+		public String getModel() {
+			return null;
+		}
+
+		@Override
+		public Double getFrequencyPenalty() {
+			return null;
+		}
+
+		@Override
+		public Integer getMaxTokens() {
+			return null;
+		}
+
+		@Override
+		public Double getPresencePenalty() {
+			return null;
+		}
+
+		@Override
+		public List<String> getStopSequences() {
+			return null;
+		}
+
+		@Override
+		public Double getTemperature() {
+			return null;
+		}
+
+		@Override
+		public Integer getTopK() {
+			return null;
+		}
+
+		@Override
+		public Double getTopP() {
+			return null;
+		}
+
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/ToolSearchToolCallingAdvisorStreamTests.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/ToolSearchToolCallingAdvisorStreamTests.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.DefaultAroundAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
+import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndex;
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolReference;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Streaming-path tests for {@link ToolSearchToolCallingAdvisor}.
+ *
+ * @author Christian Tzolov
+ */
+@ExtendWith(MockitoExtension.class)
+class ToolSearchToolCallingAdvisorStreamTests {
+
+	@Mock
+	private ToolCallingManager toolCallingManager;
+
+	@Mock
+	private ToolIndex toolIndex;
+
+	@Test
+	void streamInitializeLoopIndexesTools() {
+		ToolSearchToolCallingAdvisor advisor = advisor("\n\nTest suffix");
+
+		ToolDefinition td1 = toolDef("tool1", "Desc 1");
+		ToolDefinition td2 = toolDef("tool2", "Desc 2");
+		when(this.toolCallingManager.resolveToolDefinitions(any(ToolCallingChatOptions.class)))
+			.thenReturn(List.of(td1, td2));
+
+		drainStream(advisor, (req, ch) -> Flux.just(withContext(response(false), req)));
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<ToolReference>> captor = ArgumentCaptor.forClass(List.class);
+		verify(this.toolIndex).indexTools(anyString(), captor.capture());
+		assertThat(captor.getValue()).extracting(ToolReference::toolName).containsExactly("tool1", "tool2");
+	}
+
+	@Test
+	void streamInitializeLoopAugmentsSystemMessage() {
+		String suffix = "\n\nCUSTOM SUFFIX";
+		ToolSearchToolCallingAdvisor advisor = advisor(suffix);
+		when(this.toolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of());
+
+		ChatClientRequest[] captured = new ChatClientRequest[1];
+		drainStream(advisor, (req, ch) -> {
+			captured[0] = req;
+			return Flux.just(withContext(response(false), req));
+		});
+
+		SystemMessage sysMsg = (SystemMessage) captured[0].prompt().getInstructions().get(0);
+		assertThat(sysMsg.getText()).contains("System message").contains(suffix);
+	}
+
+	@Test
+	void streamFirstRequest_indexesOnce() {
+		ToolSearchToolCallingAdvisor advisor = advisor();
+		when(this.toolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of());
+
+		drainStream(advisor, (req, ch) -> Flux.just(withContext(response(false), req)));
+
+		// clearIndex is called once for the fingerprint miss; doAfterStream no longer
+		// clears — the index persists for the next turn.
+		verify(this.toolIndex, times(1)).clearIndex(anyString());
+		verify(this.toolIndex, times(1)).indexTools(anyString(), any());
+	}
+
+	@Test
+	void streamBeforeIterationExtractsToolReferences() {
+		ToolSearchToolCallingAdvisor advisor = advisor();
+		when(this.toolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of());
+
+		ToolResponseMessage toolResponseMessage = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "toolSearchTool",
+					"[\"weatherTool\", \"calculatorTool\"]")))
+			.build();
+
+		Prompt prompt = new Prompt(
+				List.of(new SystemMessage("System message"), new UserMessage("test"), toolResponseMessage),
+				new TestToolCallingChatOptions());
+		Map<String, Object> extractContext = new ConcurrentHashMap<>();
+		extractContext.put(ChatMemory.CONVERSATION_ID, "test-session-id");
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(prompt)
+			.build()
+			.mutate()
+			.context(extractContext)
+			.build();
+
+		ChatClientRequest[] captured = new ChatClientRequest[1];
+		StreamAdvisorChain chain = buildChain(advisor, (req, ch) -> {
+			captured[0] = req;
+			return Flux.just(withContext(response(false), req));
+		});
+		advisor.adviseStream(request, chain).collectList().block();
+
+		ToolCallingChatOptions opts = (ToolCallingChatOptions) captured[0].prompt().getOptions();
+		assertThat(opts.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactly("toolSearchTool");
+		assertThat(opts.getToolNames()).containsExactlyInAnyOrder("weatherTool", "calculatorTool");
+	}
+
+	@Test
+	void streamUsesConversationIdFromContext() {
+		String conversationId = "stream-session-42";
+		ToolSearchToolCallingAdvisor advisor = advisor();
+		when(this.toolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of());
+
+		Map<String, Object> ctx = new ConcurrentHashMap<>();
+		ctx.put(ChatMemory.CONVERSATION_ID, conversationId);
+		ChatClientRequest request = createRequest().mutate().context(ctx).build();
+
+		StreamAdvisorChain chain = buildChain(advisor, (req, ch) -> Flux.just(withContext(response(false), req)));
+		advisor.adviseStream(request, chain).collectList().block();
+
+		// clearIndex once for the fingerprint miss; doAfterStream does not clear.
+		ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+		verify(this.toolIndex, times(1)).clearIndex(idCaptor.capture());
+		assertThat(idCaptor.getValue()).isEqualTo(conversationId);
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	private ToolSearchToolCallingAdvisor advisor() {
+		return advisor("\n\nDefault suffix");
+	}
+
+	private ToolSearchToolCallingAdvisor advisor(String suffix) {
+		return ToolSearchToolCallingAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.toolIndex(this.toolIndex)
+			.systemMessageSuffix(suffix)
+			.build();
+	}
+
+	private void drainStream(ToolSearchToolCallingAdvisor advisor,
+			BiFunction<ChatClientRequest, StreamAdvisorChain, Flux<ChatClientResponse>> terminal) {
+		buildChain(advisor, terminal);
+		advisor.adviseStream(createRequest(), buildChain(advisor, terminal)).collectList().block();
+	}
+
+	private StreamAdvisorChain buildChain(ToolSearchToolCallingAdvisor advisor,
+			BiFunction<ChatClientRequest, StreamAdvisorChain, Flux<ChatClientResponse>> terminal) {
+		return DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor, new TerminalStreamAdvisor(terminal)))
+			.build();
+	}
+
+	private ChatClientRequest createRequest() {
+		Map<String, Object> context = new ConcurrentHashMap<>();
+		context.put(ChatMemory.CONVERSATION_ID, "test-session-id");
+		return ChatClientRequest.builder()
+			.prompt(new Prompt(List.of(new SystemMessage("System message"), new UserMessage("test")),
+					new TestToolCallingChatOptions()))
+			.build()
+			.mutate()
+			.context(context)
+			.build();
+	}
+
+	private ChatClientResponse response(boolean hasToolCalls) {
+		AssistantMessage msg = hasToolCalls ? AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("id", "tool", "name", "{}")))
+			.build() : new AssistantMessage("response");
+		return ChatClientResponse.builder()
+			.chatResponse(ChatResponse.builder().generations(List.of(new Generation(msg))).build())
+			.context(new ConcurrentHashMap<>())
+			.build();
+	}
+
+	// Merges the request context into the response so doAfterStream can find the session
+	// ID.
+	private ChatClientResponse withContext(ChatClientResponse response, ChatClientRequest request) {
+		Map<String, Object> merged = new ConcurrentHashMap<>(request.context());
+		merged.putAll(response.context());
+		return response.mutate().context(merged).build();
+	}
+
+	private static ToolDefinition toolDef(String name, String description) {
+		return DefaultToolDefinition.builder().name(name).description(description).inputSchema("{}").build();
+	}
+
+	private static class TerminalStreamAdvisor implements StreamAdvisor {
+
+		private final BiFunction<ChatClientRequest, StreamAdvisorChain, Flux<ChatClientResponse>> fn;
+
+		TerminalStreamAdvisor(BiFunction<ChatClientRequest, StreamAdvisorChain, Flux<ChatClientResponse>> fn) {
+			this.fn = fn;
+		}
+
+		@Override
+		public String getName() {
+			return "terminal";
+		}
+
+		@Override
+		public int getOrder() {
+			return 0;
+		}
+
+		@Override
+		public Flux<ChatClientResponse> adviseStream(ChatClientRequest req, StreamAdvisorChain chain) {
+			return this.fn.apply(req, chain);
+		}
+
+	}
+
+	private static class TestToolCallingChatOptions implements ToolCallingChatOptions {
+
+		private boolean internalToolExecutionEnabled = true;
+
+		private List<ToolCallback> toolCallbacks = new ArrayList<>();
+
+		private Set<String> toolNames = new HashSet<>();
+
+		private Map<String, Object> toolContext = new HashMap<>();
+
+		@Override
+		public List<ToolCallback> getToolCallbacks() {
+			return this.toolCallbacks;
+		}
+
+		@Override
+		public Set<String> getToolNames() {
+			return this.toolNames;
+		}
+
+		@Override
+		public Boolean getInternalToolExecutionEnabled() {
+			return this.internalToolExecutionEnabled;
+		}
+
+		@Override
+		public Map<String, Object> getToolContext() {
+			return this.toolContext;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public TestToolCallingChatOptions copy() {
+			TestToolCallingChatOptions copy = new TestToolCallingChatOptions();
+			copy.internalToolExecutionEnabled = this.internalToolExecutionEnabled;
+			copy.toolCallbacks = new ArrayList<>(this.toolCallbacks);
+			copy.toolNames = new HashSet<>(this.toolNames);
+			copy.toolContext = new HashMap<>(this.toolContext);
+			return copy;
+		}
+
+		@Override
+		public ToolCallingChatOptions.Builder<?> mutate() {
+			return ToolCallingChatOptions.builder()
+				.toolCallbacks(this.toolCallbacks)
+				.toolNames(this.toolNames)
+				.toolContext(this.toolContext)
+				.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
+		}
+
+		@Override
+		public String getModel() {
+			return null;
+		}
+
+		@Override
+		public Double getFrequencyPenalty() {
+			return null;
+		}
+
+		@Override
+		public Integer getMaxTokens() {
+			return null;
+		}
+
+		@Override
+		public Double getPresencePenalty() {
+			return null;
+		}
+
+		@Override
+		public List<String> getStopSequences() {
+			return null;
+		}
+
+		@Override
+		public Double getTemperature() {
+			return null;
+		}
+
+		@Override
+		public Integer getTopK() {
+			return null;
+		}
+
+		@Override
+		public Double getTopP() {
+			return null;
+		}
+
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/ToolIndexEvictionStrategyTests.java
+++ b/advisors/tool-search-tool/tool-search-tool-advisor/src/test/java/org/springframework/ai/chat/client/advisor/tool/search/eviction/ToolIndexEvictionStrategyTests.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.eviction;
+
+import java.time.Duration;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.advisor.tool.search.api.ToolIndexEvictionStrategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ToolIndexEvictionStrategy} implementations:
+ * {@link NeverEvictStrategy}, {@link LruEvictionStrategy}, {@link TtlEvictionStrategy},
+ * and {@link CompositeEvictionStrategy}.
+ *
+ * @author Christian Tzolov
+ */
+class ToolIndexEvictionStrategyTests {
+
+	// -------------------------------------------------------------------------
+	// AlwaysEvictStrategy
+	// -------------------------------------------------------------------------
+
+	@Test
+	void alwaysEvict_onAccess_returnsCurrentSession() {
+		AlwaysEvictStrategy strategy = AlwaysEvictStrategy.INSTANCE;
+
+		assertThat(strategy.onAccess("session-1")).containsExactly("session-1");
+		assertThat(strategy.onAccess("session-2")).containsExactly("session-2");
+		assertThat(strategy.onAccess("session-1")).containsExactly("session-1");
+	}
+
+	@Test
+	void alwaysEvict_onRemoved_doesNothing() {
+		// Must not throw.
+		AlwaysEvictStrategy.INSTANCE.onRemoved("any-session");
+	}
+
+	@Test
+	void alwaysEvict_composedWithLru_stillEvictsCurrentSession() {
+		// AlwaysEvict dominates: current session is always evicted regardless of LRU
+		// state.
+		AlwaysEvictStrategy always = AlwaysEvictStrategy.INSTANCE;
+		LruEvictionStrategy lru = new LruEvictionStrategy(10);
+		CompositeEvictionStrategy composite = new CompositeEvictionStrategy(always, lru);
+
+		Set<String> evicted = composite.onAccess("a");
+		assertThat(evicted).contains("a");
+	}
+
+	// -------------------------------------------------------------------------
+	// NeverEvictStrategy
+	// -------------------------------------------------------------------------
+
+	@Test
+	void neverEvict_onAccess_alwaysReturnsEmpty() {
+		NeverEvictStrategy strategy = NeverEvictStrategy.INSTANCE;
+
+		assertThat(strategy.onAccess("session-1")).isEmpty();
+		assertThat(strategy.onAccess("session-2")).isEmpty();
+		assertThat(strategy.onAccess("session-1")).isEmpty();
+	}
+
+	@Test
+	void neverEvict_onRemoved_doesNothing() {
+		// Must not throw.
+		NeverEvictStrategy.INSTANCE.onRemoved("any-session");
+	}
+
+	// -------------------------------------------------------------------------
+	// LruEvictionStrategy
+	// -------------------------------------------------------------------------
+
+	@Test
+	void lru_belowCapacity_noEviction() {
+		LruEvictionStrategy strategy = new LruEvictionStrategy(3);
+
+		assertThat(strategy.onAccess("a")).isEmpty();
+		assertThat(strategy.onAccess("b")).isEmpty();
+		assertThat(strategy.onAccess("c")).isEmpty();
+	}
+
+	@Test
+	void lru_capacityExceeded_evictsLruSession() {
+		LruEvictionStrategy strategy = new LruEvictionStrategy(2);
+
+		strategy.onAccess("a");
+		strategy.onAccess("b");
+
+		// "a" is LRU — accessing "c" should evict "a"
+		Set<String> evicted = strategy.onAccess("c");
+		assertThat(evicted).containsExactly("a");
+	}
+
+	@Test
+	void lru_recentAccessUpdatesOrder() {
+		LruEvictionStrategy strategy = new LruEvictionStrategy(2);
+
+		strategy.onAccess("a");
+		strategy.onAccess("b");
+		// Re-access "a" — it becomes MRU, so "b" is now LRU
+		strategy.onAccess("a");
+
+		Set<String> evicted = strategy.onAccess("c");
+		assertThat(evicted).containsExactly("b");
+	}
+
+	@Test
+	void lru_sameSessionAccess_doesNotEvict() {
+		LruEvictionStrategy strategy = new LruEvictionStrategy(1);
+
+		strategy.onAccess("a");
+
+		// Accessing the same session again should not evict it
+		Set<String> evicted = strategy.onAccess("a");
+		assertThat(evicted).isEmpty();
+	}
+
+	@Test
+	void lru_onRemoved_preventsEvictionOfAlreadyClearedSession() {
+		LruEvictionStrategy strategy = new LruEvictionStrategy(2);
+
+		strategy.onAccess("a");
+		strategy.onAccess("b");
+		strategy.onRemoved("a"); // externally removed — strategy should forget "a"
+
+		// Now only "b" is tracked; adding "c" should not evict "a" again
+		Set<String> evicted = strategy.onAccess("c");
+		assertThat(evicted).doesNotContain("a");
+	}
+
+	@Test
+	void lru_maxSessionsMustBePositive() {
+		assertThatThrownBy(() -> new LruEvictionStrategy(0)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> new LruEvictionStrategy(-1)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// TtlEvictionStrategy
+	// -------------------------------------------------------------------------
+
+	@Test
+	void ttl_freshSession_notEvicted() {
+		TtlEvictionStrategy strategy = new TtlEvictionStrategy(Duration.ofMinutes(10));
+
+		strategy.onAccess("a");
+
+		// Accessing immediately — "a" should not be expired
+		Set<String> evicted = strategy.onAccess("b");
+		assertThat(evicted).doesNotContain("a");
+	}
+
+	@Test
+	void ttl_expiredSession_evictedOnNextAccess() throws InterruptedException {
+		// Very short TTL so the test doesn't need to sleep long
+		TtlEvictionStrategy strategy = new TtlEvictionStrategy(Duration.ofMillis(50));
+
+		strategy.onAccess("a");
+		Thread.sleep(60); // wait for "a" to expire
+
+		Set<String> evicted = strategy.onAccess("b");
+		assertThat(evicted).containsExactly("a");
+	}
+
+	@Test
+	void ttl_currentSessionNotEvictedEvenIfIdle() throws InterruptedException {
+		TtlEvictionStrategy strategy = new TtlEvictionStrategy(Duration.ofMillis(50));
+
+		strategy.onAccess("a");
+		Thread.sleep(60);
+
+		// "a" itself is being accessed — it must never appear in the eviction set
+		Set<String> evicted = strategy.onAccess("a");
+		assertThat(evicted).doesNotContain("a");
+	}
+
+	@Test
+	void ttl_onRemoved_removesSessionFromTracking() throws InterruptedException {
+		TtlEvictionStrategy strategy = new TtlEvictionStrategy(Duration.ofMillis(50));
+
+		strategy.onAccess("a");
+		strategy.onRemoved("a");
+		Thread.sleep(60);
+
+		// "a" was removed from tracking — no eviction expected
+		Set<String> evicted = strategy.onAccess("b");
+		assertThat(evicted).doesNotContain("a");
+	}
+
+	@Test
+	void ttl_mustBePositive() {
+		assertThatThrownBy(() -> new TtlEvictionStrategy(Duration.ZERO)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> new TtlEvictionStrategy(Duration.ofSeconds(-1)))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	// -------------------------------------------------------------------------
+	// CompositeEvictionStrategy
+	// -------------------------------------------------------------------------
+
+	@Test
+	void composite_unionsEvictionDecisions() {
+		// LRU(1) evicts "a" when "b" accesses; TTL won't expire yet — union still has "a"
+		LruEvictionStrategy lru = new LruEvictionStrategy(1);
+		TtlEvictionStrategy ttl = new TtlEvictionStrategy(Duration.ofMinutes(10));
+		CompositeEvictionStrategy composite = new CompositeEvictionStrategy(lru, ttl);
+
+		composite.onAccess("a");
+		Set<String> evicted = composite.onAccess("b");
+
+		assertThat(evicted).containsExactly("a");
+	}
+
+	@Test
+	void composite_bothStrategiesReceiveOnRemoved() throws InterruptedException {
+		LruEvictionStrategy lru = new LruEvictionStrategy(2);
+		TtlEvictionStrategy ttl = new TtlEvictionStrategy(Duration.ofMillis(50));
+		CompositeEvictionStrategy composite = new CompositeEvictionStrategy(lru, ttl);
+
+		composite.onAccess("a");
+		composite.onRemoved("a");
+		Thread.sleep(60);
+
+		// Neither LRU nor TTL should report "a" after onRemoved
+		Set<String> evicted = composite.onAccess("b");
+		assertThat(evicted).doesNotContain("a");
+	}
+
+	@Test
+	void composite_requiresAtLeastOneDelegate() {
+		assertThatThrownBy(() -> new CompositeEvictionStrategy()).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void composite_singleDelegate_behavesLikeDelegate() {
+		NeverEvictStrategy never = NeverEvictStrategy.INSTANCE;
+		CompositeEvictionStrategy composite = new CompositeEvictionStrategy(never);
+
+		assertThat(composite.onAccess("x")).isEmpty();
+		assertThat(composite.onAccess("y")).isEmpty();
+	}
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-api/pom.xml
+++ b/advisors/tool-search-tool/tool-search-tool-api/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.ai</groupId>
+		<artifactId>spring-ai-parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-tool-search-tool-api</artifactId>
+	<name>spring-ai-tool-search-tool-api</name>
+	<description>API types for the Tool Search Tool: ToolIndex interface and related model classes</description>
+
+	<scm>
+		<url>https://github.com/spring-projects/spring-ai</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-ai.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
+	</scm>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jspecify</groupId>
+			<artifactId>jspecify</artifactId>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.12.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.21.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.21.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.27.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation</artifactId>
+			<version>1.16.2</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolIndex.java
+++ b/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolIndex.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.api;
+
+import java.util.List;
+
+/**
+ * Interface for searching and discovering tools on-demand.
+ * <p>
+ * Implementations provide different search strategies — such as embedding-based semantic
+ * search, full-text keyword search, or regex pattern matching — to find relevant tools
+ * from a registered catalog based on search queries. This aligns with the Tool Search
+ * Tool concept for dynamic tool discovery.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public interface ToolIndex {
+
+	/**
+	 * Registers a tool in the search index for the specified session.
+	 * @param sessionId the session identifier for tool isolation
+	 * @param toolReference the reference to the tool being indexed
+	 */
+	void indexTool(String sessionId, ToolReference toolReference);
+
+	/**
+	 * Registers multiple tools in the search index for the specified session in a single
+	 * batch operation.
+	 * <p>
+	 * Implementations should override this method when a batch operation is more
+	 * efficient than repeated {@link #indexTool} calls (e.g. a single embedding API call
+	 * or a single write transaction). The default implementation simply iterates and
+	 * delegates to {@link #indexTool}.
+	 * @param sessionId the session identifier for tool isolation
+	 * @param toolReferences the tools to register
+	 */
+	@SuppressWarnings("null")
+	default void indexTools(String sessionId, List<ToolReference> toolReferences) {
+		for (ToolReference ref : toolReferences) {
+			indexTool(sessionId, ref);
+		}
+	}
+
+	/**
+	 * Searches for tools matching the given request criteria.
+	 * @param toolSearchRequest the search request containing query and parameters
+	 * @return a response containing matching tool references
+	 */
+	ToolSearchResponse search(ToolSearchRequest toolSearchRequest);
+
+	/**
+	 * Clears all indexed tools for the specified session.
+	 * @param sessionId the session identifier
+	 */
+	void clearIndex(String sessionId);
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolIndexEvictionStrategy.java
+++ b/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolIndexEvictionStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.api;
+
+import java.util.Set;
+
+/**
+ * Strategy that decides which session tool indexes should be evicted.
+ * <p>
+ * {@link #onAccess(String)} is called at the start of every request. Any session IDs it
+ * returns are cleared from the {@link ToolIndex}, after which {@link #onRemoved(String)}
+ * is called so the strategy can drop its own internal tracking state.
+ * <p>
+ * Common strategies include: never evicting (indexes persist until explicitly removed),
+ * always evicting (fresh re-index on every request), LRU eviction (cap on active session
+ * count), TTL eviction (idle sessions expire after a configured duration), and composite
+ * eviction (union of multiple strategies).
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+public interface ToolIndexEvictionStrategy {
+
+	/**
+	 * Called each time a session is accessed at the start of request processing.
+	 * <p>
+	 * Implementations should update their internal tracking state for {@code sessionId}
+	 * and return the set of session IDs whose tool indexes must now be cleared. The
+	 * returned set must never include the currently-accessed {@code sessionId}.
+	 * @param sessionId the session being accessed
+	 * @return session IDs to evict; never {@code null}, may be empty
+	 */
+	Set<String> onAccess(String sessionId);
+
+	/**
+	 * Called after a session's tool index has been cleared — either because this strategy
+	 * returned it from {@link #onAccess}, or because of an explicit eviction request.
+	 * <p>
+	 * Implementations should remove any internal tracking state for the evicted session.
+	 * @param sessionId the session that was evicted
+	 */
+	void onRemoved(String sessionId);
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolReference.java
+++ b/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolReference.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.api;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reference to a retrieved Tool with its name, relevance score, and summary.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ToolReference(String toolName, @Nullable Double relevanceScore, String summary) {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		@Nullable private String toolName;
+
+		@Nullable private Double relevanceScore;
+
+		@Nullable private String summary;
+
+		public Builder toolName(String toolName) {
+			this.toolName = toolName;
+			return this;
+		}
+
+		public Builder relevanceScore(Double relevanceScore) {
+			this.relevanceScore = relevanceScore;
+			return this;
+		}
+
+		public Builder relevanceScore(Float relevanceScore) {
+			this.relevanceScore = relevanceScore.doubleValue();
+			return this;
+		}
+
+		public Builder summary(String summary) {
+			this.summary = summary;
+			return this;
+		}
+
+		public ToolReference build() {
+			return new ToolReference(Objects.requireNonNull(this.toolName), this.relevanceScore,
+					Objects.requireNonNull(this.summary));
+		}
+
+	}
+}

--- a/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolSearchRequest.java
+++ b/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolSearchRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Request for searching tools within a session's index.
+ *
+ * @param sessionId identifies the session whose tool index is searched
+ * @param query natural-language description of the needed capability
+ * @param maxResults maximum number of results to return; {@code null} lets the tool index
+ * apply its own default
+ * @param categoryFilter optional hint to narrow the search to a specific tool category;
+ * support depends on the
+ * {@link org.springframework.ai.chat.client.advisor.tool.search.ToolIndex} implementation
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ToolSearchRequest(String sessionId, String query, @Nullable Integer maxResults,
+		@Nullable String categoryFilter) {
+
+}

--- a/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolSearchResponse.java
+++ b/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/ToolSearchResponse.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.advisor.tool.search.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Response containing a list of ToolReferences matching the search criteria, total
+ * matches, and search metadata.
+ *
+ * @author Christian Tzolov
+ * @since 2.0.0
+ */
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ToolSearchResponse(List<ToolReference> toolReferences, @Nullable Integer totalMatches,
+		@Nullable SearchMetadata searchMetadata) {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private List<ToolReference> toolReferences = new ArrayList<>();
+
+		@Nullable private Integer totalMatches;
+
+		@Nullable private SearchMetadata searchMetadata;
+
+		public Builder toolReferences(List<ToolReference> toolReferences) {
+			this.toolReferences = toolReferences;
+			return this;
+		}
+
+		public Builder addToolReference(ToolReference toolReference) {
+			this.toolReferences.add(toolReference);
+			return this;
+		}
+
+		public Builder totalMatches(Integer totalMatches) {
+			this.totalMatches = totalMatches;
+			return this;
+		}
+
+		public Builder searchMetadata(SearchMetadata searchMetadata) {
+			this.searchMetadata = searchMetadata;
+			return this;
+		}
+
+		public ToolSearchResponse build() {
+			return new ToolSearchResponse(Objects.requireNonNull(this.toolReferences), this.totalMatches,
+					this.searchMetadata);
+		}
+
+	}
+
+	/**
+	 * Metadata about how a search was performed.
+	 *
+	 * @param searchType a label identifying the {@link ToolIndex} implementation that
+	 * produced this response — typically the simple class name (e.g.
+	 * {@code "LuceneToolIndex"}). Custom implementations may return any non-null,
+	 * non-empty string.
+	 * @param query the original query string passed to the tool index
+	 * @param searchTimeMs elapsed time in milliseconds, or {@code null} if not measured
+	 */
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record SearchMetadata(String searchType, String query, @Nullable Long searchTimeMs) {
+
+		public static Builder builder() {
+			return new Builder();
+		}
+
+		public static class Builder {
+
+			@Nullable private String searchType;
+
+			@Nullable private String query;
+
+			@Nullable private Long searchTimeMs;
+
+			public Builder searchType(String searchType) {
+				this.searchType = searchType;
+				return this;
+			}
+
+			public Builder query(String query) {
+				this.query = query;
+				return this;
+			}
+
+			public Builder searchTimeMs(Long searchTimeMs) {
+				this.searchTimeMs = searchTimeMs;
+				return this;
+			}
+
+			@SuppressWarnings("null")
+			public SearchMetadata build() {
+				return new SearchMetadata(Objects.requireNonNull(this.searchType), Objects.requireNonNull(this.query),
+						this.searchTimeMs);
+			}
+
+		}
+	}
+}

--- a/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/package-info.java
+++ b/advisors/tool-search-tool/tool-search-tool-api/src/main/java/org/springframework/ai/chat/client/advisor/tool/search/api/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tool Search Tool API: core interface and model types for dynamic tool discovery.
+ */
+@NullMarked
+package org.springframework.ai.chat.client.advisor.tool.search.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
 		<module>spring-ai-vector-store</module>
 		<module>spring-ai-rag</module>
 		<module>advisors/spring-ai-advisors-vector-store</module>
+		<module>advisors/tool-search-tool/tool-search-tool-api</module>
+		<module>advisors/tool-search-tool/tool-search-tool-advisor</module>
+		<module>advisors/tool-search-tool/tool-indexes/tool-index-lucene</module>
+		<module>advisors/tool-search-tool/tool-indexes/tool-index-regex</module>
+		<module>advisors/tool-search-tool/tool-indexes/tool-index-vectorstore</module>
 
 		<module>memory/repository/spring-ai-model-chat-memory-repository-cassandra</module>
 		<module>memory/repository/spring-ai-model-chat-memory-repository-jdbc</module>
@@ -261,6 +266,12 @@
 
 		<!-- production dependencies -->
 		<spring-boot.version>4.1.0-RC1</spring-boot.version>
+		<azure-identity.version>1.18.2</azure-identity.version>
+		<openai-sdk.version>4.34.0</openai-sdk.version>
+		<anthropic-sdk.version>2.30.0</anthropic-sdk.version>
+		<jtokkit.version>1.1.0</jtokkit.version>
+		<kotlin.version>2.3.20</kotlin.version>
+		<lucene.version>9.12.3</lucene.version>
 
 		<!-- Third-party dependencies -->
 		<anthropic-sdk.version>2.34.0</anthropic-sdk.version>

--- a/spring-ai-bom/pom.xml
+++ b/spring-ai-bom/pom.xml
@@ -119,6 +119,38 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<!-- Spring AI Tool SearchTool Advisors -->
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-tool-search-tool-advisor</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-tool-search-tool-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-tool-index-lucene</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-tool-index-regex</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-tool-index-vectorstore</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			
 			<!-- Spring AI retry -->
 
 			<dependency>

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -1417,3 +1417,271 @@ Optionally, Spring AI can export tool call arguments and results as span attribu
 === Logging
 
 All the main operations of the tool calling features are logged at the `DEBUG` level. You can enable the logging by setting the log level to `DEBUG` for the `org.springframework.ai` package.
+
+[[tool-search-tool]]
+== Tool Search Tool
+
+As AI agents connect to more services (Slack, GitHub, Jira, MCP servers), tool libraries grow rapidly.
+A typical multi-server setup can easily have 50+ tools consuming *55,000+ tokens* before any conversation starts.
+Tool selection accuracy also degrades when models face 30+ similarly-named tools.
+
+The **Tool Search Tool** pattern solves this by enabling on-demand tool discovery:
+
+* The model receives only a single search tool initially — minimal token usage.
+* When capabilities are needed, the model calls the search tool with a natural-language query.
+* Matching tool definitions are dynamically expanded into the context.
+* The model can then invoke the discovered tools normally.
+
+This achieves significant token savings while maintaining access to large tool catalogs.
+
+=== How It Works
+
+The `ToolSearchToolCallingAdvisor` extends Spring AI's `ToolCallAdvisor` to implement dynamic tool discovery.
+
+The flow at runtime is:
+
+1. **Indexing** — At conversation start, all registered tools are indexed in the `ToolIndex` but *not* sent to the LLM.
+2. **Initial Request** — Only the built-in `toolSearchTool` definition is sent to the LLM.
+3. **Discovery Call** — When the LLM needs a capability, it calls `toolSearchTool` with a search query.
+4. **Search & Expand** — The `ToolIndex` finds matching tools; their definitions are added to the next request.
+5. **Tool Invocation** — The LLM sees both `toolSearchTool` and the discovered tool definitions, and can call the actual tool.
+6. **Tool Execution** — The discovered tool is executed and its result returned to the LLM.
+7. **Response** — The LLM generates the final answer using the tool result.
+
+=== Installation
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-tool-search-tool-advisor</artifactId>
+</dependency>
+
+<!-- Choose a search strategy (see Search Strategies below) -->
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-tool-index-vectorstore</artifactId>
+</dependency>
+----
+
+=== Quick Start
+
+[source,java]
+----
+// 1. Configure a ToolIndex (e.g., VectorToolIndex for semantic search)
+@Bean
+ToolIndex toolIndex(VectorStore vectorStore) {
+    return new VectorToolIndex(vectorStore);
+}
+
+// 2. Create the advisor
+var smartToolRetrieverAdvisor = ToolSearchToolCallingAdvisor.builder()
+    .toolIndex(toolIndex)
+    .maxResults(5)
+    .build();
+
+// 3. Use with ChatClient — tools are registered but NOT sent to the LLM initially
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultTools(new MyTools())
+    .defaultAdvisors(smartToolRetrieverAdvisor)
+    .build();
+
+// 4. Make requests — tools are discovered on-demand
+String answer = chatClient.prompt("What's the weather in Amsterdam?")
+    .call()
+    .content();
+----
+
+=== Search Strategies
+
+The `ToolIndex` interface abstracts the search implementation.
+Three strategies are provided out of the box:
+
+[cols="1,2,2", options="header"]
+|===
+| Strategy | Module | Best For
+
+| **Semantic**
+| `tool-index-vectorstore`
+| Natural-language queries, fuzzy matching
+
+| **Keyword**
+| `tool-index-lucene`
+| Exact term matching, known tool names
+
+| **Regex**
+| `tool-index-regex`
+| Tool name patterns (`get_*_data`)
+|===
+
+==== VectorToolIndex (Semantic)
+
+[source,java]
+----
+@Bean
+ToolIndex vectorToolIndex(VectorStore vectorStore) {
+    return new VectorToolIndex(vectorStore);
+}
+----
+
+Uses embedding-based similarity search. Best for natural-language queries where users describe what they need.
+
+==== LuceneToolIndex (Keyword)
+
+[source,java]
+----
+@Bean
+ToolIndex luceneToolIndex() {
+    return new LuceneToolIndex();        // default threshold of 0.25
+    // return new LuceneToolIndex(0.4f); // custom minimum score threshold
+}
+----
+
+Uses Apache Lucene for keyword-based search. Fast and effective for exact-term matching.
+
+==== RegexToolIndex (Pattern)
+
+[source,java]
+----
+@Bean
+ToolIndex regexToolIndex() {
+    return new RegexToolIndex();
+}
+----
+
+Uses regex pattern matching. Useful when tool names follow a known naming convention (e.g., `get_*` or `*_database_*`).
+
+=== Configuration
+
+The following options are available on `ToolSearchToolCallingAdvisor.Builder`:
+
+|===
+| Option | Description | Default
+
+| `toolIndex(ToolIndex)`
+| The search implementation to use.
+| Required
+
+| `maxResults(Integer)`
+| Maximum tool references returned per search. When `null`, the LLM decides (guided by the tool description hint of 5).
+| `null`
+
+| `systemMessageSuffix(String)`
+| Custom prompt suffix appended to the system message to instruct the model how to use `toolSearchTool`.
+| Built-in template
+
+| `referenceToolNameAccumulation(boolean)`
+| When `true`, tool names discovered across all prior search calls are accumulated and injected. When `false`, only the most recent search result is used.
+| `true`
+
+| `sessionIdKeyName(String)`
+| Context key used to look up the conversation/session ID. Change this when your app stores the conversation ID under a custom key.
+| `"conversationId"`
+
+| `evictionStrategy(ToolIndexEvictionStrategy)`
+| Determines when session tool indexes are freed. See xref:_index_eviction[Index Eviction] below.
+| `LruEvictionStrategy(1000)`
+
+| `advisorOrder(int)`
+| Position of this advisor in the advisor chain.
+| `HIGHEST_PRECEDENCE + 300`
+|===
+
+=== ToolIndex API
+
+The `ToolIndex` interface and its companion types (`ToolSearchRequest`, `ToolSearchResponse`, `ToolReference`, `SearchType`) live in the `spring-ai-tool-search-tool-api` module under the package `org.springframework.ai.chat.client.advisor.tool.search.api`.
+The built-in index implementations (`spring-ai-tool-index-lucene`, `spring-ai-tool-index-vectorstore`, `spring-ai-tool-index-regex`) all depend on this module, so it is pulled in transitively when you use any of them.
+To implement a custom `ToolIndex` without pulling in a concrete search engine, depend only on the API artifact:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-tool-search-tool-api</artifactId>
+</dependency>
+----
+
+[source,java]
+----
+public interface ToolIndex {
+    void indexTool(String sessionId, ToolReference toolReference);
+    void indexTools(String sessionId, List<ToolReference> toolReferences); // default: loops over indexTool
+    ToolSearchResponse search(ToolSearchRequest request);
+    void clearIndex(String sessionId);
+}
+----
+
+Each call is scoped by `sessionId` so tool indexes are isolated across concurrent conversations.
+
+=== Index Eviction
+
+By default (`LruEvictionStrategy(1000)`), up to 1,000 active sessions are retained and the least-recently-used session is evicted when the cap is exceeded.
+Call `advisor.evictSession(sessionId)` to release a session eagerly (e.g. on logout).
+Five built-in strategies are provided:
+
+[cols="2,3", options="header"]
+|===
+| Strategy | Behaviour
+
+| `LruEvictionStrategy(maxSessions)` (**default**)
+| Evicts the least-recently-used session once the number of active sessions exceeds `maxSessions`.
+
+| `NeverEvictStrategy.INSTANCE`
+| Never evicts automatically; indexes persist until `evictSession()` is called explicitly.
+
+| `AlwaysEvictStrategy.INSTANCE`
+| Clears a session's index before every request, forcing a full re-index each turn. Useful for testing or when tool sets change every request.
+
+| `TtlEvictionStrategy(duration)`
+| Evicts sessions whose last-access time exceeds the given TTL. Evaluated lazily on each request.
+
+| `CompositeEvictionStrategy(strategies...)`
+| Delegates to multiple strategies and evicts a session if _any_ delegate requests it.
+|===
+
+[source,java]
+----
+// Default: LRU cap of 1000 sessions (no configuration needed)
+var advisor = ToolSearchToolCallingAdvisor.builder()
+    .toolIndex(toolIndex)
+    .build();
+
+// Never evict — manage session lifetime yourself
+ToolIndexEvictionStrategy eviction = NeverEvictStrategy.INSTANCE;
+
+// Always evict — re-index every request (useful for testing)
+ToolIndexEvictionStrategy eviction = AlwaysEvictStrategy.INSTANCE;
+
+// Evict least-recently-used session when more than 200 are active
+ToolIndexEvictionStrategy eviction = new LruEvictionStrategy(200);
+
+// Evict sessions idle for more than 30 minutes
+ToolIndexEvictionStrategy eviction = new TtlEvictionStrategy(Duration.ofMinutes(30));
+
+// Combine: TTL + LRU cap
+ToolIndexEvictionStrategy eviction = new CompositeEvictionStrategy(
+    new TtlEvictionStrategy(Duration.ofMinutes(30)),
+    new LruEvictionStrategy(200));
+
+var advisor = ToolSearchToolCallingAdvisor.builder()
+    .toolIndex(toolIndex)
+    .evictionStrategy(eviction)
+    .build();
+----
+
+Eviction is evaluated lazily on each request — no background thread is required.
+
+=== When to Use
+
+**Good fit:**
+
+* 10 or more tools in your system.
+* Tool definitions are consuming more than 10K tokens.
+* Building MCP-powered systems with multiple servers.
+* Experiencing tool selection accuracy issues with large tool sets.
+
+**Traditional approach may be better:**
+
+* Small tool library (fewer than 10 tools).
+* All tools are frequently used in every session.
+* Tool definitions are very compact.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/dynamic-tool-search.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/guides/dynamic-tool-search.adoc
@@ -8,7 +8,7 @@ Spring AI's implementation achieves **34-64% token reduction** across OpenAI, An
 
 == Introduction
 
-The link:https://github.com/spring-ai-community/spring-ai-tool-search-tool[Tool Search Tool] project extends Spring AI's xref:api/advisors-recursive.adoc[Recursive Advisors] to implement dynamic tool discovery that works across **any LLM provider** supported by Spring AI.
+The Tool Search Tool extends Spring AI's xref:api/advisors-recursive.adoc[Recursive Advisors] to implement dynamic tool discovery that works across **any LLM provider** supported by Spring AI.
 
 **Key benefits:**
 
@@ -36,16 +36,14 @@ Maven::
 [source,xml]
 ----
 <dependency>
-    <groupId>org.springaicommunity</groupId>
-    <artifactId>tool-search-tool</artifactId>
-    <version>2.0.0</version>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-tool-search-tool-advisor</artifactId>
 </dependency>
 
 <!-- Choose a search strategy -->
 <dependency>
-    <groupId>org.springaicommunity</groupId>
-    <artifactId>tool-searcher-lucene</artifactId>
-    <version>2.0.0</version>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-tool-index-lucene</artifactId>
 </dependency>
 ----
 
@@ -54,15 +52,13 @@ Gradle::
 [source,gradle]
 ----
 dependencies {
-    implementation 'org.springaicommunity:tool-search-tool:2.0.0'
-    
+    implementation 'org.springframework.ai:tool-search-tool-advisor'
+
     // Choose a search strategy
-    implementation 'org.springaicommunity:tool-searcher-lucene:2.0.0'
+    implementation 'org.springframework.ai:tool-index-lucene'
 }
 ----
 ======
-
-NOTE: Version link:https://github.com/spring-ai-community/spring-ai-tool-search-tool/tree/1.0.x[v1.0.x] is Spring AI 1.1.x / Spring Boot 3 compatible. Version link:https://github.com/spring-ai-community/spring-ai-tool-search-tool[v2.0.x] is Spring AI 2.x / Spring Boot 4 compatible.
 
 === Basic Usage
 
@@ -72,10 +68,10 @@ NOTE: Version link:https://github.com/spring-ai-community/spring-ai-tool-search-
 public class Application {
 
     @Bean
-    CommandLineRunner demo(ChatClient.Builder builder, ToolSearcher toolSearcher) {
+    CommandLineRunner demo(ChatClient.Builder builder, ToolIndex toolIndex) {
         return args -> {
-            var advisor = ToolSearchToolCallAdvisor.builder()
-                .toolSearcher(toolSearcher)
+            var advisor = ToolSearchToolCallingAdvisor.builder()
+                .toolIndex(toolIndex)
                 .build();
 
             ChatClient chatClient = builder
@@ -117,40 +113,40 @@ public class Application {
 
 == How It Works
 
-The `ToolSearchToolCallAdvisor` extends Spring AI's `ToolCallAdvisor` to implement dynamic tool discovery:
+The `ToolSearchToolCallingAdvisor` extends Spring AI's `ToolCallAdvisor` to implement dynamic tool discovery:
 
 image::https://raw.githubusercontent.com/spring-io/spring-io-static/refs/heads/main/blog/tzolov/20251208/spring-ai-tool-search-tool-calling-flow.png[Tool Search Tool Flow,600]
 
-1. **Indexing**: At conversation start, all registered tools are indexed in the `ToolSearcher` (but NOT sent to the LLM)
+1. **Indexing**: At conversation start, all registered tools are indexed in the `ToolIndex` (but NOT sent to the LLM)
 2. **Initial Request**: Only the **Tool Search Tool** definition is sent to the LLM
 3. **Discovery Call**: When the LLM needs capabilities, it calls the search tool with a query
-4. **Search & Expand**: The `ToolSearcher` finds matching tools and their definitions are added to the next request
+4. **Search & Expand**: The `ToolIndex` finds matching tools and their definitions are added to the next request
 5. **Tool Invocation**: The LLM now sees both the search tool and discovered tool definitions
 6. **Tool Execution**: Discovered tools are executed and results returned
 7. **Response**: The LLM generates the final answer
 
 == Search Strategies
 
-The `ToolSearcher` interface supports multiple search implementations:
+The `ToolIndex` interface supports multiple search implementations:
 
 [cols="1,2,2"]
 |===
 |Strategy |Implementation |Best For
 
 |**Semantic**
-|`VectorToolSearcher`
+|`VectorToolIndex`
 |Natural language queries, fuzzy matching
 
 |**Keyword**
-|`LuceneToolSearcher`
+|`LuceneToolIndex`
 |Exact term matching, known tool names
 
 |**Regex**
-|`RegexToolSearcher`
+|`RegexToolIndex`
 |Tool name patterns (`get_*_data`)
 |===
 
-See link:https://github.com/spring-ai-community/spring-ai-tool-search-tool/tree/main/tool-searchers[tool-searchers] for all available implementations.
+See xref:api/tools.adoc#tool-search-tool[Tool Search Tool] for all available implementations and configuration options.
 
 == Performance
 
@@ -194,16 +190,6 @@ Preliminary benchmarks with 28 tools show significant token savings:
 |Experiencing tool selection accuracy issues
 |
 |===
-
-== Example Projects
-
-* link:https://github.com/spring-ai-community/spring-ai-tool-search-tool/tree/main/examples/tool-search-tool-demo[Tool Search Tool Demo] - Complete working example
-* link:https://github.com/spring-ai-community/spring-ai-tool-search-tool/tree/main/examples/pre-select-tool-demo[Pre-Select Tool Demo] - Deterministic tool selection without LLM involvement
-
-== Community Resources
-
-* link:https://github.com/spring-ai-community/spring-ai-tool-search-tool[Tool Search Tool Repository]
-* link:https://github.com/spring-ai-community/awesome-spring-ai[Awesome Spring AI] - Community examples and resources
 
 == Related Documentation
 


### PR DESCRIPTION
Introduces the ToolSearchToolCallingAdvisor and three ToolSearcher implementations (vector store, Lucene, regex) that enable LLMs to discover and invoke tools on demand rather than loading all definitions upfront. Reduces token consumption for large tool catalogs by indexing all registered tools at session start and injecting only the built-in toolSearchTool into the initial prompt; full tool definitions are expanded lazily as the model issues search queries.

- tool-search-tool-advisor: core advisor, ToolSearcher interface, ToolReference/Request/Response types, and default system prompt
- tool-searcher-vectorstore: embedding-based semantic search via VectorStore
- tool-searcher-lucene: keyword search via Apache Lucene
- tool-searcher-regex: pattern matching by tool name
- BOM and root pom updated to include all four new modules
- tools.adoc: new "Tool Search Tool" reference section