### PR TITLE
refactor: optimize internal string building

### DIFF
--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/api/MiniMaxApi.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -126,7 +127,7 @@ public class MiniMaxApi {
 		return content.stream()
 				.filter(c -> "text".equals(c.type()))
 				.map(ChatCompletionMessage.MediaContent::text)
-				.reduce("", (a, b) -> a + b);
+				.collect(Collectors.joining());
 	}
 
 	/**

--- a/spring-ai-commons/src/main/java/org/springframework/ai/document/id/JdkSha256HexIdGenerator.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/document/id/JdkSha256HexIdGenerator.java
@@ -22,6 +22,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.UUID;
 
 import org.springframework.util.Assert;
@@ -36,7 +37,7 @@ public class JdkSha256HexIdGenerator implements IdGenerator {
 
 	private static final String SHA_256 = "SHA-256";
 
-	private final String byteHexFormat = "%02x";
+	private static final HexFormat HEX_FORMAT = HexFormat.of();
 
 	private final Charset charset;
 
@@ -64,11 +65,8 @@ public class JdkSha256HexIdGenerator implements IdGenerator {
 	// https://github.com/spring-projects/spring-ai/issues/113#issue-2000373318
 	private String hash(byte[] contentWithMetadata) {
 		byte[] hashBytes = getMessageDigest().digest(contentWithMetadata);
-		StringBuilder sb = new StringBuilder();
-		for (byte b : hashBytes) {
-			sb.append(String.format(this.byteHexFormat, b));
-		}
-		return UUID.nameUUIDFromBytes(sb.toString().getBytes(this.charset)).toString();
+		String hash = HEX_FORMAT.formatHex(hashBytes);
+		return UUID.nameUUIDFromBytes(hash.getBytes(this.charset)).toString();
 	}
 
 	private byte[] serializeToBytes(Object... contents) {

--- a/spring-ai-commons/src/test/java/org/springframework/ai/document/id/JdkSha256HexIdGeneratorTest.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/document/id/JdkSha256HexIdGeneratorTest.java
@@ -19,6 +19,8 @@ package org.springframework.ai.document.id;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Map;
+import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,13 @@ import org.junit.jupiter.api.Test;
 public class JdkSha256HexIdGeneratorTest {
 
 	private final JdkSha256HexIdGenerator testee = new JdkSha256HexIdGenerator();
+
+	@Test
+	void generateIdProducesStableId() {
+		String id = this.testee.generateId("Content", Map.of("metadata", Set.of("META_DATA")));
+
+		Assertions.assertThat(id).isEqualTo("d0c527e2-2004-31a0-af6d-93c67ccaff50");
+	}
 
 	@Test
 	void messageDigestReturnsDistinctInstances() {


### PR DESCRIPTION
## Summary

This PR optimizes a couple of internal string-building paths without changing existing behavior

- Replace per-byte `String.format("%02x", b)` usage in `JdkSha256HexIdGenerator` with Java 17 `HexFormat`
- Replace string concatenation via stream `reduce` in `MiniMaxApi#getTextContent` with `Collectors.joining()`
- Add a regression test to verify that the SHA-256 based document ID remains stable

## Performance benefit
`String.format("%02x", b)` is relatively expensive for byte-by-byte hex encoding because it goes through formatter parsing and formatting machinery on every byte. `HexFormat` is purpose-built for byte-to-hex conversion and avoids that repeated formatting overhead

Similarly, string concatenation inside `reduce` creates intermediate `String` instances as the stream is accumulated `Collectors.joining()` uses a mutable accumulation strategy internally, which avoids repeated intermediate concatenations and is the idiomatic collector for joining stream elements