### PR TITLE
Fix broken xref anchors in documentation

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-overview.adoc
@@ -114,7 +114,7 @@ Spring AI provides MCP integration through the following Spring Boot starters:
 
 |===
 |Server Type | Dependency | Property
-| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webmvc_serve[SSE WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=SSE` or empty
+| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webmvc_server[SSE WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=SSE` or empty
 | xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc#_streamable_http_webmvc_server[Streamable-HTTP WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=STREAMABLE`
 | xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc#_stateless_webmvc_server[Stateless Streamable-HTTP WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=STATELESS`
 |===
@@ -122,7 +122,7 @@ Spring AI provides MCP integration through the following Spring Boot starters:
 ==== WebMVC (Reactive)
 |===
 |Server Type | Dependency | Property
-| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webflux_serve[SSE WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=SSE` or empty
+| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webflux_server[SSE WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=SSE` or empty
 | xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc#_streamable_http_webflux_server[Streamable-HTTP WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=STREAMABLE`
 | xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc#_stateless_webflux_server[Stateless Streamable-HTTP WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=STATELESS`
 |===

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-server-boot-starter-docs.adoc
@@ -33,7 +33,7 @@ Use the dedicated starter and the correct `spring.ai.mcp.server.protocol` proper
 
 |===
 |Server Type | Dependency | Property
-| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webmvc_serve[SSE WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=SSE` or empty
+| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webmvc_server[SSE WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=SSE` or empty
 | xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc#_streamable_http_webmvc_server[Streamable-HTTP WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=STREAMABLE`
 | xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc#_stateless_webmvc_server[Stateless WebMVC] | `spring-ai-starter-mcp-server-webmvc` | `spring.ai.mcp.server.protocol=STATELESS`
 |===
@@ -41,7 +41,7 @@ Use the dedicated starter and the correct `spring.ai.mcp.server.protocol` proper
 === WebMVC (Reactive)
 |===
 |Server Type | Dependency | Property
-| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webflux_serve[SSE WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=SSE` or empty
+| xref:api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc#_sse_webflux_server[SSE WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=SSE` or empty
 | xref:api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc#_streamable_http_webflux_server[Streamable-HTTP WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=STREAMABLE`
 | xref:api/mcp/mcp-stateless-server-boot-starter-docs.adoc#_stateless_webflux_server[Stateless WebFlux] | `spring-ai-starter-mcp-server-webflux` | `spring.ai.mcp.server.protocol=STATELESS`
 |===

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/concepts.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/concepts.adoc
@@ -122,7 +122,7 @@ This intricacy has led to the emergence of a specialized field involving the cre
 
 image::structured-output-architecture.jpg[Structured Output Converter Architecture, width=800, align="center"]
 
-The xref:api/structured-output-converter.adoc#_structuredoutputconverter[Structured output conversion] employs meticulously crafted prompts, often necessitating multiple interactions with the model to achieve the desired formatting.
+The xref:api/structured-output-converter.adoc#StructuredOutputConverter[Structured output conversion] employs meticulously crafted prompts, often necessitating multiple interactions with the model to achieve the desired formatting.
 
 == Bringing Your Data & APIs to the AI Model
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -941,7 +941,7 @@ The 1.0.0-SNAPSHOT version includes significant changes to artifact IDs, package
 === Add Snapshot Repositories
 
 To use the 1.0.0-SNAPSHOT version, you need to add the snapshot repositories to your build file.
-For detailed instructions, refer to the xref:getting-started.adoc#snapshots-add-snapshot-repositories[Snapshots - Add Snapshot Repositories] section in the Getting Started guide.
+For detailed instructions, refer to the xref:getting-started.adoc#_snapshots_add_snapshot_repositories[Snapshots - Add Snapshot Repositories] section in the Getting Started guide.
 
 === Update Dependency Management
 
@@ -1338,7 +1338,7 @@ You can automate the upgrade process to 1.0.0-M7 using the Claude Code CLI tool 
 3. Paste the prompt into the Claude Code CLI
 4. The AI will analyze your project and make the necessary changes
 
-NOTE: The automated upgrade prompt currently handles artifact ID changes, package relocations, and module structure changes, but does not yet include automatic changes for upgrading to MCP 0.9.0. If you're using MCP, you'll need to manually update your code following the guidance in the xref:upgrade-notes.adoc#mcp-java-sdk-upgrade-to-0-9-0[MCP Java SDK Upgrade] section.
+NOTE: The automated upgrade prompt currently handles artifact ID changes, package relocations, and module structure changes, but does not yet include automatic changes for upgrading to MCP 0.9.0. If you're using MCP, you'll need to manually update your code following the guidance in the xref:upgrade-notes.adoc#_mcp_java_sdk_upgrade_to_0_9_0[MCP Java SDK Upgrade] section.
 
 [[common-sections]]
 == Common Changes Across Versions


### PR DESCRIPTION
Fixes broken `xref:` **anchors** in the Spring AI docs that didn't resolve to their intended sections — clicking the affected links navigated to the page top instead of the target heading.

## Changes

- `mcp-overview.adoc`, `mcp-server-boot-starter-docs.adoc`: fix `_sse_webmvc_serve` / `_sse_webflux_serve` typo. The auto-ids of the target sections are `_sse_webmvc_server` / `_sse_webflux_server`.
- `concepts.adoc`: case-correct the xref to the explicit `[[StructuredOutputConverter]]` anchor (explicit anchors override asciidoc auto-ids and are case-sensitive).
- `upgrade-notes.adoc`: fix two anchors that used dashes instead of asciidoc auto-id underscores — `_snapshots_add_snapshot_repositories` and `_mcp_java_sdk_upgrade_to_0_9_0`.

## Scope notes

- The image asset referenced in #1812 (`spring_ai_logo_with_text.svg`) is already present at `spring-ai-docs/src/main/antora/modules/ROOT/images/` and renders correctly on `main`. No change needed for that part of the issue.
- This PR is intentionally scoped to **anchor-level** xref fixes inside existing pages. The complementary **file-level** xref fixes (missing `api/audio.adoc` / `api/moderation.adoc` index pages, missing `.adoc` extensions in `nav.adoc` / `index.adoc`) are already covered by the open PR #5153 by @ranjitm2001. Between the two PRs, #1812 should be fully addressed.
- For that reason, this PR uses `Closes #1812` in the commit trailer, but feel free to retarget to "partial fix" if you'd prefer to keep the issue open until #5153 also lands. Happy to amend the commit if helpful.

## How I verified

- Built the docs locally with `./mvnw -pl spring-ai-docs antora`.
- Opened each affected rendered page in a browser and clicked every fixed link to confirm it scrolls to the correct section heading (not to the page top).
- Ran `./mvnw package

Closes #1812