### PR TITLE
Fix NPE and add support for generic return types in AsyncMcpToolProvider

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProvider.java
@@ -17,6 +17,8 @@
 package org.springframework.ai.mcp.annotation.provider.tool;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -125,12 +127,15 @@ public class AsyncMcpToolProvider extends AbstractMcpToolProvider {
 							&& !ReactiveUtils.isReactiveReturnTypeOfCallToolResult(mcpToolMethod)) {
 
 						ReactiveUtils.getReactiveReturnTypeArgument(mcpToolMethod).ifPresent(typeArgument -> {
-							Class<?> methodReturnType = typeArgument instanceof Class<?> ? (Class<?>) typeArgument
-									: null;
-							if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
-									&& !ClassUtils.isSimpleValueType(methodReturnType)) {
-								toolBuilder.outputSchema(this.getJsonMapper(),
-										McpJsonSchemaGenerator.generateFromClass((Class<?>) typeArgument));
+							if (typeArgument instanceof Class<?> methodReturnType) {
+								if (!ClassUtils.isPrimitiveOrWrapper(methodReturnType)
+										&& !ClassUtils.isSimpleValueType(methodReturnType)) {
+									toolBuilder.outputSchema(this.getJsonMapper(),
+											McpJsonSchemaGenerator.generateFromClass(methodReturnType));
+								}
+							}
+							else if (typeArgument instanceof ParameterizedType) {
+								toolBuilder.outputSchema(this.getJsonMapper(), McpJsonSchemaGenerator.generateFromType(typeArgument));
 							}
 						});
 					}

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/provider/tool/AsyncMcpToolProviderTests.java
@@ -1026,4 +1026,83 @@ public class AsyncMcpToolProviderTests {
 		assertThat(toolSpec.tool().outputSchema()).isNotNull();
 	}
 
+	@Test
+	void testGetToolSpecificationsWithGenericReturnType() {
+		// Helper class for generic response wrapper (similar to OkExApiResponse)
+		class ApiResponse<T> {
+
+			private String code;
+
+			private String msg;
+
+			private List<T> data;
+
+			public ApiResponse() {
+			}
+
+			public ApiResponse(String code, String msg, List<T> data) {
+				this.code = code;
+				this.msg = msg;
+				this.data = data;
+			}
+
+			public String getCode() {
+				return code;
+			}
+
+			public void setCode(String code) {
+				this.code = code;
+			}
+
+			public String getMsg() {
+				return msg;
+			}
+
+			public void setMsg(String msg) {
+				this.msg = msg;
+			}
+
+			public List<T> getData() {
+				return data;
+			}
+
+			public void setData(List<T> data) {
+				this.data = data;
+			}
+
+		}
+
+		// Test with parameterized type: Mono<ApiResponse<String>>
+		class GenericReturnTool {
+
+			@McpTool(name = "generic-tool", description = "Tool returning generic type",
+					generateOutputSchema = true)
+			public Mono<ApiResponse<String>> genericTool(String input) {
+				ApiResponse<String> response = new ApiResponse<>("0", "", List.of(input));
+				return Mono.just(response);
+			}
+
+		}
+
+		GenericReturnTool toolObject = new GenericReturnTool();
+		AsyncMcpToolProvider provider = new AsyncMcpToolProvider(List.of(toolObject));
+
+		List<AsyncToolSpecification> toolSpecs = provider.getToolSpecifications();
+
+		assertThat(toolSpecs).hasSize(1);
+		AsyncToolSpecification toolSpec = toolSpecs.get(0);
+
+		assertThat(toolSpec.tool().name()).isEqualTo("generic-tool");
+		assertThat(toolSpec.tool().description()).isEqualTo("Tool returning generic type");
+		assertThat(toolSpec.tool().inputSchema()).isNotNull();
+		// Output schema should be generated for parameterized types
+		assertThat(toolSpec.tool().outputSchema()).isNotNull();
+		
+		// Verify the output schema contains expected fields from ApiResponse
+		String outputSchemaString = toolSpec.tool().outputSchema().toString();
+		assertThat(outputSchemaString).contains("code");
+		assertThat(outputSchemaString).contains("msg");
+		assertThat(outputSchemaString).contains("data");
+	}
+
 }


### PR DESCRIPTION
This PR fixes a bug in `AsyncMcpToolProvider` where using generic return types (e.g., `Mono<ApiResponse<String>>`) would cause an `IllegalArgumentException` due to passing null to `ClassUtils.isPrimitiveOrWrapper()`.

## Problem

When a tool method returns a parameterized type like `Mono<ApiResponse<T>>`, the `typeArgument` extracted from the return type is a `ParameterizedType`, not a `Class<?>`. The original code would set `methodReturnType` to null and then pass it to `ClassUtils.isPrimitiveOrWrapper()`, which throws `IllegalArgumentException: Class must not be null`.

## Solution

- Handle `Class<?>` and `ParameterizedType` separately using pattern matching
- For `ParameterizedType`, use `McpJsonSchemaGenerator.generateFromType()` instead of `generateFromClass()`
- This aligns with how `SyncMcpToolProvider` handles generic return types

## Testing

Added test case `testGetToolSpecificationsWithGenericReturnType()` that verifies generic return types are properly handled and output schema is correctly generated.

## Impact

- ✅ Fixes a real bug affecting users with generic return types
- ✅ Backward compatible - no breaking changes
- ✅ Aligns async implementation with sync implementation
