### PR TITLE
Use correct provider name for OpenAI observations

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -197,7 +197,7 @@ public final class OpenAiChatModel implements ChatModel {
 
 		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 			.prompt(prompt)
-			.provider(AiProvider.OPENAI_SDK.value())
+			.provider(AiProvider.OPENAI.value())
 			.build();
 
 		ChatResponse response = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION
@@ -296,7 +296,7 @@ public final class OpenAiChatModel implements ChatModel {
 			ConcurrentHashMap<String, String> roleMap = new ConcurrentHashMap<>();
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
-				.provider(AiProvider.OPENAI_SDK.value())
+				.provider(AiProvider.OPENAI.value())
 				.build();
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(
 					this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingModel.java
@@ -211,7 +211,7 @@ public class OpenAiEmbeddingModel extends AbstractEmbeddingModel {
 
 		var observationContext = EmbeddingModelObservationContext.builder()
 			.embeddingRequest(embeddingRequestWithMergedOptions)
-			.provider(AiProvider.OPENAI_SDK.value())
+			.provider(AiProvider.OPENAI.value())
 			.build();
 
 		return Objects.requireNonNull(

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageModel.java
@@ -175,7 +175,7 @@ public class OpenAiImageModel implements ImageModel {
 
 		var observationContext = ImageModelObservationContext.builder()
 			.imagePrompt(imagePrompt)
-			.provider(AiProvider.OPENAI_SDK.value())
+			.provider(AiProvider.OPENAI.value())
 			.build();
 
 		return Objects.requireNonNull(

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiChatModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiChatModelObservationIT.java
@@ -140,7 +140,7 @@ class AzureOpenAiChatModelObservationIT {
 					ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.CHAT.value())
 			.hasLowCardinalityKeyValue(ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(),
-					AiProvider.OPENAI_SDK.value())
+					AiProvider.OPENAI.value())
 			.hasHighCardinalityKeyValue(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_FREQUENCY_PENALTY.asString(),
 					"0.0")

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiEmbeddingModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiEmbeddingModelObservationIT.java
@@ -84,7 +84,7 @@ public class AzureOpenAiEmbeddingModelObservationIT {
 			.hasContextualNameEqualTo("embedding")
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.EMBEDDING.value())
-			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.OPENAI_SDK.value())
+			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.OPENAI.value())
 			// .hasLowCardinalityKeyValue(LowCardinalityKeyNames.REQUEST_MODEL.asString(),
 			// "text-embedding-ada-002")
 			// .hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_EMBEDDING_DIMENSIONS.asString(),

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
@@ -119,7 +119,7 @@ public class OpenAiChatModelObservationIT {
 			.that()
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.CHAT.value())
-			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.OPENAI_SDK.value())
+			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.OPENAI.value())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.REQUEST_MODEL.asString(),
 					OpenAiChatOptions.DEFAULT_CHAT_MODEL)
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.RESPONSE_MODEL.asString(), responseMetadata.getModel())

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/OpenAiEmbeddingModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/OpenAiEmbeddingModelObservationIT.java
@@ -85,7 +85,7 @@ public class OpenAiEmbeddingModelObservationIT {
 			.hasContextualNameEqualTo("embedding " + EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.EMBEDDING.value())
-			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.OPENAI_SDK.value())
+			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.AI_PROVIDER.asString(), AiProvider.OPENAI.value())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.REQUEST_MODEL.asString(),
 					EmbeddingModel.TEXT_EMBEDDING_3_SMALL.toString())
 			.hasLowCardinalityKeyValue(LowCardinalityKeyNames.RESPONSE_MODEL.asString(), responseMetadata.getModel())

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageModelObservationIT.java
@@ -88,7 +88,7 @@ public class OpenAiImageModelObservationIT {
 					ImageModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.IMAGE.value())
 			.hasLowCardinalityKeyValue(ImageModelObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(),
-					AiProvider.OPENAI_SDK.value())
+					AiProvider.OPENAI.value())
 			.hasLowCardinalityKeyValue(
 					ImageModelObservationDocumentation.LowCardinalityKeyNames.REQUEST_MODEL.asString(),
 					ImageModel.DALL_E_3.asString())

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiProvider.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiProvider.java
@@ -17,14 +17,13 @@
 package org.springframework.ai.observation.conventions;
 
 /**
- * Collection of systems providing AI functionality. Based on the OpenTelemetry Semantic
- * Conventions for AI Systems.
+ * Collection of systems providing AI functionality. Inspired by the OpenTelemetry
+ * Semantic Conventions for Generative AI.
  *
  * @author Thomas Vitale
  * @since 1.0.0
- * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai">OTel
- * Semantic Conventions</a>.
+ * @see <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai">OpenTelemetry
+ * Semantic Conventions for Generative AI</a>.
  */
 public enum AiProvider {
 
@@ -34,11 +33,6 @@ public enum AiProvider {
 	 * AI system provided by Anthropic.
 	 */
 	ANTHROPIC("anthropic"),
-
-	/**
-	 * AI system provided by Azure.
-	 */
-	AZURE_OPENAI("azure-openai"),
 
 	/**
 	 * AI system provided by Bedrock Converse.
@@ -66,11 +60,6 @@ public enum AiProvider {
 	MISTRAL_AI("mistral_ai"),
 
 	/**
-	 * AI system provided by Oracle OCI.
-	 */
-	OCI_GENAI("oci_genai"),
-
-	/**
 	 * AI system provided by Ollama.
 	 */
 	OLLAMA("ollama"),
@@ -84,11 +73,6 @@ public enum AiProvider {
 	 * AI system provided by OpenAI.
 	 */
 	OPENAI("openai"),
-
-	/**
-	 * AI system provided by the official OpenAI SDK.
-	 */
-	OPENAI_SDK("openai_sdk"),
 
 	/**
 	 * AI system provided by Spring AI.


### PR DESCRIPTION
Use 'openai' as the provider name for the Spring AI OpenAI observations instead of 'openai_sdk'.

Fixes gh-5924.