### PR TITLE
Improve tool calling observations

### DIFF
--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiOperationType.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiOperationType.java
@@ -17,21 +17,20 @@
 package org.springframework.ai.observation.conventions;
 
 /**
- * Types of operations performed by AI systems. Based on the OpenTelemetry Semantic
- * Conventions for AI Systems.
+ * Types of operations performed by AI systems. Inspired by the OpenTelemetry Semantic
+ * Conventions for Generative AI.
  *
  * @author Thomas Vitale
  * @since 1.0.0
- * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai">OTel
- * Semantic Conventions</a>.
+ * @see <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai">OpenTelemetry
+ * Semantic Conventions for Generative AI</a>.
  */
 public enum AiOperationType {
 
 	// @formatter:off
 
 	/**
-	 * AI operation type for chat.
+	 * AI operation type for chat completion.
 	 */
 	CHAT("chat"),
 
@@ -39,6 +38,11 @@ public enum AiOperationType {
 	 * AI operation type for embedding.
 	 */
 	EMBEDDING("embedding"),
+
+	/**
+	 * AI operation type for tool execution.
+	 */
+	EXECUTE_TOOL("execute_tool"),
 
 	/**
 	 * AI operation type for framework.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -211,10 +211,11 @@ The `spring.ai.tool` observations are recorded when performing tool calling in t
 |===
 |Name | Description
 
-|`gen_ai.operation.name` | The name of the operation being performed. It's always `framework`.
+|`gen_ai.operation.name` | The name of the operation being performed. It's always `execute_tool`.
 |`gen_ai.system` | The provider responsible for the operation. It's always `spring_ai`.
 |`spring.ai.kind` | The kind of operation performed by Spring AI. It's always `tool_call`.
 |`spring.ai.tool.definition.name` | The name of the tool.
+|`spring.ai.tool.type` | The type of the tool. By default, it's `function`.
 |===
 
 .High Cardinality Keys
@@ -223,8 +224,9 @@ The `spring.ai.tool` observations are recorded when performing tool calling in t
 |Name | Description
 |`spring.ai.tool.definition.description` | Description of the tool.
 |`spring.ai.tool.definition.schema` | Schema of the parameters used to call the tool.
+|`spring.ai.tool.call.id` | The ID of the tool call, as identified by the chat model.
 |`spring.ai.tool.call.arguments` | The input arguments to the tool call. (Only when enabled)
-|`spring.ai.tool.call.result` | Schema of the parameters used to call the tool. (Only when enabled)
+|`spring.ai.tool.call.result` | The result of the tool call execution. (Only when enabled)
 |===
 
 === Tool Call Arguments and Result Data

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -1,6 +1,19 @@
 [[upgrade-notes]]
 = Upgrade Notes
 
+[[upgrading-to-2-0-0-M6]]
+== Upgrading to 2.0.0-M6
+
+=== Observability
+
+==== Tool Calling
+
+The observations produced for tool calling operations have changed as follows:
+
+* the span name is `execute_tool <tool-name>` instead of `tool_call <tool-name>`.
+* the metric/span attribute `gen_ai.operation.name` has value `execute_tool` instead of `framework`.
+* a new `spring.ai.tool.type` metric/span attribute has been introduced to capture the tool type (e.g. `function`).
+* a new `spring.ai.tool.call.id` span attribute has been introduced to capture the tool call ID, as identified by the chat model.
 
 [[upgrading-to-2-0-0-M5]]
 == Upgrading to 2.0.0-M5

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -216,6 +216,8 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 			ToolCallingObservationContext observationContext = ToolCallingObservationContext.builder()
 				.toolDefinition(toolCallback.getToolDefinition())
 				.toolMetadata(toolCallback.getToolMetadata())
+				.toolCallId(toolCall.id())
+				.toolType(toolCall.type())
 				.toolCallArguments(finalToolInputArguments)
 				.build();
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/observation/DefaultToolCallingObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/observation/DefaultToolCallingObservationConvention.java
@@ -19,6 +19,7 @@ package org.springframework.ai.tool.observation;
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 
+import org.springframework.ai.observation.conventions.AiOperationType;
 import org.springframework.ai.observation.conventions.SpringAiKind;
 import org.springframework.util.Assert;
 
@@ -51,13 +52,17 @@ public class DefaultToolCallingObservationConvention implements ToolCallingObser
 	public String getContextualName(ToolCallingObservationContext context) {
 		Assert.notNull(context, "context cannot be null");
 		String toolName = context.getToolDefinition().name();
-		return "%s %s".formatted(SpringAiKind.TOOL_CALL.value(), toolName);
+		return "%s %s".formatted(AiOperationType.EXECUTE_TOOL.value(), toolName);
 	}
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(ToolCallingObservationContext context) {
-		return KeyValues.of(aiOperationType(context), aiProvider(context), springAiKind(context),
+		return KeyValues.of(aiOperationType(context), aiProvider(context), springAiKind(context), toolType(context),
 				toolDefinitionName(context));
+	}
+
+	protected KeyValue toolType(ToolCallingObservationContext context) {
+		return KeyValue.of(ToolCallingObservationDocumentation.LowCardinalityKeyNames.TOOL_TYPE, context.getToolType());
 	}
 
 	protected KeyValue aiOperationType(ToolCallingObservationContext context) {
@@ -85,6 +90,7 @@ public class DefaultToolCallingObservationConvention implements ToolCallingObser
 		var keyValues = KeyValues.empty();
 		keyValues = toolDefinitionDescription(keyValues, context);
 		keyValues = toolDefinitionSchema(keyValues, context);
+		keyValues = toolCallId(keyValues, context);
 		return keyValues;
 	}
 
@@ -100,6 +106,12 @@ public class DefaultToolCallingObservationConvention implements ToolCallingObser
 		return keyValues.and(
 				ToolCallingObservationDocumentation.HighCardinalityKeyNames.TOOL_DEFINITION_SCHEMA.asString(),
 				toolSchema);
+	}
+
+	protected KeyValues toolCallId(KeyValues keyValues, ToolCallingObservationContext context) {
+		String toolCallId = context.getToolCallId();
+		return keyValues.and(ToolCallingObservationDocumentation.HighCardinalityKeyNames.TOOL_CALL_ID.asString(),
+				toolCallId);
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/observation/ToolCallingObservationContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/observation/ToolCallingObservationContext.java
@@ -25,6 +25,7 @@ import org.springframework.ai.observation.conventions.AiProvider;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Context used to store data for tool calling observations.
@@ -34,25 +35,32 @@ import org.springframework.util.Assert;
  */
 public final class ToolCallingObservationContext extends Observation.Context {
 
-	private final AiOperationMetadata operationMetadata = new AiOperationMetadata(AiOperationType.FRAMEWORK.value(),
+	private final AiOperationMetadata operationMetadata = new AiOperationMetadata(AiOperationType.EXECUTE_TOOL.value(),
 			AiProvider.SPRING_AI.value());
 
 	private final ToolDefinition toolDefinition;
 
 	private final ToolMetadata toolMetadata;
 
+	private final String toolType;
+
+	private final String toolCallId;
+
 	private final String toolCallArguments;
 
 	private @Nullable String toolCallResult;
 
 	private ToolCallingObservationContext(ToolDefinition toolDefinition, ToolMetadata toolMetadata,
-			@Nullable String toolCallArguments, @Nullable String toolCallResult) {
+			@Nullable String toolType, @Nullable String toolCallId, @Nullable String toolCallArguments,
+			@Nullable String toolCallResult) {
 		Assert.notNull(toolDefinition, "toolDefinition cannot be null");
 		Assert.notNull(toolMetadata, "toolMetadata cannot be null");
 
 		this.toolDefinition = toolDefinition;
 		this.toolMetadata = toolMetadata;
-		this.toolCallArguments = toolCallArguments != null ? toolCallArguments : "{}";
+		this.toolType = StringUtils.hasText(toolType) ? toolType : "function";
+		this.toolCallId = StringUtils.hasText(toolCallId) ? toolCallId : "";
+		this.toolCallArguments = StringUtils.hasText(toolCallArguments) ? toolCallArguments : "{}";
 		this.toolCallResult = toolCallResult;
 	}
 
@@ -66,6 +74,14 @@ public final class ToolCallingObservationContext extends Observation.Context {
 
 	public ToolMetadata getToolMetadata() {
 		return this.toolMetadata;
+	}
+
+	public String getToolCallId() {
+		return this.toolCallId;
+	}
+
+	public String getToolType() {
+		return this.toolType;
 	}
 
 	public String getToolCallArguments() {
@@ -90,6 +106,10 @@ public final class ToolCallingObservationContext extends Observation.Context {
 
 		private ToolMetadata toolMetadata = ToolMetadata.builder().build();
 
+		private @Nullable String toolType;
+
+		private @Nullable String toolCallId;
+
 		private @Nullable String toolCallArguments;
 
 		private @Nullable String toolCallResult;
@@ -107,6 +127,16 @@ public final class ToolCallingObservationContext extends Observation.Context {
 			return this;
 		}
 
+		public Builder toolType(String toolCallType) {
+			this.toolType = toolCallType;
+			return this;
+		}
+
+		public Builder toolCallId(String toolCallId) {
+			this.toolCallId = toolCallId;
+			return this;
+		}
+
 		public Builder toolCallArguments(String toolCallArguments) {
 			this.toolCallArguments = toolCallArguments;
 			return this;
@@ -118,9 +148,9 @@ public final class ToolCallingObservationContext extends Observation.Context {
 		}
 
 		public ToolCallingObservationContext build() {
-			Assert.state(this.toolDefinition != null, "toolDefinition cannot be null");
-			return new ToolCallingObservationContext(this.toolDefinition, this.toolMetadata, this.toolCallArguments,
-					this.toolCallResult);
+			Assert.notNull(this.toolDefinition, "toolDefinition cannot be null");
+			return new ToolCallingObservationContext(this.toolDefinition, this.toolMetadata, this.toolType,
+					this.toolCallId, this.toolCallArguments, this.toolCallResult);
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/observation/ToolCallingObservationDocumentation.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/observation/ToolCallingObservationDocumentation.java
@@ -97,6 +97,16 @@ public enum ToolCallingObservationDocumentation implements ObservationDocumentat
 			}
 		},
 
+		/**
+		 * The type of the tool.
+		 */
+		TOOL_TYPE {
+			@Override
+			public String asString() {
+				return "spring.ai.tool.type";
+			}
+		},
+
 	}
 
 	/**
@@ -121,6 +131,16 @@ public enum ToolCallingObservationDocumentation implements ObservationDocumentat
 			@Override
 			public String asString() {
 				return "spring.ai.tool.definition.schema";
+			}
+		},
+
+		/**
+		 * The ID of the tool call.
+		 */
+		TOOL_CALL_ID {
+			@Override
+			public String asString() {
+				return "spring.ai.tool.call.id";
 			}
 		},
 

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerIT.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/tool/DefaultToolCallingManagerIT.java
@@ -91,10 +91,11 @@ class DefaultToolCallingManagerIT {
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultToolCallingObservationConvention.DEFAULT_NAME)
 			.that()
-			.hasContextualNameEqualTo(SpringAiKind.TOOL_CALL.value() + " " + toolCallback.getToolDefinition().name())
+			.hasContextualNameEqualTo(
+					AiOperationType.EXECUTE_TOOL.value() + " " + toolCallback.getToolDefinition().name())
 			.hasLowCardinalityKeyValue(
 					ToolCallingObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
-					AiOperationType.FRAMEWORK.value())
+					AiOperationType.EXECUTE_TOOL.value())
 			.hasLowCardinalityKeyValue(
 					ToolCallingObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(),
 					AiProvider.SPRING_AI.value())

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/observation/DefaultToolCallingObservationConventionTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/observation/DefaultToolCallingObservationConventionTests.java
@@ -48,7 +48,7 @@ class DefaultToolCallingObservationConventionTests {
 			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
 			.toolCallArguments("input")
 			.build();
-		assertThat(this.observationConvention.getContextualName(observationContext)).isEqualTo("tool_call toolA");
+		assertThat(this.observationConvention.getContextualName(observationContext)).isEqualTo("execute_tool toolA");
 	}
 
 	@Test
@@ -65,17 +65,20 @@ class DefaultToolCallingObservationConventionTests {
 	void shouldHaveLowCardinalityKeyValues() {
 		ToolCallingObservationContext observationContext = ToolCallingObservationContext.builder()
 			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.toolType("function")
 			.toolCallArguments("input")
 			.build();
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(observationContext)).contains(
 				KeyValue.of(ToolCallingObservationDocumentation.LowCardinalityKeyNames.TOOL_DEFINITION_NAME.asString(),
 						"toolA"),
 				KeyValue.of(ToolCallingObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
-						AiOperationType.FRAMEWORK.value()),
+						AiOperationType.EXECUTE_TOOL.value()),
 				KeyValue.of(ToolCallingObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(),
 						AiProvider.SPRING_AI.value()),
 				KeyValue.of(ToolCallingObservationDocumentation.LowCardinalityKeyNames.SPRING_AI_KIND,
-						SpringAiKind.TOOL_CALL.value()));
+						SpringAiKind.TOOL_CALL.value()),
+				KeyValue.of(ToolCallingObservationDocumentation.LowCardinalityKeyNames.TOOL_TYPE.asString(),
+						"function"));
 	}
 
 	@Test
@@ -87,6 +90,8 @@ class DefaultToolCallingObservationConventionTests {
 				""";
 		ToolCallingObservationContext observationContext = ToolCallingObservationContext.builder()
 			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.toolType("function")
+			.toolCallId("call_abc123")
 			.toolCallArguments(toolCallInput)
 			.toolCallResult("Mission accomplished!")
 			.build();
@@ -95,13 +100,16 @@ class DefaultToolCallingObservationConventionTests {
 					.asString(), "description"),
 				KeyValue.of(
 						ToolCallingObservationDocumentation.HighCardinalityKeyNames.TOOL_DEFINITION_SCHEMA.asString(),
-						"{}"));
+						"{}"),
+				KeyValue.of(ToolCallingObservationDocumentation.HighCardinalityKeyNames.TOOL_CALL_ID.asString(),
+						"call_abc123"));
 	}
 
 	@Test
 	void shouldHaveAllStandardLowCardinalityKeys() {
 		ToolCallingObservationContext observationContext = ToolCallingObservationContext.builder()
 			.toolDefinition(ToolDefinition.builder().name("tool").description("Tool").inputSchema("{}").build())
+			.toolType("function")
 			.toolCallArguments("args")
 			.build();
 
@@ -112,7 +120,8 @@ class DefaultToolCallingObservationConventionTests {
 			.contains(ToolCallingObservationDocumentation.LowCardinalityKeyNames.TOOL_DEFINITION_NAME.asString(),
 					ToolCallingObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					ToolCallingObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER.asString(),
-					ToolCallingObservationDocumentation.LowCardinalityKeyNames.SPRING_AI_KIND.asString());
+					ToolCallingObservationDocumentation.LowCardinalityKeyNames.SPRING_AI_KIND.asString(),
+					ToolCallingObservationDocumentation.LowCardinalityKeyNames.TOOL_TYPE.asString());
 	}
 
 	@Test

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/observation/ToolCallingContentObservationFilterTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/observation/ToolCallingContentObservationFilterTests.java
@@ -75,7 +75,7 @@ class ToolCallingContentObservationFilterTests {
 	}
 
 	@Test
-	void whenToolCallArgumentsIsEmptyStringThenHighCardinalityKeyValueIsEmpty() {
+	void whenToolCallArgumentsIsEmptyStringThenHighCardinalityKeyValueIsEmptyJsonString() {
 		var originalContext = ToolCallingObservationContext.builder()
 			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
 			.toolCallArguments("")
@@ -84,7 +84,7 @@ class ToolCallingContentObservationFilterTests {
 		var augmentedContext = this.observationFilter.map(originalContext);
 
 		assertThat(augmentedContext.getHighCardinalityKeyValues()).contains(KeyValue
-			.of(ToolCallingObservationDocumentation.HighCardinalityKeyNames.TOOL_CALL_ARGUMENTS.asString(), ""));
+			.of(ToolCallingObservationDocumentation.HighCardinalityKeyNames.TOOL_CALL_ARGUMENTS.asString(), "{}"));
 		assertThat(augmentedContext.getHighCardinalityKeyValues()).contains(KeyValue
 			.of(ToolCallingObservationDocumentation.HighCardinalityKeyNames.TOOL_CALL_RESULT.asString(), "result"));
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/tool/observation/ToolCallingObservationContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/tool/observation/ToolCallingObservationContextTests.java
@@ -61,7 +61,7 @@ class ToolCallingObservationContextTests {
 	@Test
 	void whenToolDefinitionIsNullThenThrow() {
 		assertThatThrownBy(() -> ToolCallingObservationContext.builder().toolCallArguments("lizard").build())
-			.isInstanceOf(IllegalStateException.class)
+			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("toolDefinition cannot be null");
 	}
 
@@ -75,13 +75,13 @@ class ToolCallingObservationContextTests {
 	}
 
 	@Test
-	void whenToolArgumentsIsEmptyStringThenReturnEmptyString() {
+	void whenToolArgumentsIsEmptyStringThenReturnEmptyJsonObjectString() {
 		var observationContext = ToolCallingObservationContext.builder()
 			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
 			.toolCallArguments("")
 			.build();
 		assertThat(observationContext).isNotNull();
-		assertThat(observationContext.getToolCallArguments()).isEqualTo("");
+		assertThat(observationContext.getToolCallArguments()).isEqualTo("{}");
 	}
 
 	@Test
@@ -118,6 +118,58 @@ class ToolCallingObservationContextTests {
 		assertThat(observationContext.getToolDefinition().name()).isEqualTo("testTool");
 		assertThat(observationContext.getToolDefinition().description()).isEqualTo("Test description");
 		assertThat(observationContext.getToolDefinition().inputSchema()).isEqualTo("{\"type\": \"object\"}");
+	}
+
+	@Test
+	void whenToolTypeIsNullThenReturnDefaultFunction() {
+		var observationContext = ToolCallingObservationContext.builder()
+			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.build();
+		assertThat(observationContext.getToolType()).isEqualTo("function");
+	}
+
+	@Test
+	void whenToolTypeIsEmptyStringThenReturnDefaultFunction() {
+		var observationContext = ToolCallingObservationContext.builder()
+			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.toolType("")
+			.build();
+		assertThat(observationContext.getToolType()).isEqualTo("function");
+	}
+
+	@Test
+	void whenToolTypeIsSetThenReturnIt() {
+		var observationContext = ToolCallingObservationContext.builder()
+			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.toolType("mcp")
+			.build();
+		assertThat(observationContext.getToolType()).isEqualTo("mcp");
+	}
+
+	@Test
+	void whenToolCallIdIsNullThenReturnEmpty() {
+		var observationContext = ToolCallingObservationContext.builder()
+			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.build();
+		assertThat(observationContext.getToolCallId()).isEqualTo("");
+	}
+
+	@Test
+	void whenToolCallIdIsEmptyStringThenReturnEmpty() {
+		var observationContext = ToolCallingObservationContext.builder()
+			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.toolCallId("")
+			.build();
+		assertThat(observationContext.getToolCallId()).isEqualTo("");
+	}
+
+	@Test
+	void whenToolCallIdIsSetThenReturnIt() {
+		var observationContext = ToolCallingObservationContext.builder()
+			.toolDefinition(ToolDefinition.builder().name("toolA").description("description").inputSchema("{}").build())
+			.toolCallId("call_abc123")
+			.build();
+		assertThat(observationContext.getToolCallId()).isEqualTo("call_abc123");
 	}
 
 }


### PR DESCRIPTION
- Introduce “execute_tool” operation type, which is now used in tool calling observations instead of “framework”. As a consequence, tool calling spans are now named “execute_tool <tool-name>” and the “gen_ai.operation.name” attribute is set to “execute_tool” instead of “framework”. Before, we were using the SpringAIKind in the observation name instead of AiOperationType, which is what all the other observations do. The reason was due to the lack of dedicated operation type value. That is now fixed, too.
- Add new attributes in tool calling observations to capture tool call type (low cardinality, “spring.ai.tool.type”) and tool call id (high cardinality, “spring.ai.tool.call.id”)
- Fix bug when tool call arguments are an empty string. Before, it would use the empty string. Now, it correctly sets it to an empty JSON object string: “{}”, which is consistent with how the arguments are actually parsed in the DefaultToolCallingManager.

Fixes gh-5926