### PR TITLE
Switch to JDK 17.0.19 to build the project

### DIFF
--- a/.github/workflows/artifactory-milestone-release.yml
+++ b/.github/workflows/artifactory-milestone-release.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Capture release version

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)
@@ -76,8 +76,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)
@@ -123,8 +123,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)
@@ -169,8 +169,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17 '
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)
@@ -222,8 +222,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       # NOT setting up maven build-cache b/c javadoc:aggregate-jar is forking lifecyle and can't benefit from it anyway
@@ -260,8 +260,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)

--- a/.github/workflows/documentation-upload.yml
+++ b/.github/workflows/documentation-upload.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       # NOT setting up maven build-cache b/c javadoc:aggregate-jar is forking lifecyle and can't benefit from it anyway

--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: 25
+          distribution: 'liberica'
+          java-version: '17'
           cache: 'maven'
 
       - name: Install GPG key

--- a/.github/workflows/mcp-integration-tests.yml
+++ b/.github/workflows/mcp-integration-tests.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Node.js
@@ -38,11 +38,11 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Node.js

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: '17'
+          distribution: 'liberica'
           cache: 'maven'
 
       - name: Setup Maven Build-Cache (~/.m2/build-cache)

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21.0.9-tem
+java=17.0.19-librca

--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ To clone it you have to either:
 
 ## Building
 
-The project targets and build artifacts compatible with Java 17+, but requires JDK 21
-to build. This is enforced by the maven enforcer plugin.
+The project targets and builds artifacts compatible with Java 17+, and requires a JDK with support for the [`-XDaddTypeAnnotationsToSymbol` javac argument](https://bugs.openjdk.org/browse/JDK-8373586), like Liberica 17.0.19+, for nullability checks.
+
+The recommended JDK is specified in the `.sdkmanrc` file, which can be installed and configured with the [SDKMAN!](https://sdkman.io/) tool:
+ - `sdk env install` to install the related JDK locally
+ - `sdk env` to use the related JDK
 
 **NOTE:** Building Spring AI requires components that depend on your specific CPU architecture (PyTorch for example). MacOS can seamlessly run x86 Java applications on ARM processors using Rosetta, but this will fail when building this project because it tries to download architecture-specific native dependencies. (Note: this is only an issue for building the project, not for consuming the libraries). If you are unsure if you have the correct JDK distribution for your CPU, run the command `java -XshowSettings:properties -version 2>&1 | grep os.arch` from a fresh terminal to validate that it matches your machine.
 

--- a/pom.xml
+++ b/pom.xml
@@ -342,9 +342,8 @@
 		<antlr.version>4.13.1</antlr.version>
 		<maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
 		<maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
-		<!-- The version (range) of the JDK we want to use to compile.
-			This is different from ${java.version} which we use as -release target. -->
-		<compiler.jdk.version>[21.0.8,)</compiler.jdk.version>
+		<!-- The version (range) of the JDK we want to use to compile -->
+		<compiler.jdk.version>[17.0.19,)</compiler.jdk.version>
 		<maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
 		<maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -365,8 +364,8 @@
 		<spring-javaformat-checkstyle.version>0.0.47</spring-javaformat-checkstyle.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
 
-		<error-prone.version>2.46.0</error-prone.version>
-		<nullaway.version>0.13.0</nullaway.version>
+		<error-prone.version>2.42.0</error-prone.version>
+		<nullaway.version>0.13.4</nullaway.version>
 
 		<disable.checks>false</disable.checks>
 


### PR DESCRIPTION
With the recent inclusion of `-XDaddTypeAnnotationsToSymbol` in JDK 17, it is now possible to use JDK 17.0.19 to compile the project and get NullAway checks working as expected.

We use this opportunity to switch to Liberica distribution which is the preferred distribution for all Spring projects.

Build and CI configuration are updated accordingly.

This commit also upgrades NullAway to 0.13.4 and updates the documentation in README.md to explain those requirements and how to use SDKMAN! to install and configure the right JDK.

Once merged, I will update the `1.1.x` and `1.0.x` branches to use the same Liberica JDK 17.0.19 version.