### PR TITLE
Document HTTP-layer observability gap for Anthropic and OpenAI chat models

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -1589,8 +1589,28 @@ spring.ai.anthropic.chat.options.web-search-tool.user-location.country=US
 
 == Observability
 
-The Anthropic SDK implementation supports Spring AI's observability features through Micrometer.
-All chat model operations are instrumented for monitoring and tracing.
+Spring AI emits Micrometer metrics and tracing spans at the chat model layer for every Anthropic call.
+Each span wraps the SDK invocation and carries request parameters, response metadata, and token usage.
+See the xref:observability/index.adoc[observability reference] for the full set.
+
+[IMPORTANT]
+====
+**HTTP layer is not instrumented**
+
+Since `2.0.0-M3`, Anthropic chat goes through the official `anthropic-java` SDK.
+The SDK builds its own `OkHttpClient` and doesn't expose an interceptor hook on it, so Spring AI has no way to attach the Micrometer or OpenTelemetry interceptors that would instrument the HTTP request.
+You won't see:
+
+* HTTP client metrics (per-endpoint latency, status codes, retries)
+* A span for the HTTP call itself, between Spring AI and the Anthropic API
+* Outbound `traceparent` propagation to the API or any intermediary (proxy, AI gateway, OpenAI-compatible inference service)
+
+Before `2.0.0-M3` the `RestClient` based code picked up HTTP instrumentation from Spring's HTTP stack for free.
+The switch to the SDK removed that side effect.
+
+If you need HTTP-level observability today, the https://github.com/open-telemetry/opentelemetry-java-instrumentation[OpenTelemetry Java agent] is the simplest path.
+It instruments OkHttp at the JVM level, so HTTP spans, metrics, and trace propagation come back without code changes.
+====
 
 == Logging
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -1608,8 +1608,10 @@ You won't see:
 Before `2.0.0-M3` the `RestClient` based code picked up HTTP instrumentation from Spring's HTTP stack for free.
 The switch to the SDK removed that side effect.
 
-If you need HTTP-level observability today, the https://github.com/open-telemetry/opentelemetry-java-instrumentation[OpenTelemetry Java agent] is the simplest path.
-It instruments OkHttp at the JVM level, so HTTP spans, metrics, and trace propagation come back without code changes.
+For users with strict HTTP observability requirements, the SDK supports plugging in a custom HTTP client.
+See the https://platform.claude.com/docs/en/api/sdks/java#custom-http-client[Anthropic Java SDK custom HTTP client docs] for the recommended approach.
+Wire your custom-built `AnthropicClient` and `AnthropicClientAsync` into Spring AI via `AnthropicChatModel.builder().anthropicClient(...).anthropicClientAsync(...)`.
+Built-in HTTP-level observability is being explored for a future release.
 ====
 
 == Logging

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -790,8 +790,10 @@ The switch to the SDK removed that side effect.
 This is most painful when you're behind an AI gateway or hitting an OpenAI-compatible server like vLLM or Ollama.
 Traces stop at the SDK boundary.
 
-If you need HTTP-level observability today, the https://github.com/open-telemetry/opentelemetry-java-instrumentation[OpenTelemetry Java agent] is the simplest path.
-It instruments OkHttp at the JVM level, so HTTP spans, metrics, and trace propagation come back without code changes.
+For users with strict HTTP observability requirements, the SDK supports plugging in a custom HTTP client.
+See the https://github.com/openai/openai-java#customized-okhttpclient[openai-java custom HTTP client docs] for the recommended approach.
+Wire your custom-built `OpenAIClient` and `OpenAIClientAsync` into Spring AI via `OpenAiChatModel.builder().openAiClient(...).openAiClientAsync(...)`.
+Built-in HTTP-level observability is being explored for a future release.
 ====
 
 == Using Extra Parameters with OpenAI-Compatible Servers [[openai-compatible-servers]]

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/openai-chat.adoc
@@ -767,6 +767,33 @@ This is useful when you need to:
 * Rotate API keys dynamically
 * Implement custom API key selection logic
 
+== Observability
+
+Spring AI emits Micrometer metrics and tracing spans at the chat model layer for every OpenAI call.
+Each span wraps the SDK invocation and carries request parameters, response metadata, and token usage.
+See the xref:observability/index.adoc[observability reference] for the full set.
+
+[IMPORTANT]
+====
+**HTTP layer is not instrumented**
+
+Since `2.0.0-M5`, OpenAI chat goes through the official `openai-java` SDK.
+The SDK builds its own `OkHttpClient` and doesn't expose an interceptor hook on it, so Spring AI has no way to attach the Micrometer or OpenTelemetry interceptors that would instrument the HTTP request.
+You won't see:
+
+* HTTP client metrics (per-endpoint latency, status codes, retries)
+* A span for the HTTP call between Spring AI and the OpenAI endpoint
+* Outbound `traceparent` propagation to the API or any intermediary (proxy, AI gateway, OpenAI-compatible inference server)
+
+Before `2.0.0-M5` the `RestClient`-based code picked up HTTP instrumentation from Spring's HTTP stack for free.
+The switch to the SDK removed that side effect.
+This is most painful when you're behind an AI gateway or hitting an OpenAI-compatible server like vLLM or Ollama.
+Traces stop at the SDK boundary.
+
+If you need HTTP-level observability today, the https://github.com/open-telemetry/opentelemetry-java-instrumentation[OpenTelemetry Java agent] is the simplest path.
+It instruments OkHttp at the JVM level, so HTTP spans, metrics, and trace propagation come back without code changes.
+====
+
 == Using Extra Parameters with OpenAI-Compatible Servers [[openai-compatible-servers]]
 
 OpenAI-compatible inference servers like vLLM, Ollama, and others often support additional parameters beyond those defined in OpenAI's standard API.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -148,7 +148,7 @@ Additional AI model providers will be supported in a future release.
 The Anthropic (since `2.0.0-M3`) and OpenAI (since `2.0.0-M5`) chat models go through vendor-provided Java SDKs.
 Each SDK builds its own `OkHttpClient` and doesn't expose an interceptor hook on it, so Spring AI can't wire in the Micrometer or OpenTelemetry interceptors that would instrument the HTTP call.
 Only the model-level observations covered below are emitted, and traces won't connect end to end through proxies, AI gateways, or OpenAI-compatible inference servers like vLLM and Ollama.
-See the xref:api/chat/anthropic-chat.adoc#_observability[Anthropic] and xref:api/chat/openai-chat.adoc#_observability[OpenAI] chat docs for details and the workaround.
+See the xref:api/chat/anthropic-chat.adoc#_observability[Anthropic] and xref:api/chat/openai-chat.adoc#_observability[OpenAI] chat docs for details.
 ====
 
 The `gen_ai.client.operation` observations are recorded when calling the ChatModel `call` or `stream` methods. 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -141,6 +141,16 @@ NOTE: Observability features are currently supported only for `ChatModel` implem
 providers: Anthropic, Mistral AI, Ollama, OpenAI, Google GenAI, MiniMax, Moonshot, QianFan.
 Additional AI model providers will be supported in a future release.
 
+[IMPORTANT]
+====
+**Anthropic and OpenAI: HTTP layer is not instrumented**
+
+The Anthropic (since `2.0.0-M3`) and OpenAI (since `2.0.0-M5`) chat models go through vendor-provided Java SDKs.
+Each SDK builds its own `OkHttpClient` and doesn't expose an interceptor hook on it, so Spring AI can't wire in the Micrometer or OpenTelemetry interceptors that would instrument the HTTP call.
+Only the model-level observations covered below are emitted, and traces won't connect end to end through proxies, AI gateways, or OpenAI-compatible inference servers like vLLM and Ollama.
+See the xref:api/chat/anthropic-chat.adoc#_observability[Anthropic] and xref:api/chat/openai-chat.adoc#_observability[OpenAI] chat docs for details and the workaround.
+====
+
 The `gen_ai.client.operation` observations are recorded when calling the ChatModel `call` or `stream` methods. 
 They measure the time spent on method completion and propagate the related tracing information.
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-ai/issues/5916

- Vendor SDKs build their own OkHttpClient and don't expose an interceptor hook, so HTTP metrics, spans, and traceparent propagation are missing
- Add a note to both Anthropic and OpenAI chat docs
- Cross-reference from the observability index