### PR TITLE
Fix outdated Javadoc references and syntax errors

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpSseClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpSseClientProperties.java
@@ -46,7 +46,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *       sse-endpoint: /mcp-hub/sse/cf9ec4527e3c4a2cbb149a85ea45ab01
  *     custom-server:
  *       url: http://api.example.com
- *       sse-endpoint: /v1/mcp/events?token=abc123&format=json
+ *       sse-endpoint: /v1/mcp/events?token=abc123&amp;format=json
  *
  * # How to split a full URL:
  * # Full URL: http://localhost:3000/mcp-hub/sse/token123

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpProgress.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/McpProgress.java
@@ -36,10 +36,10 @@ import java.lang.annotation.Target;
  * &#64;McpProgress(clientId = "my-client-id")
  * public void handleProgressMessage(ProgressNotification notification) {
  *     // Handle the progress notification
+ * }
  * }</pre>
  *
  * @author Christian Tzolov
- *
  * @see io.modelcontextprotocol.spec.McpSchema.ProgressNotification
  */
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/progress/AsyncProgressSpecification.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/progress/AsyncProgressSpecification.java
@@ -26,7 +26,7 @@ import reactor.core.publisher.Mono;
 /**
  * Specification for asynchronous progress handlers.
  *
- * @param clientId The client ID for the progress handler
+ * @param clients The client IDs for the progress handler
  * @param progressHandler The function that handles progress notifications asynchronously
  * @author Christian Tzolov
  */

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/progress/SyncProgressSpecification.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/progress/SyncProgressSpecification.java
@@ -25,7 +25,7 @@ import io.modelcontextprotocol.spec.McpSchema.ProgressNotification;
 /**
  * Specification for synchronous progress handlers.
  *
- * @param clientId The client ID for the progress handler
+ * @param clients The client IDs for the progress handler
  * @param progressHandler The consumer that handles progress notifications
  * @author Christian Tzolov
  */

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallback.java
@@ -98,7 +98,7 @@ public final class AsyncMcpPromptMethodCallback extends AbstractMcpPromptMethodC
 	 * @param exchange The server exchange, may be null if the method doesn't require it
 	 * @param request The prompt request, must not be null
 	 * @return A Mono that emits the prompt result
-	 * @throws McpPromptMethodException if there is an error invoking the prompt method
+	 * @throws McpError if there is an error invoking the prompt method
 	 * @throws IllegalArgumentException if the request is null
 	 */
 	@Override

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallback.java
@@ -94,7 +94,7 @@ public final class AsyncStatelessMcpPromptMethodCallback extends AbstractMcpProm
 	 * @param context The transport context, may be null if the method doesn't require it
 	 * @param request The prompt request, must not be null
 	 * @return A Mono that emits the prompt result
-	 * @throws McpPromptMethodException if there is an error invoking the prompt method
+	 * @throws McpError if there is an error invoking the prompt method
 	 * @throws IllegalArgumentException if the request is null
 	 */
 	@Override

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallback.java
@@ -97,7 +97,7 @@ public final class SyncMcpPromptMethodCallback extends AbstractMcpPromptMethodCa
 	 * @param exchange The server exchange, may be null if the method doesn't require it
 	 * @param request The prompt request, must not be null
 	 * @return The prompt result
-	 * @throws McpPromptMethodException if there is an error invoking the prompt method
+	 * @throws McpError if there is an error invoking the prompt method
 	 * @throws IllegalArgumentException if the request is null
 	 */
 	@Override

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallback.java
@@ -91,7 +91,7 @@ public final class SyncStatelessMcpPromptMethodCallback extends AbstractMcpPromp
 	 * @param context The transport context, may be null if the method doesn't require it
 	 * @param request The prompt request, must not be null
 	 * @return The prompt result
-	 * @throws McpPromptMethodException if there is an error invoking the prompt method
+	 * @throws McpError if there is an error invoking the prompt method
 	 * @throws IllegalArgumentException if the request is null
 	 */
 	@Override

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncMcpResourceMethodCallback.java
@@ -108,8 +108,7 @@ public final class AsyncMcpResourceMethodCallback extends AbstractMcpResourceMet
 	 * @param exchange The server exchange, may be null if the method doesn't require it
 	 * @param request The resource request, must not be null
 	 * @return A Mono that emits the resource result
-	 * @throws McpResourceMethodException if there is an error invoking the resource
-	 * method
+	 * @throws McpError if there is an error invoking the resource method
 	 * @throws IllegalArgumentException if the request is null or if URI variable
 	 * extraction fails
 	 */

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncStatelessMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncStatelessMcpResourceMethodCallback.java
@@ -102,8 +102,7 @@ public final class AsyncStatelessMcpResourceMethodCallback extends AbstractMcpRe
 	 * @param context The transport context, may be null if the method doesn't require it
 	 * @param request The resource request, must not be null
 	 * @return A Mono that emits the resource result
-	 * @throws McpResourceMethodException if there is an error invoking the resource
-	 * method
+	 * @throws McpError if there is an error invoking the resource method
 	 * @throws IllegalArgumentException if the request is null or if URI variable
 	 * extraction fails
 	 */

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallback.java
@@ -104,8 +104,7 @@ public final class SyncMcpResourceMethodCallback extends AbstractMcpResourceMeth
 	 * @param exchange The server exchange, may be null if the method doesn't require it
 	 * @param request The resource request, must not be null
 	 * @return The resource result
-	 * @throws McpResourceMethodException if there is an error invoking the resource
-	 * method
+	 * @throws McpError if there is an error invoking the resource method
 	 * @throws IllegalArgumentException if the request is null or if URI variable
 	 * extraction fails
 	 */

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncStatelessMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncStatelessMcpResourceMethodCallback.java
@@ -99,8 +99,7 @@ public final class SyncStatelessMcpResourceMethodCallback extends AbstractMcpRes
 	 * @param context The transport context, may be null if the method doesn't require it
 	 * @param request The resource request, must not be null
 	 * @return The resource result
-	 * @throws McpResourceMethodException if there is an error invoking the resource
-	 * method
+	 * @throws McpError if there is an error invoking the resource method
 	 * @throws IllegalArgumentException if the request is null or if URI variable
 	 * extraction fails
 	 */


### PR DESCRIPTION
I noticed that CI/CD exposes some errors of Javadoc, and here's the fix:

- Escaped `&` as `&amp;`.
- Closed the {@code ...} block.
- Updated `@param` names from `clientId` to the actual clients component.
- Corrected prompt/resource callback `@throws` tags to reference the actual `McpError`.

Then use `.\mvnw.cmd -DskipTests -DskipITs javadoc:jar`, Full 175-module Javadoc build completed successfully.