### PR TITLE
Remove several ModelOptionsUtils methods

### DIFF
--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -481,8 +481,10 @@ public class BedrockProxyChatModel implements ChatModel {
 			.topP(updatedRuntimeOptions.getTopP() != null ? updatedRuntimeOptions.getTopP().floatValue() : null)
 			.build();
 
+		BedrockChatOptions bedrockOptions = (BedrockChatOptions) prompt.getOptions();
+		Assert.notNull(bedrockOptions, "options can't be null here");
 		Document additionalModelRequestFields = ConverseApiUtils
-			.getChatOptionsAdditionalModelRequestFields(this.defaultOptions, prompt.getOptions());
+			.convertObjectToDocument(bedrockOptions.getRequestParameters());
 
 		Map<String, String> requestMetadata = ConverseApiUtils
 			.getRequestMetadata(prompt.getUserMessage().getMetadata());

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/api/ConverseApiUtils.java
@@ -23,12 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.core.document.Document;
-
-import org.springframework.ai.chat.prompt.ChatOptions;
-import org.springframework.ai.model.ModelOptions;
-import org.springframework.ai.model.ModelOptionsUtils;
 
 /**
  * Amazon Bedrock Converse API utils.
@@ -41,63 +36,6 @@ import org.springframework.ai.model.ModelOptionsUtils;
 public final class ConverseApiUtils {
 
 	private ConverseApiUtils() {
-	}
-
-	public static @Nullable Document getChatOptionsAdditionalModelRequestFields(@Nullable ChatOptions defaultOptions,
-			@Nullable ModelOptions promptOptions) {
-		if (defaultOptions == null && promptOptions == null) {
-			return null;
-		}
-
-		Map<String, Object> attributes = new HashMap<>();
-
-		if (defaultOptions != null) {
-			attributes.putAll(ModelOptionsUtils.objectToMap(defaultOptions));
-		}
-
-		if (promptOptions != null) {
-			if (promptOptions instanceof ChatOptions runtimeOptions) {
-				attributes.putAll(ModelOptionsUtils.objectToMap(runtimeOptions));
-			}
-			else {
-				throw new IllegalArgumentException(
-						"Prompt options are not of type ChatOptions:" + promptOptions.getClass().getSimpleName());
-			}
-		}
-
-		attributes.remove("model");
-		attributes.remove("proxyToolCalls");
-		attributes.remove("functions");
-		attributes.remove("toolContext");
-		attributes.remove("toolCallbacks");
-
-		attributes.remove("toolCallbacks");
-		attributes.remove("toolNames");
-		attributes.remove("internalToolExecutionEnabled");
-
-		attributes.remove("temperature");
-		attributes.remove("topK");
-		attributes.remove("stopSequences");
-		attributes.remove("maxTokens");
-		attributes.remove("topP");
-
-		attributes.remove("frequencyPenalty");
-		attributes.remove("presencePenalty");
-		attributes.remove("cacheOptions");
-		attributes.remove("outputSchema");
-
-		if (attributes.containsKey("requestParameters")) {
-			Object reqMap = attributes.remove("requestParameters");
-			if (reqMap instanceof Map map) {
-				attributes.putAll(map);
-			}
-		}
-
-		if (attributes.isEmpty()) {
-			return null;
-		}
-
-		return convertObjectToDocument(attributes);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/MockWeatherService.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/MockWeatherService.java
@@ -18,12 +18,6 @@ package org.springframework.ai.ollama.api.tool;
 
 import java.util.function.Function;
 
-import com.fasterxml.jackson.annotation.JsonClassDescription;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-
 /**
  * @author Christian Tzolov
  */
@@ -74,11 +68,7 @@ public class MockWeatherService implements Function<MockWeatherService.Request, 
 	/**
 	 * Weather Function request.
 	 */
-	@JsonInclude(Include.NON_NULL)
-	@JsonClassDescription("Weather API request")
-	public record Request(@JsonProperty(required = true,
-			value = "location") @JsonPropertyDescription("The city and state e.g. San Francisco, CA") String location,
-			@JsonProperty(required = true, value = "unit") @JsonPropertyDescription("Temperature unit") Unit unit) {
+	public record Request(String location, Unit unit) {
 
 	}
 

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/OllamaApiToolFunctionCallIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/api/tool/OllamaApiToolFunctionCallIT.java
@@ -34,6 +34,7 @@ import org.springframework.ai.ollama.api.OllamaApi.Message;
 import org.springframework.ai.ollama.api.OllamaApi.Message.Role;
 import org.springframework.ai.ollama.api.OllamaApi.Message.ToolCall;
 import org.springframework.ai.ollama.api.OllamaModel;
+import org.springframework.ai.ollama.api.tool.MockWeatherService.Unit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -111,8 +112,9 @@ public class OllamaApiToolFunctionCallIT extends BaseOllamaIT {
 			var functionName = toolCall.function().name();
 			if ("getCurrentWeather".equals(functionName)) {
 				Map<String, Object> responseMap = toolCall.function().arguments();
-				MockWeatherService.Request weatherRequest = ModelOptionsUtils.mapToClass(responseMap,
-						MockWeatherService.Request.class);
+
+				var weatherRequest = new MockWeatherService.Request((String) responseMap.get("location"),
+						Unit.valueOf((String) responseMap.get("unit")));
 
 				MockWeatherService.Response weatherResponse = this.weatherService.apply(weatherRequest);
 

--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptions.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptions.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.embedding.EmbeddingOptions;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.postgresml.PostgresMlEmbeddingModel.VectorType;
 
 /**
@@ -118,11 +117,6 @@ public class PostgresMlEmbeddingOptions implements EmbeddingOptions {
 
 		public Builder vectorType(VectorType vectorType) {
 			this.options.setVectorType(vectorType);
-			return this;
-		}
-
-		public Builder kwargs(String kwargs) {
-			this.options.setKwargs(ModelOptionsUtils.objectToMap(kwargs));
 			return this;
 		}
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/ModelOptionsUtils.java
@@ -16,21 +16,13 @@
 
 package org.springframework.ai.model;
 
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
@@ -49,12 +41,8 @@ import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ObjectNode;
 
 import org.springframework.ai.util.JacksonUtils;
-import org.springframework.beans.BeanWrapper;
-import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.core.KotlinDetector;
 import org.springframework.lang.Contract;
-import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -138,208 +126,6 @@ public abstract class ModelOptionsUtils {
 	 */
 	public static String toJsonStringPrettyPrinter(Object object) {
 		return JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(object);
-	}
-
-	/**
-	 * Merges the source object into the target object and returns an object represented
-	 * by the given class. The JSON property names are used to match the fields to merge.
-	 * The source non-null values override the target values with the same field name. The
-	 * source null values are ignored. If the acceptedFieldNames is not empty, only the
-	 * fields with the given names are merged and returned. If the acceptedFieldNames is
-	 * empty, use the {@code @JsonProperty} names, inferred from the provided clazz.
-	 * @param <T> they type of the class to return.
-	 * @param source the source object to merge.
-	 * @param target the target object to merge into.
-	 * @param clazz the class to return.
-	 * @param acceptedFieldNames the list of field names accepted for the target object.
-	 * @return the merged object represented by the given class.
-	 */
-	public static <T> T merge(@Nullable Object source, Object target, Class<T> clazz,
-			@Nullable List<String> acceptedFieldNames) {
-
-		if (source == null) {
-			source = Map.of();
-		}
-
-		List<String> requestFieldNames = CollectionUtils.isEmpty(acceptedFieldNames)
-				? REQUEST_FIELD_NAMES_PER_CLASS.computeIfAbsent(clazz, ModelOptionsUtils::getJsonPropertyValues)
-				: acceptedFieldNames;
-
-		if (CollectionUtils.isEmpty(requestFieldNames)) {
-			throw new IllegalArgumentException("No @JsonProperty fields found in the " + clazz.getName());
-		}
-
-		Map<String, Object> sourceMap = ModelOptionsUtils.objectToMap(source);
-		Map<String, Object> targetMap = ModelOptionsUtils.objectToMap(target);
-
-		targetMap.putAll(sourceMap.entrySet()
-			.stream()
-			.filter(e -> e.getValue() != null)
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-
-		targetMap = targetMap.entrySet()
-			.stream()
-			.filter(e -> requestFieldNames.contains(e.getKey()))
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-		return ModelOptionsUtils.mapToClass(targetMap, clazz);
-	}
-
-	/**
-	 * Merges the source object into the target object and returns an object represented
-	 * by the given class. The JSON property names are used to match the fields to merge.
-	 * The source non-null values override the target values with the same field name. The
-	 * source null values are ignored. Returns the only field names that match the
-	 * {@code @JsonProperty} names, inferred from the provided clazz.
-	 * @param <T> they type of the class to return.
-	 * @param source the source object to merge.
-	 * @param target the target object to merge into.
-	 * @param clazz the class to return.
-	 * @return the merged object represented by the given class.
-	 */
-	public static <T> T merge(@Nullable Object source, Object target, Class<T> clazz) {
-		return ModelOptionsUtils.merge(source, target, clazz, null);
-	}
-
-	/**
-	 * Converts the given object to a Map.
-	 * @param source the object to convert to a Map.
-	 * @return the converted Map.
-	 */
-	public static Map<String, Object> objectToMap(@Nullable Object source) {
-		if (source == null) {
-			return new HashMap<>();
-		}
-		String json = JSON_MAPPER.writeValueAsString(source);
-		return JSON_MAPPER.readValue(json, new TypeReference<Map<String, @Nullable Object>>() {
-
-		})
-			.entrySet()
-			.stream()
-			.filter(e -> e.getValue() != null)
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-	}
-
-	/**
-	 * Converts the given Map to the given class.
-	 * @param <T> the type of the class to return.
-	 * @param source the Map to convert to the given class.
-	 * @param clazz the class to convert the Map to.
-	 * @return the converted class.
-	 */
-	public static <T> T mapToClass(Map<String, Object> source, Class<T> clazz) {
-		String json = JSON_MAPPER.writeValueAsString(source);
-		return JSON_MAPPER.readValue(json, clazz);
-	}
-
-	/**
-	 * Returns the list of name values of the {@link JsonProperty} annotations.
-	 * @param clazz the class that contains fields annotated with {@link JsonProperty}.
-	 * @return the list of values of the {@link JsonProperty} annotations.
-	 */
-	public static List<String> getJsonPropertyValues(Class<?> clazz) {
-		List<String> values = new ArrayList<>();
-		Field[] fields = clazz.getDeclaredFields();
-		for (Field field : fields) {
-			JsonProperty jsonPropertyAnnotation = field.getAnnotation(JsonProperty.class);
-			if (jsonPropertyAnnotation != null) {
-				values.add(jsonPropertyAnnotation.value());
-			}
-		}
-		return values;
-	}
-
-	/**
-	 * Returns a new instance of the targetBeanClazz that copies the bean values from the
-	 * sourceBean instance.
-	 * @param sourceBean the source bean to copy the values from.
-	 * @param sourceInterfaceClazz the source interface class. Only the fields with the
-	 * same name as the interface methods are copied. This allows the source object to be
-	 * a subclass of the source interface with additional, non-interface fields.
-	 * @param targetBeanClazz the target class, a subclass of the ChatOptions, to convert
-	 * into.
-	 * @param <T> the target class type.
-	 * @return a new instance of the targetBeanClazz with the values from the sourceBean
-	 * instance.
-	 */
-	public static <I, S extends I, T extends S> @Nullable T copyToTarget(@Nullable S sourceBean,
-			Class<I> sourceInterfaceClazz, Class<T> targetBeanClazz) {
-
-		Assert.notNull(sourceInterfaceClazz, "SourceOptionsClazz must not be null");
-		Assert.notNull(targetBeanClazz, "TargetOptionsClazz must not be null");
-
-		if (sourceBean == null) {
-			return null;
-		}
-
-		if (sourceBean.getClass().isAssignableFrom(targetBeanClazz)) {
-			return (T) sourceBean;
-		}
-
-		try {
-			T targetOptions = targetBeanClazz.getConstructor().newInstance();
-
-			ModelOptionsUtils.mergeBeans(sourceBean, targetOptions, sourceInterfaceClazz, true);
-
-			return targetOptions;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(
-					"Failed to convert the " + sourceInterfaceClazz.getName() + " into " + targetBeanClazz.getName(),
-					e);
-		}
-	}
-
-	/**
-	 * Merges the source object into the target object. The source null values are
-	 * ignored. Only objects with Getter and Setter methods are supported.
-	 * @param <T> the type of the source and target object.
-	 * @param source the source object to merge.
-	 * @param target the target object to merge into.
-	 * @param sourceInterfaceClazz the source interface class. Only the fields with the
-	 * same name as the interface methods are merged. This allow the source object to be a
-	 * subclass of the source interface with additional, non-interface fields.
-	 * @param overrideNonNullTargetValues if true, the source non-null values override the
-	 * target values with the same field name. If false, the source non-null values are
-	 * ignored.
-	 * @return the merged target object.
-	 */
-	public static <I, S extends I, T extends S> T mergeBeans(S source, T target, Class<I> sourceInterfaceClazz,
-			boolean overrideNonNullTargetValues) {
-		Assert.notNull(source, "Source object must not be null");
-		Assert.notNull(target, "Target object must not be null");
-
-		BeanWrapper sourceBeanWrap = new BeanWrapperImpl(source);
-		BeanWrapper targetBeanWrap = new BeanWrapperImpl(target);
-
-		Set<String> interfaceNames = Arrays.stream(sourceInterfaceClazz.getMethods())
-			.map(Method::getName)
-			.collect(Collectors.toSet());
-
-		for (PropertyDescriptor descriptor : sourceBeanWrap.getPropertyDescriptors()) {
-
-			if (!BEAN_MERGE_FIELD_EXCISIONS.contains(descriptor.getName())
-					&& interfaceNames.contains(toGetName(descriptor.getName()))) {
-
-				String propertyName = descriptor.getName();
-				Object value = sourceBeanWrap.getPropertyValue(propertyName);
-
-				// Copy value to the target object
-				if (value != null) {
-					var targetValue = targetBeanWrap.getPropertyValue(propertyName);
-
-					if (targetValue == null || overrideNonNullTargetValues) {
-						targetBeanWrap.setPropertyValue(propertyName, value);
-					}
-				}
-			}
-		}
-
-		return target;
-	}
-
-	private static String toGetName(String name) {
-		return "get" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
 	}
 
 	/**

--- a/spring-ai-model/src/test/java/org/springframework/ai/model/ModelOptionsUtilsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/model/ModelOptionsUtilsTests.java
@@ -33,99 +33,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class ModelOptionsUtilsTests {
 
 	@Test
-	public void merge() {
-		TestPortableOptionsImpl portableOptions = new TestPortableOptionsImpl();
-		portableOptions.setName("John");
-		portableOptions.setAge(30);
-		portableOptions.setNonInterfaceField("NonInterfaceField");
-
-		TestSpecificOptions specificOptions = new TestSpecificOptions();
-		specificOptions.setName("Mike");
-		specificOptions.setSpecificField("SpecificField");
-
-		assertThatThrownBy(
-				() -> ModelOptionsUtils.merge(portableOptions, specificOptions, TestPortableOptionsImpl.class))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("No @JsonProperty fields found in the ");
-
-		var specificOptions2 = ModelOptionsUtils.merge(portableOptions, specificOptions, TestSpecificOptions.class);
-
-		assertThat(specificOptions2.getAge()).isEqualTo(30);
-		assertThat(specificOptions2.getName()).isEqualTo("John"); // !!! Overridden by the
-		// portableOptions
-		assertThat(specificOptions2.getSpecificField()).isEqualTo("SpecificField");
-	}
-
-	@Test
-	public void objectToMap() {
-		TestPortableOptionsImpl portableOptions = new TestPortableOptionsImpl();
-		portableOptions.setName("John");
-		portableOptions.setAge(30);
-		portableOptions.setNonInterfaceField("NonInterfaceField");
-
-		Map<String, Object> map = ModelOptionsUtils.objectToMap(portableOptions);
-
-		assertThat(map).containsEntry("name", "John");
-		assertThat(map).containsEntry("age", 30);
-		assertThat(map).containsEntry("nonInterfaceField", "NonInterfaceField");
-	}
-
-	@Test
-	public void mapToClass() {
-		TestPortableOptionsImpl portableOptions = ModelOptionsUtils.mapToClass(
-				Map.of("name", "John", "age", 30, "nonInterfaceField", "NonInterfaceField"),
-				TestPortableOptionsImpl.class);
-
-		assertThat(portableOptions.getName()).isEqualTo("John");
-		assertThat(portableOptions.getAge()).isEqualTo(30);
-		assertThat(portableOptions.getNonInterfaceField()).isEqualTo("NonInterfaceField");
-	}
-
-	@Test
-	public void mergeBeans() {
-
-		var portableOptions = new TestPortableOptionsImpl();
-		portableOptions.setName("John");
-		portableOptions.setAge(30);
-		portableOptions.setNonInterfaceField("NonInterfaceField");
-
-		var specificOptions = new TestSpecificOptions();
-
-		specificOptions.setName("Mike");
-		specificOptions.setAge(60);
-		specificOptions.setSpecificField("SpecificField");
-
-		TestSpecificOptions specificOptions2 = ModelOptionsUtils.mergeBeans(portableOptions, specificOptions,
-				TestPortableOptions.class, false);
-
-		assertThat(specificOptions2.getAge()).isEqualTo(60);
-		assertThat(specificOptions2.getName()).isEqualTo("Mike");
-		assertThat(specificOptions2.getSpecificField()).isEqualTo("SpecificField");
-
-		TestSpecificOptions specificOptionsWithOverride = ModelOptionsUtils.mergeBeans(portableOptions, specificOptions,
-				TestPortableOptions.class, true);
-
-		assertThat(specificOptionsWithOverride.getAge()).isEqualTo(30);
-		assertThat(specificOptionsWithOverride.getName()).isEqualTo("John");
-		assertThat(specificOptionsWithOverride.getSpecificField()).isEqualTo("SpecificField");
-	}
-
-	@Test
-	public void copyToTarget() {
-		var portableOptions = new TestPortableOptionsImpl();
-		portableOptions.setName("John");
-		portableOptions.setAge(30);
-		portableOptions.setNonInterfaceField("NonInterfaceField");
-
-		TestSpecificOptions target = ModelOptionsUtils.copyToTarget(portableOptions, TestPortableOptions.class,
-				TestSpecificOptions.class);
-
-		assertThat(target.getAge()).isEqualTo(30);
-		assertThat(target.getName()).isEqualTo("John");
-		assertThat(target.getSpecificField()).isNull();
-	}
-
-	@Test
 	public void jsonToMap_emptyStringAsNullObject() {
 		String json = "{\"name\":\"\", \"age\":30}";
 		// For Map: empty string remains ""
@@ -164,15 +71,6 @@ public class ModelOptionsUtilsTests {
 		// .build();
 		// assertThatThrownBy(() -> strictMapper.readValue(jsonWithEmptyAge,
 		// Person.class)).isInstanceOf(Exception.class);
-	}
-
-	@Test
-	public void getJsonPropertyValues() {
-		record TestRecord(@JsonProperty("field1") String fieldA, @JsonProperty("field2") String fieldB) {
-
-		}
-		assertThat(ModelOptionsUtils.getJsonPropertyValues(TestRecord.class)).hasSize(2);
-		assertThat(ModelOptionsUtils.getJsonPropertyValues(TestRecord.class)).containsExactly("field1", "field2");
 	}
 
 	@Test

--- a/spring-ai-model/src/test/kotlin/org/springframework/ai/model/ModelOptionsUtilsTests.kt
+++ b/spring-ai-model/src/test/kotlin/org/springframework/ai/model/ModelOptionsUtilsTests.kt
@@ -29,19 +29,6 @@ class KotlinModelOptionsUtilsTests {
 	private val jsonMapper = JsonMapper()
 
 	@Test
-	fun `test ModelOptionsUtils with Kotlin data class`() {
-		val portableOptions = Foo("John", "Doe")
-
-		val optionsMap = ModelOptionsUtils.objectToMap(portableOptions)
-		assertThat(optionsMap).containsEntry("bar", "John")
-		assertThat(optionsMap).containsEntry("baz", "Doe")
-
-		val newPortableOptions = ModelOptionsUtils.mapToClass(optionsMap, Foo::class.java)
-		assertThat(newPortableOptions.bar).isEqualTo("John")
-		assertThat(newPortableOptions.baz).isEqualTo("Doe")
-	}
-
-	@Test
 	fun `test Kotlin data class schema generation using getJsonSchema`() {
 		val inputType: Type = Foo::class.java
 


### PR DESCRIPTION
Those methods were primarily used to merge two options beans together, but relying on serializing to JSON and back, which is not ideal. Moreover, a lot of exceptions
were needed (don't deal with tool callbacks, etc)
leading to an error prone mechanism.

This logic has broadly been replaced with XXOptions.Builder.combineWith()
