### PR TITLE
Remove Bedrock setters from options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfiguration.java
@@ -78,7 +78,7 @@ public class BedrockConverseProxyChatAutoConfiguration {
 			.asyncReadTimeout(connectionProperties.getAsyncReadTimeout())
 			.connectionAcquisitionTimeout(connectionProperties.getConnectionAcquisitionTimeout())
 			.socketTimeout(connectionProperties.getSocketTimeout())
-			.defaultOptions(chatProperties.getOptions())
+			.defaultOptions(chatProperties.toOptions())
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
 			.toolCallingManager(toolCallingManager)
 			.toolExecutionEligibilityPredicate(

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/main/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatProperties.java
@@ -16,15 +16,23 @@
 
 package org.springframework.ai.model.bedrock.converse.autoconfigure;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.bedrock.converse.BedrockChatOptions;
+import org.springframework.ai.bedrock.converse.api.BedrockCacheOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for Bedrock Converse.
  *
  * @author Christian Tzolov
  * @author Josh Long
+ * @author Sébastien Deleuze
  * @since 1.0.0
  */
 @ConfigurationProperties(BedrockConverseProxyChatProperties.CONFIG_PREFIX)
@@ -37,12 +45,29 @@ public class BedrockConverseProxyChatProperties {
 	 */
 	private boolean enabled;
 
-	@NestedConfigurationProperty
-	private final BedrockChatOptions options = BedrockChatOptions.builder().temperature(0.7).maxTokens(300).build();
+	private @Nullable String model;
 
-	public BedrockChatOptions getOptions() {
-		return this.options;
-	}
+	private @Nullable Double frequencyPenalty;
+
+	private @Nullable Integer maxTokens = 300;
+
+	private @Nullable Double presencePenalty;
+
+	private Map<String, String> requestParameters = new HashMap<>();
+
+	private @Nullable List<String> stopSequences;
+
+	private @Nullable Double temperature = 0.7;
+
+	private @Nullable Integer topK;
+
+	private @Nullable Double topP;
+
+	private @Nullable Boolean internalToolExecutionEnabled;
+
+	private @Nullable BedrockCacheOptions cacheOptions;
+
+	private final Options options = new Options();
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -50,6 +75,229 @@ public class BedrockConverseProxyChatProperties {
 
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	public @Nullable String getModel() {
+		return this.model;
+	}
+
+	public void setModel(@Nullable String model) {
+		this.model = model;
+	}
+
+	public @Nullable Double getFrequencyPenalty() {
+		return this.frequencyPenalty;
+	}
+
+	public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+		this.frequencyPenalty = frequencyPenalty;
+	}
+
+	public @Nullable Integer getMaxTokens() {
+		return this.maxTokens;
+	}
+
+	public void setMaxTokens(@Nullable Integer maxTokens) {
+		this.maxTokens = maxTokens;
+	}
+
+	public @Nullable Double getPresencePenalty() {
+		return this.presencePenalty;
+	}
+
+	public void setPresencePenalty(@Nullable Double presencePenalty) {
+		this.presencePenalty = presencePenalty;
+	}
+
+	public Map<String, String> getRequestParameters() {
+		return this.requestParameters;
+	}
+
+	public void setRequestParameters(Map<String, String> requestParameters) {
+		this.requestParameters = requestParameters;
+	}
+
+	public @Nullable List<String> getStopSequences() {
+		return this.stopSequences;
+	}
+
+	public void setStopSequences(@Nullable List<String> stopSequences) {
+		this.stopSequences = stopSequences;
+	}
+
+	public @Nullable Double getTemperature() {
+		return this.temperature;
+	}
+
+	public void setTemperature(@Nullable Double temperature) {
+		this.temperature = temperature;
+	}
+
+	public @Nullable Integer getTopK() {
+		return this.topK;
+	}
+
+	public void setTopK(@Nullable Integer topK) {
+		this.topK = topK;
+	}
+
+	public @Nullable Double getTopP() {
+		return this.topP;
+	}
+
+	public void setTopP(@Nullable Double topP) {
+		this.topP = topP;
+	}
+
+	public @Nullable Boolean getInternalToolExecutionEnabled() {
+		return this.internalToolExecutionEnabled;
+	}
+
+	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	public @Nullable BedrockCacheOptions getCacheOptions() {
+		return this.cacheOptions;
+	}
+
+	public void setCacheOptions(@Nullable BedrockCacheOptions cacheOptions) {
+		this.cacheOptions = cacheOptions;
+	}
+
+	public Options getOptions() {
+		return this.options;
+	}
+
+	public BedrockChatOptions toOptions() {
+		return BedrockChatOptions.builder()
+			.model(this.model)
+			.frequencyPenalty(this.frequencyPenalty)
+			.maxTokens(this.maxTokens)
+			.presencePenalty(this.presencePenalty)
+			.requestParameters(this.requestParameters)
+			.stopSequences(this.stopSequences)
+			.temperature(this.temperature)
+			.topK(this.topK)
+			.topP(this.topP)
+			.internalToolExecutionEnabled(this.internalToolExecutionEnabled)
+			.cacheOptions(this.cacheOptions)
+			.build();
+	}
+
+	public class Options {
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.model")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getModel() {
+			return BedrockConverseProxyChatProperties.this.getModel();
+		}
+
+		public void setModel(@Nullable String model) {
+			BedrockConverseProxyChatProperties.this.setModel(model);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.frequency-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getFrequencyPenalty() {
+			return BedrockConverseProxyChatProperties.this.getFrequencyPenalty();
+		}
+
+		public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+			BedrockConverseProxyChatProperties.this.setFrequencyPenalty(frequencyPenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.max-tokens")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getMaxTokens() {
+			return BedrockConverseProxyChatProperties.this.getMaxTokens();
+		}
+
+		public void setMaxTokens(@Nullable Integer maxTokens) {
+			BedrockConverseProxyChatProperties.this.setMaxTokens(maxTokens);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.presence-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getPresencePenalty() {
+			return BedrockConverseProxyChatProperties.this.getPresencePenalty();
+		}
+
+		public void setPresencePenalty(@Nullable Double presencePenalty) {
+			BedrockConverseProxyChatProperties.this.setPresencePenalty(presencePenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.request-parameters")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public Map<String, String> getRequestParameters() {
+			return BedrockConverseProxyChatProperties.this.getRequestParameters();
+		}
+
+		public void setRequestParameters(Map<String, String> requestParameters) {
+			BedrockConverseProxyChatProperties.this.setRequestParameters(requestParameters);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.stop-sequences")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<String> getStopSequences() {
+			return BedrockConverseProxyChatProperties.this.getStopSequences();
+		}
+
+		public void setStopSequences(@Nullable List<String> stopSequences) {
+			BedrockConverseProxyChatProperties.this.setStopSequences(stopSequences);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.temperature")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTemperature() {
+			return BedrockConverseProxyChatProperties.this.getTemperature();
+		}
+
+		public void setTemperature(@Nullable Double temperature) {
+			BedrockConverseProxyChatProperties.this.setTemperature(temperature);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.top-k")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getTopK() {
+			return BedrockConverseProxyChatProperties.this.getTopK();
+		}
+
+		public void setTopK(@Nullable Integer topK) {
+			BedrockConverseProxyChatProperties.this.setTopK(topK);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.top-p")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTopP() {
+			return BedrockConverseProxyChatProperties.this.getTopP();
+		}
+
+		public void setTopP(@Nullable Double topP) {
+			BedrockConverseProxyChatProperties.this.setTopP(topP);
+		}
+
+		@DeprecatedConfigurationProperty(
+				replacement = "spring.ai.bedrock.converse.chat.internal-tool-execution-enabled")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getInternalToolExecutionEnabled() {
+			return BedrockConverseProxyChatProperties.this.getInternalToolExecutionEnabled();
+		}
+
+		public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+			BedrockConverseProxyChatProperties.this.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.bedrock.converse.chat.cache-options")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable BedrockCacheOptions getCacheOptions() {
+			return BedrockConverseProxyChatProperties.this.getCacheOptions();
+		}
+
+		public void setCacheOptions(@Nullable BedrockCacheOptions cacheOptions) {
+			BedrockConverseProxyChatProperties.this.setCacheOptions(cacheOptions);
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatAutoConfigurationIT.java
@@ -44,9 +44,8 @@ public class BedrockConverseProxyChatAutoConfigurationIT {
 	private static final Log logger = LogFactory.getLog(BedrockConverseProxyChatAutoConfigurationIT.class);
 
 	private final ApplicationContextRunner contextRunner = BedrockTestUtils.getContextRunner()
-		.withPropertyValues(
-				"spring.ai.bedrock.converse.chat.options.model=" + "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
-				"spring.ai.bedrock.converse.chat.options.temperature=0.5")
+		.withPropertyValues("spring.ai.bedrock.converse.chat.model=" + "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+				"spring.ai.bedrock.converse.chat.temperature=0.5")
 		.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class,
 				ToolCallingAutoConfiguration.class));
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/BedrockConverseProxyChatPropertiesTests.java
@@ -39,15 +39,14 @@ public class BedrockConverseProxyChatPropertiesTests {
 
 		new ApplicationContextRunner().withPropertyValues(
 		// @formatter:off
-				"spring.ai.bedrock.converse.chat.options.model=MODEL_XYZ",
+				"spring.ai.bedrock.converse.chat.model=MODEL_XYZ",
 
-				"spring.ai.bedrock.converse.chat.options.max-tokens=123",
-				"spring.ai.bedrock.converse.chat.options.metadata.user-id=MyUserId",
-				"spring.ai.bedrock.converse.chat.options.stop_sequences=boza,koza",
+				"spring.ai.bedrock.converse.chat.max-tokens=123",
+				"spring.ai.bedrock.converse.chat.stop-sequences=boza,koza",
 
-				"spring.ai.bedrock.converse.chat.options.temperature=0.55",
-				"spring.ai.bedrock.converse.chat.options.top-p=0.56",
-				"spring.ai.bedrock.converse.chat.options.top-k=100"
+				"spring.ai.bedrock.converse.chat.temperature=0.55",
+				"spring.ai.bedrock.converse.chat.top-p=0.56",
+				"spring.ai.bedrock.converse.chat.top-k=100"
 				)
 			// @formatter:on
 			.withConfiguration(AutoConfigurations.of(BedrockConverseProxyChatAutoConfiguration.class,
@@ -55,12 +54,12 @@ public class BedrockConverseProxyChatPropertiesTests {
 			.run(context -> {
 				var chatProperties = context.getBean(BedrockConverseProxyChatProperties.class);
 
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
-				assertThat(chatProperties.getOptions().getMaxTokens()).isEqualTo(123);
-				assertThat(chatProperties.getOptions().getStopSequences()).contains("boza", "koza");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
-				assertThat(chatProperties.getOptions().getTopP()).isEqualTo(0.56);
-				assertThat(chatProperties.getOptions().getTopK()).isEqualTo(100);
+				assertThat(chatProperties.getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.getMaxTokens()).isEqualTo(123);
+				assertThat(chatProperties.getStopSequences()).contains("boza", "koza");
+				assertThat(chatProperties.getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.getTopP()).isEqualTo(0.56);
+				assertThat(chatProperties.getTopK()).isEqualTo(100);
 
 			});
 	}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithFunctionBeanIT.java
@@ -57,7 +57,7 @@ class FunctionCallWithFunctionBeanIT {
 
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.bedrock.converse.chat.options.model=" + "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+					"spring.ai.bedrock.converse.chat.model=" + "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);
@@ -86,7 +86,7 @@ class FunctionCallWithFunctionBeanIT {
 
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.bedrock.converse.chat.options.model=" + "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+					"spring.ai.bedrock.converse.chat.model=" + "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/src/test/java/org/springframework/ai/model/bedrock/converse/autoconfigure/tool/FunctionCallWithPromptFunctionIT.java
@@ -50,7 +50,7 @@ public class FunctionCallWithPromptFunctionIT {
 	void functionCallTest() {
 		this.contextRunner
 			.withPropertyValues(
-					"spring.ai.bedrock.converse.chat.options.model=" + "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+					"spring.ai.bedrock.converse.chat.model=" + "us.anthropic.claude-haiku-4-5-20251001-v1:0")
 			.run(context -> {
 
 				BedrockProxyChatModel chatModel = context.getBean(BedrockProxyChatModel.class);

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockChatOptions.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * The options to be used when sending a chat request to the Bedrock API.
  *
  * @author Sun Yuhan
+ * @author Sebastien Deleuze
  */
 public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOutputChatOptions {
 
@@ -112,17 +113,9 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		return this.model;
 	}
 
-	public void setModel(@Nullable String model) {
-		this.model = model;
-	}
-
 	@Override
 	public @Nullable Double getFrequencyPenalty() {
 		return this.frequencyPenalty;
-	}
-
-	public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
-		this.frequencyPenalty = frequencyPenalty;
 	}
 
 	@Override
@@ -130,16 +123,8 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		return this.maxTokens;
 	}
 
-	public void setMaxTokens(@Nullable Integer maxTokens) {
-		this.maxTokens = maxTokens;
-	}
-
 	public Map<String, String> getRequestParameters() {
 		return this.requestParameters;
-	}
-
-	public void setRequestParameters(Map<String, String> requestParameters) {
-		this.requestParameters = requestParameters;
 	}
 
 	@Override
@@ -147,17 +132,9 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		return this.presencePenalty;
 	}
 
-	public void setPresencePenalty(@Nullable Double presencePenalty) {
-		this.presencePenalty = presencePenalty;
-	}
-
 	@Override
 	public @Nullable List<String> getStopSequences() {
 		return this.stopSequences;
-	}
-
-	public void setStopSequences(@Nullable List<String> stopSequences) {
-		this.stopSequences = stopSequences;
 	}
 
 	@Override
@@ -165,26 +142,14 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 		return this.temperature;
 	}
 
-	public void setTemperature(@Nullable Double temperature) {
-		this.temperature = temperature;
-	}
-
 	@Override
 	public @Nullable Integer getTopK() {
 		return this.topK;
 	}
 
-	public void setTopK(@Nullable Integer topK) {
-		this.topK = topK;
-	}
-
 	@Override
 	public @Nullable Double getTopP() {
 		return this.topP;
-	}
-
-	public void setTopP(@Nullable Double topP) {
-		this.topP = topP;
 	}
 
 	@Override
@@ -234,10 +199,6 @@ public class BedrockChatOptions implements ToolCallingChatOptions, StructuredOut
 
 	public @Nullable BedrockCacheOptions getCacheOptions() {
 		return this.cacheOptions;
-	}
-
-	public void setCacheOptions(@Nullable BedrockCacheOptions cacheOptions) {
-		this.cacheOptions = cacheOptions;
 	}
 
 	@Override

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockChatOptionsTests.java
@@ -92,30 +92,6 @@ class BedrockChatOptionsTests extends AbstractChatOptionsTests<BedrockChatOption
 	}
 
 	@Test
-	void testSetters() {
-		BedrockChatOptions options = new BedrockChatOptions();
-		options.setModel("test-model");
-		options.setFrequencyPenalty(0.0);
-		options.setMaxTokens(100);
-		options.setPresencePenalty(0.0);
-		options.setTemperature(0.7);
-		options.setTopK(50);
-		options.setTopP(0.8);
-		options.setStopSequences(List.of("stop1", "stop2"));
-		options.setOutputSchema("{\"type\":\"object\"}");
-
-		assertThat(options.getModel()).isEqualTo("test-model");
-		assertThat(options.getFrequencyPenalty()).isEqualTo(0.0);
-		assertThat(options.getMaxTokens()).isEqualTo(100);
-		assertThat(options.getPresencePenalty()).isEqualTo(0.0);
-		assertThat(options.getTemperature()).isEqualTo(0.7);
-		assertThat(options.getTopK()).isEqualTo(50);
-		assertThat(options.getTopP()).isEqualTo(0.8);
-		assertThat(options.getStopSequences()).isEqualTo(List.of("stop1", "stop2"));
-		assertThat(options.getOutputSchema()).isEqualTo("{\"type\":\"object\"}");
-	}
-
-	@Test
 	void testDefaultValues() {
 		BedrockChatOptions options = new BedrockChatOptions();
 		assertThat(options.getModel()).isNull();

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/bedrock-converse.adoc
@@ -105,18 +105,18 @@ The prefix `spring.ai.bedrock.converse.chat` is the property prefix that configu
 
 | spring.ai.bedrock.converse.chat.enabled (Removed and no longer valid) | Enable Bedrock Converse chat model. | true
 | spring.ai.model.chat | Enable Bedrock Converse chat model. | bedrock-converse
-| spring.ai.bedrock.converse.chat.options.model | The model ID to use. You can use the https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html[Supported models and model features]  | None. Select your https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/models[modelId] from the AWS Bedrock console.
-| spring.ai.bedrock.converse.chat.options.temperature | Controls the randomness of the output. Values can range over [0.0,1.0] | 0.8
-| spring.ai.bedrock.converse.chat.options.top-p | The maximum cumulative probability of tokens to consider when sampling. | AWS Bedrock default
-| spring.ai.bedrock.converse.chat.options.top-k | Number of token choices for generating the next token. | AWS Bedrock default
-| spring.ai.bedrock.converse.chat.options.max-tokens | Maximum number of tokens in the generated response. | 500
+| spring.ai.bedrock.converse.chat.model | The model ID to use. You can use the https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html[Supported models and model features]  | None. Select your https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/models[modelId] from the AWS Bedrock console.
+| spring.ai.bedrock.converse.chat.temperature | Controls the randomness of the output. Values can range over [0.0,1.0] | 0.8
+| spring.ai.bedrock.converse.chat.top-p | The maximum cumulative probability of tokens to consider when sampling. | AWS Bedrock default
+| spring.ai.bedrock.converse.chat.top-k | Number of token choices for generating the next token. | AWS Bedrock default
+| spring.ai.bedrock.converse.chat.max-tokens | Maximum number of tokens in the generated response. | 500
 |====
 
 == Runtime Options [[chat-options]]
 
 Use the portable `ChatOptions` or `BedrockChatOptions` portable builders to create model configurations, such as temperature, maxToken, topP, etc.
 
-On start-up, the default options can be configured with the `BedrockConverseProxyChatModel(api, options)` constructor or the `spring.ai.bedrock.converse.chat.options.*` properties.
+On start-up, the default options can be configured with the `BedrockConverseProxyChatModel(api, options)` constructor or the `spring.ai.bedrock.converse.chat.*` properties.
 
 At run-time you can override the default options by adding new, request specific, options to the `Prompt` call:
 
@@ -989,8 +989,8 @@ spring.ai.bedrock.aws.secret-key=${AWS_SECRET_ACCESS_KEY}
 # session token is only required for temporary credentials
 spring.ai.bedrock.aws.session-token=${AWS_SESSION_TOKEN}
 
-spring.ai.bedrock.converse.chat.options.temperature=0.8
-spring.ai.bedrock.converse.chat.options.top-k=15
+spring.ai.bedrock.converse.chat.temperature=0.8
+spring.ai.bedrock.converse.chat.top-k=15
 ----
 
 Here's an example controller using the chat model:


### PR DESCRIPTION
- Remove `@NestedConfigurationProperty` from `AnthropicChatProperties`
- Expose options directly under the `spring.ai.bedrock.chat` prefix instead of `spring.ai.bedrock.chat.options`
- Implement Spring Boot deprecation mechanism for the legacy `options` nested properties to gracefully guide users during upgrades