### PR TITLE
Remove Deepseek setters from options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatAutoConfiguration.java
@@ -72,7 +72,7 @@ public class DeepSeekChatAutoConfiguration {
 
 		var chatModel = DeepSeekChatModel.builder()
 			.deepSeekApi(deepSeekApi)
-			.defaultOptions(chatProperties.getOptions())
+			.defaultOptions(chatProperties.toOptions())
 			.toolCallingManager(toolCallingManager)
 			.toolExecutionEligibilityPredicate(deepseekToolExecutionEligibilityPredicate
 				.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))

--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatProperties.java
@@ -16,10 +16,15 @@
 
 package org.springframework.ai.model.deepseek.autoconfigure;
 
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.deepseek.DeepSeekChatOptions;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
+import org.springframework.ai.deepseek.api.ResponseFormat;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for DeepSeek chat client.
@@ -46,12 +51,27 @@ public class DeepSeekChatProperties extends DeepSeekParentProperties {
 
 	private String betaPrefixPath = DEFAULT_BETA_PREFIX_PATH;
 
-	@NestedConfigurationProperty
-	private final DeepSeekChatOptions options = DeepSeekChatOptions.builder().model(DEFAULT_CHAT_MODEL).build();
+	private String model = DEFAULT_CHAT_MODEL;
 
-	public DeepSeekChatOptions getOptions() {
-		return this.options;
-	}
+	private @Nullable Double frequencyPenalty;
+
+	private @Nullable Integer maxTokens;
+
+	private @Nullable Double presencePenalty;
+
+	private @Nullable ResponseFormat responseFormat;
+
+	private @Nullable List<String> stop;
+
+	private @Nullable Double temperature;
+
+	private @Nullable Double topP;
+
+	private @Nullable Boolean logprobs;
+
+	private @Nullable Integer topLogprobs;
+
+	private @Nullable Boolean internalToolExecutionEnabled;
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -75,6 +95,256 @@ public class DeepSeekChatProperties extends DeepSeekParentProperties {
 
 	public void setBetaPrefixPath(String betaPrefixPath) {
 		this.betaPrefixPath = betaPrefixPath;
+	}
+
+	public String getModel() {
+		return this.model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	public @Nullable Double getFrequencyPenalty() {
+		return this.frequencyPenalty;
+	}
+
+	public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+		this.frequencyPenalty = frequencyPenalty;
+	}
+
+	public @Nullable Integer getMaxTokens() {
+		return this.maxTokens;
+	}
+
+	public void setMaxTokens(@Nullable Integer maxTokens) {
+		this.maxTokens = maxTokens;
+	}
+
+	public @Nullable Double getPresencePenalty() {
+		return this.presencePenalty;
+	}
+
+	public void setPresencePenalty(@Nullable Double presencePenalty) {
+		this.presencePenalty = presencePenalty;
+	}
+
+	public @Nullable ResponseFormat getResponseFormat() {
+		return this.responseFormat;
+	}
+
+	public void setResponseFormat(@Nullable ResponseFormat responseFormat) {
+		this.responseFormat = responseFormat;
+	}
+
+	public @Nullable List<String> getStop() {
+		return this.stop;
+	}
+
+	public void setStop(@Nullable List<String> stop) {
+		this.stop = stop;
+	}
+
+	public @Nullable Double getTemperature() {
+		return this.temperature;
+	}
+
+	public void setTemperature(@Nullable Double temperature) {
+		this.temperature = temperature;
+	}
+
+	public @Nullable Double getTopP() {
+		return this.topP;
+	}
+
+	public void setTopP(@Nullable Double topP) {
+		this.topP = topP;
+	}
+
+	public @Nullable Boolean getLogprobs() {
+		return this.logprobs;
+	}
+
+	public void setLogprobs(@Nullable Boolean logprobs) {
+		this.logprobs = logprobs;
+	}
+
+	public @Nullable Integer getTopLogprobs() {
+		return this.topLogprobs;
+	}
+
+	public void setTopLogprobs(@Nullable Integer topLogprobs) {
+		this.topLogprobs = topLogprobs;
+	}
+
+	public @Nullable Boolean getInternalToolExecutionEnabled() {
+		return this.internalToolExecutionEnabled;
+	}
+
+	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	public DeepSeekChatOptions toOptions() {
+		DeepSeekChatOptions.Builder builder = DeepSeekChatOptions.builder();
+		builder.model(this.model);
+		if (this.frequencyPenalty != null) {
+			builder.frequencyPenalty(this.frequencyPenalty);
+		}
+		if (this.maxTokens != null) {
+			builder.maxTokens(this.maxTokens);
+		}
+		if (this.presencePenalty != null) {
+			builder.presencePenalty(this.presencePenalty);
+		}
+		if (this.responseFormat != null) {
+			builder.responseFormat(this.responseFormat);
+		}
+		if (this.stop != null) {
+			builder.stop(this.stop);
+		}
+		if (this.temperature != null) {
+			builder.temperature(this.temperature);
+		}
+		if (this.topP != null) {
+			builder.topP(this.topP);
+		}
+		if (this.logprobs != null) {
+			builder.logprobs(this.logprobs);
+		}
+		if (this.topLogprobs != null) {
+			builder.topLogprobs(this.topLogprobs);
+		}
+		if (this.internalToolExecutionEnabled != null) {
+			builder.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
+		}
+		return builder.build();
+	}
+
+	private Options options = new Options();
+
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat")
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	public Options getOptions() {
+		return this.options;
+	}
+
+	public void setOptions(Options options) {
+		this.options = options;
+	}
+
+	public class Options {
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.model")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public String getModel() {
+			return DeepSeekChatProperties.this.getModel();
+		}
+
+		public void setModel(String model) {
+			DeepSeekChatProperties.this.setModel(model);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.frequency-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getFrequencyPenalty() {
+			return DeepSeekChatProperties.this.getFrequencyPenalty();
+		}
+
+		public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+			DeepSeekChatProperties.this.setFrequencyPenalty(frequencyPenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.max-tokens")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getMaxTokens() {
+			return DeepSeekChatProperties.this.getMaxTokens();
+		}
+
+		public void setMaxTokens(@Nullable Integer maxTokens) {
+			DeepSeekChatProperties.this.setMaxTokens(maxTokens);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.presence-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getPresencePenalty() {
+			return DeepSeekChatProperties.this.getPresencePenalty();
+		}
+
+		public void setPresencePenalty(@Nullable Double presencePenalty) {
+			DeepSeekChatProperties.this.setPresencePenalty(presencePenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.response-format")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable ResponseFormat getResponseFormat() {
+			return DeepSeekChatProperties.this.getResponseFormat();
+		}
+
+		public void setResponseFormat(@Nullable ResponseFormat responseFormat) {
+			DeepSeekChatProperties.this.setResponseFormat(responseFormat);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.stop")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<String> getStop() {
+			return DeepSeekChatProperties.this.getStop();
+		}
+
+		public void setStop(@Nullable List<String> stop) {
+			DeepSeekChatProperties.this.setStop(stop);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.temperature")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTemperature() {
+			return DeepSeekChatProperties.this.getTemperature();
+		}
+
+		public void setTemperature(@Nullable Double temperature) {
+			DeepSeekChatProperties.this.setTemperature(temperature);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.top-p")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTopP() {
+			return DeepSeekChatProperties.this.getTopP();
+		}
+
+		public void setTopP(@Nullable Double topP) {
+			DeepSeekChatProperties.this.setTopP(topP);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.logprobs")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getLogprobs() {
+			return DeepSeekChatProperties.this.getLogprobs();
+		}
+
+		public void setLogprobs(@Nullable Boolean logprobs) {
+			DeepSeekChatProperties.this.setLogprobs(logprobs);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.top-logprobs")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getTopLogprobs() {
+			return DeepSeekChatProperties.this.getTopLogprobs();
+		}
+
+		public void setTopLogprobs(@Nullable Integer topLogprobs) {
+			DeepSeekChatProperties.this.setTopLogprobs(topLogprobs);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.deepseek.chat.internal-tool-execution-enabled")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getInternalToolExecutionEnabled() {
+			return DeepSeekChatProperties.this.getInternalToolExecutionEnabled();
+		}
+
+		public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+			DeepSeekChatProperties.this.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/test/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/test/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekPropertiesTests.java
@@ -42,8 +42,8 @@ public class DeepSeekPropertiesTests {
 		// @formatter:off
 				"spring.ai.deepseek.base-url=TEST_BASE_URL",
 				"spring.ai.deepseek.api-key=abc123",
-				"spring.ai.deepseek.chat.options.model=MODEL_XYZ",
-				"spring.ai.deepseek.chat.options.temperature=0.55")
+				"spring.ai.deepseek.chat.model=MODEL_XYZ",
+				"spring.ai.deepseek.chat.temperature=0.55")
 				// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DeepSeekChatAutoConfiguration.class,
 					RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class,
@@ -58,8 +58,8 @@ public class DeepSeekPropertiesTests {
 				assertThat(chatProperties.getApiKey()).isNull();
 				assertThat(chatProperties.getBaseUrl()).isNull();
 
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.getTemperature()).isEqualTo(0.55);
 			});
 	}
 
@@ -72,8 +72,8 @@ public class DeepSeekPropertiesTests {
 				"spring.ai.deepseek.api-key=abc123",
 				"spring.ai.deepseek.chat.base-url=TEST_BASE_URL2",
 				"spring.ai.deepseek.chat.api-key=456",
-				"spring.ai.deepseek.chat.options.model=MODEL_XYZ",
-				"spring.ai.deepseek.chat.options.temperature=0.55")
+				"spring.ai.deepseek.chat.model=MODEL_XYZ",
+				"spring.ai.deepseek.chat.temperature=0.55")
 				// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DeepSeekChatAutoConfiguration.class,
 					RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class,
@@ -88,8 +88,8 @@ public class DeepSeekPropertiesTests {
 				assertThat(chatProperties.getApiKey()).isEqualTo("456");
 				assertThat(chatProperties.getBaseUrl()).isEqualTo("TEST_BASE_URL2");
 
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.getTemperature()).isEqualTo(0.55);
 			});
 	}
 
@@ -101,17 +101,17 @@ public class DeepSeekPropertiesTests {
 				"spring.ai.deepseek.api-key=API_KEY",
 				"spring.ai.deepseek.base-url=TEST_BASE_URL",
 
-				"spring.ai.deepseek.chat.options.model=MODEL_XYZ",
-				"spring.ai.deepseek.chat.options.frequencyPenalty=-1.5",
-				"spring.ai.deepseek.chat.options.logitBias.myTokenId=-5",
-				"spring.ai.deepseek.chat.options.maxTokens=123",
-				"spring.ai.deepseek.chat.options.presencePenalty=0",
-				"spring.ai.deepseek.chat.options.responseFormat.type=json_object",
-				"spring.ai.deepseek.chat.options.seed=66",
-				"spring.ai.deepseek.chat.options.stop=boza,koza",
-				"spring.ai.deepseek.chat.options.temperature=0.55",
-				"spring.ai.deepseek.chat.options.topP=0.56",
-				"spring.ai.deepseek.chat.options.user=userXYZ"
+				"spring.ai.deepseek.chat.model=MODEL_XYZ",
+				"spring.ai.deepseek.chat.frequencyPenalty=-1.5",
+				"spring.ai.deepseek.chat.logitBias.myTokenId=-5",
+				"spring.ai.deepseek.chat.maxTokens=123",
+				"spring.ai.deepseek.chat.presencePenalty=0",
+				"spring.ai.deepseek.chat.responseFormat.type=json_object",
+				"spring.ai.deepseek.chat.seed=66",
+				"spring.ai.deepseek.chat.stop=boza,koza",
+				"spring.ai.deepseek.chat.temperature=0.55",
+				"spring.ai.deepseek.chat.topP=0.56",
+				"spring.ai.deepseek.chat.user=userXYZ"
 				)
 			// @formatter:on
 			.withConfiguration(AutoConfigurations.of(DeepSeekChatAutoConfiguration.class,
@@ -124,13 +124,13 @@ public class DeepSeekPropertiesTests {
 				assertThat(connectionProperties.getBaseUrl()).isEqualTo("TEST_BASE_URL");
 				assertThat(connectionProperties.getApiKey()).isEqualTo("API_KEY");
 
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
-				assertThat(chatProperties.getOptions().getFrequencyPenalty()).isEqualTo(-1.5);
-				assertThat(chatProperties.getOptions().getMaxTokens()).isEqualTo(123);
-				assertThat(chatProperties.getOptions().getPresencePenalty()).isEqualTo(0);
-				assertThat(chatProperties.getOptions().getStop()).contains("boza", "koza");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
-				assertThat(chatProperties.getOptions().getTopP()).isEqualTo(0.56);
+				assertThat(chatProperties.getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.getFrequencyPenalty()).isEqualTo(-1.5);
+				assertThat(chatProperties.getMaxTokens()).isEqualTo(123);
+				assertThat(chatProperties.getPresencePenalty()).isEqualTo(0);
+				assertThat(chatProperties.getStop()).contains("boza", "koza");
+				assertThat(chatProperties.getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.getTopP()).isEqualTo(0.56);
 			});
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/deepseek-chat.adoc
@@ -119,31 +119,31 @@ The prefix `spring.ai.deepseek.chat` is the property prefix that lets you config
 | spring.ai.deepseek.chat.api-key | Optionally overrides the spring.ai.deepseek.api-key to provide a chat-specific API key | -
 | spring.ai.deepseek.chat.completions-path | The path to the chat completions endpoint | `/chat/completions`
 | spring.ai.deepseek.chat.beta-prefix-path | The prefix path to the beta feature endpoint | `/beta`
-| spring.ai.deepseek.chat.options.model | ID of the model to use. You can use either deepseek-reasoner or deepseek-chat. | deepseek-chat
-| spring.ai.deepseek.chat.options.frequencyPenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. | 0.0f
-| spring.ai.deepseek.chat.options.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
-| spring.ai.deepseek.chat.options.presencePenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. |  0.0f
-| spring.ai.deepseek.chat.options.stop | Up to 4 sequences where the API will stop generating further tokens. | -
-| spring.ai.deepseek.chat.options.temperature | Which sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p, but not both. | 1.0F
-| spring.ai.deepseek.chat.options.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature, but not both. | 1.0F
-| spring.ai.deepseek.chat.options.logprobs | Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the content of the message. | -
-| spring.ai.deepseek.chat.options.topLogprobs | An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. logprobs must be set to true if this parameter is used. | -
-| spring.ai.deepseek.chat.options.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
-| spring.ai.deepseek.chat.options.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
-| spring.ai.deepseek.chat.options.internal-tool-execution-enabled | If false, the Spring AI will not handle the tool calls internally, but will proxy them to the client. Then it is the client's responsibility to handle the tool calls, dispatch them to the appropriate function, and return the results. If true (the default), the Spring AI will handle the function calls internally. Applicable only for chat models with function calling support | true
+| spring.ai.deepseek.chat.model | ID of the model to use. You can use either deepseek-reasoner or deepseek-chat. | deepseek-chat
+| spring.ai.deepseek.chat.frequencyPenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. | 0.0f
+| spring.ai.deepseek.chat.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
+| spring.ai.deepseek.chat.presencePenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. |  0.0f
+| spring.ai.deepseek.chat.stop | Up to 4 sequences where the API will stop generating further tokens. | -
+| spring.ai.deepseek.chat.temperature | Which sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p, but not both. | 1.0F
+| spring.ai.deepseek.chat.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature, but not both. | 1.0F
+| spring.ai.deepseek.chat.logprobs | Whether to return log probabilities of the output tokens or not. If true, returns the log probabilities of each output token returned in the content of the message. | -
+| spring.ai.deepseek.chat.topLogprobs | An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. logprobs must be set to true if this parameter is used. | -
+| spring.ai.deepseek.chat.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
+| spring.ai.deepseek.chat.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
+| spring.ai.deepseek.chat.internal-tool-execution-enabled | If false, the Spring AI will not handle the tool calls internally, but will proxy them to the client. Then it is the client's responsibility to handle the tool calls, dispatch them to the appropriate function, and return the results. If true (the default), the Spring AI will handle the function calls internally. Applicable only for chat models with function calling support | true
 |====
 
 NOTE: You can override the common `spring.ai.deepseek.base-url` and `spring.ai.deepseek.api-key` for the `ChatModel` implementations.
 The `spring.ai.deepseek.chat.base-url` and `spring.ai.deepseek.chat.api-key` properties, if set, take precedence over the common properties.
 This is useful if you want to use different DeepSeek accounts for different models and different model endpoints.
 
-TIP: All properties prefixed with `spring.ai.deepseek.chat.options` can be overridden at runtime by adding a request-specific <<chat-options>> to the `Prompt` call.
+TIP: All properties prefixed with `spring.ai.deepseek.chat` can be overridden at runtime by adding a request-specific <<chat-options>> to the `Prompt` call.
 
 == Runtime Options [[chat-options]]
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatOptions.java[DeepSeekChatOptions.java] provides model configurations, such as the model to use, the temperature, the frequency penalty, etc.
 
-On startup, the default options can be configured with the `DeepSeekChatModel(api, options)` constructor or the `spring.ai.deepseek.chat.options.*` properties.
+On startup, the default options can be configured with the `DeepSeekChatModel(api, options)` constructor or the `spring.ai.deepseek.chat.*` properties.
 
 At runtime, you can override the default options by adding new, request-specific options to the `Prompt` call.
 For example, to override the default model and temperature for a specific request:
@@ -171,8 +171,8 @@ Add an `application.properties` file under the `src/main/resources` directory to
 [source,application.properties]
 ----
 spring.ai.deepseek.api-key=YOUR_API_KEY
-spring.ai.deepseek.chat.options.model=deepseek-chat
-spring.ai.deepseek.chat.options.temperature=0.8
+spring.ai.deepseek.chat.model=deepseek-chat
+spring.ai.deepseek.chat.temperature=0.8
 ----
 
 TIP: Replace the `api-key` with your DeepSeek credentials.


### PR DESCRIPTION
- Remove `@NestedConfigurationProperty` from `DeepSeekChatProperties`
- Expose options directly under the `spring.ai.deepseek.chat` prefix instead of `spring.ai.deepseek.chat.options`
- Implement Spring Boot deprecation mechanism for the legacy `options` nested properties to gracefully guide users during upgrades