### PR TITLE
Remove ElevenLabs setters from options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsAutoConfiguration.java
@@ -69,7 +69,7 @@ public class ElevenLabsAutoConfiguration {
 
 		return ElevenLabsTextToSpeechModel.builder()
 			.elevenLabsApi(elevenLabsApi)
-			.defaultOptions(speechProperties.getOptions())
+			.defaultOptions(speechProperties.toOptions())
 			.retryTemplate(retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE))
 			.build();
 	}

--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsSpeechProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/main/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsSpeechProperties.java
@@ -16,15 +16,20 @@
 
 package org.springframework.ai.model.elevenlabs.autoconfigure;
 
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.elevenlabs.ElevenLabsTextToSpeechOptions;
 import org.springframework.ai.elevenlabs.api.ElevenLabsApi;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for the ElevenLabs Text-to-Speech API.
  *
  * @author Alexandros Pappas
+ * @author Sebastien Deleuze
  */
 @ConfigurationProperties(ElevenLabsSpeechProperties.CONFIG_PREFIX)
 public class ElevenLabsSpeechProperties {
@@ -37,15 +42,378 @@ public class ElevenLabsSpeechProperties {
 
 	private static final ElevenLabsApi.OutputFormat DEFAULT_OUTPUT_FORMAT = ElevenLabsApi.OutputFormat.MP3_22050_32;
 
-	@NestedConfigurationProperty
-	private final ElevenLabsTextToSpeechOptions options = ElevenLabsTextToSpeechOptions.builder()
-		.modelId(DEFAULT_MODEL_ID)
-		.voiceId(DEFAULT_VOICE_ID)
-		.outputFormat(DEFAULT_OUTPUT_FORMAT.getValue())
-		.build();
+	private @Nullable String modelId = DEFAULT_MODEL_ID;
 
-	public ElevenLabsTextToSpeechOptions getOptions() {
+	private @Nullable String voiceId = DEFAULT_VOICE_ID;
+
+	private @Nullable Boolean enableLogging;
+
+	private @Nullable String outputFormat = DEFAULT_OUTPUT_FORMAT.getValue();
+
+	private ElevenLabsApi.SpeechRequest.@Nullable VoiceSettings voiceSettings;
+
+	private @Nullable String languageCode;
+
+	private @Nullable List<ElevenLabsApi.SpeechRequest.PronunciationDictionaryLocator> pronunciationDictionaryLocators;
+
+	private @Nullable Integer seed;
+
+	private @Nullable String previousText;
+
+	private @Nullable String nextText;
+
+	private @Nullable List<String> previousRequestIds;
+
+	private @Nullable List<String> nextRequestIds;
+
+	private ElevenLabsApi.SpeechRequest.@Nullable TextNormalizationMode applyTextNormalization;
+
+	private @Nullable Boolean applyLanguageTextNormalization;
+
+	public @Nullable String getModel() {
+		return getModelId();
+	}
+
+	public void setModel(@Nullable String model) {
+		setModelId(model);
+	}
+
+	public @Nullable String getModelId() {
+		return this.modelId;
+	}
+
+	public void setModelId(@Nullable String modelId) {
+		this.modelId = modelId;
+	}
+
+	public @Nullable String getVoice() {
+		return getVoiceId();
+	}
+
+	public void setVoice(@Nullable String voice) {
+		setVoiceId(voice);
+	}
+
+	public @Nullable String getVoiceId() {
+		return this.voiceId;
+	}
+
+	public void setVoiceId(@Nullable String voiceId) {
+		this.voiceId = voiceId;
+	}
+
+	public @Nullable Boolean getEnableLogging() {
+		return this.enableLogging;
+	}
+
+	public void setEnableLogging(@Nullable Boolean enableLogging) {
+		this.enableLogging = enableLogging;
+	}
+
+	public @Nullable String getFormat() {
+		return getOutputFormat();
+	}
+
+	public void setFormat(@Nullable String format) {
+		setOutputFormat(format);
+	}
+
+	public @Nullable String getOutputFormat() {
+		return this.outputFormat;
+	}
+
+	public void setOutputFormat(@Nullable String outputFormat) {
+		this.outputFormat = outputFormat;
+	}
+
+	public ElevenLabsApi.SpeechRequest.@Nullable VoiceSettings getVoiceSettings() {
+		return this.voiceSettings;
+	}
+
+	public void setVoiceSettings(ElevenLabsApi.SpeechRequest.@Nullable VoiceSettings voiceSettings) {
+		this.voiceSettings = voiceSettings;
+	}
+
+	public @Nullable String getLanguageCode() {
+		return this.languageCode;
+	}
+
+	public void setLanguageCode(@Nullable String languageCode) {
+		this.languageCode = languageCode;
+	}
+
+	public @Nullable List<ElevenLabsApi.SpeechRequest.PronunciationDictionaryLocator> getPronunciationDictionaryLocators() {
+		return this.pronunciationDictionaryLocators;
+	}
+
+	public void setPronunciationDictionaryLocators(
+			@Nullable List<ElevenLabsApi.SpeechRequest.PronunciationDictionaryLocator> pronunciationDictionaryLocators) {
+		this.pronunciationDictionaryLocators = pronunciationDictionaryLocators;
+	}
+
+	public @Nullable Integer getSeed() {
+		return this.seed;
+	}
+
+	public void setSeed(@Nullable Integer seed) {
+		this.seed = seed;
+	}
+
+	public @Nullable String getPreviousText() {
+		return this.previousText;
+	}
+
+	public void setPreviousText(@Nullable String previousText) {
+		this.previousText = previousText;
+	}
+
+	public @Nullable String getNextText() {
+		return this.nextText;
+	}
+
+	public void setNextText(@Nullable String nextText) {
+		this.nextText = nextText;
+	}
+
+	public @Nullable List<String> getPreviousRequestIds() {
+		return this.previousRequestIds;
+	}
+
+	public void setPreviousRequestIds(@Nullable List<String> previousRequestIds) {
+		this.previousRequestIds = previousRequestIds;
+	}
+
+	public @Nullable List<String> getNextRequestIds() {
+		return this.nextRequestIds;
+	}
+
+	public void setNextRequestIds(@Nullable List<String> nextRequestIds) {
+		this.nextRequestIds = nextRequestIds;
+	}
+
+	public ElevenLabsApi.SpeechRequest.@Nullable TextNormalizationMode getApplyTextNormalization() {
+		return this.applyTextNormalization;
+	}
+
+	public void setApplyTextNormalization(
+			ElevenLabsApi.SpeechRequest.@Nullable TextNormalizationMode applyTextNormalization) {
+		this.applyTextNormalization = applyTextNormalization;
+	}
+
+	public @Nullable Boolean getApplyLanguageTextNormalization() {
+		return this.applyLanguageTextNormalization;
+	}
+
+	public void setApplyLanguageTextNormalization(@Nullable Boolean applyLanguageTextNormalization) {
+		this.applyLanguageTextNormalization = applyLanguageTextNormalization;
+	}
+
+	public ElevenLabsTextToSpeechOptions toOptions() {
+		ElevenLabsTextToSpeechOptions optionsObject = ElevenLabsTextToSpeechOptions.builder()
+			.modelId(this.modelId)
+			.voiceId(this.voiceId)
+			.outputFormat(this.outputFormat)
+			.voiceSettings(this.voiceSettings)
+			.languageCode(this.languageCode)
+			.pronunciationDictionaryLocators(this.pronunciationDictionaryLocators)
+			.seed(this.seed)
+			.previousText(this.previousText)
+			.nextText(this.nextText)
+			.previousRequestIds(this.previousRequestIds)
+			.nextRequestIds(this.nextRequestIds)
+			.applyTextNormalization(this.applyTextNormalization)
+			.applyLanguageTextNormalization(this.applyLanguageTextNormalization)
+			.build();
+		optionsObject.setEnableLogging(this.enableLogging);
+		return optionsObject;
+	}
+
+	private Options options = new Options();
+
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts")
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	public Options getOptions() {
 		return this.options;
+	}
+
+	public void setOptions(Options options) {
+		this.options = options;
+	}
+
+	public class Options {
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.model")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getModel() {
+			return ElevenLabsSpeechProperties.this.getModel();
+		}
+
+		public void setModel(@Nullable String model) {
+			ElevenLabsSpeechProperties.this.setModel(model);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.model-id")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getModelId() {
+			return ElevenLabsSpeechProperties.this.getModelId();
+		}
+
+		public void setModelId(@Nullable String modelId) {
+			ElevenLabsSpeechProperties.this.setModelId(modelId);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.voice")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getVoice() {
+			return ElevenLabsSpeechProperties.this.getVoice();
+		}
+
+		public void setVoice(@Nullable String voice) {
+			ElevenLabsSpeechProperties.this.setVoice(voice);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.voice-id")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getVoiceId() {
+			return ElevenLabsSpeechProperties.this.getVoiceId();
+		}
+
+		public void setVoiceId(@Nullable String voiceId) {
+			ElevenLabsSpeechProperties.this.setVoiceId(voiceId);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.enable-logging")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getEnableLogging() {
+			return ElevenLabsSpeechProperties.this.getEnableLogging();
+		}
+
+		public void setEnableLogging(@Nullable Boolean enableLogging) {
+			ElevenLabsSpeechProperties.this.setEnableLogging(enableLogging);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.format")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getFormat() {
+			return ElevenLabsSpeechProperties.this.getFormat();
+		}
+
+		public void setFormat(@Nullable String format) {
+			ElevenLabsSpeechProperties.this.setFormat(format);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.output-format")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getOutputFormat() {
+			return ElevenLabsSpeechProperties.this.getOutputFormat();
+		}
+
+		public void setOutputFormat(@Nullable String outputFormat) {
+			ElevenLabsSpeechProperties.this.setOutputFormat(outputFormat);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.voice-settings")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public ElevenLabsApi.SpeechRequest.@Nullable VoiceSettings getVoiceSettings() {
+			return ElevenLabsSpeechProperties.this.getVoiceSettings();
+		}
+
+		public void setVoiceSettings(ElevenLabsApi.SpeechRequest.@Nullable VoiceSettings voiceSettings) {
+			ElevenLabsSpeechProperties.this.setVoiceSettings(voiceSettings);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.language-code")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getLanguageCode() {
+			return ElevenLabsSpeechProperties.this.getLanguageCode();
+		}
+
+		public void setLanguageCode(@Nullable String languageCode) {
+			ElevenLabsSpeechProperties.this.setLanguageCode(languageCode);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.pronunciation-dictionary-locators")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<ElevenLabsApi.SpeechRequest.PronunciationDictionaryLocator> getPronunciationDictionaryLocators() {
+			return ElevenLabsSpeechProperties.this.getPronunciationDictionaryLocators();
+		}
+
+		public void setPronunciationDictionaryLocators(
+				@Nullable List<ElevenLabsApi.SpeechRequest.PronunciationDictionaryLocator> pronunciationDictionaryLocators) {
+			ElevenLabsSpeechProperties.this.setPronunciationDictionaryLocators(pronunciationDictionaryLocators);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.seed")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getSeed() {
+			return ElevenLabsSpeechProperties.this.getSeed();
+		}
+
+		public void setSeed(@Nullable Integer seed) {
+			ElevenLabsSpeechProperties.this.setSeed(seed);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.previous-text")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getPreviousText() {
+			return ElevenLabsSpeechProperties.this.getPreviousText();
+		}
+
+		public void setPreviousText(@Nullable String previousText) {
+			ElevenLabsSpeechProperties.this.setPreviousText(previousText);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.next-text")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getNextText() {
+			return ElevenLabsSpeechProperties.this.getNextText();
+		}
+
+		public void setNextText(@Nullable String nextText) {
+			ElevenLabsSpeechProperties.this.setNextText(nextText);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.previous-request-ids")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<String> getPreviousRequestIds() {
+			return ElevenLabsSpeechProperties.this.getPreviousRequestIds();
+		}
+
+		public void setPreviousRequestIds(@Nullable List<String> previousRequestIds) {
+			ElevenLabsSpeechProperties.this.setPreviousRequestIds(previousRequestIds);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.next-request-ids")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<String> getNextRequestIds() {
+			return ElevenLabsSpeechProperties.this.getNextRequestIds();
+		}
+
+		public void setNextRequestIds(@Nullable List<String> nextRequestIds) {
+			ElevenLabsSpeechProperties.this.setNextRequestIds(nextRequestIds);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.apply-text-normalization")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public ElevenLabsApi.SpeechRequest.@Nullable TextNormalizationMode getApplyTextNormalization() {
+			return ElevenLabsSpeechProperties.this.getApplyTextNormalization();
+		}
+
+		public void setApplyTextNormalization(
+				ElevenLabsApi.SpeechRequest.@Nullable TextNormalizationMode applyTextNormalization) {
+			ElevenLabsSpeechProperties.this.setApplyTextNormalization(applyTextNormalization);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.elevenlabs.tts.apply-language-text-normalization")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getApplyLanguageTextNormalization() {
+			return ElevenLabsSpeechProperties.this.getApplyLanguageTextNormalization();
+		}
+
+		public void setApplyLanguageTextNormalization(@Nullable Boolean applyLanguageTextNormalization) {
+			ElevenLabsSpeechProperties.this.setApplyLanguageTextNormalization(applyLanguageTextNormalization);
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/src/test/java/org/springframework/ai/model/elevenlabs/autoconfigure/ElevenLabsPropertiesTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Alexandros Pappas
  * @author Issam El-atif
+ * @author Sebastien Deleuze
  */
 public class ElevenLabsPropertiesTests {
 
@@ -43,13 +44,13 @@ public class ElevenLabsPropertiesTests {
 		// @formatter:off
 				"spring.ai.elevenlabs.api-key=YOUR_API_KEY",
 				"spring.ai.elevenlabs.base-url=https://custom.api.elevenlabs.io",
-				"spring.ai.elevenlabs.tts.options.model-id=custom-model",
-				"spring.ai.elevenlabs.tts.options.voice=custom-voice",
-				"spring.ai.elevenlabs.tts.options.voice-settings.stability=0.6",
-				"spring.ai.elevenlabs.tts.options.voice-settings.similarity-boost=0.8",
-				"spring.ai.elevenlabs.tts.options.voice-settings.style=0.2",
-				"spring.ai.elevenlabs.tts.options.voice-settings.use-speaker-boost=false",
-				"spring.ai.elevenlabs.tts.options.voice-settings.speed=1.5"
+				"spring.ai.elevenlabs.tts.model-id=custom-model",
+				"spring.ai.elevenlabs.tts.voice=custom-voice",
+				"spring.ai.elevenlabs.tts.voice-settings.stability=0.6",
+				"spring.ai.elevenlabs.tts.voice-settings.similarity-boost=0.8",
+				"spring.ai.elevenlabs.tts.voice-settings.style=0.2",
+				"spring.ai.elevenlabs.tts.voice-settings.use-speaker-boost=false",
+				"spring.ai.elevenlabs.tts.voice-settings.speed=1.5"
 				// @formatter:on
 		)
 			.withConfiguration(
@@ -62,13 +63,14 @@ public class ElevenLabsPropertiesTests {
 				assertThat(connectionProperties.getApiKey()).isEqualTo("YOUR_API_KEY");
 				assertThat(connectionProperties.getBaseUrl()).isEqualTo("https://custom.api.elevenlabs.io");
 
-				assertThat(speechProperties.getOptions().getModelId()).isEqualTo("custom-model");
-				assertThat(speechProperties.getOptions().getVoice()).isEqualTo("custom-voice");
-				assertThat(speechProperties.getOptions().getVoiceSettings().stability()).isEqualTo(0.6);
-				assertThat(speechProperties.getOptions().getVoiceSettings().similarityBoost()).isEqualTo(0.8);
-				assertThat(speechProperties.getOptions().getVoiceSettings().style()).isEqualTo(0.2);
-				assertThat(speechProperties.getOptions().getVoiceSettings().useSpeakerBoost()).isFalse();
-				assertThat(speechProperties.getOptions().getSpeed()).isEqualTo(1.5f);
+				var options = speechProperties.toOptions();
+				assertThat(options.getModelId()).isEqualTo("custom-model");
+				assertThat(options.getVoice()).isEqualTo("custom-voice");
+				assertThat(options.getVoiceSettings().stability()).isEqualTo(0.6);
+				assertThat(options.getVoiceSettings().similarityBoost()).isEqualTo(0.8);
+				assertThat(options.getVoiceSettings().style()).isEqualTo(0.2);
+				assertThat(options.getVoiceSettings().useSpeakerBoost()).isFalse();
+				assertThat(options.getSpeed()).isEqualTo(1.5f);
 			});
 	}
 
@@ -77,20 +79,20 @@ public class ElevenLabsPropertiesTests {
 		new ApplicationContextRunner().withPropertyValues(
 		// @formatter:off
 				"spring.ai.elevenlabs.api-key=YOUR_API_KEY",
-				"spring.ai.elevenlabs.tts.options.model-id=custom-model",
-				"spring.ai.elevenlabs.tts.options.voice=custom-voice",
-				"spring.ai.elevenlabs.tts.options.format=pcm_44100",
-				"spring.ai.elevenlabs.tts.options.voice-settings.stability=0.6",
-				"spring.ai.elevenlabs.tts.options.voice-settings.similarity-boost=0.8",
-				"spring.ai.elevenlabs.tts.options.voice-settings.style=0.2",
-				"spring.ai.elevenlabs.tts.options.voice-settings.use-speaker-boost=false",
-				"spring.ai.elevenlabs.tts.options.voice-settings.speed=1.2",
-				"spring.ai.elevenlabs.tts.options.language-code=en",
-				"spring.ai.elevenlabs.tts.options.seed=12345",
-				"spring.ai.elevenlabs.tts.options.previous-text=previous",
-				"spring.ai.elevenlabs.tts.options.next-text=next",
-				"spring.ai.elevenlabs.tts.options.apply-text-normalization=ON",
-				"spring.ai.elevenlabs.tts.options.apply-language-text-normalization=true"
+				"spring.ai.elevenlabs.tts.model-id=custom-model",
+				"spring.ai.elevenlabs.tts.voice=custom-voice",
+				"spring.ai.elevenlabs.tts.format=pcm_44100",
+				"spring.ai.elevenlabs.tts.voice-settings.stability=0.6",
+				"spring.ai.elevenlabs.tts.voice-settings.similarity-boost=0.8",
+				"spring.ai.elevenlabs.tts.voice-settings.style=0.2",
+				"spring.ai.elevenlabs.tts.voice-settings.use-speaker-boost=false",
+				"spring.ai.elevenlabs.tts.voice-settings.speed=1.2",
+				"spring.ai.elevenlabs.tts.language-code=en",
+				"spring.ai.elevenlabs.tts.seed=12345",
+				"spring.ai.elevenlabs.tts.previous-text=previous",
+				"spring.ai.elevenlabs.tts.next-text=next",
+				"spring.ai.elevenlabs.tts.apply-text-normalization=ON",
+				"spring.ai.elevenlabs.tts.apply-language-text-normalization=true"
 				// @formatter:on
 		)
 			.withConfiguration(
@@ -98,23 +100,23 @@ public class ElevenLabsPropertiesTests {
 							SpringAiRetryAutoConfiguration.class, WebClientAutoConfiguration.class))
 			.run(context -> {
 				var speechProperties = context.getBean(ElevenLabsSpeechProperties.class);
-
-				assertThat(speechProperties.getOptions().getModelId()).isEqualTo("custom-model");
-				assertThat(speechProperties.getOptions().getVoice()).isEqualTo("custom-voice");
-				assertThat(speechProperties.getOptions().getFormat()).isEqualTo("pcm_44100");
-				assertThat(speechProperties.getOptions().getVoiceSettings().stability()).isEqualTo(0.6);
-				assertThat(speechProperties.getOptions().getVoiceSettings().similarityBoost()).isEqualTo(0.8);
-				assertThat(speechProperties.getOptions().getVoiceSettings().style()).isEqualTo(0.2);
-				assertThat(speechProperties.getOptions().getVoiceSettings().useSpeakerBoost()).isFalse();
-				assertThat(speechProperties.getOptions().getVoiceSettings().speed()).isEqualTo(1.2);
-				assertThat(speechProperties.getOptions().getSpeed()).isEqualTo(1.2);
-				assertThat(speechProperties.getOptions().getLanguageCode()).isEqualTo("en");
-				assertThat(speechProperties.getOptions().getSeed()).isEqualTo(12345);
-				assertThat(speechProperties.getOptions().getPreviousText()).isEqualTo("previous");
-				assertThat(speechProperties.getOptions().getNextText()).isEqualTo("next");
-				assertThat(speechProperties.getOptions().getApplyTextNormalization())
+				var options = speechProperties.toOptions();
+				assertThat(options.getModelId()).isEqualTo("custom-model");
+				assertThat(options.getVoice()).isEqualTo("custom-voice");
+				assertThat(options.getFormat()).isEqualTo("pcm_44100");
+				assertThat(options.getVoiceSettings().stability()).isEqualTo(0.6);
+				assertThat(options.getVoiceSettings().similarityBoost()).isEqualTo(0.8);
+				assertThat(options.getVoiceSettings().style()).isEqualTo(0.2);
+				assertThat(options.getVoiceSettings().useSpeakerBoost()).isFalse();
+				assertThat(options.getVoiceSettings().speed()).isEqualTo(1.2);
+				assertThat(options.getSpeed()).isEqualTo(1.2);
+				assertThat(options.getLanguageCode()).isEqualTo("en");
+				assertThat(options.getSeed()).isEqualTo(12345);
+				assertThat(options.getPreviousText()).isEqualTo("previous");
+				assertThat(options.getNextText()).isEqualTo("next");
+				assertThat(options.getApplyTextNormalization())
 					.isEqualTo(ElevenLabsApi.SpeechRequest.TextNormalizationMode.ON);
-				assertThat(speechProperties.getOptions().getApplyLanguageTextNormalization()).isTrue();
+				assertThat(options.getApplyLanguageTextNormalization()).isTrue();
 			});
 	}
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/elevenlabs-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/elevenlabs-speech.adoc
@@ -66,14 +66,14 @@ The prefix `spring.ai.elevenlabs.tts` is used as the property prefix to configur
 | Property | Description | Default
 
 | spring.ai.model.audio.speech   | Enable Audio Speech Model |  elevenlabs
-| spring.ai.elevenlabs.tts.options.model-id | The ID of the model to use. | eleven_turbo_v2_5
-| spring.ai.elevenlabs.tts.options.voice-id | The ID of the voice to use.  This is the *voice ID*, not the voice name. | 9BWtsMINqrJLrRacOk9x
-| spring.ai.elevenlabs.tts.options.output-format |  The output format for the generated audio. See xref:#output-formats[Output Formats] below. | mp3_22050_32
+| spring.ai.elevenlabs.tts.model-id | The ID of the model to use. | eleven_turbo_v2_5
+| spring.ai.elevenlabs.tts.voice-id | The ID of the voice to use.  This is the *voice ID*, not the voice name. | 9BWtsMINqrJLrRacOk9x
+| spring.ai.elevenlabs.tts.output-format |  The output format for the generated audio. See xref:#output-formats[Output Formats] below. | mp3_22050_32
 |====
 
 NOTE: The base URL and API key can also be configured *specifically* for TTS using `spring.ai.elevenlabs.tts.base-url` and `spring.ai.elevenlabs.tts.api-key`. However, it is generally recommended to use the global `spring.ai.elevenlabs` prefix for simplicity, unless you have a specific reason to use different credentials for different ElevenLabs services. The more specific `tts` properties will override the global ones.
 
-TIP: All properties prefixed with `spring.ai.elevenlabs.tts.options` can be overridden at runtime.
+TIP: All properties prefixed with `spring.ai.elevenlabs.tts` can be overridden at runtime.
 
 [[output-formats]]
 .Available Output Formats


### PR DESCRIPTION
- Remove `@NestedConfigurationProperty` from `ElevenLabsChatProperties`
- Expose options directly under the `spring.ai.elevenlabs.chat` prefix instead of `spring.ai.elevenlabs.chat.options`
- Implement Spring Boot deprecation mechanism for the legacy `options` nested properties to gracefully guide users during upgrades