### PR TITLE
Remove Google GenAI setters from options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/MIGRATION_GUIDE.md
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/MIGRATION_GUIDE.md
@@ -45,11 +45,11 @@ New properties:
 # For Vertex AI mode
 spring.ai.google.genai.project-id=my-project
 spring.ai.google.genai.location=us-central1
-spring.ai.google.genai.chat.options.model=gemini-2.0-flash
+spring.ai.google.genai.chat.model=gemini-2.0-flash
 
 # For Gemini Developer API mode (new!)
 spring.ai.google.genai.api-key=your-api-key
-spring.ai.google.genai.chat.options.model=gemini-2.0-flash
+spring.ai.google.genai.chat.model=gemini-2.0-flash
 
 # Embedding properties
 spring.ai.google.genai.embedding.project-id=my-project

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatAutoConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Pollack
  * @author Ilayaperumal Gopinathan
  * @author Yanming Zhou
+ * @author Sebastien Deleuze
  * @since 1.1.0
  */
 @AutoConfiguration
@@ -140,7 +141,7 @@ public class GoogleGenAiChatAutoConfiguration {
 
 		GoogleGenAiChatModel chatModel = GoogleGenAiChatModel.builder()
 			.genAiClient(googleGenAiClient)
-			.defaultOptions(chatProperties.getOptions())
+			.defaultOptions(chatProperties.toOptions())
 			.toolCallingManager(toolCallingManager)
 			.toolExecutionEligibilityPredicate(
 					toolExecutionEligibilityPredicate.getIfUnique(() -> new DefaultToolExecutionEligibilityPredicate()))

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/main/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiChatProperties.java
@@ -16,16 +16,26 @@
 
 package org.springframework.ai.model.google.genai.autoconfigure.chat;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+import org.springframework.ai.google.genai.common.GoogleGenAiSafetySetting;
+import org.springframework.ai.google.genai.common.GoogleGenAiThinkingLevel;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for Google GenAI Chat.
  *
  * @author Christian Tzolov
  * @author Hyunsang Han
+ * @author Sebastien Deleuze
  * @since 1.1.0
  */
 @ConfigurationProperties(GoogleGenAiChatProperties.CONFIG_PREFIX)
@@ -35,18 +45,599 @@ public class GoogleGenAiChatProperties {
 
 	public static final String DEFAULT_MODEL = GoogleGenAiChatModel.ChatModel.GEMINI_2_0_FLASH.getValue();
 
-	/**
-	 * Google GenAI API generative options.
-	 */
-	@NestedConfigurationProperty
-	private final GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
-		.temperature(0.7)
-		.candidateCount(1)
-		.model(DEFAULT_MODEL)
-		.build();
+	private @Nullable List<String> stopSequences;
 
-	public GoogleGenAiChatOptions getOptions() {
+	private @Nullable Double temperature = 0.7;
+
+	private @Nullable Double topP;
+
+	private @Nullable Integer topK;
+
+	private @Nullable Integer candidateCount = 1;
+
+	private @Nullable Integer maxOutputTokens;
+
+	private @Nullable String model = DEFAULT_MODEL;
+
+	private @Nullable String responseMimeType;
+
+	private @Nullable String responseSchema;
+
+	private @Nullable Double frequencyPenalty;
+
+	private @Nullable Double presencePenalty;
+
+	private @Nullable Integer thinkingBudget;
+
+	private @Nullable Boolean includeThoughts;
+
+	private @Nullable GoogleGenAiThinkingLevel thinkingLevel;
+
+	private @Nullable Boolean includeExtendedUsageMetadata;
+
+	private @Nullable String cachedContentName;
+
+	private @Nullable Boolean useCachedContent;
+
+	private @Nullable Integer autoCacheThreshold;
+
+	private @Nullable Duration autoCacheTtl;
+
+	private @Nullable List<String> toolNames;
+
+	private @Nullable Boolean internalToolExecutionEnabled;
+
+	private @Nullable Boolean googleSearchRetrieval = false;
+
+	private @Nullable Boolean includeServerSideToolInvocations = false;
+
+	private @Nullable List<GoogleGenAiSafetySetting> safetySettings;
+
+	private @Nullable Map<String, String> labels;
+
+	public @Nullable List<String> getStopSequences() {
+		return this.stopSequences;
+	}
+
+	public void setStopSequences(@Nullable List<String> stopSequences) {
+		this.stopSequences = stopSequences;
+	}
+
+	public @Nullable Double getTemperature() {
+		return this.temperature;
+	}
+
+	public void setTemperature(@Nullable Double temperature) {
+		this.temperature = temperature;
+	}
+
+	public @Nullable Double getTopP() {
+		return this.topP;
+	}
+
+	public void setTopP(@Nullable Double topP) {
+		this.topP = topP;
+	}
+
+	public @Nullable Integer getTopK() {
+		return this.topK;
+	}
+
+	public void setTopK(@Nullable Integer topK) {
+		this.topK = topK;
+	}
+
+	public @Nullable Integer getCandidateCount() {
+		return this.candidateCount;
+	}
+
+	public void setCandidateCount(@Nullable Integer candidateCount) {
+		this.candidateCount = candidateCount;
+	}
+
+	public @Nullable Integer getMaxOutputTokens() {
+		return this.maxOutputTokens;
+	}
+
+	public void setMaxOutputTokens(@Nullable Integer maxOutputTokens) {
+		this.maxOutputTokens = maxOutputTokens;
+	}
+
+	public @Nullable String getModel() {
+		return this.model;
+	}
+
+	public void setModel(@Nullable String model) {
+		this.model = model;
+	}
+
+	public @Nullable String getResponseMimeType() {
+		return this.responseMimeType;
+	}
+
+	public void setResponseMimeType(@Nullable String responseMimeType) {
+		this.responseMimeType = responseMimeType;
+	}
+
+	public @Nullable String getResponseSchema() {
+		return this.responseSchema;
+	}
+
+	public void setResponseSchema(@Nullable String responseSchema) {
+		this.responseSchema = responseSchema;
+	}
+
+	public @Nullable Double getFrequencyPenalty() {
+		return this.frequencyPenalty;
+	}
+
+	public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+		this.frequencyPenalty = frequencyPenalty;
+	}
+
+	public @Nullable Double getPresencePenalty() {
+		return this.presencePenalty;
+	}
+
+	public void setPresencePenalty(@Nullable Double presencePenalty) {
+		this.presencePenalty = presencePenalty;
+	}
+
+	public @Nullable Integer getThinkingBudget() {
+		return this.thinkingBudget;
+	}
+
+	public void setThinkingBudget(@Nullable Integer thinkingBudget) {
+		this.thinkingBudget = thinkingBudget;
+	}
+
+	public @Nullable Boolean getIncludeThoughts() {
+		return this.includeThoughts;
+	}
+
+	public void setIncludeThoughts(@Nullable Boolean includeThoughts) {
+		this.includeThoughts = includeThoughts;
+	}
+
+	public @Nullable GoogleGenAiThinkingLevel getThinkingLevel() {
+		return this.thinkingLevel;
+	}
+
+	public void setThinkingLevel(@Nullable GoogleGenAiThinkingLevel thinkingLevel) {
+		this.thinkingLevel = thinkingLevel;
+	}
+
+	public @Nullable Boolean getIncludeExtendedUsageMetadata() {
+		return this.includeExtendedUsageMetadata;
+	}
+
+	public void setIncludeExtendedUsageMetadata(@Nullable Boolean includeExtendedUsageMetadata) {
+		this.includeExtendedUsageMetadata = includeExtendedUsageMetadata;
+	}
+
+	public @Nullable String getCachedContentName() {
+		return this.cachedContentName;
+	}
+
+	public void setCachedContentName(@Nullable String cachedContentName) {
+		this.cachedContentName = cachedContentName;
+	}
+
+	public @Nullable Boolean getUseCachedContent() {
+		return this.useCachedContent;
+	}
+
+	public void setUseCachedContent(@Nullable Boolean useCachedContent) {
+		this.useCachedContent = useCachedContent;
+	}
+
+	public @Nullable Integer getAutoCacheThreshold() {
+		return this.autoCacheThreshold;
+	}
+
+	public void setAutoCacheThreshold(@Nullable Integer autoCacheThreshold) {
+		this.autoCacheThreshold = autoCacheThreshold;
+	}
+
+	public @Nullable Duration getAutoCacheTtl() {
+		return this.autoCacheTtl;
+	}
+
+	public void setAutoCacheTtl(@Nullable Duration autoCacheTtl) {
+		this.autoCacheTtl = autoCacheTtl;
+	}
+
+	public @Nullable List<String> getToolNames() {
+		return this.toolNames;
+	}
+
+	public void setToolNames(@Nullable List<String> toolNames) {
+		this.toolNames = toolNames;
+	}
+
+	public @Nullable Boolean getInternalToolExecutionEnabled() {
+		return this.internalToolExecutionEnabled;
+	}
+
+	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	public @Nullable Boolean getGoogleSearchRetrieval() {
+		return this.googleSearchRetrieval;
+	}
+
+	public void setGoogleSearchRetrieval(@Nullable Boolean googleSearchRetrieval) {
+		this.googleSearchRetrieval = googleSearchRetrieval;
+	}
+
+	public @Nullable Boolean getIncludeServerSideToolInvocations() {
+		return this.includeServerSideToolInvocations;
+	}
+
+	public void setIncludeServerSideToolInvocations(@Nullable Boolean includeServerSideToolInvocations) {
+		this.includeServerSideToolInvocations = includeServerSideToolInvocations;
+	}
+
+	public @Nullable List<GoogleGenAiSafetySetting> getSafetySettings() {
+		return this.safetySettings;
+	}
+
+	public void setSafetySettings(@Nullable List<GoogleGenAiSafetySetting> safetySettings) {
+		this.safetySettings = safetySettings;
+	}
+
+	public @Nullable Map<String, String> getLabels() {
+		return this.labels;
+	}
+
+	public void setLabels(@Nullable Map<String, String> labels) {
+		this.labels = labels;
+	}
+
+	public GoogleGenAiChatOptions toOptions() {
+		GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder();
+		builder.model(this.model);
+		if (this.stopSequences != null) {
+			builder.stopSequences(this.stopSequences);
+		}
+		if (this.temperature != null) {
+			builder.temperature(this.temperature);
+		}
+		if (this.topP != null) {
+			builder.topP(this.topP);
+		}
+		if (this.topK != null) {
+			builder.topK(this.topK);
+		}
+		if (this.candidateCount != null) {
+			builder.candidateCount(this.candidateCount);
+		}
+		if (this.maxOutputTokens != null) {
+			builder.maxOutputTokens(this.maxOutputTokens);
+		}
+		if (this.responseMimeType != null) {
+			builder.responseMimeType(this.responseMimeType);
+		}
+		if (this.responseSchema != null) {
+			builder.responseSchema(this.responseSchema);
+		}
+		if (this.frequencyPenalty != null) {
+			builder.frequencyPenalty(this.frequencyPenalty);
+		}
+		if (this.presencePenalty != null) {
+			builder.presencePenalty(this.presencePenalty);
+		}
+		if (this.thinkingBudget != null) {
+			builder.thinkingBudget(this.thinkingBudget);
+		}
+		if (this.includeThoughts != null) {
+			builder.includeThoughts(this.includeThoughts);
+		}
+		if (this.thinkingLevel != null) {
+			builder.thinkingLevel(this.thinkingLevel);
+		}
+		if (this.includeExtendedUsageMetadata != null) {
+			builder.includeExtendedUsageMetadata(this.includeExtendedUsageMetadata);
+		}
+		if (this.cachedContentName != null) {
+			builder.cachedContentName(this.cachedContentName);
+		}
+		if (this.useCachedContent != null) {
+			builder.useCachedContent(this.useCachedContent);
+		}
+		if (this.autoCacheThreshold != null) {
+			builder.autoCacheThreshold(this.autoCacheThreshold);
+		}
+		if (this.autoCacheTtl != null) {
+			builder.autoCacheTtl(this.autoCacheTtl);
+		}
+		if (this.toolNames != null) {
+			builder.toolNames(Set.copyOf(this.toolNames));
+		}
+		if (this.internalToolExecutionEnabled != null) {
+			builder.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
+		}
+		if (this.googleSearchRetrieval != null) {
+			builder.googleSearchRetrieval(this.googleSearchRetrieval);
+		}
+		if (this.includeServerSideToolInvocations != null) {
+			builder.includeServerSideToolInvocations(this.includeServerSideToolInvocations);
+		}
+		if (this.safetySettings != null) {
+			builder.safetySettings(this.safetySettings);
+		}
+		if (this.labels != null) {
+			builder.labels(this.labels);
+		}
+		return builder.build();
+	}
+
+	private Options options = new Options();
+
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat")
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	public Options getOptions() {
 		return this.options;
+	}
+
+	public void setOptions(Options options) {
+		this.options = options;
+	}
+
+	public class Options {
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.model")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getModel() {
+			return GoogleGenAiChatProperties.this.getModel();
+		}
+
+		public void setModel(@Nullable String model) {
+			GoogleGenAiChatProperties.this.setModel(model);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.stop-sequences")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<String> getStopSequences() {
+			return GoogleGenAiChatProperties.this.getStopSequences();
+		}
+
+		public void setStopSequences(@Nullable List<String> stopSequences) {
+			GoogleGenAiChatProperties.this.setStopSequences(stopSequences);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.temperature")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTemperature() {
+			return GoogleGenAiChatProperties.this.getTemperature();
+		}
+
+		public void setTemperature(@Nullable Double temperature) {
+			GoogleGenAiChatProperties.this.setTemperature(temperature);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.top-p")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTopP() {
+			return GoogleGenAiChatProperties.this.getTopP();
+		}
+
+		public void setTopP(@Nullable Double topP) {
+			GoogleGenAiChatProperties.this.setTopP(topP);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.top-k")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getTopK() {
+			return GoogleGenAiChatProperties.this.getTopK();
+		}
+
+		public void setTopK(@Nullable Integer topK) {
+			GoogleGenAiChatProperties.this.setTopK(topK);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.candidate-count")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getCandidateCount() {
+			return GoogleGenAiChatProperties.this.getCandidateCount();
+		}
+
+		public void setCandidateCount(@Nullable Integer candidateCount) {
+			GoogleGenAiChatProperties.this.setCandidateCount(candidateCount);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.max-output-tokens")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getMaxOutputTokens() {
+			return GoogleGenAiChatProperties.this.getMaxOutputTokens();
+		}
+
+		public void setMaxOutputTokens(@Nullable Integer maxOutputTokens) {
+			GoogleGenAiChatProperties.this.setMaxOutputTokens(maxOutputTokens);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.response-mime-type")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getResponseMimeType() {
+			return GoogleGenAiChatProperties.this.getResponseMimeType();
+		}
+
+		public void setResponseMimeType(@Nullable String responseMimeType) {
+			GoogleGenAiChatProperties.this.setResponseMimeType(responseMimeType);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.response-schema")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getResponseSchema() {
+			return GoogleGenAiChatProperties.this.getResponseSchema();
+		}
+
+		public void setResponseSchema(@Nullable String responseSchema) {
+			GoogleGenAiChatProperties.this.setResponseSchema(responseSchema);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.frequency-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getFrequencyPenalty() {
+			return GoogleGenAiChatProperties.this.getFrequencyPenalty();
+		}
+
+		public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+			GoogleGenAiChatProperties.this.setFrequencyPenalty(frequencyPenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.presence-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getPresencePenalty() {
+			return GoogleGenAiChatProperties.this.getPresencePenalty();
+		}
+
+		public void setPresencePenalty(@Nullable Double presencePenalty) {
+			GoogleGenAiChatProperties.this.setPresencePenalty(presencePenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.thinking-budget")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getThinkingBudget() {
+			return GoogleGenAiChatProperties.this.getThinkingBudget();
+		}
+
+		public void setThinkingBudget(@Nullable Integer thinkingBudget) {
+			GoogleGenAiChatProperties.this.setThinkingBudget(thinkingBudget);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.include-thoughts")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getIncludeThoughts() {
+			return GoogleGenAiChatProperties.this.getIncludeThoughts();
+		}
+
+		public void setIncludeThoughts(@Nullable Boolean includeThoughts) {
+			GoogleGenAiChatProperties.this.setIncludeThoughts(includeThoughts);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.thinking-level")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable GoogleGenAiThinkingLevel getThinkingLevel() {
+			return GoogleGenAiChatProperties.this.getThinkingLevel();
+		}
+
+		public void setThinkingLevel(@Nullable GoogleGenAiThinkingLevel thinkingLevel) {
+			GoogleGenAiChatProperties.this.setThinkingLevel(thinkingLevel);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.include-extended-usage-metadata")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getIncludeExtendedUsageMetadata() {
+			return GoogleGenAiChatProperties.this.getIncludeExtendedUsageMetadata();
+		}
+
+		public void setIncludeExtendedUsageMetadata(@Nullable Boolean includeExtendedUsageMetadata) {
+			GoogleGenAiChatProperties.this.setIncludeExtendedUsageMetadata(includeExtendedUsageMetadata);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.cached-content-name")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getCachedContentName() {
+			return GoogleGenAiChatProperties.this.getCachedContentName();
+		}
+
+		public void setCachedContentName(@Nullable String cachedContentName) {
+			GoogleGenAiChatProperties.this.setCachedContentName(cachedContentName);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.use-cached-content")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getUseCachedContent() {
+			return GoogleGenAiChatProperties.this.getUseCachedContent();
+		}
+
+		public void setUseCachedContent(@Nullable Boolean useCachedContent) {
+			GoogleGenAiChatProperties.this.setUseCachedContent(useCachedContent);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.auto-cache-threshold")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getAutoCacheThreshold() {
+			return GoogleGenAiChatProperties.this.getAutoCacheThreshold();
+		}
+
+		public void setAutoCacheThreshold(@Nullable Integer autoCacheThreshold) {
+			GoogleGenAiChatProperties.this.setAutoCacheThreshold(autoCacheThreshold);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.auto-cache-ttl")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Duration getAutoCacheTtl() {
+			return GoogleGenAiChatProperties.this.getAutoCacheTtl();
+		}
+
+		public void setAutoCacheTtl(@Nullable Duration autoCacheTtl) {
+			GoogleGenAiChatProperties.this.setAutoCacheTtl(autoCacheTtl);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.tool-names")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<String> getToolNames() {
+			return GoogleGenAiChatProperties.this.getToolNames();
+		}
+
+		public void setToolNames(@Nullable List<String> toolNames) {
+			GoogleGenAiChatProperties.this.setToolNames(toolNames);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.internal-tool-execution-enabled")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getInternalToolExecutionEnabled() {
+			return GoogleGenAiChatProperties.this.getInternalToolExecutionEnabled();
+		}
+
+		public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+			GoogleGenAiChatProperties.this.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.google-search-retrieval")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getGoogleSearchRetrieval() {
+			return GoogleGenAiChatProperties.this.getGoogleSearchRetrieval();
+		}
+
+		public void setGoogleSearchRetrieval(@Nullable Boolean googleSearchRetrieval) {
+			GoogleGenAiChatProperties.this.setGoogleSearchRetrieval(googleSearchRetrieval);
+		}
+
+		@DeprecatedConfigurationProperty(
+				replacement = "spring.ai.google.genai.chat.include-server-side-tool-invocations")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getIncludeServerSideToolInvocations() {
+			return GoogleGenAiChatProperties.this.getIncludeServerSideToolInvocations();
+		}
+
+		public void setIncludeServerSideToolInvocations(@Nullable Boolean includeServerSideToolInvocations) {
+			GoogleGenAiChatProperties.this.setIncludeServerSideToolInvocations(includeServerSideToolInvocations);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.safety-settings")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<GoogleGenAiSafetySetting> getSafetySettings() {
+			return GoogleGenAiChatProperties.this.getSafetySettings();
+		}
+
+		public void setSafetySettings(@Nullable List<GoogleGenAiSafetySetting> safetySettings) {
+			GoogleGenAiChatProperties.this.setSafetySettings(safetySettings);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.google.genai.chat.labels")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Map<String, String> getLabels() {
+			return GoogleGenAiChatProperties.this.getLabels();
+		}
+
+		public void setLabels(@Nullable Map<String, String> labels) {
+			GoogleGenAiChatProperties.this.setLabels(labels);
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiCachedContentServiceAutoConfigurationTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiCachedContentServiceAutoConfigurationTests.java
@@ -50,7 +50,7 @@ public class GoogleGenAiCachedContentServiceAutoConfigurationTests {
 	void cachedContentServiceBeanIsCreatedWhenChatModelExists() {
 		this.contextRunner.withUserConfiguration(MockGoogleGenAiConfiguration.class)
 			.withPropertyValues("spring.ai.google.genai.api-key=test-key",
-					"spring.ai.google.genai.chat.options.model=gemini-2.0-flash")
+					"spring.ai.google.genai.chat.model=gemini-2.0-flash")
 			.run(context -> {
 				assertThat(context).hasSingleBean(GoogleGenAiChatModel.class);
 				// The CachedContentServiceCondition will prevent the bean from being
@@ -67,7 +67,7 @@ public class GoogleGenAiCachedContentServiceAutoConfigurationTests {
 	void cachedContentServiceBeanIsNotCreatedWhenDisabled() {
 		this.contextRunner.withUserConfiguration(MockGoogleGenAiConfiguration.class)
 			.withPropertyValues("spring.ai.google.genai.api-key=test-key",
-					"spring.ai.google.genai.chat.options.model=gemini-2.0-flash",
+					"spring.ai.google.genai.chat.model=gemini-2.0-flash",
 					"spring.ai.google.genai.chat.enable-cached-content=false")
 			.run(context -> {
 				assertThat(context).hasSingleBean(GoogleGenAiChatModel.class);
@@ -94,7 +94,7 @@ public class GoogleGenAiCachedContentServiceAutoConfigurationTests {
 	void cachedContentServiceCannotBeCreatedWithMockClientWithoutCaches() {
 		this.contextRunner.withUserConfiguration(MockGoogleGenAiConfigurationWithoutCachedContent.class)
 			.withPropertyValues("spring.ai.google.genai.api-key=test-key",
-					"spring.ai.google.genai.chat.options.model=gemini-2.0-flash")
+					"spring.ai.google.genai.chat.model=gemini-2.0-flash")
 			.run(context -> {
 				assertThat(context).hasSingleBean(GoogleGenAiChatModel.class);
 				// The bean will actually be created but return null (which should be
@@ -109,11 +109,11 @@ public class GoogleGenAiCachedContentServiceAutoConfigurationTests {
 	void cachedContentPropertiesArePassedToChatModel() {
 		this.contextRunner.withUserConfiguration(MockGoogleGenAiConfiguration.class)
 			.withPropertyValues("spring.ai.google.genai.api-key=test-key",
-					"spring.ai.google.genai.chat.options.model=gemini-2.0-flash",
-					"spring.ai.google.genai.chat.options.use-cached-content=true",
-					"spring.ai.google.genai.chat.options.cached-content-name=cachedContent/test123",
-					"spring.ai.google.genai.chat.options.auto-cache-threshold=50000",
-					"spring.ai.google.genai.chat.options.auto-cache-ttl=PT2H")
+					"spring.ai.google.genai.chat.model=gemini-2.0-flash",
+					"spring.ai.google.genai.chat.use-cached-content=true",
+					"spring.ai.google.genai.chat.cached-content-name=cachedContent/test123",
+					"spring.ai.google.genai.chat.auto-cache-threshold=50000",
+					"spring.ai.google.genai.chat.auto-cache-ttl=PT2H")
 			.run(context -> {
 				GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
 				assertThat(chatModel).isNotNull();
@@ -130,8 +130,8 @@ public class GoogleGenAiCachedContentServiceAutoConfigurationTests {
 	void extendedUsageMetadataPropertyIsPassedToChatModel() {
 		this.contextRunner.withUserConfiguration(MockGoogleGenAiConfiguration.class)
 			.withPropertyValues("spring.ai.google.genai.api-key=test-key",
-					"spring.ai.google.genai.chat.options.model=gemini-2.0-flash",
-					"spring.ai.google.genai.chat.options.include-extended-usage-metadata=true")
+					"spring.ai.google.genai.chat.model=gemini-2.0-flash",
+					"spring.ai.google.genai.chat.include-extended-usage-metadata=true")
 			.run(context -> {
 				GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
 				assertThat(chatModel).isNotNull();
@@ -165,7 +165,7 @@ public class GoogleGenAiCachedContentServiceAutoConfigurationTests {
 			GoogleGenAiChatModel mockModel = Mockito.mock(GoogleGenAiChatModel.class);
 			GoogleGenAiCachedContentService mockService = Mockito.mock(GoogleGenAiCachedContentService.class);
 			when(mockModel.getCachedContentService()).thenReturn(mockService);
-			when(mockModel.getDefaultOptions()).thenReturn(properties.getOptions());
+			when(mockModel.getDefaultOptions()).thenReturn(properties.toOptions());
 			return mockModel;
 		}
 
@@ -191,7 +191,7 @@ public class GoogleGenAiCachedContentServiceAutoConfigurationTests {
 			// This simulates using a mock client that doesn't support cached content
 			GoogleGenAiChatModel mockModel = Mockito.mock(GoogleGenAiChatModel.class);
 			when(mockModel.getCachedContentService()).thenReturn(null);
-			when(mockModel.getDefaultOptions()).thenReturn(properties.getOptions());
+			when(mockModel.getDefaultOptions()).thenReturn(properties.toOptions());
 			return mockModel;
 		}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/GoogleGenAiPropertiesTests.java
@@ -27,6 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for Google GenAI properties binding.
+ *
+ * @author Sebastien Deleuze
  */
 public class GoogleGenAiPropertiesTests {
 
@@ -50,18 +52,17 @@ public class GoogleGenAiPropertiesTests {
 	@Test
 	void chatPropertiesBinding() {
 		this.contextRunner
-			.withPropertyValues("spring.ai.google.genai.chat.options.model=gemini-2.0-flash",
-					"spring.ai.google.genai.chat.options.temperature=0.5",
-					"spring.ai.google.genai.chat.options.max-output-tokens=2048",
-					"spring.ai.google.genai.chat.options.top-p=0.9",
-					"spring.ai.google.genai.chat.options.response-mime-type=application/json")
+			.withPropertyValues("spring.ai.google.genai.chat.model=gemini-2.0-flash",
+					"spring.ai.google.genai.chat.temperature=0.5", "spring.ai.google.genai.chat.max-output-tokens=2048",
+					"spring.ai.google.genai.chat.top-p=0.9",
+					"spring.ai.google.genai.chat.response-mime-type=application/json")
 			.run(context -> {
 				GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("gemini-2.0-flash");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.5);
-				assertThat(chatProperties.getOptions().getMaxOutputTokens()).isEqualTo(2048);
-				assertThat(chatProperties.getOptions().getTopP()).isEqualTo(0.9);
-				assertThat(chatProperties.getOptions().getResponseMimeType()).isEqualTo("application/json");
+				assertThat(chatProperties.toOptions().getModel()).isEqualTo("gemini-2.0-flash");
+				assertThat(chatProperties.toOptions().getTemperature()).isEqualTo(0.5);
+				assertThat(chatProperties.toOptions().getMaxOutputTokens()).isEqualTo(2048);
+				assertThat(chatProperties.toOptions().getTopP()).isEqualTo(0.9);
+				assertThat(chatProperties.toOptions().getResponseMimeType()).isEqualTo("application/json");
 			});
 	}
 
@@ -83,28 +84,27 @@ public class GoogleGenAiPropertiesTests {
 	@Test
 	void cachedContentPropertiesBinding() {
 		this.contextRunner
-			.withPropertyValues("spring.ai.google.genai.chat.options.use-cached-content=true",
-					"spring.ai.google.genai.chat.options.cached-content-name=cachedContent/test123",
-					"spring.ai.google.genai.chat.options.auto-cache-threshold=100000",
-					"spring.ai.google.genai.chat.options.auto-cache-ttl=PT1H")
+			.withPropertyValues("spring.ai.google.genai.chat.use-cached-content=true",
+					"spring.ai.google.genai.chat.cached-content-name=cachedContent/test123",
+					"spring.ai.google.genai.chat.auto-cache-threshold=100000",
+					"spring.ai.google.genai.chat.auto-cache-ttl=PT1H")
 			.run(context -> {
 				GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
-				assertThat(chatProperties.getOptions().getUseCachedContent()).isTrue();
-				assertThat(chatProperties.getOptions().getCachedContentName()).isEqualTo("cachedContent/test123");
-				assertThat(chatProperties.getOptions().getAutoCacheThreshold()).isEqualTo(100000);
+				assertThat(chatProperties.toOptions().getUseCachedContent()).isTrue();
+				assertThat(chatProperties.toOptions().getCachedContentName()).isEqualTo("cachedContent/test123");
+				assertThat(chatProperties.toOptions().getAutoCacheThreshold()).isEqualTo(100000);
 				// The Duration keeps its original ISO-8601 format
-				assertThat(chatProperties.getOptions().getAutoCacheTtl()).isNotNull();
-				assertThat(chatProperties.getOptions().getAutoCacheTtl().toString()).isEqualTo("PT1H");
+				assertThat(chatProperties.toOptions().getAutoCacheTtl()).isNotNull();
+				assertThat(chatProperties.toOptions().getAutoCacheTtl().toString()).isEqualTo("PT1H");
 			});
 	}
 
 	@Test
 	void extendedUsageMetadataPropertiesBinding() {
-		this.contextRunner
-			.withPropertyValues("spring.ai.google.genai.chat.options.include-extended-usage-metadata=true")
+		this.contextRunner.withPropertyValues("spring.ai.google.genai.chat.include-extended-usage-metadata=true")
 			.run(context -> {
 				GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
-				assertThat(chatProperties.getOptions().getIncludeExtendedUsageMetadata()).isTrue();
+				assertThat(chatProperties.toOptions().getIncludeExtendedUsageMetadata()).isTrue();
 			});
 	}
 
@@ -114,10 +114,10 @@ public class GoogleGenAiPropertiesTests {
 		this.contextRunner.run(context -> {
 			GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
 			// These should be null when not set
-			assertThat(chatProperties.getOptions().getUseCachedContent()).isNull();
-			assertThat(chatProperties.getOptions().getCachedContentName()).isNull();
-			assertThat(chatProperties.getOptions().getAutoCacheThreshold()).isNull();
-			assertThat(chatProperties.getOptions().getAutoCacheTtl()).isNull();
+			assertThat(chatProperties.toOptions().getUseCachedContent()).isNull();
+			assertThat(chatProperties.toOptions().getCachedContentName()).isNull();
+			assertThat(chatProperties.toOptions().getAutoCacheThreshold()).isNull();
+			assertThat(chatProperties.toOptions().getAutoCacheTtl()).isNull();
 		});
 	}
 
@@ -127,17 +127,16 @@ public class GoogleGenAiPropertiesTests {
 		this.contextRunner.run(context -> {
 			GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
 			// Should be null when not set (defaults to true in the model implementation)
-			assertThat(chatProperties.getOptions().getIncludeExtendedUsageMetadata()).isNull();
+			assertThat(chatProperties.toOptions().getIncludeExtendedUsageMetadata()).isNull();
 		});
 	}
 
 	@Test
 	void includeThoughtsPropertiesBinding() {
-		this.contextRunner.withPropertyValues("spring.ai.google.genai.chat.options.include-thoughts=true")
-			.run(context -> {
-				GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
-				assertThat(chatProperties.getOptions().getIncludeThoughts()).isTrue();
-			});
+		this.contextRunner.withPropertyValues("spring.ai.google.genai.chat.include-thoughts=true").run(context -> {
+			GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
+			assertThat(chatProperties.toOptions().getIncludeThoughts()).isTrue();
+		});
 	}
 
 	@Test
@@ -146,7 +145,7 @@ public class GoogleGenAiPropertiesTests {
 		this.contextRunner.run(context -> {
 			GoogleGenAiChatProperties chatProperties = context.getBean(GoogleGenAiChatProperties.class);
 			// Should be null when not set
-			assertThat(chatProperties.getOptions().getIncludeThoughts()).isNull();
+			assertThat(chatProperties.toOptions().getIncludeThoughts()).isNull();
 		});
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithPromptFunctionIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/src/test/java/org/springframework/ai/model/google/genai/autoconfigure/chat/tool/FunctionCallWithPromptFunctionIT.java
@@ -54,8 +54,8 @@ public class FunctionCallWithPromptFunctionIT {
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
 		contextRunner
-			.withPropertyValues("spring.ai.google.genai.chat.options.model="
-					+ GoogleGenAiChatModel.ChatModel.GEMINI_2_0_FLASH.getValue())
+			.withPropertyValues(
+					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_0_FLASH.getValue())
 			.run(context -> {
 
 				GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);
@@ -100,8 +100,8 @@ public class FunctionCallWithPromptFunctionIT {
 					SpringAiRetryAutoConfiguration.class, ToolCallingAutoConfiguration.class));
 
 		contextRunner
-			.withPropertyValues("spring.ai.google.genai.chat.options.model="
-					+ GoogleGenAiChatModel.ChatModel.GEMINI_2_0_FLASH.getValue())
+			.withPropertyValues(
+					"spring.ai.google.genai.chat.model=" + GoogleGenAiChatModel.ChatModel.GEMINI_2_0_FLASH.getValue())
 			.run(context -> {
 
 				GoogleGenAiChatModel chatModel = context.getBean(GoogleGenAiChatModel.class);

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Ilayaperumal Gopinathan
  * @author Soby Chacko
  * @author Dan Dobrin
+ * @author Sebastien Deleuze
  * @since 1.0.0
  */
 public class GoogleGenAiChatOptions implements ToolCallingChatOptions, StructuredOutputChatOptions {
@@ -284,17 +285,9 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		return this.stopSequences;
 	}
 
-	public void setStopSequences(List<String> stopSequences) {
-		this.stopSequences = stopSequences;
-	}
-
 	@Override
 	public @Nullable Double getTemperature() {
 		return this.temperature;
-	}
-
-	public void setTemperature(Double temperature) {
-		this.temperature = temperature;
 	}
 
 	@Override
@@ -302,25 +295,13 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		return this.topP;
 	}
 
-	public void setTopP(Double topP) {
-		this.topP = topP;
-	}
-
 	@Override
 	public @Nullable Integer getTopK() {
 		return this.topK;
 	}
 
-	public void setTopK(Integer topK) {
-		this.topK = topK;
-	}
-
 	public @Nullable Integer getCandidateCount() {
 		return this.candidateCount;
-	}
-
-	public void setCandidateCount(Integer candidateCount) {
-		this.candidateCount = candidateCount;
 	}
 
 	@Override
@@ -328,16 +309,8 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		return getMaxOutputTokens();
 	}
 
-	public void setMaxTokens(Integer maxTokens) {
-		setMaxOutputTokens(maxTokens);
-	}
-
 	public @Nullable Integer getMaxOutputTokens() {
 		return this.maxOutputTokens;
-	}
-
-	public void setMaxOutputTokens(Integer maxOutputTokens) {
-		this.maxOutputTokens = maxOutputTokens;
 	}
 
 	@Override
@@ -345,24 +318,12 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		return this.model;
 	}
 
-	public void setModel(String modelName) {
-		this.model = modelName;
-	}
-
 	public @Nullable String getResponseMimeType() {
 		return this.responseMimeType;
 	}
 
-	public void setResponseMimeType(String mimeType) {
-		this.responseMimeType = mimeType;
-	}
-
 	public @Nullable String getResponseSchema() {
 		return this.responseSchema;
-	}
-
-	public void setResponseSchema(String responseSchema) {
-		this.responseSchema = responseSchema;
 	}
 
 	@Override
@@ -371,33 +332,13 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	}
 
 	@Override
-	public void setToolCallbacks(List<ToolCallback> toolCallbacks) {
-		Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
-		Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
-		this.toolCallbacks = toolCallbacks;
-	}
-
-	@Override
 	public Set<String> getToolNames() {
 		return this.toolNames;
 	}
 
 	@Override
-	public void setToolNames(Set<String> toolNames) {
-		Assert.notNull(toolNames, "toolNames cannot be null");
-		Assert.noNullElements(toolNames, "toolNames cannot contain null elements");
-		toolNames.forEach(tool -> Assert.hasText(tool, "toolNames cannot contain empty elements"));
-		this.toolNames = toolNames;
-	}
-
-	@Override
 	public @Nullable Boolean getInternalToolExecutionEnabled() {
 		return this.internalToolExecutionEnabled;
-	}
-
-	@Override
-	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
-		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
 	}
 
 	@Override
@@ -410,110 +351,52 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 		return this.presencePenalty;
 	}
 
-	public void setFrequencyPenalty(Double frequencyPenalty) {
-		this.frequencyPenalty = frequencyPenalty;
-	}
-
-	public void setPresencePenalty(Double presencePenalty) {
-		this.presencePenalty = presencePenalty;
-	}
-
 	public @Nullable Integer getThinkingBudget() {
 		return this.thinkingBudget;
-	}
-
-	public void setThinkingBudget(Integer thinkingBudget) {
-		this.thinkingBudget = thinkingBudget;
 	}
 
 	public @Nullable Boolean getIncludeThoughts() {
 		return this.includeThoughts;
 	}
 
-	public void setIncludeThoughts(Boolean includeThoughts) {
-		this.includeThoughts = includeThoughts;
-	}
-
 	public @Nullable GoogleGenAiThinkingLevel getThinkingLevel() {
 		return this.thinkingLevel;
-	}
-
-	public void setThinkingLevel(GoogleGenAiThinkingLevel thinkingLevel) {
-		this.thinkingLevel = thinkingLevel;
 	}
 
 	public @Nullable Boolean getIncludeExtendedUsageMetadata() {
 		return this.includeExtendedUsageMetadata;
 	}
 
-	public void setIncludeExtendedUsageMetadata(Boolean includeExtendedUsageMetadata) {
-		this.includeExtendedUsageMetadata = includeExtendedUsageMetadata;
-	}
-
 	public @Nullable String getCachedContentName() {
 		return this.cachedContentName;
-	}
-
-	public void setCachedContentName(String cachedContentName) {
-		this.cachedContentName = cachedContentName;
 	}
 
 	public @Nullable Boolean getUseCachedContent() {
 		return this.useCachedContent;
 	}
 
-	public void setUseCachedContent(Boolean useCachedContent) {
-		this.useCachedContent = useCachedContent;
-	}
-
 	public @Nullable Integer getAutoCacheThreshold() {
 		return this.autoCacheThreshold;
-	}
-
-	public void setAutoCacheThreshold(Integer autoCacheThreshold) {
-		this.autoCacheThreshold = autoCacheThreshold;
 	}
 
 	public @Nullable Duration getAutoCacheTtl() {
 		return this.autoCacheTtl;
 	}
 
-	public void setAutoCacheTtl(Duration autoCacheTtl) {
-		this.autoCacheTtl = autoCacheTtl;
-	}
-
 	public @Nullable Boolean getGoogleSearchRetrieval() {
 		return this.googleSearchRetrieval;
-	}
-
-	public void setGoogleSearchRetrieval(Boolean googleSearchRetrieval) {
-		this.googleSearchRetrieval = googleSearchRetrieval;
 	}
 
 	public @Nullable Boolean getIncludeServerSideToolInvocations() {
 		return this.includeServerSideToolInvocations;
 	}
 
-	public void setIncludeServerSideToolInvocations(Boolean includeServerSideToolInvocations) {
-		this.includeServerSideToolInvocations = includeServerSideToolInvocations;
-	}
-
 	public List<GoogleGenAiSafetySetting> getSafetySettings() {
 		return this.safetySettings;
 	}
 
-	public void setSafetySettings(List<GoogleGenAiSafetySetting> safetySettings) {
-		Assert.notNull(safetySettings, "safetySettings must not be null");
-		this.safetySettings = safetySettings;
-	}
-
 	public Map<String, String> getLabels() {
 		return this.labels;
-	}
-
-	public void setLabels(Map<String, String> labels) {
-		Assert.notNull(labels, "labels must not be null");
-		this.labels = labels;
 	}
 
 	@Override
@@ -522,19 +405,39 @@ public class GoogleGenAiChatOptions implements ToolCallingChatOptions, Structure
 	}
 
 	@Override
-	public void setToolContext(Map<String, Object> toolContext) {
-		this.toolContext = toolContext;
-	}
-
-	@Override
 	public @Nullable String getOutputSchema() {
 		return this.getResponseSchema();
 	}
 
 	@Override
+	public void setToolCallbacks(List<ToolCallback> toolCallbacks) {
+		Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
+		Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
+		this.toolCallbacks = toolCallbacks;
+	}
+
+	@Override
+	public void setToolNames(Set<String> toolNames) {
+		Assert.notNull(toolNames, "toolNames cannot be null");
+		Assert.noNullElements(toolNames, "toolNames cannot contain null elements");
+		toolNames.forEach(tool -> Assert.hasText(tool, "toolNames cannot contain empty elements"));
+		this.toolNames = toolNames;
+	}
+
+	@Override
+	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	@Override
+	public void setToolContext(Map<String, Object> toolContext) {
+		this.toolContext = toolContext;
+	}
+
+	@Override
 	public void setOutputSchema(String jsonSchemaText) {
-		this.setResponseSchema(jsonSchemaText);
-		this.setResponseMimeType("application/json");
+		this.responseSchema = jsonSchemaText;
+		this.responseMimeType = "application/json";
 	}
 
 	@Override

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatOptionsTest.java
@@ -45,19 +45,6 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 	}
 
 	@Test
-	public void testThinkingBudgetGetterSetter() {
-		GoogleGenAiChatOptions options = new GoogleGenAiChatOptions();
-
-		assertThat(options.getThinkingBudget()).isNull();
-
-		options.setThinkingBudget(12853);
-		assertThat(options.getThinkingBudget()).isEqualTo(12853);
-
-		options.setThinkingBudget(null);
-		assertThat(options.getThinkingBudget()).isNull();
-	}
-
-	@Test
 	public void testThinkingBudgetWithBuilder() {
 		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
 			.model("test-model")
@@ -183,22 +170,6 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 	}
 
 	@Test
-	public void testThinkingLevelGetterSetter() {
-		GoogleGenAiChatOptions options = new GoogleGenAiChatOptions();
-
-		assertThat(options.getThinkingLevel()).isNull();
-
-		options.setThinkingLevel(GoogleGenAiThinkingLevel.HIGH);
-		assertThat(options.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.HIGH);
-
-		options.setThinkingLevel(GoogleGenAiThinkingLevel.LOW);
-		assertThat(options.getThinkingLevel()).isEqualTo(GoogleGenAiThinkingLevel.LOW);
-
-		options.setThinkingLevel(null);
-		assertThat(options.getThinkingLevel()).isNull();
-	}
-
-	@Test
 	public void testThinkingLevelWithBuilder() {
 		GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
 			.model("test-model")
@@ -292,19 +263,6 @@ public class GoogleGenAiChatOptionsTest extends AbstractChatOptionsTests<GoogleG
 				.build();
 			assertThat(options.getThinkingLevel()).isEqualTo(level);
 		}
-	}
-
-	@Test
-	public void testIncludeServerSideToolInvocationsGetterSetter() {
-		GoogleGenAiChatOptions options = new GoogleGenAiChatOptions();
-
-		assertThat(options.getIncludeServerSideToolInvocations()).isFalse();
-
-		options.setIncludeServerSideToolInvocations(true);
-		assertThat(options.getIncludeServerSideToolInvocations()).isTrue();
-
-		options.setIncludeServerSideToolInvocations(false);
-		assertThat(options.getIncludeServerSideToolInvocations()).isFalse();
 	}
 
 	@Test

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/google-genai-chat.adoc
@@ -105,39 +105,39 @@ The prefix `spring.ai.google.genai.chat` is the property prefix that lets you co
 |====
 | Property | Description | Default
 
-| spring.ai.google.genai.chat.options.model | Supported https://ai.google.dev/gemini-api/docs/models[Google GenAI Chat models] to use include `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-pro`, and `gemini-1.5-flash`. | gemini-2.0-flash
-| spring.ai.google.genai.chat.options.response-mime-type | Output response mimetype of the generated candidate text. |  `text/plain`: (default) Text output or `application/json`: JSON response.
-| spring.ai.google.genai.chat.options.google-search-retrieval | Use Google search Grounding feature | `true` or `false`, default `false`.
-| spring.ai.google.genai.chat.options.include-server-side-tool-invocations | When true, the API response includes server-side tool calls and responses (e.g., Google Search invocations) in the response metadata, allowing observation of the server's tool usage. Only supported with Gemini Developer API (MLDev), not Vertex AI. See <<server-side-tool-invocations>>. | `false`
-| spring.ai.google.genai.chat.options.temperature | Controls the randomness of the output. Values can range over [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied, while a value closer to 0.0 will typically result in less surprising responses from the generative. | -
-| spring.ai.google.genai.chat.options.top-k | The maximum number of tokens to consider when sampling. The generative uses combined Top-k and nucleus sampling. Top-k sampling considers the set of topK most probable tokens. | -
-| spring.ai.google.genai.chat.options.top-p | The maximum cumulative probability of tokens to consider when sampling. The generative uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least topP.  | -
-| spring.ai.google.genai.chat.options.candidate-count | The number of generated response messages to return. This value must be between [1, 8], inclusive. Defaults to 1. | 1
-| spring.ai.google.genai.chat.options.max-output-tokens | The maximum number of tokens to generate. | -
-| spring.ai.google.genai.chat.options.frequency-penalty | Frequency penalties for reducing repetition. | -
-| spring.ai.google.genai.chat.options.presence-penalty | Presence penalties for reducing repetition. | -
-| spring.ai.google.genai.chat.options.thinking-budget | Thinking budget for the thinking process. See <<thinking-config>>. | -
-| spring.ai.google.genai.chat.options.thinking-level | The level of thinking tokens the model should generate. Valid values: `LOW`, `HIGH`, `THINKING_LEVEL_UNSPECIFIED`. See <<thinking-config>>. | -
-| spring.ai.google.genai.chat.options.include-thoughts | Enable thought signatures for function calling. **Required** for Gemini 3 Pro to avoid validation errors during the internal tool execution loop. See <<thought-signatures>>. | false
-| spring.ai.google.genai.chat.options.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
-| spring.ai.google.genai.chat.options.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
-| spring.ai.google.genai.chat.options.internal-tool-execution-enabled | If true, the tool execution should be performed, otherwise the response from the model is returned back to the user. Default is null, but if it's null, `ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_ENABLED` which is true will take into account | -
-| spring.ai.google.genai.chat.options.safety-settings | List of safety settings to control safety filters, as defined by https://ai.google.dev/gemini-api/docs/safety-settings[Google GenAI Safety Settings]. Each safety setting can have a method, threshold, and category. | -
-| spring.ai.google.genai.chat.options.cached-content-name | The name of cached content to use for this request. When set along with `use-cached-content=true`, the cached content will be used as context. See <<cached-content>>. | -
-| spring.ai.google.genai.chat.options.use-cached-content | Whether to use cached content if available. When true and `cached-content-name` is set, the system will use the cached content. | false
-| spring.ai.google.genai.chat.options.auto-cache-threshold | Automatically cache prompts that exceed this token threshold. When set, prompts larger than this value will be automatically cached for reuse. Set to null to disable auto-caching. | -
-| spring.ai.google.genai.chat.options.auto-cache-ttl | Time-to-live (Duration) for auto-cached content in ISO-8601 format (e.g., `PT1H` for 1 hour). Used when auto-caching is enabled. | PT1H
+| spring.ai.google.genai.chat.model | Supported https://ai.google.dev/gemini-api/docs/models[Google GenAI Chat models] to use include `gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-pro`, and `gemini-1.5-flash`. | gemini-2.0-flash
+| spring.ai.google.genai.chat.response-mime-type | Output response mimetype of the generated candidate text. |  `text/plain`: (default) Text output or `application/json`: JSON response.
+| spring.ai.google.genai.chat.google-search-retrieval | Use Google search Grounding feature | `true` or `false`, default `false`.
+| spring.ai.google.genai.chat.include-server-side-tool-invocations | When true, the API response includes server-side tool calls and responses (e.g., Google Search invocations) in the response metadata, allowing observation of the server's tool usage. Only supported with Gemini Developer API (MLDev), not Vertex AI. See <<server-side-tool-invocations>>. | `false`
+| spring.ai.google.genai.chat.temperature | Controls the randomness of the output. Values can range over [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied, while a value closer to 0.0 will typically result in less surprising responses from the generative. | -
+| spring.ai.google.genai.chat.top-k | The maximum number of tokens to consider when sampling. The generative uses combined Top-k and nucleus sampling. Top-k sampling considers the set of topK most probable tokens. | -
+| spring.ai.google.genai.chat.top-p | The maximum cumulative probability of tokens to consider when sampling. The generative uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least topP.  | -
+| spring.ai.google.genai.chat.candidate-count | The number of generated response messages to return. This value must be between [1, 8], inclusive. Defaults to 1. | 1
+| spring.ai.google.genai.chat.max-output-tokens | The maximum number of tokens to generate. | -
+| spring.ai.google.genai.chat.frequency-penalty | Frequency penalties for reducing repetition. | -
+| spring.ai.google.genai.chat.presence-penalty | Presence penalties for reducing repetition. | -
+| spring.ai.google.genai.chat.thinking-budget | Thinking budget for the thinking process. See <<thinking-config>>. | -
+| spring.ai.google.genai.chat.thinking-level | The level of thinking tokens the model should generate. Valid values: `LOW`, `HIGH`, `THINKING_LEVEL_UNSPECIFIED`. See <<thinking-config>>. | -
+| spring.ai.google.genai.chat.include-thoughts | Enable thought signatures for function calling. **Required** for Gemini 3 Pro to avoid validation errors during the internal tool execution loop. See <<thought-signatures>>. | false
+| spring.ai.google.genai.chat.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
+| spring.ai.google.genai.chat.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
+| spring.ai.google.genai.chat.internal-tool-execution-enabled | If true, the tool execution should be performed, otherwise the response from the model is returned back to the user. Default is null, but if it's null, `ToolCallingChatOptions.DEFAULT_TOOL_EXECUTION_ENABLED` which is true will take into account | -
+| spring.ai.google.genai.chat.safety-settings | List of safety settings to control safety filters, as defined by https://ai.google.dev/gemini-api/docs/safety-settings[Google GenAI Safety Settings]. Each safety setting can have a method, threshold, and category. | -
+| spring.ai.google.genai.chat.cached-content-name | The name of cached content to use for this request. When set along with `use-cached-content=true`, the cached content will be used as context. See <<cached-content>>. | -
+| spring.ai.google.genai.chat.use-cached-content | Whether to use cached content if available. When true and `cached-content-name` is set, the system will use the cached content. | false
+| spring.ai.google.genai.chat.auto-cache-threshold | Automatically cache prompts that exceed this token threshold. When set, prompts larger than this value will be automatically cached for reuse. Set to null to disable auto-caching. | -
+| spring.ai.google.genai.chat.auto-cache-ttl | Time-to-live (Duration) for auto-cached content in ISO-8601 format (e.g., `PT1H` for 1 hour). Used when auto-caching is enabled. | PT1H
 | spring.ai.google.genai.chat.enable-cached-content | Enable the `GoogleGenAiCachedContentService` bean for managing cached content. | true
 
 |====
 
-TIP: All properties prefixed with `spring.ai.google.genai.chat.options` can be overridden at runtime by adding a request specific <<chat-options>> to the `Prompt` call.
+TIP: All properties prefixed with `spring.ai.google.genai.chat` can be overridden at runtime by adding a request specific <<chat-options>> to the `Prompt` call.
 
 == Runtime options [[chat-options]]
 
 The https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatOptions.java[GoogleGenAiChatOptions.java] provides model configurations, such as the temperature, the topK, etc.
 
-On start-up, the default options can be configured with the `GoogleGenAiChatModel(client, options)` constructor or the `spring.ai.google.genai.chat.options.*` properties.
+On start-up, the default options can be configured with the `GoogleGenAiChatModel(client, options)` constructor or the `spring.ai.google.genai.chat.*` properties.
 
 At runtime, you can override the default options by adding new, request specific, options to the `Prompt` call.
 For example, to override the default temperature for a specific request:
@@ -213,8 +213,8 @@ Enable via application properties:
 
 [source,application.properties]
 ----
-spring.ai.google.genai.chat.options.google-search-retrieval=true
-spring.ai.google.genai.chat.options.include-server-side-tool-invocations=true
+spring.ai.google.genai.chat.google-search-retrieval=true
+spring.ai.google.genai.chat.include-server-side-tool-invocations=true
 ----
 
 Or programmatically at runtime:
@@ -325,8 +325,8 @@ The `thinkingLevel` option controls the depth of reasoning tokens the model gene
 
 [source,application.properties]
 ----
-spring.ai.google.genai.chat.options.model=gemini-3-pro-preview
-spring.ai.google.genai.chat.options.thinking-level=HIGH
+spring.ai.google.genai.chat.model=gemini-3-pro-preview
+spring.ai.google.genai.chat.thinking-level=HIGH
 ----
 
 ==== Programmatic Configuration
@@ -468,8 +468,8 @@ Enable thought signatures using configuration properties:
 
 [source,application.properties]
 ----
-spring.ai.google.genai.chat.options.model=gemini-3-pro-preview
-spring.ai.google.genai.chat.options.include-thoughts=true
+spring.ai.google.genai.chat.model=gemini-3-pro-preview
+spring.ai.google.genai.chat.include-thoughts=true
 ----
 
 Or programmatically at runtime:
@@ -651,8 +651,8 @@ Or via configuration properties:
 
 [source,application.properties]
 ----
-spring.ai.google.genai.chat.options.use-cached-content=true
-spring.ai.google.genai.chat.options.cached-content-name=cachedContent/your-cache-name
+spring.ai.google.genai.chat.use-cached-content=true
+spring.ai.google.genai.chat.cached-content-name=cachedContent/your-cache-name
 ----
 
 ==== Managing Cached Content
@@ -706,9 +706,9 @@ Spring AI can automatically cache large prompts when they exceed a specified tok
 [source,application.properties]
 ----
 # Automatically cache prompts larger than 100,000 tokens
-spring.ai.google.genai.chat.options.auto-cache-threshold=100000
+spring.ai.google.genai.chat.auto-cache-threshold=100000
 # Set auto-cache TTL to 1 hour
-spring.ai.google.genai.chat.options.auto-cache-ttl=PT1H
+spring.ai.google.genai.chat.auto-cache-ttl=PT1H
 ----
 
 Or programmatically:
@@ -766,12 +766,12 @@ Complete configuration example:
 spring.ai.google.genai.chat.enable-cached-content=true
 
 # Use a specific cached content
-spring.ai.google.genai.chat.options.use-cached-content=true
-spring.ai.google.genai.chat.options.cached-content-name=cachedContent/my-cache-123
+spring.ai.google.genai.chat.use-cached-content=true
+spring.ai.google.genai.chat.cached-content-name=cachedContent/my-cache-123
 
 # Auto-caching configuration
-spring.ai.google.genai.chat.options.auto-cache-threshold=50000
-spring.ai.google.genai.chat.options.auto-cache-ttl=PT30M
+spring.ai.google.genai.chat.auto-cache-threshold=50000
+spring.ai.google.genai.chat.auto-cache-ttl=PT30M
 ----
 
 == Sample Controller
@@ -785,8 +785,8 @@ Add a `application.properties` file, under the `src/main/resources` directory, t
 [source,application.properties]
 ----
 spring.ai.google.genai.api-key=YOUR_API_KEY
-spring.ai.google.genai.chat.options.model=gemini-2.0-flash
-spring.ai.google.genai.chat.options.temperature=0.5
+spring.ai.google.genai.chat.model=gemini-2.0-flash
+spring.ai.google.genai.chat.temperature=0.5
 ----
 
 === Using Vertex AI
@@ -795,8 +795,8 @@ spring.ai.google.genai.chat.options.temperature=0.5
 ----
 spring.ai.google.genai.project-id=PROJECT_ID
 spring.ai.google.genai.location=LOCATION
-spring.ai.google.genai.chat.options.model=gemini-2.0-flash
-spring.ai.google.genai.chat.options.temperature=0.5
+spring.ai.google.genai.chat.model=gemini-2.0-flash
+spring.ai.google.genai.chat.temperature=0.5
 ----
 
 TIP: Replace the `project-id` with your Google Cloud Project ID and `location` is Google Cloud Region


### PR DESCRIPTION
- Remove `@NestedConfigurationProperty` from `GoogleGenAiChatProperties`
- Expose options directly under the `spring.ai.google.genai.chat` prefix instead of `spring.ai.google.genai.chat.options`
- Implement Spring Boot deprecation mechanism for the legacy `options` nested properties to gracefully guide users during upgrades
