### PR TITLE
Remove MiniMax GenAI setters from options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.web.client.RestClient;
  * @author Ilayaperumal Gopinathan
  * @author Issam El-atif
  * @author Yanming Zhou
+ * @author Sebastien Deleuze
  */
 @AutoConfiguration
 @ConditionalOnClass(MiniMaxApi.class)
@@ -70,7 +71,7 @@ public class MiniMaxChatAutoConfiguration {
 				chatProperties.getApiKey(), commonProperties.getApiKey(),
 				restClientBuilderProvider.getIfAvailable(RestClient::builder), responseErrorHandler);
 
-		var chatModel = new MiniMaxChatModel(miniMaxApi, chatProperties.getOptions(), toolCallingManager,
+		var chatModel = new MiniMaxChatModel(miniMaxApi, chatProperties.toOptions(), toolCallingManager,
 				retryTemplate.getIfUnique(() -> RetryUtils.DEFAULT_RETRY_TEMPLATE),
 				observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
 				openAiToolExecutionEligibilityPredicate.getIfUnique(DefaultToolExecutionEligibilityPredicate::new));

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/main/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxChatProperties.java
@@ -16,15 +16,20 @@
 
 package org.springframework.ai.model.minimax.autoconfigure;
 
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.minimax.MiniMaxChatOptions;
 import org.springframework.ai.minimax.api.MiniMaxApi;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for MiniMax chat model.
  *
  * @author Geng Rong
+ * @author Sebastien Deleuze
  */
 @ConfigurationProperties(MiniMaxChatProperties.CONFIG_PREFIX)
 public class MiniMaxChatProperties extends MiniMaxParentProperties {
@@ -33,11 +38,345 @@ public class MiniMaxChatProperties extends MiniMaxParentProperties {
 
 	public static final String DEFAULT_CHAT_MODEL = MiniMaxApi.ChatModel.ABAB_5_5_Chat.value;
 
-	@NestedConfigurationProperty
-	private final MiniMaxChatOptions options = MiniMaxChatOptions.builder().model(DEFAULT_CHAT_MODEL).build();
+	private String model = DEFAULT_CHAT_MODEL;
 
-	public MiniMaxChatOptions getOptions() {
+	private @Nullable Double frequencyPenalty;
+
+	private @Nullable Integer maxTokens;
+
+	private @Nullable Integer n;
+
+	private @Nullable Double presencePenalty;
+
+	private MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat responseFormat;
+
+	private @Nullable Integer seed;
+
+	private @Nullable List<String> stop;
+
+	private @Nullable Double temperature;
+
+	private @Nullable Double topP;
+
+	private @Nullable Boolean maskSensitiveInfo;
+
+	private @Nullable List<MiniMaxApi.FunctionTool> tools;
+
+	private @Nullable String toolChoice;
+
+	private @Nullable Boolean internalToolExecutionEnabled;
+
+	public String getModel() {
+		return this.model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	public @Nullable Double getFrequencyPenalty() {
+		return this.frequencyPenalty;
+	}
+
+	public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+		this.frequencyPenalty = frequencyPenalty;
+	}
+
+	public @Nullable Integer getMaxTokens() {
+		return this.maxTokens;
+	}
+
+	public void setMaxTokens(@Nullable Integer maxTokens) {
+		this.maxTokens = maxTokens;
+	}
+
+	public @Nullable Integer getN() {
+		return this.n;
+	}
+
+	public void setN(@Nullable Integer n) {
+		this.n = n;
+	}
+
+	public @Nullable Double getPresencePenalty() {
+		return this.presencePenalty;
+	}
+
+	public void setPresencePenalty(@Nullable Double presencePenalty) {
+		this.presencePenalty = presencePenalty;
+	}
+
+	public MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat getResponseFormat() {
+		return this.responseFormat;
+	}
+
+	public void setResponseFormat(MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat responseFormat) {
+		this.responseFormat = responseFormat;
+	}
+
+	public @Nullable Integer getSeed() {
+		return this.seed;
+	}
+
+	public void setSeed(@Nullable Integer seed) {
+		this.seed = seed;
+	}
+
+	public @Nullable List<String> getStop() {
+		return this.stop;
+	}
+
+	public void setStop(@Nullable List<String> stop) {
+		this.stop = stop;
+	}
+
+	public @Nullable Double getTemperature() {
+		return this.temperature;
+	}
+
+	public void setTemperature(@Nullable Double temperature) {
+		this.temperature = temperature;
+	}
+
+	public @Nullable Double getTopP() {
+		return this.topP;
+	}
+
+	public void setTopP(@Nullable Double topP) {
+		this.topP = topP;
+	}
+
+	public @Nullable Boolean getMaskSensitiveInfo() {
+		return this.maskSensitiveInfo;
+	}
+
+	public void setMaskSensitiveInfo(@Nullable Boolean maskSensitiveInfo) {
+		this.maskSensitiveInfo = maskSensitiveInfo;
+	}
+
+	public @Nullable List<MiniMaxApi.FunctionTool> getTools() {
+		return this.tools;
+	}
+
+	public void setTools(@Nullable List<MiniMaxApi.FunctionTool> tools) {
+		this.tools = tools;
+	}
+
+	public @Nullable String getToolChoice() {
+		return this.toolChoice;
+	}
+
+	public void setToolChoice(@Nullable String toolChoice) {
+		this.toolChoice = toolChoice;
+	}
+
+	public @Nullable Boolean getInternalToolExecutionEnabled() {
+		return this.internalToolExecutionEnabled;
+	}
+
+	public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+		this.internalToolExecutionEnabled = internalToolExecutionEnabled;
+	}
+
+	public MiniMaxChatOptions toOptions() {
+		MiniMaxChatOptions.Builder builder = MiniMaxChatOptions.builder();
+		builder.model(this.model);
+		if (this.frequencyPenalty != null) {
+			builder.frequencyPenalty(this.frequencyPenalty);
+		}
+		if (this.maxTokens != null) {
+			builder.maxTokens(this.maxTokens);
+		}
+		if (this.n != null) {
+			builder.N(this.n);
+		}
+		if (this.presencePenalty != null) {
+			builder.presencePenalty(this.presencePenalty);
+		}
+		if (this.responseFormat != null) {
+			builder.responseFormat(this.responseFormat);
+		}
+		if (this.seed != null) {
+			builder.seed(this.seed);
+		}
+		if (this.stop != null) {
+			builder.stop(this.stop);
+		}
+		if (this.temperature != null) {
+			builder.temperature(this.temperature);
+		}
+		if (this.topP != null) {
+			builder.topP(this.topP);
+		}
+		if (this.maskSensitiveInfo != null) {
+			builder.maskSensitiveInfo(this.maskSensitiveInfo);
+		}
+		if (this.tools != null) {
+			builder.tools(this.tools);
+		}
+		if (this.toolChoice != null) {
+			builder.toolChoice(this.toolChoice);
+		}
+		if (this.internalToolExecutionEnabled != null) {
+			builder.internalToolExecutionEnabled(this.internalToolExecutionEnabled);
+		}
+		return builder.build();
+	}
+
+	private Options options = new Options();
+
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat")
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	public Options getOptions() {
 		return this.options;
+	}
+
+	public void setOptions(Options options) {
+		this.options = options;
+	}
+
+	public class Options {
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.model")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public String getModel() {
+			return MiniMaxChatProperties.this.getModel();
+		}
+
+		public void setModel(String model) {
+			MiniMaxChatProperties.this.setModel(model);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.frequency-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getFrequencyPenalty() {
+			return MiniMaxChatProperties.this.getFrequencyPenalty();
+		}
+
+		public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
+			MiniMaxChatProperties.this.setFrequencyPenalty(frequencyPenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.max-tokens")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getMaxTokens() {
+			return MiniMaxChatProperties.this.getMaxTokens();
+		}
+
+		public void setMaxTokens(@Nullable Integer maxTokens) {
+			MiniMaxChatProperties.this.setMaxTokens(maxTokens);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.n")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getN() {
+			return MiniMaxChatProperties.this.getN();
+		}
+
+		public void setN(@Nullable Integer n) {
+			MiniMaxChatProperties.this.setN(n);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.presence-penalty")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getPresencePenalty() {
+			return MiniMaxChatProperties.this.getPresencePenalty();
+		}
+
+		public void setPresencePenalty(@Nullable Double presencePenalty) {
+			MiniMaxChatProperties.this.setPresencePenalty(presencePenalty);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.response-format")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat getResponseFormat() {
+			return MiniMaxChatProperties.this.getResponseFormat();
+		}
+
+		public void setResponseFormat(MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat responseFormat) {
+			MiniMaxChatProperties.this.setResponseFormat(responseFormat);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.seed")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getSeed() {
+			return MiniMaxChatProperties.this.getSeed();
+		}
+
+		public void setSeed(@Nullable Integer seed) {
+			MiniMaxChatProperties.this.setSeed(seed);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.stop")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<String> getStop() {
+			return MiniMaxChatProperties.this.getStop();
+		}
+
+		public void setStop(@Nullable List<String> stop) {
+			MiniMaxChatProperties.this.setStop(stop);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.temperature")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTemperature() {
+			return MiniMaxChatProperties.this.getTemperature();
+		}
+
+		public void setTemperature(@Nullable Double temperature) {
+			MiniMaxChatProperties.this.setTemperature(temperature);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.top-p")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Double getTopP() {
+			return MiniMaxChatProperties.this.getTopP();
+		}
+
+		public void setTopP(@Nullable Double topP) {
+			MiniMaxChatProperties.this.setTopP(topP);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.mask-sensitive-info")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getMaskSensitiveInfo() {
+			return MiniMaxChatProperties.this.getMaskSensitiveInfo();
+		}
+
+		public void setMaskSensitiveInfo(@Nullable Boolean maskSensitiveInfo) {
+			MiniMaxChatProperties.this.setMaskSensitiveInfo(maskSensitiveInfo);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.tools")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable List<MiniMaxApi.FunctionTool> getTools() {
+			return MiniMaxChatProperties.this.getTools();
+		}
+
+		public void setTools(@Nullable List<MiniMaxApi.FunctionTool> tools) {
+			MiniMaxChatProperties.this.setTools(tools);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.tool-choice")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getToolChoice() {
+			return MiniMaxChatProperties.this.getToolChoice();
+		}
+
+		public void setToolChoice(@Nullable String toolChoice) {
+			MiniMaxChatProperties.this.setToolChoice(toolChoice);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.minimax.chat.internal-tool-execution-enabled")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Boolean getInternalToolExecutionEnabled() {
+			return MiniMaxChatProperties.this.getInternalToolExecutionEnabled();
+		}
+
+		public void setInternalToolExecutionEnabled(@Nullable Boolean internalToolExecutionEnabled) {
+			MiniMaxChatProperties.this.setInternalToolExecutionEnabled(internalToolExecutionEnabled);
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackInPromptIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackInPromptIT.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Geng Rong
  * @author Issam El-atif
+ * @author Sebastien Deleuze
  */
 @EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
 public class FunctionCallbackInPromptIT {
@@ -57,7 +58,7 @@ public class FunctionCallbackInPromptIT {
 
 	@Test
 	void functionCallTest() {
-		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.options.model=abab6.5s-chat").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.model=abab6.5s-chat").run(context -> {
 
 			MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 
@@ -82,7 +83,7 @@ public class FunctionCallbackInPromptIT {
 	@Test
 	void streamingFunctionCallTest() {
 
-		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.options.model=abab6.5s-chat").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.model=abab6.5s-chat").run(context -> {
 
 			MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Geng Rong
  * @author Issam El-atif
+ * @author Sebastien Deleuze
  */
 @EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
 class FunctionCallbackWithPlainFunctionBeanIT {
@@ -63,7 +64,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 	// FIXME: multiple function calls may stop prematurely due to model performance
 	@Test
 	void functionCallTest() {
-		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.options.model=abab6.5s-chat").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.model=abab6.5s-chat").run(context -> {
 
 			MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 
@@ -91,7 +92,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 	@Test
 	void functionCallWithPortableFunctionCallingOptions() {
-		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.options.model=abab6.5s-chat").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.model=abab6.5s-chat").run(context -> {
 
 			MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 
@@ -112,7 +113,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 	// FIXME: multiple function calls may stop prematurely due to model performance
 	@Test
 	void streamFunctionCallTest() {
-		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.options.model=abab6.5s-chat").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.model=abab6.5s-chat").run(context -> {
 
 			MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxFunctionCallbackIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxFunctionCallbackIT.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Geng Rong
  * @author Issam El-atif
+ * @author Sebastien Deleuze
  */
 @EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
 public class MiniMaxFunctionCallbackIT {
@@ -60,7 +61,7 @@ public class MiniMaxFunctionCallbackIT {
 
 	@Test
 	void functionCallTest() {
-		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.options.model=abab6.5s-chat").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.model=abab6.5s-chat").run(context -> {
 
 			MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 
@@ -79,7 +80,7 @@ public class MiniMaxFunctionCallbackIT {
 
 	@Test
 	void streamFunctionCallTest() {
-		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.options.model=abab6.5s-chat").run(context -> {
+		this.contextRunner.withPropertyValues("spring.ai.minimax.chat.model=abab6.5s-chat").run(context -> {
 
 			MiniMaxChatModel chatModel = context.getBean(MiniMaxChatModel.class);
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/src/test/java/org/springframework/ai/model/minimax/autoconfigure/MiniMaxPropertiesTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Geng Rong
  * @author Issam El-atif
+ * @author Sebastien Deleuze
  */
 public class MiniMaxPropertiesTests {
 
@@ -48,8 +49,8 @@ public class MiniMaxPropertiesTests {
 		// @formatter:off
 				"spring.ai.minimax.base-url=TEST_BASE_URL",
 				"spring.ai.minimax.api-key=abc123",
-				"spring.ai.minimax.chat.options.model=MODEL_XYZ",
-				"spring.ai.minimax.chat.options.temperature=0.55")
+				"spring.ai.minimax.chat.model=MODEL_XYZ",
+				"spring.ai.minimax.chat.temperature=0.55")
 				// @formatter:on
 			.withConfiguration(
 					AutoConfigurations.of(MiniMaxChatAutoConfiguration.class, RestClientAutoConfiguration.class,
@@ -64,8 +65,8 @@ public class MiniMaxPropertiesTests {
 				assertThat(chatProperties.getApiKey()).isNull();
 				assertThat(chatProperties.getBaseUrl()).isNull();
 
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.toOptions().getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.toOptions().getTemperature()).isEqualTo(0.55);
 			});
 	}
 
@@ -78,8 +79,8 @@ public class MiniMaxPropertiesTests {
 				"spring.ai.minimax.api-key=abc123",
 				"spring.ai.minimax.chat.base-url=TEST_BASE_URL2",
 				"spring.ai.minimax.chat.api-key=456",
-				"spring.ai.minimax.chat.options.model=MODEL_XYZ",
-				"spring.ai.minimax.chat.options.temperature=0.55")
+				"spring.ai.minimax.chat.model=MODEL_XYZ",
+				"spring.ai.minimax.chat.temperature=0.55")
 				// @formatter:on
 			.withConfiguration(
 					AutoConfigurations.of(MiniMaxChatAutoConfiguration.class, RestClientAutoConfiguration.class,
@@ -94,8 +95,8 @@ public class MiniMaxPropertiesTests {
 				assertThat(chatProperties.getApiKey()).isEqualTo("456");
 				assertThat(chatProperties.getBaseUrl()).isEqualTo("TEST_BASE_URL2");
 
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.toOptions().getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.toOptions().getTemperature()).isEqualTo(0.55);
 			});
 	}
 
@@ -159,24 +160,24 @@ public class MiniMaxPropertiesTests {
 				"spring.ai.minimax.api-key=API_KEY",
 				"spring.ai.minimax.base-url=TEST_BASE_URL",
 
-				"spring.ai.minimax.chat.options.model=MODEL_XYZ",
-				"spring.ai.minimax.chat.options.frequencyPenalty=-1.5",
-				"spring.ai.minimax.chat.options.logitBias.myTokenId=-5",
-				"spring.ai.minimax.chat.options.maxTokens=123",
-				"spring.ai.minimax.chat.options.n=10",
-				"spring.ai.minimax.chat.options.presencePenalty=0",
-				"spring.ai.minimax.chat.options.responseFormat.type=json",
-				"spring.ai.minimax.chat.options.seed=66",
-				"spring.ai.minimax.chat.options.stop=boza,koza",
-				"spring.ai.minimax.chat.options.temperature=0.55",
-				"spring.ai.minimax.chat.options.topP=0.56",
+				"spring.ai.minimax.chat.model=MODEL_XYZ",
+				"spring.ai.minimax.chat.frequencyPenalty=-1.5",
+				"spring.ai.minimax.chat.logitBias.myTokenId=-5",
+				"spring.ai.minimax.chat.maxTokens=123",
+				"spring.ai.minimax.chat.n=10",
+				"spring.ai.minimax.chat.presencePenalty=0",
+				"spring.ai.minimax.chat.responseFormat.type=json",
+				"spring.ai.minimax.chat.seed=66",
+				"spring.ai.minimax.chat.stop=boza,koza",
+				"spring.ai.minimax.chat.temperature=0.55",
+				"spring.ai.minimax.chat.topP=0.56",
 
-				// "spring.ai.minimax.chat.options.toolChoice.functionName=toolChoiceFunctionName",
-				"spring.ai.minimax.chat.options.toolChoice=" + ModelOptionsUtils.toJsonString(MiniMaxApi.ChatCompletionRequest.ToolChoiceBuilder.function("toolChoiceFunctionName")),
+				// "spring.ai.minimax.chat.toolChoice.functionName=toolChoiceFunctionName",
+				"spring.ai.minimax.chat.toolChoice=" + ModelOptionsUtils.toJsonString(MiniMaxApi.ChatCompletionRequest.ToolChoiceBuilder.function("toolChoiceFunctionName")),
 
-				"spring.ai.minimax.chat.options.tools[0].function.name=myFunction1",
-				"spring.ai.minimax.chat.options.tools[0].function.description=function description",
-				"spring.ai.minimax.chat.options.tools[0].function.jsonSchema=" + """
+				"spring.ai.minimax.chat.tools[0].function.name=myFunction1",
+				"spring.ai.minimax.chat.tools[0].function.description=function description",
+				"spring.ai.minimax.chat.tools[0].function.jsonSchema=" + """
 					{
 						"type": "object",
 						"properties": {
@@ -212,23 +213,23 @@ public class MiniMaxPropertiesTests {
 				assertThat(connectionProperties.getBaseUrl()).isEqualTo("TEST_BASE_URL");
 				assertThat(connectionProperties.getApiKey()).isEqualTo("API_KEY");
 
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
-				assertThat(chatProperties.getOptions().getFrequencyPenalty()).isEqualTo(-1.5);
-				assertThat(chatProperties.getOptions().getMaxTokens()).isEqualTo(123);
-				assertThat(chatProperties.getOptions().getN()).isEqualTo(10);
-				assertThat(chatProperties.getOptions().getPresencePenalty()).isEqualTo(0);
-				assertThat(chatProperties.getOptions().getResponseFormat())
+				assertThat(chatProperties.toOptions().getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.toOptions().getFrequencyPenalty()).isEqualTo(-1.5);
+				assertThat(chatProperties.toOptions().getMaxTokens()).isEqualTo(123);
+				assertThat(chatProperties.toOptions().getN()).isEqualTo(10);
+				assertThat(chatProperties.toOptions().getPresencePenalty()).isEqualTo(0);
+				assertThat(chatProperties.toOptions().getResponseFormat())
 					.isEqualTo(new MiniMaxApi.ChatCompletionRequest.ResponseFormat("json"));
-				assertThat(chatProperties.getOptions().getSeed()).isEqualTo(66);
-				assertThat(chatProperties.getOptions().getStop()).contains("boza", "koza");
-				assertThat(chatProperties.getOptions().getTemperature()).isEqualTo(0.55);
-				assertThat(chatProperties.getOptions().getTopP()).isEqualTo(0.56);
+				assertThat(chatProperties.toOptions().getSeed()).isEqualTo(66);
+				assertThat(chatProperties.toOptions().getStop()).contains("boza", "koza");
+				assertThat(chatProperties.toOptions().getTemperature()).isEqualTo(0.55);
+				assertThat(chatProperties.toOptions().getTopP()).isEqualTo(0.56);
 
 				JSONAssert.assertEquals("{\"type\":\"function\",\"function\":{\"name\":\"toolChoiceFunctionName\"}}",
-						chatProperties.getOptions().getToolChoice(), JSONCompareMode.LENIENT);
+						chatProperties.toOptions().getToolChoice(), JSONCompareMode.LENIENT);
 
-				assertThat(chatProperties.getOptions().getTools()).hasSize(1);
-				var tool = chatProperties.getOptions().getTools().get(0);
+				assertThat(chatProperties.toOptions().getTools()).hasSize(1);
+				var tool = chatProperties.toOptions().getTools().get(0);
 				assertThat(tool.getType()).isEqualTo(MiniMaxApi.FunctionTool.Type.FUNCTION);
 				var function = tool.getFunction();
 				assertThat(function.getName()).isEqualTo("myFunction1");

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
  * @author Alexandros Pappas
+ * @author Sebastien Deleuze
  * @since 1.0.0 M1
  */
 public class MiniMaxChatOptions implements ToolCallingChatOptions {
@@ -193,17 +194,9 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		return this.model;
 	}
 
-	public void setModel(String model) {
-		this.model = model;
-	}
-
 	@Override
 	public @Nullable Double getFrequencyPenalty() {
 		return this.frequencyPenalty;
-	}
-
-	public void setFrequencyPenalty(@Nullable Double frequencyPenalty) {
-		this.frequencyPenalty = frequencyPenalty;
 	}
 
 	@Override
@@ -211,16 +204,8 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		return this.maxTokens;
 	}
 
-	public void setMaxTokens(@Nullable Integer maxTokens) {
-		this.maxTokens = maxTokens;
-	}
-
 	public @Nullable Integer getN() {
 		return this.n;
-	}
-
-	public void setN(@Nullable Integer n) {
-		this.n = n;
 	}
 
 	@Override
@@ -228,24 +213,12 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		return this.presencePenalty;
 	}
 
-	public void setPresencePenalty(@Nullable Double presencePenalty) {
-		this.presencePenalty = presencePenalty;
-	}
-
 	public MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat getResponseFormat() {
 		return this.responseFormat;
 	}
 
-	public void setResponseFormat(MiniMaxApi.ChatCompletionRequest.@Nullable ResponseFormat responseFormat) {
-		this.responseFormat = responseFormat;
-	}
-
 	public @Nullable Integer getSeed() {
 		return this.seed;
-	}
-
-	public void setSeed(@Nullable Integer seed) {
-		this.seed = seed;
 	}
 
 	@Override
@@ -253,16 +226,8 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		return getStop();
 	}
 
-	public void setStopSequences(@Nullable List<String> stopSequences) {
-		setStop(stopSequences);
-	}
-
 	public @Nullable List<String> getStop() {
 		return (this.stop != null) ? Collections.unmodifiableList(this.stop) : null;
-	}
-
-	public void setStop(@Nullable List<String> stop) {
-		this.stop = stop;
 	}
 
 	@Override
@@ -270,41 +235,21 @@ public class MiniMaxChatOptions implements ToolCallingChatOptions {
 		return this.temperature;
 	}
 
-	public void setTemperature(@Nullable Double temperature) {
-		this.temperature = temperature;
-	}
-
 	@Override
 	public @Nullable Double getTopP() {
 		return this.topP;
-	}
-
-	public void setTopP(@Nullable Double topP) {
-		this.topP = topP;
 	}
 
 	public @Nullable Boolean getMaskSensitiveInfo() {
 		return this.maskSensitiveInfo;
 	}
 
-	public void setMaskSensitiveInfo(@Nullable Boolean maskSensitiveInfo) {
-		this.maskSensitiveInfo = maskSensitiveInfo;
-	}
-
 	public @Nullable List<MiniMaxApi.FunctionTool> getTools() {
 		return (this.tools != null) ? Collections.unmodifiableList(this.tools) : null;
 	}
 
-	public void setTools(@Nullable List<MiniMaxApi.FunctionTool> tools) {
-		this.tools = tools;
-	}
-
 	public @Nullable String getToolChoice() {
 		return this.toolChoice;
-	}
-
-	public void setToolChoice(@Nullable String toolChoice) {
-		this.toolChoice = toolChoice;
 	}
 
 	@Override

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/MiniMaxChatOptionsTests.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/MiniMaxChatOptionsTests.java
@@ -110,21 +110,22 @@ class MiniMaxChatOptionsTests extends AbstractChatOptionsTests<MiniMaxChatOption
 
 	@Test
 	void testSettersWithNulls() {
-		MiniMaxChatOptions options = new MiniMaxChatOptions();
-		options.setModel(null);
-		options.setFrequencyPenalty(null);
-		options.setMaxTokens(null);
-		options.setN(null);
-		options.setPresencePenalty(null);
-		options.setResponseFormat(null);
-		options.setSeed(null);
-		options.setStop(null);
-		options.setTemperature(null);
-		options.setTopP(null);
-		options.setMaskSensitiveInfo(null);
-		options.setTools(null);
-		options.setToolChoice(null);
-		options.setInternalToolExecutionEnabled(null);
+		MiniMaxChatOptions options = MiniMaxChatOptions.builder()
+			.model(null)
+			.frequencyPenalty(null)
+			.maxTokens(null)
+			.N(null)
+			.presencePenalty(null)
+			.responseFormat(null)
+			.seed(null)
+			.stopSequences(null)
+			.temperature(null)
+			.topP(null)
+			.maskSensitiveInfo(null)
+			.tools(null)
+			.toolChoice(null)
+			.internalToolExecutionEnabled(null)
+			.build();
 
 		assertThat(options.getModel()).isNull();
 		assertThat(options.getFrequencyPenalty()).isNull();
@@ -165,21 +166,22 @@ class MiniMaxChatOptionsTests extends AbstractChatOptionsTests<MiniMaxChatOption
 
 	@Test
 	void testSetters() {
-		MiniMaxChatOptions options = new MiniMaxChatOptions();
-		options.setModel("test-model");
-		options.setFrequencyPenalty(0.5);
-		options.setMaxTokens(10);
-		options.setN(1);
-		options.setPresencePenalty(0.5);
-		options.setResponseFormat(new MiniMaxApi.ChatCompletionRequest.ResponseFormat("text"));
-		options.setSeed(1);
-		options.setStop(List.of("test"));
-		options.setTemperature(0.6);
-		options.setTopP(0.6);
-		options.setMaskSensitiveInfo(false);
-		options.setToolChoice("test");
-		options.setInternalToolExecutionEnabled(true);
-		options.setToolContext(Map.of("key1", "value1"));
+		MiniMaxChatOptions options = MiniMaxChatOptions.builder()
+			.model("test-model")
+			.frequencyPenalty(0.5)
+			.maxTokens(10)
+			.N(1)
+			.presencePenalty(0.5)
+			.responseFormat(new MiniMaxApi.ChatCompletionRequest.ResponseFormat("text"))
+			.seed(1)
+			.stopSequences(List.of("test"))
+			.temperature(0.6)
+			.topP(0.6)
+			.maskSensitiveInfo(false)
+			.toolChoice("test")
+			.internalToolExecutionEnabled(true)
+			.toolContext(Map.of("key1", "value1"))
+			.build();
 
 		assertThat(options.getModel()).isEqualTo("test-model");
 		assertThat(options.getFrequencyPenalty()).isEqualTo(0.5);

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/minimax-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/minimax-chat.adoc
@@ -136,30 +136,30 @@ The prefix `spring.ai.minimax.chat` is the property prefix that lets you configu
 | spring.ai.model.chat | Enable MiniMax chat model.  | minimax
 | spring.ai.minimax.chat.base-url | Optional overrides the spring.ai.minimax.base-url to provide chat specific url |  https://api.minimax.chat
 | spring.ai.minimax.chat.api-key | Optional overrides the spring.ai.minimax.api-key to provide chat specific api-key |  -
-| spring.ai.minimax.chat.options.model | This is the MiniMax Chat model to use | `abab6.5g-chat` (the `abab5.5-chat`, `abab5.5s-chat`, `abab6.5-chat`, `abab6.5g-chat`, `abab6.5t-chat` and `abab6.5s-chat` point to the latest model versions)
-| spring.ai.minimax.chat.options.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
-| spring.ai.minimax.chat.options.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | -
-| spring.ai.minimax.chat.options.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both. | 1.0
-| spring.ai.minimax.chat.options.n | How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Default value is 1 and cannot be greater than 5. Specifically, when the temperature is very small and close to 0, we can only return 1 result. If n is already set and>1 at this time, service will return an illegal input parameter (invalid_request_error) | 1
-| spring.ai.minimax.chat.options.presencePenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. |  0.0f
-| spring.ai.minimax.chat.options.frequencyPenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. | 0.0f
-| spring.ai.minimax.chat.options.stop | The model will stop generating characters specified by stop, and currently only supports a single stop word in the format of ["stop_word1"] | -
-| spring.ai.minimax.chat.options.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
-| spring.ai.minimax.chat.options.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
-| spring.ai.minimax.chat.options.internal-tool-execution-enabled | If false, the Spring AI will not handle the tool calls internally, but will proxy them to the client. Then it is the client's responsibility to handle the tool calls, dispatch them to the appropriate function, and return the results. If true (the default), the Spring AI will handle the function calls internally. Applicable only for chat models with function calling support | true
+| spring.ai.minimax.chat.model | This is the MiniMax Chat model to use | `abab6.5g-chat` (the `abab5.5-chat`, `abab5.5s-chat`, `abab6.5-chat`, `abab6.5g-chat`, `abab6.5t-chat` and `abab6.5s-chat` point to the latest model versions)
+| spring.ai.minimax.chat.maxTokens | The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length. | -
+| spring.ai.minimax.chat.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | -
+| spring.ai.minimax.chat.topP | An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both. | 1.0
+| spring.ai.minimax.chat.n | How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Default value is 1 and cannot be greater than 5. Specifically, when the temperature is very small and close to 0, we can only return 1 result. If n is already set and>1 at this time, service will return an illegal input parameter (invalid_request_error) | 1
+| spring.ai.minimax.chat.presencePenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. |  0.0f
+| spring.ai.minimax.chat.frequencyPenalty | Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. | 0.0f
+| spring.ai.minimax.chat.stop | The model will stop generating characters specified by stop, and currently only supports a single stop word in the format of ["stop_word1"] | -
+| spring.ai.minimax.chat.tool-names | List of tools, identified by their names, to enable for function calling in a single prompt request. Tools with those names must exist in the ToolCallback registry. | -
+| spring.ai.minimax.chat.tool-callbacks | Tool Callbacks to register with the ChatModel. | -
+| spring.ai.minimax.chat.internal-tool-execution-enabled | If false, the Spring AI will not handle the tool calls internally, but will proxy them to the client. Then it is the client's responsibility to handle the tool calls, dispatch them to the appropriate function, and return the results. If true (the default), the Spring AI will handle the function calls internally. Applicable only for chat models with function calling support | true
 |====
 
 NOTE: You can override the common `spring.ai.minimax.base-url` and `spring.ai.minimax.api-key` for the `ChatModel` implementations.
 The `spring.ai.minimax.chat.base-url` and `spring.ai.minimax.chat.api-key` properties if set take precedence over the common properties.
 This is useful if you want to use different MiniMax accounts for different models and different model endpoints.
 
-TIP: All properties prefixed with `spring.ai.minimax.chat.options` can be overridden at runtime by adding a request specific <<chat-options>> to the `Prompt` call.
+TIP: All properties prefixed with `spring.ai.minimax.chat` can be overridden at runtime by adding a request specific <<chat-options>> to the `Prompt` call.
 
 == Runtime Options [[chat-options]]
 
 The link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatOptions.java[MiniMaxChatOptions.java] provides model configurations, such as the model to use, the temperature, the frequency penalty, etc.
 
-On start-up, the default options can be configured with the `MiniMaxChatModel(api, options)` constructor or the `spring.ai.minimax.chat.options.*` properties.
+On start-up, the default options can be configured with the `MiniMaxChatModel(api, options)` constructor or the `spring.ai.minimax.chat.*` properties.
 
 At run-time you can override the default options by adding new, request specific, options to the `Prompt` call.
 For example to override the default model and temperature for a specific request:
@@ -187,8 +187,8 @@ Add a `application.properties` file, under the `src/main/resources` directory, t
 [source,application.properties]
 ----
 spring.ai.minimax.api-key=YOUR_API_KEY
-spring.ai.minimax.chat.options.model=abab6.5g-chat
-spring.ai.minimax.chat.options.temperature=0.7
+spring.ai.minimax.chat.model=abab6.5g-chat
+spring.ai.minimax.chat.temperature=0.7
 ----
 
 TIP: replace the `api-key` with your MiniMax credentials.


### PR DESCRIPTION
- Remove `@NestedConfigurationProperty` from `MiniMaxChatProperties`
- Expose options directly under the `spring.ai.minimax.chat` prefix instead of `spring.ai.minimax.chat.options`
- Implement Spring Boot deprecation mechanism for the legacy `options` nested properties to gracefully guide users during upgrades