### PR TITLE
Remove PostgresMl embedding setters from options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  *
  * @author Utkarsh Srivastava
  * @author Christian Tzolov
+ * @author Sebastien Deleuze
  */
 @AutoConfiguration
 @ConditionalOnClass(PostgresMlEmbeddingModel.class)
@@ -45,7 +46,7 @@ public class PostgresMlEmbeddingAutoConfiguration {
 	public PostgresMlEmbeddingModel postgresMlEmbeddingModel(JdbcTemplate jdbcTemplate,
 			PostgresMlEmbeddingProperties embeddingProperties) {
 
-		return new PostgresMlEmbeddingModel(jdbcTemplate, embeddingProperties.getOptions(),
+		return new PostgresMlEmbeddingModel(jdbcTemplate, embeddingProperties.toOptions(),
 				embeddingProperties.isCreateExtension());
 	}
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/main/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingProperties.java
@@ -18,17 +18,21 @@ package org.springframework.ai.model.postgresml.autoconfigure;
 
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.postgresml.PostgresMlEmbeddingModel;
+import org.springframework.ai.postgresml.PostgresMlEmbeddingModel.VectorType;
 import org.springframework.ai.postgresml.PostgresMlEmbeddingOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for Postgres ML.
  *
  * @author Utkarsh Srivastava
  * @author Christian Tzolov
+ * @author Sebastien Deleuze
  */
 @ConfigurationProperties(PostgresMlEmbeddingProperties.CONFIG_PREFIX)
 public class PostgresMlEmbeddingProperties {
@@ -40,17 +44,13 @@ public class PostgresMlEmbeddingProperties {
 	 */
 	private boolean createExtension;
 
-	@NestedConfigurationProperty
-	private final PostgresMlEmbeddingOptions options = PostgresMlEmbeddingOptions.builder()
-		.transformer(PostgresMlEmbeddingModel.DEFAULT_TRANSFORMER_MODEL)
-		.vectorType(PostgresMlEmbeddingModel.VectorType.PG_ARRAY)
-		.kwargs(Map.of())
-		.metadataMode(MetadataMode.EMBED)
-		.build();
+	private @Nullable String transformer = PostgresMlEmbeddingModel.DEFAULT_TRANSFORMER_MODEL;
 
-	public PostgresMlEmbeddingOptions getOptions() {
-		return this.options;
-	}
+	private @Nullable VectorType vectorType = VectorType.PG_ARRAY;
+
+	private @Nullable Map<String, Object> kwargs = Map.of();
+
+	private @Nullable MetadataMode metadataMode = MetadataMode.EMBED;
 
 	public boolean isCreateExtension() {
 		return this.createExtension;
@@ -58,6 +58,111 @@ public class PostgresMlEmbeddingProperties {
 
 	public void setCreateExtension(boolean createExtension) {
 		this.createExtension = createExtension;
+	}
+
+	public @Nullable String getTransformer() {
+		return this.transformer;
+	}
+
+	public void setTransformer(@Nullable String transformer) {
+		this.transformer = transformer;
+	}
+
+	public @Nullable VectorType getVectorType() {
+		return this.vectorType;
+	}
+
+	public void setVectorType(@Nullable VectorType vectorType) {
+		this.vectorType = vectorType;
+	}
+
+	public @Nullable Map<String, Object> getKwargs() {
+		return this.kwargs;
+	}
+
+	public void setKwargs(@Nullable Map<String, Object> kwargs) {
+		this.kwargs = kwargs;
+	}
+
+	public @Nullable MetadataMode getMetadataMode() {
+		return this.metadataMode;
+	}
+
+	public void setMetadataMode(@Nullable MetadataMode metadataMode) {
+		this.metadataMode = metadataMode;
+	}
+
+	public PostgresMlEmbeddingOptions toOptions() {
+		PostgresMlEmbeddingOptions.Builder builder = PostgresMlEmbeddingOptions.builder();
+		if (this.transformer != null) {
+			builder.transformer(this.transformer);
+		}
+		if (this.vectorType != null) {
+			builder.vectorType(this.vectorType);
+		}
+		if (this.kwargs != null) {
+			builder.kwargs(this.kwargs);
+		}
+		if (this.metadataMode != null) {
+			builder.metadataMode(this.metadataMode);
+		}
+		return builder.build();
+	}
+
+	private Options options = new Options();
+
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.postgresml.embedding")
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	public Options getOptions() {
+		return this.options;
+	}
+
+	public void setOptions(Options options) {
+		this.options = options;
+	}
+
+	public class Options {
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.postgresml.embedding.transformer")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getTransformer() {
+			return PostgresMlEmbeddingProperties.this.getTransformer();
+		}
+
+		public void setTransformer(@Nullable String transformer) {
+			PostgresMlEmbeddingProperties.this.setTransformer(transformer);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.postgresml.embedding.vector-type")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable VectorType getVectorType() {
+			return PostgresMlEmbeddingProperties.this.getVectorType();
+		}
+
+		public void setVectorType(@Nullable VectorType vectorType) {
+			PostgresMlEmbeddingProperties.this.setVectorType(vectorType);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.postgresml.embedding.kwargs")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Map<String, Object> getKwargs() {
+			return PostgresMlEmbeddingProperties.this.getKwargs();
+		}
+
+		public void setKwargs(@Nullable Map<String, Object> kwargs) {
+			PostgresMlEmbeddingProperties.this.setKwargs(kwargs);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.postgresml.embedding.metadata-mode")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable MetadataMode getMetadataMode() {
+			return PostgresMlEmbeddingProperties.this.getMetadataMode();
+		}
+
+		public void setMetadataMode(@Nullable MetadataMode metadataMode) {
+			PostgresMlEmbeddingProperties.this.setMetadataMode(metadataMode);
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/test/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/src/test/java/org/springframework/ai/model/postgresml/autoconfigure/PostgresMlEmbeddingPropertiesTests.java
@@ -34,11 +34,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Utkarsh Srivastava
  * @author Christian Tzolov
+ * @author Sebastien Deleuze
  */
-@SpringBootTest(properties = { "spring.ai.postgresml.embedding.options.metadata-mode=all",
-		"spring.ai.postgresml.embedding.options.kwargs.key1=value1",
-		"spring.ai.postgresml.embedding.options.kwargs.key2=value2",
-		"spring.ai.postgresml.embedding.options.transformer=abc123" })
+@SpringBootTest(properties = { "spring.ai.postgresml.embedding.metadata-mode=all",
+		"spring.ai.postgresml.embedding.kwargs.key1=value1", "spring.ai.postgresml.embedding.kwargs.key2=value2",
+		"spring.ai.postgresml.embedding.transformer=abc123" })
 class PostgresMlEmbeddingPropertiesTests {
 
 	@Autowired
@@ -47,12 +47,10 @@ class PostgresMlEmbeddingPropertiesTests {
 	@Test
 	void postgresMlPropertiesAreCorrect() {
 		assertThat(this.postgresMlProperties).isNotNull();
-		assertThat(this.postgresMlProperties.getOptions().getTransformer()).isEqualTo("abc123");
-		assertThat(this.postgresMlProperties.getOptions().getVectorType())
-			.isEqualTo(PostgresMlEmbeddingModel.VectorType.PG_ARRAY);
-		assertThat(this.postgresMlProperties.getOptions().getKwargs())
-			.isEqualTo(Map.of("key1", "value1", "key2", "value2"));
-		assertThat(this.postgresMlProperties.getOptions().getMetadataMode()).isEqualTo(MetadataMode.ALL);
+		assertThat(this.postgresMlProperties.getTransformer()).isEqualTo("abc123");
+		assertThat(this.postgresMlProperties.getVectorType()).isEqualTo(PostgresMlEmbeddingModel.VectorType.PG_ARRAY);
+		assertThat(this.postgresMlProperties.getKwargs()).isEqualTo(Map.of("key1", "value1", "key2", "value2"));
+		assertThat(this.postgresMlProperties.getMetadataMode()).isEqualTo(MetadataMode.ALL);
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptions.java
+++ b/models/spring-ai-postgresml/src/main/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptions.java
@@ -30,66 +30,53 @@ import org.springframework.ai.postgresml.PostgresMlEmbeddingModel.VectorType;
  * @author Christian Tzolov
  * @author Thomas Vitale
  * @author Ilayaperumal Gopinathan
+ * @author Sebasrtien Deleuze
  */
 public class PostgresMlEmbeddingOptions implements EmbeddingOptions {
 
-	// @formatter:off
 	/**
 	 * The Huggingface transformer model to use for the embedding.
 	 */
-	private String transformer = PostgresMlEmbeddingModel.DEFAULT_TRANSFORMER_MODEL;
+	private final String transformer;
 
 	/**
-	 * PostgresML vector type to use for the embedding.
-	 * Two options are supported: PG_ARRAY and PG_VECTOR.
+	 * PostgresML vector type to use for the embedding. Two options are supported:
+	 * PG_ARRAY and PG_VECTOR.
 	 */
-	private VectorType vectorType = VectorType.PG_ARRAY;
+	private final VectorType vectorType;
 
 	/**
 	 * Additional transformer specific options.
 	 */
-	private Map<String, Object> kwargs = Map.of();
+	private final Map<String, Object> kwargs;
 
 	/**
 	 * The Document metadata aggregation mode.
 	 */
-	private MetadataMode metadataMode = MetadataMode.EMBED;
-	// @formatter:on
+	private final MetadataMode metadataMode;
 
-	public static Builder builder() {
-		return new Builder();
+	protected PostgresMlEmbeddingOptions(String transformer, VectorType vectorType, Map<String, Object> kwargs,
+			MetadataMode metadataMode) {
+		this.transformer = transformer;
+		this.vectorType = vectorType;
+		this.kwargs = kwargs;
+		this.metadataMode = metadataMode;
 	}
 
 	public String getTransformer() {
 		return this.transformer;
 	}
 
-	public void setTransformer(String transformer) {
-		this.transformer = transformer;
-	}
-
 	public VectorType getVectorType() {
 		return this.vectorType;
-	}
-
-	public void setVectorType(VectorType vectorType) {
-		this.vectorType = vectorType;
 	}
 
 	public Map<String, Object> getKwargs() {
 		return this.kwargs;
 	}
 
-	public void setKwargs(Map<String, Object> kwargs) {
-		this.kwargs = kwargs;
-	}
-
 	public MetadataMode getMetadataMode() {
 		return this.metadataMode;
-	}
-
-	public void setMetadataMode(MetadataMode metadataMode) {
-		this.metadataMode = metadataMode;
 	}
 
 	@Override
@@ -102,36 +89,44 @@ public class PostgresMlEmbeddingOptions implements EmbeddingOptions {
 		return null;
 	}
 
+	public static Builder builder() {
+		return new Builder();
+	}
+
 	public static final class Builder {
 
-		protected PostgresMlEmbeddingOptions options;
+		private String transformer = PostgresMlEmbeddingModel.DEFAULT_TRANSFORMER_MODEL;
 
-		public Builder() {
-			this.options = new PostgresMlEmbeddingOptions();
-		}
+		private VectorType vectorType = VectorType.PG_ARRAY;
+
+		private Map<String, Object> kwargs = Map.of();
+
+		private MetadataMode metadataMode = MetadataMode.EMBED;
 
 		public Builder transformer(String transformer) {
-			this.options.setTransformer(transformer);
+			this.transformer = transformer;
 			return this;
 		}
 
 		public Builder vectorType(VectorType vectorType) {
-			this.options.setVectorType(vectorType);
+			this.vectorType = vectorType;
 			return this;
 		}
 
-		public Builder kwargs(Map<String, Object> kwargs) {
-			this.options.setKwargs(kwargs);
+		public Builder kwargs(@Nullable Map<String, Object> kwargs) {
+			if (kwargs != null) {
+				this.kwargs = kwargs;
+			}
 			return this;
 		}
 
 		public Builder metadataMode(MetadataMode metadataMode) {
-			this.options.setMetadataMode(metadataMode);
+			this.metadataMode = metadataMode;
 			return this;
 		}
 
 		public PostgresMlEmbeddingOptions build() {
-			return this.options;
+			return new PostgresMlEmbeddingOptions(this.transformer, this.vectorType, this.kwargs, this.metadataMode);
 		}
 
 	}

--- a/models/spring-ai-postgresml/src/test/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptionsTests.java
+++ b/models/spring-ai-postgresml/src/test/java/org/springframework/ai/postgresml/PostgresMlEmbeddingOptionsTests.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Sebastien Deleuze
  */
 public class PostgresMlEmbeddingOptionsTests {
 
@@ -204,19 +205,6 @@ public class PostgresMlEmbeddingOptionsTests {
 	}
 
 	@Test
-	public void settersModifyOptions() {
-		PostgresMlEmbeddingOptions options = new PostgresMlEmbeddingOptions();
-
-		options.setVectorType(PostgresMlEmbeddingModel.VectorType.PG_VECTOR);
-		options.setKwargs(Map.of("key", "value"));
-		options.setMetadataMode(org.springframework.ai.document.MetadataMode.NONE);
-
-		assertThat(options.getVectorType()).isEqualTo(PostgresMlEmbeddingModel.VectorType.PG_VECTOR);
-		assertThat(options.getKwargs()).containsEntry("key", "value");
-		assertThat(options.getMetadataMode()).isEqualTo(org.springframework.ai.document.MetadataMode.NONE);
-	}
-
-	@Test
 	public void getModelReturnsNull() {
 		PostgresMlEmbeddingOptions options = PostgresMlEmbeddingOptions.builder().build();
 
@@ -231,19 +219,19 @@ public class PostgresMlEmbeddingOptionsTests {
 	}
 
 	@Test
-	public void builderReturnsSameInstance() {
+	public void builderReturnsNewInstance() {
 		PostgresMlEmbeddingOptions.Builder builder = PostgresMlEmbeddingOptions.builder().transformer("model-1");
 
 		PostgresMlEmbeddingOptions options1 = builder.build();
 		PostgresMlEmbeddingOptions options2 = builder.build();
 
-		// Builder returns the same instance on multiple build() calls
-		assertThat(options1).isSameAs(options2);
+		// Builder returns a new instance on multiple build() calls
+		assertThat(options1).isNotSameAs(options2);
 		assertThat(options1.getTransformer()).isEqualTo(options2.getTransformer());
 	}
 
 	@Test
-	public void modifyingBuilderAfterBuildAffectsPreviousInstance() {
+	public void modifyingBuilderAfterBuildDoesNotAffectPreviousInstance() {
 		PostgresMlEmbeddingOptions.Builder builder = PostgresMlEmbeddingOptions.builder().transformer("model-1");
 
 		PostgresMlEmbeddingOptions options1 = builder.build();
@@ -252,18 +240,17 @@ public class PostgresMlEmbeddingOptionsTests {
 		builder.transformer("model-2");
 		PostgresMlEmbeddingOptions options2 = builder.build();
 
-		// Both instances are the same and have the updated value
-		assertThat(options1).isSameAs(options2);
-		assertThat(options1.getTransformer()).isEqualTo("model-2");
+		// Instances are different and have different values
+		assertThat(options1).isNotSameAs(options2);
+		assertThat(options1.getTransformer()).isEqualTo("model-1");
 		assertThat(options2.getTransformer()).isEqualTo("model-2");
 	}
 
 	@Test
 	public void setAdditionalParametersAcceptsNull() {
-		PostgresMlEmbeddingOptions options = new PostgresMlEmbeddingOptions();
-		options.setKwargs(null);
+		PostgresMlEmbeddingOptions options = PostgresMlEmbeddingOptions.builder().kwargs(null).build();
 
-		assertThat(options.getKwargs()).isNull();
+		assertThat(options.getKwargs()).isEmpty();
 	}
 
 }

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/postgresml-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/postgresml-embeddings.adoc
@@ -47,7 +47,7 @@ dependencies {
 
 TIP: Refer to the xref:getting-started.adoc#dependency-management[Dependency Management] section to add the Spring AI BOM to your build file.
 
-Use the `spring.ai.postgresml.embedding.options.*` properties to configure your `PostgresMlEmbeddingModel`. links
+Use the `spring.ai.postgresml.embedding.*` properties to configure your `PostgresMlEmbeddingModel`. links
 
 === Embedding Properties
 
@@ -70,14 +70,14 @@ The prefix `spring.ai.postgresml.embedding` is property prefix that configures t
 | spring.ai.postgresml.embedding.enabled (Removed and no longer valid) | Enable PostgresML embedding model.  | true
 | spring.ai.model.embedding | Enable PostgresML embedding model.  | postgresml
 | spring.ai.postgresml.embedding.create-extension | Execute the SQL 'CREATE EXTENSION IF NOT EXISTS pgml' to enable the extension | false
-| spring.ai.postgresml.embedding.options.transformer  | The Hugging Face transformer model to use for the embedding.  | distilbert-base-uncased
-| spring.ai.postgresml.embedding.options.kwargs   | Additional transformer specific options.  | empty map
-| spring.ai.postgresml.embedding.options.vectorType   | PostgresML vector type to use for the embedding. Two options are supported: `PG_ARRAY` and `PG_VECTOR`. | PG_ARRAY
-| spring.ai.postgresml.embedding.options.metadataMode   | Document metadata aggregation mode  | EMBED
+| spring.ai.postgresml.embedding.transformer  | The Hugging Face transformer model to use for the embedding.  | distilbert-base-uncased
+| spring.ai.postgresml.embedding.kwargs   | Additional transformer specific options.  | empty map
+| spring.ai.postgresml.embedding.vector-type   | PostgresML vector type to use for the embedding. Two options are supported: `PG_ARRAY` and `PG_VECTOR`. | PG_ARRAY
+| spring.ai.postgresml.embedding.metadata-mode   | Document metadata aggregation mode  | EMBED
 |====
 
 
-TIP: All properties prefixed with `spring.ai.postgresml.embedding.options` can be overridden at runtime by adding a request specific <<embedding-options>> to the `EmbeddingRequest` call.
+TIP: All properties prefixed with `spring.ai.postgresml.embedding` can be overridden at runtime by adding a request specific <<embedding-options>> to the `EmbeddingRequest` call.
 
 == Runtime Options [[embedding-options]]
 
@@ -109,10 +109,10 @@ Here is an example of a simple `@Controller` class that uses the `EmbeddingModel
 
 [source,application.properties]
 ----
-spring.ai.postgresml.embedding.options.transformer=distilbert-base-uncased
-spring.ai.postgresml.embedding.options.vectorType=PG_ARRAY
-spring.ai.postgresml.embedding.options.metadataMode=EMBED
-spring.ai.postgresml.embedding.options.kwargs.device=cpu
+spring.ai.postgresml.embedding.transformer=distilbert-base-uncased
+spring.ai.postgresml.embedding.vector-type=PG_ARRAY
+spring.ai.postgresml.embedding.metadata-mode=EMBED
+spring.ai.postgresml.embedding.kwargs.device=cpu
 ----
 
 [source,java]


### PR DESCRIPTION
- Remove `@NestedConfigurationProperty` from `PostgresMlEmbeddingProperties`
- Expose options directly under the `spring.ai.postgresml.embedding` prefix instead of `spring.ai.postgresml.embedding.options`
- Implement Spring Boot deprecation mechanism for the legacy `options` nested properties to gracefully guide users during upgrades