### PR TITLE
Remove Stability AI setters from options

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.web.client.RestClient;
  * @author Mark Pollack
  * @author Christian Tzolov
  * @author Ilayaperumal Gopinathan
+ * @author Sebastien Deleuze
  * @since 0.8.0
  */
 @AutoConfiguration
@@ -60,7 +61,7 @@ public class StabilityAiImageAutoConfiguration {
 		Assert.hasText(apiKey, "StabilityAI API key must be set");
 		Assert.hasText(baseUrl, "StabilityAI base URL must be set");
 
-		return new StabilityAiApi(apiKey, imageProperties.getOptions().getModel(), baseUrl,
+		return new StabilityAiApi(apiKey, imageProperties.toOptions().getModel(), baseUrl,
 				restClientBuilderProvider.getIfAvailable(RestClient::builder));
 	}
 
@@ -68,7 +69,7 @@ public class StabilityAiImageAutoConfiguration {
 	@ConditionalOnMissingBean
 	public StabilityAiImageModel stabilityAiImageModel(StabilityAiApi stabilityAiApi,
 			StabilityAiImageProperties stabilityAiImageProperties) {
-		return new StabilityAiImageModel(stabilityAiApi, stabilityAiImageProperties.getOptions());
+		return new StabilityAiImageModel(stabilityAiApi, stabilityAiImageProperties.toOptions());
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/main/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImageProperties.java
@@ -16,15 +16,19 @@
 
 package org.springframework.ai.model.stabilityai.autoconfigure;
 
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.stabilityai.api.StabilityAiApi;
 import org.springframework.ai.stabilityai.api.StabilityAiImageOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
 /**
  * Configuration properties for Stability AI image model.
  *
  * @author Mark Pollack
  * @author Christian Tzolov
+ * @author Sebastien Deleuze
  * @since 0.8.0
  */
 @ConfigurationProperties(StabilityAiImageProperties.CONFIG_PREFIX)
@@ -32,11 +36,276 @@ public class StabilityAiImageProperties extends StabilityAiParentProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.stabilityai.image";
 
-	@NestedConfigurationProperty
-	private final StabilityAiImageOptions options = StabilityAiImageOptions.builder().build(); // stable-diffusion-v1-6
+	private @Nullable Integer n;
 
-	public StabilityAiImageOptions getOptions() {
+	private String model = StabilityAiApi.DEFAULT_IMAGE_MODEL;
+
+	private @Nullable Integer width;
+
+	private @Nullable Integer height;
+
+	private @Nullable String responseFormat;
+
+	private @Nullable Float cfgScale;
+
+	private @Nullable String clipGuidancePreset;
+
+	private @Nullable String sampler;
+
+	private @Nullable Long seed;
+
+	private @Nullable Integer steps;
+
+	private @Nullable String stylePreset;
+
+	public @Nullable Integer getN() {
+		return this.n;
+	}
+
+	public void setN(@Nullable Integer n) {
+		this.n = n;
+	}
+
+	public String getModel() {
+		return this.model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	public @Nullable Integer getWidth() {
+		return this.width;
+	}
+
+	public void setWidth(@Nullable Integer width) {
+		this.width = width;
+	}
+
+	public @Nullable Integer getHeight() {
+		return this.height;
+	}
+
+	public void setHeight(@Nullable Integer height) {
+		this.height = height;
+	}
+
+	public @Nullable String getResponseFormat() {
+		return this.responseFormat;
+	}
+
+	public void setResponseFormat(@Nullable String responseFormat) {
+		this.responseFormat = responseFormat;
+	}
+
+	public @Nullable Float getCfgScale() {
+		return this.cfgScale;
+	}
+
+	public void setCfgScale(@Nullable Float cfgScale) {
+		this.cfgScale = cfgScale;
+	}
+
+	public @Nullable String getClipGuidancePreset() {
+		return this.clipGuidancePreset;
+	}
+
+	public void setClipGuidancePreset(@Nullable String clipGuidancePreset) {
+		this.clipGuidancePreset = clipGuidancePreset;
+	}
+
+	public @Nullable String getSampler() {
+		return this.sampler;
+	}
+
+	public void setSampler(@Nullable String sampler) {
+		this.sampler = sampler;
+	}
+
+	public @Nullable Long getSeed() {
+		return this.seed;
+	}
+
+	public void setSeed(@Nullable Long seed) {
+		this.seed = seed;
+	}
+
+	public @Nullable Integer getSteps() {
+		return this.steps;
+	}
+
+	public void setSteps(@Nullable Integer steps) {
+		this.steps = steps;
+	}
+
+	public @Nullable String getStylePreset() {
+		return this.stylePreset;
+	}
+
+	public void setStylePreset(@Nullable String stylePreset) {
+		this.stylePreset = stylePreset;
+	}
+
+	public StabilityAiImageOptions toOptions() {
+		StabilityAiImageOptions.Builder builder = StabilityAiImageOptions.builder();
+		builder.model(this.model);
+		if (this.n != null) {
+			builder.N(this.n);
+		}
+		if (this.width != null) {
+			builder.width(this.width);
+		}
+		if (this.height != null) {
+			builder.height(this.height);
+		}
+		if (this.responseFormat != null) {
+			builder.responseFormat(this.responseFormat);
+		}
+		if (this.cfgScale != null) {
+			builder.cfgScale(this.cfgScale);
+		}
+		if (this.clipGuidancePreset != null) {
+			builder.clipGuidancePreset(this.clipGuidancePreset);
+		}
+		if (this.sampler != null) {
+			builder.sampler(this.sampler);
+		}
+		if (this.seed != null) {
+			builder.seed(this.seed);
+		}
+		if (this.steps != null) {
+			builder.steps(this.steps);
+		}
+		if (this.stylePreset != null) {
+			builder.stylePreset(this.stylePreset);
+		}
+		return builder.build();
+	}
+
+	private Options options = new Options();
+
+	@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image")
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	public Options getOptions() {
 		return this.options;
+	}
+
+	public void setOptions(Options options) {
+		this.options = options;
+	}
+
+	public class Options {
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.n")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getN() {
+			return StabilityAiImageProperties.this.getN();
+		}
+
+		public void setN(@Nullable Integer n) {
+			StabilityAiImageProperties.this.setN(n);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.model")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public String getModel() {
+			return StabilityAiImageProperties.this.getModel();
+		}
+
+		public void setModel(String model) {
+			StabilityAiImageProperties.this.setModel(model);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.width")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getWidth() {
+			return StabilityAiImageProperties.this.getWidth();
+		}
+
+		public void setWidth(@Nullable Integer width) {
+			StabilityAiImageProperties.this.setWidth(width);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.height")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getHeight() {
+			return StabilityAiImageProperties.this.getHeight();
+		}
+
+		public void setHeight(@Nullable Integer height) {
+			StabilityAiImageProperties.this.setHeight(height);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.response-format")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getResponseFormat() {
+			return StabilityAiImageProperties.this.getResponseFormat();
+		}
+
+		public void setResponseFormat(@Nullable String responseFormat) {
+			StabilityAiImageProperties.this.setResponseFormat(responseFormat);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.cfg-scale")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Float getCfgScale() {
+			return StabilityAiImageProperties.this.getCfgScale();
+		}
+
+		public void setCfgScale(@Nullable Float cfgScale) {
+			StabilityAiImageProperties.this.setCfgScale(cfgScale);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.clip-guidance-preset")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getClipGuidancePreset() {
+			return StabilityAiImageProperties.this.getClipGuidancePreset();
+		}
+
+		public void setClipGuidancePreset(@Nullable String clipGuidancePreset) {
+			StabilityAiImageProperties.this.setClipGuidancePreset(clipGuidancePreset);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.sampler")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getSampler() {
+			return StabilityAiImageProperties.this.getSampler();
+		}
+
+		public void setSampler(@Nullable String sampler) {
+			StabilityAiImageProperties.this.setSampler(sampler);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.seed")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Long getSeed() {
+			return StabilityAiImageProperties.this.getSeed();
+		}
+
+		public void setSeed(@Nullable Long seed) {
+			StabilityAiImageProperties.this.setSeed(seed);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.steps")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable Integer getSteps() {
+			return StabilityAiImageProperties.this.getSteps();
+		}
+
+		public void setSteps(@Nullable Integer steps) {
+			StabilityAiImageProperties.this.setSteps(steps);
+		}
+
+		@DeprecatedConfigurationProperty(replacement = "spring.ai.stabilityai.image.style-preset")
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		public @Nullable String getStylePreset() {
+			return StabilityAiImageProperties.this.getStylePreset();
+		}
+
+		public void setStylePreset(@Nullable String stylePreset) {
+			StabilityAiImageProperties.this.setStylePreset(stylePreset);
+		}
+
 	}
 
 }

--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/test/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiAutoConfigurationIT.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/test/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiAutoConfigurationIT.java
@@ -31,6 +31,10 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * @author Christian Tzolov
+ * @author Sebastien Deleuze
+ */
 @EnabledIfEnvironmentVariable(named = "STABILITYAI_API_KEY", matches = ".+")
 public class StabilityAiAutoConfigurationIT {
 

--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/test/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImagePropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/src/test/java/org/springframework/ai/model/stabilityai/autoconfigure/StabilityAiImagePropertiesTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Christian Tzolov
+ * @author Sebastien Deleuze
  * @since 0.8.0
  */
 public class StabilityAiImagePropertiesTests {
@@ -37,18 +38,18 @@ public class StabilityAiImagePropertiesTests {
 		// @formatter:off
 		"spring.ai.stabilityai.image.api-key=API_KEY",
 				"spring.ai.stabilityai.image.base-url=ENDPOINT",
-				"spring.ai.stabilityai.image.options.n=10",
-				"spring.ai.stabilityai.image.options.model=MODEL_XYZ",
-				"spring.ai.stabilityai.image.options.width=512",
-				"spring.ai.stabilityai.image.options.height=256",
-				"spring.ai.stabilityai.image.options.response-format=application/json",
-				"spring.ai.stabilityai.image.options.n=4",
-				"spring.ai.stabilityai.image.options.cfg-scale=7",
-				"spring.ai.stabilityai.image.options.clip-guidance-preset=SIMPLE",
-				"spring.ai.stabilityai.image.options.sampler=K_EULER",
-				"spring.ai.stabilityai.image.options.seed=0",
-				"spring.ai.stabilityai.image.options.steps=30",
-				"spring.ai.stabilityai.image.options.style-preset=neon-punk"
+				"spring.ai.stabilityai.image.n=10",
+				"spring.ai.stabilityai.image.model=MODEL_XYZ",
+				"spring.ai.stabilityai.image.width=512",
+				"spring.ai.stabilityai.image.height=256",
+				"spring.ai.stabilityai.image.response-format=application/json",
+				"spring.ai.stabilityai.image.n=4",
+				"spring.ai.stabilityai.image.cfg-scale=7",
+				"spring.ai.stabilityai.image.clip-guidance-preset=SIMPLE",
+				"spring.ai.stabilityai.image.sampler=K_EULER",
+				"spring.ai.stabilityai.image.seed=0",
+				"spring.ai.stabilityai.image.steps=30",
+				"spring.ai.stabilityai.image.style-preset=neon-punk"
 				)
 			// @formatter:on
 			.withConfiguration(AutoConfigurations.of(StabilityAiImageAutoConfiguration.class))
@@ -57,18 +58,18 @@ public class StabilityAiImagePropertiesTests {
 
 				assertThat(chatProperties.getBaseUrl()).isEqualTo("ENDPOINT");
 				assertThat(chatProperties.getApiKey()).isEqualTo("API_KEY");
-				assertThat(chatProperties.getOptions().getModel()).isEqualTo("MODEL_XYZ");
+				assertThat(chatProperties.toOptions().getModel()).isEqualTo("MODEL_XYZ");
 
-				assertThat(chatProperties.getOptions().getWidth()).isEqualTo(512);
-				assertThat(chatProperties.getOptions().getHeight()).isEqualTo(256);
-				assertThat(chatProperties.getOptions().getResponseFormat()).isEqualTo("application/json");
-				assertThat(chatProperties.getOptions().getN()).isEqualTo(4);
-				assertThat(chatProperties.getOptions().getCfgScale()).isEqualTo(7);
-				assertThat(chatProperties.getOptions().getClipGuidancePreset()).isEqualTo("SIMPLE");
-				assertThat(chatProperties.getOptions().getSampler()).isEqualTo("K_EULER");
-				assertThat(chatProperties.getOptions().getSeed()).isEqualTo(0);
-				assertThat(chatProperties.getOptions().getSteps()).isEqualTo(30);
-				assertThat(chatProperties.getOptions().getStylePreset()).isEqualTo("neon-punk");
+				assertThat(chatProperties.toOptions().getWidth()).isEqualTo(512);
+				assertThat(chatProperties.toOptions().getHeight()).isEqualTo(256);
+				assertThat(chatProperties.toOptions().getResponseFormat()).isEqualTo("application/json");
+				assertThat(chatProperties.toOptions().getN()).isEqualTo(4);
+				assertThat(chatProperties.toOptions().getCfgScale()).isEqualTo(7);
+				assertThat(chatProperties.toOptions().getClipGuidancePreset()).isEqualTo("SIMPLE");
+				assertThat(chatProperties.toOptions().getSampler()).isEqualTo("K_EULER");
+				assertThat(chatProperties.toOptions().getSeed()).isEqualTo(0L);
+				assertThat(chatProperties.toOptions().getSteps()).isEqualTo(30);
+				assertThat(chatProperties.toOptions().getStylePreset()).isEqualTo("neon-punk");
 			});
 	}
 

--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiImageOptions.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiImageOptions.java
@@ -18,9 +18,6 @@ package org.springframework.ai.stabilityai.api;
 
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.ai.image.ImageOptions;
@@ -29,8 +26,9 @@ import org.springframework.ai.stabilityai.StyleEnum;
 /**
  * StabilityAiImageOptions is an interface that extends ImageOptions. It provides
  * additional stability AI specific image options.
+ *
+ * @author Sebastien Deleuze
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StabilityAiImageOptions implements ImageOptions {
 
 	/**
@@ -48,10 +46,7 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * Valid range of values: 1 to 10. This ensures that the request remains within a
 	 * manageable scale and aligns with system capabilities or limitations.
 	 * </p>
-	 *
-	 *
 	 */
-	@JsonProperty("samples")
 	private @Nullable Integer n;
 
 	/**
@@ -87,7 +82,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * </ul>
 	 *
 	 */
-	@JsonProperty("width")
 	private @Nullable Integer width;
 
 	/**
@@ -115,14 +109,12 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * </ul>
 	 *
 	 */
-	@JsonProperty("height")
 	private @Nullable Integer height;
 
 	/**
 	 * The format in which the generated images are returned. It is sent as part of the
 	 * accept header. Must be "application/json" or "image/png"
 	 */
-	@JsonProperty("response_format")
 	private @Nullable String responseFormat;
 
 	/**
@@ -139,7 +131,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * </ul>
 	 *
 	 */
-	@JsonProperty("cfg_scale")
 	private @Nullable Float cfgScale;
 
 	/**
@@ -171,7 +162,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * Defaults to {@code NONE} if no specific preset is configured.
 	 *
 	 */
-	@JsonProperty("clip_guidance_preset")
 	private @Nullable String clipGuidancePreset;
 
 	/**
@@ -211,7 +201,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * An appropriate sampler is automatically selected if this value is omitted.
 	 *
 	 */
-	@JsonProperty("sampler")
 	private @Nullable String sampler;
 
 	/**
@@ -228,7 +217,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 *
 	 * Default is 0, which indicates that a random seed will be used.
 	 */
-	@JsonProperty("seed")
 	private @Nullable Long seed;
 
 	/**
@@ -245,7 +233,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 *
 	 * Defaults to 30 if not explicitly set.
 	 */
-	@JsonProperty("steps")
 	private @Nullable Integer steps;
 
 	/**
@@ -285,7 +272,6 @@ public class StabilityAiImageOptions implements ImageOptions {
 	 * </p>
 	 *
 	 */
-	@JsonProperty("style_preset")
 	private @Nullable String stylePreset;
 
 	public static Builder builder() {
@@ -297,103 +283,49 @@ public class StabilityAiImageOptions implements ImageOptions {
 		return this.n;
 	}
 
-	public void setN(@Nullable Integer n) {
-		this.n = n;
-	}
-
-	@Override
 	public String getModel() {
 		return this.model;
 	}
 
-	public void setModel(String model) {
-		this.model = model;
-	}
-
-	@Override
 	public @Nullable Integer getWidth() {
 		return this.width;
 	}
 
-	public void setWidth(@Nullable Integer width) {
-		this.width = width;
-	}
-
-	@Override
 	public @Nullable Integer getHeight() {
 		return this.height;
 	}
 
-	public void setHeight(@Nullable Integer height) {
-		this.height = height;
-	}
-
-	@Override
 	public @Nullable String getResponseFormat() {
 		return this.responseFormat;
-	}
-
-	public void setResponseFormat(@Nullable String responseFormat) {
-		this.responseFormat = responseFormat;
 	}
 
 	public @Nullable Float getCfgScale() {
 		return this.cfgScale;
 	}
 
-	public void setCfgScale(@Nullable Float cfgScale) {
-		this.cfgScale = cfgScale;
-	}
-
 	public @Nullable String getClipGuidancePreset() {
 		return this.clipGuidancePreset;
-	}
-
-	public void setClipGuidancePreset(@Nullable String clipGuidancePreset) {
-		this.clipGuidancePreset = clipGuidancePreset;
 	}
 
 	public @Nullable String getSampler() {
 		return this.sampler;
 	}
 
-	public void setSampler(@Nullable String sampler) {
-		this.sampler = sampler;
-	}
-
 	public @Nullable Long getSeed() {
 		return this.seed;
-	}
-
-	public void setSeed(@Nullable Long seed) {
-		this.seed = seed;
 	}
 
 	public @Nullable Integer getSteps() {
 		return this.steps;
 	}
 
-	public void setSteps(@Nullable Integer steps) {
-		this.steps = steps;
-	}
-
 	@Override
-	@JsonIgnore
 	public @Nullable String getStyle() {
 		return getStylePreset();
 	}
 
-	@JsonIgnore
-	public void setStyle(@Nullable String style) {
-		setStylePreset(style);
-	}
-
 	public @Nullable String getStylePreset() {
 		return this.stylePreset;
-	}
-
-	public void setStylePreset(@Nullable String stylePreset) {
-		this.stylePreset = stylePreset;
 	}
 
 	@Override
@@ -430,74 +362,105 @@ public class StabilityAiImageOptions implements ImageOptions {
 
 	public static final class Builder {
 
-		private final StabilityAiImageOptions options;
+		private @Nullable Integer n;
+
+		private String model = StabilityAiApi.DEFAULT_IMAGE_MODEL;
+
+		private @Nullable Integer width;
+
+		private @Nullable Integer height;
+
+		private @Nullable String responseFormat;
+
+		private @Nullable Float cfgScale;
+
+		private @Nullable String clipGuidancePreset;
+
+		private @Nullable String sampler;
+
+		private @Nullable Long seed;
+
+		private @Nullable Integer steps;
+
+		private @Nullable String stylePreset;
 
 		private Builder() {
-			this.options = new StabilityAiImageOptions();
 		}
 
 		public Builder N(@Nullable Integer n) {
-			this.options.setN(n);
+			this.n = n;
 			return this;
 		}
 
 		public Builder model(String model) {
-			this.options.setModel(model);
+			this.model = model;
 			return this;
 		}
 
 		public Builder width(@Nullable Integer width) {
-			this.options.setWidth(width);
+			this.width = width;
 			return this;
 		}
 
 		public Builder height(@Nullable Integer height) {
-			this.options.setHeight(height);
+			this.height = height;
 			return this;
 		}
 
 		public Builder responseFormat(@Nullable String responseFormat) {
-			this.options.setResponseFormat(responseFormat);
+			this.responseFormat = responseFormat;
 			return this;
 		}
 
 		public Builder cfgScale(@Nullable Float cfgScale) {
-			this.options.setCfgScale(cfgScale);
+			this.cfgScale = cfgScale;
 			return this;
 		}
 
 		public Builder clipGuidancePreset(@Nullable String clipGuidancePreset) {
-			this.options.setClipGuidancePreset(clipGuidancePreset);
+			this.clipGuidancePreset = clipGuidancePreset;
 			return this;
 		}
 
 		public Builder sampler(@Nullable String sampler) {
-			this.options.setSampler(sampler);
+			this.sampler = sampler;
 			return this;
 		}
 
 		public Builder seed(@Nullable Long seed) {
-			this.options.setSeed(seed);
+			this.seed = seed;
 			return this;
 		}
 
 		public Builder steps(@Nullable Integer steps) {
-			this.options.setSteps(steps);
+			this.steps = steps;
 			return this;
 		}
 
 		public Builder stylePreset(@Nullable String stylePreset) {
-			this.options.setStylePreset(stylePreset);
+			this.stylePreset = stylePreset;
 			return this;
 		}
 
 		public Builder stylePreset(@Nullable StyleEnum styleEnum) {
-			this.options.setStylePreset(styleEnum != null ? styleEnum.toString() : null);
+			this.stylePreset = styleEnum != null ? styleEnum.toString() : null;
 			return this;
 		}
 
 		public StabilityAiImageOptions build() {
-			return this.options;
+			StabilityAiImageOptions options = new StabilityAiImageOptions();
+			options.n = this.n;
+			options.model = this.model;
+			options.width = this.width;
+			options.height = this.height;
+			options.responseFormat = this.responseFormat;
+			options.cfgScale = this.cfgScale;
+			options.clipGuidancePreset = this.clipGuidancePreset;
+			options.sampler = this.sampler;
+			options.seed = this.seed;
+			options.steps = this.steps;
+			options.stylePreset = this.stylePreset;
+			return options;
 		}
 
 	}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/stabilityai-image.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/image/stabilityai-image.adoc
@@ -104,17 +104,17 @@ The prefix `spring.ai.stabilityai.image` is the property prefix that lets you co
 | spring.ai.model.image | Enable Stability AI image model.  | stabilityai
 | spring.ai.stabilityai.image.base-url              | Optional overrides the spring.ai.openai.base-url to provide a specific url |  `+https://api.stability.ai/v1+`
 | spring.ai.stabilityai.image.api-key              | Optional overrides the spring.ai.openai.api-key to provide a specific api-key |  -
-| spring.ai.stabilityai.image.option.n               | The number of images to be generated. Must be between 1 and 10.                                                            | 1
-| spring.ai.stabilityai.image.option.model                 | The engine/model to use in Stability AI. The model is passed in the URL as a path parameter.          | `stable-diffusion-v1-6`
-| spring.ai.stabilityai.image.option.width                 | Width of the image to generate, in pixels, in an increment divisible by 64. Engine-specific dimension validation applies. | 512
-| spring.ai.stabilityai.image.option.height               | Height of the image to generate, in pixels, in an increment divisible by 64. Engine-specific dimension validation applies.| 512
-| spring.ai.stabilityai.image.option.responseFormat        | The format in which the generated images are returned. Must be "application/json" or "image/png".                         | -
-| spring.ai.stabilityai.image.option.cfg_scale             | The strictness level of the diffusion process adherence to the prompt text. Range: 0 to 35.                               | 7
-| spring.ai.stabilityai.image.option.clip_guidance_preset  | Pass in a style preset to guide the image model towards a particular style. This list of style presets is subject to change. | `NONE`
-| spring.ai.stabilityai.image.option.sampler               | Which sampler to use for the diffusion process. If this value is omitted, an appropriate sampler will be automatically selected. | -
-| spring.ai.stabilityai.image.option.seed                  | Random noise seed (omit this option or use 0 for a random seed). Valid range: 0 to 4294967295.                             | 0
-| spring.ai.stabilityai.image.option.steps                 | Number of diffusion steps to run. Valid range: 10 to 50.                                                                   | 30
-| spring.ai.stabilityai.image.option.style_preset          | Pass in a style preset to guide the image model towards a particular style. This list of style presets is subject to change. | -
+| spring.ai.stabilityai.image.n               | The number of images to be generated. Must be between 1 and 10.                                                            | 1
+| spring.ai.stabilityai.image.model                 | The engine/model to use in Stability AI. The model is passed in the URL as a path parameter.          | `stable-diffusion-v1-6`
+| spring.ai.stabilityai.image.width                 | Width of the image to generate, in pixels, in an increment divisible by 64. Engine-specific dimension validation applies. | 512
+| spring.ai.stabilityai.image.height               | Height of the image to generate, in pixels, in an increment divisible by 64. Engine-specific dimension validation applies.| 512
+| spring.ai.stabilityai.image.responseFormat        | The format in which the generated images are returned. Must be "application/json" or "image/png".                         | -
+| spring.ai.stabilityai.image.cfg_scale             | The strictness level of the diffusion process adherence to the prompt text. Range: 0 to 35.                               | 7
+| spring.ai.stabilityai.image.clip_guidance_preset  | Pass in a style preset to guide the image model towards a particular style. This list of style presets is subject to change. | `NONE`
+| spring.ai.stabilityai.image.sampler               | Which sampler to use for the diffusion process. If this value is omitted, an appropriate sampler will be automatically selected. | -
+| spring.ai.stabilityai.image.seed                  | Random noise seed (omit this option or use 0 for a random seed). Valid range: 0 to 4294967295.                             | 0
+| spring.ai.stabilityai.image.steps                 | Number of diffusion steps to run. Valid range: 10 to 50.                                                                   | 30
+| spring.ai.stabilityai.image.style_preset          | Pass in a style preset to guide the image model towards a particular style. This list of style presets is subject to change. | -
 |====
 
 
@@ -122,7 +122,7 @@ The prefix `spring.ai.stabilityai.image` is the property prefix that lets you co
 
 The https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-stabilityai/src/main/java/org/springframework/ai/stabilityai/api/StabilityAiImageOptions.java[StabilityAiImageOptions.java] provides model configurations, such as the model to use, the style, the size, etc.
 
-On start-up, the default options can be configured with the `StabilityAiImageModel(StabilityAiApi stabilityAiApi, StabilityAiImageOptions options)` constructor. Alternatively, use the `spring.ai.openai.image.options.*` properties described previously.
+On start-up, the default options can be configured with the `StabilityAiImageModel(StabilityAiApi stabilityAiApi, StabilityAiImageOptions options)` constructor. Alternatively, use the `spring.ai.stabilityai.image.*` properties described previously.
 
 At runtime, you can override the default options by adding new, request specific, options to the `ImagePrompt` call.
 For example to override the Stability AI specific options such as quality and the number of images to create, use the following code example:


### PR DESCRIPTION
- Remove `@NestedConfigurationProperty` from `StabilityAiImageOptions`
- Expose options directly under the `spring.ai.stabilityai.image` prefix instead of `spring.ai.stabilityai.image.options`
- Implement Spring Boot deprecation mechanism for the legacy `options` nested properties to gracefully guide users during upgrades
- Remove Jackson annotations on `StabilityAiImageOptions`