### PR TITLE
Remove common ChatOptions setters calls

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ChatModelCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ChatModelCallAdvisor.java
@@ -74,13 +74,22 @@ public final class ChatModelCallAdvisor implements CallAdvisor {
 			return chatClientRequest;
 		}
 
-		if (chatClientRequest.context().containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey())
-				&& StringUtils.hasText(outputSchema) && chatClientRequest.prompt()
-					.getOptions() instanceof StructuredOutputChatOptions structuredOutputChatOptions) {
+		boolean usesNativeStructuredOutput = chatClientRequest.context()
+			.containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 
-			structuredOutputChatOptions.setOutputSchema(outputSchema);
+		if (usesNativeStructuredOutput && StringUtils.hasText(outputSchema) && chatClientRequest.prompt()
+			.getOptions() instanceof StructuredOutputChatOptions structuredOutputChatOptions) {
 
-			return chatClientRequest;
+			// Cast is necessary because of non-linear hierarchy in options interfaces
+			var augmentedOptions = ((StructuredOutputChatOptions.Builder<?>) structuredOutputChatOptions.mutate())
+				.outputSchema(outputSchema)
+				.build();
+			Prompt augmentedPrompt = chatClientRequest.prompt().mutate().chatOptions(augmentedOptions).build();
+
+			return ChatClientRequest.builder()
+				.prompt(augmentedPrompt)
+				.context(Map.copyOf(chatClientRequest.context()))
+				.build();
 		}
 
 		Prompt augmentedPrompt = chatClientRequest.prompt()

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -230,8 +230,9 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 		// Overwrite the ToolCallingChatOptions to disable internal tool execution.
 		// Use the validated options from the original request to satisfy NullAway,
 		// as doInitializeLoopStream should preserve the options contract.
-		var optionsCopy = (ToolCallingChatOptions) chatClientRequest.prompt().getOptions().copy();
-		optionsCopy.setInternalToolExecutionEnabled(false);
+		var optionsCopy = ((ToolCallingChatOptions.Builder<?>) chatClientRequest.prompt().getOptions().mutate())
+			.internalToolExecutionEnabled(false)
+			.build();
 
 		return this.internalStream(streamAdvisorChain, initializedRequest, optionsCopy,
 				initializedRequest.prompt().getInstructions());

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientNativeStructuredResponseTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientNativeStructuredResponseTests.java
@@ -47,12 +47,7 @@ import org.springframework.ai.model.tool.StructuredOutputChatOptions;
 import org.springframework.ai.util.json.JsonParser;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -85,9 +80,6 @@ public class ChatClientNativeStructuredResponseTests {
 
 	@Mock
 	ChatModel chatModel;
-
-	@Mock
-	StructuredOutputChatOptions structuredOutputChatOptions;
 
 	@Captor
 	ArgumentCaptor<Prompt> promptCaptor;
@@ -127,7 +119,6 @@ public class ChatClientNativeStructuredResponseTests {
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).contains("Tell me about John", "Your response should be in JSON format");
-		verify(this.structuredOutputChatOptions, never()).setOutputSchema(anyString());
 	}
 
 	@Test
@@ -163,15 +154,11 @@ public class ChatClientNativeStructuredResponseTests {
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).contains("Tell me about John", "Your response should be in JSON format");
-		verify(this.structuredOutputChatOptions, never()).setOutputSchema(anyString());
 	}
 
 	@Test
-	public void nativeResponseEntityTest(@Captor ArgumentCaptor<String> outputSchemaCaptor) {
-		ChatOptions.Builder builder = mock(ChatOptions.Builder.class);
-		when(this.chatModel.getDefaultOptions()).thenReturn(this.structuredOutputChatOptions);
-		when(this.structuredOutputChatOptions.mutate()).thenReturn(builder);
-		when(builder.build()).thenReturn(this.structuredOutputChatOptions);
+	public void nativeResponseEntityTest() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -180,7 +167,6 @@ public class ChatClientNativeStructuredResponseTests {
 				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
-		willDoNothing().given(this.structuredOutputChatOptions).setOutputSchema(outputSchemaCaptor.capture());
 
 		var textCallAdvisor = new ContextCatcherCallAdvisor();
 
@@ -208,13 +194,17 @@ public class ChatClientNativeStructuredResponseTests {
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).isEqualTo("Tell me about John");
 
-		JsonAssertions.assertThatJson(outputSchemaCaptor.getValue())
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
+
+		JsonAssertions.assertThatJson(soco.getOutputSchema())
 			.when(Option.IGNORING_ARRAY_ORDER)
 			.isEqualTo(USER_JSON_SCHEMA);
+
 	}
 
 	@Test
-	public void nativeEntityTest(@Captor ArgumentCaptor<String> outputSchemaCaptor) {
+	public void nativeEntityTest() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -223,11 +213,6 @@ public class ChatClientNativeStructuredResponseTests {
 				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
-		ChatOptions.Builder builder = mock(ChatOptions.Builder.class);
-		when(this.chatModel.getDefaultOptions()).thenReturn(this.structuredOutputChatOptions);
-		when(this.structuredOutputChatOptions.mutate()).thenReturn(builder);
-		when(builder.build()).thenReturn(this.structuredOutputChatOptions);
-		willDoNothing().given(this.structuredOutputChatOptions).setOutputSchema(outputSchemaCaptor.capture());
 
 		var textCallAdvisor = new ContextCatcherCallAdvisor();
 
@@ -252,7 +237,9 @@ public class ChatClientNativeStructuredResponseTests {
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).isEqualTo("Tell me about John");
 
-		JsonAssertions.assertThatJson(outputSchemaCaptor.getValue())
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
+
+		JsonAssertions.assertThatJson(soco.getOutputSchema())
 			.when(Option.IGNORING_ARRAY_ORDER)
 			.isEqualTo(USER_JSON_SCHEMA);
 	}
@@ -260,7 +247,7 @@ public class ChatClientNativeStructuredResponseTests {
 	@Test
 	public void dynamicDisableNativeResponseEntityTest() {
 
-		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -296,13 +283,14 @@ public class ChatClientNativeStructuredResponseTests {
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).contains("Tell me about John", "Your response should be in JSON format");
-		verify(this.structuredOutputChatOptions, never()).setOutputSchema(anyString());
+
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
+		assertThat(soco.getOutputSchema()).isNull();
 	}
 
 	@Test
 	public void dynamicDisableNativeEntityTest() {
-
-		when(this.chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -335,12 +323,14 @@ public class ChatClientNativeStructuredResponseTests {
 		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).contains("Tell me about John", "Your response should be in JSON format");
-		verify(this.structuredOutputChatOptions, never()).setOutputSchema(anyString());
+
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
+		assertThat(soco.getOutputSchema()).isNull();
 	}
 
 	@Test
-	public void nativeWithCustomStructuredOutputConverterResponseEntityTest(
-			@Captor ArgumentCaptor<String> outputSchemaCaptor) {
+	public void nativeWithCustomStructuredOutputConverterResponseEntityTest() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -349,11 +339,6 @@ public class ChatClientNativeStructuredResponseTests {
 				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
-		ChatOptions.Builder builder = mock(ChatOptions.Builder.class);
-		when(this.chatModel.getDefaultOptions()).thenReturn(this.structuredOutputChatOptions);
-		when(this.structuredOutputChatOptions.mutate()).thenReturn(builder);
-		when(builder.build()).thenReturn(this.structuredOutputChatOptions);
-		willDoNothing().given(this.structuredOutputChatOptions).setOutputSchema(outputSchemaCaptor.capture());
 
 		var textCallAdvisor = new ContextCatcherCallAdvisor();
 
@@ -372,8 +357,9 @@ public class ChatClientNativeStructuredResponseTests {
 		assertThat(context).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_SCHEMA.getKey());
 		assertThat(context).containsKey(ChatClientAttributes.STRUCTURED_OUTPUT_NATIVE.getKey());
 
-		assertThat(responseEntity.getResponse()).isEqualTo(chatResponse);
-		assertThat(responseEntity.getResponse().getMetadata().get("key1").toString()).isEqualTo("value1");
+		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
+		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
+		assertThat(userMessage.getText()).isEqualTo("Tell me about John");
 
 		JsonAssertions.assertThatJson(responseEntity.getEntity()).isEqualTo("""
 				{
@@ -382,17 +368,17 @@ public class ChatClientNativeStructuredResponseTests {
 				}
 				""");
 
-		Message userMessage = this.promptCaptor.getValue().getInstructions().get(0);
-		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
-		assertThat(userMessage.getText()).isEqualTo("Tell me about John");
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
 
-		JsonAssertions.assertThatJson(outputSchemaCaptor.getValue())
+		JsonAssertions.assertThatJson(soco.getOutputSchema())
 			.when(Option.IGNORING_ARRAY_ORDER)
 			.isEqualTo(USER_JSON_SCHEMA);
+
 	}
 
 	@Test
-	public void nativeWithCustomStructuredOutputConverterEntityTest(@Captor ArgumentCaptor<String> outputSchemaCaptor) {
+	public void nativeWithCustomStructuredOutputConverterEntityTest() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -401,11 +387,6 @@ public class ChatClientNativeStructuredResponseTests {
 				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
-		ChatOptions.Builder builder = mock(ChatOptions.Builder.class);
-		when(this.chatModel.getDefaultOptions()).thenReturn(this.structuredOutputChatOptions);
-		when(this.structuredOutputChatOptions.mutate()).thenReturn(builder);
-		when(builder.build()).thenReturn(this.structuredOutputChatOptions);
-		willDoNothing().given(this.structuredOutputChatOptions).setOutputSchema(outputSchemaCaptor.capture());
 
 		var textCallAdvisor = new ContextCatcherCallAdvisor();
 
@@ -435,13 +416,16 @@ public class ChatClientNativeStructuredResponseTests {
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).isEqualTo("Tell me about John");
 
-		JsonAssertions.assertThatJson(outputSchemaCaptor.getValue())
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
+
+		JsonAssertions.assertThatJson(soco.getOutputSchema())
 			.when(Option.IGNORING_ARRAY_ORDER)
 			.isEqualTo(USER_JSON_SCHEMA);
 	}
 
 	@Test
 	public void nativeWithCustomStructuredOutputConverterWithoutJsonSchemaResponseEntityTest() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -450,10 +434,6 @@ public class ChatClientNativeStructuredResponseTests {
 				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
-		ChatOptions.Builder builder = mock(ChatOptions.Builder.class);
-		when(this.chatModel.getDefaultOptions()).thenReturn(this.structuredOutputChatOptions);
-		when(this.structuredOutputChatOptions.mutate()).thenReturn(builder);
-		when(builder.build()).thenReturn(this.structuredOutputChatOptions);
 
 		var textCallAdvisor = new ContextCatcherCallAdvisor();
 
@@ -486,11 +466,13 @@ public class ChatClientNativeStructuredResponseTests {
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).contains("Tell me about John", "Your response should be in JSON format");
 
-		verify(this.structuredOutputChatOptions, never()).setOutputSchema(anyString());
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
+		assertThat(soco.getOutputSchema()).isNull();
 	}
 
 	@Test
 	public void nativeWithCustomStructuredOutputConverterWithoutJsonSchemaEntityTest() {
+		when(this.chatModel.getDefaultOptions()).thenReturn(StructuredOutputChatOptions.builder().build());
 
 		ChatResponseMetadata metadata = ChatResponseMetadata.builder().keyValue("key1", "value1").build();
 
@@ -499,10 +481,6 @@ public class ChatClientNativeStructuredResponseTests {
 				"""))), metadata);
 
 		given(this.chatModel.call(this.promptCaptor.capture())).willReturn(chatResponse);
-		ChatOptions.Builder builder = mock(ChatOptions.Builder.class);
-		when(this.chatModel.getDefaultOptions()).thenReturn(this.structuredOutputChatOptions);
-		when(this.structuredOutputChatOptions.mutate()).thenReturn(builder);
-		when(builder.build()).thenReturn(this.structuredOutputChatOptions);
 
 		var textCallAdvisor = new ContextCatcherCallAdvisor();
 
@@ -532,7 +510,8 @@ public class ChatClientNativeStructuredResponseTests {
 		assertThat(userMessage.getMessageType()).isEqualTo(MessageType.USER);
 		assertThat(userMessage.getText()).contains("Tell me about John", "Your response should be in JSON format");
 
-		verify(this.structuredOutputChatOptions, never()).setOutputSchema(anyString());
+		StructuredOutputChatOptions soco = (StructuredOutputChatOptions) this.promptCaptor.getValue().getOptions();
+		assertThat(soco.getOutputSchema()).isNull();
 	}
 
 	record UserEntity(String name, int age) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptions.java
@@ -48,7 +48,7 @@ public class DefaultChatOptions implements ChatOptions {
 		// TODO remove
 	}
 
-	/* private */ /* TODO move builder as an inner class */ DefaultChatOptions(@Nullable String model,
+	protected /* TODO move builder as an inner class */ DefaultChatOptions(@Nullable String model,
 			@Nullable Double frequencyPenalty, @Nullable Integer maxTokens, @Nullable Double presencePenalty,
 			@Nullable List<String> stopSequences, @Nullable Double temperature, @Nullable Integer topK,
 			@Nullable Double topP) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultStructuredOutputChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultStructuredOutputChatOptions.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.model.tool;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.DefaultChatOptions;
+import org.springframework.ai.chat.prompt.DefaultChatOptionsBuilder;
+
+/**
+ * Default implementation of {@link StructuredOutputChatOptions}.
+ *
+ * Mainly to be used in model generic tests, as concrete chat implementations typically
+ * use dedicated sub implementations specific to the model.
+ *
+ * @author Eric Bottard
+ */
+public class DefaultStructuredOutputChatOptions extends DefaultChatOptions implements StructuredOutputChatOptions {
+
+	private @Nullable String outputSchema;
+
+	protected DefaultStructuredOutputChatOptions(@Nullable String model, @Nullable Double frequencyPenalty,
+			@Nullable Integer maxTokens, @Nullable Double presencePenalty, @Nullable List<String> stopSequences,
+			@Nullable Double temperature, @Nullable Integer topK, @Nullable Double topP,
+			@Nullable String outputSchema) {
+		super(model, frequencyPenalty, maxTokens, presencePenalty, stopSequences, temperature, topK, topP);
+		this.outputSchema = outputSchema;
+	}
+
+	@Override
+	public @Nullable String getOutputSchema() {
+		return this.outputSchema;
+	}
+
+	@Override
+	public void setOutputSchema(String outputSchema) {
+		this.outputSchema = outputSchema;
+	}
+
+	@Override
+	public StructuredOutputChatOptions.Builder<?> mutate() {
+		return StructuredOutputChatOptions.builder()
+			.model(this.getModel())
+			.frequencyPenalty(this.getFrequencyPenalty())
+			.maxTokens(this.getMaxTokens())
+			.presencePenalty(this.getPresencePenalty())
+			.stopSequences(this.getStopSequences())
+			.temperature(this.getTemperature())
+			.topK(this.getTopK())
+			.topP(this.getTopP())
+			.outputSchema(this.getOutputSchema());
+	}
+
+	public static class Builder<B extends DefaultStructuredOutputChatOptions.Builder<B>>
+			extends DefaultChatOptionsBuilder<B> implements StructuredOutputChatOptions.Builder<B> {
+
+		protected @Nullable String outputSchema;
+
+		@Override
+		public B outputSchema(@Nullable String outputSchema) {
+			this.outputSchema = outputSchema;
+			return self();
+		}
+
+		@Override
+		public B clone() {
+			B copy = super.clone();
+			copy.outputSchema = this.outputSchema;
+			return copy;
+		}
+
+		@Override
+		public StructuredOutputChatOptions build() {
+			return new DefaultStructuredOutputChatOptions(this.model, this.frequencyPenalty, this.maxTokens,
+					this.presencePenalty, this.stopSequences, this.temperature, this.topK, this.topP,
+					this.outputSchema);
+		}
+
+		@Override
+		public B combineWith(ChatOptions.Builder<?> other) {
+			super.combineWith(other);
+			if (other instanceof DefaultStructuredOutputChatOptions.Builder<?> that) {
+				if (that.outputSchema != null) {
+					this.outputSchema = that.outputSchema;
+				}
+			}
+			return self();
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/StructuredOutputChatOptions.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/StructuredOutputChatOptions.java
@@ -32,7 +32,14 @@ public interface StructuredOutputChatOptions extends ChatOptions {
 
 	void setOutputSchema(String outputSchema);
 
-	interface Builder<B extends Builder<B>> extends ChatOptions.Builder<B> {
+	/**
+	 * A builder to create a new {@link StructuredOutputChatOptions} instance.
+	 */
+	static StructuredOutputChatOptions.Builder<?> builder() {
+		return new DefaultStructuredOutputChatOptions.Builder<>();
+	}
+
+	interface Builder<B extends StructuredOutputChatOptions.Builder<B>> extends ChatOptions.Builder<B> {
 
 		B outputSchema(@Nullable String outputSchema);
 


### PR DESCRIPTION
After this commit, there are no explicit setters being called in production code.

Setters may still be used by tests, and reflectively when options are used as `@ConfigurationProperties`

