### PR TITLE
Improve chat model observations

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaImage.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/src/test/java/org/springframework/ai/model/ollama/autoconfigure/OllamaImage.java
@@ -18,7 +18,7 @@ package org.springframework.ai.model.ollama.autoconfigure;
 
 public final class OllamaImage {
 
-	public static final String DEFAULT_IMAGE = "ollama/ollama:0.10.1";
+	public static final String DEFAULT_IMAGE = "ollama/ollama:0.23.1";
 
 	private OllamaImage() {
 

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -255,6 +255,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(AiProvider.ANTHROPIC.value())
+				.streaming(true)
 				.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelObservationIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelObservationIT.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for observation instrumentation in {@link AnthropicChatModel}.
  *
  * @author Soby Chacko
+ * @author Thomas Vitale
  */
 @SpringBootTest(classes = AnthropicChatModelObservationIT.Config.class)
 @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
@@ -79,12 +80,13 @@ public class AnthropicChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, false);
 	}
 
 	@Test
@@ -117,11 +119,11 @@ public class AnthropicChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata) {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+	private void validate(ChatResponseMetadata responseMetadata, boolean streaming) {
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -147,6 +149,13 @@ public class AnthropicChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
+++ b/models/spring-ai-bedrock-converse/src/main/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModel.java
@@ -142,6 +142,7 @@ import org.springframework.web.client.RestClientException;
  * @author Jihoon Kim
  * @author Soby Chacko
  * @author Sun Yuhan
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 public class BedrockProxyChatModel implements ChatModel {
@@ -777,6 +778,7 @@ public class BedrockProxyChatModel implements ChatModel {
 			ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(AiProvider.BEDROCK_CONVERSE.value())
+				.streaming(true)
 				.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(

--- a/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelObservationIT.java
+++ b/models/spring-ai-bedrock-converse/src/test/java/org/springframework/ai/bedrock/converse/BedrockProxyChatModelObservationIT.java
@@ -78,12 +78,13 @@ public class BedrockProxyChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata, "[\"end_turn\"]");
+		validate(responseMetadata, "[\"end_turn\"]", false);
 	}
 
 	@Test
@@ -116,11 +117,11 @@ public class BedrockProxyChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata, "[\"end_turn\"]");
+		validate(responseMetadata, "[\"end_turn\"]", true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata, String finishReasons) {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+	private void validate(ChatResponseMetadata responseMetadata, String finishReasons, boolean streaming) {
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -153,6 +154,13 @@ public class BedrockProxyChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -76,6 +76,7 @@ import org.springframework.util.CollectionUtils;
  * backed by {@link DeepSeekApi}.
  *
  * @author Geng Rong
+ * @author Thomas Vitale
  */
 public class DeepSeekChatModel implements ChatModel {
 
@@ -246,6 +247,7 @@ public class DeepSeekChatModel implements ChatModel {
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(DeepSeekConstants.PROVIDER_NAME)
+				.streaming(true)
 				.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelObservationIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelObservationIT.java
@@ -50,6 +50,7 @@ import static org.springframework.ai.chat.observation.ChatModelObservationDocume
  * Integration tests for observation instrumentation in {@link DeepSeekChatModel}.
  *
  * @author Geng Rong
+ * @author Thomas Vitale
  */
 @SpringBootTest(classes = DeepSeekChatModelObservationIT.Config.class)
 @EnabledIfEnvironmentVariable(named = "DEEPSEEK_API_KEY", matches = ".+")
@@ -81,12 +82,13 @@ public class DeepSeekChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, false);
 	}
 
 	@Test
@@ -120,11 +122,11 @@ public class DeepSeekChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata) {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+	private void validate(ChatResponseMetadata responseMetadata, boolean streaming) {
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -153,6 +155,13 @@ public class DeepSeekChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -141,6 +141,7 @@ import org.springframework.util.StringUtils;
  * @author Alexandros Pappas
  * @author Ilayaperumal Gopinathan
  * @author Dan Dobrin
+ * @author Thomas Vitale
  * @since 0.8.1
  * @see GoogleGenAiChatOptions
  * @see ToolCallingManager
@@ -505,6 +506,7 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 			ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(GoogleGenAiConstants.PROVIDER_NAME)
+				.streaming(true)
 				.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelObservationIT.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/GoogleGenAiChatModelObservationIT.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Soby Chacko
+ * @author Thomas Vitale
  */
 @SpringBootTest
 @EnabledIfEnvironmentVariable(named = "GOOGLE_CLOUD_PROJECT", matches = ".+")
@@ -74,12 +75,13 @@ public class GoogleGenAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, false);
 	}
 
 	@Test
@@ -111,11 +113,11 @@ public class GoogleGenAiChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata) {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+	private void validate(ChatResponseMetadata responseMetadata, boolean streaming) {
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -152,6 +154,14 @@ public class GoogleGenAiChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert.doesNotHaveHighCardinalityKeyValueWithKey(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
+++ b/models/spring-ai-minimax/src/main/java/org/springframework/ai/minimax/MiniMaxChatModel.java
@@ -342,6 +342,7 @@ public class MiniMaxChatModel implements ChatModel {
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(requestPrompt)
 				.provider(MiniMaxApiConstants.PROVIDER_NAME)
+				.streaming(true)
 				.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(

--- a/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelObservationIT.java
+++ b/models/spring-ai-minimax/src/test/java/org/springframework/ai/minimax/chat/MiniMaxChatModelObservationIT.java
@@ -83,12 +83,13 @@ public class MiniMaxChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, false);
 	}
 
 	@Test
@@ -121,11 +122,11 @@ public class MiniMaxChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata) {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+	private void validate(ChatResponseMetadata responseMetadata, boolean streaming) {
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -154,6 +155,13 @@ public class MiniMaxChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
+++ b/models/spring-ai-mistral-ai/src/main/java/org/springframework/ai/mistralai/MistralAiChatModel.java
@@ -263,6 +263,7 @@ public class MistralAiChatModel implements ChatModel {
 			ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(MistralAiApi.PROVIDER_NAME)
+				.streaming(true)
 				.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(

--- a/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelObservationIT.java
+++ b/models/spring-ai-mistral-ai/src/test/java/org/springframework/ai/mistralai/MistralAiChatModelObservationIT.java
@@ -82,12 +82,13 @@ public class MistralAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, false);
 	}
 
 	@Test
@@ -121,11 +122,11 @@ public class MistralAiChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata) {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+	private void validate(ChatResponseMetadata responseMetadata, boolean streaming) {
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -167,6 +168,13 @@ public class MistralAiChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -326,6 +326,7 @@ public class OllamaChatModel implements ChatModel {
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(OllamaApiConstants.PROVIDER_NAME)
+				.streaming(true)
 				.build();
 
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelObservationIT.java
@@ -83,12 +83,13 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, false);
 	}
 
 	@Test
@@ -123,11 +124,11 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		Awaitility.await().untilAsserted(() -> validate(responseMetadata));
+		Awaitility.await().untilAsserted(() -> validate(responseMetadata, true));
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata) {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+	private void validate(ChatResponseMetadata responseMetadata, boolean streaming) {
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -155,6 +156,13 @@ public class OllamaChatModelObservationIT extends BaseOllamaIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaImage.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class OllamaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.12.10");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.23.1");
 
 	private OllamaImage() {
 

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -108,6 +108,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Soby Chacko
  * @author Ilayaperumal Gopinathan
+ * @author Thomas Vitale
  */
 public final class OpenAiChatModel implements ChatModel {
 
@@ -297,6 +298,7 @@ public final class OpenAiChatModel implements ChatModel {
 			final ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
 				.prompt(prompt)
 				.provider(AiProvider.OPENAI.value())
+				.streaming(true)
 				.build();
 			Observation observation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(
 					this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiChatModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/azure/AzureOpenAiChatModelObservationIT.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Soby Chacko
+ * @author Thomas Vitale
  */
 @SpringBootTest(classes = AzureOpenAiChatModelObservationIT.TestConfiguration.class)
 @EnabledIfEnvironmentVariables({ @EnabledIfEnvironmentVariable(named = "AZURE_OPENAI_API_KEY", matches = ".+"),
@@ -78,12 +79,13 @@ class AzureOpenAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata, true);
+		validate(responseMetadata, true, false);
 	}
 
 	@Test
@@ -118,10 +120,10 @@ class AzureOpenAiChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata, false);
+		validate(responseMetadata, false, true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata, boolean checkModel) {
+	private void validate(ChatResponseMetadata responseMetadata, boolean checkModel, boolean streaming) {
 
 		TestObservationRegistryAssert.That that = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
@@ -135,7 +137,7 @@ class AzureOpenAiChatModelObservationIT {
 						responseMetadata.getModel());
 		}
 
-		that.that()
+		var observationAssert = that.that()
 			.hasLowCardinalityKeyValue(
 					ChatModelObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE.asString(),
 					AiOperationType.CHAT.value())
@@ -175,6 +177,14 @@ class AzureOpenAiChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert.doesNotHaveHighCardinalityKeyValueWithKey(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/OpenAiChatModelObservationIT.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Julien Dubois
  * @author Soby Chacko
+ * @author Thomas Vitale
  */
 @SpringBootTest
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
@@ -73,12 +74,13 @@ public class OpenAiChatModelObservationIT {
 		Prompt prompt = new Prompt("Why does a raven look like a desk?", options);
 
 		ChatResponse chatResponse = this.chatModel.call(prompt);
+		assertThat(chatResponse.getResult()).isNotNull();
 		assertThat(chatResponse.getResult().getOutput().getText()).isNotEmpty();
 
 		ChatResponseMetadata responseMetadata = chatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, false);
 	}
 
 	@Test
@@ -107,13 +109,13 @@ public class OpenAiChatModelObservationIT {
 		ChatResponseMetadata responseMetadata = lastChatResponse.getMetadata();
 		assertThat(responseMetadata).isNotNull();
 
-		validate(responseMetadata);
+		validate(responseMetadata, true);
 	}
 
-	private void validate(ChatResponseMetadata responseMetadata) throws InterruptedException {
+	private void validate(ChatResponseMetadata responseMetadata, boolean streaming) throws InterruptedException {
 		Thread.sleep(100); // Wait for observation to be recorded
 
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+		var observationAssert = TestObservationRegistryAssert.assertThat(this.observationRegistry)
 			.doesNotHaveAnyRemainingCurrentObservation()
 			.hasObservationWithNameEqualTo(DefaultChatModelObservationConvention.DEFAULT_NAME)
 			.that()
@@ -133,6 +135,13 @@ public class OpenAiChatModelObservationIT {
 					String.valueOf(responseMetadata.getUsage().getTotalTokens()))
 			.hasBeenStarted()
 			.hasBeenStopped();
+		if (streaming) {
+			observationAssert.hasHighCardinalityKeyValue(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true");
+		}
+		else {
+			observationAssert
+				.doesNotHaveHighCardinalityKeyValueWithKey(HighCardinalityKeyNames.REQUEST_STREAM.asString());
+		}
 	}
 
 	@SpringBootConfiguration

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/OllamaWithOpenAiChatModelIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/OllamaWithOpenAiChatModelIT.java
@@ -93,7 +93,7 @@ class OllamaWithOpenAiChatModelIT {
 	@BeforeAll
 	public static void beforeAll() throws IOException, InterruptedException {
 		if (!SKIP_CONTAINER_CREATION) {
-			ollamaContainer = new OllamaContainer("ollama/ollama:0.10.1").withReuse(true);
+			ollamaContainer = new OllamaContainer("ollama/ollama:0.23.1").withReuse(true);
 			ollamaContainer.start();
 			logger.info(
 					"Start pulling the '" + DEFAULT_OLLAMA_MODEL + " ' generative ... would take several minutes ...");

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/AiObservationAttributes.java
@@ -17,14 +17,13 @@
 package org.springframework.ai.observation.conventions;
 
 /**
- * Collection of attribute keys used in AI observations (spans, metrics, events). Based on
- * the OpenTelemetry Semantic Conventions for AI Systems.
+ * Collection of attribute keys used in AI observations (spans, metrics, events). Inspired
+ * by the OpenTelemetry Semantic Conventions for Generative AI.
  *
  * @author Thomas Vitale
  * @since 1.0.0
- * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai">OTel
- * Semantic Conventions</a>.
+ * @see <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai">OpenTelemetry
+ * Semantic Conventions for Generative AI</a>.
  */
 public enum AiObservationAttributes {
 
@@ -63,6 +62,10 @@ public enum AiObservationAttributes {
 	 * List of sequences that the model will use to stop generating further tokens.
 	 */
 	REQUEST_STOP_SEQUENCES("gen_ai.request.stop_sequences"),
+	/**
+	 * Indicates whether the GenAI request was made in streaming mode.
+	 */
+	REQUEST_STREAM("gen_ai.request.stream"),
 	/**
 	 * The temperature setting for the model request.
 	 */
@@ -115,6 +118,14 @@ public enum AiObservationAttributes {
 
 	// GenAI Usage
 
+	/**
+	 * The number of input tokens written to a provider-managed cache.
+	 */
+	USAGE_CACHE_WRITE_INPUT_TOKENS("gen_ai.usage.cache_creation.input_tokens"),
+	/**
+	 * The number of input tokens served from a provider-managed cache.
+	 */
+	USAGE_CACHE_READ_INPUT_TOKENS("gen_ai.usage.cache_read.input_tokens"),
 	/**
 	 * The number of tokens used in the model input.
 	 */

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -1,45 +1,12 @@
 [[introduction]]
 = Observability
 
-Spring AI builds upon the observability features in the Spring ecosystem to provide insights into AI-related operations.
+Spring AI builds upon the observability features in the Spring ecosystem to provide insights into AI-related operations. It provides metrics and tracing capabilities for its core components: `ChatClient` (including `Advisor`), `ChatModel`, `EmbeddingModel`, `ImageModel`, and `VectorStore`.
 
-The spring-boot-actuator module is required for enabling observability.
-Add the Spring Boot Actuator dependency to your project's Maven `pom.xml` build file:
+Refer to the https://docs.spring.io/spring-boot/reference/actuator/metrics.html[Spring Boot Metrics] and
+https://docs.spring.io/spring-boot/reference/actuator/tracing.html[Spring Boot Tracing] documentation to enable metrics and tracing support in your application.
 
-[source,xml]
-----
-<dependency>
- <groupId>org.springframework.boot</groupId>
- <artifactId>spring-boot-starter-actuator</artifactId>
-</dependency>
-----
-
-or to your Gradle `build.gradle` build file.
-
-[source,groovy]
-----
-dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-}
-----
-
-Spring AI provides metrics and tracing capabilities for its core components: `ChatClient` (including `Advisor`),
-`ChatModel`, `EmbeddingModel`, `ImageModel`, and `VectorStore`.
-
-NOTE: Low cardinality keys will be added to metrics and traces, while high cardinality keys will only be added to traces.
-
-[WARNING]
-====
-**1.0.0-RC1 Breaking Changes** 
-
-Following configuration properties have been renamed to better reflect their purpose:
-
-* `spring.ai.chat.client.observations.include-prompt` → `spring.ai.chat.client.observations.log-prompt`
-* `spring.ai.chat.observations.include-prompt` → `spring.ai.chat.observations.log-prompt`
-* `spring.ai.chat.observations.include-completion` → `spring.ai.chat.observations.log-completion`
-* `spring.ai.image.observations.include-prompt` → `spring.ai.image.observations.log-prompt`
-* `spring.ai.vectorstore.observations.include-query-response` → `spring.ai.vectorstore.observations.log-query-response`
-====
+NOTE: Low-cardinality keys will be added to metrics and traces, while high-cardinality keys will only be added to traces.
 
 == Chat Client
 
@@ -61,18 +28,9 @@ They measure the time spent performing the invocation and propagate the related 
 [cols="a,a", stripes=even]
 |===
 |Name | Description
-
-|`gen_ai.prompt` | The content of the prompt sent via the chat client. Optional.
-|`spring.ai.chat.client.advisor.params` (deprecated) | Map of advisor parameters. The conversation ID is now included in `spring.ai.chat.client.conversation.id`.
 |`spring.ai.chat.client.advisors` | List of configured chat client advisors.
 |`spring.ai.chat.client.conversation.id` | Identifier of the conversation when using the chat memory.
-|`spring.ai.chat.client.system.params` (deprecated) |Chat client system parameters. Optional. Superseded by `gen_ai.prompt`.
-|`spring.ai.chat.client.system.text` (deprecated) |Chat client system text. Optional. Superseded by `gen_ai.prompt`.
-|`spring.ai.chat.client.tool.function.names` (deprecated) | Enabled tool function names. Superseded by `spring.ai.chat.client.tool.names`.
-|`spring.ai.chat.client.tool.function.callbacks` (deprecated) |List of configured chat client function callbacks. Superseded by `spring.ai.chat.client.tool.names`.
 |`spring.ai.chat.client.tool.names` | Names of the tools passed to the chat client.
-|`spring.ai.chat.client.user.params` (deprecated) | Chat client user parameters. Optional. Superseded by `gen_ai.prompt`.
-|`spring.ai.chat.client.user.text` (deprecated) | Chat client user text. Optional. Superseded by `gen_ai.prompt`.
 |===
 
 === Prompt and Completion Data
@@ -92,28 +50,10 @@ Spring AI supports logging the prompt and completion data to help with debugging
 
 WARNING: If you enable logging of the chat client prompt and completion data, there's a risk of exposing sensitive or private information. Please, be careful!
 
-=== Input Data (Deprecated)
-
-WARNING: The `spring.ai.chat.client.observations.include-input` property is deprecated, replaced by `spring.ai.chat.client.observations.log-prompt`. See xref:_prompt_content[Prompt Content].
-
-The `ChatClient` input data is typically big and possibly containing sensitive information.
-For those reasons, it is not exported by default.
-
-Spring AI supports logging input data to help with debugging and troubleshooting.
-
-[cols="6,3,1", stripes=even]
-|====
-| Property | Description | Default
-
-| `spring.ai.chat.client.observations.include-input` |  Whether to include the input content in the observations. | `false`
-|====
-
-WARNING: If you enable the inclusion of the input content in the observations, there's a risk of exposing sensitive or private information. Please, be careful!
-
 === Chat Client Advisors
 
 The `spring.ai.advisor` observations are recorded when an advisor is executed.
-They measure the time spent in the advisor (including the time spend on the inner advisors) and propagate the related tracing information.
+They measure the time spent in the advisor (including the time spent on the inner advisors) and propagate the related tracing information.
 
 .Low Cardinality Keys
 [cols="a,a", stripes=even]
@@ -122,7 +62,7 @@ They measure the time spent in the advisor (including the time spend on the inne
 
 |`gen_ai.operation.name` | Always `framework`.
 |`gen_ai.system` | Always `spring_ai`.
-|`spring.ai.advisor.type` (deprecated) | Where the advisor applies it's logic in the request processing, one of `BEFORE`, `AFTER`, or `AROUND`. This distinction doesn't apply anymore since all Advisors are always of the same type.
+|`spring.ai.advisor.name` | Name of the advisor.
 |`spring.ai.kind` | The kind of framework API in Spring AI: `advisor`.
 |===
 
@@ -131,15 +71,10 @@ They measure the time spent in the advisor (including the time spend on the inne
 |===
 |Name | Description
 
-|`spring.ai.advisor.name`| Name of the advisor.
 |`spring.ai.advisor.order`| Advisor order in the advisor chain.
 |===
 
 == Chat Model
-
-NOTE: Observability features are currently supported only for `ChatModel` implementations from the following AI model
-providers: Anthropic, Mistral AI, Ollama, OpenAI, Google GenAI, MiniMax, Moonshot, QianFan.
-Additional AI model providers will be supported in a future release.
 
 [IMPORTANT]
 ====
@@ -155,7 +90,6 @@ The `gen_ai.client.operation` observations are recorded when calling the ChatMod
 They measure the time spent on method completion and propagate the related tracing information.
 
 IMPORTANT: The `gen_ai.client.token.usage` metrics measures number of input and output tokens used by a single model call.
-
 
 .Low Cardinality Keys
 [cols="a,a", stripes=even]
@@ -177,22 +111,22 @@ IMPORTANT: The `gen_ai.client.token.usage` metrics measures number of input and 
 |`gen_ai.request.max_tokens` | The maximum number of tokens the model generates for a request.
 |`gen_ai.request.presence_penalty` | The presence penalty setting for the model request.
 |`gen_ai.request.stop_sequences` | List of sequences that the model will use to stop generating further tokens.
+|`gen_ai.request.stream` | Whether the request was made in streaming mode. Only present when `true`.
 |`gen_ai.request.temperature` | The temperature setting for the model request.
 |`gen_ai.request.top_k` | The top_k sampling setting for the model request.
 |`gen_ai.request.top_p` | The top_p sampling setting for the model request.
 |`gen_ai.response.finish_reasons` | Reasons the model stopped generating tokens, corresponding to each generation received.
 |`gen_ai.response.id` | The unique identifier for the AI response.
+|`gen_ai.usage.cache_creation.input_tokens` | The number of input tokens written to a provider-managed cache.
+|`gen_ai.usage.cache_read.input_tokens` | The number of input tokens served from a provider-managed cache.
 |`gen_ai.usage.input_tokens` | The number of tokens used in the model input (prompt).
 |`gen_ai.usage.output_tokens` | The number of tokens used in the model output (completion).
 |`gen_ai.usage.total_tokens` | The total number of tokens used in the model exchange.
-|`gen_ai.prompt` | The full prompt sent to the model. Optional.
-|`gen_ai.completion` | The full response received from the model. Optional.
 |`spring.ai.model.request.tool.names` | List of tool definitions provided to the model in the request.
 |===
 
 NOTE: For measuring user tokens, the previous table lists the values present in an observation trace.
 Use the metric name `gen_ai.client.token.usage` that is provided by the `ChatModel`.
-
 
 === Chat Prompt and Completion Data
 
@@ -214,7 +148,7 @@ WARNING: If you enable logging of the chat prompt and completion data, there's a
 
 == Tool Calling
 
-The `spring.ai.tool` observations are recorded when performing tool calling in the context of a chat model interaction. They measure the time spent on toll call completion and propagate the related tracing information.
+The `spring.ai.tool` observations are recorded when performing tool calling in the context of a chat model interaction. They measure the time spent on tool call completion and propagate the related tracing information.
 
 .Low Cardinality Keys
 [cols="a,a", stripes=even]
@@ -291,15 +225,10 @@ Use the metric name `gen_ai.client.token.usage` that is provided by the `Embeddi
 
 == Image Model
 
-NOTE: Observability features are currently supported only for `ImageModel` implementations from the following AI model
-providers: OpenAI.
-Additional AI model providers will be supported in a future release.
+NOTE: Observability features are currently supported only for `ImageModel` implementations from the following AI model providers: OpenAI. Additional AI model providers will be supported in a future release.
 
-The `gen_ai.client.operation` observations are recorded on image model method calls. 
+The `gen_ai.client.operation` observations are recorded on image model method calls.
 They measure the time spent on method completion and propagate the related tracing information.
-
-IMPORTANT: The `gen_ai.client.token.usage` metrics measures number of input and output tokens used by a single model call.
-
 
 .Low Cardinality Keys
 [cols="a,a", stripes=even]
@@ -312,23 +241,14 @@ IMPORTANT: The `gen_ai.client.token.usage` metrics measures number of input and 
 |===
 
 .High Cardinality Keys
+[cols="a,a", stripes=even]
 |===
 |Name | Description
 
 |`gen_ai.request.image.response_format` | The format in which the generated image is returned.
-|`gen_ai.request.image.size` | The size of the image to generate.
+|`gen_ai.request.image.size` | The size of the image to generate (e.g. `1024x1024`).
 |`gen_ai.request.image.style` | The style of the image to generate.
-|`gen_ai.response.id` | The unique identifier for the AI response.
-|`gen_ai.response.model` | The name of the model that generated the response.
-|`gen_ai.usage.input_tokens` | The number of tokens used in the model input (prompt).
-|`gen_ai.usage.output_tokens` | The number of tokens used in the model output (generation).
-|`gen_ai.usage.total_tokens` | The total number of tokens used in the model exchange.
-|`gen_ai.prompt` | The full prompt sent to the model. Optional.
 |===
-
-NOTE: For measuring user tokens, the previous table lists the values present in an observation trace.
-Use the metric name `gen_ai.client.token.usage` that is provided by the `ImageModel`.
-
 
 === Image Prompt Data
 
@@ -370,7 +290,6 @@ They measure the time spent on the `query`, `add` and `remove` operations and pr
 
 |`db.collection.name` | The name of a collection (table, container) within the database.
 |`db.namespace` | The name of the database, fully qualified within the server address and port.
-|`db.record.id` | The record identifier if present.
 |`db.search.similarity_metric` | The metric used in similarity search.
 |`db.vector.dimension_count` | The dimension of the vector.
 |`db.vector.field_name` | The name field as of the vector (e.g. a field name).
@@ -380,7 +299,6 @@ They measure the time spent on the `query`, `add` and `remove` operations and pr
 |`db.vector.query.similarity_threshold` | Similarity threshold that accepts all search scores. A threshold value of 0.0 means any similarity is accepted or disable the similarity threshold filtering. A threshold value of 1.0 means an exact match is required.
 |`db.vector.query.top_k` | The top-k most similar vectors returned by a query.
 |===
-
 
 === Response Data
 

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationContext.java
@@ -33,9 +33,16 @@ import org.springframework.util.Assert;
  */
 public class ChatModelObservationContext extends ModelObservationContext<Prompt, ChatResponse> {
 
-	ChatModelObservationContext(Prompt prompt, String provider) {
+	private final boolean streaming;
+
+	ChatModelObservationContext(Prompt prompt, String provider, boolean streaming) {
 		super(prompt,
 				AiOperationMetadata.builder().operationType(AiOperationType.CHAT.value()).provider(provider).build());
+		this.streaming = streaming;
+	}
+
+	public boolean isStreaming() {
+		return this.streaming;
 	}
 
 	public static Builder builder() {
@@ -47,6 +54,8 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 		private @Nullable Prompt prompt;
 
 		private @Nullable String provider;
+
+		private boolean streaming;
 
 		private Builder() {
 		}
@@ -61,10 +70,15 @@ public class ChatModelObservationContext extends ModelObservationContext<Prompt,
 			return this;
 		}
 
+		public Builder streaming(boolean streaming) {
+			this.streaming = streaming;
+			return this;
+		}
+
 		public ChatModelObservationContext build() {
 			Assert.state(this.prompt != null, "Prompt must not be null");
 			Assert.state(this.provider != null, "Provider must not be null");
-			return new ChatModelObservationContext(this.prompt, this.provider);
+			return new ChatModelObservationContext(this.prompt, this.provider, this.streaming);
 		}
 
 	}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/ChatModelObservationDocumentation.java
@@ -142,6 +142,16 @@ public enum ChatModelObservationDocumentation implements ObservationDocumentatio
 		},
 
 		/**
+		 * Indicates whether the GenAI request was made in streaming mode.
+		 */
+		REQUEST_STREAM {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.REQUEST_STREAM.value();
+			}
+		},
+
+		/**
 		 * The temperature setting for the model request.
 		 */
 		REQUEST_TEMPERATURE {
@@ -205,6 +215,26 @@ public enum ChatModelObservationDocumentation implements ObservationDocumentatio
 		},
 
 		// Usage
+
+		/**
+		 * The number of input tokens written to a provider-managed cache.
+		 */
+		USAGE_CACHE_WRITE_INPUT_TOKENS {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.USAGE_CACHE_WRITE_INPUT_TOKENS.value();
+			}
+		},
+
+		/**
+		 * The number of input tokens served from a provider-managed cache.
+		 */
+		USAGE_CACHE_READ_INPUT_TOKENS {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.USAGE_CACHE_READ_INPUT_TOKENS.value();
+			}
+		},
 
 		/**
 		 * The number of tokens used in the model input (prompt).

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConvention.java
@@ -85,8 +85,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 	}
 
 	protected KeyValue responseModel(ChatModelObservationContext context) {
-		if (context.getResponse() != null && context.getResponse().getMetadata() != null
-				&& StringUtils.hasText(context.getResponse().getMetadata().getModel())) {
+		if (context.getResponse() != null && StringUtils.hasText(context.getResponse().getMetadata().getModel())) {
 			return KeyValue.of(ChatModelObservationDocumentation.LowCardinalityKeyNames.RESPONSE_MODEL,
 					context.getResponse().getMetadata().getModel());
 		}
@@ -101,6 +100,7 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 		keyValues = requestMaxTokens(keyValues, context);
 		keyValues = requestPresencePenalty(keyValues, context);
 		keyValues = requestStopSequences(keyValues, context);
+		keyValues = requestStream(keyValues, context);
 		keyValues = requestTemperature(keyValues, context);
 		keyValues = requestTools(keyValues, context);
 		keyValues = requestTopK(keyValues, context);
@@ -108,6 +108,8 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 		// Response
 		keyValues = responseFinishReasons(keyValues, context);
 		keyValues = responseId(keyValues, context);
+		keyValues = usageCacheWriteInputTokens(keyValues, context);
+		keyValues = usageCacheReadInputTokens(keyValues, context);
 		keyValues = usageInputTokens(keyValues, context);
 		keyValues = usageOutputTokens(keyValues, context);
 		keyValues = usageTotalTokens(keyValues, context);
@@ -142,6 +144,14 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString(),
 					String.valueOf(options.getPresencePenalty()));
+		}
+		return keyValues;
+	}
+
+	protected KeyValues requestStream(KeyValues keyValues, ChatModelObservationContext context) {
+		if (context.isStreaming()) {
+			return keyValues.and(ChatModelObservationDocumentation.HighCardinalityKeyNames.REQUEST_STREAM.asString(),
+					String.valueOf(true));
 		}
 		return keyValues;
 	}
@@ -227,18 +237,36 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 	}
 
 	protected KeyValues responseId(KeyValues keyValues, ChatModelObservationContext context) {
-		if (context.getResponse() != null && context.getResponse().getMetadata() != null
-				&& StringUtils.hasText(context.getResponse().getMetadata().getId())) {
+		if (context.getResponse() != null && StringUtils.hasText(context.getResponse().getMetadata().getId())) {
 			return keyValues.and(ChatModelObservationDocumentation.HighCardinalityKeyNames.RESPONSE_ID.asString(),
 					context.getResponse().getMetadata().getId());
 		}
 		return keyValues;
 	}
 
+	protected KeyValues usageCacheWriteInputTokens(KeyValues keyValues, ChatModelObservationContext context) {
+		if (context.getResponse() != null && context.getResponse().getMetadata().getUsage() != null
+				&& context.getResponse().getMetadata().getUsage().getCacheWriteInputTokens() != null) {
+			return keyValues.and(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_CACHE_WRITE_INPUT_TOKENS.asString(),
+					String.valueOf(context.getResponse().getMetadata().getUsage().getCacheWriteInputTokens()));
+		}
+		return keyValues;
+	}
+
+	protected KeyValues usageCacheReadInputTokens(KeyValues keyValues, ChatModelObservationContext context) {
+		if (context.getResponse() != null && context.getResponse().getMetadata().getUsage() != null
+				&& context.getResponse().getMetadata().getUsage().getCacheReadInputTokens() != null) {
+			return keyValues.and(
+					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_CACHE_READ_INPUT_TOKENS.asString(),
+					String.valueOf(context.getResponse().getMetadata().getUsage().getCacheReadInputTokens()));
+		}
+		return keyValues;
+	}
+
 	protected KeyValues usageInputTokens(KeyValues keyValues, ChatModelObservationContext context) {
-		if (context.getResponse() != null && context.getResponse().getMetadata() != null
-				&& context.getResponse().getMetadata().getUsage() != null
-				&& context.getResponse().getMetadata().getUsage().getPromptTokens() != null) {
+		if (context.getResponse() != null && context.getResponse().getMetadata().getUsage() != null) {
+			context.getResponse().getMetadata().getUsage().getPromptTokens();
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_INPUT_TOKENS.asString(),
 					String.valueOf(context.getResponse().getMetadata().getUsage().getPromptTokens()));
@@ -247,9 +275,8 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 	}
 
 	protected KeyValues usageOutputTokens(KeyValues keyValues, ChatModelObservationContext context) {
-		if (context.getResponse() != null && context.getResponse().getMetadata() != null
-				&& context.getResponse().getMetadata().getUsage() != null
-				&& context.getResponse().getMetadata().getUsage().getCompletionTokens() != null) {
+		if (context.getResponse() != null && context.getResponse().getMetadata().getUsage() != null) {
+			context.getResponse().getMetadata().getUsage().getCompletionTokens();
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_OUTPUT_TOKENS.asString(),
 					String.valueOf(context.getResponse().getMetadata().getUsage().getCompletionTokens()));
@@ -258,9 +285,8 @@ public class DefaultChatModelObservationConvention implements ChatModelObservati
 	}
 
 	protected KeyValues usageTotalTokens(KeyValues keyValues, ChatModelObservationContext context) {
-		if (context.getResponse() != null && context.getResponse().getMetadata() != null
-				&& context.getResponse().getMetadata().getUsage() != null
-				&& context.getResponse().getMetadata().getUsage().getTotalTokens() != null) {
+		if (context.getResponse() != null && context.getResponse().getMetadata().getUsage() != null) {
+			context.getResponse().getMetadata().getUsage().getTotalTokens();
 			return keyValues.and(
 					ChatModelObservationDocumentation.HighCardinalityKeyNames.USAGE_TOTAL_TOKENS.asString(),
 					String.valueOf(context.getResponse().getMetadata().getUsage().getTotalTokens()));

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/ChatModelObservationContextTests.java
@@ -40,6 +40,38 @@ class ChatModelObservationContextTests {
 		assertThat(observationContext).isNotNull();
 	}
 
+	@Test
+	void whenStreamingNotSetThenDefaultToFalse() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.build();
+
+		assertThat(observationContext.isStreaming()).isFalse();
+	}
+
+	@Test
+	void whenStreamingTrueThenReturn() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+
+		assertThat(observationContext.isStreaming()).isTrue();
+	}
+
+	@Test
+	void whenStreamingFalseThenReturn() {
+		var observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("supermodel").build()))
+			.provider("superprovider")
+			.streaming(false)
+			.build();
+
+		assertThat(observationContext.isStreaming()).isFalse();
+	}
+
 	private Prompt generatePrompt(ChatOptions chatOptions) {
 		return new Prompt("hello", chatOptions);
 	}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/observation/DefaultChatModelObservationConventionTests.java
@@ -149,11 +149,14 @@ class DefaultChatModelObservationConventionTests {
 					HighCardinalityKeyNames.REQUEST_MAX_TOKENS.asString(),
 					HighCardinalityKeyNames.REQUEST_PRESENCE_PENALTY.asString(),
 					HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
+					HighCardinalityKeyNames.REQUEST_STREAM.asString(),
 					HighCardinalityKeyNames.REQUEST_TEMPERATURE.asString(),
 					HighCardinalityKeyNames.REQUEST_TOOL_NAMES.asString(),
 					HighCardinalityKeyNames.REQUEST_TOP_K.asString(), HighCardinalityKeyNames.REQUEST_TOP_P.asString(),
 					HighCardinalityKeyNames.RESPONSE_FINISH_REASONS.asString(),
 					HighCardinalityKeyNames.RESPONSE_ID.asString(),
+					HighCardinalityKeyNames.USAGE_CACHE_WRITE_INPUT_TOKENS.asString(),
+					HighCardinalityKeyNames.USAGE_CACHE_READ_INPUT_TOKENS.asString(),
 					HighCardinalityKeyNames.USAGE_INPUT_TOKENS.asString(),
 					HighCardinalityKeyNames.USAGE_OUTPUT_TOKENS.asString(),
 					HighCardinalityKeyNames.USAGE_TOTAL_TOKENS.asString());
@@ -175,6 +178,32 @@ class DefaultChatModelObservationConventionTests {
 			.toList()).doesNotContain(HighCardinalityKeyNames.REQUEST_STOP_SEQUENCES.asString(),
 					HighCardinalityKeyNames.RESPONSE_FINISH_REASONS.asString(),
 					HighCardinalityKeyNames.RESPONSE_ID.asString());
+	}
+
+	@Test
+	void shouldHaveRequestStreamWhenStreaming() {
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.streaming(true)
+			.build();
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext))
+			.contains(KeyValue.of(HighCardinalityKeyNames.REQUEST_STREAM.asString(), "true"));
+	}
+
+	@Test
+	void shouldHaveKeyValuesWhenCacheTokensDefined() {
+		ChatModelObservationContext observationContext = ChatModelObservationContext.builder()
+			.prompt(generatePrompt(ChatOptions.builder().model("mistral").build()))
+			.provider("superprovider")
+			.build();
+		observationContext.setResponse(new ChatResponse(
+				List.of(new Generation(new AssistantMessage("response"),
+						ChatGenerationMetadata.builder().finishReason("stop").build())),
+				ChatResponseMetadata.builder().id("id42").model("mistral-42").usage(new TestCacheUsage()).build()));
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(observationContext)).contains(
+				KeyValue.of(HighCardinalityKeyNames.USAGE_CACHE_WRITE_INPUT_TOKENS.asString(), "200"),
+				KeyValue.of(HighCardinalityKeyNames.USAGE_CACHE_READ_INPUT_TOKENS.asString(), "100"));
 	}
 
 	@Test
@@ -217,6 +246,20 @@ class DefaultChatModelObservationConventionTests {
 			usage.put("completionTokens", getCompletionTokens());
 			usage.put("totalTokens", getTotalTokens());
 			return usage;
+		}
+
+	}
+
+	static class TestCacheUsage extends TestUsage {
+
+		@Override
+		public Long getCacheWriteInputTokens() {
+			return 200L;
+		}
+
+		@Override
+		public Long getCacheReadInputTokens() {
+			return 100L;
 		}
 
 	}

--- a/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaImage.java
+++ b/spring-ai-spring-boot-testcontainers/src/test/java/org/springframework/ai/testcontainers/service/connection/ollama/OllamaImage.java
@@ -23,7 +23,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public final class OllamaImage {
 
-	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.10.1");
+	public static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("ollama/ollama:0.23.1");
 
 	private OllamaImage() {
 


### PR DESCRIPTION
* Add gen_ai.request.stream attribute indicating whether the request was made in streaming mode.
* Add provider cache token usage tracking via gen_ai.usage.cache_creation.input_tokens and gen_ai.usage.cache_read.input_tokens attributes.
* Update observability documentation.