### PR TITLE
Pass back `reasoning_content` in tool-calling for DeepSeek API

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java
@@ -415,14 +415,17 @@ public class DeepSeekChatModel implements ChatModel {
 					}).toList();
 				}
 				Boolean isPrefixAssistantMessage = null;
-				if (message instanceof DeepSeekAssistantMessage
-						&& Boolean.TRUE.equals(((DeepSeekAssistantMessage) message).getPrefix())) {
-					isPrefixAssistantMessage = true;
+				String reasoningContent = null;
+				if (message instanceof DeepSeekAssistantMessage deepSeekAssistantMessage) {
+					if (Boolean.TRUE.equals(deepSeekAssistantMessage.getPrefix())) {
+						isPrefixAssistantMessage = true;
+					}
+					reasoningContent = deepSeekAssistantMessage.getReasoningContent();
 				}
 				String text = assistantMessage.getText();
 				Assert.state(text != null, "text must not be null");
 				return List.of(new ChatCompletionMessage(text, ChatCompletionMessage.Role.ASSISTANT, null, null,
-						toolCalls, isPrefixAssistantMessage, null));
+						toolCalls, isPrefixAssistantMessage, reasoningContent));
 			}
 			else if (message.getMessageType() == MessageType.TOOL) {
 				ToolResponseMessage toolMessage = (ToolResponseMessage) message;

--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
@@ -86,6 +86,10 @@ public class DeepSeekStreamFunctionCallingHelper {
 		String toolCallId = (current.toolCallId() != null ? current.toolCallId()
 				: (previous != null ? previous.toolCallId() : null));
 
+		Boolean prefix = (current.prefix() != null ? current.prefix() : (previous != null ? previous.prefix() : null));
+		String reasoningContent = (current.reasoningContent() != null ? current.reasoningContent()
+				: (previous != null ? previous.reasoningContent() : null));
+
 		List<ToolCall> toolCalls = new ArrayList<>();
 		ToolCall lastPreviousTooCall = null;
 		if (previous != null && !CollectionUtils.isEmpty(previous.toolCalls())) {
@@ -114,7 +118,7 @@ public class DeepSeekStreamFunctionCallingHelper {
 				toolCalls.add(lastPreviousTooCall);
 			}
 		}
-		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls);
+		return new ChatCompletionMessage(content, role, name, toolCallId, toolCalls, prefix, reasoningContent);
 	}
 
 	private ToolCall merge(@Nullable ToolCall previous, ToolCall current) {

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/chat/DeepSeekChatModelFunctionCallingIT.java
@@ -35,6 +35,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.deepseek.DeepSeekAssistantMessage;
 import org.springframework.ai.deepseek.DeepSeekChatOptions;
 import org.springframework.ai.deepseek.DeepSeekTestConfiguration;
 import org.springframework.ai.deepseek.api.DeepSeekApi;
@@ -178,6 +179,34 @@ class DeepSeekChatModelFunctionCallingIT {
 		assertThat(chatResponse).isNotNull();
 		assertThat(chatResponse.getMetadata()).isNotNull();
 		assertThat(chatResponse.getMetadata().getUsage()).isNotNull();
+	}
+
+	@Test
+	void reasonerFunctionCallTest() {
+		UserMessage userMessage = new UserMessage(
+				"What's the weather like in San Francisco? Return the temperature in Celsius.");
+		List<Message> messages = new ArrayList<>(List.of(userMessage));
+
+		var promptOptions = DeepSeekChatOptions.builder()
+			.model("deepseek-v4-pro")
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+				.description("Get the weather in location")
+				.inputType(MockWeatherService.Request.class)
+				.build()))
+			.build();
+
+		ChatResponse response = this.chatModel.call(new Prompt(messages, promptOptions));
+
+		logger.info("Response: {}", response);
+
+		assertThat(response).isNotNull();
+		assertThat(response.getResult()).isNotNull();
+		assertThat(response.getResult().getOutput()).isNotNull();
+		assertThat(response.getResult().getOutput()).isInstanceOf(DeepSeekAssistantMessage.class);
+		DeepSeekAssistantMessage assistantMessage = (DeepSeekAssistantMessage) response.getResult().getOutput();
+		assertThat(assistantMessage.getReasoningContent()).isNotEmpty();
+		assertThat(assistantMessage.getText()).isNotEmpty();
+		assertThat(assistantMessage.getText()).contains("30");
 	}
 
 }


### PR DESCRIPTION
Fix GH-5963.

DeepSeek API requires the `reasoning_content` from previous assistant messages to be included in the conversation history, especially during multi-turn tool calling. Omitting this field results in an HTTP 400 error. See the original issue for more details.