### PR TITLE
Deprecate SSE transports, set Streamable HTTP as default server protocol

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/PropertiesMcpSseClientConnectionDetails.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/PropertiesMcpSseClientConnectionDetails.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.springframework.ai.mcp.client.common.autoconfigure.properties.McpSseClientProperties;
 
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class PropertiesMcpSseClientConnectionDetails implements McpSseClientConnectionDetails {
 
 	private final McpSseClientProperties properties;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpSseClientProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/src/main/java/org/springframework/ai/mcp/client/common/autoconfigure/properties/McpSseClientProperties.java
@@ -59,6 +59,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @see SseParameters
  */
 @ConfigurationProperties(McpSseClientProperties.CONFIG_PREFIX)
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class McpSseClientProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.mcp.client.sse";

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/src/main/java/org/springframework/ai/mcp/client/httpclient/autoconfigure/SseHttpClientTransportAutoConfiguration.java
@@ -66,6 +66,7 @@ import org.springframework.core.log.LogAccessor;
 @EnableConfigurationProperties({ McpSseClientProperties.class, McpClientCommonProperties.class })
 @ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 		matchIfMissing = true)
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class SseHttpClientTransportAutoConfiguration {
 
 	private static final LogAccessor logger = new LogAccessor(SseHttpClientTransportAutoConfiguration.class);

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/autoconfigure/SseWebFluxTransportAutoConfiguration.java
@@ -69,6 +69,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @EnableConfigurationProperties({ McpSseClientProperties.class, McpClientCommonProperties.class })
 @ConditionalOnProperty(prefix = McpClientCommonProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
 		matchIfMissing = true)
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class SseWebFluxTransportAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
@@ -97,7 +97,7 @@ public class McpServerProperties {
 
 	private final Capabilities capabilities = new Capabilities();
 
-	private ServerProtocol protocol = ServerProtocol.SSE;
+	private ServerProtocol protocol = ServerProtocol.STREAMABLE;
 
 	/**
 	 * Whether to re-expose downstream MCP tools (provided by MCP clients) as tools in

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerSseProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerSseProperties.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  */
 @ConfigurationProperties(McpServerSseProperties.CONFIG_PREFIX)
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class McpServerSseProperties {
 
 	public static final String CONFIG_PREFIX = "spring.ai.mcp.server";

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerSseWebFluxAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/autoconfigure/McpServerSseWebFluxAutoConfiguration.java
@@ -67,6 +67,7 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 @ConditionalOnClass(WebFluxSseServerTransportProvider.class)
 @ConditionalOnMissingBean(McpServerTransportProvider.class)
 @Conditional({ McpServerStdioDisabledCondition.class, McpServerAutoConfiguration.EnabledSseServerCondition.class })
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class McpServerSseWebFluxAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerSseWebMvcAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/autoconfigure/McpServerSseWebMvcAutoConfiguration.java
@@ -73,6 +73,7 @@ import org.springframework.web.servlet.function.ServerResponse;
 @ConditionalOnClass(WebMvcSseServerTransportProvider.class)
 @ConditionalOnMissingBean(McpServerTransportProvider.class)
 @Conditional({ McpServerStdioDisabledCondition.class, McpServerAutoConfiguration.EnabledSseServerCondition.class })
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class McpServerSseWebMvcAutoConfiguration {
 
 	@Bean

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransport.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/client/webflux/transport/WebFluxSseClientTransport.java
@@ -74,7 +74,13 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @see <a href=
  * "https://spec.modelcontextprotocol.io/specification/basic/transports/#http-with-sse">MCP
  * HTTP with SSE Transport Specification</a>
+ * @deprecated The SSE transport has been deprecated in the 2025-03-26 version of the
+ * spec, and should not be used anymore. We keep it for backwards compatibility.
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility">Transports
+ * backwards compatibility</a>
  */
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class WebFluxSseClientTransport implements McpClientTransport {
 
 	private static final Logger logger = LoggerFactory.getLogger(WebFluxSseClientTransport.class);

--- a/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webflux/src/main/java/org/springframework/ai/mcp/server/webflux/transport/WebFluxSseServerTransportProvider.java
@@ -90,8 +90,13 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Dariusz Jędrzejczyk
  * @see McpServerTransport
  * @see ServerSentEvent
+ * @deprecated The SSE transport has been deprecated in the 2025-03-26 version of the
+ * spec, and should not be used anymore. We keep it for backwards compatibility.
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility">Transports
+ * backwards compatibility</a>
  */
-
+@Deprecated(since = "2.0.0", forRemoval = true)
 public final class WebFluxSseServerTransportProvider implements McpServerTransportProvider {
 
 	private static final Logger logger = LoggerFactory.getLogger(WebFluxSseServerTransportProvider.class);

--- a/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
+++ b/mcp/transport/mcp-spring-webmvc/src/main/java/org/springframework/ai/mcp/server/webmvc/transport/WebMvcSseServerTransportProvider.java
@@ -86,7 +86,13 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Alexandros Pappas
  * @see McpServerTransportProvider
  * @see RouterFunction
+ * @deprecated The SSE transport has been deprecated in the 2025-03-26 version of the
+ * spec, and should not be used anymore. We keep it for backwards compatibility.
+ * @see <a href=
+ * "https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility">Transports
+ * backwards compatibility</a>
  */
+@Deprecated(since = "2.0.0", forRemoval = true)
 public final class WebMvcSseServerTransportProvider implements McpServerTransportProvider {
 
 	private static final Logger logger = LoggerFactory.getLogger(WebMvcSseServerTransportProvider.class);


### PR DESCRIPTION
Port of https://github.com/modelcontextprotocol/java-sdk/pull/950