### PR TITLE
fix: Fix streaming tool call merge logic to use index field instead of id

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelper.java
@@ -126,13 +126,27 @@ public class OpenAiStreamFunctionCallingHelper {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (StringUtils.hasText(currentToolCall.id())) {
+
+			// Determine if this is the same tool call being continued (based on index
+			// field).
+			// OpenAI streaming sends the same index for all chunks of the same tool call.
+			// This handles the case where each chunk contains the same id (some
+			// implementations
+			// send id in every chunk), which should still be merged as it's the same tool
+			// call.
+			boolean isSameToolCall = lastPreviousTooCall != null && currentToolCall.index() != null
+					&& currentToolCall.index().equals(lastPreviousTooCall.index());
+
+			if (StringUtils.hasText(currentToolCall.id()) && !isSameToolCall) {
+				// This is a genuinely new tool call with a different index
 				if (lastPreviousTooCall != null) {
 					toolCalls.add(lastPreviousTooCall);
 				}
 				toolCalls.add(currentToolCall);
 			}
 			else {
+				// Same tool call (same index) or continuation without id - merge the
+				// arguments
 				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
 			}
 		}
@@ -149,10 +163,12 @@ public class OpenAiStreamFunctionCallingHelper {
 		if (previous == null) {
 			return current;
 		}
+		// Preserve the index field from either current or previous
+		Integer index = (current.index() != null ? current.index() : previous.index());
 		String id = (StringUtils.hasText(current.id()) ? current.id() : previous.id());
 		String type = (current.type() != null ? current.type() : previous.type());
 		ChatCompletionFunction function = merge(previous.function(), current.function());
-		return new ToolCall(id, type, function);
+		return new ToolCall(index, id, type, function);
 	}
 
 	private ChatCompletionFunction merge(ChatCompletionFunction previous, ChatCompletionFunction current) {

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelperTest.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/api/OpenAiStreamFunctionCallingHelperTest.java
@@ -335,4 +335,91 @@ public class OpenAiStreamFunctionCallingHelperTest {
 		assertThat(this.helper.isStreamingToolFunctionCall(chunk)).isFalse();
 	}
 
+	/**
+	 * Test that tool call arguments are properly merged when each chunk contains the same
+	 * id field. This tests the fix for the case where some API implementations send the
+	 * id in every chunk, but they should still be merged as the same tool call based on
+	 * the index field.
+	 */
+	@Test
+	public void merge_toolCallsWithSameIndexShouldMergeArguments() {
+		// First chunk: has id, name, and empty arguments
+		var toolCall1 = new OpenAiApi.ChatCompletionMessage.ToolCall(0, "call_123", "function",
+				new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction("get_weather", ""));
+		var delta1 = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall1), null, null, null,
+				null);
+		var choice1 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta1, null);
+		var chunk1 = new OpenAiApi.ChatCompletionChunk("id1", List.of(choice1), 1L, "model", null, null, null, null);
+
+		// Second chunk: same index, same id, but with partial arguments
+		var toolCall2 = new OpenAiApi.ChatCompletionMessage.ToolCall(0, "call_123", "function",
+				new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction(null, "{\"city\": \""));
+		var delta2 = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall2), null, null, null,
+				null);
+		var choice2 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta2, null);
+		var chunk2 = new OpenAiApi.ChatCompletionChunk("id1", List.of(choice2), 1L, "model", null, null, null, null);
+
+		// Third chunk: same index, same id, rest of arguments
+		var toolCall3 = new OpenAiApi.ChatCompletionMessage.ToolCall(0, "call_123", "function",
+				new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction(null, "Beijing\"}"));
+		var delta3 = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall3), null, null, null,
+				null);
+		var choice3 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta3, null);
+		var chunk3 = new OpenAiApi.ChatCompletionChunk("id1", List.of(choice3), 1L, "model", null, null, null, null);
+
+		// Merge chunks
+		var merged1 = this.helper.merge(null, chunk1);
+		var merged2 = this.helper.merge(merged1, chunk2);
+		var merged3 = this.helper.merge(merged2, chunk3);
+
+		// Verify the merged result
+		assertThat(merged3.choices()).hasSize(1);
+		var mergedChoice = merged3.choices().get(0);
+		assertThat(mergedChoice.delta().toolCalls()).hasSize(1);
+
+		var mergedToolCall = mergedChoice.delta().toolCalls().get(0);
+		assertThat(mergedToolCall.id()).isEqualTo("call_123");
+		assertThat(mergedToolCall.function().name()).isEqualTo("get_weather");
+		assertThat(mergedToolCall.function().arguments()).isEqualTo("{\"city\": \"Beijing\"}");
+	}
+
+	/**
+	 * Test that tool calls with different indices are treated as separate tool calls.
+	 */
+	@Test
+	public void merge_toolCallsWithDifferentIndexShouldBeSeparate() {
+		// First tool call (index 0)
+		var toolCall1 = new OpenAiApi.ChatCompletionMessage.ToolCall(0, "call_1", "function",
+				new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction("func1", "{}"));
+		var delta1 = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall1), null, null, null,
+				null);
+		var choice1 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta1, null);
+		var chunk1 = new OpenAiApi.ChatCompletionChunk("id1", List.of(choice1), 1L, "model", null, null, null, null);
+
+		// Second tool call (index 1) - different index, should be treated as new tool
+		// call
+		var toolCall2 = new OpenAiApi.ChatCompletionMessage.ToolCall(1, "call_2", "function",
+				new OpenAiApi.ChatCompletionMessage.ChatCompletionFunction("func2", "[]"));
+		var delta2 = new OpenAiApi.ChatCompletionMessage(null, null, null, null, List.of(toolCall2), null, null, null,
+				null);
+		var choice2 = new OpenAiApi.ChatCompletionChunk.ChunkChoice(null, 0, delta2, null);
+		var chunk2 = new OpenAiApi.ChatCompletionChunk("id1", List.of(choice2), 1L, "model", null, null, null, null);
+
+		// Merge chunks
+		var merged = this.helper.merge(chunk1, chunk2);
+
+		// Verify - should have 2 tool calls now
+		assertThat(merged.choices()).hasSize(1);
+		var mergedChoice = merged.choices().get(0);
+		assertThat(mergedChoice.delta().toolCalls()).hasSize(2);
+
+		var firstToolCall = mergedChoice.delta().toolCalls().get(0);
+		assertThat(firstToolCall.id()).isEqualTo("call_1");
+		assertThat(firstToolCall.function().name()).isEqualTo("func1");
+
+		var secondToolCall = mergedChoice.delta().toolCalls().get(1);
+		assertThat(secondToolCall.id()).isEqualTo("call_2");
+		assertThat(secondToolCall.function().name()).isEqualTo("func2");
+	}
+
 }


### PR DESCRIPTION
https://github.com/spring-projects/spring-ai/issues/5974

Problem:
When streaming tool calls from vLLM or other OpenAI-compatible APIs,
each chunk contains the same `id` field. The current merge logic uses
`id` presence to determine if it's a new tool call, which incorrectly
treats all chunks as separate tool calls, preventing argument merging.

Solution:
- Use the `index` field to determine if chunks belong to the same tool call
- According to OpenAI SDK, chunks with the same `index` should be merged
- Preserve the `index` field in the merge(ToolCall, ToolCall) method

Changes:
- Modified OpenAiStreamFunctionCallingHelper.merge() to compare index fields
- Added boolean `isSameToolCall` check based on index comparison
- Fixed ToolCall constructor call to include index parameter
- Added detailed comments explaining the logic

Tests:
- Added merge_toolCallsWithSameIndexShouldMergeArguments() test
- Added merge_toolCallsWithDifferentIndexShouldBeSeparate() test
- Both tests verify correct behavior with index-based merging

Impact:
- Fixes tool calling for vLLM-deployed models in streaming mode
- Maintains backward compatibility with standard OpenAI API
- Supports APIs that send `id` in every chunk