### PR TITLE
GH-5971: fix streaming tool-call observation context propagation

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import io.micrometer.observation.Observation;
@@ -577,12 +578,19 @@ public class DefaultChatClient implements ChatClient {
 
 				observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null))
 					.start();
+				AtomicBoolean observationStopped = new AtomicBoolean();
+				Runnable stopObservation = () -> {
+					if (observationStopped.compareAndSet(false, true)) {
+						observation.stop();
+					}
+				};
 
 				// @formatter:off
 				// Apply the advisor chain that terminates with the ChatModelStreamAdvisor.
 				Flux<ChatClientResponse> chatClientResponse = this.advisorChain.nextStream(chatClientRequest)
 						.doOnError(observation::error)
-						.doFinally(s -> observation.stop())
+						.doOnTerminate(stopObservation)
+						.doOnCancel(stopObservation)
 						.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
 				// @formatter:on
 				return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(chatClientResponse,

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -139,11 +140,18 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 					DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, this.observationRegistry);
 
 			observation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null)).start();
+			AtomicBoolean observationStopped = new AtomicBoolean();
+			Runnable stopObservation = () -> {
+				if (observationStopped.compareAndSet(false, true)) {
+					observation.stop();
+				}
+			};
 
 			// @formatter:off
 			Flux<ChatClientResponse> chatClientResponse = Flux.defer(() -> advisor.adviseStream(chatClientRequest, this)
 						.doOnError(observation::error)
-						.doFinally(s -> observation.stop())
+						.doOnTerminate(stopObservation)
+						.doOnCancel(stopObservation)
 						.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation)));
 			// @formatter:on
 			return CHAT_CLIENT_MESSAGE_AGGREGATOR.aggregateChatClientResponse(chatClientResponse,

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.context.ContextView;
 
 import org.springframework.ai.chat.client.ChatClientMessageAggregator;
 import org.springframework.ai.chat.client.ChatClientRequest;
@@ -262,7 +263,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 			AtomicReference<ChatClientResponse> aggregatedResponseRef = new AtomicReference<>();
 
 			return streamWithToolCallResponses(responseFlux, aggregatedResponseRef, finalRequest, streamAdvisorChain,
-					originalRequest, optionsCopy);
+					originalRequest, optionsCopy, contextView);
 		});
 	}
 
@@ -273,7 +274,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
 			AtomicReference<ChatClientResponse> aggregatedResponseRef, ChatClientRequest finalRequest,
 			StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy) {
+			ToolCallingChatOptions optionsCopy, ContextView toolCallContext) {
 
 		return responseFlux.publish(shared -> {
 			// Branch 1: Stream chunks immediately for real-time streaming UX
@@ -284,7 +285,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 			// potentially recurse.
 			Flux<ChatClientResponse> recursionBranch = Flux
 				.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest, streamAdvisorChain,
-						originalRequest, optionsCopy));
+						originalRequest, optionsCopy, toolCallContext));
 
 			// Emit all streaming chunks first, then append any recursive results
 			return streamingBranch.concatWith(recursionBranch);
@@ -299,7 +300,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 	 */
 	private Flux<ChatClientResponse> handleToolCallRecursion(ChatClientResponse aggregatedResponse,
 			ChatClientRequest finalRequest, StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
-			ToolCallingChatOptions optionsCopy) {
+			ToolCallingChatOptions optionsCopy, ContextView toolCallContext) {
 
 		if (aggregatedResponse == null) {
 			return Flux.empty();
@@ -322,7 +323,7 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 		Flux<ChatClientResponse> toolCallFlux = Flux.deferContextual(ctx -> {
 			ToolExecutionResult toolExecutionResult;
 			try {
-				ToolCallReactiveContextHolder.setContext(ctx);
+				ToolCallReactiveContextHolder.setContext(toolCallContext);
 				toolExecutionResult = this.toolCallingManager.executeToolCalls(finalRequest.prompt(), chatResponse);
 			}
 			finally {

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/ChatClientStreamingObservationOrderTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/observation/ChatClientStreamingObservationOrderTests.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.client.observation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.util.context.ContextView;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.chat.observation.ChatModelObservationConvention;
+import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.DefaultToolDefinition;
+import org.springframework.ai.tool.observation.DefaultToolCallingObservationConvention;
+import org.springframework.ai.tool.observation.ToolCallingObservationContext;
+import org.springframework.ai.tool.observation.ToolCallingObservationDocumentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the order of observation start/stop events during streaming with tool calls.
+ *
+ * @author yaner-here
+ */
+class ChatClientStreamingObservationOrderTests {
+
+	private static final ChatModelObservationConvention DEFAULT_MODEL_OBSERVATION_CONVENTION = new DefaultChatModelObservationConvention();
+
+	private static final String CHAT_CLIENT_OBSERVATION = "spring.ai.chat.client";
+
+	private static final String ADVISOR_OBSERVATION = "spring.ai.advisor";
+
+	private static final String MODEL_OBSERVATION = "gen_ai.client.operation";
+
+	private static final String TOOL_OBSERVATION = "spring.ai.tool";
+
+	@Test
+	void streamingObservationsShouldFollowCorrectOrder() {
+		ObservationRegistry observationRegistry = ObservationRegistry.create();
+		EventRecorder handler = new EventRecorder();
+		observationRegistry.observationConfig().observationHandler(handler);
+
+		// Build the ChatClient with a model that creates observations and returns tool
+		// call responses
+		ChatModel model = new ObservingChatModel(observationRegistry);
+		ChatClient chatClient = ChatClient.builder(model, observationRegistry, null, null).build();
+		ToolCallback toolCallback = DefaultChatClientObservationConventionTests.dummyFunction("testTool");
+		chatClient.prompt().user("test message").toolCallbacks(toolCallback).stream().content().blockLast();
+		List<String> events = handler.getStartStopSequence();
+		System.out.println("Observation events: " + events);
+
+		// Verify the start/stop order matches the expected sequence.
+		assertThat(events).containsExactly("start:" + CHAT_CLIENT_OBSERVATION, "start:" + ADVISOR_OBSERVATION,
+				"start:" + MODEL_OBSERVATION, "stop:" + MODEL_OBSERVATION, "start:" + TOOL_OBSERVATION,
+				"stop:" + TOOL_OBSERVATION, "start:" + MODEL_OBSERVATION, "stop:" + MODEL_OBSERVATION,
+				"stop:" + ADVISOR_OBSERVATION, "stop:" + CHAT_CLIENT_OBSERVATION);
+
+		// Verify each observation has the correct parent
+		assertThat(handler.getParentObservation(CHAT_CLIENT_OBSERVATION)).as("chat.client parent").isNull();
+		assertThat(handler.getParentObservation(ADVISOR_OBSERVATION)).as("advisor parent")
+			.isEqualTo(CHAT_CLIENT_OBSERVATION);
+		assertThat(handler.getParentObservation(TOOL_OBSERVATION)).as("tool parent").isEqualTo(ADVISOR_OBSERVATION);
+	}
+
+	/**
+	 * Records observation start/stop events and parent relationships.
+	 */
+	static class EventRecorder implements ObservationHandler<Observation.Context> {
+
+		final List<String> events = new ArrayList<>();
+
+		final List<String> parentRelationships = new ArrayList<>();
+
+		@Override
+		public void onStart(Observation.Context context) {
+			String name = context.getName();
+			this.events.add("start:" + name);
+			String parentName = (context.getParentObservation() != null)
+					? context.getParentObservation().getContextView().getName() : null;
+			this.parentRelationships.add(name + " -> " + parentName);
+		}
+
+		@Override
+		public void onStop(Observation.Context context) {
+			this.events.add("stop:" + context.getName());
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return true;
+		}
+
+		List<String> getStartStopSequence() {
+			return this.events;
+		}
+
+		String getParentObservation(String observationName) {
+			return this.parentRelationships.stream()
+				.filter(r -> r.startsWith(observationName + " -> "))
+				.map(r -> r.substring((observationName + " -> ").length()))
+				.findFirst()
+				.map(name -> "null".equals(name) ? null : name)
+				.orElse(null);
+		}
+
+	}
+
+	static class ObservingChatModel implements ChatModel {
+
+		private final ObservationRegistry observationRegistry;
+
+		private final AtomicInteger invocationCount = new AtomicInteger(0);
+
+		ObservingChatModel(ObservationRegistry observationRegistry) {
+			this.observationRegistry = observationRegistry;
+		}
+
+		@Override
+		public ChatOptions getDefaultOptions() {
+			return ToolCallingChatOptions.builder().build();
+		}
+
+		@Override
+		public @NonNull ChatResponse call(@NonNull Prompt prompt) {
+			return getStreamResponse(false);
+		}
+
+		@Override
+		public @NonNull Flux<ChatResponse> stream(@NonNull Prompt prompt) {
+			return Flux.deferContextual(contextView -> {
+				int callIndex = this.invocationCount.getAndIncrement();
+
+				// Determine if this is the first call (with tool call) or subsequent
+				// (final answer)
+				boolean firstCall = (callIndex == 0);
+
+				ChatModelObservationContext modelObsContext = ChatModelObservationContext.builder()
+					.prompt(prompt)
+					.provider("test")
+					.build();
+				Observation modelObservation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(null,
+						DEFAULT_MODEL_OBSERVATION_CONVENTION, () -> modelObsContext, this.observationRegistry);
+				modelObservation.parentObservation(contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null))
+					.start();
+				ChatResponse response = getStreamResponse(firstCall);
+				Flux<ChatResponse> result;
+				if (firstCall) {
+					// First call: emit tool call response, execute tool, then recurse
+					result = Flux.just(response)
+						.doFinally(signalType -> modelObservation.stop())
+						.concatWith(Flux.defer(() -> executeToolAndRecurse(contextView, prompt)));
+				}
+				else {
+					// Subsequent call: emit final response and stop
+					result = Flux.just(response).doFinally(signalType -> modelObservation.stop());
+				}
+
+				return result.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, modelObservation));
+			});
+		}
+
+		private Flux<ChatResponse> executeToolAndRecurse(ContextView contextView, Prompt prompt) {
+			ToolCallingObservationContext toolObsContext = ToolCallingObservationContext.builder()
+				.toolDefinition(DefaultToolDefinition.builder().name("testTool").inputSchema("{}").build())
+				.toolCallId("call-1")
+				.build();
+
+			Observation toolObservation = ToolCallingObservationDocumentation.TOOL_CALL.observation(null,
+					new DefaultToolCallingObservationConvention(), () -> toolObsContext, this.observationRegistry);
+
+			Observation parentObs = contextView.getOrDefault(ObservationThreadLocalAccessor.KEY, null);
+			toolObservation.parentObservation(parentObs).start();
+
+			toolObsContext.setToolCallResult("tool result");
+			toolObservation.stop();
+
+			// Recursive model call
+			ChatModelObservationContext recursiveModelObsContext = ChatModelObservationContext.builder()
+				.prompt(prompt)
+				.provider("test")
+				.build();
+			Observation recursiveModelObservation = ChatModelObservationDocumentation.CHAT_MODEL_OPERATION.observation(
+					null, DEFAULT_MODEL_OBSERVATION_CONVENTION, () -> recursiveModelObsContext,
+					this.observationRegistry);
+			recursiveModelObservation.parentObservation(toolObservation).start();
+			ChatResponse finalResponse = getStreamResponse(false);
+			return Flux.just(finalResponse).doFinally(signalType -> recursiveModelObservation.stop());
+		}
+
+		private static ChatResponse getStreamResponse(boolean withToolCall) {
+			Generation generation;
+			if (withToolCall) {
+				AssistantMessage assistantMessage = AssistantMessage.builder()
+					.content("Let me check that")
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "testTool", "{}")))
+					.build();
+				generation = new Generation(assistantMessage);
+			}
+			else {
+				generation = new Generation(new AssistantMessage("Here is the final answer."));
+			}
+			return ChatResponse.builder().generations(List.of(generation)).build();
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/model/tool/DefaultToolCallingManager.java
@@ -25,7 +25,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +38,7 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.internal.ToolCallReactiveContextHolder;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.execution.DefaultToolExecutionExceptionProcessor;
@@ -227,20 +230,23 @@ public final class DefaultToolCallingManager implements ToolCallingManager {
 				.toolCallArguments(finalToolInputArguments)
 				.build();
 
-			String toolCallResult = ToolCallingObservationDocumentation.TOOL_CALL
-				.observation(this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
-						this.observationRegistry)
-				.observe(() -> {
-					String toolResult;
-					try {
-						toolResult = toolCallback.call(finalToolInputArguments, toolContext);
-					}
-					catch (ToolExecutionException ex) {
-						toolResult = this.toolExecutionExceptionProcessor.process(ex);
-					}
-					observationContext.setToolCallResult(toolResult);
-					return toolResult;
-				});
+			Observation observation = ToolCallingObservationDocumentation.TOOL_CALL.observation(
+					this.observationConvention, DEFAULT_OBSERVATION_CONVENTION, () -> observationContext,
+					this.observationRegistry);
+			observation.parentObservation(
+					ToolCallReactiveContextHolder.getContext().getOrDefault(ObservationThreadLocalAccessor.KEY, null));
+
+			String toolCallResult = observation.observe(() -> {
+				String toolResult;
+				try {
+					toolResult = toolCallback.call(finalToolInputArguments, toolContext);
+				}
+				catch (ToolExecutionException ex) {
+					toolResult = this.toolExecutionExceptionProcessor.process(ex);
+				}
+				observationContext.setToolCallResult(toolResult);
+				return toolResult;
+			});
 
 			toolResponses.add(new ToolResponseMessage.ToolResponse(toolCall.id(), toolName,
 					toolCallResult != null ? toolCallResult : ""));


### PR DESCRIPTION
Fix GH-5971.

### 1. Pass the `ContextView` through the advisor chain

In the streaming tool-call loop (`ToolCallAdvisor`), after receiving the streaming response, tool execution happens on `Schedulers.boundedElastic()`. Since Reactor's context is scoped to the reactive chain and doesn't automatically propagate across `subscribeOn` boundaries, the parent observation (e.g., the `ChatClient` observation) is lost when `DefaultToolCallingManager.executeToolCalls()` creates its tool observations, thus breaks the observation hierarchy. Tool observations would have no parent, making it impossible to correlate them correctly in metrics/tracing backends.

`reactor.util.context.ContextView` is the immutable snapshot of Reactor's Context. The commit uses it in a capture-and-restore pattern across all components in the streaming pipeline:


### 2. Adjust the stop timing for streaming observations

The execution timing of .doFinally() is not suitable for maintaining the correct stop order of parent-child observations. We expect the semantics of Observation to be:

```
start spring.ai.chat.client
  start spring.ai.advisor
    start spring.ai.tool
    stop spring.ai.tool
  stop spring.ai.advisor
stop spring.ai.chat.client
```

Instead of:

```
start spring.ai.chat.client
  start spring.ai.advisor
    start spring.ai.tool
stop spring.ai.chat.client
  stop spring.ai.advisor
    stop spring.ai.tool
```

Therefore, I replaced .doFinally() with .doOnTerminate() and .doOnCancel(). I used `AtomicBoolean` to ensure that the observation is stopped only once by a single signal.
