### PR TITLE
DeepSeek auto-config should respect `spring.ai.deepseek.chat.enabled`

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekChatAutoConfiguration.java
@@ -55,6 +55,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 @EnableConfigurationProperties({ DeepSeekConnectionProperties.class, DeepSeekChatProperties.class })
 @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = SpringAIModels.DEEPSEEK,
 		matchIfMissing = true)
+@ConditionalOnProperty(prefix = DeepSeekChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",
+		matchIfMissing = true)
 public class DeepSeekChatAutoConfiguration {
 
 	@Bean

--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/test/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/test/java/org/springframework/ai/model/deepseek/autoconfigure/DeepSeekPropertiesTests.java
@@ -170,4 +170,18 @@ public class DeepSeekPropertiesTests {
 			});
 	}
 
+	@Test
+	void chatDisabledViaEnabledProperty() {
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.deepseek.api-key=API_KEY", "spring.ai.deepseek.base-url=TEST_BASE_URL",
+					"spring.ai.deepseek.chat.enabled=false")
+			.withConfiguration(AutoConfigurations.of(DeepSeekChatAutoConfiguration.class,
+					RestClientAutoConfiguration.class, SpringAiRetryAutoConfiguration.class,
+					ToolCallingAutoConfiguration.class, WebClientAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context.getBeansOfType(DeepSeekChatProperties.class)).isEmpty();
+				assertThat(context.getBeansOfType(DeepSeekChatModel.class)).isEmpty();
+			});
+	}
+
 }


### PR DESCRIPTION
## Description

Previously `DeepSeekChatAutoConfiguration` only checked `spring.ai.model.chat` and ignored the `spring.ai.deepseek.chat.enabled` property, causing startup failures when users tried to disable DeepSeek chat without an API key.

Fixes #5981

## Root Cause

The `@ConditionalOnProperty` on `DeepSeekChatAutoConfiguration` only gated on `spring.ai.model.chat=deepseek`, not on the per-provider `enabled` flag. When a user set `spring.ai.deepseek.chat.enabled=false`, the configuration still loaded and tried to create the `DeepSeekChatModel` bean, which failed because no API key was provided.

## Fix

Added a second `@ConditionalOnProperty` check for `spring.ai.deepseek.chat.enabled` with `matchIfMissing = true` (so existing users are unaffected):

```java
@ConditionalOnProperty(prefix = DeepSeekChatProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
```

Both conditions must be met:
1. Global model selector: `spring.ai.model.chat=deepseek` (or missing)
2. Per-provider enabled flag: `spring.ai.deepseek.chat.enabled=true` (or missing)

## Test

Added `chatDisabledViaEnabledProperty()` test in `DeepSeekPropertiesTests` that verifies when `spring.ai.deepseek.chat.enabled=false`, neither `DeepSeekChatProperties` nor `DeepSeekChatModel` beans are created.

## Files changed

- `auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/main/java/.../DeepSeekChatAutoConfiguration.java` — added `@ConditionalOnProperty` for enabled flag
- `auto-configurations/models/spring-ai-autoconfigure-model-deepseek/src/test/java/.../DeepSeekPropertiesTests.java` — added disable test