### PR TITLE
GH-5987: fix OpenAI chat streaming latency without tools

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -77,6 +77,7 @@ import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.MessageAggregator;
 import org.springframework.ai.chat.observation.ChatModelObservationContext;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
@@ -357,6 +358,12 @@ public final class OpenAiChatModel implements ChatModel {
 
 			Flux<ChatResponse> flux = chatResponses
 				.contextWrite(ctx -> ctx.put(ObservationThreadLocalAccessor.KEY, observation));
+
+			if (request.tools().isEmpty()) {
+				return new MessageAggregator().aggregate(flux, observationContext::setResponse)
+					.doOnError(observation::error)
+					.doFinally(s -> observation.stop());
+			}
 
 			return flux.collectList().flatMapMany(list -> {
 				if (list.isEmpty()) {


### PR DESCRIPTION
Fix GH-5987.

OpenAI chat streaming responses were being collected with `collectList()` before being emitted downstream, so even normal non-tool streaming requests only delivered chunks after the upstream SSE stream completed. This happened because the same aggregation path was used to detect and merge streaming tool calls.

This PR lets requests without configured tools stream responses immediately while still aggregating the final response for observation metadata.