### PR TITLE
fix: parse large integer constants as Long in FilterExpressionTextParser

### DIFF
--- a/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
+++ b/spring-ai-vector-store/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParser.java
@@ -230,7 +230,13 @@ public class FilterExpressionTextParser {
 
 		@Override
 		public Filter.Operand visitIntegerConstant(FiltersParser.IntegerConstantContext ctx) {
-			return new Filter.Value(Integer.valueOf(ctx.getText()));
+			String text = ctx.getText();
+			try {
+				return new Filter.Value(Integer.parseInt(text));
+			}
+			catch (NumberFormatException ex) {
+				return new Filter.Value(Long.parseLong(text));
+			}
 		}
 
 		@Override

--- a/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
+++ b/spring-ai-vector-store/src/test/java/org/springframework/ai/vectorstore/filter/FilterExpressionTextParserTests.java
@@ -204,6 +204,23 @@ public class FilterExpressionTextParserTests {
 	}
 
 	@Test
+	public void testLargeIntegerFallsBackToLong() {
+		// Values exceeding Integer.MAX_VALUE should be parsed as Long without L suffix
+		Expression exp = this.parser.parse("id == " + Long.MAX_VALUE);
+		assertThat(exp).isEqualTo(new Expression(EQ, new Key("id"), new Value(Long.MAX_VALUE)));
+		assertThat(((Value) exp.right()).value()).isInstanceOf(Long.class);
+
+		exp = this.parser.parse("id == " + Long.MIN_VALUE);
+		assertThat(exp).isEqualTo(new Expression(EQ, new Key("id"), new Value(Long.MIN_VALUE)));
+		assertThat(((Value) exp.right()).value()).isInstanceOf(Long.class);
+
+		// Values within Integer range should still be parsed as Integer
+		exp = this.parser.parse("id == 42");
+		assertThat(exp).isEqualTo(new Expression(EQ, new Key("id"), new Value(42)));
+		assertThat(((Value) exp.right()).value()).isInstanceOf(Integer.class);
+	}
+
+	@Test
 	public void testIdentifiers() {
 		Expression exp = this.parser.parse("'country.1' == 'BG'");
 		assertThat(exp).isEqualTo(new Expression(EQ, new Key("country.1"), new Value("BG")));


### PR DESCRIPTION
Fixes #4705

## Summary

`FilterExpressionTextParser.visitIntegerConstant` uses `Integer.valueOf()` which throws `NumberFormatException` for values exceeding `Integer.MAX_VALUE` (2147483647). This prevents using filter expressions with `long` metadata IDs.

## Change

Fall back to `Long.parseLong()` when the integer literal overflows the 32-bit range:

```java
// before
return new Filter.Value(Integer.valueOf(ctx.getText()));

// after
String text = ctx.getText();
try {
    return new Filter.Value(Integer.parseInt(text));
} catch (NumberFormatException ex) {
    return new Filter.Value(Long.parseLong(text));
}
```

- Values within `Integer` range continue to produce `Integer` (backward compatible)
- The existing `L`-suffixed long syntax is unaffected

## Testing

Added `testLargeIntegerFallsBackToLong()` covering:
- `Long.MAX_VALUE` without L suffix parsed as `Long`
- `Long.MIN_VALUE` without L suffix parsed as `Long`
- Values within Integer range still parsed as `Integer`

All 16 tests pass (including 15 existing + 1 new).

## Notes

Two prior PRs (#5431 and #5770) were closed without merge for the same issue.