### PR TITLE
Fix Kotlin nullable fields in MCP tool input schema

### DIFF
--- a/mcp/mcp-annotations/pom.xml
+++ b/mcp/mcp-annotations/pom.xml
@@ -67,6 +67,18 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
@@ -51,8 +51,10 @@ import org.springframework.ai.mcp.annotation.McpProgressToken;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.mcp.annotation.context.McpAsyncRequestContext;
 import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
+import org.springframework.ai.model.KotlinModule;
 import org.springframework.ai.util.json.JsonParser;
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator.SchemaOption;
+import org.springframework.core.KotlinDetector;
 import org.springframework.core.Nullness;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ConcurrentReferenceHashMap;
@@ -85,16 +87,21 @@ public final class McpJsonSchemaGenerator {
 		Module springAiSchemaModule = PROPERTY_REQUIRED_BY_DEFAULT ? new McpSpringAiSchemaModule()
 				: new McpSpringAiSchemaModule(McpSpringAiSchemaModule.Option.PROPERTY_REQUIRED_FALSE_BY_DEFAULT);
 
-		SchemaGeneratorConfig subtypeConfig = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12,
-				OptionPreset.PLAIN_JSON)
+		SchemaGeneratorConfigBuilder subtypeConfigBuilder = new SchemaGeneratorConfigBuilder(
+				SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
 			.with(jacksonModule)
 			.with(openApiModule)
 			.with(springAiSchemaModule)
 			.with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
 			.with(Option.STANDARD_FORMATS)
 			.with(Option.PLAIN_DEFINITION_KEYS)
-			.without(Option.SCHEMA_VERSION_INDICATOR)
-			.build();
+			.without(Option.SCHEMA_VERSION_INDICATOR);
+
+		if (KotlinDetector.isKotlinReflectPresent()) {
+			subtypeConfigBuilder.with(new KotlinModule());
+		}
+
+		SchemaGeneratorConfig subtypeConfig = subtypeConfigBuilder.build();
 
 		SUBTYPE_SCHEMA_GENERATOR = new SchemaGenerator(subtypeConfig);
 	}

--- a/mcp/mcp-annotations/src/test/kotlin/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorKotlinTests.kt
+++ b/mcp/mcp-annotations/src/test/kotlin/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorKotlinTests.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.method.tool.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.ai.mcp.annotation.McpTool
+import org.springframework.ai.mcp.annotation.McpToolParam
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+
+class McpJsonSchemaGeneratorKotlinTests {
+
+	private val jsonMapper = JsonMapper()
+
+	@Test
+	fun `nullable Kotlin properties are not required in MCP tool input schemas`() {
+		val method = SearchTools::class.java.getMethod("search", Filter::class.java)
+
+		val schema = McpJsonSchemaGenerator.generateForMethodInput(method)
+		val schemaNode = jsonMapper.readTree(schema)
+		val filterNode = schemaNode["properties"]["filter"]
+		val topLevelRequired = schemaNode["required"]
+		val filterRequired = filterNode["required"]
+
+		assertThat(requiredNames(topLevelRequired)).doesNotContain("filter")
+		assertThat(requiredNames(filterRequired)).doesNotContain("name", "ids")
+	}
+
+	@Test
+	fun `non-null Kotlin constructor properties without defaults remain required`() {
+		val method = SearchTools::class.java.getMethod("mixed", SearchRequest::class.java)
+
+		val schema = McpJsonSchemaGenerator.generateForMethodInput(method)
+		val schemaNode = jsonMapper.readTree(schema)
+		val requestNode = schemaNode["properties"]["request"]
+		val requestRequired = requiredNames(requestNode["required"])
+
+		assertThat(requestRequired).contains("query")
+		assertThat(requestRequired).doesNotContain("filter")
+	}
+
+	private fun requiredNames(required: JsonNode?): List<String> {
+		if (required == null || required.isNull) {
+			return emptyList()
+		}
+		return required.iterator().asSequence().map { it.asString() }.toList()
+	}
+
+	private data class Filter(val name: String? = null, val ids: List<String>? = null)
+
+	private data class SearchRequest(val query: String, val filter: String? = null)
+
+	private class SearchTools {
+
+		@McpTool(description = "Search")
+		fun search(@McpToolParam(required = false) filter: Filter? = null): String {
+			return "ok"
+		}
+
+		@McpTool(description = "Mixed")
+		fun mixed(@McpToolParam(required = false) request: SearchRequest? = null): String {
+			return "ok"
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary
This PR is related to #5978 and fixes the MCP Tools schema generation path for Kotlin nullable fields. 

PR #5897 addresses the standard `@Tool` schema path by registering `org.springframework.ai.model.KotlinModule` in `JsonSchemaGenerator`. MCP tools use `McpJsonSchemaGenerator` for method input schemas, so Kotlin nullable properties inside MCP tool parameter data classes could still be emitted as required in nested JSON Schema objects.

This change applies the same conditional `KotlinModule` registration pattern to `McpJsonSchemaGenerator`, keeping the fix narrowly scoped to MCP tool input schema generation.

## Tests

The regression test verifies both sides of Kotlin requiredness behavior:

- nullable Kotlin constructor properties with default null values, such as `String? = null` and `List<String>? = null`, are not included in nested `required` arrays
- non-null Kotlin constructor properties without defaults remain required

Commands run:

```bash
./mvnw -pl mcp/mcp-annotations '-Denforcer.skip=true' 'kotlin:test-compile@test-compile'
./mvnw -pl mcp/mcp-annotations -Dtest=McpJsonSchemaGeneratorKotlinTests '-Denforcer.skip=true' surefire:test
./mvnw -pl mcp/mcp-annotations -Dtest=McpJsonSchemaGeneratorKotlinTests '-Denforcer.skip=true' package
```

Related issue: Addresses the MCP Tools portion of #5978.
