### PR TITLE
Update Ollama OpenAI API compatibility example to use builder pattern

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -631,11 +631,12 @@ Here's an example of accessing reasoning content from Ollama through the OpenAI 
 class OllamaConfig {
     @Bean
     OpenAiChatModel ollamaChatModel() {
-        var openAiApi = new OpenAiApi("http://localhost:11434", "ollama");
-        return new OpenAiChatModel(openAiApi,
-            OpenAiChatOptions.builder()
+        return OpenAiChatModel.builder()
+            .options(OpenAiChatOptions.builder()
+                .baseUrl("http://localhost:11434/v1")
                 .model("deepseek-r1")  // or qwen3, deepseek-v3.1, etc.
-                .build());
+                .build())
+            .build();
     }
 }
 


### PR DESCRIPTION
Fixes #5980

## Summary

The "OpenAI API Compatibility" section of ollama-chat.adoc used `new OpenAiApi(...)` and `new OpenAiChatModel(api, options)` which no longer exist in the current API. Updated to use the builder pattern:

```java
OpenAiChatModel.builder()
    .options(OpenAiChatOptions.builder()
        .baseUrl("http://localhost:11434/v1")
        .model("deepseek-r1")
        .build())
    .build()
```

## Files changed

- `spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc` — Updated the OpenAI API Compatibility example