### PR TITLE
fix: use index instead of id for streaming tool call merge (vLLM compatibility)

### DIFF
--- a/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
+++ b/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelper.java
@@ -99,14 +99,27 @@ public class DeepSeekStreamFunctionCallingHelper {
 				throw new IllegalStateException("Currently only one tool call is supported per message!");
 			}
 			var currentToolCall = current.toolCalls().iterator().next();
-			if (StringUtils.hasText(currentToolCall.id())) {
+			// Use index to determine if this is a continuation of the previous tool
+			// call. Some providers (e.g. vLLM) send the id in every chunk, so
+			// checking hasText(id) would incorrectly treat each chunk as a new tool
+			// call. We prefer index when available, and fall back to the id-based
+			// check for providers that don't include index.
+			boolean isSameToolCall;
+			if (lastPreviousTooCall != null && currentToolCall.index() != null
+					&& lastPreviousTooCall.index() != null) {
+				isSameToolCall = currentToolCall.index().equals(lastPreviousTooCall.index());
+			}
+			else {
+				isSameToolCall = lastPreviousTooCall != null && !StringUtils.hasText(currentToolCall.id());
+			}
+			if (isSameToolCall) {
+				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
+			}
+			else {
 				if (lastPreviousTooCall != null) {
 					toolCalls.add(lastPreviousTooCall);
 				}
 				toolCalls.add(currentToolCall);
-			}
-			else {
-				toolCalls.add(merge(lastPreviousTooCall, currentToolCall));
 			}
 		}
 		else {

--- a/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
+++ b/models/spring-ai-deepseek/src/test/java/org/springframework/ai/deepseek/api/DeepSeekStreamFunctionCallingHelperTest.java
@@ -232,4 +232,78 @@ class DeepSeekStreamFunctionCallingHelperTest {
 		assertThat(result).isNotNull();
 	}
 
+	/**
+	 * vLLM sends the tool call id in every chunk (unlike OpenAI which only sends it
+	 * once). When id is present in every chunk, the merge logic must use the tool call
+	 * index to determine whether to merge or create a new entry.
+	 * <p>
+	 * Without the index-based fix, each chunk with a non-empty id would be treated as a
+	 * new tool call, resulting in duplicate entries.
+	 */
+	@Test
+	void mergeVllmToolCallsWithIdInEveryChunkShouldUseIndex() {
+		// Given: vLLM sends id="call_1" in every chunk with index=0
+		ChatCompletionFunction funcChunk1 = new ChatCompletionFunction("get_weather", "{\"location\":");
+		ToolCall toolCall1 = new ToolCall(0, "call_1", "function", funcChunk1);
+
+		ChatCompletionFunction funcChunk2 = new ChatCompletionFunction("get_weather", "\"Beijing\"}");
+		ToolCall toolCall2 = new ToolCall(0, "call_1", "function", funcChunk2);
+
+		ChatCompletionMessage msg1 = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall1));
+		ChatCompletionMessage msg2 = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall2));
+
+		ChatCompletionChunk previous = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, msg1, null)), 123L, "model", null, null, null,
+				null);
+
+		ChatCompletionChunk current = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, msg2, null)), 123L, "model", null, null, null,
+				null);
+
+		// When
+		ChatCompletionChunk result = this.helper.merge(previous, current);
+
+		// Then: should have 1 merged tool call, not 2 separate ones
+		assertThat(result.choices()).hasSize(1);
+		assertThat(result.choices().get(0).delta().toolCalls()).hasSize(1);
+		ToolCall merged = result.choices().get(0).delta().toolCalls().get(0);
+		assertThat(merged.id()).isEqualTo("call_1");
+		assertThat(merged.function().name()).isEqualTo("get_weather");
+		assertThat(merged.function().arguments()).isEqualTo("{\"location\":\"Beijing\"}");
+	}
+
+	/**
+	 * When index is available on two tool calls with different indices, they should NOT
+	 * be merged — they represent separate tool calls.
+	 */
+	@Test
+	void mergeWithDifferentIndicesShouldNotMerge() {
+		// Given: two parallel tool calls with different indices
+		ChatCompletionFunction func1 = new ChatCompletionFunction("func_a", "{\"a\":");
+		ToolCall toolCall1 = new ToolCall(0, "call_1", "function", func1);
+
+		ChatCompletionFunction func2 = new ChatCompletionFunction("func_b", "{\"b\":");
+		ToolCall toolCall2 = new ToolCall(1, "call_2", "function", func2);
+
+		ChatCompletionMessage msg1 = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall1));
+		ChatCompletionMessage msg2 = new ChatCompletionMessage(null, Role.ASSISTANT, null, null, List.of(toolCall2));
+
+		ChatCompletionChunk previous = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, msg1, null)), 123L, "model", null, null, null,
+				null);
+
+		ChatCompletionChunk current = new ChatCompletionChunk("id",
+				List.of(new ChatCompletionChunk.ChunkChoice(null, 0, msg2, null)), 123L, "model", null, null, null,
+				null);
+
+		// When
+		ChatCompletionChunk result = this.helper.merge(previous, current);
+
+		// Then: should have 2 separate tool calls
+		assertThat(result.choices()).hasSize(1);
+		assertThat(result.choices().get(0).delta().toolCalls()).hasSize(2);
+		assertThat(result.choices().get(0).delta().toolCalls().get(0).function().name()).isEqualTo("func_a");
+		assertThat(result.choices().get(0).delta().toolCalls().get(1).function().name()).isEqualTo("func_b");
+	}
+
 }


### PR DESCRIPTION
Fixes #5974

## Summary

`DeepSeekStreamFunctionCallingHelper.merge()` used `hasText(currentToolCall.id())` to detect whether a new tool call chunk should start a new entry or be appended to the previous one. This breaks with vLLM and similar providers that include the tool call id in every chunk (unlike OpenAI which only sends it in the first chunk), causing each chunk to be treated as a separate tool call.

## Fix

When `index` is available on both the previous and current tool calls, use index equality to determine whether they represent the same tool call. Fall back to the original id-based check for providers that don't include index.

```java
// Before
if (StringUtils.hasText(currentToolCall.id())) {
    // new tool call
} else {
    // merge with previous
}

// After
boolean isSameToolCall;
if (lastPreviousTooCall != null && currentToolCall.index() != null
        && lastPreviousTooCall.index() != null) {
    isSameToolCall = currentToolCall.index().equals(lastPreviousTooCall.index());
} else {
    isSameToolCall = lastPreviousTooCall != null && !StringUtils.hasText(currentToolCall.id());
}
```

## Tests

Added 2 tests:
- `mergeVllmToolCallsWithIdInEveryChunkShouldUseIndex`: verifies that tool calls with the same index are merged even when id is present in every chunk
- `mergeWithDifferentIndicesShouldNotMerge`: verifies that tool calls with different indices are kept separate (parallel tool calls)