### PR TITLE
Add missing version of maven-checkstyle-plugin

### DIFF
--- a/memory/repository/spring-ai-model-chat-memory-repository-redis/pom.xml
+++ b/memory/repository/spring-ai-model-chat-memory-repository-redis/pom.xml
@@ -94,6 +94,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${maven-checkstyle-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>checkstyle-validation</id>


### PR DESCRIPTION
Fix the following warnings that occurred during Maven build:

```shell
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.springframework.ai:spring-ai-model-chat-memory-repository-redis:jar:2.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-checkstyle-plugin is missing. @ line 94, column 12
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```