### PR TITLE
Perform `Optional` unwrapping in `OpenAiChatModel#buildGeneration`

### DIFF
--- a/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryIT.java
+++ b/memory-repositories/spring-ai-model-chat-memory-repository-neo4j/src/test/java/org/springframework/ai/chat/memory/repository/neo4j/Neo4jChatMemoryRepositoryIT.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +50,7 @@ import org.springframework.ai.content.Media;
 import org.springframework.util.MimeType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Integration tests for {@link Neo4jChatMemoryRepository}.
@@ -406,6 +408,27 @@ class Neo4jChatMemoryRepositoryIT {
 		assertThat(retrievedEmptyMetadataMsg.getMetadata()).containsEntry("messageType", MessageType.USER);
 		assertThat(retrievedEmptyMetadataMsg.getMetadata().keySet()).hasSize(1); // Only
 																					// messageType
+	}
+
+	@Test
+	void saveAssistantMessageWithOptionalMetadataFails() {
+		var conversationId = UUID.randomUUID().toString();
+
+		// Simulate what the OpenAI SDK returns: Optional-typed fields like
+		// "refusal" and "toolCalls" in the AssistantMessage metadata.
+		// Neo4j's Values.value() cannot convert java.util.Optional to a Neo4j Value,
+		// which causes a ClientException during serialization.
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("Message with Optional metadata")
+			.properties(Map.of(
+				"refusal", Optional.of("I cannot answer that"),
+				"toolCalls", Optional.empty(),
+				"normalKey", "normalValue"))
+			.build();
+
+		assertThatThrownBy(() -> this.chatMemoryRepository.saveAll(conversationId, List.of(assistantMessage)))
+			.isInstanceOf(org.neo4j.driver.exceptions.ClientException.class)
+			.hasMessageContaining("Unable to convert java.util.Optional");
 	}
 
 	private Message createMessageByType(String content, MessageType messageType) {

--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -104,6 +104,7 @@ import org.springframework.ai.openai.setup.OpenAiSetup;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.util.JacksonUtils;
+import org.springframework.ai.util.MapUtils;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
@@ -400,6 +401,8 @@ public final class OpenAiChatModel implements ChatModel {
 			generationMetadataBuilder.metadata("audioId", audioOutput.id());
 			generationMetadataBuilder.metadata("audioExpiresAt", audioOutput.expiresAt());
 		}
+
+		assistantMessageMetadata = MapUtils.unwrapOptionals(assistantMessageMetadata);
 
 		var assistantMessage = AssistantMessage.builder()
 			.content(textContent)

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -55,6 +55,7 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.util.JsonHelper;
@@ -780,5 +781,53 @@ class OpenAiChatModelTests {
 			.file();
 		assertThat(file.fileData()).contains("data:application/pdf;base64,JVBERi0xLjc=");
 	}
+
+	@Test
+	void metadataDoesNotContainOptionalValues() {
+		ChatService chatService = mock(ChatService.class);
+		ChatCompletionService chatCompletionService = mock(ChatCompletionService.class);
+		when(this.openAiClient.chat()).thenReturn(chatService);
+		when(chatService.completions()).thenReturn(chatCompletionService);
+		when(chatCompletionService.create(any(ChatCompletionCreateParams.class))).thenReturn(ChatCompletion.builder()
+			.id("test-id")
+			.created(1777799928)
+			.model("test-model")
+			.usage(CompletionUsage.builder().promptTokens(1).completionTokens(1).totalTokens(2).build())
+			.addChoice(ChatCompletion.Choice.builder()
+				.finishReason(ChatCompletion.Choice.FinishReason.STOP)
+				.index(0)
+				.logprobs(Optional.empty())
+				.message(ChatCompletionMessage.builder()
+					.content("hello")
+					.refusal(Optional.empty())
+					.role(JsonValue.from("assistant"))
+					.annotations(List.of())
+					.toolCalls(List.of())
+					.build())
+				.build())
+			.build());
+
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		ChatResponse response = chatModel.call(new Prompt("hi", options));
+		Generation generation = response.getResult();
+		assertThat(generation).isNotNull();
+
+		// Verify no Optional values leak into generation metadata
+		generation.getMetadata().forEach((key, value) -> {
+			assertThat(value).isNotInstanceOf(Optional.class);
+		});
+
+		// Verify no Optional values leak into assistant message metadata
+		generation.getOutput().getMetadata().forEach((key, value) -> {
+			assertThat(value).isNotInstanceOf(Optional.class);
+		});
+	}
+
 
 }

--- a/spring-ai-commons/src/main/java/org/springframework/ai/util/MapUtils.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/util/MapUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Utility methods for working with {@link Map} instances.
+ *
+ * @author Evan Yao
+ * @since 1.0.0
+ */
+public abstract class MapUtils {
+
+	private MapUtils() {
+	}
+
+	/**
+	 * Unwrap any {@link Optional} values in the given map, replacing them with their
+	 * contained value or {@code null} if empty. Non-{@link Optional} values are left
+	 * unchanged. This is useful when serializing metadata maps to drivers (e.g. Neo4j,
+	 * MongoDB) that do not support {@link Optional} as a value type.
+	 * @param map the source map, must not be {@literal null}
+	 * @return a new map with all {@link Optional} values unwrapped
+	 */
+	public static Map<String, Object> unwrapOptionals(Map<String, Object> map) {
+		Map<String, Object> result = new HashMap<>(map.size());
+		for (Map.Entry<String, Object> entry : map.entrySet()) {
+			Object value = entry.getValue();
+			if (value instanceof Optional<?> optional) {
+				result.put(entry.getKey(), optional.orElse(null));
+			}
+			else {
+				result.put(entry.getKey(), value);
+			}
+		}
+		return result;
+	}
+
+}

--- a/spring-ai-commons/src/test/java/org/springframework/ai/util/MapUtilsTests.java
+++ b/spring-ai-commons/src/test/java/org/springframework/ai/util/MapUtilsTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MapUtils}.
+ *
+ * @author Evan Yao
+ * @since 1.0.0
+ */
+class MapUtilsTests {
+
+	@Test
+	void unwrapPresentOptional() {
+		Map<String, Object> map = Map.of("key", Optional.of("value"));
+		Map<String, Object> result = MapUtils.unwrapOptionals(map);
+		assertThat(result).containsEntry("key", "value");
+	}
+
+	@Test
+	void unwrapEmptyOptional() {
+		Map<String, Object> map = Map.of("key", Optional.empty());
+		Map<String, Object> result = MapUtils.unwrapOptionals(map);
+		assertThat(result).containsEntry("key", null);
+	}
+
+	@Test
+	void nonOptionalValuesPreserved() {
+		Map<String, Object> map = Map.of("str", "hello", "num", 42, "bool", true);
+		Map<String, Object> result = MapUtils.unwrapOptionals(map);
+		assertThat(result).containsEntry("str", "hello");
+		assertThat(result).containsEntry("num", 42);
+		assertThat(result).containsEntry("bool", true);
+	}
+
+	@Test
+	void mixedOptionalAndNonOptional() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("present", Optional.of("yes"));
+		map.put("empty", Optional.empty());
+		map.put("plain", "no");
+		Map<String, Object> result = MapUtils.unwrapOptionals(map);
+		assertThat(result).containsEntry("present", "yes");
+		assertThat(result).containsEntry("empty", null);
+		assertThat(result).containsEntry("plain", "no");
+	}
+
+	@Test
+	void emptyMapReturnsEmptyMap() {
+		Map<String, Object> result = MapUtils.unwrapOptionals(Map.of());
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void returnsNewMapInstance() {
+		Map<String, Object> original = Map.of("key", "value");
+		Map<String, Object> result = MapUtils.unwrapOptionals(original);
+		assertThat(result).isNotSameAs(original);
+	}
+
+}


### PR DESCRIPTION
## Description

The OpenAI Java SDK returns `Optional`-typed fields (such as `refusal` and `toolCalls`) in `AssistantMessage` metadata. When downstream repositories (Neo4j, MongoDB, JDBC, etc.) serialize these metadata maps, `Optional` values cause serialization failures since these drivers cannot convert `java.util.Optional`.

This PR adds a general-purpose `unwrapOptionals()` utility in `spring-ai-commons` and invokes it in `OpenAiChatModel#buildGeneration` so that **all downstream consumers** receive clean, unwrapped metadata — not just Neo4j.

## Changes

- **`MapUtils.unwrapOptionals()`** in `spring-ai-commons/util` — reusable utility that unwraps all `Optional` values in a metadata map
- **`OpenAiChatModel#buildGeneration`** — calls `MapUtils.unwrapOptionals()` on `assistantMessageMetadata` before passing it to `AssistantMessage.builder()`
- **`MapUtilsTests`** — 6 unit tests covering present/empty Optionals, mixed maps, and edge cases
- **`OpenAiChatModelTests#metadataDoesNotContainOptionalValues`** — verifies no `Optional` instances leak into generation or message metadata

Fixes #6007