### PR TITLE
GH-5931: Shut down ExecutorService in CassandraVectorStore.close()

### DIFF
--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
@@ -28,8 +28,9 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -191,6 +192,8 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 
 	public static final int DEFAULT_ADD_CONCURRENCY = 16;
 
+	static final int DEFAULT_EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 30;
+
 	public static final String DRIVER_PROFILE_UPDATES = "spring-ai-updates";
 
 	public static final String DRIVER_PROFILE_SEARCH = "spring-ai-search";
@@ -213,7 +216,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 
 	private final PrimaryKeyTranslator primaryKeyTranslator;
 
-	private final Executor executor;
+	private final ExecutorService executor;
 
 	private final boolean closeSessionOnClose;
 
@@ -508,8 +511,26 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 
 	@Override
 	public void close() throws Exception {
+		if (this.executor.isShutdown()) {
+			return;
+		}
+		this.executor.shutdown();
+		try {
+			if (!this.executor.awaitTermination(DEFAULT_EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+				logger.warn(
+						"Executor did not terminate within {} seconds; forcing shutdown. Some in-flight writes may be lost.",
+						DEFAULT_EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS);
+				this.executor.shutdownNow();
+			}
+		}
+		catch (InterruptedException ex) {
+			this.executor.shutdownNow();
+		}
 		if (this.closeSessionOnClose) {
 			this.session.close();
+		}
+		if (Thread.interrupted()) {
+			Thread.currentThread().interrupt();
 		}
 	}
 

--- a/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStoreIT.java
+++ b/vector-stores/spring-ai-cassandra-store/src/test/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStoreIT.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -53,6 +54,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -136,6 +138,19 @@ class CassandraVectorStoreIT extends BaseVectorStoreTests {
 				Assertions.assertNotNull(store);
 				store.checkSchemaValid();
 			}
+		});
+	}
+
+	@Test
+	void closeShutsDownExecutor() {
+		this.contextRunner.run(context -> {
+			CassandraVectorStore store = createTestStore(context);
+			ExecutorService executor = (ExecutorService) ReflectionTestUtils.getField(store, "executor");
+			Assertions.assertNotNull(executor);
+			Assertions.assertFalse(executor.isShutdown());
+			store.close();
+			Assertions.assertTrue(executor.isShutdown());
+			Assertions.assertTrue(executor.isTerminated());
 		});
 	}
 


### PR DESCRIPTION
## What

`CassandraVectorStore` creates a fixed-size `ExecutorService` thread pool in its constructor but never shuts it down in `close()`. This causes a thread leak — threads accumulate and are never reclaimed, which can exhaust resources in multi-tenant applications that dynamically create and destroy store instances.

## Fix

- Changed the `executor` field type from `Executor` to `ExecutorService`
- Added `this.executor.shutdownNow()` at the start of `close()` so all threads are released promptly

## Test

Added `closeShutsDownExecutor` to `CassandraVectorStoreIT` which uses `ReflectionTestUtils` to access the private executor field and asserts it is shut down after `close()` is called.

Fixes GH-5931 (https://github.com/spring-projects/spring-ai/issues/5931)