### PR TITLE
GH-6017: avoid unexpected stream source cancellation of `ToolCallAdvisor`

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java
@@ -268,27 +268,26 @@ public class ToolCallAdvisor implements CallAdvisor, StreamAdvisor {
 
 	/**
 	 * Streams all chunks immediately including intermediate tool call responses. Uses
-	 * publish() to multicast the stream for parallel streaming and aggregation.
+	 * ChatClientMessageAggregator to forward chunks while aggregating in parallel.
 	 */
 	private Flux<ChatClientResponse> streamWithToolCallResponses(Flux<ChatClientResponse> responseFlux,
 			AtomicReference<ChatClientResponse> aggregatedResponseRef, ChatClientRequest finalRequest,
 			StreamAdvisorChain streamAdvisorChain, ChatClientRequest originalRequest,
 			ToolCallingChatOptions optionsCopy) {
 
-		return responseFlux.publish(shared -> {
-			// Branch 1: Stream chunks immediately for real-time streaming UX
-			Flux<ChatClientResponse> streamingBranch = new ChatClientMessageAggregator()
-				.aggregateChatClientResponse(shared, aggregatedResponseRef::set);
+		// Branch 1: Stream chunks immediately for real-time streaming UX while
+		// also aggregating the response for tool call detection.
+		Flux<ChatClientResponse> streamingBranch = new ChatClientMessageAggregator()
+			.aggregateChatClientResponse(responseFlux, aggregatedResponseRef::set);
 
-			// Branch 2: After streaming completes, check for tool calls and
-			// potentially recurse.
-			Flux<ChatClientResponse> recursionBranch = Flux
-				.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest, streamAdvisorChain,
-						originalRequest, optionsCopy));
+		// Branch 2: After streaming completes, check for tool calls and
+		// potentially recurse.
+		Flux<ChatClientResponse> recursionBranch = Flux
+			.defer(() -> this.handleToolCallRecursion(aggregatedResponseRef.get(), finalRequest, streamAdvisorChain,
+					originalRequest, optionsCopy));
 
-			// Emit all streaming chunks first, then append any recursive results
-			return streamingBranch.concatWith(recursionBranch);
-		})
+		// Emit all streaming chunks first, then append any recursive results
+		return streamingBranch.concatWith(recursionBranch)
 			.filter(ccr -> this.streamToolCallResponses
 					|| !(ccr.chatResponse() != null && ccr.chatResponse().hasToolCalls()));
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisorTests.java
@@ -18,6 +18,7 @@ package org.springframework.ai.chat.client.advisor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import io.micrometer.observation.ObservationRegistry;
@@ -618,6 +619,51 @@ public class ToolCallAdvisorTests {
 		ToolCallAdvisor.Builder<?> builder = ToolCallAdvisor.builder().suppressToolCallStreaming();
 
 		assertThat(builder.isStreamToolCallResponses()).isFalse();
+	}
+
+	@Test
+	void testAdviseStreamWithSourceSignals() {
+		ToolCallAdvisor advisor = ToolCallAdvisor.builder()
+			.toolCallingManager(this.toolCallingManager)
+			.streamToolCallResponses(true)
+			.build();
+
+		ChatClientRequest request = createMockRequest(true);
+		ChatClientResponse responseWithToolCall = createMockResponse(true);
+		ChatClientResponse finalResponse = createMockResponse(false);
+		AtomicInteger completeSignals = new AtomicInteger();
+		AtomicInteger cancelSignals = new AtomicInteger();
+
+		int[] callCount = { 0 };
+		TerminalStreamAdvisor terminalAdvisor = new TerminalStreamAdvisor((req, chain) -> {
+			callCount[0]++;
+			Flux<ChatClientResponse> source = Flux.just(callCount[0] == 1 ? responseWithToolCall : finalResponse);
+			if (callCount[0] == 1) {
+				source = source.doOnComplete(completeSignals::incrementAndGet)
+					.doOnCancel(cancelSignals::incrementAndGet);
+			}
+			return source;
+		});
+
+		StreamAdvisorChain realChain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.<Advisor>of(advisor, terminalAdvisor))
+			.build();
+
+		List<Message> conversationHistory = List.of(new UserMessage("test"),
+				AssistantMessage.builder().content("").build(), ToolResponseMessage.builder().build());
+		ToolExecutionResult toolExecutionResult = ToolExecutionResult.builder()
+			.conversationHistory(conversationHistory)
+			.build();
+		when(this.toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(toolExecutionResult);
+
+		List<ChatClientResponse> results = advisor.adviseStream(request, realChain).collectList().block();
+
+		assertThat(results).isNotNull().hasSize(2);
+		assertThat(callCount[0]).isEqualTo(2);
+		assertThat(completeSignals).hasValue(1);
+		assertThat(cancelSignals).as("source should not be cancelled after normal stream completion").hasValue(0);
+		verify(this.toolCallingManager, times(1)).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
 	}
 
 	@Test


### PR DESCRIPTION
Fix #6017.

`ToolCallAdvisor` used `publish(...)` when handling streamed tool call responses. This made the source stream shared, and the source could get a cancel signal after it had already completed. This could run `doOnCancel` logic even though the stream ended normally.

https://github.com/spring-projects/spring-ai/blob/e1cc9ebe7ef60fe2abeb36eaeab685e768a3b15c/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/ToolCallAdvisor.java#L273-L294

This PR removes the publish(...) use in this path. The stream is now passed directly to `ChatClientMessageAggregator`.
