### PR TITLE
GH-6023: Fix IndexOutOfBoundException when choice.index() != list position

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.openai.client.OpenAIClient;
@@ -310,6 +311,7 @@ public final class OpenAiChatModel implements ChatModel {
 					try {
 						ChatCompletion chatCompletion = chunkToChatCompletion(chunk);
 						String id = chatCompletion.id();
+						Map<Long, ChatCompletionChunk.Choice> chunkChoiceByIndex = chunk.choices().stream().collect(Collectors.toMap(ChatCompletionChunk.Choice::index, Function.identity()));
 						List<Generation> generations = chatCompletion.choices().stream().map(choice -> {
 							roleMap.putIfAbsent(id, choice.message()._role().asString().isPresent()
 									? choice.message()._role().asStringOrThrow() : "");
@@ -319,7 +321,7 @@ public final class OpenAiChatModel implements ChatModel {
 									choice.message().refusal().isPresent() ? choice.message().refusal() : "",
 									"annotations", choice.message().annotations().isPresent()
 											? choice.message().annotations() : List.of(),
-									"chunkChoice", chunk.choices().get((int) choice.index()));
+									"chunkChoice", chunkChoiceByIndex.get(choice.index()));
 
 							return buildGeneration(choice, metadata, request);
 						}).toList();


### PR DESCRIPTION
Fixes #6023 

## Problem
- OpenAiChatModel.java:322 internalStream() used choice.index() as a positional index into chunk.choices() list
- When a gateway sends a chunk, where choice.index() == 1, but the choices list has only 1 element, which caused IOBE

## Fix
- Build a Hashmap inside chunk.choices() is gettting stored based on there index & corresponding object
- So when look was happening from hasmap the correct object based on the index ID value was getting mapped