### PR TITLE
Add `AGENTS.md` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ shell.log
 nbproject/
 
 CLAUDE.md
+AGENTS.md
 **/.claude/settings.local.json
 .devcontainer
 


### PR DESCRIPTION
## Problem

The `.gitignore` already excludes `CLAUDE.md` (Anthropic's Claude Code agent instructions file), but `AGENTS.md` — the equivalent file used by OpenAI Codex and other AI coding agents — is not excluded.

As AI coding assistants proliferate, contributors may inadvertently commit their local `AGENTS.md` configuration files.

## Solution

Add `AGENTS.md` alongside the existing `CLAUDE.md` entry in `.gitignore`.

## Changes

- `.gitignore`: add `AGENTS.md` next to `CLAUDE.md`

Closes #5883