### PR TITLE
Fix MessageWindowChatMemory to drop orphaned ToolResponseMessages after window eviction

### DIFF
--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.util.Assert;
 
 /**
@@ -108,7 +109,36 @@ public final class MessageWindowChatMemory implements ChatMemory {
 			}
 		}
 
-		return trimmedMessages;
+		return dropOrphanedToolResponses(trimmedMessages);
+	}
+
+	/**
+	 * Drop any {@link ToolResponseMessage} instances at the head of the non-system
+	 * portion of the list whose paired {@code AssistantMessage} tool-use was evicted by
+	 * the window trim. Leaving such messages causes providers (e.g. Anthropic) to reject
+	 * the request with a 400 because the {@code tool_result} has no matching
+	 * {@code tool_use} in the preceding turn.
+	 */
+	private static List<Message> dropOrphanedToolResponses(List<Message> messages) {
+		// Find where non-system messages begin
+		int firstNonSystem = 0;
+		while (firstNonSystem < messages.size() && messages.get(firstNonSystem) instanceof SystemMessage) {
+			firstNonSystem++;
+		}
+
+		// Advance past any ToolResponseMessages at the head (their tool_use was evicted)
+		int cutFrom = firstNonSystem;
+		while (cutFrom < messages.size() && messages.get(cutFrom) instanceof ToolResponseMessage) {
+			cutFrom++;
+		}
+
+		if (cutFrom == firstNonSystem) {
+			return messages;
+		}
+
+		List<Message> result = new ArrayList<>(messages.subList(0, firstNonSystem));
+		result.addAll(messages.subList(cutFrom, messages.size()));
+		return result;
 	}
 
 	public static Builder builder() {

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
@@ -17,9 +17,9 @@
 package org.springframework.ai.chat.memory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -81,17 +81,10 @@ public final class MessageWindowChatMemory implements ChatMemory {
 	private List<Message> process(List<Message> memoryMessages, List<Message> newMessages) {
 		List<Message> processedMessages = new ArrayList<>();
 
-		// Compare by text only — AbstractMessage.equals() includes metadata, which
-		// persistence stores (Cassandra, JDBC, MongoDB) may enrich on save, causing a
-		// false "new system message" detection that silently wipes existing system
-		// context.
-		Set<String> memorySystemTexts = memoryMessages.stream()
-			.filter(SystemMessage.class::isInstance)
-			.map(Message::getText)
-			.collect(Collectors.toSet());
+		Set<Message> memoryMessagesSet = new HashSet<>(memoryMessages);
 		boolean hasNewSystemMessage = newMessages.stream()
 			.filter(SystemMessage.class::isInstance)
-			.anyMatch(message -> !memorySystemTexts.contains(message.getText()));
+			.anyMatch(message -> !memoryMessagesSet.contains(message));
 
 		memoryMessages.stream()
 			.filter(message -> !(hasNewSystemMessage && message instanceof SystemMessage))

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/memory/MessageWindowChatMemory.java
@@ -17,9 +17,9 @@
 package org.springframework.ai.chat.memory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -81,10 +81,17 @@ public final class MessageWindowChatMemory implements ChatMemory {
 	private List<Message> process(List<Message> memoryMessages, List<Message> newMessages) {
 		List<Message> processedMessages = new ArrayList<>();
 
-		Set<Message> memoryMessagesSet = new HashSet<>(memoryMessages);
+		// Compare by text only — AbstractMessage.equals() includes metadata, which
+		// persistence stores (Cassandra, JDBC, MongoDB) may enrich on save, causing a
+		// false "new system message" detection that silently wipes existing system
+		// context.
+		Set<String> memorySystemTexts = memoryMessages.stream()
+			.filter(SystemMessage.class::isInstance)
+			.map(Message::getText)
+			.collect(Collectors.toSet());
 		boolean hasNewSystemMessage = newMessages.stream()
 			.filter(SystemMessage.class::isInstance)
-			.anyMatch(message -> !memoryMessagesSet.contains(message));
+			.anyMatch(message -> !memorySystemTexts.contains(message.getText()));
 
 		memoryMessages.stream()
 			.filter(message -> !(hasNewSystemMessage && message instanceof SystemMessage))
@@ -118,6 +125,11 @@ public final class MessageWindowChatMemory implements ChatMemory {
 	 * the window trim. Leaving such messages causes providers (e.g. Anthropic) to reject
 	 * the request with a 400 because the {@code tool_result} has no matching
 	 * {@code tool_use} in the preceding turn.
+	 * <p>
+	 * <strong>Assumption:</strong> this method is only correct under FIFO (head-first)
+	 * eviction. If a future eviction strategy removes an {@code AssistantMessage} that
+	 * has tool calls from a non-leading position, its corresponding
+	 * {@link ToolResponseMessage} will not be detected as an orphan by this scan.
 	 */
 	private static List<Message> dropOrphanedToolResponses(List<Message> messages) {
 		// Find where non-system messages begin

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
@@ -396,35 +396,38 @@ public class MessageWindowChatMemoryTests {
 	}
 
 	@Test
-	void systemMessageMetadataDifferenceDoesNotTriggerFalseNewSystemMessageDetection() {
-		// AbstractMessage.equals() includes metadata. A persistence store that enriches
-		// messages on save (e.g. JDBC adding a timestamp) returns a SystemMessage with
-		// extra metadata on reload. Without text-based comparison, every resumed
-		// conversation would incorrectly wipe all SystemMessages.
-		int limit = 5;
+	void multipleConsecutiveOrphanedToolResponsesAreAllDropped() {
+		// Two tool calls in one turn produce two orphaned ToolResponseMessages when
+		// both their paired AssistantMessages(tool_call) are evicted by the window.
+		// All leading ToolResponseMessages must be dropped, not just the first.
+		int limit = 3;
 		MessageWindowChatMemory mem = MessageWindowChatMemory.builder().maxMessages(limit).build();
 		String id = UUID.randomUUID().toString();
 
-		mem.add(id, List.of(new SystemMessage("System instruction"), new UserMessage("u1")));
-
-		// Simulate a persistence round-trip: reload the system message with extra
-		// metadata
-		SystemMessage reloadedWithMetadata = SystemMessage.builder()
-			.text("System instruction")
-			.metadata(java.util.Map.of("persisted_at", "2025-01-01T00:00:00Z"))
+		AssistantMessage assistantWithTool1 = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("t1", "function", "tool_a", "{}")))
 			.build();
-		mem.add(id, List.of(reloadedWithMetadata, new UserMessage("u2")));
+		ToolResponseMessage toolResponse1 = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("t1", "tool_a", "result_a")))
+			.build();
+		AssistantMessage assistantWithTool2 = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("t2", "function", "tool_b", "{}")))
+			.build();
+		ToolResponseMessage toolResponse2 = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("t2", "tool_b", "result_b")))
+			.build();
+		AssistantMessage done = new AssistantMessage("done");
+
+		// 7 messages, limit=3 → remove 4: evicts [u1, assistantWithTool1,
+		// toolResponse1, assistantWithTool2], leaving [toolResponse2, done, u2]
+		mem.add(id, List.of(new UserMessage("u1"), assistantWithTool1, toolResponse1, assistantWithTool2, toolResponse2,
+				done, new UserMessage("u2")));
 
 		List<Message> result = mem.get(id);
 
-		// With text-based detection the reloaded SM has the same text → not treated as
-		// "new", so the original SM is NOT wiped. Both messages are retained (the
-		// original
-		// and the reloaded one) rather than the old code silently discarding the
-		// original.
-		assertThat(result.stream()
-			.filter(SystemMessage.class::isInstance)
-			.anyMatch(m -> "System instruction".equals(m.getText()))).isTrue();
+		assertThat(result).doesNotContain(toolResponse1, toolResponse2);
+		assertThat(result.stream().filter(ToolResponseMessage.class::isInstance).count()).isZero();
+		assertThat(result).contains(done);
 	}
 
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
@@ -370,4 +370,61 @@ public class MessageWindowChatMemoryTests {
 		assertThat(result.stream().filter(ToolResponseMessage.class::isInstance).count()).isZero();
 	}
 
+	@Test
+	void loneOrphanedToolResponseWithMaxMessagesOneResultsInEmptyHistory() {
+		// A ToolResponseMessage stored as the only message (maxMessages=1) whose
+		// AssistantMessage(toolCall) was evicted in the same cycle should be dropped,
+		// leaving an empty history rather than sending an invalid lone tool_result to
+		// the provider.
+		MessageWindowChatMemory mem = MessageWindowChatMemory.builder().maxMessages(1).build();
+		String id = UUID.randomUUID().toString();
+
+		AssistantMessage assistantWithTool = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("t1", "function", "tool_a", "{}")))
+			.build();
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("t1", "tool_a", "result_a")))
+			.build();
+
+		// 2 messages, limit=1 → evicts assistantWithTool, toolResponse becomes lone
+		// orphan
+		mem.add(id, List.of(assistantWithTool, toolResponse));
+
+		List<Message> result = mem.get(id);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void systemMessageMetadataDifferenceDoesNotTriggerFalseNewSystemMessageDetection() {
+		// AbstractMessage.equals() includes metadata. A persistence store that enriches
+		// messages on save (e.g. JDBC adding a timestamp) returns a SystemMessage with
+		// extra metadata on reload. Without text-based comparison, every resumed
+		// conversation would incorrectly wipe all SystemMessages.
+		int limit = 5;
+		MessageWindowChatMemory mem = MessageWindowChatMemory.builder().maxMessages(limit).build();
+		String id = UUID.randomUUID().toString();
+
+		mem.add(id, List.of(new SystemMessage("System instruction"), new UserMessage("u1")));
+
+		// Simulate a persistence round-trip: reload the system message with extra
+		// metadata
+		SystemMessage reloadedWithMetadata = SystemMessage.builder()
+			.text("System instruction")
+			.metadata(java.util.Map.of("persisted_at", "2025-01-01T00:00:00Z"))
+			.build();
+		mem.add(id, List.of(reloadedWithMetadata, new UserMessage("u2")));
+
+		List<Message> result = mem.get(id);
+
+		// With text-based detection the reloaded SM has the same text → not treated as
+		// "new", so the original SM is NOT wiped. Both messages are retained (the
+		// original
+		// and the reloaded one) rather than the old code silently discarding the
+		// original.
+		assertThat(result.stream()
+			.filter(SystemMessage.class::isInstance)
+			.anyMatch(m -> "System instruction".equals(m.getText()))).isTrue();
+	}
+
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/memory/MessageWindowChatMemoryTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -290,6 +291,83 @@ public class MessageWindowChatMemoryTests {
 		assertThat(result).hasSize(2);
 		assertThat(result).containsExactly(new SystemMessage("System instruction 1"),
 				new SystemMessage("System instruction 2"));
+	}
+
+	// --- tool_use / tool_result pair-awareness tests (GH-5940) ---
+
+	@Test
+	void orphanedToolResponseIsDroppedWhenToolUseEvicted() {
+		// window=4, 6 messages → messagesToRemove=2.
+		// Trim drops [u1, assistantWithTool(t1)], leaving toolResponse(t1) as the new
+		// head. dropOrphanedToolResponses must remove it (its tool_use is gone).
+		int limit = 4;
+		MessageWindowChatMemory mem = MessageWindowChatMemory.builder().maxMessages(limit).build();
+		String id = UUID.randomUUID().toString();
+
+		AssistantMessage assistantWithTool = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("t1", "function", "tool_a", "{}")))
+			.build();
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("t1", "tool_a", "result_a")))
+			.build();
+		AssistantMessage done = new AssistantMessage("done");
+
+		// 6 messages with limit=4 → removes 2: [u1, assistantWithTool]
+		mem.add(id, List.of(new UserMessage("u1"), assistantWithTool, toolResponse, done, new UserMessage("u2"),
+				new UserMessage("u3")));
+
+		List<Message> result = mem.get(id);
+
+		assertThat(result).doesNotContain(toolResponse);
+		assertThat(result.get(0)).isNotInstanceOf(ToolResponseMessage.class);
+		assertThat(result).contains(done);
+	}
+
+	@Test
+	void toolPairPreservedWhenBothFitInWindow() {
+		int limit = 5;
+		MessageWindowChatMemory mem = MessageWindowChatMemory.builder().maxMessages(limit).build();
+		String id = UUID.randomUUID().toString();
+
+		AssistantMessage assistantWithTool = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("t1", "function", "tool_a", "{}")))
+			.build();
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("t1", "tool_a", "result_a")))
+			.build();
+
+		mem.add(id, List.of(new UserMessage("u1"), assistantWithTool, toolResponse, new AssistantMessage("done"),
+				new UserMessage("u2")));
+
+		List<Message> result = mem.get(id);
+
+		assertThat(result).hasSize(limit);
+		assertThat(result).contains(assistantWithTool, toolResponse);
+	}
+
+	@Test
+	void systemMessagePreservedWhenOrphanedToolResponseDropped() {
+		int limit = 4;
+		MessageWindowChatMemory mem = MessageWindowChatMemory.builder().maxMessages(limit).build();
+		String id = UUID.randomUUID().toString();
+
+		SystemMessage sys = new SystemMessage("System instruction");
+		AssistantMessage assistantWithTool = AssistantMessage.builder()
+			.toolCalls(List.of(new AssistantMessage.ToolCall("t1", "function", "tool_a", "{}")))
+			.build();
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("t1", "tool_a", "result_a")))
+			.build();
+
+		// sys is always preserved; 5 total with limit=4 → removes 1 non-system message.
+		// assistantWithTool (first non-system) is dropped → toolResponse becomes orphan.
+		mem.add(id, List.of(sys, assistantWithTool, toolResponse, new AssistantMessage("done"), new UserMessage("u2")));
+
+		List<Message> result = mem.get(id);
+
+		assertThat(result).contains(sys);
+		assertThat(result).doesNotContain(toolResponse);
+		assertThat(result.stream().filter(ToolResponseMessage.class::isInstance).count()).isZero();
 	}
 
 }


### PR DESCRIPTION
## Problem

\`MessageWindowChatMemory\` truncates the message list from the head when the window size is exceeded. However, it does not account for the structural constraint that every \`ToolResponseMessage\` must be preceded by an \`AssistantMessage\` containing the matching tool-use call.

When the window evicts exactly enough messages to remove an \`AssistantMessage\` that contained a tool-use block, the corresponding \`ToolResponseMessage\` is left at the start of the retained list — as an orphan with no preceding tool call. Sending this to an LLM causes an API error (e.g. Anthropic returns \`400: tool_use block must be followed by tool_result\`).

### Reproduction scenario

\`\`\`
Window limit = 3, per-add saves (as done by MessageChatMemoryAdvisor):
  add([UserMsg1])             → [UserMsg1]
  add([AssistantMsg(tool)])   → [UserMsg1, AssistantMsg(tool)]
  add([ToolResponseMsg])      → [UserMsg1, AssistantMsg(tool), ToolResponseMsg]   ← at limit
  add([AssistantMsg_final])   → trim 1 → [AssistantMsg(tool), ToolResponseMsg, AssistantMsg_final]

Next turn:
  add([UserMsg2])             → trim 1 → [ToolResponseMsg, AssistantMsg_final, UserMsg2]
                                           ^^^ orphaned — no preceding tool_use → Anthropic 400
\`\`\`

## Solution

After the standard head-truncation, scan the retained list for any \`ToolResponseMessage\` entries that appear before the first non-system, non-tool-response message. Drop all of them — they are orphans whose \`AssistantMessage(tool_use)\` partner was evicted.

\`\`\`java
private static List<Message> dropOrphanedToolResponses(List<Message> messages) {
    // skip leading SystemMessages (always preserved)
    // drop all consecutive ToolResponseMessages at the head
    // (their AssistantMessage partner was evicted by the window trim)
}
\`\`\`

## Changes

- \`MessageWindowChatMemory.java\`: call \`dropOrphanedToolResponses()\` after head-truncation
- \`MessageWindowChatMemoryTests.java\`: four new tests

## Tests

All existing 18 tests continue to pass. Four new tests added:

- \`orphanedToolResponseIsDroppedWhenToolUseEvicted\` — single orphan
- \`multipleConsecutiveOrphanedToolResponsesAreAllDropped\` — two back-to-back orphans from a multi-tool-call turn
- \`toolPairPreservedWhenBothFitInWindow\` — complete pair survives eviction
- \`systemMessagePreservedWhenOrphanedToolResponseDropped\` — system message stays at position 0
- \`loneOrphanedToolResponseWithMaxMessagesOneResultsInEmptyHistory\` — edge case: single orphan leaves empty history

## Known limitation

\`dropOrphanedToolResponses\` only catches orphans created by **FIFO head-first eviction** — the only eviction strategy currently implemented. If a future strategy evicts an \`AssistantMessage(tool_call)\` from a non-leading position, its \`ToolResponseMessage\` would not be detected.

After orphan drop, the conversation may start with an \`AssistantMessage\` (clean text, no tool calls) if the user message that preceded it was also evicted in the same cycle. This is a separate concern — the specific error reported in \#5940 (\`tool_result\` with no matching \`tool_use\`) is fully addressed here.

Closes #5940