### PR TITLE
Add health indicators for VectorStore beans via Spring Boot Actuator

### DIFF
--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/pom.xml
@@ -50,6 +50,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-health</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthContributorAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthContributorAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -36,18 +37,24 @@ import org.springframework.context.annotation.Bean;
  * Registers a {@link HealthContributor} named {@code vectorStoreHealthContributor} for
  * every {@link VectorStore} bean present in the application context. When there is a
  * single store the contributor is a plain {@link HealthIndicator}; when multiple stores
- * are present a {@link CompositeHealthContributor} is created, keyed by bean name, so
- * each store is individually visible under
- * {@code /actuator/health/vectorStore/<beanName>}.
+ * are present a {@link CompositeHealthContributor} is created, keyed by Spring bean name,
+ * so each store is individually visible under
+ * {@code /actuator/health/vectorStore/<beanName>}. In the composite case each leaf
+ * indicator also reports the store's {@link VectorStore#getName()} as a detail value,
+ * which may differ from the bean name used as the path segment.
  * <p>
  * The contributor is only registered when the {@code vectorStore} health indicator is
  * enabled (controlled via {@code management.health.vectorStore.enabled=true/false},
  * defaulting to {@code true}).
+ * <p>
+ * To override this auto-configuration, register a bean named
+ * {@code vectorStoreHealthContributor}.
  *
  * @author Surya Teja Gorre
  * @since 2.0.0
  */
 @AutoConfiguration
+@AutoConfigureAfter(VectorStoreObservationAutoConfiguration.class)
 @ConditionalOnClass({ VectorStore.class, HealthIndicator.class })
 @ConditionalOnBean(VectorStore.class)
 @ConditionalOnEnabledHealthIndicator("vectorStore")

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthContributorAutoConfiguration.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthContributorAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.observation.autoconfigure;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.health.contributor.CompositeHealthContributor;
+import org.springframework.boot.health.contributor.HealthContributor;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * {@link AutoConfiguration Auto-configuration} for {@link VectorStoreHealthIndicator}.
+ * <p>
+ * Registers a {@link HealthContributor} named {@code vectorStoreHealthContributor} for
+ * every {@link VectorStore} bean present in the application context. When there is a
+ * single store the contributor is a plain {@link HealthIndicator}; when multiple stores
+ * are present a {@link CompositeHealthContributor} is created, keyed by bean name, so
+ * each store is individually visible under
+ * {@code /actuator/health/vectorStore/<beanName>}.
+ * <p>
+ * The contributor is only registered when the {@code vectorStore} health indicator is
+ * enabled (controlled via {@code management.health.vectorStore.enabled=true/false},
+ * defaulting to {@code true}).
+ *
+ * @author Surya Teja Gorre
+ * @since 2.0.0
+ */
+@AutoConfiguration
+@ConditionalOnClass({ VectorStore.class, HealthIndicator.class })
+@ConditionalOnBean(VectorStore.class)
+@ConditionalOnEnabledHealthIndicator("vectorStore")
+public class VectorStoreHealthContributorAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(name = "vectorStoreHealthContributor")
+	public HealthContributor vectorStoreHealthContributor(Map<String, VectorStore> vectorStores) {
+		if (vectorStores.size() == 1) {
+			return new VectorStoreHealthIndicator(vectorStores.values().iterator().next());
+		}
+		Map<String, HealthContributor> contributors = new LinkedHashMap<>();
+		vectorStores.forEach((name, store) -> contributors.put(name, new VectorStoreHealthIndicator(store)));
+		return CompositeHealthContributor.fromMap(contributors);
+	}
+
+}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthIndicator.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthIndicator.java
@@ -25,12 +25,23 @@ import org.springframework.util.StringUtils;
 
 /**
  * {@link org.springframework.boot.health.contributor.HealthIndicator} for a
- * {@link VectorStore}. Performs a lightweight similarity search with {@code topK=0} to
- * verify that the store is reachable and responding without retrieving any results.
+ * {@link VectorStore}. Issues a {@code topK=1} similarity search probe to verify the
+ * store is reachable and responding. The single result is discarded.
  * <p>
- * Note: the probe issues a query through the store's configured embedding pipeline. If
- * the underlying embedding model is unavailable, this indicator will report {@code DOWN}
- * even if the vector store itself is healthy.
+ * <strong>Embedding model dependency:</strong> most {@link VectorStore} implementations
+ * route {@code similaritySearch} through the configured embedding pipeline, which means
+ * every health-check poll issues a remote call to the embedding model (OpenAI, Azure
+ * OpenAI, Bedrock, etc.). Consequences:
+ * <ul>
+ * <li>If the embedding model is unavailable or rate-limited this indicator reports
+ * {@code DOWN} even when the vector store itself is healthy.</li>
+ * <li>Each poll incurs an embedding API call that may be billed and counted against
+ * rate-limit quotas. In a multi-replica deployment with frequent Actuator polling, this
+ * generates significant background API traffic. Adjust
+ * {@code management.health.vectorStore.enabled} and the poll interval accordingly.</li>
+ * </ul>
+ * To suppress health checks for a specific store, set
+ * {@code management.health.vectorStore.enabled=false}.
  *
  * @author Surya Teja Gorre
  * @since 2.0.0
@@ -47,7 +58,7 @@ public class VectorStoreHealthIndicator extends AbstractHealthIndicator {
 
 	@Override
 	protected void doHealthCheck(Health.Builder builder) throws Exception {
-		this.vectorStore.similaritySearch(SearchRequest.builder().query("health").topK(0).build());
+		this.vectorStore.similaritySearch(SearchRequest.builder().query("health").topK(1).build());
 		String name = this.vectorStore.getName();
 		builder.up()
 			.withDetail("vectorStore", StringUtils.hasText(name) ? name : this.vectorStore.getClass().getSimpleName());

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthIndicator.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthIndicator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.observation.autoconfigure;
+
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.boot.health.contributor.AbstractHealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * {@link org.springframework.boot.health.contributor.HealthIndicator} for a
+ * {@link VectorStore}. Performs a lightweight similarity search with {@code topK=0} to
+ * verify that the store is reachable and responding without retrieving any results.
+ * <p>
+ * Note: the probe issues a query through the store's configured embedding pipeline. If
+ * the underlying embedding model is unavailable, this indicator will report {@code DOWN}
+ * even if the vector store itself is healthy.
+ *
+ * @author Surya Teja Gorre
+ * @since 2.0.0
+ */
+public class VectorStoreHealthIndicator extends AbstractHealthIndicator {
+
+	private final VectorStore vectorStore;
+
+	public VectorStoreHealthIndicator(VectorStore vectorStore) {
+		super("VectorStore health check failed");
+		Assert.notNull(vectorStore, "VectorStore must not be null");
+		this.vectorStore = vectorStore;
+	}
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) throws Exception {
+		this.vectorStore.similaritySearch(SearchRequest.builder().query("health").topK(0).build());
+		String name = this.vectorStore.getName();
+		builder.up()
+			.withDetail("vectorStore", StringUtils.hasText(name) ? name : this.vectorStore.getClass().getSimpleName());
+	}
+
+}

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 org.springframework.ai.vectorstore.observation.autoconfigure.VectorStoreObservationAutoConfiguration
+org.springframework.ai.vectorstore.observation.autoconfigure.VectorStoreHealthContributorAutoConfiguration

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/test/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthContributorAutoConfigurationTests.java
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/src/test/java/org/springframework/ai/vectorstore/observation/autoconfigure/VectorStoreHealthContributorAutoConfigurationTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.vectorstore.observation.autoconfigure;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.health.contributor.CompositeHealthContributor;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthContributor;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link VectorStoreHealthContributorAutoConfiguration}.
+ *
+ * @author Surya Teja Gorre
+ */
+class VectorStoreHealthContributorAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(VectorStoreHealthContributorAutoConfiguration.class));
+
+	@Test
+	void healthIndicatorRegisteredForSingleVectorStore() {
+		this.contextRunner.withUserConfiguration(SingleVectorStoreConfiguration.class).run(ctx -> {
+			assertThat(ctx).hasSingleBean(HealthContributor.class);
+			HealthContributor contributor = ctx.getBean("vectorStoreHealthContributor", HealthContributor.class);
+			assertThat(contributor).isInstanceOf(HealthIndicator.class);
+			Health health = ((HealthIndicator) contributor).health();
+			assertThat(health.getStatus()).isEqualTo(Status.UP);
+			assertThat(health.getDetails()).containsEntry("vectorStore", "SimpleVectorStore");
+		});
+	}
+
+	@Test
+	void compositeHealthContributorRegisteredForMultipleVectorStores() {
+		this.contextRunner.withUserConfiguration(MultipleVectorStoreConfiguration.class).run(ctx -> {
+			HealthContributor contributor = ctx.getBean("vectorStoreHealthContributor", HealthContributor.class);
+			assertThat(contributor).isInstanceOf(CompositeHealthContributor.class);
+			CompositeHealthContributor composite = (CompositeHealthContributor) contributor;
+			assertThat(composite.iterator()).toIterable().hasSize(2);
+		});
+	}
+
+	@Test
+	void healthIndicatorCanBeDisabled() {
+		this.contextRunner.withUserConfiguration(SingleVectorStoreConfiguration.class)
+			.withPropertyValues("management.health.vectorStore.enabled=false")
+			.run(ctx -> assertThat(ctx).doesNotHaveBean("vectorStoreHealthContributor"));
+	}
+
+	@Test
+	void healthIndicatorReportsDownWhenStoreThrows() {
+		this.contextRunner.withUserConfiguration(FailingVectorStoreConfiguration.class).run(ctx -> {
+			HealthContributor contributor = ctx.getBean("vectorStoreHealthContributor", HealthContributor.class);
+			Health health = ((HealthIndicator) contributor).health();
+			assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+		});
+	}
+
+	@Test
+	void noContributorRegisteredWhenNoVectorStorePresent() {
+		this.contextRunner.run(ctx -> assertThat(ctx).doesNotHaveBean(HealthContributor.class));
+	}
+
+	@Test
+	void userDefinedContributorIsNotReplaced() {
+		this.contextRunner.withUserConfiguration(SingleVectorStoreConfiguration.class)
+			.withBean("vectorStoreHealthContributor", HealthContributor.class,
+					() -> (HealthIndicator) () -> Health.up().withDetail("custom", true).build())
+			.run(ctx -> {
+				HealthContributor contributor = ctx.getBean("vectorStoreHealthContributor", HealthContributor.class);
+				Health health = ((HealthIndicator) contributor).health();
+				assertThat(health.getDetails()).containsKey("custom");
+			});
+	}
+
+	// --- test configurations ---
+
+	@Configuration(proxyBeanMethods = false)
+	static class SingleVectorStoreConfiguration {
+
+		@Bean
+		VectorStore vectorStore() {
+			return new StubVectorStore("SimpleVectorStore", false);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MultipleVectorStoreConfiguration {
+
+		@Bean
+		VectorStore firstVectorStore() {
+			return new StubVectorStore("FirstStore", false);
+		}
+
+		@Bean
+		VectorStore secondVectorStore() {
+			return new StubVectorStore("SecondStore", false);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class FailingVectorStoreConfiguration {
+
+		@Bean
+		VectorStore vectorStore() {
+			return new StubVectorStore("FailingStore", true);
+		}
+
+	}
+
+	static class StubVectorStore implements VectorStore {
+
+		private final String name;
+
+		private final boolean failOnSearch;
+
+		StubVectorStore(String name, boolean failOnSearch) {
+			this.name = name;
+			this.failOnSearch = failOnSearch;
+		}
+
+		@Override
+		public String getName() {
+			return this.name;
+		}
+
+		@Override
+		public void add(List<Document> documents) {
+		}
+
+		@Override
+		public void delete(List<String> idList) {
+		}
+
+		@Override
+		public void delete(Filter.Expression filterExpression) {
+		}
+
+		@Override
+		public List<Document> similaritySearch(SearchRequest request) {
+			if (this.failOnSearch) {
+				throw new RuntimeException("Connection refused");
+			}
+			return List.of();
+		}
+
+		@Override
+		public <T> Optional<T> getNativeClient() {
+			return Optional.empty();
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Problem

Spring AI's `VectorStore` implementations have no out-of-the-box integration with Spring Boot Actuator's health endpoint. Users cannot tell whether their vector store is reachable simply by checking `/actuator/health`.

Closes #1611

## Solution

Add `VectorStoreHealthIndicator` and `VectorStoreHealthContributorAutoConfiguration` to the `spring-ai-autoconfigure-vector-store-observation` module.

### Behaviour

- **Single store** → a plain `HealthIndicator` named `vectorStoreHealthContributor` is registered; visible at `/actuator/health/vectorStore`.
- **Multiple stores** → a `CompositeHealthContributor` is registered, keyed by bean name; each store is individually visible at `/actuator/health/vectorStore/<beanName>`.
- **Health check** → performs a lightweight `similaritySearch(query="health", topK=1)`. Reports `UP` with the store name as a detail; reports `DOWN` with the exception message on failure.
- **Toggle** → respects `management.health.vectorStore.enabled=false` (defaults to `true`).

### Example output

```json
{
  "status": "UP",
  "components": {
    "vectorStore": {
      "status": "UP",
      "details": { "vectorStore": "SimpleVectorStore" }
    }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `pom.xml` | Add optional `spring-boot-health` dependency (Spring Boot 4.x module) |
| `VectorStoreHealthIndicator.java` | New — `AbstractHealthIndicator` implementation |
| `VectorStoreHealthContributorAutoConfiguration.java` | New — auto-configuration with `@ConditionalOnEnabledHealthIndicator("vectorStore")` |
| `AutoConfiguration.imports` | Register new auto-configuration |
| `VectorStoreHealthContributorAutoConfigurationTests.java` | New — 4 tests via `ApplicationContextRunner` |

## Tests

- `healthIndicatorRegisteredForSingleVectorStore` — single store → plain `HealthIndicator`, status `UP`
- `compositeHealthContributorRegisteredForMultipleVectorStores` — two stores → `CompositeHealthContributor` with 2 entries
- `healthIndicatorCanBeDisabled` — `management.health.vectorStore.enabled=false` → no bean registered
- `healthIndicatorReportsDownWhenStoreThrows` — store throws on search → status `DOWN`

All 4 tests pass.