### PR TITLE
GH-5894: Pass mcpServerJsonMapper to McpServerStatelessAutoConfiguration

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification;
@@ -37,9 +38,11 @@ import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -80,13 +83,16 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
-			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment) {
+			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment,
+			@Qualifier("mcpServerJsonMapper") JsonMapper mcpServerJsonMapper) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
-		StatelessSyncSpecification serverBuilder = McpServer.sync(statelessTransport).serverInfo(serverInfo);
+		StatelessSyncSpecification serverBuilder = McpServer.sync(statelessTransport)
+			.serverInfo(serverInfo)
+			.jsonMapper(new JacksonMcpJsonMapper(mcpServerJsonMapper));
 
 		// Tools
 		if (serverProperties.getCapabilities().isTool()) {
@@ -170,13 +176,16 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
-			ObjectProvider<List<AsyncCompletionSpecification>> completions) {
+			ObjectProvider<List<AsyncCompletionSpecification>> completions,
+			@Qualifier("mcpServerJsonMapper") JsonMapper mcpServerJsonMapper) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
 
 		// Create the server with both tool and resource capabilities
-		StatelessAsyncSpecification serverBuilder = McpServer.async(statelessTransport).serverInfo(serverInfo);
+		StatelessAsyncSpecification serverBuilder = McpServer.async(statelessTransport)
+			.serverInfo(serverInfo)
+			.jsonMapper(new JacksonMcpJsonMapper(mcpServerJsonMapper));
 
 		// Tools
 		if (serverProperties.getCapabilities().isTool()) {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -63,6 +63,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -71,8 +72,8 @@ public class McpStatelessServerAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withPropertyValues("spring.ai.mcp.server.protocol=STATELESS")
-		.withConfiguration(AutoConfigurations.of(McpServerStatelessAutoConfiguration.class,
-				StatelessToolCallbackConverterAutoConfiguration.class))
+		.withConfiguration(AutoConfigurations.of(McpServerJsonMapperAutoConfiguration.class,
+				McpServerStatelessAutoConfiguration.class, StatelessToolCallbackConverterAutoConfiguration.class))
 		.withUserConfiguration(TestStatelessTransportConfiguration.class);
 
 	@Test
@@ -93,6 +94,14 @@ public class McpStatelessServerAutoConfigurationIT {
 			assertThat(properties.getCapabilities().isResource()).isTrue();
 			assertThat(properties.getCapabilities().isPrompt()).isTrue();
 			assertThat(properties.getCapabilities().isCompletion()).isTrue();
+		});
+	}
+
+	@Test
+	void mcpServerJsonMapperIsRegistered() {
+		this.contextRunner.run(context -> {
+			assertThat(context).hasBean("mcpServerJsonMapper");
+			assertThat(context.getBean("mcpServerJsonMapper")).isInstanceOf(JsonMapper.class);
 		});
 	}
 


### PR DESCRIPTION
## Summary

- `McpServerStatelessAutoConfiguration.mcpStatelessSyncServer()` and `mcpStatelessAsyncServer()` now accept `@Qualifier("mcpServerJsonMapper") JsonMapper` and pass it as `JacksonMcpJsonMapper` to the `McpServer.sync/async()` builder via `.jsonMapper()`
- This ensures the stateless server uses the same configured Jackson 3 mapper as the transport layer (`McpServerStatelessWebMvcAutoConfiguration` and `McpServerStatelessWebFluxAutoConfiguration` already do this for the transport)
- Adds `McpServerJsonMapperAutoConfiguration` to the `ApplicationContextRunner` in `McpStatelessServerAutoConfigurationIT` and adds a test asserting the `mcpServerJsonMapper` bean is present

## How to test locally

```bash
./mvnw test -pl auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common -Dtest=McpStatelessServerAutoConfigurationIT
```

Fixes https://github.com/spring-projects/spring-ai/issues/5894