### PR TITLE
Fix stateless MCP "handler not configured" with lazy init

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.util.CollectionUtils;
@@ -55,6 +56,7 @@ import org.springframework.web.context.support.StandardServletEnvironment;
 
 /**
  * @author Christian Tzolov
+ * @author Jewoo Shin
  */
 @AutoConfiguration
 @ConditionalOnClass(McpSchema.class)
@@ -72,6 +74,7 @@ public class McpServerStatelessAutoConfiguration {
 	}
 
 	@Bean
+	@Lazy(false)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
 	public McpStatelessSyncServer mcpStatelessSyncServer(McpStatelessServerTransport statelessTransport,
@@ -163,6 +166,7 @@ public class McpServerStatelessAutoConfiguration {
 	}
 
 	@Bean
+	@Lazy(false)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	public McpStatelessAsyncServer mcpStatelessAsyncServer(McpStatelessServerTransport statelessTransport,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -56,17 +56,24 @@ import org.springframework.ai.mcp.server.common.autoconfigure.annotations.Statel
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+/**
+ * Integration tests for {@link McpServerStatelessAutoConfiguration}.
+ *
+ * @author Jewoo Shin
+ */
 public class McpStatelessServerAutoConfigurationIT {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -145,6 +152,31 @@ public class McpStatelessServerAutoConfigurationIT {
 
 				McpStatelessSyncServer server = context.getBean(McpStatelessSyncServer.class);
 				assertThat(server).isNotNull();
+			});
+	}
+
+	@Test
+	void syncServerIsEagerlyCreatedWithLazyInitialization() {
+		// gh-5964: with spring.main.lazy-initialization=true the stateless sync server
+		// must still be eagerly created so the transport handler is wired before any
+		// request arrives.
+		this.contextRunner
+			.withInitializer(context -> ((GenericApplicationContext) context)
+				.registerBean(LazyInitializationBeanFactoryPostProcessor.class))
+			.run(context -> {
+				assertThat(context).hasSingleBean(McpStatelessSyncServer.class);
+				assertThat(context.getBeanFactory().containsSingleton("mcpStatelessSyncServer")).isTrue();
+			});
+	}
+
+	@Test
+	void asyncServerIsEagerlyCreatedWithLazyInitialization() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.type=ASYNC")
+			.withInitializer(context -> ((GenericApplicationContext) context)
+				.registerBean(LazyInitializationBeanFactoryPostProcessor.class))
+			.run(context -> {
+				assertThat(context).hasSingleBean(McpStatelessAsyncServer.class);
+				assertThat(context.getBeanFactory().containsSingleton("mcpStatelessAsyncServer")).isTrue();
 			});
 	}
 


### PR DESCRIPTION
### Summary

Closes #5964.

When `spring.main.lazy-initialization=true` is enabled, the stateless MCP server beans are deferred during context refresh. The stateless transport endpoint is still registered, but the MCP handler is only wired when the server bean is built. That leaves incoming stateless requests failing with `MCP handler not configured`.

### Changes

- Add `@Lazy(false)` to `mcpStatelessSyncServer(...)`.
- Add `@Lazy(false)` to `mcpStatelessAsyncServer(...)`, which has the same lazy-init failure mode as the reported sync case.

### Tests

Added regression coverage in `McpStatelessServerAutoConfigurationIT` for:

- sync server eager creation under `LazyInitializationBeanFactoryPostProcessor`
- async server eager creation under the same post-processor

Each test asserts `beanFactory.containsSingleton(...)` after refresh, verifying eager instantiation without triggering the bean by lookup. This directly covers the eager-creation contract required for stateless transport handler wiring.

```bash
./mvnw -pl auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common -am test -Dtest='McpStatelessServerAutoConfigurationIT' -Dsurefire.failIfNoSpecifiedTests=false
```

Passes with 25 tests and 0 failures.

### Risk

Low. This only forces eager creation for stateless MCP server beans that must run their handler-wiring side effect during context refresh. It does not change behavior when global lazy initialization is disabled.

### Scope

This PR intentionally covers only the stateless path requested in #5964. The SSE / stateful path tracked in #3868 lives in different auto-configurations and is left out of this PR.
