### PR TITLE
GH-3116: Normalize MCP tool input schemas

### DIFF
--- a/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
+++ b/mcp/common/src/test/java/org/springframework/ai/mcp/ToolUtilsTests.java
@@ -39,6 +39,7 @@ import reactor.test.StepVerifier;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.DefaultToolDefinition;
 import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.util.JsonHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,6 +49,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ToolUtilsTests {
+
+	private static final JsonHelper jsonHelper = new JsonHelper();
 
 	@Test
 	void prefixedToolNameShouldConcatenateWithUnderscore() {
@@ -208,6 +211,59 @@ class ToolUtilsTests {
 		// Compatibility
 		String result = McpToolUtils.prefixedToolName("前缀\u3400", "缀\\u3400", "工具\u9fff名称\uf900");
 		assertThat(result).isEqualTo("前_缀u3400_工具鿿名称豈");
+	}
+
+	@Test
+	void createToolDefinitionShouldNormalizeParameterlessToolSchema() {
+		Tool tool = Tool.builder()
+			.name("currentTime")
+			.description("Get the current time")
+			.inputSchema(jsonHelper.fromJson("{\"type\":\"object\"}", McpSchema.JsonSchema.class))
+			.build();
+
+		ToolDefinition toolDefinition = McpToolUtils.createToolDefinition("server_currentTime", tool);
+
+		Map<String, Object> schemaMap = jsonHelper.fromJsonToMap(toolDefinition.inputSchema());
+		assertThat(schemaMap).containsEntry("type", "object");
+		assertThat((Map<?, ?>) schemaMap.get("properties")).isEmpty();
+		assertThat((List<?>) schemaMap.get("required")).isEmpty();
+	}
+
+	@Test
+	void createToolDefinitionShouldNormalizeNestedParameterlessToolSchemas() {
+		Tool tool = Tool.builder()
+			.name("projectContext")
+			.description("Get project context")
+			.inputSchema(jsonHelper.fromJsonToMap("""
+					{
+						"type": "object",
+						"properties": {
+							"selection": {
+								"type": "object"
+							},
+							"files": {
+								"type": "array",
+								"items": {
+									"type": "object"
+								}
+							}
+						}
+					}
+					"""))
+			.build();
+
+		ToolDefinition toolDefinition = McpToolUtils.createToolDefinition("server_projectContext", tool);
+
+		Map<String, Object> schemaMap = jsonHelper.fromJsonToMap(toolDefinition.inputSchema());
+		Map<String, Object> properties = (Map<String, Object>) schemaMap.get("properties");
+		Map<String, Object> selection = (Map<String, Object>) properties.get("selection");
+		Map<String, Object> files = (Map<String, Object>) properties.get("files");
+		Map<String, Object> fileItems = (Map<String, Object>) files.get("items");
+
+		assertThat((Map<?, ?>) selection.get("properties")).isEmpty();
+		assertThat((List<?>) selection.get("required")).isEmpty();
+		assertThat((Map<?, ?>) fileItems.get("properties")).isEmpty();
+		assertThat((List<?>) fileItems.get("required")).isEmpty();
 	}
 
 	@Test

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaUtils.java
@@ -18,6 +18,7 @@ package org.springframework.ai.util.json.schema;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -188,23 +189,11 @@ public final class JsonSchemaUtils {
 
 		Map<String, Object> schemaMap = jsonHelper.fromJsonToMap(inputSchema);
 
-		if (schemaMap.isEmpty()) {
-			// Create a minimal valid schema
-			schemaMap = new java.util.HashMap<>();
-			schemaMap.put("type", "object");
-			schemaMap.put("properties", new java.util.HashMap<>());
-			return jsonHelper.toJson(schemaMap);
+		if (schemaMap == null || schemaMap.isEmpty()) {
+			schemaMap = new HashMap<>();
 		}
 
-		// Ensure "type" field exists
-		if (!schemaMap.containsKey("type")) {
-			schemaMap.put("type", "object");
-		}
-
-		// Ensure "properties" field exists for object types
-		if ("object".equals(schemaMap.get("type")) && !schemaMap.containsKey("properties")) {
-			schemaMap.put("properties", new java.util.HashMap<>());
-		}
+		normalizeObjectSchema(schemaMap);
 
 		return jsonHelper.toJson(schemaMap);
 	}
@@ -227,6 +216,42 @@ public final class JsonSchemaUtils {
 		}
 
 		return node;
+	}
+
+	private static void normalizeObjectSchema(Map<String, Object> schemaMap) {
+		if (!schemaMap.containsKey("type")) {
+			schemaMap.put("type", "object");
+		}
+
+		if ("object".equals(schemaMap.get("type"))) {
+			schemaMap.computeIfAbsent("properties", key -> new HashMap<>());
+			schemaMap.computeIfAbsent("required", key -> List.of());
+		}
+
+		normalizeSchemaMapValues(schemaMap.get("properties"));
+		normalizeSchemaNode(schemaMap.get("items"));
+		normalizeSchemaMapValues(schemaMap.get("$defs"));
+		normalizeSchemaMapValues(schemaMap.get("definitions"));
+		normalizeSchemaNode(schemaMap.get("additionalProperties"));
+		normalizeSchemaNode(schemaMap.get("allOf"));
+		normalizeSchemaNode(schemaMap.get("anyOf"));
+		normalizeSchemaNode(schemaMap.get("oneOf"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void normalizeSchemaNode(@Nullable Object schemaNode) {
+		if (schemaNode instanceof Map<?, ?> schemaMap) {
+			normalizeObjectSchema((Map<String, Object>) schemaMap);
+		}
+		else if (schemaNode instanceof Iterable<?> schemaNodes) {
+			schemaNodes.forEach(JsonSchemaUtils::normalizeSchemaNode);
+		}
+	}
+
+	private static void normalizeSchemaMapValues(@Nullable Object schemaMapNode) {
+		if (schemaMapNode instanceof Map<?, ?> schemaMap) {
+			schemaMap.values().forEach(JsonSchemaUtils::normalizeSchemaNode);
+		}
 	}
 
 }

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/schema/JsonSchemaUtilsTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/schema/JsonSchemaUtilsTests.java
@@ -72,6 +72,18 @@ class JsonSchemaUtilsTests {
 		assertThat(properties).isEmpty();
 	}
 
+	@Test
+	void testEnsureValidInputSchemaAddsRequiredFieldForObjectSchema() {
+		String inputSchema = "{\"type\":\"object\"}";
+
+		String normalizedSchema = JsonSchemaUtils.ensureValidInputSchema(inputSchema);
+
+		Map<String, Object> schemaMap = jsonHelper.fromJsonToMap(normalizedSchema);
+		assertThat(schemaMap).isNotNull();
+		assertThat(schemaMap).containsKey("required");
+		assertThat((List<?>) schemaMap.get("required")).isEmpty();
+	}
+
 	/**
 	 * Test that a schema without a "type" field is normalized to include both "type" and
 	 * "properties" fields.
@@ -129,6 +141,108 @@ class JsonSchemaUtilsTests {
 		Map<String, Object> properties = (Map<String, Object>) schemaMap.get("properties");
 		assertThat(properties).isNotEmpty();
 		assertThat(properties).containsKey("cityName");
+	}
+
+	@Test
+	void testEnsureValidInputSchemaPreservesExistingRequiredFields() {
+		String inputSchema = """
+				{"type":"object","properties":{"cityName":{"type":"string"}},"required":["cityName"]}
+				""";
+
+		String normalizedSchema = JsonSchemaUtils.ensureValidInputSchema(inputSchema);
+
+		Map<String, Object> schemaMap = jsonHelper.fromJsonToMap(normalizedSchema);
+		assertThat(schemaMap).isNotNull();
+		assertThat(schemaMap.get("required")).isEqualTo(List.of("cityName"));
+	}
+
+	@Test
+	void ensureValidInputSchemaNormalizesNestedObjectSchemas() {
+		String inputSchema = """
+				{
+					"type": "object",
+					"properties": {
+						"filters": {
+							"type": "object",
+							"properties": {
+								"owner": {
+									"type": "object"
+								}
+							}
+						},
+						"matches": {
+							"type": "array",
+							"items": {
+								"type": "object"
+							}
+						},
+						"metadata": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "object"
+							}
+						}
+					},
+					"oneOf": [
+						{
+							"type": "object"
+						}
+					]
+				}
+				""";
+
+		String normalizedSchema = JsonSchemaUtils.ensureValidInputSchema(inputSchema);
+
+		Map<String, Object> schemaMap = jsonHelper.fromJsonToMap(normalizedSchema);
+		Map<String, Object> properties = (Map<String, Object>) schemaMap.get("properties");
+		Map<String, Object> filters = (Map<String, Object>) properties.get("filters");
+		Map<String, Object> filterProperties = (Map<String, Object>) filters.get("properties");
+		Map<String, Object> owner = (Map<String, Object>) filterProperties.get("owner");
+		Map<String, Object> matches = (Map<String, Object>) properties.get("matches");
+		Map<String, Object> items = (Map<String, Object>) matches.get("items");
+		Map<String, Object> metadata = (Map<String, Object>) properties.get("metadata");
+		Map<String, Object> metadataValues = (Map<String, Object>) metadata.get("additionalProperties");
+		List<Map<String, Object>> oneOf = (List<Map<String, Object>>) schemaMap.get("oneOf");
+
+		assertThat((List<?>) filters.get("required")).isEmpty();
+		assertThat((Map<?, ?>) owner.get("properties")).isEmpty();
+		assertThat((List<?>) owner.get("required")).isEmpty();
+		assertThat((Map<?, ?>) items.get("properties")).isEmpty();
+		assertThat((List<?>) items.get("required")).isEmpty();
+		assertThat((Map<?, ?>) metadataValues.get("properties")).isEmpty();
+		assertThat((List<?>) metadataValues.get("required")).isEmpty();
+		assertThat((Map<?, ?>) oneOf.get(0).get("properties")).isEmpty();
+		assertThat((List<?>) oneOf.get(0).get("required")).isEmpty();
+	}
+
+	@Test
+	void ensureValidInputSchemaDoesNotTreatPropertyNamesAsSchemaKeywords() {
+		String inputSchema = """
+				{
+					"type": "object",
+					"properties": {
+						"type": {
+							"type": "string"
+						},
+						"properties": {
+							"type": "string"
+						}
+					}
+				}
+				""";
+
+		String normalizedSchema = JsonSchemaUtils.ensureValidInputSchema(inputSchema);
+
+		Map<String, Object> schemaMap = jsonHelper.fromJsonToMap(normalizedSchema);
+		Map<String, Object> properties = (Map<String, Object>) schemaMap.get("properties");
+		Map<String, Object> typeProperty = (Map<String, Object>) properties.get("type");
+		Map<String, Object> propertiesProperty = (Map<String, Object>) properties.get("properties");
+
+		assertThat(properties).containsOnlyKeys("type", "properties");
+		assertThat(typeProperty).containsEntry("type", "string");
+		assertThat(typeProperty).doesNotContainKeys("properties", "required");
+		assertThat(propertiesProperty).containsEntry("type", "string");
+		assertThat(propertiesProperty).doesNotContainKeys("properties", "required");
 	}
 
 	/**


### PR DESCRIPTION
Addresses the MCP tool input schema case reported in #3116.

Some MCP servers expose object schemas without the fields that model tool-calling APIs commonly expect, for example `{"type":"object"}` for parameterless tools. This normalizes those schemas before creating Spring AI tool definitions by adding empty `properties` and `required` fields when they are missing, while preserving existing required fields.

The normalization also walks nested schema containers such as object properties, array items, `additionalProperties`, and composed schemas (`oneOf` / `anyOf` / `allOf`). This keeps the fix useful for MCP tools with nested object inputs, not only the top-level parameterless case.

Regression coverage includes:
- parameterless MCP tools with `{"type":"object"}` input schemas
- nested object schemas under properties and array items
- tool parameters named `type` or `properties`, so those names are not treated as schema keywords during traversal

Validation:
- `./mvnw.cmd -pl spring-ai-model -Dtest=JsonSchemaUtilsTests test`
- `./mvnw.cmd -pl mcp/common -am -Dtest=ToolUtilsTests '-Dsurefire.failIfNoSpecifiedTests=false' test`
