### PR TITLE
Fix recursive tool input schema by hoisting $defs to root

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +45,7 @@ import io.modelcontextprotocol.util.Assert;
 import io.modelcontextprotocol.util.Utils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 
 import org.springframework.ai.mcp.annotation.McpMeta;
@@ -179,6 +181,12 @@ public final class McpJsonSchemaGenerator {
 				required.add(parameterName);
 			}
 			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			// victools generates self-contained schemas where $defs and the $ref
+			// pointers into them are rooted at the sub-schema. Inlining the
+			// sub-schema under properties.<paramName> re-parents existing
+			// "#/$defs/<Name>" refs to the outer root, leaving them unresolvable.
+			// Hoist $defs to the outer root so those refs resolve again.
+			hoistDefsToRoot(schema, parameterNode);
 			String parameterDescription = getMethodParameterDescription(method, i);
 			if (Utils.hasText(parameterDescription)) {
 				parameterNode.put("description", parameterDescription);
@@ -226,6 +234,83 @@ public final class McpJsonSchemaGenerator {
 	 */
 	public static boolean hasCallToolRequestParameter(Method method) {
 		return Arrays.stream(method.getParameterTypes()).anyMatch(type -> CallToolRequest.class.isAssignableFrom(type));
+	}
+
+	/**
+	 * Moves any {@code $defs} block found on {@code subSchema} into the {@code $defs}
+	 * block of {@code rootSchema}, creating one on the root if needed. On key collisions
+	 * the existing root entry is reused when the two definitions are structurally equal;
+	 * otherwise the incoming entry is renamed with a numeric suffix and every
+	 * {@code "#/$defs/<oldKey>"} reference in the inlined sub-schema and in every
+	 * definition inserted by this hoist call is rewritten to point at the new key.
+	 */
+	private static void hoistDefsToRoot(ObjectNode rootSchema, ObjectNode subSchema) {
+		JsonNode nestedDefs = subSchema.remove("$defs");
+		if (nestedDefs == null || !nestedDefs.isObject()) {
+			return;
+		}
+		ObjectNode rootDefs = rootSchema.has("$defs") ? (ObjectNode) rootSchema.get("$defs")
+				: rootSchema.putObject("$defs");
+		Map<String, String> renames = new LinkedHashMap<>();
+		List<String> insertedKeys = new ArrayList<>();
+		((ObjectNode) nestedDefs).properties().forEach(entry -> {
+			String key = entry.getKey();
+			JsonNode value = entry.getValue();
+			if (!rootDefs.has(key)) {
+				rootDefs.set(key, value);
+				insertedKeys.add(key);
+				return;
+			}
+			if (rootDefs.get(key).equals(value)) {
+				return;
+			}
+			String renamed = uniqueDefsKey(rootDefs, key);
+			rootDefs.set(renamed, value);
+			renames.put(key, renamed);
+			insertedKeys.add(renamed);
+		});
+		if (renames.isEmpty()) {
+			return;
+		}
+		rewriteDefsRefs(subSchema, renames);
+		for (String insertedKey : insertedKeys) {
+			rewriteDefsRefs(rootDefs.get(insertedKey), renames);
+		}
+	}
+
+	private static String uniqueDefsKey(ObjectNode rootDefs, String base) {
+		int suffix = 2;
+		while (rootDefs.has(base + "_" + suffix)) {
+			suffix++;
+		}
+		return base + "_" + suffix;
+	}
+
+	private static void rewriteDefsRefs(JsonNode node, Map<String, String> renames) {
+		if (node == null) {
+			return;
+		}
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			JsonNode refNode = object.get("$ref");
+			if (refNode != null && refNode.isTextual()) {
+				String ref = refNode.asText();
+				String prefix = "#/$defs/";
+				if (ref.startsWith(prefix)) {
+					String rest = ref.substring(prefix.length());
+					int slash = rest.indexOf('/');
+					String key = slash < 0 ? rest : rest.substring(0, slash);
+					String renamed = renames.get(key);
+					if (renamed != null) {
+						object.put("$ref", prefix + renamed + (slash < 0 ? "" : rest.substring(slash)));
+					}
+				}
+			}
+			object.properties().forEach(entry -> rewriteDefsRefs(entry.getValue(), renames));
+		}
+		else if (node.isArray()) {
+			node.forEach(child -> rewriteDefsRefs(child, renames));
+		}
 	}
 
 	private static boolean isMethodParameterRequired(Method method, int index) {

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.annotation.method.tool.utils;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+
+import org.springframework.ai.util.json.JsonParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link McpJsonSchemaGenerator}.
+ */
+class McpJsonSchemaGeneratorTests {
+
+	// gh-5888: when a method parameter type transitively contains a recursive type,
+	// victools emits $defs nested inside the parameter sub-schema while $ref values
+	// remain root-relative ("#/$defs/<Name>"). Inlining the sub-schema under
+	// properties.<paramName> would otherwise leave those $refs unresolvable.
+	// The generator must hoist $defs to the outer schema root.
+	@Test
+	void generateSchemaForMethodWithTransitivelyRecursiveParameterTypeHoistsDefs() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("searchBooksMethod", SearchRequest.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.has("$defs")).as("$defs must be hoisted to the outer schema root").isTrue();
+		assertThat(schemaNode.get("$defs").has("RecursiveFilter")).isTrue();
+		assertThat(schemaNode.at("/properties/request").has("$defs"))
+			.as("$defs must not remain nested inside the parameter sub-schema")
+			.isFalse();
+		assertThat(schemaNode.at("/properties/request/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+		assertThat(schemaNode.at("/$defs/RecursiveFilter/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+	}
+
+	// gh-5888: when two parameters share the same recursive type, the two
+	// generated $defs entries collide on an identical key and value. The hoist
+	// must reuse the single root entry; both parameters' $refs continue to
+	// resolve to it.
+	@Test
+	void generateSchemaForMethodReusesRootDefsWhenColliding$defsValuesAreEqual() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("sameOuterTwoParamsMethod", SearchRequest.class,
+				SearchRequest.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/$defs").size()).isEqualTo(1);
+		assertThat(schemaNode.at("/$defs").has("RecursiveFilter")).isTrue();
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+	}
+
+	// gh-5888: when two parameters carry different recursive types that share
+	// the same simple class name, victools (with Option.PLAIN_DEFINITION_KEYS)
+	// emits the same $defs key for both. First-wins would silently drop the
+	// second definition and leave its $ref pointing at the first definition.
+	// The hoist must rename the colliding entry and rewrite the inlined
+	// sub-schema's $refs to point at the new key.
+	@Test
+	void generateSchemaForMethodRenames$defsAndRewritesRefsOnSimpleNameCollision() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("collidingSimpleNameMethod", OuterA.SearchRequest.class,
+				OuterB.SearchRequest.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/$defs/Filter").has("properties")).isTrue();
+		assertThat(schemaNode.at("/$defs/Filter_2").has("properties")).isTrue();
+		assertThat(schemaNode.at("/$defs/Filter/properties").has("label")).isTrue();
+		assertThat(schemaNode.at("/$defs/Filter_2/properties").has("code")).isTrue();
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText()).isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText()).isEqualTo("#/$defs/Filter_2");
+		assertThat(schemaNode.at("/$defs/Filter/properties/children/items/$ref").asText()).isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+			.isEqualTo("#/$defs/Filter_2");
+	}
+
+	// gh-5888: when a sub-schema brings in several $defs entries and one of them
+	// collides while a peer entry references the colliding key, the peer's $ref
+	// must be rewritten too.
+	@Test
+	void generateSchemaForMethodRewritesPeerDefinitionRefsAfterRename() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("peerReferenceMethod", PeerA.SearchRequest.class,
+				PeerB.SearchRequest.class);
+
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/$defs/Filter/properties").has("label")).isTrue();
+		assertThat(schemaNode.at("/$defs/Filter_2/properties").has("code")).isTrue();
+		assertThat(schemaNode.at("/$defs/Wrapper").has("properties")).isTrue();
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/Filter_2");
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/nested/items/$ref").asText()).isEqualTo("#/$defs/Wrapper");
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+			.isEqualTo("#/$defs/Filter_2");
+	}
+
+	static class TestMethods {
+
+		public void searchBooksMethod(SearchRequest request) {
+		}
+
+		public void sameOuterTwoParamsMethod(SearchRequest a, SearchRequest b) {
+		}
+
+		public void collidingSimpleNameMethod(OuterA.SearchRequest a, OuterB.SearchRequest b) {
+		}
+
+		public void peerReferenceMethod(PeerA.SearchRequest a, PeerB.SearchRequest b) {
+		}
+
+	}
+
+	record RecursiveFilter(String field, String operator, List<RecursiveFilter> filters) {
+	}
+
+	record SearchRequest(List<RecursiveFilter> filters, int limit) {
+	}
+
+	static class OuterA {
+
+		record Filter(String label, List<Filter> children) {
+		}
+
+		record SearchRequest(List<Filter> filters, int limit) {
+		}
+
+	}
+
+	static class OuterB {
+
+		record Filter(String code, List<Filter> children) {
+		}
+
+		record SearchRequest(List<Filter> filters, int limit) {
+		}
+
+	}
+
+	static class PeerA {
+
+		record Filter(String label, List<Filter> children) {
+		}
+
+		record SearchRequest(List<Filter> filters) {
+		}
+
+	}
+
+	static class PeerB {
+
+		record Filter(String code, List<Filter> children) {
+		}
+
+		record Wrapper(List<Filter> filters, List<Wrapper> nested) {
+		}
+
+		record SearchRequest(Wrapper wrapper) {
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -20,7 +20,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -148,6 +150,12 @@ public final class JsonSchemaGenerator {
 				required.add(parameterName);
 			}
 			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			// victools generates self-contained schemas where $defs and the $ref
+			// pointers into them are rooted at the sub-schema. Inlining the
+			// sub-schema under properties.<paramName> re-parents existing
+			// "#/$defs/<Name>" refs to the outer root, leaving them unresolvable.
+			// Hoist $defs to the outer root so those refs resolve again.
+			hoistDefsToRoot(schema, parameterNode);
 			// Remove OpenAPI format as some LLMs (like Mistral) don't handle them.
 			parameterNode.remove("format");
 			String parameterDescription = getMethodParameterDescription(method, i);
@@ -176,6 +184,83 @@ public final class JsonSchemaGenerator {
 		}
 		processSchemaOptions(schemaOptions, schema);
 		return schema.toPrettyString();
+	}
+
+	/**
+	 * Moves any {@code $defs} block found on {@code subSchema} into the {@code $defs}
+	 * block of {@code rootSchema}, creating one on the root if needed. On key collisions
+	 * the existing root entry is reused when the two definitions are structurally equal;
+	 * otherwise the incoming entry is renamed with a numeric suffix and every
+	 * {@code "#/$defs/<oldKey>"} reference in the inlined sub-schema and in every
+	 * definition inserted by this hoist call is rewritten to point at the new key.
+	 */
+	private static void hoistDefsToRoot(ObjectNode rootSchema, ObjectNode subSchema) {
+		JsonNode nestedDefs = subSchema.remove("$defs");
+		if (nestedDefs == null || !nestedDefs.isObject()) {
+			return;
+		}
+		ObjectNode rootDefs = rootSchema.has("$defs") ? (ObjectNode) rootSchema.get("$defs")
+				: rootSchema.putObject("$defs");
+		Map<String, String> renames = new LinkedHashMap<>();
+		List<String> insertedKeys = new ArrayList<>();
+		((ObjectNode) nestedDefs).properties().forEach(entry -> {
+			String key = entry.getKey();
+			JsonNode value = entry.getValue();
+			if (!rootDefs.has(key)) {
+				rootDefs.set(key, value);
+				insertedKeys.add(key);
+				return;
+			}
+			if (rootDefs.get(key).equals(value)) {
+				return;
+			}
+			String renamed = uniqueDefsKey(rootDefs, key);
+			rootDefs.set(renamed, value);
+			renames.put(key, renamed);
+			insertedKeys.add(renamed);
+		});
+		if (renames.isEmpty()) {
+			return;
+		}
+		rewriteDefsRefs(subSchema, renames);
+		for (String insertedKey : insertedKeys) {
+			rewriteDefsRefs(rootDefs.get(insertedKey), renames);
+		}
+	}
+
+	private static String uniqueDefsKey(ObjectNode rootDefs, String base) {
+		int suffix = 2;
+		while (rootDefs.has(base + "_" + suffix)) {
+			suffix++;
+		}
+		return base + "_" + suffix;
+	}
+
+	private static void rewriteDefsRefs(JsonNode node, Map<String, String> renames) {
+		if (node == null) {
+			return;
+		}
+		if (node.isObject()) {
+			ObjectNode object = (ObjectNode) node;
+			JsonNode refNode = object.get("$ref");
+			if (refNode != null && refNode.isTextual()) {
+				String ref = refNode.asText();
+				String prefix = "#/$defs/";
+				if (ref.startsWith(prefix)) {
+					String rest = ref.substring(prefix.length());
+					int slash = rest.indexOf('/');
+					String key = slash < 0 ? rest : rest.substring(0, slash);
+					String renamed = renames.get(key);
+					if (renamed != null) {
+						object.put("$ref", prefix + renamed + (slash < 0 ? "" : rest.substring(slash)));
+					}
+				}
+			}
+			object.properties().forEach(entry -> rewriteDefsRefs(entry.getValue(), renames));
+		}
+		else if (node.isArray()) {
+			node.forEach(child -> rewriteDefsRefs(child, renames));
+		}
 	}
 
 	private static void processSchemaOptions(SchemaOption[] schemaOptions, ObjectNode schema) {

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -694,6 +694,110 @@ class JsonSchemaGeneratorTests {
 		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
 	}
 
+	// gh-5888: when a method parameter type transitively contains a recursive type,
+	// victools emits $defs nested inside the parameter sub-schema while $ref values
+	// remain root-relative ("#/$defs/<Name>"). Inlining the sub-schema under
+	// properties.<paramName> would otherwise leave those $refs unresolvable.
+	// The generator must hoist $defs to the outer schema root.
+	@Test
+	void generateSchemaForMethodWithTransitivelyRecursiveParameterTypeHoistsDefs() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("searchBooksMethod", SearchRequest.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.has("$defs")).as("$defs must be hoisted to the outer schema root").isTrue();
+		assertThat(schemaNode.get("$defs").has("RecursiveFilter")).isTrue();
+		assertThat(schemaNode.at("/properties/request").has("$defs"))
+			.as("$defs must not remain nested inside the parameter sub-schema")
+			.isFalse();
+		assertThat(schemaNode.at("/properties/request/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+		assertThat(schemaNode.at("/$defs/RecursiveFilter/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+	}
+
+	// gh-5888: when two parameters share the same recursive type, the two
+	// generated $defs entries collide on an identical key and value. The hoist
+	// must reuse the single root entry; both parameters' $refs continue to
+	// resolve to it.
+	@Test
+	void generateSchemaForMethodReusesRootDefsWhenColliding$defsValuesAreEqual() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("sameOuterTwoParamsMethod", SearchRequest.class,
+				SearchRequest.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/$defs").size()).isEqualTo(1);
+		assertThat(schemaNode.at("/$defs").has("RecursiveFilter")).isTrue();
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText())
+			.isEqualTo("#/$defs/RecursiveFilter");
+	}
+
+	// gh-5888: when two parameters carry different recursive types that share
+	// the same simple class name, victools (with Option.PLAIN_DEFINITION_KEYS)
+	// emits the same $defs key for both. First-wins would silently drop the
+	// second definition and leave its $ref pointing at the first definition.
+	// The hoist must rename the colliding entry and rewrite the inlined
+	// sub-schema's $refs to point at the new key.
+	@Test
+	void generateSchemaForMethodRenames$defsAndRewritesRefsOnSimpleNameCollision() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("collidingSimpleNameMethod", OuterA.SearchRequest.class,
+				OuterB.SearchRequest.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/$defs/Filter").has("properties")).isTrue();
+		assertThat(schemaNode.at("/$defs/Filter_2").has("properties")).isTrue();
+		assertThat(schemaNode.at("/$defs/Filter/properties").has("label"))
+			.as("first colliding entry retains OuterA.Filter shape (label field)")
+			.isTrue();
+		assertThat(schemaNode.at("/$defs/Filter_2/properties").has("code"))
+			.as("second colliding entry retains OuterB.Filter shape (code field)")
+			.isTrue();
+		assertThat(schemaNode.at("/properties/a/properties/filters/items/$ref").asText()).isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/properties/b/properties/filters/items/$ref").asText())
+			.as("second parameter's $ref must be rewritten to the renamed entry")
+			.isEqualTo("#/$defs/Filter_2");
+		assertThat(schemaNode.at("/$defs/Filter/properties/children/items/$ref").asText()).isEqualTo("#/$defs/Filter");
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+			.as("self-reference inside the renamed entry must follow the rename")
+			.isEqualTo("#/$defs/Filter_2");
+	}
+
+	// gh-5888: when a sub-schema brings in several $defs entries and one of them
+	// collides while a peer entry references the colliding key, the peer's $ref
+	// must be rewritten too — otherwise the peer would point at the existing
+	// root entry instead of the renamed one.
+	@Test
+	void generateSchemaForMethodRewritesPeerDefinitionRefsAfterRename() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("peerReferenceMethod", PeerA.SearchRequest.class,
+				PeerB.SearchRequest.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		JsonNode schemaNode = JsonParser.fromJson(schema, JsonNode.class);
+
+		assertThat(schemaNode.at("/$defs/Filter/properties").has("label")).as("first definition keeps PeerA shape")
+			.isTrue();
+		assertThat(schemaNode.at("/$defs/Filter_2/properties").has("code"))
+			.as("colliding definition is renamed with PeerB shape")
+			.isTrue();
+		assertThat(schemaNode.at("/$defs/Wrapper").has("properties")).isTrue();
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/filters/items/$ref").asText())
+			.as("peer Wrapper's $ref to the colliding name must be rewritten to the renamed entry")
+			.isEqualTo("#/$defs/Filter_2");
+		assertThat(schemaNode.at("/$defs/Wrapper/properties/nested/items/$ref").asText())
+			.as("peer Wrapper's self-reference must be left alone")
+			.isEqualTo("#/$defs/Wrapper");
+		assertThat(schemaNode.at("/$defs/Filter_2/properties/children/items/$ref").asText())
+			.as("renamed entry's self-reference must follow the rename")
+			.isEqualTo("#/$defs/Filter_2");
+	}
+
 	@Test
 	void throwExceptionWhenTypeIsNull() {
 		assertThatThrownBy(() -> JsonSchemaGenerator.generateForType(null)).isInstanceOf(IllegalArgumentException.class)
@@ -737,6 +841,67 @@ class JsonSchemaGeneratorTests {
 		}
 
 		public void contextMethod(String deliveryStatus, LocalDateTime expectedDelivery, ToolContext toolContext) {
+		}
+
+		public void searchBooksMethod(SearchRequest request) {
+		}
+
+		public void sameOuterTwoParamsMethod(SearchRequest a, SearchRequest b) {
+		}
+
+		public void collidingSimpleNameMethod(OuterA.SearchRequest a, OuterB.SearchRequest b) {
+		}
+
+		public void peerReferenceMethod(PeerA.SearchRequest a, PeerB.SearchRequest b) {
+		}
+
+	}
+
+	record RecursiveFilter(String field, String operator, List<RecursiveFilter> filters) {
+	}
+
+	record SearchRequest(List<RecursiveFilter> filters, int limit) {
+	}
+
+	static class OuterA {
+
+		record Filter(String label, List<Filter> children) {
+		}
+
+		record SearchRequest(List<Filter> filters, int limit) {
+		}
+
+	}
+
+	static class OuterB {
+
+		record Filter(String code, List<Filter> children) {
+		}
+
+		record SearchRequest(List<Filter> filters, int limit) {
+		}
+
+	}
+
+	static class PeerA {
+
+		record Filter(String label, List<Filter> children) {
+		}
+
+		record SearchRequest(List<Filter> filters) {
+		}
+
+	}
+
+	static class PeerB {
+
+		record Filter(String code, List<Filter> children) {
+		}
+
+		record Wrapper(List<Filter> filters, List<Wrapper> nested) {
+		}
+
+		record SearchRequest(Wrapper wrapper) {
 		}
 
 	}


### PR DESCRIPTION
### Summary

Fixes #5888.

- **Why**: Spring AI currently inlines parameter schemas under `properties.<param>`, but their generated `$ref`s still point to root-level `$defs`.

- **Fix**: Move each parameter schema's `$defs` to the wrapper schema root before inlining the parameter. Reuse structurally equal definitions; rename conflicting simple names and rewrite refs within the hoisted schema.

### Tests
Added regression coverage in both generators for:
- transitive recursive parameter schemas
- duplicate equal definitions
- colliding simple-name definitions with ref rewrites

```bash
./mvnw -pl spring-ai-model,mcp/mcp-annotations test \
    -Dtest='JsonSchemaGeneratorTests,McpJsonSchemaGeneratorTests'
```

### Scope
This PR covers the transitive `$defs` failure reported in #5888 for both `JsonSchemaGenerator` and `McpJsonSchemaGenerator`. Direct self-recursive `$ref: "#"` handling is outside this PR.
