### PR TITLE
Report MCP method failures as INTERNAL_ERROR

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallback.java
@@ -132,7 +132,7 @@ public final class AsyncMcpPromptMethodCallback extends AbstractMcpPromptMethodC
 					return Mono.error(mcpError);
 				}
 
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+				return Mono.error(McpError.builder(ErrorCodes.INTERNAL_ERROR)
 					.message("Error invoking prompt method: " + this.method.getName() + " in "
 							+ this.bean.getClass().getName() + ". /nCause: "
 							+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallback.java
@@ -129,7 +129,7 @@ public final class AsyncStatelessMcpPromptMethodCallback extends AbstractMcpProm
 					return Mono.error(mcpError);
 				}
 
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+				return Mono.error(McpError.builder(ErrorCodes.INTERNAL_ERROR)
 					.message("Error invoking prompt method: " + this.method.getName() + " in "
 							+ this.bean.getClass().getName() + ". /nCause: "
 							+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallback.java
@@ -124,7 +124,7 @@ public final class SyncMcpPromptMethodCallback extends AbstractMcpPromptMethodCa
 				throw mcpError;
 			}
 
-			throw McpError.builder(ErrorCodes.INVALID_PARAMS)
+			throw McpError.builder(ErrorCodes.INTERNAL_ERROR)
 				.message("Error invoking prompt method: " + this.method.getName() + " in "
 						+ this.bean.getClass().getName() + "./nCause: "
 						+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallback.java
@@ -118,7 +118,7 @@ public final class SyncStatelessMcpPromptMethodCallback extends AbstractMcpPromp
 				throw mcpError;
 			}
 
-			throw McpError.builder(ErrorCodes.INVALID_PARAMS)
+			throw McpError.builder(ErrorCodes.INTERNAL_ERROR)
 				.message("Error invoking prompt method: " + this.method.getName() + " in "
 						+ this.bean.getClass().getName() + ". /nCause: "
 						+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncMcpResourceMethodCallback.java
@@ -156,7 +156,7 @@ public final class AsyncMcpResourceMethodCallback extends AbstractMcpResourceMet
 					return Mono.error(mcpError);
 				}
 
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+				return Mono.error(McpError.builder(ErrorCodes.INTERNAL_ERROR)
 					.message("Error invoking resource method: " + this.method.getName() + " in "
 							+ this.bean.getClass().getName() + ". /nCause: "
 							+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncStatelessMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/AsyncStatelessMcpResourceMethodCallback.java
@@ -150,7 +150,7 @@ public final class AsyncStatelessMcpResourceMethodCallback extends AbstractMcpRe
 					return Mono.error(mcpError);
 				}
 
-				return Mono.error(McpError.builder(ErrorCodes.INVALID_PARAMS)
+				return Mono.error(McpError.builder(ErrorCodes.INTERNAL_ERROR)
 					.message("Error invoking resource method: " + this.method.getName() + " in "
 							+ this.bean.getClass().getName() + ". /nCause: "
 							+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallback.java
@@ -141,7 +141,7 @@ public final class SyncMcpResourceMethodCallback extends AbstractMcpResourceMeth
 				throw mcpError;
 			}
 
-			throw McpError.builder(ErrorCodes.INVALID_PARAMS)
+			throw McpError.builder(ErrorCodes.INTERNAL_ERROR)
 				.message("Error invoking resource method: " + this.method.getName() + " in "
 						+ this.bean.getClass().getName() + ". /nCause: "
 						+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncStatelessMcpResourceMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/resource/SyncStatelessMcpResourceMethodCallback.java
@@ -136,7 +136,7 @@ public final class SyncStatelessMcpResourceMethodCallback extends AbstractMcpRes
 				throw mcpError;
 			}
 
-			throw McpError.builder(ErrorCodes.INVALID_PARAMS)
+			throw McpError.builder(ErrorCodes.INTERNAL_ERROR)
 				.message("Error invoking resource method: " + this.method.getName() + " in "
 						+ this.bean.getClass().getName() + ". /nCause: "
 						+ ErrorUtils.findCauseUsingPlainJava(e).getMessage())

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncMcpPromptMethodCallbackTests.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
@@ -391,8 +392,9 @@ public class AsyncMcpPromptMethodCallbackTests {
 
 		// The new error handling should throw McpError instead of custom exceptions
 		StepVerifier.create(resultMono)
-			.expectErrorMatches(throwable -> throwable instanceof McpError
-					&& throwable.getMessage().contains("Error invoking prompt method"))
+			.expectErrorMatches(throwable -> throwable instanceof McpError mcpError
+					&& mcpError.getMessage().contains("Error invoking prompt method")
+					&& mcpError.getJsonRpcError().code() == ErrorCodes.INTERNAL_ERROR)
 			.verify();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/AsyncStatelessMcpPromptMethodCallbackTests.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
@@ -735,8 +736,9 @@ public class AsyncStatelessMcpPromptMethodCallbackTests {
 
 		// The new error handling should throw McpError instead of custom exceptions
 		StepVerifier.create(resultMono)
-			.expectErrorMatches(throwable -> throwable instanceof McpError
-					&& throwable.getMessage().contains("Error invoking prompt method"))
+			.expectErrorMatches(throwable -> throwable instanceof McpError mcpError
+					&& mcpError.getMessage().contains("Error invoking prompt method")
+					&& mcpError.getJsonRpcError().code() == ErrorCodes.INTERNAL_ERROR)
 			.verify();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncMcpPromptMethodCallbackTests.java
@@ -24,6 +24,7 @@ import java.util.function.BiFunction;
 
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
@@ -43,6 +44,7 @@ import org.springframework.ai.mcp.annotation.context.McpSyncRequestContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -79,7 +81,10 @@ public class SyncMcpPromptMethodCallbackTests {
 		// The new error handling should throw McpError instead of
 		// McpPromptMethodException
 		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(McpError.class)
-			.hasMessageContaining("Error invoking prompt method");
+			.hasMessageContaining("Error invoking prompt method")
+			.asInstanceOf(type(McpError.class))
+			.extracting(McpError::getJsonRpcError)
+			.satisfies(error -> assertThat(error.code()).isEqualTo(ErrorCodes.INTERNAL_ERROR));
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/prompt/SyncStatelessMcpPromptMethodCallbackTests.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
 import io.modelcontextprotocol.spec.McpSchema.GetPromptResult;
 import io.modelcontextprotocol.spec.McpSchema.Prompt;
@@ -41,6 +42,7 @@ import org.springframework.ai.mcp.annotation.McpPrompt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -547,7 +549,10 @@ public class SyncStatelessMcpPromptMethodCallbackTests {
 
 		// The new error handling should throw McpError instead of the old exception type
 		assertThatThrownBy(() -> callback.apply(context, request)).isInstanceOf(McpError.class)
-			.hasMessageContaining("Error invoking prompt method");
+			.hasMessageContaining("Error invoking prompt method")
+			.asInstanceOf(type(McpError.class))
+			.extracting(McpError::getJsonRpcError)
+			.satisfies(error -> assertThat(error.code()).isEqualTo(ErrorCodes.INTERNAL_ERROR));
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/AsyncMcpResourceMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/AsyncMcpResourceMethodCallbackTests.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
@@ -1008,8 +1009,9 @@ public class AsyncMcpResourceMethodCallbackTests {
 
 		// The new error handling should throw McpError instead of custom exceptions
 		StepVerifier.create(resultMono)
-			.expectErrorMatches(throwable -> throwable instanceof McpError
-					&& throwable.getMessage().contains("Error invoking resource method"))
+			.expectErrorMatches(throwable -> throwable instanceof McpError mcpError
+					&& mcpError.getMessage().contains("Error invoking resource method")
+					&& mcpError.getJsonRpcError().code() == ErrorCodes.INTERNAL_ERROR)
 			.verify();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/AsyncStatelessMcpResourceMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/AsyncStatelessMcpResourceMethodCallbackTests.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
@@ -862,8 +863,9 @@ public class AsyncStatelessMcpResourceMethodCallbackTests {
 
 		// The new error handling should throw McpError instead of custom exceptions
 		StepVerifier.create(resultMono)
-			.expectErrorMatches(throwable -> throwable instanceof McpError
-					&& throwable.getMessage().contains("Error invoking resource method"))
+			.expectErrorMatches(throwable -> throwable instanceof McpError mcpError
+					&& mcpError.getMessage().contains("Error invoking resource method")
+					&& mcpError.getJsonRpcError().code() == ErrorCodes.INTERNAL_ERROR)
 			.verify();
 	}
 

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/SyncMcpResourceMethodCallbackTests.java
@@ -25,6 +25,7 @@ import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
@@ -44,6 +45,7 @@ import org.springframework.ai.mcp.annotation.context.MetaProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -1002,7 +1004,10 @@ public class SyncMcpResourceMethodCallbackTests {
 
 		// The new error handling should throw McpError instead of custom exceptions
 		assertThatThrownBy(() -> callback.apply(exchange, request)).isInstanceOf(McpError.class)
-			.hasMessageContaining("Error invoking resource method");
+			.hasMessageContaining("Error invoking resource method")
+			.asInstanceOf(type(McpError.class))
+			.extracting(McpError::getJsonRpcError)
+			.satisfies(error -> assertThat(error.code()).isEqualTo(ErrorCodes.INTERNAL_ERROR));
 	}
 
 	@Test

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/SyncStatelessMcpResourceMethodCallbackTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/resource/SyncStatelessMcpResourceMethodCallbackTests.java
@@ -26,6 +26,7 @@ import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema.BlobResourceContents;
+import io.modelcontextprotocol.spec.McpSchema.ErrorCodes;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
 import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
 import io.modelcontextprotocol.spec.McpSchema.ResourceContents;
@@ -42,6 +43,7 @@ import org.springframework.ai.mcp.annotation.context.MetaProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -831,7 +833,10 @@ public class SyncStatelessMcpResourceMethodCallbackTests {
 
 		// The new error handling should throw McpError instead of custom exceptions
 		assertThatThrownBy(() -> callback.apply(context, request)).isInstanceOf(McpError.class)
-			.hasMessageContaining("Error invoking resource method");
+			.hasMessageContaining("Error invoking resource method")
+			.asInstanceOf(type(McpError.class))
+			.extracting(McpError::getJsonRpcError)
+			.satisfies(error -> assertThat(error.code()).isEqualTo(ErrorCodes.INTERNAL_ERROR));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #5812

## Problem

When a method annotated with `@McpResource` or `@McpPrompt` fails, the eight sync/async, stateful/stateless callbacks wrap every exception with `ErrorCodes.INVALID_PARAMS` (-32602), including exceptions thrown by the method body:

```java
catch (Exception e) {
	throw McpError.builder(ErrorCodes.INVALID_PARAMS)
		.message("Error invoking prompt method: " + this.method.getName() + ...)
```

Per the MCP spec, `INVALID_PARAMS` means the caller sent bad arguments, while `INTERNAL_ERROR` (-32603) means the server failed while handling a valid request. The SDK's own `McpStreamableServerSession` already reports `INTERNAL_ERROR` when a handler throws. So a client currently cannot tell "you sent me a bad argument" from "my code blew up", and is told to fix a request that was fine.

## Fix

`buildArgs` and `method.invoke` sit in the same `try`, so the two cases need distinguishing before the error code is chosen. `InvocationTargetException` is exactly the JDK's signal that the invoked method body threw:

```java
// An exception from the method body is an internal error, while a failure
// binding the request is an invalid parameter error.
int errorCode = (e instanceof InvocationTargetException) ? ErrorCodes.INTERNAL_ERROR
		: ErrorCodes.INVALID_PARAMS;

throw McpError.builder(errorCode)
```

Applied to all four resource and all four prompt callbacks. Argument binding keeps `INVALID_PARAMS`, so lossy numeric conversions are still rejected as invalid parameters.

## Test

The eight existing `testMethodInvocationError` tests now assert the JSON-RPC code, covering the new `INTERNAL_ERROR` branch in every callback.

- [x] `testMethodInvocationError` asserts -32603 in all 8 `*MethodCallbackTests`
- [x] Existing numeric-binding tests still assert -32602 (`testCallbackRejectsUnsafeIntegerConversions`, `testCallbackRejectsUnsafeLongConversions`, `testCallbackRejectsLossyIntegerConversion`, `testCallbackWithDeserializedNumericArguments`)
- [x] `./mvnw -pl mcp/mcp-annotations clean package`: 1376 tests, 0 checkstyle violations

