### PR TITLE
GH-5882: Preserve observation convention when copying advisor chain

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChain.java
@@ -175,6 +175,7 @@ public class DefaultAroundAdvisorChain implements BaseAdvisorChain {
 		var remainingStreamAdvisors = advisors.subList(afterAdvisorIndex + 1, advisors.size());
 
 		return DefaultAroundAdvisorChain.builder(this.getObservationRegistry())
+			.observationConvention(this.observationConvention)
 			.pushAll(remainingStreamAdvisors)
 			.build();
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChainTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/advisor/DefaultAroundAdvisorChainTests.java
@@ -31,7 +31,11 @@ import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisor;
 import org.springframework.ai.chat.client.advisor.api.StreamAdvisorChain;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationContext;
+import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
+import org.springframework.ai.chat.client.advisor.observation.DefaultAdvisorObservationConvention;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -243,6 +247,48 @@ class DefaultAroundAdvisorChainTests {
 		CallAdvisorChain newChain = chain.copy(advisor1);
 
 		assertThat(newChain.getObservationRegistry()).isSameAs(customRegistry);
+	}
+
+	@Test
+	void whenCopyingChainThenCustomObservationConventionIsPreserved() {
+		CallAdvisor advisor1 = createMockAdvisor("advisor1", 1);
+		CallAdvisor advisor2 = createMockAdvisor("advisor2", 2);
+
+		AdvisorObservationConvention customConvention = new AdvisorObservationConvention() {
+			@Override
+			public String getName() {
+				return "custom.advisor";
+			}
+
+			@Override
+			public boolean supportsContext(io.micrometer.observation.Observation.Context context) {
+				return context instanceof AdvisorObservationContext;
+			}
+		};
+
+		CallAdvisorChain chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.observationConvention(customConvention)
+			.pushAll(List.of(advisor1, advisor2))
+			.build();
+
+		CallAdvisorChain newChain = chain.copy(advisor1);
+
+		assertThat(ReflectionTestUtils.getField(newChain, "observationConvention")).isSameAs(customConvention);
+	}
+
+	@Test
+	void whenCopyingChainWithoutCustomObservationConventionThenDefaultIsPreserved() {
+		CallAdvisor advisor1 = createMockAdvisor("advisor1", 1);
+		CallAdvisor advisor2 = createMockAdvisor("advisor2", 2);
+
+		CallAdvisorChain chain = DefaultAroundAdvisorChain.builder(ObservationRegistry.NOOP)
+			.pushAll(List.of(advisor1, advisor2))
+			.build();
+
+		CallAdvisorChain newChain = chain.copy(advisor1);
+
+		assertThat(ReflectionTestUtils.getField(newChain, "observationConvention"))
+			.isInstanceOf(DefaultAdvisorObservationConvention.class);
 	}
 
 	private CallAdvisor createMockAdvisor(String name, int order) {


### PR DESCRIPTION
## Summary

`DefaultAroundAdvisorChain.copy(Advisor)` (used for example by `ToolCallAdvisor` to invoke the remaining chain after itself) constructs the child chain via the `DefaultAroundAdvisorChain.Builder` but does not propagate the parent's `AdvisorObservationConvention`. Advisors that run through the copied chain are therefore observed with the default convention, even when a custom one is configured on the original chain.

This change passes `this.observationConvention` to the builder in `copyAdvisorsAfter` so the custom convention is preserved across copies.

## Changes

- `DefaultAroundAdvisorChain.copyAdvisorsAfter`: forward the stored `observationConvention` to the child builder.
- `DefaultAroundAdvisorChainTests`: added two tests for the copy behavior. One verifies that a custom convention is preserved, and the other verifies that the default convention is preserved when none is configured.

Fixes #5882