### PR TITLE
GH-5964: Add @Lazy(false) to stateless MCP server beans to fix lazy-init startup failure

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.util.CollectionUtils;
@@ -72,6 +73,7 @@ public class McpServerStatelessAutoConfiguration {
 	}
 
 	@Bean
+	@Lazy(false)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "SYNC",
 			matchIfMissing = true)
 	public McpStatelessSyncServer mcpStatelessSyncServer(McpStatelessServerTransport statelessTransport,
@@ -163,6 +165,7 @@ public class McpServerStatelessAutoConfiguration {
 	}
 
 	@Bean
+	@Lazy(false)
 	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX, name = "type", havingValue = "ASYNC")
 	public McpStatelessAsyncServer mcpStatelessAsyncServer(McpStatelessServerTransport statelessTransport,
 			McpSchema.ServerCapabilities.Builder capabilitiesBuilder, McpServerProperties serverProperties,

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -149,6 +149,18 @@ public class McpStatelessServerAutoConfigurationIT {
 	}
 
 	@Test
+	void syncServerIsInitializedEagerlyUnderGlobalLazyInit() {
+		this.contextRunner.withPropertyValues("spring.main.lazy-initialization=true")
+			.run(context -> assertThat(context).hasSingleBean(McpStatelessSyncServer.class));
+	}
+
+	@Test
+	void asyncServerIsInitializedEagerlyUnderGlobalLazyInit() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.type=ASYNC", "spring.main.lazy-initialization=true")
+			.run(context -> assertThat(context).hasSingleBean(McpStatelessAsyncServer.class));
+	}
+
+	@Test
 	void disabledConfiguration() {
 		this.contextRunner.withPropertyValues("spring.ai.mcp.server.enabled=false").run(context -> {
 			assertThat(context).doesNotHaveBean(McpStatelessSyncServer.class);

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiModalityTokenCount.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiModalityTokenCount.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai.metadata;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.genai.types.MediaModality;
 import com.google.genai.types.ModalityTokenCount;
@@ -68,7 +70,7 @@ public class GoogleGenAiModalityTokenCount {
 		}
 
 		// MediaModality returns its string value via toString()
-		String modalityStr = modality.toString().toUpperCase();
+		String modalityStr = modality.toString().toUpperCase(Locale.ROOT);
 
 		// Map SDK values to cleaner names
 		return switch (modalityStr) {

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiTrafficType.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiTrafficType.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai.metadata;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.genai.types.TrafficType;
 
@@ -60,7 +62,7 @@ public enum GoogleGenAiTrafficType {
 		}
 
 		// Try to match by string value
-		String typeStr = trafficType.toString().toUpperCase();
+		String typeStr = trafficType.toString().toUpperCase(Locale.ROOT);
 
 		// Map SDK values to our enum values
 		return switch (typeStr) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -280,7 +281,7 @@ public final class JsonSchemaGenerator {
 				}
 				else if (value.isTextual() && entry.getKey().equals("type")) {
 					String oldValue = node.get("type").asText();
-					node.put("type", oldValue.toUpperCase());
+					node.put("type", oldValue.toUpperCase(Locale.ROOT));
 				}
 			});
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
+import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -698,6 +700,31 @@ class JsonSchemaGeneratorTests {
 	void throwExceptionWhenTypeIsNull() {
 		assertThatThrownBy(() -> JsonSchemaGenerator.generateForType(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("type cannot be null");
+	}
+
+	@Test
+	void convertTypeValuesToUpperCaseIsLocaleNeutral() throws Exception {
+		String schema = """
+				{
+				    "type": "object",
+				    "properties": {
+				        "count": { "type": "integer" },
+				        "name": { "type": "string" }
+				    }
+				}
+				""";
+		ObjectNode node = (ObjectNode) JsonParser.getJsonMapper().readTree(schema);
+		Locale original = Locale.getDefault();
+		try {
+			Locale.setDefault(new Locale("tr", "TR"));
+			JsonSchemaGenerator.convertTypeValuesToUpperCase(node);
+		}
+		finally {
+			Locale.setDefault(original);
+		}
+		assertThat(node.get("type").asText()).isEqualTo("OBJECT");
+		assertThat(node.path("properties").path("count").get("type").asText()).isEqualTo("INTEGER");
+		assertThat(node.path("properties").path("name").get("type").asText()).isEqualTo("STRING");
 	}
 
 	static class TestMethods {


### PR DESCRIPTION
Fixes #5964.

When `spring.main.lazy-initialization=true` is active, `McpStatelessSyncServer` and `McpStatelessAsyncServer` were never constructed at context refresh. The transport's `setMcpHandler` is called only during `build()`, so the handler stayed `null` permanently. Every incoming MCP request then hit the null-check in `WebMvcStatelessServerTransport.handlePost` and returned HTTP 500 with JSON-RPC `-32603 INTERNAL_ERROR: MCP handler not configured`.

`@Lazy(false)` is the standard Spring Boot pattern to override a global `spring.main.lazy-initialization=true` for beans that must be instantiated eagerly to wire side-effects. Without it, the transport endpoint is reachable but permanently misconfigured.

## Changes

- `McpServerStatelessAutoConfiguration` — added `@Lazy(false)` to `mcpStatelessSyncServer` and `mcpStatelessAsyncServer` bean methods
- `McpStatelessServerAutoConfigurationIT` — added two tests covering both SYNC and ASYNC variants under global lazy-init

## How to test locally

```bash
./mvnw test -pl auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common -Dtest=McpStatelessServerAutoConfigurationIT
```

## Risk

Low — adds `@Lazy(false)` to two bean methods with no other behavioural change. Has no effect when `spring.main.lazy-initialization` is not set.