### PR TITLE
Fix OpenAI embedding generic options merging

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiEmbeddingOptions.java
@@ -177,6 +177,12 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 			if (from == null) {
 				return this;
 			}
+			if (from.getModel() != null) {
+				this.model = from.getModel();
+			}
+			if (from.getDimensions() != null) {
+				this.dimensions = from.getDimensions();
+			}
 			if (from instanceof OpenAiEmbeddingOptions castFrom) {
 				// Parent class fields
 				if (castFrom.getBaseUrl() != null) {
@@ -187,9 +193,6 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 				}
 				if (castFrom.getCredential() != null) {
 					this.credential = castFrom.getCredential();
-				}
-				if (castFrom.getModel() != null) {
-					this.model = castFrom.getModel();
 				}
 				if (castFrom.getDeploymentName() != null) {
 					this.microsoftDeploymentName = castFrom.getDeploymentName();
@@ -218,9 +221,6 @@ public class OpenAiEmbeddingOptions extends AbstractOpenAiOptions implements Emb
 				}
 				if (castFrom.getEncodingFormat() != null) {
 					this.encodingFormat = castFrom.getEncodingFormat();
-				}
-				if (castFrom.getDimensions() != null) {
-					this.dimensions = castFrom.getDimensions();
 				}
 			}
 			return this;

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/OpenAiEmbeddingModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/embedding/OpenAiEmbeddingModelTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.embedding;
+
+import java.util.List;
+
+import com.openai.client.OpenAIClient;
+import com.openai.models.embeddings.CreateEmbeddingResponse;
+import com.openai.models.embeddings.Embedding;
+import com.openai.models.embeddings.EmbeddingCreateParams;
+import com.openai.services.blocking.EmbeddingService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.embedding.EmbeddingOptions;
+import org.springframework.ai.embedding.EmbeddingRequest;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit tests for {@link OpenAiEmbeddingModel}.
+ */
+@ExtendWith(MockitoExtension.class)
+class OpenAiEmbeddingModelTests {
+
+	@Mock
+	OpenAIClient openAiClient;
+
+	@Mock
+	EmbeddingService embeddingService;
+
+	@Captor
+	ArgumentCaptor<EmbeddingCreateParams> embeddingCreateParamsCaptor;
+
+	@Test
+	void requestLevelGenericOptionsOverrideDefaults() {
+		given(this.openAiClient.embeddings()).willReturn(this.embeddingService);
+		given(this.embeddingService.create(this.embeddingCreateParamsCaptor.capture()))
+			.willReturn(CreateEmbeddingResponse.builder()
+				.model("text-embedding-3-small")
+				.addData(Embedding.builder().embedding(List.of(0.1f, 0.2f, 0.3f)).index(0).build())
+				.usage(CreateEmbeddingResponse.Usage.builder().promptTokens(1).totalTokens(1).build())
+				.build());
+
+		OpenAiEmbeddingModel embeddingModel = new OpenAiEmbeddingModel(this.openAiClient, null,
+				OpenAiEmbeddingOptions.builder().model("text-embedding-ada-002").build());
+
+		embeddingModel.call(new EmbeddingRequest(List.of("Hello World"),
+				EmbeddingOptions.builder().model("text-embedding-3-small").dimensions(512).build()));
+
+		EmbeddingCreateParams createParams = this.embeddingCreateParamsCaptor.getValue();
+		assertThat(createParams.input().asArrayOfStrings()).containsExactly("Hello World");
+		assertThat(createParams.model().asString()).isEqualTo("text-embedding-3-small");
+		assertThat(createParams.dimensions()).contains(512L);
+	}
+
+}


### PR DESCRIPTION
## Summary

Fixes #6042.

This PR updates OpenAI embedding option merging so request-level generic `EmbeddingOptions` are honored by `OpenAiEmbeddingModel`.

The current call path already passes `embeddingRequest.getOptions()` into `OpenAiEmbeddingOptions.Builder.merge(...)`, but `merge(...)` only copied fields from `OpenAiEmbeddingOptions`. As a result, common fields supplied through the generic `EmbeddingOptions.builder()`, such as `model` and `dimensions`, were ignored and the model-level defaults were still used.

The change keeps the existing OpenAI-specific merge behavior, while merging the common `EmbeddingOptions` fields before the OpenAI-specific fields. The existing `deploymentName` precedence in `toOpenAiCreateParams(...)` is unchanged.

## Test Plan

- `./mvnw -s <temp-empty-settings> -Dmaven.build.cache.enabled=false -pl models/spring-ai-openai -am -Dtest=OpenAiEmbeddingModelTests,OpenAiEmbeddingOptionsTests -Dsurefire.failIfNoSpecifiedTests=false test`

Note: I used a temporary empty Maven settings file locally because my default Maven settings currently route dependencies through a mirror that is not reachable from my environment. The test run above disabled Maven build cache and executed the OpenAI embedding tests directly.
