### PR TITLE
GH-5340: Use Locale.ROOT in toUpperCase calls for locale-neutral type normalization

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiModalityTokenCount.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiModalityTokenCount.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai.metadata;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.genai.types.MediaModality;
 import com.google.genai.types.ModalityTokenCount;
@@ -68,7 +70,7 @@ public class GoogleGenAiModalityTokenCount {
 		}
 
 		// MediaModality returns its string value via toString()
-		String modalityStr = modality.toString().toUpperCase();
+		String modalityStr = modality.toString().toUpperCase(Locale.ROOT);
 
 		// Map SDK values to cleaner names
 		return switch (modalityStr) {

--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiTrafficType.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/metadata/GoogleGenAiTrafficType.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.google.genai.metadata;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.genai.types.TrafficType;
 
@@ -60,7 +62,7 @@ public enum GoogleGenAiTrafficType {
 		}
 
 		// Try to match by string value
-		String typeStr = trafficType.toString().toUpperCase();
+		String typeStr = trafficType.toString().toUpperCase(Locale.ROOT);
 
 		// Map SDK values to our enum values
 		return switch (typeStr) {

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -280,7 +281,7 @@ public final class JsonSchemaGenerator {
 				}
 				else if (value.isTextual() && entry.getKey().equals("type")) {
 					String oldValue = node.get("type").asText();
-					node.put("type", oldValue.toUpperCase());
+					node.put("type", oldValue.toUpperCase(Locale.ROOT));
 				}
 			});
 		}

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
+import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -698,6 +700,31 @@ class JsonSchemaGeneratorTests {
 	void throwExceptionWhenTypeIsNull() {
 		assertThatThrownBy(() -> JsonSchemaGenerator.generateForType(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("type cannot be null");
+	}
+
+	@Test
+	void convertTypeValuesToUpperCaseIsLocaleNeutral() throws Exception {
+		String schema = """
+				{
+				    "type": "object",
+				    "properties": {
+				        "count": { "type": "integer" },
+				        "name": { "type": "string" }
+				    }
+				}
+				""";
+		ObjectNode node = (ObjectNode) JsonParser.getJsonMapper().readTree(schema);
+		Locale original = Locale.getDefault();
+		try {
+			Locale.setDefault(new Locale("tr", "TR"));
+			JsonSchemaGenerator.convertTypeValuesToUpperCase(node);
+		}
+		finally {
+			Locale.setDefault(original);
+		}
+		assertThat(node.get("type").asText()).isEqualTo("OBJECT");
+		assertThat(node.path("properties").path("count").get("type").asText()).isEqualTo("INTEGER");
+		assertThat(node.path("properties").path("name").get("type").asText()).isEqualTo("STRING");
 	}
 
 	static class TestMethods {


### PR DESCRIPTION
## Problem

`String.toUpperCase()` without an explicit locale is locale-sensitive. On JVMs with a Turkish locale (`tr_TR`), it transforms `integer` → `İNTEGER` and `string` → `STRİNG`. This breaks Gemini tool calling because the API expects strict ASCII enum values (`INTEGER`, `STRING`, etc.), causing:

> Invalid value at 'tools[0].function_declarations[1].parameters.properties[0].value.type' (type.googleapis.com/google.ai.generativelanguage.v1beta.Type), "İNTEGER"

Three call sites were affected:

- `JsonSchemaGenerator.convertTypeValuesToUpperCase()` — used when building Gemini tool schemas
- `GoogleGenAiTrafficType.from()` — used when parsing traffic type metadata
- `GoogleGenAiModalityTokenCount.convertModality()` — used when parsing modality token count metadata

## Fix

Replace `.toUpperCase()` with `.toUpperCase(Locale.ROOT)` at all three sites. `Locale.ROOT` is the correct choice for any case conversion that produces or compares protocol/API strings rather than user-visible text.

## Test

Added `JsonSchemaGeneratorTests#convertTypeValuesToUpperCaseIsLocaleNeutral` which temporarily sets the JVM default locale to `tr_TR`, runs `convertTypeValuesToUpperCase`, and asserts that the resulting type values are plain ASCII uppercase (`OBJECT`, `INTEGER`, `STRING`).

Closes #5340