### PR TITLE
GH-5437: Handle plain-text and partial-JSON tool responses in GoogleGenAiChatModel

### DIFF
--- a/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
+++ b/models/spring-ai-google-genai/src/main/java/org/springframework/ai/google/genai/GoogleGenAiChatModel.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.annotation.JsonDeserialize;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -189,6 +190,11 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 
 	private final JsonMapper jsonMapper = ModelOptionsUtils.JSON_MAPPER.rebuild()
 		.addMixIn(Schema.class, SchemaMixin.class)
+		.build();
+
+	private final JsonMapper strictJsonMapper = ModelOptionsUtils.JSON_MAPPER.rebuild()
+		.addMixIn(Schema.class, SchemaMixin.class)
+		.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
 		.build();
 
 	/**
@@ -382,27 +388,18 @@ public class GoogleGenAiChatModel implements ChatModel, DisposableBean {
 	// Helper methods for JSON/Map conversion
 	private Map<String, Object> parseJsonToMap(String json) {
 		try {
-			// First, try to parse as an array
-			Object parsed = this.jsonMapper.readValue(json, Object.class);
-			if (parsed instanceof List) {
-				// It's an array, wrap it in a map with "result" key
-				Map<String, Object> wrapper = new HashMap<>();
-				wrapper.put("result", parsed);
-				return wrapper;
-			}
-			else if (parsed instanceof Map) {
-				// It's already a map, return it
+			Object parsed = this.strictJsonMapper.readValue(json, Object.class);
+			if (parsed instanceof Map) {
 				return (Map<String, Object>) parsed;
 			}
-			else {
-				// It's a primitive or other type, wrap it
-				Map<String, Object> wrapper = new HashMap<>();
-				wrapper.put("result", parsed);
-				return wrapper;
-			}
+			Map<String, Object> wrapper = new HashMap<>();
+			wrapper.put("result", parsed);
+			return wrapper;
 		}
 		catch (Exception e) {
-			throw new RuntimeException("Failed to parse JSON: " + json, e);
+			Map<String, Object> wrapper = new HashMap<>();
+			wrapper.put("result", json);
+			return wrapper;
 		}
 	}
 

--- a/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
+++ b/models/spring-ai-google-genai/src/test/java/org/springframework/ai/google/genai/CreateGeminiRequestTests.java
@@ -19,6 +19,7 @@ package org.springframework.ai.google.genai;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import com.google.genai.Client;
 import com.google.genai.types.Content;
@@ -30,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
@@ -773,6 +775,44 @@ public class CreateGeminiRequestTests {
 
 		assertThat(request.config().toolConfig()).isPresent();
 		assertThat(request.config().toolConfig().get().includeServerSideToolInvocations().get()).isTrue();
+	}
+
+	@Test
+	public void toolResponseWithPlainTextIsWrappedInResultKey() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.defaultOptions(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "myTool", "2026-05-15 10:00:00 (Thursday)")))
+			.build();
+
+		List<com.google.genai.types.Part> parts = client.messageToGeminiParts(toolResponse);
+
+		assertThat(parts).hasSize(1);
+		Map<String, Object> response = parts.get(0).functionResponse().get().response().get();
+		assertThat(response).containsKey("result");
+		assertThat(response.get("result")).isEqualTo("2026-05-15 10:00:00 (Thursday)");
+	}
+
+	@Test
+	public void toolResponseWithPartialJsonIsWrappedInResultKey() {
+		var client = GoogleGenAiChatModel.builder()
+			.genAiClient(this.genAiClient)
+			.defaultOptions(GoogleGenAiChatOptions.builder().model("DEFAULT_MODEL").build())
+			.build();
+
+		ToolResponseMessage toolResponse = ToolResponseMessage.builder()
+			.responses(List.of(new ToolResponseMessage.ToolResponse("id1", "calculator", "3.0 + 5.0 = 8.0")))
+			.build();
+
+		List<com.google.genai.types.Part> parts = client.messageToGeminiParts(toolResponse);
+
+		assertThat(parts).hasSize(1);
+		Map<String, Object> response = parts.get(0).functionResponse().get().response().get();
+		assertThat(response).containsKey("result");
+		assertThat(response.get("result")).isEqualTo("3.0 + 5.0 = 8.0");
 	}
 
 }


### PR DESCRIPTION
## Problem

`GoogleGenAiChatModel.parseJsonToMap()` had two defects when handling `ToolResponseMessage` payloads:

1. **Crash** — any tool that returns plain text (e.g. `"2026-05-15 10:00:00 (Thursday)"`) caused an unrecoverable `RuntimeException`, terminating the whole agent loop.

2. **Silent data loss** — inputs that begin with a valid JSON token but contain trailing non-JSON content (e.g. `"3.0 + 5.0 = 8.0"`) were silently truncated: Jackson parsed the leading `3.0` and discarded ` + 5.0 = 8.0`.

Both defects stem from the fact that `ObjectMapper.readValue` is lenient by default (no `FAIL_ON_TRAILING_TOKENS`), and the catch block re-threw as `RuntimeException` rather than recovering gracefully.

## Fix

Add a second `JsonMapper` instance built with `DeserializationFeature.FAIL_ON_TRAILING_TOKENS` enabled (`strictJsonMapper`). Use it in `parseJsonToMap`:

- Valid complete JSON objects → returned as-is or wrapped under `"result"` for arrays/scalars (same as before).
- Non-JSON text or partial-JSON input → exception is caught and the raw string is wrapped as `{"result": "<input>"}` so Gemini receives a well-formed `FunctionResponse`.

## Test

Added two unit tests to `CreateGeminiRequestTests`:

- `toolResponseWithPlainTextIsWrappedInResultKey` — verifies that a date-time string tool result is wrapped as `{"result": "..."}`.
- `toolResponseWithPartialJsonIsWrappedInResultKey` — verifies that `"3.0 + 5.0 = 8.0"` is not truncated to `3.0` but preserved in full.

Closes #5437