### PR TITLE
fix: omit blank content on assistant tool-call messages (OpenAI)

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatModel.java
@@ -770,7 +770,7 @@ public final class OpenAiChatModel implements ChatModel {
 					ChatCompletionAssistantMessageParam.Builder builder = ChatCompletionAssistantMessageParam.builder()
 						.role(JsonValue.from(MessageType.ASSISTANT.getValue()));
 
-					if (assistantMessage.getText() != null) {
+					if (StringUtils.hasText(assistantMessage.getText())) {
 						builder.content(ChatCompletionAssistantMessageParam.builder()
 							.content(assistantMessage.getText())
 							.build()

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/OpenAiChatModelTests.java
@@ -26,8 +26,10 @@ import com.openai.client.OpenAIClient;
 import com.openai.client.OpenAIClientAsync;
 import com.openai.core.JsonValue;
 import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
 import com.openai.models.chat.completions.ChatCompletionMessage;
+import com.openai.models.chat.completions.ChatCompletionMessageParam;
 import com.openai.models.completions.CompletionUsage;
 import com.openai.services.blocking.ChatService;
 import com.openai.services.blocking.chat.ChatCompletionService;
@@ -36,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.PromptMetadata;
 import org.springframework.ai.chat.metadata.RateLimit;
@@ -224,6 +227,38 @@ class OpenAiChatModelTests {
 		assertThat(aggregatedMetadata.getRateLimit()).isSameAs(rateLimit);
 		assertThat(aggregatedMetadata.getPromptMetadata()).isSameAs(promptMetadata);
 		assertThat((String) aggregatedMetadata.get("custom-key")).isEqualTo("custom-value");
+	}
+
+	@Test
+	void assistantToolCallMessageOmitsContentWhenBlank() {
+		OpenAiChatOptions options = OpenAiChatOptions.builder().model("test-model").build();
+		OpenAiChatModel chatModel = OpenAiChatModel.builder()
+			.openAiClient(this.openAiClient)
+			.openAiClientAsync(this.openAiClientAsync)
+			.options(options)
+			.build();
+
+		AssistantMessage assistantWithToolCall = AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "myTool", "{}")))
+			.build();
+
+		ChatCompletionCreateParams request = chatModel.createRequest(
+				new org.springframework.ai.chat.prompt.Prompt(List.of(assistantWithToolCall), options), false);
+
+		assertThat(request.messages()).isNotEmpty();
+		for (ChatCompletionMessageParam msg : request.messages()) {
+			if (msg.isAssistant()) {
+				ChatCompletionAssistantMessageParam assistant = msg.asAssistant();
+				assertThat(assistant.content())
+					.as("assistant message with only tool_calls must not have blank text content")
+					.satisfies(content -> {
+						if (content.isPresent() && content.get().isText()) {
+							assertThat(content.get().asText()).isNotBlank();
+						}
+					});
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
## Summary

Fixes #5480

- Changed the guard from `assistantMessage.getText() != null` to `StringUtils.hasText(assistantMessage.getText())` in `OpenAiChatModel.java`
- When an `AssistantMessage` carries `toolCalls` but has empty or blank text, the `content` field is now omitted from the serialized request rather than serialized as `""`
- Added a unit test that verifies the assistant message with blank content + tool calls produces a request with no empty-string content field

## Background

Anthropic-compatible OpenAI endpoints (e.g. Kimi-K2, DeepSeek, and other proxies) reject requests where `content` is an empty string on an assistant message that has `tool_calls`. The OpenAI spec itself says `content` should be absent—not blank—in this case. The root cause was that a null check was used instead of a blank-string check, so Spring AI would serialize `"content": ""` for assistant messages built with an empty string.

## Test plan

- [x] `OpenAiChatModelTests#assistantToolCallMessageOmitsContentWhenBlank` — new test verifying the fix
- [x] All existing `OpenAiChatModelTests` pass
- [ ] Manually test with an Anthropic-compatible endpoint that rejects `"content": ""`