### PR TITLE
Fix GoogleGenAiTextEmbeddingModel ignoring taskType, title and autoTruncate options

### DIFF
--- a/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
+++ b/models/spring-ai-google-genai-embedding/src/main/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingModel.java
@@ -52,7 +52,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * A class representing a Vertex AI Text Embedding Model using the new Google Gen AI SDK.
+ * A class representing a Google Gen AI Text Embedding Model using the Google Gen AI SDK.
  *
  * @author Christian Tzolov
  * @author Mark Pollack
@@ -150,9 +150,15 @@ public class GoogleGenAiTextEmbeddingModel extends AbstractEmbeddingModel {
 					configBuilder.outputDimensionality(options.getDimensions());
 				}
 
-				// Set task type if specified - this might need to be handled differently
-				// as the new SDK might not have a direct taskType field
-				// We'll need to check the SDK documentation for this
+				if (options.getTaskType() != null) {
+					configBuilder.taskType(options.getTaskType().name());
+				}
+				if (StringUtils.hasText(options.getTitle())) {
+					configBuilder.title(options.getTitle());
+				}
+				if (options.getAutoTruncate() != null) {
+					configBuilder.autoTruncate(options.getAutoTruncate().booleanValue());
+				}
 
 				EmbedContentConfig config = configBuilder.build();
 

--- a/models/spring-ai-google-genai-embedding/src/test/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingRetryTests.java
+++ b/models/spring-ai-google-genai-embedding/src/test/java/org/springframework/ai/google/genai/text/GoogleGenAiTextEmbeddingRetryTests.java
@@ -27,6 +27,7 @@ import com.google.genai.types.EmbedContentResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -134,6 +135,36 @@ public class GoogleGenAiTextEmbeddingRetryTests {
 		// Verify that embedContent was called only once (no retries for non-transient
 		// errors)
 		verify(this.mockModels, times(1)).embedContent(anyString(), any(List.class), any(EmbedContentConfig.class));
+	}
+
+	@Test
+	public void embeddingOptionsAreForwardedToConfig() {
+		ContentEmbedding mockEmbedding = mock(ContentEmbedding.class);
+		given(mockEmbedding.values()).willReturn(java.util.Optional.of(List.of(1.0f)));
+		given(mockEmbedding.statistics()).willReturn(java.util.Optional.empty());
+
+		EmbedContentResponse mockResponse = mock(EmbedContentResponse.class);
+		given(mockResponse.embeddings()).willReturn(java.util.Optional.of(List.of(mockEmbedding)));
+
+		given(this.mockModels.embedContent(anyString(), any(List.class), any(EmbedContentConfig.class)))
+			.willReturn(mockResponse);
+
+		GoogleGenAiTextEmbeddingOptions options = GoogleGenAiTextEmbeddingOptions.builder()
+			.model("model")
+			.taskType(GoogleGenAiTextEmbeddingOptions.TaskType.RETRIEVAL_DOCUMENT)
+			.title("my-title")
+			.autoTruncate(false)
+			.build();
+
+		this.embeddingModel.call(new EmbeddingRequest(List.of("text1"), options));
+
+		ArgumentCaptor<EmbedContentConfig> configCaptor = ArgumentCaptor.forClass(EmbedContentConfig.class);
+		verify(this.mockModels).embedContent(anyString(), any(List.class), configCaptor.capture());
+
+		EmbedContentConfig capturedConfig = configCaptor.getValue();
+		assertThat(capturedConfig.taskType()).isPresent().hasValue("RETRIEVAL_DOCUMENT");
+		assertThat(capturedConfig.title()).isPresent().hasValue("my-title");
+		assertThat(capturedConfig.autoTruncate()).isPresent().hasValue(false);
 	}
 
 	private static class TestRetryListener implements RetryListener {


### PR DESCRIPTION
## Problem

`GoogleGenAiTextEmbeddingModel.embed()` builds an `EmbedContentConfig` but silently ignores three options that callers can set via `GoogleGenAiTextEmbeddingOptions`:
- `taskType` — determines the embedding space optimization (retrieval, classification, etc.)
- `title` — only relevant for `RETRIEVAL_DOCUMENT` task type
- `autoTruncate` — controls whether the model truncates inputs exceeding the token limit

A TODO comment in the code acknowledged this but left these options unwired.

Closes #5966

## Fix

Replace the TODO comment block with actual calls to `EmbedContentConfig.Builder`:
```java
if (options.getTaskType() != null) {
    configBuilder.taskType(options.getTaskType().name());
}
if (StringUtils.hasText(options.getTitle())) {
    configBuilder.title(options.getTitle());
}
if (options.getAutoTruncate() != null) {
    configBuilder.autoTruncate(options.getAutoTruncate());
}
```

`EmbedContentConfig.Builder.taskType()` accepts a `String`, and `GoogleGenAiTextEmbeddingOptions.TaskType` is an enum whose `.name()` produces the correct Google API string value.

## Test plan
- [ ] Verify `GoogleGenAiTextEmbeddingModel` compiles cleanly
- [ ] Manual test: create `GoogleGenAiTextEmbeddingOptions` with `taskType = RETRIEVAL_DOCUMENT`, verify the config is passed to the SDK