### PR TITLE
GH-4560: Add MCP server tool observations

### DIFF
--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/pom.xml
@@ -36,6 +36,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-mcp</artifactId>
 			<version>${project.parent.version}</version>
 			<optional>true</optional>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
+import io.micrometer.observation.ObservationRegistry;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
@@ -51,6 +52,8 @@ import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.ai.mcp.customizer.McpAsyncServerCustomizer;
 import org.springframework.ai.mcp.customizer.McpSyncServerCustomizer;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolContentObservationFilter;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolObservationConvention;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerChangeNotificationProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
@@ -88,6 +91,8 @@ public class McpServerAutoConfiguration {
 
 	private static final LogAccessor logger = new LogAccessor(McpServerAutoConfiguration.class);
 
+	static final String TOOL_CONTENT_OBSERVATION_WARNING = "You have enabled the inclusion of the tool call arguments and result in the observations, with the risk of exposing sensitive or private information. Please, be careful!";
+
 	@Bean
 	@ConditionalOnMissingBean
 	public McpServerTransportProviderBase stdioServerTransport(
@@ -113,6 +118,8 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
 			ObjectProvider<List<SyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpSyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumers,
+			ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<McpServerToolObservationConvention> observationConvention,
 			Optional<McpSyncServerCustomizer> mcpSyncServerCustomizer) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
@@ -138,6 +145,10 @@ public class McpServerAutoConfiguration {
 					tools.stream().flatMap(List::stream).toList());
 
 			if (!CollectionUtils.isEmpty(toolSpecifications)) {
+				toolSpecifications = new McpServerToolObservationSupport(
+						observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
+						observationConvention.getIfAvailable())
+					.wrapStatefulSync(toolSpecifications);
 				serverBuilder.tools(toolSpecifications);
 				logger.info("Registered tools: " + toolSpecifications.size());
 			}
@@ -234,6 +245,8 @@ public class McpServerAutoConfiguration {
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
 			ObjectProvider<List<AsyncCompletionSpecification>> completions,
 			ObjectProvider<BiConsumer<McpAsyncServerExchange, List<McpSchema.Root>>> rootsChangeConsumer,
+			ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<McpServerToolObservationConvention> observationConvention,
 			Optional<McpAsyncServerCustomizer> asyncServerCustomizer) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
@@ -259,6 +272,10 @@ public class McpServerAutoConfiguration {
 			capabilitiesBuilder.tools(changeNotificationProperties.isToolChangeNotification());
 
 			if (!CollectionUtils.isEmpty(toolSpecifications)) {
+				toolSpecifications = new McpServerToolObservationSupport(
+						observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
+						observationConvention.getIfAvailable())
+					.wrapStatefulAsync(toolSpecifications);
 				serverBuilder.tools(toolSpecifications);
 				logger.info("Registered tools: " + toolSpecifications.size());
 			}
@@ -336,6 +353,15 @@ public class McpServerAutoConfiguration {
 		asyncServerCustomizer.ifPresent(customizer -> customizer.customize(serverBuilder));
 
 		return serverBuilder.build();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX + ".observations", name = "include-content",
+			havingValue = "true")
+	McpServerToolContentObservationFilter mcpServerToolContentObservationFilter() {
+		logger.warn(TOOL_CONTENT_OBSERVATION_WARNING);
+		return new McpServerToolContentObservationFilter();
 	}
 
 	public static class NonStatelessServerCondition extends AnyNestedCondition {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerStatelessAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.ai.mcp.server.common.autoconfigure;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.micrometer.observation.ObservationRegistry;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServer.StatelessAsyncSpecification;
 import io.modelcontextprotocol.server.McpServer.StatelessSyncSpecification;
@@ -38,6 +39,8 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.Implementation;
 import io.modelcontextprotocol.spec.McpStatelessServerTransport;
 
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolContentObservationFilter;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolObservationConvention;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -80,7 +83,9 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<SyncResourceSpecification>> resources,
 			ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<SyncPromptSpecification>> prompts,
-			ObjectProvider<List<SyncCompletionSpecification>> completions, Environment environment) {
+			ObjectProvider<List<SyncCompletionSpecification>> completions,
+			ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<McpServerToolObservationConvention> observationConvention, Environment environment) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
@@ -96,6 +101,10 @@ public class McpServerStatelessAutoConfiguration {
 					tools.stream().flatMap(List::stream).toList());
 
 			if (!CollectionUtils.isEmpty(toolSpecifications)) {
+				toolSpecifications = new McpServerToolObservationSupport(
+						observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
+						observationConvention.getIfAvailable())
+					.wrapStatelessSync(toolSpecifications);
 				serverBuilder.tools(toolSpecifications);
 				logger.info("Registered tools: " + toolSpecifications.size());
 			}
@@ -170,7 +179,9 @@ public class McpServerStatelessAutoConfiguration {
 			ObjectProvider<List<AsyncResourceSpecification>> resources,
 			ObjectProvider<List<AsyncResourceTemplateSpecification>> resourceTemplates,
 			ObjectProvider<List<AsyncPromptSpecification>> prompts,
-			ObjectProvider<List<AsyncCompletionSpecification>> completions) {
+			ObjectProvider<List<AsyncCompletionSpecification>> completions,
+			ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<McpServerToolObservationConvention> observationConvention) {
 
 		McpSchema.Implementation serverInfo = new Implementation(serverProperties.getName(),
 				serverProperties.getVersion());
@@ -186,6 +197,10 @@ public class McpServerStatelessAutoConfiguration {
 			capabilitiesBuilder.tools(false);
 
 			if (!CollectionUtils.isEmpty(toolSpecifications)) {
+				toolSpecifications = new McpServerToolObservationSupport(
+						observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
+						observationConvention.getIfAvailable())
+					.wrapStatelessAsync(toolSpecifications);
 				serverBuilder.tools(toolSpecifications);
 				logger.info("Registered tools: " + toolSpecifications.size());
 			}
@@ -247,6 +262,15 @@ public class McpServerStatelessAutoConfiguration {
 		serverBuilder.requestTimeout(serverProperties.getRequestTimeout());
 
 		return serverBuilder.build();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(prefix = McpServerProperties.CONFIG_PREFIX + ".observations", name = "include-content",
+			havingValue = "true")
+	McpServerToolContentObservationFilter mcpServerToolContentObservationFilter() {
+		logger.warn(McpServerAutoConfiguration.TOOL_CONTENT_OBSERVATION_WARNING);
+		return new McpServerToolContentObservationFilter();
 	}
 
 	public static class EnabledStatelessServerCondition extends AllNestedConditions {

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerToolObservationSupport.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerToolObservationSupport.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpStatelessServerFeatures;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Mono;
+
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.DefaultMcpServerToolObservationConvention;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolObservationContext;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolObservationConvention;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolObservationDocumentation;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.util.json.schema.JsonSchemaUtils;
+
+/**
+ * Observability support for MCP server tool calls.
+ *
+ * @author Michal Grandys
+ */
+final class McpServerToolObservationSupport {
+
+	private static final String PROTOCOL_STATEFUL = "stateful";
+
+	private static final String PROTOCOL_STATELESS = "stateless";
+
+	private static final String TYPE_SYNC = "sync";
+
+	private static final String TYPE_ASYNC = "async";
+
+	private static final McpServerToolObservationConvention DEFAULT_OBSERVATION_CONVENTION = new DefaultMcpServerToolObservationConvention();
+
+	private final ObservationRegistry observationRegistry;
+
+	private final McpServerToolObservationConvention observationConvention;
+
+	McpServerToolObservationSupport(ObservationRegistry observationRegistry,
+			@Nullable McpServerToolObservationConvention observationConvention) {
+		this.observationRegistry = observationRegistry;
+		this.observationConvention = observationConvention != null ? observationConvention
+				: DEFAULT_OBSERVATION_CONVENTION;
+	}
+
+	List<SyncToolSpecification> wrapStatefulSync(List<SyncToolSpecification> toolSpecifications) {
+		return toolSpecifications.stream().map(this::wrapStatefulSync).toList();
+	}
+
+	List<AsyncToolSpecification> wrapStatefulAsync(List<AsyncToolSpecification> toolSpecifications) {
+		return toolSpecifications.stream().map(this::wrapStatefulAsync).toList();
+	}
+
+	List<McpStatelessServerFeatures.SyncToolSpecification> wrapStatelessSync(
+			List<McpStatelessServerFeatures.SyncToolSpecification> toolSpecifications) {
+		return toolSpecifications.stream().map(this::wrapStatelessSync).toList();
+	}
+
+	List<McpStatelessServerFeatures.AsyncToolSpecification> wrapStatelessAsync(
+			List<McpStatelessServerFeatures.AsyncToolSpecification> toolSpecifications) {
+		return toolSpecifications.stream().map(this::wrapStatelessAsync).toList();
+	}
+
+	private SyncToolSpecification wrapStatefulSync(SyncToolSpecification toolSpecification) {
+		ToolDefinition toolDefinition = createToolDefinition(toolSpecification.tool());
+		return new SyncToolSpecification(toolSpecification.tool(), (exchange, request) -> observeSync(toolDefinition,
+				request, PROTOCOL_STATEFUL, () -> toolSpecification.callHandler().apply(exchange, request)));
+	}
+
+	private AsyncToolSpecification wrapStatefulAsync(AsyncToolSpecification toolSpecification) {
+		ToolDefinition toolDefinition = createToolDefinition(toolSpecification.tool());
+		return new AsyncToolSpecification(toolSpecification.tool(), (exchange, request) -> observeAsync(toolDefinition,
+				request, PROTOCOL_STATEFUL, () -> toolSpecification.callHandler().apply(exchange, request)));
+	}
+
+	private McpStatelessServerFeatures.SyncToolSpecification wrapStatelessSync(
+			McpStatelessServerFeatures.SyncToolSpecification toolSpecification) {
+		ToolDefinition toolDefinition = createToolDefinition(toolSpecification.tool());
+		return new McpStatelessServerFeatures.SyncToolSpecification(toolSpecification.tool(),
+				(context, request) -> observeSync(toolDefinition, request, PROTOCOL_STATELESS,
+						() -> toolSpecification.callHandler().apply(context, request)));
+	}
+
+	private McpStatelessServerFeatures.AsyncToolSpecification wrapStatelessAsync(
+			McpStatelessServerFeatures.AsyncToolSpecification toolSpecification) {
+		ToolDefinition toolDefinition = createToolDefinition(toolSpecification.tool());
+		return new McpStatelessServerFeatures.AsyncToolSpecification(toolSpecification.tool(),
+				(context, request) -> observeAsync(toolDefinition, request, PROTOCOL_STATELESS,
+						() -> toolSpecification.callHandler().apply(context, request)));
+	}
+
+	private CallToolResult observeSync(ToolDefinition toolDefinition, CallToolRequest request, String protocol,
+			Supplier<CallToolResult> toolCallSupplier) {
+		return observe(toolDefinition, request, protocol, TYPE_SYNC,
+				(observationContext, observation) -> observation.observe(() -> {
+					CallToolResult result = toolCallSupplier.get();
+					observationContext.setToolCallResult(toJson(result));
+					recordErrorResult(observation, result);
+					return result;
+				}));
+	}
+
+	private Mono<CallToolResult> observeAsync(ToolDefinition toolDefinition, CallToolRequest request, String protocol,
+			Supplier<Mono<CallToolResult>> toolCallSupplier) {
+		return Mono
+			.defer(() -> observe(toolDefinition, request, protocol, TYPE_ASYNC, (observationContext, observation) -> {
+				observation.start();
+				try {
+					return toolCallSupplier.get().doOnNext(result -> {
+						observationContext.setToolCallResult(toJson(result));
+						recordErrorResult(observation, result);
+					}).doOnError(observation::error).doFinally(signalType -> observation.stop());
+				}
+				catch (RuntimeException | Error ex) {
+					observation.error(ex);
+					observation.stop();
+					return Mono.error(ex);
+				}
+			}));
+	}
+
+	private <T> T observe(ToolDefinition toolDefinition, CallToolRequest request, String protocol, String type,
+			BiFunction<McpServerToolObservationContext, Observation, T> observationHandler) {
+		McpServerToolObservationContext observationContext = createObservationContext(toolDefinition, request, protocol,
+				type);
+		Observation observation = createObservation(observationContext);
+		return observationHandler.apply(observationContext, observation);
+	}
+
+	private Observation createObservation(McpServerToolObservationContext observationContext) {
+		return McpServerToolObservationDocumentation.MCP_SERVER_TOOL_CALL.observation(this.observationConvention,
+				DEFAULT_OBSERVATION_CONVENTION, () -> observationContext, this.observationRegistry);
+	}
+
+	private McpServerToolObservationContext createObservationContext(ToolDefinition toolDefinition,
+			CallToolRequest request, String protocol, String type) {
+		return McpServerToolObservationContext.builder()
+			.toolDefinition(toolDefinition)
+			.toolCallArguments(toJson(request.arguments()))
+			.mcpServerProtocol(protocol)
+			.mcpServerType(type)
+			.build();
+	}
+
+	private static ToolDefinition createToolDefinition(McpSchema.Tool tool) {
+		return ToolDefinition.builder()
+			.name(tool.name())
+			.description(tool.description())
+			.inputSchema(JsonSchemaUtils.ensureValidInputSchema(toJson(tool.inputSchema())))
+			.build();
+	}
+
+	private static String toJson(@Nullable Object value) {
+		if (value == null) {
+			return "{}";
+		}
+		return ModelOptionsUtils.toJsonString(value);
+	}
+
+	private static void recordErrorResult(Observation observation, @Nullable CallToolResult result) {
+		if (result != null && Boolean.TRUE.equals(result.isError())) {
+			observation.error(new McpToolCallResultErrorException());
+		}
+	}
+
+	private static final class McpToolCallResultErrorException extends RuntimeException {
+
+		private McpToolCallResultErrorException() {
+			super("MCP tool call returned an error result", null, false, false);
+		}
+
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/DefaultMcpServerToolObservationConvention.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/DefaultMcpServerToolObservationConvention.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.observation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+
+import org.springframework.ai.observation.conventions.AiOperationType;
+import org.springframework.ai.observation.conventions.SpringAiKind;
+import org.springframework.util.Assert;
+
+/**
+ * Default conventions to populate observations for MCP server tool call operations.
+ *
+ * @author Michal Grandys
+ * @since 2.0.0
+ */
+public class DefaultMcpServerToolObservationConvention implements McpServerToolObservationConvention {
+
+	public static final String DEFAULT_NAME = "spring.ai.mcp.server.tool";
+
+	private final String name;
+
+	public DefaultMcpServerToolObservationConvention() {
+		this(DEFAULT_NAME);
+	}
+
+	public DefaultMcpServerToolObservationConvention(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	@Override
+	public String getContextualName(McpServerToolObservationContext context) {
+		Assert.notNull(context, "context cannot be null");
+		String toolName = context.getToolDefinition().name();
+		return "%s %s".formatted(AiOperationType.EXECUTE_TOOL.value(), toolName);
+	}
+
+	@Override
+	public KeyValues getLowCardinalityKeyValues(McpServerToolObservationContext context) {
+		return KeyValues.of(aiOperationType(context), aiProvider(context), springAiKind(context), toolType(context),
+				toolDefinitionName(context), mcpServerProtocol(context), mcpServerType(context));
+	}
+
+	protected KeyValue aiOperationType(McpServerToolObservationContext context) {
+		return KeyValue.of(McpServerToolObservationDocumentation.LowCardinalityKeyNames.AI_OPERATION_TYPE,
+				context.getOperationMetadata().operationType());
+	}
+
+	protected KeyValue aiProvider(McpServerToolObservationContext context) {
+		return KeyValue.of(McpServerToolObservationDocumentation.LowCardinalityKeyNames.AI_PROVIDER,
+				context.getOperationMetadata().provider());
+	}
+
+	protected KeyValue springAiKind(McpServerToolObservationContext context) {
+		return KeyValue.of(McpServerToolObservationDocumentation.LowCardinalityKeyNames.SPRING_AI_KIND,
+				SpringAiKind.MCP_SERVER_TOOL_CALL.value());
+	}
+
+	protected KeyValue toolType(McpServerToolObservationContext context) {
+		return KeyValue.of(McpServerToolObservationDocumentation.LowCardinalityKeyNames.TOOL_TYPE,
+				context.getToolType());
+	}
+
+	protected KeyValue toolDefinitionName(McpServerToolObservationContext context) {
+		String toolName = context.getToolDefinition().name();
+		return KeyValue.of(McpServerToolObservationDocumentation.LowCardinalityKeyNames.TOOL_DEFINITION_NAME, toolName);
+	}
+
+	protected KeyValue mcpServerProtocol(McpServerToolObservationContext context) {
+		return KeyValue.of(McpServerToolObservationDocumentation.LowCardinalityKeyNames.MCP_SERVER_PROTOCOL,
+				context.getMcpServerProtocol());
+	}
+
+	protected KeyValue mcpServerType(McpServerToolObservationContext context) {
+		return KeyValue.of(McpServerToolObservationDocumentation.LowCardinalityKeyNames.MCP_SERVER_TYPE,
+				context.getMcpServerType());
+	}
+
+	@Override
+	public KeyValues getHighCardinalityKeyValues(McpServerToolObservationContext context) {
+		var keyValues = KeyValues.empty();
+		keyValues = toolDefinitionDescription(keyValues, context);
+		keyValues = toolDefinitionSchema(keyValues, context);
+		return keyValues;
+	}
+
+	protected KeyValues toolDefinitionDescription(KeyValues keyValues, McpServerToolObservationContext context) {
+		String toolDescription = context.getToolDefinition().description();
+		return keyValues.and(
+				McpServerToolObservationDocumentation.HighCardinalityKeyNames.TOOL_DEFINITION_DESCRIPTION.asString(),
+				toolDescription);
+	}
+
+	protected KeyValues toolDefinitionSchema(KeyValues keyValues, McpServerToolObservationContext context) {
+		String toolSchema = context.getToolDefinition().inputSchema();
+		return keyValues.and(
+				McpServerToolObservationDocumentation.HighCardinalityKeyNames.TOOL_DEFINITION_SCHEMA.asString(),
+				toolSchema);
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolContentObservationFilter.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolContentObservationFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.observation;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationFilter;
+
+/**
+ * An {@link ObservationFilter} to include MCP server tool call content (input/output) in
+ * the observation.
+ *
+ * @author Michal Grandys
+ * @since 2.0.0
+ */
+public class McpServerToolContentObservationFilter implements ObservationFilter {
+
+	@Override
+	public Observation.Context map(Observation.Context context) {
+		if (!(context instanceof McpServerToolObservationContext mcpServerToolObservationContext)) {
+			return context;
+		}
+
+		String toolCallArguments = mcpServerToolObservationContext.getToolCallArguments();
+		mcpServerToolObservationContext.addHighCardinalityKeyValue(
+				McpServerToolObservationDocumentation.HighCardinalityKeyNames.TOOL_CALL_ARGUMENTS
+					.withValue(toolCallArguments));
+
+		String toolCallResult = mcpServerToolObservationContext.getToolCallResult();
+		if (toolCallResult != null) {
+			mcpServerToolObservationContext.addHighCardinalityKeyValue(
+					McpServerToolObservationDocumentation.HighCardinalityKeyNames.TOOL_CALL_RESULT
+						.withValue(toolCallResult));
+		}
+
+		return mcpServerToolObservationContext;
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolObservationContext.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolObservationContext.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.observation;
+
+import io.micrometer.observation.Observation;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.observation.AiOperationMetadata;
+import org.springframework.ai.observation.conventions.AiOperationType;
+import org.springframework.ai.observation.conventions.AiProvider;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Context used to store data for MCP server tool call observations.
+ *
+ * @author Michal Grandys
+ * @since 2.0.0
+ */
+public final class McpServerToolObservationContext extends Observation.Context {
+
+	private final AiOperationMetadata operationMetadata = new AiOperationMetadata(AiOperationType.EXECUTE_TOOL.value(),
+			AiProvider.SPRING_AI.value());
+
+	private final ToolDefinition toolDefinition;
+
+	private final String toolType;
+
+	private final String toolCallArguments;
+
+	private final String mcpServerProtocol;
+
+	private final String mcpServerType;
+
+	private @Nullable String toolCallResult;
+
+	private McpServerToolObservationContext(ToolDefinition toolDefinition, @Nullable String toolType,
+			@Nullable String toolCallArguments, @Nullable String toolCallResult, String mcpServerProtocol,
+			String mcpServerType) {
+		Assert.notNull(toolDefinition, "toolDefinition cannot be null");
+		Assert.hasText(mcpServerProtocol, "mcpServerProtocol cannot be empty");
+		Assert.hasText(mcpServerType, "mcpServerType cannot be empty");
+
+		this.toolDefinition = toolDefinition;
+		this.toolType = StringUtils.hasText(toolType) ? toolType : "function";
+		this.toolCallArguments = StringUtils.hasText(toolCallArguments) ? toolCallArguments : "{}";
+		this.toolCallResult = toolCallResult;
+		this.mcpServerProtocol = mcpServerProtocol;
+		this.mcpServerType = mcpServerType;
+	}
+
+	public AiOperationMetadata getOperationMetadata() {
+		return this.operationMetadata;
+	}
+
+	public ToolDefinition getToolDefinition() {
+		return this.toolDefinition;
+	}
+
+	public String getToolType() {
+		return this.toolType;
+	}
+
+	public String getToolCallArguments() {
+		return this.toolCallArguments;
+	}
+
+	public @Nullable String getToolCallResult() {
+		return this.toolCallResult;
+	}
+
+	public void setToolCallResult(@Nullable String toolCallResult) {
+		this.toolCallResult = toolCallResult;
+	}
+
+	public String getMcpServerProtocol() {
+		return this.mcpServerProtocol;
+	}
+
+	public String getMcpServerType() {
+		return this.mcpServerType;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		private @Nullable ToolDefinition toolDefinition;
+
+		private @Nullable String toolType;
+
+		private @Nullable String toolCallArguments;
+
+		private @Nullable String toolCallResult;
+
+		private @Nullable String mcpServerProtocol;
+
+		private @Nullable String mcpServerType;
+
+		private Builder() {
+		}
+
+		public Builder toolDefinition(ToolDefinition toolDefinition) {
+			this.toolDefinition = toolDefinition;
+			return this;
+		}
+
+		public Builder toolType(@Nullable String toolType) {
+			this.toolType = toolType;
+			return this;
+		}
+
+		public Builder toolCallArguments(@Nullable String toolCallArguments) {
+			this.toolCallArguments = toolCallArguments;
+			return this;
+		}
+
+		public Builder toolCallResult(@Nullable String toolCallResult) {
+			this.toolCallResult = toolCallResult;
+			return this;
+		}
+
+		public Builder mcpServerProtocol(String mcpServerProtocol) {
+			this.mcpServerProtocol = mcpServerProtocol;
+			return this;
+		}
+
+		public Builder mcpServerType(String mcpServerType) {
+			this.mcpServerType = mcpServerType;
+			return this;
+		}
+
+		public McpServerToolObservationContext build() {
+			Assert.notNull(this.toolDefinition, "toolDefinition cannot be null");
+			String mcpServerProtocol = this.mcpServerProtocol;
+			Assert.hasText(mcpServerProtocol, "mcpServerProtocol cannot be empty");
+			String mcpServerType = this.mcpServerType;
+			Assert.hasText(mcpServerType, "mcpServerType cannot be empty");
+			return new McpServerToolObservationContext(this.toolDefinition, this.toolType, this.toolCallArguments,
+					this.toolCallResult, mcpServerProtocol, mcpServerType);
+		}
+
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolObservationConvention.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolObservationConvention.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.observation;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+
+/**
+ * Convention for MCP server tool call observations.
+ *
+ * @author Michal Grandys
+ * @since 2.0.0
+ */
+public interface McpServerToolObservationConvention extends ObservationConvention<McpServerToolObservationContext> {
+
+	@Override
+	default boolean supportsContext(Observation.Context context) {
+		return context instanceof McpServerToolObservationContext;
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolObservationDocumentation.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/McpServerToolObservationDocumentation.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure.observation;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+
+/**
+ * MCP server tool call observation documentation.
+ *
+ * @author Michal Grandys
+ * @since 2.0.0
+ */
+public enum McpServerToolObservationDocumentation implements ObservationDocumentation {
+
+	/**
+	 * MCP server tool call observations.
+	 */
+	MCP_SERVER_TOOL_CALL {
+		@Override
+		public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return DefaultMcpServerToolObservationConvention.class;
+		}
+
+		@Override
+		public KeyName[] getLowCardinalityKeyNames() {
+			return LowCardinalityKeyNames.values();
+		}
+
+		@Override
+		public KeyName[] getHighCardinalityKeyNames() {
+			return HighCardinalityKeyNames.values();
+		}
+	};
+
+	/**
+	 * Low cardinality key names.
+	 */
+	public enum LowCardinalityKeyNames implements KeyName {
+
+		/**
+		 * The name of the operation being performed.
+		 */
+		AI_OPERATION_TYPE {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.AI_OPERATION_TYPE.value();
+			}
+		},
+
+		/**
+		 * The provider responsible for the operation.
+		 */
+		AI_PROVIDER {
+			@Override
+			public String asString() {
+				return AiObservationAttributes.AI_PROVIDER.value();
+			}
+		},
+
+		/**
+		 * Spring AI kind.
+		 */
+		SPRING_AI_KIND {
+			@Override
+			public String asString() {
+				return "spring.ai.kind";
+			}
+		},
+
+		/**
+		 * The name of the tool.
+		 */
+		TOOL_DEFINITION_NAME {
+			@Override
+			public String asString() {
+				return "spring.ai.tool.definition.name";
+			}
+		},
+
+		/**
+		 * The type of the tool.
+		 */
+		TOOL_TYPE {
+			@Override
+			public String asString() {
+				return "spring.ai.tool.type";
+			}
+		},
+
+		/**
+		 * MCP server protocol used to handle the tool call.
+		 */
+		MCP_SERVER_PROTOCOL {
+			@Override
+			public String asString() {
+				return "spring.ai.mcp.server.protocol";
+			}
+		},
+
+		/**
+		 * MCP server execution type used to handle the tool call.
+		 */
+		MCP_SERVER_TYPE {
+			@Override
+			public String asString() {
+				return "spring.ai.mcp.server.type";
+			}
+		}
+
+	}
+
+	/**
+	 * High cardinality key names.
+	 */
+	public enum HighCardinalityKeyNames implements KeyName {
+
+		/**
+		 * Description of the tool.
+		 */
+		TOOL_DEFINITION_DESCRIPTION {
+			@Override
+			public String asString() {
+				return "spring.ai.tool.definition.description";
+			}
+		},
+
+		/**
+		 * Schema of the parameters used to call the tool.
+		 */
+		TOOL_DEFINITION_SCHEMA {
+			@Override
+			public String asString() {
+				return "spring.ai.tool.definition.schema";
+			}
+		},
+
+		/**
+		 * The input arguments to the MCP server tool call.
+		 */
+		TOOL_CALL_ARGUMENTS {
+			@Override
+			public String asString() {
+				return "spring.ai.mcp.server.tool.call.arguments";
+			}
+		},
+
+		/**
+		 * The result of the MCP server tool call.
+		 */
+		TOOL_CALL_RESULT {
+			@Override
+			public String asString() {
+				return "spring.ai.mcp.server.tool.call.result";
+			}
+		}
+
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/package-info.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/observation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.mcp.server.common.autoconfigure.observation;
+
+import org.jspecify.annotations.NullMarked;

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/main/java/org/springframework/ai/mcp/server/common/autoconfigure/properties/McpServerProperties.java
@@ -97,6 +97,8 @@ public class McpServerProperties {
 
 	private final Capabilities capabilities = new Capabilities();
 
+	private final Observations observations = new Observations();
+
 	private ServerProtocol protocol = ServerProtocol.STREAMABLE;
 
 	/**
@@ -131,6 +133,10 @@ public class McpServerProperties {
 
 	public Capabilities getCapabilities() {
 		return this.capabilities;
+	}
+
+	public Observations getObservations() {
+		return this.observations;
 	}
 
 	public enum ServerProtocol {
@@ -265,6 +271,23 @@ public class McpServerProperties {
 
 		public void setCompletion(boolean completion) {
 			this.completion = completion;
+		}
+
+	}
+
+	public static class Observations {
+
+		/**
+		 * Whether to include MCP server tool call content in the observations.
+		 */
+		private boolean includeContent = false;
+
+		public boolean isIncludeContent() {
+			return this.includeContent;
+		}
+
+		public void setIncludeContent(boolean includeContent) {
+			this.includeContent = includeContent;
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerAutoConfigurationIT.java
@@ -17,12 +17,15 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.json.TypeRef;
 import io.modelcontextprotocol.server.McpAsyncServer;
@@ -56,6 +59,7 @@ import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolContentObservationFilter;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerChangeNotificationProperties;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.tool.ToolCallback;
@@ -89,6 +93,7 @@ public class McpServerAutoConfigurationIT {
 			assertThat(properties.getVersion()).isEqualTo("1.0.0");
 			assertThat(properties.getType()).isEqualTo(McpServerProperties.ApiType.SYNC);
 			assertThat(properties.getRequestTimeout().getSeconds()).isEqualTo(20);
+			assertThat(properties.getObservations().isIncludeContent()).isFalse();
 
 			// Check capabilities
 			assertThat(properties.getCapabilities().isTool()).isTrue();
@@ -443,6 +448,75 @@ public class McpServerAutoConfigurationIT {
 			});
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void syncServerToolCallsAreObserved() {
+		this.contextRunner.withUserConfiguration(ObservedToolConfiguration.class).run(context -> {
+			McpSyncServer syncServer = context.getBean(McpSyncServer.class);
+			McpAsyncServer asyncServer = (McpAsyncServer) ReflectionTestUtils.getField(syncServer, "asyncServer");
+			CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+				.getField(asyncServer, "tools");
+
+			tools.get(0).callHandler().apply(null, request()).block();
+
+			assertObservation(context.getBean(TestObservationRegistry.class), "stateful", "sync");
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void asyncServerToolCallsAreObserved() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.type=ASYNC")
+			.withUserConfiguration(ObservedToolConfiguration.class)
+			.run(context -> {
+				McpAsyncServer asyncServer = context.getBean(McpAsyncServer.class);
+				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "tools");
+
+				tools.get(0).callHandler().apply(null, request()).block();
+
+				assertObservation(context.getBean(TestObservationRegistry.class), "stateful", "async");
+			});
+	}
+
+	@Test
+	void mcpServerToolContentObservationFilterIsConditional() {
+		this.contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean("mcpServerToolContentObservationFilter");
+			assertThat(context).doesNotHaveBean(McpServerToolContentObservationFilter.class);
+		});
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.observations.include-content=true").run(context -> {
+			assertThat(context).hasBean("mcpServerToolContentObservationFilter");
+			assertThat(context).hasSingleBean(McpServerToolContentObservationFilter.class);
+		});
+	}
+
+	@Test
+	void mcpServerToolContentObservationFilterDoesNotUseToolCallingProperty() {
+		this.contextRunner.withPropertyValues("spring.ai.tools.observations.include-content=true")
+			.run(context -> assertThat(context).doesNotHaveBean(McpServerToolContentObservationFilter.class));
+	}
+
+	private static void assertObservation(TestObservationRegistry observationRegistry, String protocol, String type) {
+		TestObservationRegistryAssert.assertThat(observationRegistry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("spring.ai.mcp.server.tool")
+			.hasLowCardinalityKeyValue("spring.ai.kind", "mcp_server_tool_call")
+			.hasLowCardinalityKeyValue("spring.ai.mcp.server.protocol", protocol)
+			.hasLowCardinalityKeyValue("spring.ai.mcp.server.type", type);
+	}
+
+	private static McpSchema.CallToolRequest request() {
+		return new McpSchema.CallToolRequest("observed", Map.of("input", "test"));
+	}
+
+	private static McpSchema.CallToolResult result() {
+		return McpSchema.CallToolResult.builder()
+			.content(List.of(new McpSchema.TextContent("observed")))
+			.isError(false)
+			.build();
+	}
+
 	@Configuration
 	static class TestResourceConfiguration {
 
@@ -537,6 +611,34 @@ public class McpServerAutoConfigurationIT {
 
 			return List.of(new McpServerFeatures.SyncCompletionSpecification(
 					new McpSchema.PromptReference("ref/prompt", "code_review", "Code review"), completionHandler));
+		}
+
+	}
+
+	@Configuration
+	static class ObservedToolConfiguration {
+
+		@Bean
+		TestObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
+		}
+
+		@Bean
+		List<SyncToolSpecification> observedSyncTools() {
+			return List.of(new SyncToolSpecification(tool(), (exchange, request) -> result()));
+		}
+
+		@Bean
+		List<AsyncToolSpecification> observedAsyncTools() {
+			return List.of(new AsyncToolSpecification(tool(), (exchange, request) -> Mono.just(result())));
+		}
+
+		private static McpSchema.Tool tool() {
+			return McpSchema.Tool.builder()
+				.name("observed")
+				.description("Observed tool")
+				.inputSchema(Map.of("type", "object"))
+				.build();
 		}
 
 	}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerToolObservationSupportTests.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpServerToolObservationSupportTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server.common.autoconfigure;
+
+import java.util.List;
+import java.util.Map;
+
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
+
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.DefaultMcpServerToolObservationConvention;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolContentObservationFilter;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolObservationContext;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.observation.DefaultToolCallingObservationConvention;
+import org.springframework.ai.tool.observation.ToolCallingObservationContext;
+import org.springframework.ai.tool.observation.ToolCallingObservationDocumentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class McpServerToolObservationSupportTests {
+
+	private final TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+
+	private final McpServerToolObservationSupport observationSupport = new McpServerToolObservationSupport(
+			this.observationRegistry, null);
+
+	@Test
+	void statefulSyncToolCallEmitsObservation() {
+		SyncToolSpecification toolSpecification = new SyncToolSpecification(tool(), (exchange, request) -> result());
+
+		SyncToolSpecification wrapped = this.observationSupport.wrapStatefulSync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request());
+
+		assertObservation("stateful", "sync").doesNotHaveError();
+	}
+
+	@Test
+	void statefulAsyncToolCallEmitsObservation() {
+		AsyncToolSpecification toolSpecification = new AsyncToolSpecification(tool(),
+				(exchange, request) -> Mono.just(result()));
+
+		AsyncToolSpecification wrapped = this.observationSupport.wrapStatefulAsync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request()).block();
+
+		assertObservation("stateful", "async").doesNotHaveError();
+	}
+
+	@Test
+	void statelessSyncToolCallEmitsObservation() {
+		var toolSpecification = new io.modelcontextprotocol.server.McpStatelessServerFeatures.SyncToolSpecification(
+				tool(), (exchange, request) -> result());
+
+		var wrapped = this.observationSupport.wrapStatelessSync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request());
+
+		assertObservation("stateless", "sync").doesNotHaveError();
+	}
+
+	@Test
+	void statelessAsyncToolCallEmitsObservation() {
+		var toolSpecification = new io.modelcontextprotocol.server.McpStatelessServerFeatures.AsyncToolSpecification(
+				tool(), (exchange, request) -> Mono.just(result()));
+
+		var wrapped = this.observationSupport.wrapStatelessAsync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request()).block();
+
+		assertObservation("stateless", "async").doesNotHaveError();
+	}
+
+	@Test
+	void syncExceptionMarksObservationError() {
+		SyncToolSpecification toolSpecification = new SyncToolSpecification(tool(), (exchange, request) -> {
+			throw new IllegalStateException("boom");
+		});
+
+		SyncToolSpecification wrapped = this.observationSupport.wrapStatefulSync(List.of(toolSpecification)).get(0);
+
+		assertThatThrownBy(() -> wrapped.callHandler().apply(null, request()))
+			.isInstanceOf(IllegalStateException.class);
+		assertObservation("stateful", "sync").hasError();
+	}
+
+	@Test
+	void asyncExceptionMarksObservationError() {
+		AsyncToolSpecification toolSpecification = new AsyncToolSpecification(tool(),
+				(exchange, request) -> Mono.error(new IllegalStateException("boom")));
+
+		AsyncToolSpecification wrapped = this.observationSupport.wrapStatefulAsync(List.of(toolSpecification)).get(0);
+
+		assertThatThrownBy(() -> wrapped.callHandler().apply(null, request()).block())
+			.isInstanceOf(IllegalStateException.class);
+		assertObservation("stateful", "async").hasError();
+	}
+
+	@Test
+	void asyncCancellationStopsObservationWithoutError() {
+		AsyncToolSpecification toolSpecification = new AsyncToolSpecification(tool(),
+				(exchange, request) -> Mono.never());
+
+		AsyncToolSpecification wrapped = this.observationSupport.wrapStatefulAsync(List.of(toolSpecification)).get(0);
+
+		Disposable subscription = wrapped.callHandler().apply(null, request()).subscribe();
+		subscription.dispose();
+
+		assertObservation("stateful", "async").doesNotHaveError();
+	}
+
+	@Test
+	void errorResultMarksObservationError() {
+		SyncToolSpecification toolSpecification = new SyncToolSpecification(tool(),
+				(exchange, request) -> errorResult());
+
+		SyncToolSpecification wrapped = this.observationSupport.wrapStatefulSync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request());
+
+		assertObservation("stateful", "sync").hasError();
+	}
+
+	@Test
+	void contentIsAvailableInContextAndFilteredIntoHighCardinalityValues() {
+		this.observationRegistry.observationConfig().observationFilter(new McpServerToolContentObservationFilter());
+		SyncToolSpecification toolSpecification = new SyncToolSpecification(tool(), (exchange, request) -> result());
+
+		SyncToolSpecification wrapped = this.observationSupport.wrapStatefulSync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request());
+
+		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+			.hasSingleObservationThat()
+			.hasHighCardinalityKeyValueWithKey("spring.ai.mcp.server.tool.call.arguments")
+			.hasHighCardinalityKeyValueWithKey("spring.ai.mcp.server.tool.call.result");
+		TestObservationRegistryAssert.assertThat(this.observationRegistry).hasHandledContextsThatSatisfy(contexts -> {
+			assertThat(contexts).singleElement()
+				.isInstanceOfSatisfying(McpServerToolObservationContext.class, context -> {
+					JsonAssertions.assertThatJson(context.getToolCallArguments()).isEqualTo("{\"city\":\"Warsaw\"}");
+					assertThat(context.getHighCardinalityKeyValues()).anySatisfy(keyValue -> {
+						assertThat(keyValue.getKey()).isEqualTo("spring.ai.mcp.server.tool.call.arguments");
+						JsonAssertions.assertThatJson(keyValue.getValue()).isEqualTo("{\"city\":\"Warsaw\"}");
+					});
+					assertThat(context.getToolCallResult()).contains("ok");
+				});
+		});
+	}
+
+	@Test
+	void customObservationConventionIsHonored() {
+		var support = new McpServerToolObservationSupport(this.observationRegistry,
+				new DefaultMcpServerToolObservationConvention("custom.tool"));
+		SyncToolSpecification toolSpecification = new SyncToolSpecification(tool(), (exchange, request) -> result());
+
+		SyncToolSpecification wrapped = support.wrapStatefulSync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request());
+
+		TestObservationRegistryAssert.assertThat(this.observationRegistry).hasObservationWithNameEqualTo("custom.tool");
+	}
+
+	@Test
+	void mcpServerToolObservationIsDistinctFromClientToolCallingObservation() {
+		ToolCallingObservationContext clientObservationContext = ToolCallingObservationContext.builder()
+			.toolDefinition(
+					ToolDefinition.builder().name("weather").description("Get the weather").inputSchema("{}").build())
+			.build();
+		ToolCallingObservationDocumentation.TOOL_CALL
+			.observation(null, new DefaultToolCallingObservationConvention(), () -> clientObservationContext,
+					this.observationRegistry)
+			.start()
+			.stop();
+		SyncToolSpecification toolSpecification = new SyncToolSpecification(tool(), (exchange, request) -> result());
+		SyncToolSpecification wrapped = this.observationSupport.wrapStatefulSync(List.of(toolSpecification)).get(0);
+
+		wrapped.callHandler().apply(null, request());
+
+		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+			.hasObservationWithNameEqualTo("spring.ai.tool");
+		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+			.hasObservationWithNameEqualTo("spring.ai.mcp.server.tool");
+		TestObservationRegistryAssert.assertThat(this.observationRegistry).hasHandledContextsThatSatisfy(contexts -> {
+			assertThat(contexts).hasSize(2);
+			assertThat(contexts)
+				.anySatisfy(context -> assertThat(context.getLowCardinalityKeyValues()).anySatisfy(keyValue -> {
+					assertThat(keyValue.getKey()).isEqualTo("spring.ai.kind");
+					assertThat(keyValue.getValue()).isEqualTo("tool_call");
+				}));
+			assertThat(contexts)
+				.anySatisfy(context -> assertThat(context.getLowCardinalityKeyValues()).anySatisfy(keyValue -> {
+					assertThat(keyValue.getKey()).isEqualTo("spring.ai.kind");
+					assertThat(keyValue.getValue()).isEqualTo("mcp_server_tool_call");
+				}));
+		});
+	}
+
+	private io.micrometer.observation.tck.ObservationContextAssert<?> assertObservation(String protocol, String type) {
+		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("spring.ai.mcp.server.tool")
+			.hasLowCardinalityKeyValue("gen_ai.operation.name", "execute_tool")
+			.hasLowCardinalityKeyValue("gen_ai.system", "spring_ai")
+			.hasLowCardinalityKeyValue("spring.ai.kind", "mcp_server_tool_call")
+			.hasLowCardinalityKeyValue("spring.ai.tool.definition.name", "weather")
+			.hasLowCardinalityKeyValue("spring.ai.tool.type", "function")
+			.hasLowCardinalityKeyValue("spring.ai.mcp.server.protocol", protocol)
+			.hasLowCardinalityKeyValue("spring.ai.mcp.server.type", type)
+			.doesNotHaveHighCardinalityKeyValueWithKey("spring.ai.mcp.server.tool.call.arguments")
+			.doesNotHaveHighCardinalityKeyValueWithKey("spring.ai.mcp.server.tool.call.result");
+	}
+
+	private static McpSchema.Tool tool() {
+		return McpSchema.Tool.builder()
+			.name("weather")
+			.description("Get the weather")
+			.inputSchema(Map.of("type", "object", "properties", Map.of("city", Map.of("type", "string"))))
+			.build();
+	}
+
+	private static McpSchema.CallToolRequest request() {
+		return new McpSchema.CallToolRequest("weather", Map.of("city", "Warsaw"));
+	}
+
+	private static McpSchema.CallToolResult result() {
+		return McpSchema.CallToolResult.builder()
+			.content(List.of(new McpSchema.TextContent("ok")))
+			.isError(false)
+			.build();
+	}
+
+	private static McpSchema.CallToolResult errorResult() {
+		return McpSchema.CallToolResult.builder()
+			.content(List.of(new McpSchema.TextContent("failed")))
+			.isError(true)
+			.build();
+	}
+
+}

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/src/test/java/org/springframework/ai/mcp/server/common/autoconfigure/McpStatelessServerAutoConfigurationIT.java
@@ -17,12 +17,15 @@
 package org.springframework.ai.mcp.server.common.autoconfigure;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpStatelessAsyncServer;
@@ -53,6 +56,7 @@ import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.McpServerAnnotationScannerAutoConfiguration;
 import org.springframework.ai.mcp.server.common.autoconfigure.annotations.StatelessServerSpecificationFactoryAutoConfiguration;
+import org.springframework.ai.mcp.server.common.autoconfigure.observation.McpServerToolContentObservationFilter;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -86,6 +90,7 @@ public class McpStatelessServerAutoConfigurationIT {
 			assertThat(properties.getVersion()).isEqualTo("1.0.0");
 			assertThat(properties.getType()).isEqualTo(McpServerProperties.ApiType.SYNC);
 			assertThat(properties.getRequestTimeout().getSeconds()).isEqualTo(20);
+			assertThat(properties.getObservations().isIncludeContent()).isFalse();
 			// assertThat(properties.getMcpEndpoint()).isEqualTo("/mcp");
 
 			// Check capabilities
@@ -393,6 +398,76 @@ public class McpStatelessServerAutoConfigurationIT {
 			});
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void syncStatelessServerToolCallsAreObserved() {
+		this.contextRunner.withUserConfiguration(ObservedToolConfiguration.class).run(context -> {
+			McpStatelessSyncServer syncServer = context.getBean(McpStatelessSyncServer.class);
+			McpStatelessAsyncServer asyncServer = (McpStatelessAsyncServer) ReflectionTestUtils.getField(syncServer,
+					"asyncServer");
+			CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+				.getField(asyncServer, "tools");
+
+			tools.get(0).callHandler().apply(null, request()).block();
+
+			assertObservation(context.getBean(TestObservationRegistry.class), "stateless", "sync");
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void asyncStatelessServerToolCallsAreObserved() {
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.type=ASYNC")
+			.withUserConfiguration(ObservedToolConfiguration.class)
+			.run(context -> {
+				McpStatelessAsyncServer asyncServer = context.getBean(McpStatelessAsyncServer.class);
+				CopyOnWriteArrayList<AsyncToolSpecification> tools = (CopyOnWriteArrayList<AsyncToolSpecification>) ReflectionTestUtils
+					.getField(asyncServer, "tools");
+
+				tools.get(0).callHandler().apply(null, request()).block();
+
+				assertObservation(context.getBean(TestObservationRegistry.class), "stateless", "async");
+			});
+	}
+
+	@Test
+	void mcpServerToolContentObservationFilterIsConditional() {
+		this.contextRunner.run(context -> {
+			assertThat(context).doesNotHaveBean("mcpServerToolContentObservationFilter");
+			assertThat(context).doesNotHaveBean(McpServerToolContentObservationFilter.class);
+		});
+		this.contextRunner.withPropertyValues("spring.ai.mcp.server.observations.include-content=true").run(context -> {
+			assertThat(context).hasBean("mcpServerToolContentObservationFilter");
+			assertThat(context).hasSingleBean(McpServerToolContentObservationFilter.class);
+		});
+	}
+
+	@Test
+	void mcpServerToolContentObservationFilterDoesNotUseToolCallingProperty() {
+		this.contextRunner.withPropertyValues("spring.ai.tools.observations.include-content=true")
+			.run(context -> assertThat(context).doesNotHaveBean(McpServerToolContentObservationFilter.class));
+	}
+
+	private static void assertObservation(TestObservationRegistry observationRegistry, String protocol, String type) {
+		TestObservationRegistryAssert.assertThat(observationRegistry)
+			.hasSingleObservationThat()
+			.hasNameEqualTo("spring.ai.mcp.server.tool")
+			.hasLowCardinalityKeyValue("spring.ai.kind", "mcp_server_tool_call")
+			.hasLowCardinalityKeyValue("spring.ai.mcp.server.protocol", protocol)
+			.hasLowCardinalityKeyValue("spring.ai.mcp.server.type", type);
+	}
+
+	private static McpSchema.CallToolRequest request() {
+		return new McpSchema.CallToolRequest("observed", Map.of("input", "test"));
+	}
+
+	private static McpSchema.CallToolResult result() {
+		return McpSchema.CallToolResult.builder()
+			.content(List.of(new McpSchema.TextContent("observed")))
+			.isError(false)
+			.build();
+	}
+
 	@Configuration
 	static class TestResourceConfiguration {
 
@@ -480,6 +555,34 @@ public class McpStatelessServerAutoConfigurationIT {
 
 			return List.of(new McpStatelessServerFeatures.SyncCompletionSpecification(
 					new McpSchema.PromptReference("ref/prompt", "code_review", "Code review"), completionHandler));
+		}
+
+	}
+
+	@Configuration
+	static class ObservedToolConfiguration {
+
+		@Bean
+		TestObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
+		}
+
+		@Bean
+		List<SyncToolSpecification> observedSyncTools() {
+			return List.of(new SyncToolSpecification(tool(), (context, request) -> result()));
+		}
+
+		@Bean
+		List<AsyncToolSpecification> observedAsyncTools() {
+			return List.of(new AsyncToolSpecification(tool(), (context, request) -> Mono.just(result())));
+		}
+
+		private static McpSchema.Tool tool() {
+			return McpSchema.Tool.builder()
+				.name("observed")
+				.description("Observed tool")
+				.inputSchema(Map.of("type", "object"))
+				.build();
 		}
 
 	}

--- a/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/SpringAiKind.java
+++ b/spring-ai-commons/src/main/java/org/springframework/ai/observation/conventions/SpringAiKind.java
@@ -37,6 +37,12 @@ public enum SpringAiKind {
 	CHAT_CLIENT("chat_client"),
 
 	/**
+	 * Spring AI kind for MCP server tool calling.
+	 * @since 2.0.0
+	 */
+	MCP_SERVER_TOOL_CALL("mcp_server_tool_call"),
+
+	/**
 	 * Spring AI kind for tool calling.
 	 */
 	TOOL_CALL("tool_call"),

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stateless-server-boot-starter-docs.adoc
@@ -67,6 +67,7 @@ All Common properties are prefixed with `spring.ai.mcp.server`:
 |`name` |Server name for identification |`mcp-server`
 |`version` |Server version |`1.0.0`
 |`instructions` |Optional instructions for client interaction |`null`
+|`observations.include-content` |Whether to include MCP server tool call content in observations |`false`
 |`type` |Server type (SYNC/ASYNC) |`SYNC`
 |`capabilities.resource` |Enable/disable resource capabilities |`true`
 |`capabilities.tool` |Enable/disable tool capabilities |`true`

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-stdio-sse-server-boot-starter-docs.adoc
@@ -80,6 +80,7 @@ All Common properties are prefixed with `spring.ai.mcp.server`:
 |`name` |Server name for identification |`mcp-server`
 |`version` |Server version |`1.0.0`
 |`instructions` |Optional instructions to provide guidance to the client on how to interact with this server |`null`
+|`observations.include-content` |Whether to include MCP server tool call content in observations |`false`
 |`type` |Server type (SYNC/ASYNC) |`SYNC`
 |`capabilities.resource` |Enable/disable resource capabilities |`true`
 |`capabilities.tool` |Enable/disable tool capabilities |`true`

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/mcp/mcp-streamable-http-server-boot-starter-docs.adoc
@@ -60,6 +60,7 @@ All common properties are prefixed with `spring.ai.mcp.server`:
 |`name` |Server name for identification |`mcp-server`
 |`version` |Server version |`1.0.0`
 |`instructions` |Optional instructions for client interaction |`null`
+|`observations.include-content` |Whether to include MCP server tool call content in observations |`false`
 |`type` |Server type (SYNC/ASYNC) |`SYNC`
 |`capabilities.resource` |Enable/disable resource capabilities |`true`
 |`capabilities.tool` |Enable/disable tool capabilities |`true`

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -1,7 +1,7 @@
 [[introduction]]
 = Observability
 
-Spring AI builds upon the observability features in the Spring ecosystem to provide insights into AI-related operations. It provides metrics and tracing capabilities for its core components: `ChatClient` (including `Advisor`), `ChatModel`, `EmbeddingModel`, `ImageModel`, and `VectorStore`.
+Spring AI builds upon the observability features in the Spring ecosystem to provide insights into AI-related operations. It provides metrics and tracing capabilities for its core components: `ChatClient` (including `Advisor`), `ChatModel`, `EmbeddingModel`, `ImageModel`, `VectorStore`, and MCP server tool execution.
 
 Refer to the https://docs.spring.io/spring-boot/reference/actuator/metrics.html[Spring Boot Metrics] and
 https://docs.spring.io/spring-boot/reference/actuator/tracing.html[Spring Boot Tracing] documentation to enable metrics and tracing support in your application.
@@ -148,7 +148,8 @@ WARNING: If you enable logging of the chat prompt and completion data, there's a
 
 == Tool Calling
 
-The `spring.ai.tool` observations are recorded when performing tool calling in the context of a chat model interaction. They measure the time spent on tool call completion and propagate the related tracing information.
+The `spring.ai.tool` observations are recorded when performing tool calling in the context of a chat model interaction.
+They measure the time spent on tool call completion and propagate the related tracing information.
 
 .Low Cardinality Keys
 [cols="a,a", stripes=even]
@@ -183,10 +184,58 @@ Spring AI supports exporting tool call arguments and result data as span attribu
 |====
 | Property | Description | Default
 
-| `spring.ai.tools.observations.include-content` | Include the tool call content in observations. `true` or `false` | `false`
+| `spring.ai.tools.observations.include-content` | Include chat model tool call content in observations. `true` or `false` | `false`
 |====
 
 WARNING: If you enable the inclusion of the tool call arguments and result in the observations, there's a risk of exposing sensitive or private information. Please, be careful!
+
+== MCP Server Tool Calling
+
+The `spring.ai.mcp.server.tool` observations are recorded when executing MCP server `tools/call` handlers registered through the Spring Boot MCP server auto-configurations.
+They measure the time spent on MCP server tool call completion and propagate the related tracing information.
+
+Protocol-level error results (`CallToolResult.isError() == true`) are recorded as observation errors.
+Success and failure can be derived from the observation metric count and its standard `error` tag.
+
+.Low Cardinality Keys
+[cols="a,a", stripes=even]
+|===
+|Name | Description
+
+|`gen_ai.operation.name` | The name of the operation being performed. It's always `execute_tool`.
+|`gen_ai.system` | The provider responsible for the operation. It's always `spring_ai`.
+|`spring.ai.kind` | The kind of operation performed by Spring AI. It's always `mcp_server_tool_call`.
+|`spring.ai.tool.definition.name` | The name of the tool.
+|`spring.ai.tool.type` | The type of the tool. By default, it's `function`.
+|`spring.ai.mcp.server.protocol` | MCP server protocol used to handle the tool call. It's `stateful` or `stateless`.
+|`spring.ai.mcp.server.type` | MCP server execution type used to handle the tool call. It's `sync` or `async`.
+|===
+
+.High Cardinality Keys
+[cols="a,a", stripes=even]
+|===
+|Name | Description
+
+|`spring.ai.tool.definition.description` | Description of the tool.
+|`spring.ai.tool.definition.schema` | Schema of the parameters used to call the tool.
+|`spring.ai.mcp.server.tool.call.arguments` | The input arguments to the MCP server tool call. (Only when enabled)
+|`spring.ai.mcp.server.tool.call.result` | The result of the MCP server tool call execution. (Only when enabled)
+|===
+
+=== MCP Server Tool Call Arguments and Result Data
+
+The input arguments and result from the MCP server tool call are not exported by default, as they can be potentially sensitive.
+
+Spring AI supports exporting MCP server tool call arguments and result data as span attributes.
+
+[cols="6,3,1", stripes=even]
+|====
+| Property | Description | Default
+
+| `spring.ai.mcp.server.observations.include-content` | Include MCP server tool call content in observations. `true` or `false` | `false`
+|====
+
+WARNING: If you enable the inclusion of the MCP server tool call arguments and result in the observations, there's a risk of exposing sensitive or private information. Please, be careful!
 
 == EmbeddingModel
 

--- a/spring-ai-docs/src/main/asciidoc/mcp.md
+++ b/spring-ai-docs/src/main/asciidoc/mcp.md
@@ -190,6 +190,36 @@ public class MyAiTool implements ToolCallback {
 
 2. The auto-configuration will automatically discover and register your tools with the MCP server, converting them to either sync or async implementations based on your server type configuration.
 
+## Observability
+
+MCP server `tools/call` execution emits a dedicated Micrometer observation named `spring.ai.mcp.server.tool`.
+This metric is intentionally separate from Spring AI client-side tool execution, which uses `spring.ai.tool`, so applications that both call tools internally and expose MCP tools can distinguish the two roles.
+
+MCP server tool observations include the following low-cardinality tags:
+
+| Tag | Description |
+|-----|-------------|
+| `gen_ai.operation.name` | Always `execute_tool` |
+| `gen_ai.system` | Always `spring_ai` |
+| `spring.ai.kind` | Always `mcp_server_tool_call` |
+| `spring.ai.tool.definition.name` | Name of the invoked tool |
+| `spring.ai.tool.type` | Type of the invoked tool, typically `function` |
+| `spring.ai.mcp.server.protocol` | `stateful` or `stateless` |
+| `spring.ai.mcp.server.type` | `sync` or `async` |
+
+MCP server tool observations include the following high-cardinality tags:
+
+| Tag | Description |
+|-----|-------------|
+| `spring.ai.tool.definition.description` | Description of the invoked tool |
+| `spring.ai.tool.definition.schema` | Input schema of the invoked tool |
+| `spring.ai.mcp.server.tool.call.arguments` | Arguments passed to the MCP server tool call, when enabled |
+| `spring.ai.mcp.server.tool.call.result` | Result returned from the MCP server tool call, when enabled |
+
+Tool call arguments and results are not exported by default.
+You can opt into those high-cardinality values with `spring.ai.mcp.server.observations.include-content=true`.
+Only enable this property when you are prepared to handle sensitive or private data in observations.
+
 ## Monitoring
 
 The MCP server provides notifications for changes in:


### PR DESCRIPTION
## Summary

  Adds Micrometer observability for MCP server `tools/call` execution.

  This introduces a dedicated `spring.ai.mcp.server.tool` observation for stateful/stateless and sync/async MCP server tool handlers, with MCP-specific low-
  cardinality tags and opt-in high-cardinality tool call content.

  ## Changes

  - Add MCP server tool observation support for:
    - stateful sync handlers
    - stateful async handlers
    - stateless sync handlers
    - stateless async handlers
  - Add MCP observation context, convention, documentation enum, and content observation filter.
  - Add `spring.ai.mcp.server.observations.include-content` to opt into tool call arguments/result span attributes.
  - Record MCP protocol-level error results as observation errors.
  - Document MCP server observability fields and configuration.
  - Add tests for observation emission, errors, content filtering, custom conventions, and async cancellation.
  
  Fixes GH-4560