### PR TITLE
feat: expose Anthropic rate-limit headers in ChatResponseMetadata

### DIFF
--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.AnthropicClientAsync;
 import com.anthropic.core.JsonValue;
+import com.anthropic.core.http.HttpResponseFor;
 import com.anthropic.models.messages.Base64ImageSource;
 import com.anthropic.models.messages.Base64PdfSource;
 import com.anthropic.models.messages.CacheControlEphemeral;
@@ -75,10 +76,12 @@ import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.anthropic.metadata.AnthropicRateLimit;
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.metadata.EmptyUsage;
+import org.springframework.ai.chat.metadata.RateLimit;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -553,7 +556,11 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 					this.observationRegistry)
 			.observe(() -> {
 
-				Message message = this.anthropicClient.messages().create(request);
+				HttpResponseFor<Message> rawResponse = this.anthropicClient.messages()
+					.withRawResponse()
+					.create(request);
+				Message message = rawResponse.parse();
+				RateLimit rateLimit = AnthropicRateLimit.from(rawResponse.headers());
 
 				List<ContentBlock> contentBlocks = message.content();
 				if (contentBlocks.isEmpty()) {
@@ -573,7 +580,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 						: currentChatResponseUsage;
 
 				ChatResponse chatResponse = new ChatResponse(generations,
-						from(message, accumulatedUsage, citations, webSearchResults));
+						from(message, accumulatedUsage, citations, webSearchResults, rateLimit));
 
 				observationContext.setResponse(chatResponse);
 
@@ -1022,12 +1029,13 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	 * @return the chat response metadata
 	 */
 	private ChatResponseMetadata from(Message message, Usage usage, List<Citation> citations,
-			List<AnthropicWebSearchResult> webSearchResults) {
+			List<AnthropicWebSearchResult> webSearchResults, RateLimit rateLimit) {
 		Assert.notNull(message, "Anthropic Message must not be null");
 		ChatResponseMetadata.Builder metadataBuilder = ChatResponseMetadata.builder()
 			.id(message.id())
 			.usage(usage)
 			.model(message.model().asString())
+			.rateLimit(rateLimit)
 			.keyValue("anthropic-response", message);
 		if (!citations.isEmpty()) {
 			metadataBuilder.keyValue("citations", citations).keyValue("citationCount", citations.size());

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/AnthropicRateLimit.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/AnthropicRateLimit.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.metadata;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import com.anthropic.core.http.Headers;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.ai.chat.metadata.RateLimit;
+import org.springframework.util.Assert;
+
+/**
+ * {@link RateLimit} implementation for the Anthropic SDK.
+ *
+ * <p>
+ * Parses Anthropic rate-limit response headers as documented at
+ * <a href="https://docs.anthropic.com/en/api/rate-limits">Anthropic rate limits</a>.
+ *
+ * @author Gorre Surya
+ * @see RateLimit
+ * @see <a href="https://docs.anthropic.com/en/api/rate-limits">Anthropic rate limits</a>
+ */
+@SuppressWarnings("NullAway")
+public class AnthropicRateLimit implements RateLimit {
+
+	private static final String REQUESTS_LIMIT_HEADER = "anthropic-ratelimit-requests-limit";
+
+	private static final String REQUESTS_REMAINING_HEADER = "anthropic-ratelimit-requests-remaining";
+
+	private static final String REQUESTS_RESET_HEADER = "anthropic-ratelimit-requests-reset";
+
+	private static final String TOKENS_LIMIT_HEADER = "anthropic-ratelimit-tokens-limit";
+
+	private static final String TOKENS_REMAINING_HEADER = "anthropic-ratelimit-tokens-remaining";
+
+	private static final String TOKENS_RESET_HEADER = "anthropic-ratelimit-tokens-reset";
+
+	private final @Nullable Long requestsLimit;
+
+	private final @Nullable Long requestsRemaining;
+
+	private final @Nullable Duration requestsReset;
+
+	private final @Nullable Long tokensLimit;
+
+	private final @Nullable Long tokensRemaining;
+
+	private final @Nullable Duration tokensReset;
+
+	public AnthropicRateLimit(@Nullable Long requestsLimit, @Nullable Long requestsRemaining,
+			@Nullable Duration requestsReset, @Nullable Long tokensLimit, @Nullable Long tokensRemaining,
+			@Nullable Duration tokensReset) {
+		this.requestsLimit = requestsLimit;
+		this.requestsRemaining = requestsRemaining;
+		this.requestsReset = requestsReset;
+		this.tokensLimit = tokensLimit;
+		this.tokensRemaining = tokensRemaining;
+		this.tokensReset = tokensReset;
+	}
+
+	/**
+	 * Parses Anthropic rate-limit headers from the given {@link Headers}.
+	 * @param headers the HTTP response headers
+	 * @return a new {@link AnthropicRateLimit} populated from the headers
+	 */
+	public static AnthropicRateLimit from(Headers headers) {
+		Assert.notNull(headers, "Headers must not be null");
+		return new AnthropicRateLimit(parseLong(headers, REQUESTS_LIMIT_HEADER),
+				parseLong(headers, REQUESTS_REMAINING_HEADER), parseResetDuration(headers, REQUESTS_RESET_HEADER),
+				parseLong(headers, TOKENS_LIMIT_HEADER), parseLong(headers, TOKENS_REMAINING_HEADER),
+				parseResetDuration(headers, TOKENS_RESET_HEADER));
+	}
+
+	@Override
+	public Long getRequestsLimit() {
+		return this.requestsLimit;
+	}
+
+	@Override
+	public Long getRequestsRemaining() {
+		return this.requestsRemaining;
+	}
+
+	@Override
+	public Duration getRequestsReset() {
+		return this.requestsReset;
+	}
+
+	@Override
+	public Long getTokensLimit() {
+		return this.tokensLimit;
+	}
+
+	@Override
+	public Long getTokensRemaining() {
+		return this.tokensRemaining;
+	}
+
+	@Override
+	public Duration getTokensReset() {
+		return this.tokensReset;
+	}
+
+	@Override
+	public String toString() {
+		return "{ @type: %1$s, requestsLimit: %2$s, requestsRemaining: %3$s, requestsReset: %4$s, tokensLimit: %5$s, tokensRemaining: %6$s, tokensReset: %7$s }"
+			.formatted(getClass().getName(), this.requestsLimit, this.requestsRemaining, this.requestsReset,
+					this.tokensLimit, this.tokensRemaining, this.tokensReset);
+	}
+
+	private static @Nullable Long parseLong(Headers headers, String name) {
+		List<String> values = headers.values(name);
+		if (values.isEmpty()) {
+			return null;
+		}
+		try {
+			return Long.parseLong(values.get(0).trim());
+		}
+		catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private static @Nullable Duration parseResetDuration(Headers headers, String name) {
+		List<String> values = headers.values(name);
+		if (values.isEmpty()) {
+			return null;
+		}
+		try {
+			Instant resetAt = Instant.parse(values.get(0).trim());
+			Duration remaining = Duration.between(Instant.now(), resetAt);
+			return remaining.isNegative() ? Duration.ZERO : remaining;
+		}
+		catch (Exception e) {
+			return null;
+		}
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/package-info.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/metadata/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Metadata support classes for the Anthropic chat model.
+ */
+@org.jspecify.annotations.NullMarked
+package org.springframework.ai.anthropic.metadata;

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/AnthropicChatModelTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.ai.anthropic;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,6 +25,8 @@ import java.util.Optional;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.AnthropicClientAsync;
 import com.anthropic.core.JsonValue;
+import com.anthropic.core.http.Headers;
+import com.anthropic.core.http.HttpResponseFor;
 import com.anthropic.models.messages.ContentBlock;
 import com.anthropic.models.messages.Message;
 import com.anthropic.models.messages.MessageCreateParams;
@@ -45,6 +49,8 @@ import org.mockito.quality.Strictness;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.RateLimit;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 
@@ -73,11 +79,24 @@ class AnthropicChatModelTests {
 	@Mock
 	private MessageService messageService;
 
+	@Mock
+	private MessageService.WithRawResponse messageServiceWithRawResponse;
+
 	private AnthropicChatModel chatModel;
 
 	@BeforeEach
+	@SuppressWarnings("unchecked")
 	void setUp() {
 		given(this.anthropicClient.messages()).willReturn(this.messageService);
+		given(this.messageService.withRawResponse()).willReturn(this.messageServiceWithRawResponse);
+		given(this.messageServiceWithRawResponse.create(any(MessageCreateParams.class))).willAnswer(invocation -> {
+			MessageCreateParams params = invocation.getArgument(0);
+			Message message = this.messageService.create(params);
+			HttpResponseFor<Message> rawResponse = mock(HttpResponseFor.class);
+			given(rawResponse.parse()).willReturn(message);
+			given(rawResponse.headers()).willReturn(Headers.builder().build());
+			return rawResponse;
+		});
 
 		this.chatModel = AnthropicChatModel.builder()
 			.anthropicClient(this.anthropicClient)
@@ -387,6 +406,44 @@ class AnthropicChatModelTests {
 		given(message.usage()).willReturn(usage);
 
 		return message;
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void rateLimitHeadersArePopulatedInMetadata() {
+		Message mockResponse = createMockMessage("OK", StopReason.END_TURN);
+		given(this.messageService.create(any(MessageCreateParams.class))).willReturn(mockResponse);
+
+		Instant resetAt = Instant.now().plus(30, ChronoUnit.SECONDS);
+		Headers rateLimitHeaders = Headers.builder()
+			.put("anthropic-ratelimit-requests-limit", "100")
+			.put("anthropic-ratelimit-requests-remaining", "99")
+			.put("anthropic-ratelimit-requests-reset", resetAt.toString())
+			.put("anthropic-ratelimit-tokens-limit", "50000")
+			.put("anthropic-ratelimit-tokens-remaining", "49000")
+			.put("anthropic-ratelimit-tokens-reset", resetAt.toString())
+			.build();
+
+		given(this.messageServiceWithRawResponse.create(any(MessageCreateParams.class))).willAnswer(invocation -> {
+			MessageCreateParams params = invocation.getArgument(0);
+			Message message = this.messageService.create(params);
+			HttpResponseFor<Message> rawResponse = mock(HttpResponseFor.class);
+			given(rawResponse.parse()).willReturn(message);
+			given(rawResponse.headers()).willReturn(rateLimitHeaders);
+			return rawResponse;
+		});
+
+		ChatResponse response = this.chatModel.call(new Prompt("test"));
+
+		ChatResponseMetadata metadata = response.getMetadata();
+		RateLimit rateLimit = metadata.getRateLimit();
+		assertThat(rateLimit).isNotNull();
+		assertThat(rateLimit.getRequestsLimit()).isEqualTo(100L);
+		assertThat(rateLimit.getRequestsRemaining()).isEqualTo(99L);
+		assertThat(rateLimit.getRequestsReset()).isNotNull().isPositive();
+		assertThat(rateLimit.getTokensLimit()).isEqualTo(50000L);
+		assertThat(rateLimit.getTokensRemaining()).isEqualTo(49000L);
+		assertThat(rateLimit.getTokensReset()).isNotNull().isPositive();
 	}
 
 }


### PR DESCRIPTION
## Summary

Fixes #5345

- Added `AnthropicRateLimit` (new class in `o.s.a.anthropic.metadata`) that parses the six standard Anthropic rate-limit response headers:
  - `anthropic-ratelimit-requests-limit/remaining/reset`
  - `anthropic-ratelimit-tokens-limit/remaining/reset`
- Changed `AnthropicChatModel.internalCall()` to use `withRawResponse()` so HTTP headers are available alongside the parsed body
- Populated `ChatResponseMetadata.rateLimit()` from those headers
- Added `package-info.java` for the new `metadata` package

## Design notes

- Reset headers are ISO 8601 datetimes; parsed into `Duration` as time-until-reset via `Instant.parse()` + `Duration.between(now, resetAt)`
- If any header is absent or malformed the corresponding field is `null`, matching the `OpenAiRateLimit` pattern
- Only the synchronous call path is covered — the streaming path does not expose response headers via the current SDK

## Test plan

- [x] `AnthropicChatModelTests#rateLimitHeadersArePopulatedInMetadata` — new test that passes headers with known values and asserts the `RateLimit` object is populated correctly
- [x] All 13 existing `AnthropicChatModelTests` pass unchanged (mock setup updated to stub `withRawResponse()`)