### PR TITLE
Fix `OllamaChatModel` dropping thinking field in multi-turn conversation history

### DIFF
--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -264,8 +264,8 @@ public class OllamaChatModel implements ChatModel {
 							.toList();
 
 				String thinking = ollamaResponse.message().thinking();
-				Map<String, Object> messageProperties = thinking != null
-						? Map.of(THINKING_METADATA_KEY, thinking) : Map.of();
+				Map<String, Object> messageProperties = thinking != null ? Map.of(THINKING_METADATA_KEY, thinking)
+						: Map.of();
 				var assistantMessage = AssistantMessage.builder()
 					.content(ollamaResponse.message().content())
 					.properties(messageProperties)
@@ -357,8 +357,8 @@ public class OllamaChatModel implements ChatModel {
 
 				boolean hasEvalCount = chunk.promptEvalCount() != null && chunk.evalCount() != null;
 				String thinking = chunk.message().thinking();
-				Map<String, Object> messageProperties = thinking != null
-						? Map.of(THINKING_METADATA_KEY, thinking) : Map.of();
+				Map<String, Object> messageProperties = thinking != null ? Map.of(THINKING_METADATA_KEY, thinking)
+						: Map.of();
 				var assistantMessage = AssistantMessage.builder()
 					.content(content)
 					.properties(messageProperties)

--- a/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
+++ b/models/spring-ai-ollama/src/main/java/org/springframework/ai/ollama/OllamaChatModel.java
@@ -263,9 +263,12 @@ public class OllamaChatModel implements ChatModel {
 									ModelOptionsUtils.toJsonString(toolCall.function().arguments())))
 							.toList();
 
+				String thinking = ollamaResponse.message().thinking();
+				Map<String, Object> messageProperties = thinking != null
+						? Map.of(THINKING_METADATA_KEY, thinking) : Map.of();
 				var assistantMessage = AssistantMessage.builder()
 					.content(ollamaResponse.message().content())
-					.properties(Map.of())
+					.properties(messageProperties)
 					.toolCalls(toolCalls)
 					.build();
 
@@ -273,7 +276,6 @@ public class OllamaChatModel implements ChatModel {
 				if (ollamaResponse.promptEvalCount() != null && ollamaResponse.evalCount() != null) {
 					ChatGenerationMetadata.Builder builder = ChatGenerationMetadata.builder()
 						.finishReason(ollamaResponse.doneReason());
-					String thinking = ollamaResponse.message().thinking();
 					if (thinking != null) {
 						builder.metadata(THINKING_METADATA_KEY, thinking);
 					}
@@ -353,16 +355,17 @@ public class OllamaChatModel implements ChatModel {
 						.toList();
 				}
 
+				boolean hasEvalCount = chunk.promptEvalCount() != null && chunk.evalCount() != null;
+				String thinking = chunk.message().thinking();
+				Map<String, Object> messageProperties = thinking != null
+						? Map.of(THINKING_METADATA_KEY, thinking) : Map.of();
 				var assistantMessage = AssistantMessage.builder()
 					.content(content)
-					.properties(Map.of())
+					.properties(messageProperties)
 					.toolCalls(toolCalls)
 					.build();
 
 				ChatGenerationMetadata generationMetadata = ChatGenerationMetadata.NULL;
-				boolean hasEvalCount = chunk.promptEvalCount() != null && chunk.evalCount() != null;
-				String thinking = chunk.message().thinking();
-
 				if (hasEvalCount || thinking != null) {
 					ChatGenerationMetadata.Builder builder = ChatGenerationMetadata.builder();
 					if (hasEvalCount) {

--- a/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
+++ b/models/spring-ai-ollama/src/test/java/org/springframework/ai/ollama/OllamaChatModelTests.java
@@ -28,10 +28,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.metadata.ChatResponseMetadata;
 import org.springframework.ai.chat.metadata.DefaultUsage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
@@ -44,6 +48,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Jihoon Kim
@@ -341,6 +347,54 @@ class OllamaChatModelTests {
 
 		assertThat(chatModel).isNotNull();
 		assertThat(chatModel).isInstanceOf(OllamaChatModel.class);
+	}
+
+	@Test
+	void thinkingFieldIsStoredInAssistantMessageProperties() {
+		String thinkingText = "Let me reason step by step...";
+		OllamaApi.Message assistantApiMessage = OllamaApi.Message.builder(OllamaApi.Message.Role.ASSISTANT)
+			.content("The answer is 42.")
+			.thinking(thinkingText)
+			.build();
+		OllamaApi.ChatResponse apiResponse = new OllamaApi.ChatResponse("model", Instant.now(), assistantApiMessage,
+				"stop", true, null, null, 10, 1000L, 20, 2000L);
+		when(this.ollamaApi.chat(any())).thenReturn(apiResponse);
+
+		OllamaChatModel chatModel = OllamaChatModel.builder().ollamaApi(this.ollamaApi).build();
+		ChatResponse response = chatModel.call(new Prompt(new UserMessage("What is the answer?")));
+
+		Generation generation = response.getResult();
+		AssistantMessage message = generation.getOutput();
+		assertThat(message.getMetadata()).containsKey("thinking");
+		assertThat(message.getMetadata().get("thinking")).isEqualTo(thinkingText);
+	}
+
+	@Test
+	void thinkingFieldRoundTripsThroughConversationHistory() {
+		String thinkingText = "Step 1: understand the question...";
+		OllamaApi.Message firstApiMessage = OllamaApi.Message.builder(OllamaApi.Message.Role.ASSISTANT)
+			.content("First answer.")
+			.thinking(thinkingText)
+			.build();
+		OllamaApi.ChatResponse firstApiResponse = new OllamaApi.ChatResponse("model", Instant.now(), firstApiMessage,
+				"stop", true, null, null, 10, 1000L, 20, 2000L);
+
+		OllamaApi.Message secondApiMessage = OllamaApi.Message.builder(OllamaApi.Message.Role.ASSISTANT)
+			.content("Second answer.")
+			.build();
+		OllamaApi.ChatResponse secondApiResponse = new OllamaApi.ChatResponse("model", Instant.now(), secondApiMessage,
+				"stop", true, null, null, 10, 1000L, 20, 2000L);
+		when(this.ollamaApi.chat(any())).thenReturn(firstApiResponse).thenReturn(secondApiResponse);
+
+		OllamaChatModel chatModel = OllamaChatModel.builder().ollamaApi(this.ollamaApi).build();
+
+		ChatResponse firstResponse = chatModel.call(new Prompt(new UserMessage("Turn 1")));
+		AssistantMessage firstAssistantMessage = firstResponse.getResult().getOutput();
+		assertThat(firstAssistantMessage.getMetadata().get("thinking")).isEqualTo(thinkingText);
+
+		Prompt secondPrompt = new Prompt(
+				List.of(new UserMessage("Turn 1"), firstAssistantMessage, new UserMessage("Turn 2")));
+		chatModel.call(secondPrompt);
 	}
 
 }


### PR DESCRIPTION
Closes #6016 (Ollama path).

## Problem

`OllamaChatModel` stores the `thinking` field from model responses in
`ChatGenerationMetadata` (via `builder.metadata("thinking", thinking)`),
but when an `AssistantMessage` is replayed as conversation history in a
follow-up request, only `AssistantMessage.properties` is accessible —
`ChatGenerationMetadata` is not available at that point. As a result,
`thinking` was always `null` when building the outbound `OllamaApi.Message`,
silently breaking multi-turn conversations with Qwen3 and other thinking models.

## Fix

Extract `thinking` from the Ollama response at both receive sites (blocking
and streaming) and store it in `AssistantMessage.properties` under the same
`"thinking"` key, in addition to the existing `ChatGenerationMetadata` storage.
The `createRequest()` ASSISTANT branch already reads that key from
`AssistantMessage.getMetadata()` and passes it to `Message.Builder.thinking()`.

## Test plan

- [ ] Unit test: build an `AssistantMessage` with `thinking` in properties, call `ollamaChatRequest()`, verify the outbound `OllamaApi.Message` carries `thinking`
- [ ] Existing `OllamaChatModelTests` pass
- [ ] Streaming path: same round-trip test using the streaming code path