### PR TITLE
Fix latest version banner wording in reference docs

### DIFF
--- a/supplemental-ui/partials/article-latest.hbs
+++ b/supplemental-ui/partials/article-latest.hbs
@@ -7,7 +7,7 @@
       </td>
       <td class="content">
         <div class="paragraph">
-          <p>{{#if page.componentVersion.prerelease}}This version is still in development and is not considered stable yet.{{/if}} For the latest snapshot version, please use <a href="{{{relativize ./page.latest.url}}}">{{page.component.title}} {{page.latest.displayVersion}}</a>!</p>
+          <p>{{#if page.componentVersion.prerelease}}This version is still in development and is not considered stable yet.{{/if}} For the latest stable version, please use <a href="{{{relativize ./page.latest.url}}}">{{page.component.title}} {{page.latest.displayVersion}}</a>!</p>
         </div>
       </td>
     </tr></tbody>


### PR DESCRIPTION
## Summary

This fixes the version banner shown on non-latest Spring AI reference documentation pages.

The banner currently says:

> For the latest snapshot version

However, the linked version is the latest stable release. This updates the wording to:

> For the latest stable version

## Issue

Closes #5822