### PR TITLE
Generate optional nullable schemas for `JsonNullable<T>`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@
 		<pdfbox.version>3.0.7</pdfbox.version>
 
 		<!-- Utilities -->
+		<jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
 		<jsonschema.version>5.0.0</jsonschema.version>
 		<jtokkit.version>1.1.0</jtokkit.version>
 		<lucene.version>9.12.3</lucene.version>

--- a/spring-ai-model/pom.xml
+++ b/spring-ai-model/pom.xml
@@ -84,6 +84,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.openapitools</groupId>
+			<artifactId>jackson-databind-nullable</artifactId>
+			<version>${jackson-databind-nullable.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-stdlib</artifactId>
 			<optional>true</optional>
@@ -120,7 +127,7 @@
 			<version>${mockk-jvm.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 	</dependencies>
 
 	<build>

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/AbstractSpringAiSchemaModule.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/AbstractSpringAiSchemaModule.java
@@ -40,6 +40,7 @@ import org.springframework.core.Nullness;
  *
  * @author Thomas Vitale
  * @author Christian Tzolov
+ * @author Jewoo Shin
  * @since 1.0.0
  */
 public abstract class AbstractSpringAiSchemaModule implements Module {
@@ -109,6 +110,10 @@ public abstract class AbstractSpringAiSchemaModule implements Module {
 		if (schemaAnnotation != null) {
 			return schemaAnnotation.requiredMode() == Schema.RequiredMode.REQUIRED
 					|| schemaAnnotation.requiredMode() == Schema.RequiredMode.AUTO || schemaAnnotation.required();
+		}
+
+		if (JsonNullableSupport.isJsonNullableType(member.getDeclaredType().getErasedType())) {
+			return false;
 		}
 
 		Nullness nullness;

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonNullableSchemaModule.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonNullableSchemaModule.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.util.json.schema;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.impl.module.FlattenedWrapperModule;
+import org.openapitools.jackson.nullable.JsonNullable;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * JSON Schema Generator Module that unwraps
+ * {@link org.openapitools.jackson.nullable.JsonNullable JsonNullable&lt;T&gt;} to its
+ * wrapped type {@code T} and marks the resulting schema as nullable, so the model can
+ * either omit the field or send an explicit {@code null}.
+ * <p>
+ * This module is registered automatically by {@link JsonSchemaGenerator} when
+ * {@code org.openapitools.jackson.nullable.JsonNullable} is present on the classpath.
+ *
+ * @author Jewoo Shin
+ * @since 2.0.0
+ */
+public final class JsonNullableSchemaModule extends FlattenedWrapperModule<JsonNullable> {
+
+	public JsonNullableSchemaModule() {
+		super(JsonNullable.class);
+	}
+
+	@Override
+	public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+		builder.forTypesInGeneral().withCustomDefinitionProvider((javaType, context) -> {
+			if (!this.isWrapperType(javaType)) {
+				return null;
+			}
+			ResolvedType wrappedType = context.getTypeContext().getTypeParameterFor(javaType, JsonNullable.class, 0);
+			if (wrappedType == null) {
+				return null;
+			}
+			ObjectNode schema = context.createStandardDefinition(wrappedType, null);
+			addNullToType(schema);
+			return new CustomDefinition(schema, CustomDefinition.DefinitionType.INLINE,
+					CustomDefinition.AttributeInclusion.YES);
+		});
+	}
+
+	private static void addNullToType(ObjectNode schema) {
+		JsonNode typeNode = schema.get("type");
+		if (typeNode == null) {
+			ArrayNode types = schema.putArray("type");
+			types.add("null");
+			return;
+		}
+		if (typeNode.isTextual()) {
+			String existing = typeNode.asText();
+			ArrayNode types = schema.putArray("type");
+			types.add(existing);
+			types.add("null");
+			return;
+		}
+		if (typeNode.isArray()) {
+			ArrayNode types = (ArrayNode) typeNode;
+			for (int i = 0; i < types.size(); i++) {
+				if ("null".equals(types.get(i).asText())) {
+					return;
+				}
+			}
+			types.add("null");
+		}
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonNullableSupport.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonNullableSupport.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.util.json.schema;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * Internal helper for detecting {@code org.openapitools.jackson.nullable.JsonNullable}
+ * without making it a hard dependency. Keeps the optional class lookup in one place so
+ * that {@link JsonSchemaGenerator} and {@link AbstractSpringAiSchemaModule} can stay
+ * compilable when the {@code jackson-databind-nullable} artifact is absent.
+ *
+ * @author Jewoo Shin
+ */
+final class JsonNullableSupport {
+
+	private static final String JSON_NULLABLE_CLASS_NAME = "org.openapitools.jackson.nullable.JsonNullable";
+
+	private static final @Nullable Class<?> JSON_NULLABLE_CLASS = loadJsonNullableClass();
+
+	private JsonNullableSupport() {
+	}
+
+	private static @Nullable Class<?> loadJsonNullableClass() {
+		ClassLoader classLoader = JsonNullableSupport.class.getClassLoader();
+		if (!ClassUtils.isPresent(JSON_NULLABLE_CLASS_NAME, classLoader)) {
+			return null;
+		}
+		try {
+			return ClassUtils.forName(JSON_NULLABLE_CLASS_NAME, classLoader);
+		}
+		catch (ClassNotFoundException ex) {
+			return null;
+		}
+	}
+
+	static boolean isPresent() {
+		return JSON_NULLABLE_CLASS != null;
+	}
+
+	/**
+	 * Whether the given reflective type is {@code JsonNullable} or
+	 * {@code JsonNullable<T>}. Accepts both raw {@link Class} and
+	 * {@link ParameterizedType}; safe to call when {@code JsonNullable} is not on the
+	 * classpath.
+	 */
+	static boolean isJsonNullableType(Type type) {
+		if (JSON_NULLABLE_CLASS == null) {
+			return false;
+		}
+		if (type instanceof ParameterizedType parameterizedType) {
+			return parameterizedType.getRawType() == JSON_NULLABLE_CLASS;
+		}
+		return type instanceof Class<?> rawClass && rawClass == JSON_NULLABLE_CLASS;
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/util/json/schema/JsonSchemaGenerator.java
@@ -74,6 +74,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Thomas Vitale
  * @author Sebastien Deleuze
+ * @author Jewoo Shin
  * @since 1.0.0
  */
 public final class JsonSchemaGenerator {
@@ -110,6 +111,10 @@ public final class JsonSchemaGenerator {
 
 		if (KotlinDetector.isKotlinReflectPresent()) {
 			schemaGeneratorConfigBuilder.with(new KotlinModule());
+		}
+
+		if (JsonNullableSupport.isPresent()) {
+			schemaGeneratorConfigBuilder.with(new JsonNullableSchemaModule());
 		}
 
 		SchemaGeneratorConfig typeSchemaGeneratorConfig = schemaGeneratorConfigBuilder.build();
@@ -246,6 +251,10 @@ public final class JsonSchemaGenerator {
 		if (schemaAnnotation != null) {
 			return schemaAnnotation.requiredMode() == Schema.RequiredMode.REQUIRED
 					|| schemaAnnotation.requiredMode() == Schema.RequiredMode.AUTO || schemaAnnotation.required();
+		}
+
+		if (JsonNullableSupport.isJsonNullableType(parameter.getParameterizedType())) {
+			return false;
 		}
 
 		Nullness nullness = Nullness.forParameter(parameter);

--- a/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/util/json/JsonSchemaGeneratorTests.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
 import tools.jackson.databind.JsonNode;
 
 import org.springframework.ai.chat.model.ToolContext;
@@ -55,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *
  * @author Thomas Vitale
  * @author Christian Tzolov
+ * @author Jewoo Shin
  */
 class JsonSchemaGeneratorTests {
 
@@ -245,6 +247,189 @@ class JsonSchemaGeneratorTests {
 				    "required": [
 				        "password"
 				    ],
+				    "additionalProperties": false
+				}
+				""";
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithJsonNullableParameter() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("jsonNullableMethod", JsonNullable.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		String expectedJsonSchema = """
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "nickname": {
+				            "type": ["string", "null"]
+				        }
+				    },
+				    "required": [],
+				    "additionalProperties": false
+				}
+				""";
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithOptionalJsonNullableParameter() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("optionalJsonNullableMethod", JsonNullable.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		String expectedJsonSchema = """
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "nickname": {
+				            "type": ["string", "null"]
+				        }
+				    },
+				    "required": [],
+				    "additionalProperties": false
+				}
+				""";
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithRequiredJsonNullableParameter() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("requiredJsonNullableMethod", JsonNullable.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		String expectedJsonSchema = """
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "nickname": {
+				            "type": ["string", "null"]
+				        }
+				    },
+				    "required": ["nickname"],
+				    "additionalProperties": false
+				}
+				""";
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithJsonNullableListParameter() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("jsonNullableListMethod", JsonNullable.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		String expectedJsonSchema = """
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "tags": {
+				            "type": ["array", "null"],
+				            "items": {
+				                "type": "string"
+				            }
+				        }
+				    },
+				    "required": [],
+				    "additionalProperties": false
+				}
+				""";
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForMethodWithJsonNullableObjectParameter() throws Exception {
+		Method method = TestMethods.class.getDeclaredMethod("jsonNullableObjectMethod", JsonNullable.class);
+
+		String schema = JsonSchemaGenerator.generateForMethodInput(method);
+		String expectedJsonSchema = """
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "address": {
+				            "type": ["object", "null"],
+				            "properties": {
+				                "city": {
+				                    "type": "string"
+				                },
+				                "zip": {
+				                    "type": "string"
+				                }
+				            },
+				            "required": ["city", "zip"],
+				            "additionalProperties": false
+				        }
+				    },
+				    "required": [],
+				    "additionalProperties": false
+				}
+				""";
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForTypeWithJsonNullableObjectField() {
+		String schema = JsonSchemaGenerator.generateForType(JsonNullableAddressPerson.class);
+
+		String expectedJsonSchema = """
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "address": {
+				            "type": ["object", "null"],
+				            "properties": {
+				                "city": {
+				                    "type": "string"
+				                },
+				                "zip": {
+				                    "type": "string"
+				                }
+				            },
+				            "required": ["city", "zip"],
+				            "additionalProperties": false
+				        },
+				        "id": {
+				            "type": "integer",
+				            "format": "int32"
+				        }
+				    },
+				    "required": ["id"],
+				    "additionalProperties": false
+				}
+				""";
+
+		assertThat(schema).isEqualToIgnoringWhitespace(expectedJsonSchema);
+	}
+
+	@Test
+	void generateSchemaForTypeWithJsonNullableField() {
+		String schema = JsonSchemaGenerator.generateForType(JsonNullablePerson.class);
+
+		String expectedJsonSchema = """
+				{
+				    "$schema": "https://json-schema.org/draft/2020-12/schema",
+				    "type": "object",
+				    "properties": {
+				        "email": {
+				            "type": ["string", "null"]
+				        },
+				        "id": {
+				            "type": "integer",
+				            "format": "int32"
+				        }
+				    },
+				    "required": ["id"],
 				    "additionalProperties": false
 				}
 				""";
@@ -1011,6 +1196,21 @@ class JsonSchemaGeneratorTests {
 		public void nullableMethod(@Nullable String username, String password) {
 		}
 
+		public void jsonNullableMethod(JsonNullable<String> nickname) {
+		}
+
+		public void optionalJsonNullableMethod(@ToolParam(required = false) JsonNullable<String> nickname) {
+		}
+
+		public void requiredJsonNullableMethod(@ToolParam(required = true) JsonNullable<String> nickname) {
+		}
+
+		public void jsonNullableListMethod(JsonNullable<List<String>> tags) {
+		}
+
+		public void jsonNullableObjectMethod(JsonNullable<SimpleAddress> address) {
+		}
+
 		public void complexMethod(List<String> items, TestData data, MoreTestData moreData) {
 		}
 
@@ -1124,6 +1324,18 @@ class JsonSchemaGeneratorTests {
 	@JsonPropertyOrder({ "accountId", "accountName", "currency", "totals" })
 	record OrderedStatement(@JsonProperty(required = true) String accountId,
 			@JsonProperty(required = true) String accountName, String currency, Map<String, Double> totals) {
+	}
+
+	record JsonNullablePerson(int id, JsonNullable<String> email) {
+
+	}
+
+	record SimpleAddress(String city, String zip) {
+
+	}
+
+	record JsonNullableAddressPerson(int id, JsonNullable<SimpleAddress> address) {
+
 	}
 
 	static class Person {

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -46,6 +46,7 @@
 
 	<suppress files="[\\/]src[\\/]test[\\/]java[\\/]" id="bannedNullabilityImports" />
 	<suppress files="spring-ai-integration-tests" id="bannedNullabilityImports" />
+	<suppress files="JsonNullableSchemaModule\.java" id="bannedNullabilityImports" />
 
 	<suppress files="spring-ai-integration-tests" checks="JavadocPackage" />
 </suppressions>


### PR DESCRIPTION
This fixes the schema-generation gap from #6046: MCP tools that use `JsonNullable<T>` for partial updates need input schemas that let the model either omit a value or send an explicit `null`.

When `jackson-databind-nullable` is on the classpath, `JsonSchemaGenerator` now registers a `JsonNullable` schema module. It unwraps `JsonNullable<T>` to the wrapped type, adds `null` to the allowed schema type, and keeps unannotated wrappers out of `required` while explicit `@ToolParam`, `@JsonProperty`, and `@Schema` required settings still take precedence.

Tests cover top-level tool parameters and record fields for scalar, list, and object wrappers, including required overrides.

Closes #6046