### PR TITLE
Fix ChatClient#prompt method ignored chatOptions from prompt input

### DIFF
--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -118,6 +118,17 @@ public class DefaultChatClient implements ChatClient {
 			spec.messages(prompt.getInstructions());
 		}
 
+		// ChatOptions
+		if (prompt.getOptions() != null) {
+			ChatOptions.Builder<?> requestOptionsBuilder = prompt.getOptions().mutate();
+			if (spec.getOptionsCustomizer() != null) {
+				spec.getOptionsCustomizer().combineWith(requestOptionsBuilder);
+			}
+			else {
+				spec.options(requestOptionsBuilder);
+			}
+		}
+
 		return spec;
 	}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -131,6 +131,25 @@ class DefaultChatClientTests {
 	}
 
 	@Test
+	void whenPromptWithMessagesAndChatOptionsThenReturn() {
+		ChatModel chatModel = mock(ChatModel.class);
+		ChatClient chatClient = new DefaultChatClientBuilder(chatModel)
+			.defaultOptions(ChatOptions.builder().model("default-model").topK(3))
+			.build();
+		ChatOptions chatOptions = ChatOptions.builder().model("test-model").temperature(0.7).build();
+		Prompt prompt = new Prompt(List.of(new UserMessage("my question")), chatOptions);
+		DefaultChatClient.DefaultChatClientRequestSpec spec = (DefaultChatClient.DefaultChatClientRequestSpec) chatClient
+			.prompt(prompt);
+		assertThat(spec.getMessages()).hasSize(1);
+		assertThat(spec.getMessages().get(0).getText()).isEqualTo("my question");
+		assertThat(spec.getOptionsCustomizer()).isNotNull();
+		ChatOptions builtOptions = spec.getOptionsCustomizer().build();
+		assertThat(builtOptions.getModel()).isEqualTo("test-model");
+		assertThat(builtOptions.getTemperature()).isEqualTo(0.7);
+		assertThat(builtOptions.getTopK()).isEqualTo(3);
+	}
+
+	@Test
 	void testMutate() {
 		var media = mock(Media.class);
 		var toolCallback = mock(ToolCallback.class);


### PR DESCRIPTION
# Summary
Fix ChatClient#prompt method ignored chatOptions from prompt input.
# Related Issues
* Fixes: #6072 
#  Resolution
* Create a mutable builder from the Prompt's options via prompt.getOptions().mutate().
* If a optionsCustomizer already exists on the spec (from default options), merge the prompt's options into it using combineWith — this preserves defaults and overlays the prompt's specific options.
* If no optionsCustomizer exists, directly set the prompt's options builder as the spec's options.