### PR TITLE
GH-5930: Restore HTTP-layer observability for Anthropic chat model

### DIFF
--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfiguration.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.ai.model.anthropic.autoconfigure;
 
 import com.anthropic.client.AnthropicClient;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.ai.anthropic.AnthropicChatModel;
@@ -53,7 +54,7 @@ public class AnthropicChatAutoConfiguration {
 	@ConditionalOnMissingBean
 	public AnthropicChatModel anthropicChatModel(AnthropicConnectionProperties connectionProperties,
 			AnthropicChatProperties chatProperties, ToolCallingManager toolCallingManager,
-			ObjectProvider<ObservationRegistry> observationRegistry,
+			ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<MeterRegistry> meterRegistry,
 			ObjectProvider<ChatModelObservationConvention> observationConvention,
 			ObjectProvider<ToolExecutionEligibilityPredicate> anthropicToolExecutionEligibilityPredicate) {
 
@@ -82,6 +83,7 @@ public class AnthropicChatAutoConfiguration {
 			.options(options)
 			.toolCallingManager(toolCallingManager)
 			.observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
+			.meterRegistry(chatProperties.isConnectionPoolMetricsEnabled() ? meterRegistry.getIfAvailable() : null)
 			.toolExecutionEligibilityPredicate(anthropicToolExecutionEligibilityPredicate
 				.getIfUnique(DefaultToolExecutionEligibilityPredicate::new))
 			.build();

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatProperties.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/main/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicChatProperties.java
@@ -79,6 +79,8 @@ public class AnthropicChatProperties {
 
 	private Map<String, String> httpHeaders = new HashMap<>();
 
+	private boolean connectionPoolMetricsEnabled = false;
+
 	private Options options = new Options();
 
 	public AnthropicChatProperties() {
@@ -219,6 +221,14 @@ public class AnthropicChatProperties {
 
 	public void setHttpHeaders(Map<String, String> httpHeaders) {
 		this.httpHeaders = httpHeaders;
+	}
+
+	public boolean isConnectionPoolMetricsEnabled() {
+		return this.connectionPoolMetricsEnabled;
+	}
+
+	public void setConnectionPoolMetricsEnabled(boolean connectionPoolMetricsEnabled) {
+		this.connectionPoolMetricsEnabled = connectionPoolMetricsEnabled;
 	}
 
 	public AnthropicChatOptions toOptions() {

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicPropertiesTests.java
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/src/test/java/org/springframework/ai/model/anthropic/autoconfigure/AnthropicPropertiesTests.java
@@ -16,12 +16,16 @@
 
 package org.springframework.ai.model.anthropic.autoconfigure;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.anthropic.AnthropicChatModel;
 import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -113,6 +117,40 @@ class AnthropicPropertiesTests {
 	}
 
 	@Test
+	void connectionPoolMetricsDisabledByDefault() {
+		new ApplicationContextRunner().withPropertyValues("spring.ai.anthropic.api-key=API_KEY")
+			.withUserConfiguration(MeterRegistryConfiguration.class)
+			.withConfiguration(
+					AutoConfigurations.of(AnthropicChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var chatProperties = context.getBean(AnthropicChatProperties.class);
+				assertThat(chatProperties.isConnectionPoolMetricsEnabled()).isFalse();
+
+				// MeterRegistry is present, but the property defaults to false, so no
+				// okhttp.pool.* gauges should be bound by the auto-configured chat model.
+				assertThat(context.getBean(AnthropicChatModel.class)).isNotNull();
+				assertThat(poolGaugeCount(context.getBean(MeterRegistry.class))).isZero();
+			});
+	}
+
+	@Test
+	void connectionPoolMetricsBoundWhenEnabled() {
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.ai.anthropic.api-key=API_KEY",
+					"spring.ai.anthropic.chat.connection-pool-metrics-enabled=true")
+			.withUserConfiguration(MeterRegistryConfiguration.class)
+			.withConfiguration(
+					AutoConfigurations.of(AnthropicChatAutoConfiguration.class, ToolCallingAutoConfiguration.class))
+			.run(context -> {
+				var chatProperties = context.getBean(AnthropicChatProperties.class);
+				assertThat(chatProperties.isConnectionPoolMetricsEnabled()).isTrue();
+
+				assertThat(context.getBean(AnthropicChatModel.class)).isNotNull();
+				assertThat(poolGaugeCount(context.getBean(MeterRegistry.class))).isGreaterThan(0);
+			});
+	}
+
+	@Test
 	void chatCompletionDisabled() {
 		// Enabled by default
 		new ApplicationContextRunner().withPropertyValues("spring.ai.anthropic.api-key=API_KEY")
@@ -137,6 +175,24 @@ class AnthropicPropertiesTests {
 		new ApplicationContextRunner().withPropertyValues("spring.ai.model.chat=none")
 			.withConfiguration(AutoConfigurations.of(AnthropicChatAutoConfiguration.class))
 			.run(context -> assertThat(context.getBeansOfType(AnthropicChatModel.class)).isEmpty());
+	}
+
+	private static long poolGaugeCount(MeterRegistry registry) {
+		return registry.getMeters()
+			.stream()
+			.map(meter -> meter.getId().getName())
+			.filter(name -> name.startsWith("okhttp.pool"))
+			.count();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MeterRegistryConfiguration {
+
+		@Bean
+		MeterRegistry meterRegistry() {
+			return new SimpleMeterRegistry();
+		}
+
 	}
 
 }

--- a/models/spring-ai-anthropic/pom.xml
+++ b/models/spring-ai-anthropic/pom.xml
@@ -44,10 +44,30 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 
+		<!--
+			Use anthropic-java-core (no OkHttp transitive) so we can supply our own
+			OkHttp-backed HttpClient with Micrometer observability wired in.
+		-->
 		<dependency>
 			<groupId>com.anthropic</groupId>
-			<artifactId>anthropic-java</artifactId>
+			<artifactId>anthropic-java-core</artifactId>
 			<version>${anthropic-sdk.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>${okhttp3.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>context-propagation</artifactId>
 		</dependency>
 
 		<dependency>

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicChatModel.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -64,6 +65,7 @@ import com.anthropic.models.messages.UserLocation;
 import com.anthropic.models.messages.WebSearchResultBlock;
 import com.anthropic.models.messages.WebSearchTool20260209;
 import com.anthropic.models.messages.WebSearchToolResultBlock;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -116,6 +118,17 @@ import org.springframework.util.MimeType;
  * observability. API credentials are auto-detected from {@code ANTHROPIC_API_KEY} if not
  * configured.
  *
+ * <p>
+ * <b>Observability.</b> Two layers of Micrometer observations are emitted: a
+ * {@code gen_ai.client.operation} span per chat-model call (with token usage, model
+ * metadata, and request parameters), and an {@code okhttp.requests} span per outbound
+ * HTTP attempt (with HTTP method, URI, status code, and {@code traceparent} propagation).
+ * Optional OkHttp connection-pool gauges are bound to the
+ * {@link io.micrometer.core.instrument.MeterRegistry} when supplied. For synchronous
+ * calls the HTTP span nests under the chat-model span; for streaming calls the HTTP span
+ * fires but is not parented under the chat-model span due to an SDK-internal thread
+ * boundary — see {@link #stream(org.springframework.ai.chat.prompt.Prompt)}.
+ *
  * @author Christian Tzolov
  * @author luocongqiu
  * @author Mariusz Bernacki
@@ -155,6 +168,10 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 	private final ObservationRegistry observationRegistry;
 
+	private final @Nullable MeterRegistry meterRegistry;
+
+	private final @Nullable ExecutorService dispatcherExecutor;
+
 	private final ToolCallingManager toolCallingManager;
 
 	private final ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
@@ -177,6 +194,7 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 	private AnthropicChatModel(@Nullable AnthropicClient anthropicClient,
 			@Nullable AnthropicClientAsync anthropicClientAsync, @Nullable AnthropicChatOptions options,
 			@Nullable ToolCallingManager toolCallingManager, @Nullable ObservationRegistry observationRegistry,
+			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor,
 			@Nullable ToolExecutionEligibilityChecker toolExecutionEligibilityChecker) {
 
 		if (options == null) {
@@ -186,17 +204,24 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 			this.options = options;
 		}
 
+		// Must precede the AnthropicSetup calls below so the HTTP client gets the user's
+		// registries and dispatcher.
+		this.observationRegistry = Objects.requireNonNullElse(observationRegistry, ObservationRegistry.NOOP);
+		this.meterRegistry = meterRegistry;
+		this.dispatcherExecutor = dispatcherExecutor;
+
 		this.anthropicClient = Objects.requireNonNullElseGet(anthropicClient,
 				() -> AnthropicSetup.setupSyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders()));
+						this.options.getCustomHeaders(), this.observationRegistry, this.meterRegistry,
+						this.dispatcherExecutor));
 
 		this.anthropicClientAsync = Objects.requireNonNullElseGet(anthropicClientAsync,
 				() -> AnthropicSetup.setupAsyncClient(this.options.getBaseUrl(), this.options.getApiKey(),
 						this.options.getTimeout(), this.options.getMaxRetries(), this.options.getProxy(),
-						this.options.getCustomHeaders()));
+						this.options.getCustomHeaders(), this.observationRegistry, this.meterRegistry,
+						this.dispatcherExecutor));
 
-		this.observationRegistry = Objects.requireNonNullElse(observationRegistry, ObservationRegistry.NOOP);
 		this.toolCallingManager = Objects.requireNonNullElse(toolCallingManager, DEFAULT_TOOL_CALLING_MANAGER);
 		this.toolExecutionEligibilityChecker = Objects.requireNonNullElse(toolExecutionEligibilityChecker,
 				chatResponse -> chatResponse != null && chatResponse.hasToolCalls());
@@ -234,6 +259,21 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		return this.internalCall(requestPrompt, null);
 	}
 
+	/**
+	 * Streams the chat completion as a {@link Flux} of {@link ChatResponse} events.
+	 *
+	 * <p>
+	 * <b>Observability note.</b> The outbound HTTP attempt is observed as
+	 * {@code okhttp.requests} with timer + {@code traceparent}, but for streaming calls
+	 * the HTTP span is not parented under the chat-model's
+	 * {@code gen_ai.client.operation} span. The SDK's async path internally schedules the
+	 * HTTP call on {@code ForkJoinPool.commonPool()} before Spring AI's HTTP client runs,
+	 * which drops the calling thread's observation context. Filter by
+	 * {@code okhttp.requests} + host {@code api.anthropic.com} and correlate by trace ID
+	 * or timestamp if you need to join the spans in your tracing UI.
+	 * @param prompt the prompt
+	 * @return a {@link Flux} of streamed {@link ChatResponse} events
+	 */
 	@Override
 	public Flux<ChatResponse> stream(Prompt prompt) {
 		Prompt requestPrompt = buildRequestPrompt(prompt);
@@ -1593,6 +1633,10 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 
 		private @Nullable ObservationRegistry observationRegistry;
 
+		private @Nullable MeterRegistry meterRegistry;
+
+		private @Nullable ExecutorService dispatcherExecutor;
+
 		private @Nullable ToolExecutionEligibilityChecker toolExecutionEligibilityChecker;
 
 		private Builder() {
@@ -1653,6 +1697,36 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		}
 
 		/**
+		 * Sets the meter registry used to bind OkHttp connection-pool gauges (active/idle
+		 * connections). Optional; when omitted, no pool gauges are registered.
+		 * Auto-configuration wires the application's {@link MeterRegistry} bean here
+		 * automatically.
+		 * @param meterRegistry the meter registry
+		 * @return this builder
+		 * @since 2.0.0
+		 */
+		public Builder meterRegistry(@Nullable MeterRegistry meterRegistry) {
+			this.meterRegistry = meterRegistry;
+			return this;
+		}
+
+		/**
+		 * Sets the executor used by the underlying OkHttp dispatcher for both the sync
+		 * and async clients. The caller owns the executor's lifecycle — Spring AI will
+		 * not shut it down. Typical use: pass
+		 * {@code Executors.newVirtualThreadPerTaskExecutor()} on Java 21+ to back HTTP
+		 * dispatch with virtual threads. When omitted, an internal platform-thread
+		 * executor is created and managed by the HTTP client.
+		 * @param dispatcherExecutor the dispatcher executor; null restores the default
+		 * @return this builder
+		 * @since 2.0.0
+		 */
+		public Builder dispatcherExecutor(@Nullable ExecutorService dispatcherExecutor) {
+			this.dispatcherExecutor = dispatcherExecutor;
+			return this;
+		}
+
+		/**
 		 * Sets the predicate to determine tool execution eligibility.
 		 * @param toolExecutionEligibilityPredicate the predicate
 		 * @return this builder
@@ -1697,7 +1771,8 @@ public final class AnthropicChatModel implements ChatModel, StreamingChatModel {
 		 */
 		public AnthropicChatModel build() {
 			return new AnthropicChatModel(this.anthropicClient, this.anthropicClientAsync, this.options,
-					this.toolCallingManager, this.observationRegistry, this.toolExecutionEligibilityChecker);
+					this.toolCallingManager, this.observationRegistry, this.meterRegistry, this.dispatcherExecutor,
+					this.toolExecutionEligibilityChecker);
 		}
 
 	}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicSetup.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/AnthropicSetup.java
@@ -18,17 +18,24 @@ package org.springframework.ai.anthropic;
 
 import java.net.Proxy;
 import java.time.Duration;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.concurrent.ExecutorService;
 
+import com.anthropic.backends.AnthropicBackend;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.AnthropicClientAsync;
-import com.anthropic.client.okhttp.AnthropicOkHttpClient;
-import com.anthropic.client.okhttp.AnthropicOkHttpClientAsync;
+import com.anthropic.client.AnthropicClientAsyncImpl;
+import com.anthropic.client.AnthropicClientImpl;
+import com.anthropic.core.ClientOptions;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.observation.ObservationRegistry;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.springframework.ai.anthropic.http.okhttp.SpringAiAnthropicHttpClient;
 
 /**
  * Factory class for creating and configuring Anthropic SDK client instances.
@@ -90,11 +97,20 @@ public final class AnthropicSetup {
 
 	private static final int DEFAULT_MAX_RETRIES = 2;
 
+	// Disambiguates sync/async client connection-pool gauges sharing one MeterRegistry.
+	private static final List<Tag> SYNC_CLIENT_TAGS = List.of(Tag.of("client.kind", "sync"));
+
+	private static final List<Tag> ASYNC_CLIENT_TAGS = List.of(Tag.of("client.kind", "async"));
+
 	private AnthropicSetup() {
 	}
 
 	/**
-	 * Creates a synchronous Anthropic client with the specified configuration.
+	 * Creates a synchronous Anthropic client with the specified configuration. Delegates
+	 * to
+	 * {@link #setupSyncClient(String, String, Duration, Integer, Proxy, Map, ObservationRegistry, MeterRegistry)}
+	 * with a {@link ObservationRegistry#NOOP no-op} observation registry and no meter
+	 * registry — i.e. HTTP-layer observability is disabled.
 	 * @param baseUrl the base URL for the API (null to use default or environment
 	 * variable)
 	 * @param apiKey the API key (null to detect from environment)
@@ -107,47 +123,65 @@ public final class AnthropicSetup {
 	public static AnthropicClient setupSyncClient(@Nullable String baseUrl, @Nullable String apiKey,
 			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
 			@Nullable Map<String, String> customHeaders) {
-
-		baseUrl = detectBaseUrlFromEnv(baseUrl);
-
-		if (timeout == null) {
-			timeout = DEFAULT_TIMEOUT;
-		}
-		if (maxRetries == null) {
-			maxRetries = DEFAULT_MAX_RETRIES;
-		}
-
-		AnthropicOkHttpClient.Builder builder = AnthropicOkHttpClient.builder();
-
-		if (baseUrl != null) {
-			builder.baseUrl(baseUrl);
-		}
-
-		String resolvedApiKey = apiKey != null ? apiKey : detectApiKey();
-		if (resolvedApiKey != null) {
-			builder.apiKey(resolvedApiKey);
-		}
-
-		if (proxy != null) {
-			builder.proxy(proxy);
-		}
-
-		builder.putHeader("User-Agent", DEFAULT_USER_AGENT);
-		if (customHeaders != null) {
-			builder.putAllHeaders(customHeaders.entrySet()
-				.stream()
-				.collect(Collectors.toMap(Map.Entry::getKey, entry -> Collections.singletonList(entry.getValue()))));
-		}
-
-		builder.timeout(timeout);
-		builder.maxRetries(maxRetries);
-
-		return builder.build();
+		return setupSyncClient(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders, ObservationRegistry.NOOP,
+				null);
 	}
 
 	/**
-	 * Creates an asynchronous Anthropic client with the specified configuration. The
-	 * async client is used for streaming responses.
+	 * Creates a synchronous Anthropic client whose underlying OkHttp client is
+	 * instrumented with Micrometer: each HTTP attempt emits an observation (span + metric
+	 * + {@code traceparent} propagation), and, when a {@link MeterRegistry} is supplied,
+	 * OkHttp connection-pool gauges are bound to it.
+	 * @param baseUrl the base URL for the API (null to use default or environment
+	 * variable)
+	 * @param apiKey the API key (null to detect from environment)
+	 * @param timeout the request timeout (null to use default of 60 seconds)
+	 * @param maxRetries the maximum number of retries (null to use default of 2)
+	 * @param proxy the proxy to use (null for no proxy)
+	 * @param customHeaders additional HTTP headers to include in requests
+	 * @param observationRegistry the registry the OkHttp observation interceptor reports
+	 * to; pass {@link ObservationRegistry#NOOP} to disable
+	 * @param meterRegistry optional; when supplied, OkHttp connection-pool gauges
+	 * (active/idle connections) are registered
+	 * @return a configured Anthropic client
+	 * @since 2.0.0
+	 */
+	public static AnthropicClient setupSyncClient(@Nullable String baseUrl, @Nullable String apiKey,
+			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
+			@Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
+			@Nullable MeterRegistry meterRegistry) {
+		return setupSyncClient(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders, observationRegistry,
+				meterRegistry, null);
+	}
+
+	/**
+	 * Creates a synchronous Anthropic client backed by a caller-supplied dispatcher
+	 * executor (e.g. one built around {@code Executors.newVirtualThreadPerTaskExecutor()}
+	 * on Java 21+). The caller owns the executor's lifecycle; closing the resulting
+	 * client will not shut it down. See
+	 * {@link #setupSyncClient(String, String, Duration, Integer, Proxy, Map, ObservationRegistry, MeterRegistry)}
+	 * for the remaining parameter semantics.
+	 * @param dispatcherExecutor the OkHttp dispatcher executor; null to use the
+	 * library-managed default
+	 * @return a configured Anthropic client
+	 * @since 2.0.0
+	 */
+	public static AnthropicClient setupSyncClient(@Nullable String baseUrl, @Nullable String apiKey,
+			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
+			@Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
+			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor) {
+
+		ClientOptions opts = buildClientOptions(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders,
+				observationRegistry, meterRegistry, SYNC_CLIENT_TAGS, dispatcherExecutor);
+		return new AnthropicClientImpl(opts);
+	}
+
+	/**
+	 * Creates an asynchronous Anthropic client with the specified configuration.
+	 * Delegates to
+	 * {@link #setupAsyncClient(String, String, Duration, Integer, Proxy, Map, ObservationRegistry, MeterRegistry)}
+	 * with a {@link ObservationRegistry#NOOP no-op} observation registry and no meter
+	 * registry — i.e. HTTP-layer observability is disabled.
 	 * @param baseUrl the base URL for the API (null to use default or environment
 	 * variable)
 	 * @param apiKey the API key (null to detect from environment)
@@ -160,42 +194,104 @@ public final class AnthropicSetup {
 	public static AnthropicClientAsync setupAsyncClient(@Nullable String baseUrl, @Nullable String apiKey,
 			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
 			@Nullable Map<String, String> customHeaders) {
+		return setupAsyncClient(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders, ObservationRegistry.NOOP,
+				null);
+	}
 
-		baseUrl = detectBaseUrlFromEnv(baseUrl);
+	/**
+	 * Creates an asynchronous Anthropic client whose underlying OkHttp client is
+	 * instrumented with Micrometer. See
+	 * {@link #setupSyncClient(String, String, Duration, Integer, Proxy, Map, ObservationRegistry, MeterRegistry)}
+	 * for parameter semantics.
+	 * @param baseUrl the base URL for the API (null to use default or environment
+	 * variable)
+	 * @param apiKey the API key (null to detect from environment)
+	 * @param timeout the request timeout (null to use default of 60 seconds)
+	 * @param maxRetries the maximum number of retries (null to use default of 2)
+	 * @param proxy the proxy to use (null for no proxy)
+	 * @param customHeaders additional HTTP headers to include in requests
+	 * @param observationRegistry the registry the OkHttp observation interceptor reports
+	 * to; pass {@link ObservationRegistry#NOOP} to disable
+	 * @param meterRegistry optional; when supplied, OkHttp connection-pool gauges are
+	 * registered
+	 * @return a configured async Anthropic client
+	 * @since 2.0.0
+	 */
+	public static AnthropicClientAsync setupAsyncClient(@Nullable String baseUrl, @Nullable String apiKey,
+			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
+			@Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
+			@Nullable MeterRegistry meterRegistry) {
+		return setupAsyncClient(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders, observationRegistry,
+				meterRegistry, null);
+	}
 
-		if (timeout == null) {
-			timeout = DEFAULT_TIMEOUT;
-		}
-		if (maxRetries == null) {
-			maxRetries = DEFAULT_MAX_RETRIES;
-		}
+	/**
+	 * Creates an asynchronous Anthropic client backed by a caller-supplied dispatcher
+	 * executor. The caller owns the executor's lifecycle; closing the resulting client
+	 * will not shut it down. See
+	 * {@link #setupSyncClient(String, String, Duration, Integer, Proxy, Map, ObservationRegistry, MeterRegistry, ExecutorService)}
+	 * for the dispatcher executor's role.
+	 * @param dispatcherExecutor the OkHttp dispatcher executor; null to use the
+	 * library-managed default
+	 * @return a configured async Anthropic client
+	 * @since 2.0.0
+	 */
+	public static AnthropicClientAsync setupAsyncClient(@Nullable String baseUrl, @Nullable String apiKey,
+			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
+			@Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
+			@Nullable MeterRegistry meterRegistry, @Nullable ExecutorService dispatcherExecutor) {
 
-		AnthropicOkHttpClientAsync.Builder builder = AnthropicOkHttpClientAsync.builder();
+		ClientOptions opts = buildClientOptions(baseUrl, apiKey, timeout, maxRetries, proxy, customHeaders,
+				observationRegistry, meterRegistry, ASYNC_CLIENT_TAGS, dispatcherExecutor);
+		return new AnthropicClientAsyncImpl(opts);
+	}
 
-		if (baseUrl != null) {
-			builder.baseUrl(baseUrl);
-		}
+	private static ClientOptions buildClientOptions(@Nullable String baseUrl, @Nullable String apiKey,
+			@Nullable Duration timeout, @Nullable Integer maxRetries, @Nullable Proxy proxy,
+			@Nullable Map<String, String> customHeaders, ObservationRegistry observationRegistry,
+			@Nullable MeterRegistry meterRegistry, Iterable<Tag> connectionPoolTags,
+			@Nullable ExecutorService dispatcherExecutor) {
 
+		String resolvedBaseUrl = detectBaseUrlFromEnv(baseUrl);
 		String resolvedApiKey = apiKey != null ? apiKey : detectApiKey();
-		if (resolvedApiKey != null) {
-			builder.apiKey(resolvedApiKey);
-		}
+		Duration resolvedTimeout = timeout != null ? timeout : DEFAULT_TIMEOUT;
+		int resolvedMaxRetries = maxRetries != null ? maxRetries : DEFAULT_MAX_RETRIES;
 
-		if (proxy != null) {
-			builder.proxy(proxy);
-		}
+		AnthropicBackend backend = buildBackend(resolvedBaseUrl, resolvedApiKey);
 
-		builder.putHeader("User-Agent", DEFAULT_USER_AGENT);
+		ClientOptions.Builder optsBuilder = ClientOptions.builder()
+			.timeout(resolvedTimeout)
+			.maxRetries(resolvedMaxRetries)
+			.putHeader("User-Agent", DEFAULT_USER_AGENT);
 		if (customHeaders != null) {
-			builder.putAllHeaders(customHeaders.entrySet()
-				.stream()
-				.collect(Collectors.toMap(Map.Entry::getKey, entry -> Collections.singletonList(entry.getValue()))));
+			customHeaders.forEach(optsBuilder::putHeader);
 		}
 
-		builder.timeout(timeout);
-		builder.maxRetries(maxRetries);
+		SpringAiAnthropicHttpClient rawHttp = SpringAiAnthropicHttpClient.builder()
+			.backend(backend)
+			.timeout(resolvedTimeout)
+			.proxy(proxy)
+			.observationRegistry(observationRegistry)
+			.meterRegistry(meterRegistry)
+			.meterTags(connectionPoolTags)
+			.dispatcherExecutorService(dispatcherExecutor)
+			.build();
 
-		return builder.build();
+		// No-op when a static apiKey/authToken is set; otherwise fetches WIF credentials.
+		backend.applyCredentials(rawHttp, optsBuilder);
+
+		return optsBuilder.httpClient(rawHttp).build();
+	}
+
+	private static AnthropicBackend buildBackend(@Nullable String baseUrl, @Nullable String apiKey) {
+		AnthropicBackend.Builder b = AnthropicBackend.builder();
+		if (baseUrl != null) {
+			b.baseUrl(baseUrl);
+		}
+		if (apiKey != null) {
+			b.apiKey(apiKey);
+		}
+		return b.build();
 	}
 
 	/**

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/http/okhttp/SpringAiAnthropicHttpClient.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/http/okhttp/SpringAiAnthropicHttpClient.java
@@ -1,0 +1,651 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.http.okhttp;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
+
+import com.anthropic.backends.Backend;
+import com.anthropic.core.RequestOptions;
+import com.anthropic.core.Timeout;
+import com.anthropic.core.http.Headers;
+import com.anthropic.core.http.HttpClient;
+import com.anthropic.core.http.HttpMethod;
+import com.anthropic.core.http.HttpRequest;
+import com.anthropic.core.http.HttpRequestBody;
+import com.anthropic.core.http.HttpResponse;
+import com.anthropic.core.http.ProxyAuthenticator;
+import com.anthropic.errors.AnthropicIoException;
+import io.micrometer.context.ContextExecutorService;
+import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.okhttp3.OkHttpConnectionPoolMetrics;
+import io.micrometer.core.instrument.binder.okhttp3.OkHttpObservationInterceptor;
+import io.micrometer.observation.ObservationRegistry;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.ConnectionPool;
+import okhttp3.Dispatcher;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okio.BufferedSink;
+import okio.Okio;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * OkHttp-backed {@link HttpClient} for the Anthropic Java SDK, with Micrometer's
+ * {@link OkHttpObservationInterceptor} attached so each HTTP attempt produces an
+ * observation (span + metric + traceparent propagation). When a {@link MeterRegistry} is
+ * supplied, {@link OkHttpConnectionPoolMetrics} is also bound. We own this code because
+ * the SDK's stock {@code AnthropicOkHttpClient.Builder} doesn't expose an interceptor
+ * seam — see the SDK's
+ * <a href="https://platform.claude.com/docs/en/api/sdks/java#custom-http-client">Custom
+ * HTTP client</a> guide for the integration pattern and
+ * <a href="https://github.com/anthropics/anthropic-sdk-java/pull/315">anthropic-sdk-java
+ * #315</a> for the upstream fix being tracked.
+ *
+ * <p>
+ * <b>Attribution:</b> the body of this class is a Java port of {@code OkHttpClient} from
+ * {@code anthropic-java-client-okhttp} (Apache License 2.0, authored by Anthropic). Only
+ * the Micrometer wiring in {@link Builder#build()} is original to Spring AI.
+ *
+ * @author Soby Chacko
+ * @since 2.0.0
+ */
+public final class SpringAiAnthropicHttpClient implements HttpClient {
+
+	private final OkHttpClient okHttpClient;
+
+	private final Backend backend;
+
+	private final boolean ownsDispatcherExecutor;
+
+	private SpringAiAnthropicHttpClient(OkHttpClient okHttpClient, Backend backend, boolean ownsDispatcherExecutor) {
+		this.okHttpClient = okHttpClient;
+		this.backend = backend;
+		this.ownsDispatcherExecutor = ownsDispatcherExecutor;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	@Override
+	public HttpResponse execute(HttpRequest request, RequestOptions requestOptions) {
+		HttpRequest preparedRequest = prepareRequest(request);
+		Call call = newCall(preparedRequest, requestOptions);
+		try {
+			return this.backend.prepareResponse(toHttpResponse(call.execute()));
+		}
+		catch (IOException e) {
+			throw new AnthropicIoException("Request failed", e);
+		}
+		finally {
+			HttpRequestBody body = preparedRequest.body();
+			if (body != null) {
+				body.close();
+			}
+		}
+	}
+
+	@Override
+	public CompletableFuture<HttpResponse> executeAsync(HttpRequest request, RequestOptions requestOptions) {
+		HttpRequest preparedRequest = prepareRequest(request);
+		CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+
+		Call call = newCall(preparedRequest, requestOptions);
+		call.enqueue(new Callback() {
+			@Override
+			public void onResponse(Call call, Response response) {
+				future.complete(SpringAiAnthropicHttpClient.this.backend.prepareResponse(toHttpResponse(response)));
+			}
+
+			@Override
+			public void onFailure(Call call, IOException e) {
+				future.completeExceptionally(new AnthropicIoException("Request failed", e));
+			}
+		});
+
+		future.whenComplete((unused, error) -> {
+			if (error instanceof CancellationException) {
+				call.cancel();
+			}
+			HttpRequestBody body = preparedRequest.body();
+			if (body != null) {
+				body.close();
+			}
+		});
+
+		return future;
+	}
+
+	@Override
+	public void close() {
+		this.backend.close();
+		if (this.ownsDispatcherExecutor) {
+			this.okHttpClient.dispatcher().executorService().shutdown();
+		}
+		this.okHttpClient.connectionPool().evictAll();
+		if (this.okHttpClient.cache() != null) {
+			try {
+				this.okHttpClient.cache().close();
+			}
+			catch (IOException ignored) {
+				// Matches SDK behavior: cache close errors during shutdown are swallowed.
+			}
+		}
+	}
+
+	private HttpRequest prepareRequest(HttpRequest request) {
+		HttpRequest prepared = this.backend.prepareRequest(request);
+		HttpRequest resolved = resolveUrl(prepared);
+		return this.backend.authorizeRequest(resolved);
+	}
+
+	private Call newCall(HttpRequest request, RequestOptions requestOptions) {
+		OkHttpClient.Builder clientBuilder = this.okHttpClient.newBuilder();
+
+		Timeout perCallTimeout = requestOptions.getTimeout();
+		if (perCallTimeout != null) {
+			clientBuilder.connectTimeout(perCallTimeout.connect())
+				.readTimeout(perCallTimeout.read())
+				.writeTimeout(perCallTimeout.write())
+				.callTimeout(perCallTimeout.request());
+		}
+
+		OkHttpClient client = clientBuilder.build();
+		return client.newCall(toRequestWithStainlessHeaders(request, client));
+	}
+
+	// URL is expected to be fully resolved by `prepareRequest()`; read directly from
+	// baseUrl.
+	private static Request toRequestWithStainlessHeaders(HttpRequest request, OkHttpClient client) {
+		RequestBody body = toOkHttpRequestBody(request.body());
+		if (body == null && requiresBody(request.method())) {
+			body = RequestBody.create("", null);
+		}
+
+		String baseUrl = request.baseUrl();
+		Request.Builder builder = new Request.Builder().url(baseUrl != null ? baseUrl : "")
+			.method(request.method().name(), body);
+
+		Headers headers = request.headers();
+		for (String name : headers.names()) {
+			for (String value : headers.values(name)) {
+				builder.addHeader(name, value);
+			}
+		}
+
+		if (!headers.names().contains("X-Stainless-Read-Timeout") && client.readTimeoutMillis() != 0) {
+			builder.addHeader("X-Stainless-Read-Timeout",
+					Long.toString(Duration.ofMillis(client.readTimeoutMillis()).getSeconds()));
+		}
+		if (!headers.names().contains("X-Stainless-Timeout") && client.callTimeoutMillis() != 0) {
+			builder.addHeader("X-Stainless-Timeout",
+					Long.toString(Duration.ofMillis(client.callTimeoutMillis()).getSeconds()));
+		}
+
+		return builder.build();
+	}
+
+	// URL is computed from scratch; client may be null (proxy-authenticator path).
+	private static Request toRequestComputeUrl(HttpRequest request, @Nullable OkHttpClient client) {
+		RequestBody body = toOkHttpRequestBody(request.body());
+		if (body == null && requiresBody(request.method())) {
+			body = RequestBody.create("", null);
+		}
+
+		Request.Builder builder = new Request.Builder().url(toUrl(request)).method(request.method().name(), body);
+
+		Headers headers = request.headers();
+		for (String name : headers.names()) {
+			for (String value : headers.values(name)) {
+				builder.addHeader(name, value);
+			}
+		}
+
+		if (client != null) {
+			if (!headers.names().contains("X-Stainless-Read-Timeout") && client.readTimeoutMillis() != 0) {
+				builder.addHeader("X-Stainless-Read-Timeout",
+						Long.toString(Duration.ofMillis(client.readTimeoutMillis()).getSeconds()));
+			}
+			if (!headers.names().contains("X-Stainless-Timeout") && client.callTimeoutMillis() != 0) {
+				builder.addHeader("X-Stainless-Timeout",
+						Long.toString(Duration.ofMillis(client.callTimeoutMillis()).getSeconds()));
+			}
+		}
+
+		return builder.build();
+	}
+
+	private HttpRequest resolveUrl(HttpRequest request) {
+		return request.toBuilder().baseUrl(computeBaseAndPath(request)).build();
+	}
+
+	private String computeBaseAndPath(HttpRequest request) {
+		String base = request.baseUrl() != null ? request.baseUrl() : this.backend.baseUrl();
+		HttpUrl.Builder builder = HttpUrl.get(base).newBuilder();
+		for (String segment : request.pathSegments()) {
+			builder.addPathSegment(segment);
+		}
+		for (String key : request.queryParams().keys()) {
+			for (String value : request.queryParams().values(key)) {
+				builder.addQueryParameter(key, value);
+			}
+		}
+		return builder.toString();
+	}
+
+	private static String toUrl(HttpRequest request) {
+		HttpUrl.Builder builder = HttpUrl.get(Objects.requireNonNull(request.baseUrl())).newBuilder();
+		for (String segment : request.pathSegments()) {
+			builder.addPathSegment(segment);
+		}
+		for (String key : request.queryParams().keys()) {
+			for (String value : request.queryParams().values(key)) {
+				builder.addQueryParameter(key, value);
+			}
+		}
+		return builder.toString();
+	}
+
+	private static boolean requiresBody(HttpMethod method) {
+		return method == HttpMethod.POST || method == HttpMethod.PUT || method == HttpMethod.PATCH;
+	}
+
+	private static @Nullable RequestBody toOkHttpRequestBody(@Nullable HttpRequestBody source) {
+		if (source == null) {
+			return null;
+		}
+		final String mediaTypeString = source.contentType();
+		final MediaType mediaType = mediaTypeString != null ? MediaType.parse(mediaTypeString) : null;
+		final long length = source.contentLength();
+
+		return new RequestBody() {
+			@Override
+			public @Nullable MediaType contentType() {
+				return mediaType;
+			}
+
+			@Override
+			public long contentLength() {
+				return length;
+			}
+
+			@Override
+			public boolean isOneShot() {
+				return !source.repeatable();
+			}
+
+			@Override
+			public void writeTo(BufferedSink sink) throws IOException {
+				source.writeTo(sink.outputStream());
+			}
+		};
+	}
+
+	private static HttpResponse toHttpResponse(Response response) {
+		final Headers headers = toAnthropicHeaders(response.headers());
+		return new HttpResponse() {
+			@Override
+			public int statusCode() {
+				return response.code();
+			}
+
+			@Override
+			public Headers headers() {
+				return headers;
+			}
+
+			@Override
+			public InputStream body() {
+				return Objects.requireNonNull(response.body()).byteStream();
+			}
+
+			@Override
+			public void close() {
+				Objects.requireNonNull(response.body()).close();
+			}
+		};
+	}
+
+	private static HttpRequest toHttpRequest(Request request) {
+		HttpRequest.Builder builder = HttpRequest.builder()
+			.method(HttpMethod.valueOf(request.method()))
+			.baseUrl(toBaseUrl(request.url()));
+		for (String segment : request.url().pathSegments()) {
+			builder.addPathSegment(segment);
+		}
+		for (String name : request.url().queryParameterNames()) {
+			for (String value : request.url().queryParameterValues(name)) {
+				if (value != null) {
+					builder.putQueryParam(name, value);
+				}
+			}
+		}
+		okhttp3.Headers reqHeaders = request.headers();
+		for (int i = 0, n = reqHeaders.size(); i < n; i++) {
+			builder.putHeader(reqHeaders.name(i), reqHeaders.value(i));
+		}
+		RequestBody body = request.body();
+		if (body != null) {
+			builder.body(toHttpRequestBody(body));
+		}
+		return builder.build();
+	}
+
+	private static String toBaseUrl(HttpUrl url) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(url.scheme()).append("://").append(url.host());
+		if (url.port() != HttpUrl.defaultPort(url.scheme())) {
+			sb.append(':').append(url.port());
+		}
+		return sb.toString();
+	}
+
+	private static HttpRequestBody toHttpRequestBody(RequestBody source) {
+		final MediaType mediaType = source.contentType();
+		final String mediaTypeString = mediaType != null ? mediaType.toString() : null;
+		final long length;
+		try {
+			length = source.contentLength();
+		}
+		catch (IOException e) {
+			throw new AnthropicIoException("Could not read content length", e);
+		}
+		final boolean isOneShot = source.isOneShot();
+
+		return new HttpRequestBody() {
+			@Override
+			public @Nullable String contentType() {
+				return mediaTypeString;
+			}
+
+			@Override
+			public long contentLength() {
+				return length;
+			}
+
+			@Override
+			public boolean repeatable() {
+				return !isOneShot;
+			}
+
+			@Override
+			public void writeTo(OutputStream outputStream) {
+				BufferedSink sink = Okio.buffer(Okio.sink(outputStream));
+				try {
+					source.writeTo(sink);
+					sink.flush();
+				}
+				catch (IOException e) {
+					throw new AnthropicIoException("Failed to write request body", e);
+				}
+			}
+
+			@Override
+			public void close() {
+			}
+		};
+	}
+
+	private static Headers toAnthropicHeaders(okhttp3.Headers okHttpHeaders) {
+		Headers.Builder builder = Headers.builder();
+		for (int i = 0, n = okHttpHeaders.size(); i < n; i++) {
+			builder.put(okHttpHeaders.name(i), okHttpHeaders.value(i));
+		}
+		return builder.build();
+	}
+
+	/**
+	 * Builder for {@link SpringAiAnthropicHttpClient}. Mirrors the upstream
+	 * {@code com.anthropic.client.okhttp.OkHttpClient.Builder} surface, with two
+	 * additional optional inputs: an {@link ObservationRegistry} (defaults to
+	 * {@link ObservationRegistry#NOOP}) and a {@link MeterRegistry} (optional; when
+	 * supplied, OkHttp connection-pool gauges are bound to it).
+	 */
+	public static final class Builder {
+
+		private static final String OBSERVATION_NAME = "okhttp.requests";
+
+		private Timeout timeout = Timeout.builder().build();
+
+		private @Nullable Proxy proxy;
+
+		private @Nullable Backend backend;
+
+		private @Nullable ProxyAuthenticator proxyAuthenticator;
+
+		private @Nullable Integer maxIdleConnections;
+
+		private @Nullable Duration keepAliveDuration;
+
+		private @Nullable ExecutorService dispatcherExecutorService;
+
+		private @Nullable SSLSocketFactory sslSocketFactory;
+
+		private @Nullable X509TrustManager trustManager;
+
+		private @Nullable HostnameVerifier hostnameVerifier;
+
+		private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+
+		private @Nullable MeterRegistry meterRegistry;
+
+		private Iterable<Tag> meterTags = Collections.emptyList();
+
+		private Builder() {
+		}
+
+		public Builder timeout(Timeout timeout) {
+			this.timeout = timeout;
+			return this;
+		}
+
+		public Builder timeout(Duration timeout) {
+			return timeout(Timeout.builder().request(timeout).build());
+		}
+
+		public Builder proxy(@Nullable Proxy proxy) {
+			this.proxy = proxy;
+			return this;
+		}
+
+		public Builder backend(Backend backend) {
+			this.backend = backend;
+			return this;
+		}
+
+		public Builder proxyAuthenticator(@Nullable ProxyAuthenticator proxyAuthenticator) {
+			this.proxyAuthenticator = proxyAuthenticator;
+			return this;
+		}
+
+		public Builder maxIdleConnections(@Nullable Integer maxIdleConnections) {
+			this.maxIdleConnections = maxIdleConnections;
+			return this;
+		}
+
+		public Builder keepAliveDuration(@Nullable Duration keepAliveDuration) {
+			this.keepAliveDuration = keepAliveDuration;
+			return this;
+		}
+
+		/**
+		 * Sets the executor used by the OkHttp dispatcher. When supplied, the caller owns
+		 * the executor's lifecycle — {@link SpringAiAnthropicHttpClient#close()} will not
+		 * shut it down. When null, an internal default is created and closed with the
+		 * client.
+		 */
+		public Builder dispatcherExecutorService(@Nullable ExecutorService dispatcherExecutorService) {
+			this.dispatcherExecutorService = dispatcherExecutorService;
+			return this;
+		}
+
+		public Builder sslSocketFactory(@Nullable SSLSocketFactory sslSocketFactory) {
+			this.sslSocketFactory = sslSocketFactory;
+			return this;
+		}
+
+		public Builder trustManager(@Nullable X509TrustManager trustManager) {
+			this.trustManager = trustManager;
+			return this;
+		}
+
+		public Builder hostnameVerifier(@Nullable HostnameVerifier hostnameVerifier) {
+			this.hostnameVerifier = hostnameVerifier;
+			return this;
+		}
+
+		/**
+		 * Registers the Micrometer observation registry used by the OkHttp interceptor.
+		 * Defaults to {@link ObservationRegistry#NOOP}, which makes the interceptor a
+		 * no-op — no metric/span overhead in environments that don't wire observability.
+		 */
+		public Builder observationRegistry(ObservationRegistry observationRegistry) {
+			this.observationRegistry = Objects.requireNonNull(observationRegistry, "observationRegistry");
+			return this;
+		}
+
+		/**
+		 * Registers a meter registry to bind OkHttp connection-pool gauges (active/idle
+		 * connections). Optional; when omitted, no pool gauges are registered.
+		 */
+		public Builder meterRegistry(@Nullable MeterRegistry meterRegistry) {
+			this.meterRegistry = meterRegistry;
+			return this;
+		}
+
+		/**
+		 * Tags applied to the connection-pool gauges registered with the
+		 * {@link MeterRegistry}. Useful for distinguishing multiple clients writing pool
+		 * metrics into the same registry (e.g. a sync and an async client sharing a
+		 * registry). Has no effect when no meter registry is set.
+		 */
+		public Builder meterTags(Iterable<Tag> meterTags) {
+			this.meterTags = Objects.requireNonNull(meterTags, "meterTags");
+			return this;
+		}
+
+		public SpringAiAnthropicHttpClient build() {
+			Backend resolvedBackend = Objects.requireNonNull(this.backend, "backend");
+
+			OkHttpClient.Builder okBuilder = new OkHttpClient.Builder()
+				// SDK's RetryingHttpClient owns retries; disable here to avoid doubling.
+				.retryOnConnectionFailure(false)
+				.pingInterval(Duration.ofMinutes(1))
+				.connectTimeout(this.timeout.connect())
+				.readTimeout(this.timeout.read())
+				.writeTimeout(this.timeout.write())
+				.callTimeout(this.timeout.request())
+				.proxy(this.proxy);
+
+			OkHttpObservationInterceptor observationInterceptor = OkHttpObservationInterceptor
+				.builder(this.observationRegistry, OBSERVATION_NAME)
+				.build();
+			okBuilder.addInterceptor(observationInterceptor);
+
+			if (this.proxyAuthenticator != null) {
+				final ProxyAuthenticator pa = this.proxyAuthenticator;
+				okBuilder.proxyAuthenticator((route, response) -> {
+					Proxy routeProxy = route != null ? route.proxy() : Proxy.NO_PROXY;
+					Optional<HttpRequest> authed = pa.authenticate(routeProxy, toHttpRequest(response.request()),
+							toHttpResponse(response));
+					return authed.map(req -> toRequestComputeUrl(req, null)).orElse(null);
+				});
+			}
+
+			ExecutorService userDispatcherExecutor = this.dispatcherExecutorService;
+			boolean ownsDispatcherExecutor = userDispatcherExecutor == null;
+			ExecutorService dispatcherBase = (userDispatcherExecutor != null) ? userDispatcherExecutor
+					: defaultDispatcherExecutor();
+			ExecutorService dispatcherExecutor = ContextExecutorService.wrap(dispatcherBase,
+					ContextSnapshotFactory.builder().build());
+			okBuilder.dispatcher(new Dispatcher(dispatcherExecutor));
+
+			if (this.maxIdleConnections != null && this.keepAliveDuration != null) {
+				okBuilder.connectionPool(new ConnectionPool(this.maxIdleConnections, this.keepAliveDuration.toNanos(),
+						TimeUnit.NANOSECONDS));
+			}
+			else if ((this.maxIdleConnections == null) != (this.keepAliveDuration == null)) {
+				throw new IllegalStateException(
+						"Both or none of `maxIdleConnections` and `keepAliveDuration` must be set, but only one was set");
+			}
+
+			if (this.sslSocketFactory != null && this.trustManager != null) {
+				okBuilder.sslSocketFactory(this.sslSocketFactory, this.trustManager);
+			}
+			else if ((this.sslSocketFactory == null) != (this.trustManager == null)) {
+				throw new IllegalStateException(
+						"Both or none of `sslSocketFactory` and `trustManager` must be set, but only one was set");
+			}
+
+			if (this.hostnameVerifier != null) {
+				okBuilder.hostnameVerifier(this.hostnameVerifier);
+			}
+
+			OkHttpClient okClient = okBuilder.build();
+			// Same-host traffic: raise per-host limit to overall request limit. Matches
+			// the SDK's tuning at the bottom of `OkHttpClient.Builder.build()`.
+			okClient.dispatcher().setMaxRequestsPerHost(okClient.dispatcher().getMaxRequests());
+
+			if (this.meterRegistry != null) {
+				new OkHttpConnectionPoolMetrics(okClient.connectionPool(), this.meterTags).bindTo(this.meterRegistry);
+			}
+
+			return new SpringAiAnthropicHttpClient(okClient, resolvedBackend, ownsDispatcherExecutor);
+		}
+
+		// Replicates OkHttp's default dispatcher so wrapping for context propagation
+		// preserves the standard "OkHttp Dispatcher-N" thread names.
+		private static ExecutorService defaultDispatcherExecutor() {
+			AtomicInteger counter = new AtomicInteger(1);
+			ThreadFactory threadFactory = runnable -> {
+				Thread thread = new Thread(runnable, "OkHttp Dispatcher-" + counter.getAndIncrement());
+				thread.setDaemon(false);
+				return thread;
+			};
+			return new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+					threadFactory);
+		}
+
+	}
+
+}

--- a/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/http/okhttp/package-info.java
+++ b/models/spring-ai-anthropic/src/main/java/org/springframework/ai/anthropic/http/okhttp/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spring AI's customized OkHttp-backed implementation of the Anthropic Java SDK's
+ * {@link com.anthropic.core.http.HttpClient} contract. Exists to wire Micrometer
+ * HTTP-layer observability (span + metric + {@code traceparent} propagation) onto the
+ * underlying OkHttp client, which the SDK's stock {@code AnthropicOkHttpClient.Builder}
+ * does not expose a seam for. See the SDK's
+ * <a href="https://platform.claude.com/docs/en/api/sdks/java#custom-http-client">Custom
+ * HTTP client</a> guide for the integration pattern.
+ *
+ * @since 2.0.0
+ * @see org.springframework.ai.anthropic.http.okhttp.SpringAiAnthropicHttpClient
+ */
+@NullMarked
+package org.springframework.ai.anthropic.http.okhttp;
+
+import org.jspecify.annotations.NullMarked;

--- a/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelHttpObservabilityIT.java
+++ b/models/spring-ai-anthropic/src/test/java/org/springframework/ai/anthropic/chat/AnthropicChatModelHttpObservabilityIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.anthropic.chat;
+
+import java.util.List;
+
+import com.anthropic.models.messages.Model;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests proving HTTP-layer observability is restored after the Anthropic SDK
+ * migration. Each outbound HTTP attempt to the Anthropic API must:
+ * <ul>
+ * <li>emit an {@code okhttp.requests} observation,</li>
+ * <li>record a timer in the {@link MeterRegistry},</li>
+ * <li>register OkHttp connection-pool gauges.</li>
+ * </ul>
+ * For synchronous calls the HTTP observation is also parented under the
+ * {@code gen_ai.client.operation} chat-model observation. The streaming case verifies the
+ * wiring still fires but does not assert the parent linkage — see the comment on
+ * {@link #httpObservationFiresAndMetricsRecordedForStreamingCall()} for the SDK
+ * limitation behind this.
+ *
+ * @author Soby Chacko
+ */
+@SpringBootTest(classes = AnthropicChatModelHttpObservabilityIT.Config.class)
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+public class AnthropicChatModelHttpObservabilityIT {
+
+	private static final String TEST_MODEL = Model.CLAUDE_HAIKU_4_5.asString();
+
+	private static final String HTTP_OBSERVATION_NAME = "okhttp.requests";
+
+	@Autowired
+	TestObservationRegistry observationRegistry;
+
+	@Autowired
+	MeterRegistry meterRegistry;
+
+	@Autowired
+	AnthropicChatModel chatModel;
+
+	@BeforeEach
+	void beforeEach() {
+		this.observationRegistry.clear();
+	}
+
+	@Test
+	void httpObservationFiresAndIsParentedUnderChatObservationForSyncCall() {
+		var options = AnthropicChatOptions.builder().model(TEST_MODEL).maxTokens(128).build();
+
+		ChatResponse response = this.chatModel.call(new Prompt("Say hi in one word.", options));
+		assertThat(response.getResult().getOutput().getText()).isNotEmpty();
+
+		assertHttpObservationParentedUnderChatModel();
+		assertHttpTimerRecorded();
+		assertConnectionPoolGaugesBound();
+	}
+
+	/**
+	 * Asserts streaming wiring (observation, timer, pool gauges) but deliberately not the
+	 * parent-child linkage: the SDK's async path uses
+	 * {@code CompletableFuture.thenComposeAsync(...)} without an explicit executor,
+	 * jumping to {@code ForkJoinPool.commonPool()} before our HTTP client runs. The
+	 * calling thread's parent observation is gone by then, so the HTTP span is recorded
+	 * but unparented.
+	 */
+	@Test
+	void httpObservationFiresAndMetricsRecordedForStreamingCall() {
+		var options = AnthropicChatOptions.builder().model(TEST_MODEL).maxTokens(128).build();
+
+		Flux<ChatResponse> flux = this.chatModel.stream(new Prompt("Say hi in one word.", options));
+		List<ChatResponse> responses = flux.collectList().block();
+		assertThat(responses).isNotEmpty();
+
+		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+			.hasObservationWithNameEqualTo(HTTP_OBSERVATION_NAME);
+		assertHttpTimerRecorded();
+		assertConnectionPoolGaugesBound();
+	}
+
+	private void assertHttpObservationParentedUnderChatModel() {
+		TestObservationRegistryAssert.assertThat(this.observationRegistry)
+			.hasObservationWithNameEqualTo(HTTP_OBSERVATION_NAME)
+			.that()
+			.hasParentObservationContextMatching(
+					parent -> DefaultChatModelObservationConvention.DEFAULT_NAME.equals(parent.getName()),
+					"parent observation '%s'".formatted(DefaultChatModelObservationConvention.DEFAULT_NAME));
+	}
+
+	private void assertHttpTimerRecorded() {
+		Timer httpTimer = this.meterRegistry.find(HTTP_OBSERVATION_NAME).timer();
+		assertThat(httpTimer).as("Micrometer should record an %s timer", HTTP_OBSERVATION_NAME).isNotNull();
+		assertThat(httpTimer.count()).isGreaterThanOrEqualTo(1L);
+	}
+
+	private void assertConnectionPoolGaugesBound() {
+		long poolMeters = this.meterRegistry.getMeters()
+			.stream()
+			.map(m -> m.getId().getName())
+			.filter(n -> n.startsWith("okhttp.pool"))
+			.count();
+		assertThat(poolMeters).as("OkHttpConnectionPoolMetrics should register at least one okhttp.pool.* gauge")
+			.isGreaterThan(0);
+	}
+
+	@SpringBootConfiguration
+	static class Config {
+
+		@Bean
+		public MeterRegistry meterRegistry() {
+			return new SimpleMeterRegistry();
+		}
+
+		@Bean
+		public TestObservationRegistry observationRegistry(MeterRegistry meterRegistry) {
+			TestObservationRegistry registry = TestObservationRegistry.create();
+			// Bridge observations to meters so the OkHttp interceptor's Observation
+			// becomes a Timer entry in the SimpleMeterRegistry.
+			registry.observationConfig().observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+			return registry;
+		}
+
+		@Bean
+		public AnthropicChatModel anthropicSdkChatModel(TestObservationRegistry observationRegistry,
+				MeterRegistry meterRegistry) {
+			return AnthropicChatModel.builder()
+				.options(AnthropicChatOptions.builder().build())
+				.observationRegistry(observationRegistry)
+				.meterRegistry(meterRegistry)
+				.build();
+		}
+
+	}
+
+}

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/anthropic-chat.adoc
@@ -1650,29 +1650,74 @@ spring.ai.anthropic.chat.web-search-tool.user-location.country=US
 
 == Observability
 
-Spring AI emits Micrometer metrics and tracing spans at the chat model layer for every Anthropic call.
-Each span wraps the SDK invocation and carries request parameters, response metadata, and token usage.
-See the xref:observability/index.adoc[observability reference] for the full set.
+Spring AI emits Micrometer observations at two layers for every Anthropic call:
+
+* **Chat-model layer.** A `gen_ai.client.operation` observation wraps every call to `AnthropicChatModel.call(...)` or `.stream(...)`, carrying request parameters, response metadata, and token usage. See the xref:observability/index.adoc[observability reference] for the full set of tags and metrics.
+* **HTTP layer.** An `okhttp.requests` observation wraps every HTTP attempt to the Anthropic API, carrying HTTP method, URI, status code, and exception tags. Each request also propagates `traceparent` on the wire to any downstream services (AI gateways, OpenAI-compatible inference servers, proxies).
+
+In a Spring Boot application with `spring-boot-starter-actuator` and a tracing bridge (`micrometer-tracing-bridge-otel` or `micrometer-tracing-bridge-brave`), both layers are wired automatically — no opt-in required.
+For non-Boot applications, pass an `ObservationRegistry` to `AnthropicChatModel.builder()`:
+
+[source,java]
+----
+AnthropicChatModel chatModel = AnthropicChatModel.builder()
+    .options(...)
+    .observationRegistry(observationRegistry)
+    .build();
+----
+
+=== Connection-pool metrics (opt-in)
+
+Spring AI can additionally bind OkHttp connection-pool gauges (`okhttp.pool.connection.count` with `state=active|idle` and `client.kind=sync|async`) to the application's `MeterRegistry`.
+These are secondary telemetry — useful for capacity tuning but not required for tracing or per-request latency — so they're disabled by default.
+
+To enable them in a Spring Boot application:
+
+[source,properties]
+----
+spring.ai.anthropic.chat.connection-pool-metrics-enabled=true
+----
+
+For non-Boot applications, pass a `MeterRegistry` directly to the builder; the gauges bind whenever a registry is supplied:
+
+[source,java]
+----
+AnthropicChatModel chatModel = AnthropicChatModel.builder()
+    .options(...)
+    .observationRegistry(observationRegistry)
+    .meterRegistry(meterRegistry)
+    .build();
+----
+
+=== HTTP dispatcher executor (advanced)
+
+By default Spring AI manages the OkHttp dispatcher's executor — an unbounded pool of platform threads, replicating the SDK's stock behavior.
+For workloads with high HTTP concurrency, or to take advantage of Java 21+ virtual threads, you can supply your own `ExecutorService`:
+
+[source,java]
+----
+AnthropicChatModel chatModel = AnthropicChatModel.builder()
+    .options(...)
+    .dispatcherExecutor(Executors.newVirtualThreadPerTaskExecutor())
+    .build();
+----
+
+The same executor backs both the sync and async (streaming) clients.
+When you supply your own executor, you own its lifecycle — Spring AI will never call `shutdown()` on it.
+When omitted, the internal executor is created and cleaned up automatically.
 
 [IMPORTANT]
 ====
-**HTTP layer is not instrumented**
+**Streaming HTTP observations are not parented under the chat-model observation**
 
-Since `2.0.0-M3`, Anthropic chat goes through the official `anthropic-java` SDK.
-The SDK builds its own `OkHttpClient` and doesn't expose an interceptor hook on it, so Spring AI has no way to attach the Micrometer or OpenTelemetry interceptors that would instrument the HTTP request.
-You won't see:
+For synchronous calls, the `okhttp.requests` span is correctly nested under the `gen_ai.client.operation` span — the full trace tree forms as expected.
 
-* HTTP client metrics (per-endpoint latency, status codes, retries)
-* A span for the HTTP call itself, between Spring AI and the Anthropic API
-* Outbound `traceparent` propagation to the API or any intermediary (proxy, AI gateway, OpenAI-compatible inference service)
+For streaming calls, the `okhttp.requests` span fires and is recorded in the registry, the timer is recorded in `MeterRegistry`, and `traceparent` is still propagated on the outbound request — but the span is **not** nested under the chat-model span.
+This is because the Anthropic SDK's async streaming implementation hops onto `ForkJoinPool.commonPool()` before invoking Spring AI's HTTP client, dropping the calling thread's observation context at that boundary.
+Spring AI cannot recover the context from within its HTTP-client wrapper.
 
-Before `2.0.0-M3` the `RestClient` based code picked up HTTP instrumentation from Spring's HTTP stack for free.
-The switch to the SDK removed that side effect.
-
-For users with strict HTTP observability requirements, the SDK supports plugging in a custom HTTP client.
-See the https://platform.claude.com/docs/en/api/sdks/java#custom-http-client[Anthropic Java SDK custom HTTP client docs] for the recommended approach.
-Wire your custom-built `AnthropicClient` and `AnthropicClientAsync` into Spring AI via `AnthropicChatModel.builder().anthropicClient(...).anthropicClientAsync(...)`.
-Built-in HTTP-level observability is being explored for a future release.
+If you need to correlate streaming HTTP spans with their parent chat-model span in your tracing UI, filter by span name `okhttp.requests` with host `api.anthropic.com` and join to the corresponding `gen_ai.client.operation` span by trace ID or timestamp range.
+Built-in parent linkage for streaming is being pursued upstream in the Anthropic Java SDK.
 ====
 
 == Logging

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/observability/index.adoc
@@ -78,12 +78,14 @@ They measure the time spent in the advisor (including the time spent on the inne
 
 [IMPORTANT]
 ====
-**Anthropic and OpenAI: HTTP layer is not instrumented**
+**OpenAI: HTTP layer is not instrumented**
 
-The Anthropic (since `2.0.0-M3`) and OpenAI (since `2.0.0-M5`) chat models go through vendor-provided Java SDKs.
-Each SDK builds its own `OkHttpClient` and doesn't expose an interceptor hook on it, so Spring AI can't wire in the Micrometer or OpenTelemetry interceptors that would instrument the HTTP call.
-Only the model-level observations covered below are emitted, and traces won't connect end to end through proxies, AI gateways, or OpenAI-compatible inference servers like vLLM and Ollama.
-See the xref:api/chat/anthropic-chat.adoc#_observability[Anthropic] and xref:api/chat/openai-chat.adoc#_observability[OpenAI] chat docs for details.
+The OpenAI chat model goes through the official `openai-java` SDK, which builds its own `OkHttpClient` and doesn't expose an interceptor hook on it, so Spring AI can't wire in the Micrometer or OpenTelemetry interceptors that would instrument the HTTP call.
+Only the model-level observations covered below are emitted for OpenAI, and traces won't connect end to end through proxies, AI gateways, or OpenAI-compatible inference servers like vLLM and Ollama.
+See the xref:api/chat/openai-chat.adoc#_observability[OpenAI chat docs] for details.
+
+The Anthropic chat model **does** emit HTTP-layer observations (chat-model layer + HTTP layer), with one limitation specific to streaming calls.
+See the xref:api/chat/anthropic-chat.adoc#_observability[Anthropic chat docs] for details.
 ====
 
 The `gen_ai.client.operation` observations are recorded when calling the ChatModel `call` or `stream` methods. 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-ai/issues/5930

- Swap anthropic-java (umbrella) for anthropic-java-core; supply our own OkHttp-backed HttpClient via the SDK-documented Custom-HTTP-Client path
- New SpringAiAnthropicHttpClient: Java port of the SDK's OkHttpClient.kt, plus Micrometer OkHttpObservationInterceptor and OkHttpConnectionPoolMetrics
- AnthropicChatModel.Builder now accepts MeterRegistry; auto-config wires it from the Spring Boot context
- Sync calls: okhttp.requests span correctly nested under gen_ai.client.operation; timer, traceparent, and connection-pool gauges all flow as expected
- Streaming HTTP spans fire and timer/pool gauges record, but the span is not parented under gen_ai.client.operation — SDK's thenComposeAsync hops onto ForkJoinPool.commonPool() before our client runs, dropping context. Documented with span-name-filtering workaround.