### PR TITLE
GH-6082: Propagate custom headers for OpenAI image requests

### DIFF
--- a/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
+++ b/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiImageOptions.java
@@ -213,6 +213,9 @@ public class OpenAiImageOptions extends AbstractOpenAiOptions implements ImageOp
 		if (this.getUser() != null) {
 			builder.user(this.getUser());
 		}
+		if (this.getCustomHeaders() != null && !this.getCustomHeaders().isEmpty()) {
+			this.getCustomHeaders().forEach(builder::putAdditionalHeader);
+		}
 
 		return builder.build();
 	}

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageOptionsTests.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/image/OpenAiImageOptionsTests.java
@@ -16,10 +16,13 @@
 
 package org.springframework.ai.openai.image;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.image.ImageOptions;
 import org.springframework.ai.image.ImageOptionsBuilder;
+import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.openai.OpenAiImageOptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +48,18 @@ class OpenAiImageOptionsTests {
 		assertThat(merged.getHeight()).isEqualTo(1024);
 		assertThat(merged.getResponseFormat()).isEqualTo("b64_json");
 		assertThat(merged.getStyle()).isEqualTo("vivid");
+	}
+
+	@Test
+	void customHeadersArePropagatedToImageGenerateParams() {
+		OpenAiImageOptions options = OpenAiImageOptions.builder()
+			.model("gpt-image-1")
+			.customHeaders(Map.of("x-budget-id", "BUDGET_123"))
+			.build();
+
+		var params = options.toOpenAiImageGenerateParams(new ImagePrompt("a ducati motorcycle", options));
+
+		assertThat(params._additionalHeaders().values("x-budget-id")).containsExactly("BUDGET_123");
 	}
 
 }


### PR DESCRIPTION
Fixes #6082.

This applies `OpenAiImageOptions.getCustomHeaders()` to the OpenAI `ImageGenerateParams` builder so per-call image generation headers are passed through the same way chat requests already handle them.

Validation:
- `.\mvnw.cmd -pl models\spring-ai-openai -am -Dtest=OpenAiImageOptionsTests '-Dsurefire.failIfNoSpecifiedTests=false' test`