### PR TITLE
Use `Stream.toList()` instead of `Collectors.toList()`

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/prompt/AbstractMcpPromptMethodCallback.java
@@ -348,7 +348,7 @@ public abstract class AbstractMcpPromptMethodCallback {
 					List<PromptMessage> messages = ((List<String>) list).stream()
 						.map(text -> new PromptMessage(io.modelcontextprotocol.spec.McpSchema.Role.ASSISTANT,
 								new io.modelcontextprotocol.spec.McpSchema.TextContent(text)))
-						.collect(java.util.stream.Collectors.toList());
+						.toList();
 					return new GetPromptResult(null, messages);
 				}
 			}

--- a/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-cosmos-db/src/main/java/org/springframework/ai/chat/memory/repository/cosmosdb/CosmosDBChatMemoryRepository.java
@@ -96,7 +96,7 @@ public final class CosmosDBChatMemoryRepository implements ChatMemoryRepository 
 			.map(doc -> (Map<?, ?>) doc)
 			.map(doc -> (String) doc.get("conversationId"))
 			.distinct()
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public final class CosmosDBChatMemoryRepository implements ChatMemoryRepository 
 			.filter(Map.class::isInstance)
 			.map(doc -> (Map<String, Object>) doc)
 			.map(this::mapToMessage)
-			.collect(Collectors.toList());
+			.toList();
 
 		return messages;
 	}
@@ -177,7 +177,7 @@ public final class CosmosDBChatMemoryRepository implements ChatMemoryRepository 
 			.map(item -> (Map<String, Object>) item)
 			.map(item -> CosmosBulkOperations.getDeleteItemOperation((String) item.get("id"),
 					new PartitionKey(conversationId)))
-			.collect(Collectors.toList());
+			.toList();
 
 		this.container.executeBulkOperations(Flux.fromIterable(operations)).collectList().block();
 	}

--- a/memory/repository/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
+++ b/memory/repository/spring-ai-model-chat-memory-repository-mongodb/src/main/java/org/springframework/ai/chat/memory/repository/mongo/MongoChatMemoryRepository.java
@@ -19,7 +19,6 @@ package org.springframework.ai.chat.memory.repository.mongo;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -62,7 +61,7 @@ public final class MongoChatMemoryRepository implements ChatMemoryRepository {
 		var messages = this.mongoTemplate.query(Conversation.class)
 			.matching(Query.query(Criteria.where("conversationId").is(conversationId))
 				.with(Sort.by("timestamp").ascending()));
-		return messages.stream().map(MongoChatMemoryRepository::mapMessage).collect(Collectors.toList());
+		return messages.stream().map(MongoChatMemoryRepository::mapMessage).toList();
 	}
 
 	@Override

--- a/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
+++ b/models/spring-ai-bedrock/src/main/java/org/springframework/ai/bedrock/cohere/BedrockCohereEmbeddingModel.java
@@ -18,7 +18,6 @@ package org.springframework.ai.bedrock.cohere;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
 
@@ -115,7 +114,7 @@ public class BedrockCohereEmbeddingModel extends AbstractEmbeddingModel {
 				default -> text.substring(0, COHERE_MAX_CHARACTERS); // Default to END
 																		// behavior
 			};
-		}).collect(Collectors.toList());
+		}).toList();
 
 		var apiRequest = new CohereEmbeddingRequest(truncatedInstructions, inputType, truncate);
 		CohereEmbeddingResponse apiResponse = this.embeddingApi.embedding(apiRequest);

--- a/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
+++ b/models/spring-ai-stability-ai/src/main/java/org/springframework/ai/stabilityai/StabilityAiImageModel.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.stabilityai;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
 
@@ -61,7 +60,7 @@ public class StabilityAiImageModel implements ImageModel {
 				.stream()
 				.map(message -> new StabilityAiApi.GenerateImageRequest.TextPrompts(message.getText(),
 						message.getWeight()))
-				.collect(Collectors.toList()))
+				.toList())
 			.height(optionsToUse.getHeight())
 			.width(optionsToUse.getWidth())
 			.cfgScale(optionsToUse.getCfgScale())

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolUtils.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/support/ToolUtils.java
@@ -112,7 +112,7 @@ public final class ToolUtils {
 			.stream()
 			.filter(entry -> entry.getValue() > 1)
 			.map(Map.Entry::getKey)
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	public static List<String> getDuplicateToolNames(ToolCallback... toolCallbacks) {

--- a/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
+++ b/vector-stores/spring-ai-azure-cosmos-db-store/src/main/java/org/springframework/ai/vectorstore/cosmosdb/CosmosDBVectorStore.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.azure.cosmos.CosmosAsyncClient;
@@ -258,7 +257,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 			// Extract just the CosmosItemOperations from the pairs
 			List<CosmosItemOperation> itemOperations = itemOperationsWithIds.stream()
 				.map(ImmutablePair::getValue)
-				.collect(Collectors.toList());
+				.toList();
 
 			this.container.executeBulkOperations(Flux.fromIterable(itemOperations)).doOnNext(response -> {
 				if (response != null && response.getResponse() != null) {
@@ -344,7 +343,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 				}
 
 				return CosmosBulkOperations.getDeleteItemOperation(id, new PartitionKey(partitionKeyValue));
-			}).collect(Collectors.toList());
+			}).toList();
 
 			// Execute bulk delete operations synchronously by using blockLast() on the
 			// Flux
@@ -377,9 +376,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 
 		logger.info("similarity threshold: {}", request.getSimilarityThreshold());
 
-		List<Float> embeddingList = IntStream.range(0, embedding.length)
-			.mapToObj(i -> embedding[i])
-			.collect(Collectors.toList());
+		List<Float> embeddingList = IntStream.range(0, embedding.length).mapToObj(i -> embedding[i]).toList();
 
 		// Start building query for similarity search
 		StringBuilder queryBuilder = new StringBuilder("SELECT TOP @topK * FROM c WHERE ");
@@ -441,7 +438,7 @@ public class CosmosDBVectorStore extends AbstractObservationVectorStore implemen
 					.text(doc.get("content").asText())
 					.metadata(docFields)
 					.build())
-				.collect(Collectors.toList());
+				.toList();
 		}
 		catch (Exception e) {
 			logger.error("Error during similarity search: {}", e.getMessage());

--- a/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
+++ b/vector-stores/spring-ai-azure-store/src/main/java/org/springframework/ai/vectorstore/azure/AzureVectorStore.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.alibaba.fastjson2.JSONObject;
@@ -267,7 +266,7 @@ public class AzureVectorStore extends AbstractObservationVectorStore implements 
 
 				return Document.builder().id(id).text(content).metadata(metadata).score(result.getScore()).build();
 			})
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	@Override

--- a/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
+++ b/vector-stores/spring-ai-cassandra-store/src/main/java/org/springframework/ai/vectorstore/cassandra/CassandraVectorStore.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -336,7 +335,7 @@ public class CassandraVectorStore extends AbstractObservationVectorStore impleme
 
 			if (!matchingDocs.isEmpty()) {
 				// Then delete those documents by ID
-				List<String> idsToDelete = matchingDocs.stream().map(Document::getId).collect(Collectors.toList());
+				List<String> idsToDelete = matchingDocs.stream().map(Document::getId).toList();
 				delete(idsToDelete);
 				logger.debug("Deleted {} documents matching filter expression", idsToDelete.size());
 			}

--- a/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
+++ b/vector-stores/spring-ai-elasticsearch-store/src/main/java/org/springframework/ai/vectorstore/elasticsearch/ElasticsearchVectorStore.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.mapping.DenseVectorSimilarity;
@@ -267,7 +266,7 @@ public class ElasticsearchVectorStore extends AbstractObservationVectorStore imp
 						.queryString(qs -> qs.query(getElasticsearchQueryString(searchRequest.getFilterExpression())))))
 				.size(searchRequest.getTopK()), ObjectNode.class);
 
-			return res.hits().hits().stream().map(this::toDocument).collect(Collectors.toList());
+			return res.hits().hits().stream().map(this::toDocument).toList();
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);

--- a/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
+++ b/vector-stores/spring-ai-opensearch-store/src/main/java/org/springframework/ai/vectorstore/opensearch/OpenSearchVectorStore.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
 import org.opensearch.client.json.JsonData;
@@ -378,7 +377,7 @@ public class OpenSearchVectorStore extends AbstractObservationVectorStore implem
 				.hits()
 				.stream()
 				.map(this::toDocument)
-				.collect(Collectors.toList());
+				.toList();
 		}
 		catch (IOException e) {
 			throw new RuntimeException(e);

--- a/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
+++ b/vector-stores/spring-ai-pinecone-store/src/main/java/org/springframework/ai/vectorstore/pinecone/PineconeVectorStore.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
@@ -265,7 +264,7 @@ public class PineconeVectorStore extends AbstractObservationVectorStore {
 
 			if (!matchingDocs.isEmpty()) {
 				// Then delete those documents by ID
-				List<String> idsToDelete = matchingDocs.stream().map(Document::getId).collect(Collectors.toList());
+				List<String> idsToDelete = matchingDocs.stream().map(Document::getId).toList();
 				delete(idsToDelete, this.pineconeNamespace);
 				logger.debug("Deleted {} documents matching filter expression", idsToDelete.size());
 			}

--- a/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactory.java
+++ b/vector-stores/spring-ai-qdrant-store/src/main/java/org/springframework/ai/vectorstore/qdrant/QdrantObjectFactory.java
@@ -18,7 +18,6 @@ package org.springframework.ai.vectorstore.qdrant;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import io.qdrant.client.grpc.JsonWithInt.ListValue;
 import io.qdrant.client.grpc.JsonWithInt.Value;
@@ -52,7 +51,7 @@ final class QdrantObjectFactory {
 	}
 
 	private static Object object(ListValue listValue) {
-		return listValue.getValuesList().stream().map(QdrantObjectFactory::object).collect(Collectors.toList());
+		return listValue.getValuesList().stream().map(QdrantObjectFactory::object).toList();
 	}
 
 	private static @Nullable Object object(Value value) {

--- a/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
+++ b/vector-stores/spring-ai-redis-store/src/main/java/org/springframework/ai/vectorstore/redis/RedisVectorStore.java
@@ -787,7 +787,7 @@ public class RedisVectorStore extends AbstractObservationVectorStore implements 
 						this.metadataFields.stream()
 							.filter(field -> field.fieldType() == FieldType.TEXT)
 							.map(MetadataField::name)
-							.collect(Collectors.toList()));
+							.toList());
 			}
 			throw new IllegalArgumentException(String.format("Field '%s' is not a TEXT field", normalizedFieldName));
 		}

--- a/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStore.java
+++ b/vector-stores/spring-ai-s3-vector-store/src/main/java/org/springframework/ai/vectorstore/s3/S3VectorStore.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
 import software.amazon.awssdk.services.s3vectors.S3VectorsClient;
@@ -123,7 +122,7 @@ public class S3VectorStore extends AbstractObservationVectorStore implements Ini
 			.vectors()
 			.stream()
 			.map(QueryOutputVector::key)
-			.collect(Collectors.toList());
+			.toList();
 
 		this.s3VectorsClient.deleteVectors(DeleteVectorsRequest.builder()
 			.vectorBucketName(this.vectorBucketName)
@@ -155,7 +154,7 @@ public class S3VectorStore extends AbstractObservationVectorStore implements Ini
 		requestBuilder.queryVector(vectorData);
 
 		QueryVectorsResponse response = this.s3VectorsClient.queryVectors(requestBuilder.build());
-		return response.vectors().stream().map(this::toDocument).collect(Collectors.toList());
+		return response.vectors().stream().map(this::toDocument).toList();
 	}
 
 	private Document toDocument(QueryOutputVector vector) {

--- a/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
+++ b/vector-stores/spring-ai-weaviate-store/src/main/java/org/springframework/ai/vectorstore/weaviate/WeaviateVectorStore.java
@@ -307,7 +307,7 @@ public class WeaviateVectorStore extends AbstractObservationVectorStore {
 			List<Document> matchingDocs = similaritySearch(searchRequest);
 
 			if (!matchingDocs.isEmpty()) {
-				List<String> idsToDelete = matchingDocs.stream().map(Document::getId).collect(Collectors.toList());
+				List<String> idsToDelete = matchingDocs.stream().map(Document::getId).toList();
 
 				delete(idsToDelete);
 


### PR DESCRIPTION
Java 16+ ships a shorter `.toList()` on Stream that does the same thing as `.collect(Collectors.toList())`. It also returns an unmodifiable list, which is what we wanted at these call sites anyway — none of them mutate the result after collecting; they either return it, pass it to a vendor SDK, log it, or hand it to Flux.fromIterable.
  
Replaces 22 call sites across 16 files (memory repos, vector stores, chat/image models, MCP, tool utils) and removes the 11 Collectors imports that became unused.
  
A couple of sites were left alone on purpose:
  - Neo4jChatMemoryRepository uses Collectors.toList() as the downstream
    collector inside Collectors.mapping(...) — that is a different API,
    not a stream terminal op.
  - MultiQueryExpander later does add(0, query) on the result, so it
    needs to stay a mutable ArrayList.
    
No behavior changes intended; the only externally observable shift is that the returned list is now unmodifiable. Each call site was reviewed to confirm nothing downstream mutates it.