### PR TITLE
Introduce `ToolSpec` fluent API

### DIFF
--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAIToolCallAdvisorAutoRegistration2IT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAIToolCallAdvisorAutoRegistration2IT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.openai.chat.client;
+
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.test.chat.client.advisor.AbstractToolCallAdvisorAutoRegistration2IT;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Integration test for auto-registration of {@link ToolCallAdvisor} with OpenAI chat
+ * model.
+ *
+ * @author Christian Tzolov
+ */
+@SpringBootTest(classes = OpenAIToolCallAdvisorAutoRegistrationIT.TestConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+@ActiveProfiles("logging-test")
+class OpenAIToolCallAdvisorAutoRegistration2IT extends AbstractToolCallAdvisorAutoRegistration2IT {
+
+	@Override
+	protected ChatModel getChatModel() {
+		return OpenAiChatModel.builder()
+			.options(org.springframework.ai.openai.OpenAiChatOptions.builder()
+				.apiKey(System.getenv("OPENAI_API_KEY"))
+				.model(org.springframework.ai.openai.OpenAiChatOptions.DEFAULT_CHAT_MODEL)
+				.build())
+			.build();
+	}
+
+	@SpringBootConfiguration
+	public static class TestConfiguration {
+
+	}
+
+}

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -28,6 +28,7 @@ import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
 import org.springframework.ai.chat.messages.Message;
@@ -220,16 +221,43 @@ public interface ChatClient {
 
 		<B extends ChatOptions.Builder<?>> ChatClientRequestSpec options(B customizer);
 
-		ChatClientRequestSpec toolNames(String... toolNames);
+		ChatClientRequestSpec tools(Consumer<ToolSpec> consumer);
 
 		ChatClientRequestSpec tools(Object... toolObjects);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)}. To be removed in
+		 * 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		ChatClientRequestSpec toolNames(String... toolNames);
+
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
+		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(ToolCallback... toolCallbacks);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
+		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(List<ToolCallback> toolCallbacks);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
+		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolCallbacks(ToolCallbackProvider... toolCallbackProviders);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #tools(Consumer)} and
+		 * {@link #tools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		ChatClientRequestSpec toolContext(Map<String, Object> toolContext);
 
 		ChatClientRequestSpec system(String text);
@@ -253,6 +281,26 @@ public interface ChatClient {
 		CallResponseSpec call();
 
 		StreamResponseSpec stream();
+
+	}
+
+	interface ToolSpec {
+
+		ToolSpec instances(Object... toolObjects);
+
+		ToolSpec instances(List<Object> toolObjects);
+
+		ToolSpec callbacks(ToolCallback... toolCallbacks);
+
+		ToolSpec callbacks(List<ToolCallback> toolCallbacks);
+
+		ToolSpec callbacks(ToolCallbackProvider... toolCallbackProvider);
+
+		ToolSpec context(Map<String, Object> toolContext);
+
+		ToolSpec context(String key, Object value);
+
+		ToolSpec advisor(ToolAdvisor toolAdvisor);
 
 	}
 
@@ -287,16 +335,43 @@ public interface ChatClient {
 
 		Builder defaultTemplateRenderer(TemplateRenderer templateRenderer);
 
-		Builder defaultToolNames(String... toolNames);
+		Builder defaultTools(Consumer<ToolSpec> consumer);
 
 		Builder defaultTools(Object... toolObjects);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be
+		 * removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
+		Builder defaultToolNames(String... toolNames);
+
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
+		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(ToolCallback... toolCallbacks);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
+		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(List<ToolCallback> toolCallbacks);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
+		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolCallbacks(ToolCallbackProvider... toolCallbackProviders);
 
+		/**
+		 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)} and
+		 * {@link #defaultTools(Object...)} To be removed in 3.0.0.
+		 */
+		@Deprecated(since = "2.0.0", forRemoval = true)
 		Builder defaultToolContext(Map<String, Object> toolContext);
 
 		Builder clone();

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClient.java
@@ -625,6 +625,98 @@ public class DefaultChatClient implements ChatClient {
 
 	}
 
+	public static class DefaultToolSpec implements ToolSpec {
+
+		private final Map<String, Object> context = new HashMap<>();
+
+		private final List<ToolCallback> toolCallbacks = new ArrayList<>();
+
+		private final List<ToolCallbackProvider> toolCallbackProviders = new ArrayList<>();
+
+		private @Nullable ToolAdvisor toolAdvisor;
+
+		public Map<String, Object> getContext() {
+			return this.context;
+		}
+
+		public List<ToolCallback> getToolCallbacks() {
+			return this.toolCallbacks;
+		}
+
+		public List<ToolCallbackProvider> getToolCallbackProviders() {
+			return this.toolCallbackProviders;
+		}
+
+		public @Nullable ToolAdvisor getAdvisor() {
+			return this.toolAdvisor;
+		}
+
+		@Override
+		public ToolSpec context(String key, Object value) {
+			Assert.hasText(key, "context key cannot be null or empty");
+			Assert.notNull(value, "context value cannot be null");
+			this.context.put(key, value);
+			return this;
+		}
+
+		@Override
+		public ToolSpec context(Map<String, Object> context) {
+			Assert.notNull(context, "context cannot be null");
+			Assert.noNullElements(context.keySet(), "context keys cannot contain null elements");
+			Assert.noNullElements(context.values(), "context values cannot contain null elements");
+			this.context.putAll(context);
+			return this;
+		}
+
+		@Override
+		public ToolSpec instances(Object... toolObjects) {
+			Assert.notNull(toolObjects, "toolObjects cannot be null");
+			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
+			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects)));
+			return this;
+		}
+
+		@Override
+		public ToolSpec instances(List<Object> toolObjects) {
+			Assert.notNull(toolObjects, "toolObjects cannot be null");
+			Assert.noNullElements(toolObjects, "toolObjects cannot contain null elements");
+			this.toolCallbacks.addAll(Arrays.asList(ToolCallbacks.from(toolObjects.toArray(new Object[0]))));
+			return this;
+		}
+
+		@Override
+		public ToolSpec callbacks(ToolCallback... toolCallbacks) {
+			Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
+			Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
+			this.toolCallbacks.addAll(Arrays.asList(toolCallbacks));
+			return this;
+		}
+
+		@Override
+		public ToolSpec callbacks(List<ToolCallback> toolCallbacks) {
+			Assert.notNull(toolCallbacks, "toolCallbacks cannot be null");
+			Assert.noNullElements(toolCallbacks, "toolCallbacks cannot contain null elements");
+			this.toolCallbacks.addAll(toolCallbacks);
+			return this;
+		}
+
+		@Override
+		public ToolSpec callbacks(ToolCallbackProvider... toolCallbackProvider) {
+			Assert.notNull(toolCallbackProvider, "toolCallbackProvider cannot be null");
+			Assert.noNullElements(toolCallbackProvider, "toolCallbackProvider cannot contain null elements");
+			this.toolCallbackProviders.addAll(Arrays.asList(toolCallbackProvider));
+			return this;
+		}
+
+		@Override
+		public ToolSpec advisor(ToolAdvisor toolAdvisor) {
+			Assert.notNull(toolAdvisor, "toolAdvisor cannot be null");
+			this.toolAdvisor = toolAdvisor;
+			return this;
+		}
+
+	}
+
 	public static class DefaultChatClientRequestSpec implements ChatClientRequestSpec {
 
 		private final ObservationRegistry observationRegistry;
@@ -855,6 +947,22 @@ public class DefaultChatClient implements ChatClient {
 			builder.addMessages(this.messages);
 
 			return builder;
+		}
+
+		@Override
+		public ChatClientRequestSpec tools(Consumer<ToolSpec> consumer) {
+			Assert.notNull(consumer, "consumer cannot be null");
+			var toolSpec = new DefaultToolSpec();
+			consumer.accept(toolSpec);
+
+			this.toolContext.putAll(toolSpec.getContext());
+			this.toolCallbacks.addAll(toolSpec.getToolCallbacks());
+			this.toolCallbackProviders.addAll(toolSpec.getToolCallbackProviders());
+			if (toolSpec.getAdvisor() != null) {
+				this.advisors.add(toolSpec.getAdvisor());
+			}
+
+			return this;
 		}
 
 		@Override

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.client.ChatClient.Builder;
 import org.springframework.ai.chat.client.ChatClient.PromptSystemSpec;
 import org.springframework.ai.chat.client.ChatClient.PromptUserSpec;
+import org.springframework.ai.chat.client.ChatClient.ToolSpec;
 import org.springframework.ai.chat.client.DefaultChatClient.DefaultChatClientRequestSpec;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
@@ -163,20 +164,19 @@ public class DefaultChatClientBuilder implements Builder {
 	}
 
 	@Override
+	public Builder defaultTools(Consumer<ToolSpec> consumer) {
+		this.defaultRequest.tools(consumer);
+		return this;
+	}
+
+	/**
+	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
+	 * in 3.0.0.
+	 */
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	@Override
 	public Builder defaultToolNames(String... toolNames) {
 		this.defaultRequest.toolNames(toolNames);
-		return this;
-	}
-
-	@Override
-	public Builder defaultToolCallbacks(ToolCallback... toolCallbacks) {
-		this.defaultRequest.toolCallbacks(toolCallbacks);
-		return this;
-	}
-
-	@Override
-	public Builder defaultToolCallbacks(List<ToolCallback> toolCallbacks) {
-		this.defaultRequest.toolCallbacks(toolCallbacks);
 		return this;
 	}
 
@@ -186,12 +186,45 @@ public class DefaultChatClientBuilder implements Builder {
 		return this;
 	}
 
+	/**
+	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
+	 * in 3.0.0.
+	 */
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	@Override
+	public Builder defaultToolCallbacks(ToolCallback... toolCallbacks) {
+		this.defaultRequest.toolCallbacks(toolCallbacks);
+		return this;
+	}
+
+	/**
+	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
+	 * in 3.0.0.
+	 */
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	@Override
+	public Builder defaultToolCallbacks(List<ToolCallback> toolCallbacks) {
+		this.defaultRequest.toolCallbacks(toolCallbacks);
+		return this;
+	}
+
+	/**
+	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
+	 * in 3.0.0.
+	 */
+	@Deprecated(since = "2.0.0", forRemoval = true)
 	@Override
 	public Builder defaultToolCallbacks(ToolCallbackProvider... toolCallbackProviders) {
 		this.defaultRequest.toolCallbacks(toolCallbackProviders);
 		return this;
 	}
 
+	/**
+	 * @deprecated as of 2.0.0, in favor of {@link #defaultTools(Consumer)}. To be removed
+	 * in 3.0.0.
+	 */
+	@Deprecated(since = "2.0.0", forRemoval = true)
+	@Override
 	public Builder defaultToolContext(Map<String, Object> toolContext) {
 		this.defaultRequest.toolContext(toolContext);
 		return this;

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/ChatClientTests.java
@@ -267,11 +267,10 @@ public class ChatClientTests {
 						.param("param2", "value2")
 						.metadata("smetadata1", "svalue1")
 						.metadata("smetadata2", "svalue2"))
-				.defaultToolNames("fun1", "fun2")
-				.defaultToolCallbacks(FunctionToolCallback.builder("fun3", mockFunction)
-						.description("fun3description")
-						.inputType(String.class)
-						.build())
+				.defaultTools(t -> t.callbacks(
+						FunctionToolCallback.builder("fun1", mockFunction).description("fun1").inputType(String.class).build(),
+						FunctionToolCallback.builder("fun2", mockFunction).description("fun2").inputType(String.class).build(),
+						FunctionToolCallback.builder("fun3", mockFunction).description("fun3description").inputType(String.class).build()))
 				.defaultUser(u -> u.text("Default user text {uparam1}, {uparam2}")
 						.param("uparam1", "value1")
 						.param("uparam2", "value2")
@@ -309,8 +308,8 @@ public class ChatClientTests {
 
 		var fco = (ToolCallingChatOptions) prompt.getOptions();
 
-		assertThat(fco.getToolNames()).containsExactlyInAnyOrder("fun1", "fun2");
-		assertThat(fco.getToolCallbacks().iterator().next().getToolDefinition().name()).isEqualTo("fun3");
+		assertThat(fco.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("fun1", "fun2", "fun3");
 
 		// Streaming
 		content = join(chatClient.prompt().stream().content());
@@ -339,14 +338,15 @@ public class ChatClientTests {
 
 		fco = (ToolCallingChatOptions) prompt.getOptions();
 
-		assertThat(fco.getToolNames()).containsExactlyInAnyOrder("fun1", "fun2");
-		assertThat(fco.getToolCallbacks().iterator().next().getToolDefinition().name()).isEqualTo("fun3");
+		assertThat(fco.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("fun1", "fun2", "fun3");
 
 		// mutate builder
 		// @formatter:off
 		chatClient = chatClient.mutate()
 				.defaultSystem("Mutated default system text {param1}, {param2}")
-				.defaultToolNames("fun4")
+				.defaultTools(t -> t.callbacks(
+						FunctionToolCallback.builder("fun4", mockFunction).description("fun4").inputType(String.class).build()))
 				.defaultUser("Mutated default user text {uparam1}, {uparam2}")
 				.build();
 		// @formatter:on
@@ -377,8 +377,8 @@ public class ChatClientTests {
 
 		fco = (ToolCallingChatOptions) prompt.getOptions();
 
-		assertThat(fco.getToolNames()).containsExactlyInAnyOrder("fun1", "fun2", "fun4");
-		assertThat(fco.getToolCallbacks().iterator().next().getToolDefinition().name()).isEqualTo("fun3");
+		assertThat(fco.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("fun1", "fun2", "fun3", "fun4");
 
 		// Streaming
 		content = join(chatClient.prompt().stream().content());
@@ -407,8 +407,8 @@ public class ChatClientTests {
 
 		fco = (ToolCallingChatOptions) prompt.getOptions();
 
-		assertThat(fco.getToolNames()).containsExactlyInAnyOrder("fun1", "fun2", "fun4");
-		assertThat(fco.getToolCallbacks().iterator().next().getToolDefinition().name()).isEqualTo("fun3");
+		assertThat(fco.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("fun1", "fun2", "fun3", "fun4");
 
 	}
 
@@ -434,11 +434,10 @@ public class ChatClientTests {
 						.param("param2", "value2")
 						.metadata("smetadata1", "svalue1")
 						.metadata("smetadata2", "svalue2"))
-				.defaultToolNames("fun1", "fun2")
-				.defaultToolCallbacks(FunctionToolCallback.builder("fun3", mockFunction)
-						.description("fun3description")
-						.inputType(String.class)
-						.build())
+				.defaultTools(t -> t.callbacks(
+						FunctionToolCallback.builder("fun1", mockFunction).description("fun1").inputType(String.class).build(),
+						FunctionToolCallback.builder("fun2", mockFunction).description("fun2").inputType(String.class).build(),
+						FunctionToolCallback.builder("fun3", mockFunction).description("fun3description").inputType(String.class).build()))
 				.defaultUser(u -> u.text("Default user text {uparam1}, {uparam2}")
 						.param("uparam1", "value1")
 						.param("uparam2", "value2")
@@ -454,7 +453,8 @@ public class ChatClientTests {
 					.user(u -> u.param("uparam1", "userValue1")
 						.param("uparam2", "userValue2")
 						.metadata("umetadata2", "userData2"))
-					.toolNames("fun5")
+					.tools(t -> t.callbacks(
+							FunctionToolCallback.builder("fun5", mockFunction).description("fun5").inputType(String.class).build()))
 				.mutate().build() // mutate and build new prompt
 				.prompt().call().content();
 		// @formatter:on
@@ -483,8 +483,8 @@ public class ChatClientTests {
 
 		var tco = (ToolCallingChatOptions) prompt.getOptions();
 
-		assertThat(tco.getToolNames()).containsExactlyInAnyOrder("fun1", "fun2", "fun5");
-		assertThat(tco.getToolCallbacks().iterator().next().getToolDefinition().name()).isEqualTo("fun3");
+		assertThat(tco.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("fun1", "fun2", "fun3", "fun5");
 
 		// Streaming
 		// @formatter:off
@@ -494,7 +494,8 @@ public class ChatClientTests {
 						.user(u -> u.param("uparam1", "userValue1")
 							.param("uparam2", "userValue2")
 							.metadata("umetadata2", "userData2"))
-						.toolNames("fun5")
+						.tools(t -> t.callbacks(
+							FunctionToolCallback.builder("fun5", mockFunction).description("fun5").inputType(String.class).build()))
 					.mutate().build() // mutate and build new prompt
 					.prompt().stream().content());
 		// @formatter:on
@@ -523,8 +524,8 @@ public class ChatClientTests {
 
 		var tcoptions = (ToolCallingChatOptions) prompt.getOptions();
 
-		assertThat(tcoptions.getToolNames()).containsExactlyInAnyOrder("fun1", "fun2", "fun5");
-		assertThat(tcoptions.getToolCallbacks().iterator().next().getToolDefinition().name()).isEqualTo("fun3");
+		assertThat(tcoptions.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactlyInAnyOrder("fun1", "fun2", "fun3", "fun5");
 	}
 
 	@Test
@@ -648,7 +649,8 @@ public class ChatClientTests {
 		// @formatter:off
 		ChatClient client = ChatClient.builder(this.chatModel)
 				.defaultSystem("System text")
-				.defaultToolNames("function1")
+				.defaultTools(t -> t.callbacks(
+						FunctionToolCallback.builder("function1", mockFunction).description("function1").inputType(String.class).build()))
 				.build();
 
 		String response = client.prompt()
@@ -679,7 +681,8 @@ public class ChatClientTests {
 
 		assertThat(modelOptions.getToolNames()).isEmpty();
 
-		assertThat(promptOptions.getToolNames()).containsExactly("function1");
+		assertThat(promptOptions.getToolCallbacks()).extracting(cb -> cb.getToolDefinition().name())
+			.containsExactly("function1");
 	}
 
 	// Constructors

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -37,6 +37,7 @@ import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.client.advisor.api.BaseAdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.ToolAdvisor;
 import org.springframework.ai.chat.client.advisor.observation.AdvisorObservationConvention;
 import org.springframework.ai.chat.client.observation.ChatClientObservationContext;
 import org.springframework.ai.chat.client.observation.ChatClientObservationConvention;
@@ -156,9 +157,7 @@ class DefaultChatClientTests {
 				.metadata("userMetadata", "user data3"))
 			.defaultSystem(s -> s.text("original system {sysParams}").param("sysParams", "system value1"))
 			.defaultTemplateRenderer(templateRenderer)
-			.defaultToolNames("toolName1", "toolName2")
-			.defaultToolCallbacks(toolCallback)
-			.defaultToolContext(toolContext)
+			.defaultTools(t -> t.callbacks(toolCallback).context(toolContext))
 			.build();
 		var originalSpec = (DefaultChatClient.DefaultChatClientRequestSpec) originalChatClient.prompt();
 
@@ -177,7 +176,6 @@ class DefaultChatClientTests {
 		assertThat(mutateSpec.getSystemText()).isEqualTo("original system {sysParams}");
 		assertThat(mutateSpec.getSystemParams()).containsEntry("sysParams", "system value1");
 		assertThat(mutateSpec.getTemplateRenderer()).isEqualTo(templateRenderer);
-		assertThat(mutateSpec.getToolNames()).containsExactly("toolName1", "toolName2");
 		assertThat(mutateSpec.getToolCallbacks()).containsExactly(toolCallback);
 		assertThat(mutateSpec.getToolContext()).isEqualTo(toolContext);
 	}
@@ -1951,6 +1949,128 @@ class DefaultChatClientTests {
 		assertThat(defaultSpec.getToolContext()).containsEntry("key", "value");
 	}
 
+	// -------------------------------------------------------------------------
+	// ToolSpec validation
+	// -------------------------------------------------------------------------
+
+	@Test
+	void whenToolSpecCallbacksElementIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.callbacks(mock(ToolCallback.class), null)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("toolCallbacks cannot contain null elements");
+	}
+
+	@Test
+	void whenToolSpecCallbacksThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallback toolCallback = mock(ToolCallback.class);
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().tools(t -> t.callbacks(toolCallback));
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolCallbacks()).contains(toolCallback);
+	}
+
+	@Test
+	void whenToolSpecCallbacksListElementIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		List<ToolCallback> callbacks = new ArrayList<>();
+		callbacks.add(mock(ToolCallback.class));
+		callbacks.add(null);
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.callbacks(callbacks)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("toolCallbacks cannot contain null elements");
+	}
+
+	@Test
+	void whenToolSpecContextIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context((Map<String, Object>) null)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context cannot be null");
+	}
+
+	@Test
+	void whenToolSpecContextKeyIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		Map<String, Object> ctx = new HashMap<>();
+		ctx.put(null, "value");
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context(ctx)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context keys cannot contain null elements");
+	}
+
+	@Test
+	void whenToolSpecContextValueIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		Map<String, Object> ctx = new HashMap<>();
+		ctx.put("key", null);
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context(ctx)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context values cannot contain null elements");
+	}
+
+	@Test
+	void whenToolSpecContextThenReturn() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().tools(t -> t.context("key", "value"));
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolContext()).containsEntry("key", "value");
+	}
+
+	@Test
+	void whenToolSpecContextSingleKvKeyIsBlankThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context("", "value")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context key cannot be null or empty");
+	}
+
+	@Test
+	void whenToolSpecContextSingleKvValueIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.context("key", null)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("context value cannot be null");
+	}
+
+	@Test
+	void whenToolSpecConsumerIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		assertThatThrownBy(() -> chatClient.prompt().tools((Consumer<ChatClient.ToolSpec>) null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("consumer cannot be null");
+	}
+
+	@Test
+	void whenToolSpecAdvisorIsNullThenThrow() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		assertThatThrownBy(() -> chatClient.prompt().tools(t -> t.advisor(null)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("toolAdvisor cannot be null");
+	}
+
+	@Test
+	void whenToolSpecAdvisorThenAddedToAdvisors() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolAdvisor toolAdvisor = mock(ToolAdvisor.class);
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().tools(t -> t.advisor(toolAdvisor));
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getAdvisors()).contains(toolAdvisor);
+	}
+
+	@Test
+	void whenToolSpecCombinesAllTypesTheyAreAllPresent() {
+		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
+		ToolCallback cb = mock(ToolCallback.class);
+		ToolAdvisor toolAdvisor = mock(ToolAdvisor.class);
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt()
+			.tools(t -> t.callbacks(cb).context("k", "v").advisor(toolAdvisor));
+		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
+		assertThat(defaultSpec.getToolCallbacks()).contains(cb);
+		assertThat(defaultSpec.getToolContext()).containsEntry("k", "v");
+		assertThat(defaultSpec.getAdvisors()).contains(toolAdvisor);
+	}
+
 	@Test
 	void whenSystemTextIsNullThenThrow() {
 		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
@@ -2217,15 +2337,6 @@ class DefaultChatClientTests {
 	}
 
 	@Test
-	void whenToolNamesWithEmptyArrayThenReturn() {
-		ChatClient chatClient = new DefaultChatClientBuilder(mockChatModel()).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().toolNames();
-
-		DefaultChatClient.DefaultChatClientRequestSpec defaultSpec = (DefaultChatClient.DefaultChatClientRequestSpec) spec;
-		assertThat(defaultSpec.getToolNames()).isEmpty();
-	}
-
-	@Test
 	void whenUserParamsWithEmptyMapThenReturn() {
 		DefaultChatClient.DefaultPromptUserSpec spec = new DefaultChatClient.DefaultPromptUserSpec();
 		spec = (DefaultChatClient.DefaultPromptUserSpec) spec.params(Map.of());
@@ -2295,7 +2406,7 @@ class DefaultChatClientTests {
 		ToolCallbackProvider provider = mock(ToolCallbackProvider.class);
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").toolCallbacks(provider);
+		chatClient.prompt().user("test").tools(t -> t.callbacks(provider));
 
 		// Verify that getToolCallbacks() was NOT called during configuration
 		verify(provider, never()).getToolCallbacks();
@@ -2315,7 +2426,7 @@ class DefaultChatClientTests {
 		when(provider.getToolCallbacks()).thenReturn(new ToolCallback[] {});
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").toolCallbacks(provider);
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").tools(t -> t.callbacks(provider));
 
 		// Verify not called yet
 		verify(provider, never()).getToolCallbacks();
@@ -2339,7 +2450,7 @@ class DefaultChatClientTests {
 		when(provider.getToolCallbacks()).thenReturn(new ToolCallback[] {});
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").toolCallbacks(provider);
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").tools(t -> t.callbacks(provider));
 
 		// Verify not called yet
 		verify(provider, never()).getToolCallbacks();
@@ -2366,7 +2477,9 @@ class DefaultChatClientTests {
 		when(provider2.getToolCallbacks()).thenReturn(new ToolCallback[] {});
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").toolCallbacks(provider1, provider2);
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt()
+			.user("test")
+			.tools(t -> t.callbacks(provider1, provider2));
 
 		// Verify not called yet
 		verify(provider1, never()).getToolCallbacks();
@@ -2392,7 +2505,7 @@ class DefaultChatClientTests {
 		when(provider.getToolCallbacks()).thenReturn(new ToolCallback[] {});
 
 		ChatClient chatClient = new DefaultChatClientBuilder(chatModel).build();
-		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").toolCallbacks(provider);
+		ChatClient.ChatClientRequestSpec spec = chatClient.prompt().user("test").tools(t -> t.callbacks(provider));
 
 		// Verify provider not called yet
 		verify(provider, never()).getToolCallbacks();

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chatclient.adoc
@@ -754,7 +754,7 @@ TIP: Be cautious about logging sensitive information in production environments.
 
 === Tool Calling
 
-When tools are registered on a `ChatClient` call — via `.tools(...)`, `.toolCallbacks(...)`, `.toolNames(...)`, defaults set on the builder, tools pre-configured in the `ChatModel`'s default options, or tools passed through `.options(...)` — the `ChatClient` automatically registers a `ToolCallAdvisor` in the advisor chain to handle the tool execution lifecycle.
+When tools are registered on a `ChatClient` call (via `.tools(...)` or defaults set on the builder), the `ChatClient` automatically registers a `ToolCallAdvisor` in the advisor chain to handle the tool execution lifecycle.
 This means you do not need to add a `ToolCallAdvisor` manually for the common case.
 
 [source,java]
@@ -782,7 +782,9 @@ chatClient.prompt("What day is tomorrow?")
     .content();
 ----
 
-Or you can provide your own `ToolCallAdvisor` (or any other advisor implementing `ToolAdvisor`) — in that case auto-registration is suppressed automatically because the chain already contains a `ToolAdvisor`:
+Or you can provide your own `ToolCallAdvisor` (or any other advisor implementing `ToolAdvisor`) — in that case auto-registration is suppressed automatically because the chain already contains a `ToolAdvisor`.
+
+The preferred way is to pass the advisor directly inside the `ToolSpec` consumer, keeping tools and their advisor co-located:
 
 [source,java]
 ----
@@ -790,6 +792,18 @@ var customAdvisor = ToolCallAdvisor.builder()
     .toolCallingManager(myToolCallingManager)
     .build();
 
+chatClient.prompt("What day is tomorrow?")
+    .tools(t -> t
+        .instances(new DateTimeTools())
+        .advisor(customAdvisor))   // auto-registration suppressed
+    .call()
+    .content();
+----
+
+Alternatively, you can pass the advisor separately via `.advisors()`:
+
+[source,java]
+----
 chatClient.prompt("What day is tomorrow?")
     .tools(new DateTimeTools())
     .advisors(customAdvisor)    // auto-registration suppressed

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/tools.adoc
@@ -387,7 +387,7 @@ Besides the `@ToolParam` annotation, you can also use the `@Schema` annotation f
 
 ==== Adding Tools to `ChatClient` and `ChatModel`
 
-When using the programmatic specification approach, you can pass the `MethodToolCallback` instance to the `toolCallbacks()` method of `ChatClient`.
+When using the programmatic specification approach, you can pass the `MethodToolCallback` instance via the `tools()` consumer to `ChatClient`.
 The tool will only be available for the specific chat request it's added to.
 
 [source,java]
@@ -395,14 +395,14 @@ The tool will only be available for the specific chat request it's added to.
 ToolCallback toolCallback = ...
 ChatClient.create(chatModel)
     .prompt("What day is tomorrow?")
-    .toolCallbacks(toolCallback)
+    .tools(t -> t.callbacks(toolCallback))
     .call()
     .content();
 ----
 
 ==== Adding Default Tools to `ChatClient`
 
-When using the programmatic specification approach, you can add default tools to a `ChatClient.Builder` by passing the `MethodToolCallback` instance to the `defaultToolCallbacks()` method.
+When using the programmatic specification approach, you can add default tools to a `ChatClient.Builder` via the `defaultTools()` consumer.
 If both default and runtime tools are provided, the runtime tools will completely override the default tools.
 
 WARNING: Default tools are shared across all the chat requests performed by all the `ChatClient` instances built from the same `ChatClient.Builder`. They are useful for tools that are commonly used across different chat requests, but they can also be dangerous if not used carefully, risking to make them available when they shouldn't.
@@ -412,7 +412,7 @@ WARNING: Default tools are shared across all the chat requests performed by all 
 ChatModel chatModel = ...
 ToolCallback toolCallback = ...
 ChatClient chatClient = ChatClient.builder(chatModel)
-    .defaultToolCallbacks(toolCallback)
+    .defaultTools(t -> t.callbacks(toolCallback))
     .build();
 ----
 
@@ -510,21 +510,21 @@ NOTE: Some types are not supported. See xref:_function_tool_limitations[] for mo
 
 ==== Adding Tools to `ChatClient`
 
-When using the programmatic specification approach, you can pass the `FunctionToolCallback` instance to the `toolCallbacks()` method of `ChatClient`. The tool will only be available for the specific chat request it's added to.
+When using the programmatic specification approach, you can pass the `FunctionToolCallback` instance via the `tools()` consumer to `ChatClient`. The tool will only be available for the specific chat request it's added to.
 
 [source,java]
 ----
 ToolCallback toolCallback = ...
 ChatClient.create(chatModel)
     .prompt("What's the weather like in Copenhagen?")
-    .toolCallbacks(toolCallback)
+    .tools(t -> t.callbacks(toolCallback))
     .call()
     .content();
 ----
 
 ==== Adding Default Tools to `ChatClient`
 
-When using the programmatic specification approach, you can add default tools to a `ChatClient.Builder` by passing the `FunctionToolCallback` instance to the `defaultToolCallbacks()` method.
+When using the programmatic specification approach, you can add default tools to a `ChatClient.Builder` via the `defaultTools()` consumer.
 If both default and runtime tools are provided, the runtime tools will completely override the default tools.
 
 WARNING: Default tools are shared across all the chat requests performed by all the `ChatClient` instances built from the same `ChatClient.Builder`. They are useful for tools that are commonly used across different chat requests, but they can also be dangerous if not used carefully, risking to make them available when they shouldn't.
@@ -534,7 +534,7 @@ WARNING: Default tools are shared across all the chat requests performed by all 
 ChatModel chatModel = ...
 ToolCallback toolCallback = ...
 ChatClient chatClient = ChatClient.builder(chatModel)
-    .defaultToolCallbacks(toolCallback)
+    .defaultTools(t -> t.callbacks(toolCallback))
     .build();
 ----
 
@@ -620,8 +620,10 @@ class WeatherTools {
 
 ==== Adding Tools to `ChatClient`
 
-When using the dynamic specification approach, you can pass the tool name (i.e. the function bean name) to the `toolNames()` method of `ChatClient`.
+When using the dynamic specification approach, you can pass the tool name (i.e. the function bean name) to the `toolNames()` method on `ChatClient`.
 The tool will only be available for the specific chat request it's added to.
+
+CAUTION: `toolNames()` is deprecated as of 2.0.0. Prefer injecting a resolved `ToolCallback` instance via `.tools(t -> t.callbacks(...))` instead.
 
 [source,java]
 ----
@@ -634,10 +636,12 @@ ChatClient.create(chatModel)
 
 ==== Adding Default Tools to `ChatClient`
 
-When using the dynamic specification approach, you can add default tools to a `ChatClient.Builder` by passing the tool name to the `defaultToolNames()` method.
+When using the dynamic specification approach, you can add default tools to a `ChatClient.Builder` via the `defaultToolNames()` method.
 If both default and runtime tools are provided, the runtime tools will completely override the default tools.
 
 WARNING: Default tools are shared across all the chat requests performed by all the `ChatClient` instances built from the same `ChatClient.Builder`. They are useful for tools that are commonly used across different chat requests, but they can also be dangerous if not used carefully, risking to make them available when they shouldn't.
+
+CAUTION: `defaultToolNames()` is deprecated as of 2.0.0. Prefer injecting a resolved `ToolCallback` instance via `.defaultTools(t -> t.callbacks(...))` instead.
 
 [source,java]
 ----
@@ -955,8 +959,7 @@ ChatModel chatModel = ...
 
 String response = ChatClient.create(chatModel)
         .prompt("Tell me more about the customer with ID 42")
-        .tools(new CustomerTools())
-        .toolContext(Map.of("tenantId", "acme"))
+        .tools(t -> t.instances(new CustomerTools()).context(Map.of("tenantId", "acme")))
         .call()
         .content();
 
@@ -1384,7 +1387,7 @@ AugmentedToolCallbackProvider<AgentThinking> provider = AugmentedToolCallbackPro
 [source,java]
 ----
 ChatClient chatClient = ChatClient.builder(chatModel)
-    .defaultToolCallbacks(provider)
+    .defaultTools(t -> t.callbacks(provider))
     .build();
 ----
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/upgrade-notes.adoc
@@ -70,6 +70,64 @@ Spring Boot users should prefer one of the following instead:
 * Set `spring.ai.chat.client.tool-calling.advisor-order` to control the advisor's position in the chain.
 * Declare a `ToolCallAdvisor.Builder<?>` bean to fully replace the auto-configured builder (suppressed via `@ConditionalOnMissingBean`).
 
+==== Deprecated: Scattered Tool Methods on `ChatClient`
+
+The individual `toolCallbacks()`, `toolContext()`, and `toolNames()` methods on `ChatClientRequestSpec`, and their `defaultToolCallbacks()`, `defaultToolContext()`, and `defaultToolNames()` counterparts on `ChatClient.Builder`, are deprecated in favour of the unified `tools(Consumer<ToolSpec>)` / `defaultTools(Consumer<ToolSpec>)` API.
+
+===== Migration
+
+[source,java]
+----
+// Before
+chatClient.prompt()
+    .toolCallbacks(myCallback)
+    .toolContext(Map.of("tenantId", "acme"))
+    .call().content();
+
+// After
+chatClient.prompt()
+    .tools(t -> t.callbacks(myCallback).context("tenantId", "acme"))
+    .call().content();
+----
+
+==== Deprecated: Spring Bean Tool Resolution (`SpringBeanToolCallbackResolver`)
+
+`SpringBeanToolCallbackResolver` and the pattern of declaring bare `Function` / `Supplier` / `Consumer` beans and referencing them by name via `toolNames()` are deprecated since 2.0.0 and will be removed in 3.0.0.
+
+===== Migration
+
+Declare `ToolCallback` beans directly instead of raw functional beans:
+
+[source,java]
+----
+// Before — bare Function bean resolved by name at runtime
+@Bean
+@Description("Get the weather in location")
+Function<WeatherRequest, WeatherResponse> currentWeather() {
+    return weatherService::getWeather;
+}
+
+// After — explicit ToolCallback bean
+@Bean
+ToolCallback currentWeather() {
+    return FunctionToolCallback.builder("currentWeather", weatherService::getWeather)
+        .description("Get the weather in location")
+        .inputType(WeatherRequest.class)
+        .build();
+}
+----
+
+Then register the bean via the `ToolSpec` consumer:
+
+[source,java]
+----
+chatClient.prompt("What's the weather like in Copenhagen?")
+    .tools(t -> t.callbacks(currentWeather))
+    .call().content();
+----
+
+Alternatively, use `@Tool`-annotated methods for the declarative approach (see xref:api/tools.adoc[Tools API]).
+
 === Cloud Bindings
 
 The `spring-ai-spring-cloud-bindings` module that provided integration for https://github.com/spring-cloud/spring-cloud-bindings has been removed.

--- a/spring-ai-model/src/main/java/org/springframework/ai/tool/resolution/SpringBeanToolCallbackResolver.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/tool/resolution/SpringBeanToolCallbackResolver.java
@@ -55,7 +55,10 @@ import org.springframework.util.StringUtils;
  * @author Sebastien Deleuze
  * @author Thomas Vitale
  * @since 1.0.0
+ * @deprecated since 2.0.0 in favor of using {@link ToolCallback} beans directly and
+ * retrieving them via a {@link FunctionToolCallback}.
  */
+@Deprecated(since = "2.0.0", forRemoval = true)
 public class SpringBeanToolCallbackResolver implements ToolCallbackResolver {
 
 	private static final Logger logger = LoggerFactory.getLogger(SpringBeanToolCallbackResolver.class);

--- a/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorAutoRegistration2IT.java
+++ b/spring-ai-test/src/main/java/org/springframework/ai/test/chat/client/advisor/AbstractToolCallAdvisorAutoRegistration2IT.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.test.chat.client.advisor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.ai.chat.client.AdvisorParams;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientAttributes;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+import org.springframework.ai.tool.metadata.ToolMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Abstract integration-test base for {@link ToolCallAdvisor} auto-registration behaviour.
+ *
+ * <p>
+ * Covers functional correctness (do the right temperatures come back?) and structural
+ * correctness (is {@code ToolCallAdvisor} actually in control of the loop?). The
+ * structural proof uses a {@link ChainIterationCountingAdvisor} positioned just after the
+ * auto-registered {@code ToolCallAdvisor}. Because the advisor recurses via
+ * {@code chain.copy(this).nextCall()}, the counting advisor is invoked once per tool-call
+ * iteration plus once for the final answer — a count &gt; 1 proves the advisor chain owns
+ * the loop. When only the model's built-in path runs the count is always 1.
+ *
+ * <p>
+ * Subclasses provide the {@link ChatModel} implementation via {@link #getChatModel()}.
+ *
+ * @author Christian Tzolov
+ */
+public abstract class AbstractToolCallAdvisorAutoRegistration2IT {
+
+	protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+	protected abstract ChatModel getChatModel();
+
+	protected ToolCallback createWeatherToolCallback() {
+		return FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+			.description("Get the weather in location")
+			.inputType(MockWeatherService.Request.class)
+			.build();
+	}
+
+	protected ToolCallback createReturnDirectWeatherToolCallback() {
+		return FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
+			.description("Get the weather in location")
+			.inputType(MockWeatherService.Request.class)
+			.toolMetadata(ToolMetadata.builder().returnDirect(true).build())
+			.build();
+	}
+
+	private static String collect(Flux<String> flux) {
+		return Objects.requireNonNull(flux.collectList().block()).stream().collect(Collectors.joining());
+	}
+
+	// -------------------------------------------------------------------------
+	// Call path: functional
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class CallFunctional {
+
+		@Test
+		void autoRegisteredAdvisorExecutesTools() {
+			String response = ChatClient.create(getChatModel())
+				.prompt()
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@Test
+		void autoRegisteredAdvisorWithDownstreamMemory() {
+			String response = ChatClient.create(getChatModel())
+				.prompt()
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.advisors(MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
+					.build())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "auto-register-with-memory"))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@Test
+		void disabledAutoRegisterFallsBackToModelBuiltIn() {
+			// With auto-register off the model's internal tool-calling handles execution.
+			// Functional result should be identical.
+			String response = ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@Test
+		void defaultAdvisorsWithAutoRegistration() {
+			var chatClient = ChatClient.builder(getChatModel()).build();
+
+			String response = chatClient.prompt()
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@Test
+		void defaultAdvisorsWithMemoryAndAutoRegistration() {
+			var chatClient = ChatClient.builder(getChatModel())
+				.defaultAdvisors(MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
+				.build();
+
+			String response = chatClient.prompt()
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "default-advisors-memory"))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("30", "10", "15");
+		}
+
+		@Test
+		void returnDirectWithAutoRegistration() {
+			String response = ChatClient.create(getChatModel())
+				.prompt()
+				.user("What's the weather in Tokyo?")
+				.tools(tool -> tool.callbacks(createReturnDirectWeatherToolCallback()))
+				.call()
+				.content();
+
+			logger.info("Response: {}", response);
+			assertThat(response).contains("temp");
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Call path: structural (prove ToolCallAdvisor is in control)
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class CallStructural {
+
+		@Test
+		void advisorChainLoopsWhenAutoRegistered() {
+			var counter = new ChainIterationCountingAdvisor();
+
+			ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(counter)
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			// chain.copy(this) restarts after ToolCallAdvisor on every iteration
+			assertThat(counter.getCallCount())
+				.as("ToolCallAdvisor should loop: at least one tool iteration + final answer")
+				.isGreaterThanOrEqualTo(2);
+		}
+
+		@Test
+		void advisorChainDoesNotLoopWhenAutoRegisterDisabled() {
+			var counter = new ChainIterationCountingAdvisor();
+
+			ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(counter)
+				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			// Model handles tools internally; chain traversed exactly once
+			assertThat(counter.getCallCount()).as("Without ToolCallAdvisor the chain should be traversed exactly once")
+				.isEqualTo(1);
+		}
+
+		@Test
+		void toolResponseMessagesVisibleInChainWhenAutoRegistered() {
+			var counter = new ChainIterationCountingAdvisor();
+
+			ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(counter)
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			// On the second iteration the request must contain tool-response messages
+			// proving they are visible to every advisor after ToolCallAdvisor.
+			List<ChatClientRequest> requests = counter.getCapturedRequests();
+			assertThat(requests).hasSizeGreaterThanOrEqualTo(2);
+
+			boolean toolResponseVisible = requests.stream()
+				.skip(1) // skip first (no tool results yet)
+				.anyMatch(req -> req.prompt()
+					.getInstructions()
+					.stream()
+					.anyMatch(m -> m instanceof org.springframework.ai.chat.messages.ToolResponseMessage));
+
+			assertThat(toolResponseVisible)
+				.as("Tool response messages must be visible in the advisor chain on subsequent iterations")
+				.isTrue();
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Stream path: functional
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class StreamFunctional {
+
+		@Test
+		void autoRegisteredAdvisorExecutesTools() {
+			String content = collect(ChatClient.create(getChatModel())
+				.prompt()
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.stream()
+				.content());
+
+			logger.info("Response: {}", content);
+			assertThat(content).contains("30", "10", "15");
+		}
+
+		@Test
+		void autoRegisteredAdvisorWithDownstreamMemory() {
+			String content = collect(ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
+					.build())
+				.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "stream-auto-register-with-memory"))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.stream()
+				.content());
+
+			logger.info("Response: {}", content);
+			assertThat(content).contains("30", "10", "15");
+		}
+
+		@Test
+		void disabledAutoRegisterFallsBackToModelBuiltIn() {
+			String content = collect(ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.stream()
+				.content());
+
+			logger.info("Response: {}", content);
+			assertThat(content).contains("30", "10", "15");
+		}
+
+		@Test
+		void returnDirectWithAutoRegistration() {
+			String content = collect(ChatClient.create(getChatModel())
+				.prompt()
+				.user("What's the weather in Tokyo?")
+				.tools(tool -> tool.callbacks(createReturnDirectWeatherToolCallback()))
+				.stream()
+				.content());
+
+			logger.info("Response: {}", content);
+			assertThat(content).contains("temp");
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Stream path: structural
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class StreamStructural {
+
+		@Test
+		void advisorChainLoopsWhenAutoRegistered() {
+			var counter = new ChainIterationCountingAdvisor();
+
+			collect(ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(counter)
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.stream()
+				.content());
+
+			assertThat(counter.getCallCount())
+				.as("ToolCallAdvisor should loop on stream: at least one tool iteration + final answer")
+				.isGreaterThanOrEqualTo(2);
+		}
+
+		@Test
+		void advisorChainDoesNotLoopWhenAutoRegisterDisabled() {
+			var counter = new ChainIterationCountingAdvisor();
+
+			collect(ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(counter)
+				.advisors(a -> a.param(ChatClientAttributes.TOOL_CALL_ADVISOR_AUTO_REGISTER.getKey(), false))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.stream()
+				.content());
+
+			assertThat(counter.getCallCount())
+				.as("Without ToolCallAdvisor the stream chain should be traversed exactly once")
+				.isEqualTo(1);
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// AdvisorParams API
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class AdvisorParamsApi {
+
+		@Test
+		void toolCallAdvisorAutoRegisterFalseViaFactory() {
+			var counter = new ChainIterationCountingAdvisor();
+
+			ChatClient.create(getChatModel())
+				.prompt()
+				.advisors(counter)
+				.advisors(AdvisorParams.toolCallAdvisorAutoRegister(false))
+				.user("What's the weather in San Francisco, Tokyo, and Paris in Celsius?")
+				.tools(tool -> tool.callbacks(createWeatherToolCallback()))
+				.call()
+				.content();
+
+			assertThat(counter.getCallCount()).isEqualTo(1);
+		}
+
+	}
+
+	// -------------------------------------------------------------------------
+	// Inner types (InnerTypeLast)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Counts how many times the advisor chain passes through this advisor. Positioned
+	 * just after {@link ToolCallAdvisor} (order = DEFAULT_ORDER + 100), it is invoked
+	 * once per recursive tool-call iteration when the advisor manages the loop, and
+	 * exactly once when the model handles tool calls internally.
+	 */
+	protected static class ChainIterationCountingAdvisor implements BaseAdvisor {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		private final List<ChatClientRequest> capturedRequests = new ArrayList<>();
+
+		private final int order;
+
+		public ChainIterationCountingAdvisor() {
+			this(ToolCallAdvisor.DEFAULT_ORDER + 100);
+		}
+
+		public ChainIterationCountingAdvisor(int order) {
+			this.order = order;
+		}
+
+		@Override
+		public ChatClientRequest before(ChatClientRequest request, AdvisorChain advisorChain) {
+			this.callCount.incrementAndGet();
+			this.capturedRequests.add(request);
+			return request;
+		}
+
+		@Override
+		public ChatClientResponse after(ChatClientResponse response, AdvisorChain advisorChain) {
+			return response;
+		}
+
+		@Override
+		public int getOrder() {
+			return this.order;
+		}
+
+		public int getCallCount() {
+			return this.callCount.get();
+		}
+
+		public List<ChatClientRequest> getCapturedRequests() {
+			return Collections.unmodifiableList(this.capturedRequests);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Replace scattered tool-registration methods with a single ToolSpec consumer:

- tools(Consumer<ToolSpec>) / defaultTools(Consumer<ToolSpec>) as the primary entry points; old toolCallbacks/toolNames/toolContext overloads are deprecated in favour of ToolSpec
- ToolSpec exposes: instances(Object...|List), callbacks(ToolCallback...|List, ToolCallbackProvider...), context(Map|key+value), advisor(ToolAdvisor)
- advisor(ToolAdvisor) co-locates a custom ToolAdvisor with its tools; suppresses auto-registration of ToolCallAdvisor, consistent with the existing .advisors() path
- toolNames() are deprecated. For java.util.function tools with ToolSpec use explicit ToolCallback instances and FunctionToolCallback.
- Update tests and docs accordingly

