### PR TITLE
Sanitize Spring Boot related dependencies

### DIFF
--- a/auto-configurations/common/spring-ai-autoconfigure-retry/pom.xml
+++ b/auto-configurations/common/spring-ai-autoconfigure-retry/pom.xml
@@ -28,12 +28,14 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-common/pom.xml
@@ -24,14 +24,10 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-mcp</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -41,12 +37,17 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-httpclient/pom.xml
@@ -24,8 +24,17 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-mcp</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -35,18 +44,17 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Boot dependencies -->
 		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
-			<version>${project.parent.version}</version>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-client-webflux/pom.xml
@@ -24,8 +24,17 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-mcp</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
+			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -37,28 +46,28 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-common/pom.xml
@@ -22,16 +22,11 @@
 	</scm>
 
 	<dependencies>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-commons</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -55,12 +50,17 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
@@ -73,6 +73,12 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webflux/pom.xml
@@ -27,11 +27,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-mcp-server-common</artifactId>
 			<version>${project.parent.version}</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -57,10 +53,14 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
@@ -77,6 +77,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>net.javacrumbs.json-unit</groupId>
 			<artifactId>json-unit-assertj</artifactId>
 			<version>${json-unit-assertj.version}</version>
@@ -85,7 +91,21 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-mcp-client-webflux</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/pom.xml
+++ b/auto-configurations/mcp/spring-ai-autoconfigure-mcp-server-webmvc/pom.xml
@@ -27,11 +27,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-mcp-server-common</artifactId>
 			<version>${project.parent.version}</version>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -57,10 +53,14 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
@@ -73,6 +73,12 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
@@ -28,6 +28,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-client-chat</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -39,15 +40,14 @@
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cassandra/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cassandra/pom.xml
@@ -27,35 +27,33 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model-chat-memory-repository-cassandra</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-cassandra</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 
 		<!-- Test dependencies -->
 		<dependency>
@@ -82,6 +80,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cassandra</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-cosmos-db/pom.xml
@@ -43,30 +43,33 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-model-chat-memory-repository-cosmos-db</artifactId>
             <version>${project.version}</version>
+			<optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
             <version>${project.parent.version}</version>
+			<optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-        </dependency>
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
 
 		<dependency>
 			<groupId>com.azure</groupId>
@@ -79,11 +82,13 @@
 			<groupId>com.azure</groupId>
 			<artifactId>azure-identity</artifactId>
 			<version>${azure-identity.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
+			<optional>true</optional>
 		</dependency>
 
         <!-- Test dependencies -->

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-jdbc/pom.xml
@@ -27,33 +27,36 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model-chat-memory-repository-jdbc</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-jdbc</artifactId>
 			<optional>true</optional>
 		</dependency>
 

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-mongodb/pom.xml
@@ -28,34 +28,36 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model-chat-memory-repository-mongodb</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-mongodb</artifactId>
 			<optional>true</optional>
 		</dependency>
 

--- a/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-neo4j/pom.xml
+++ b/auto-configurations/models/chat/memory/repository/spring-ai-autoconfigure-model-chat-memory-repository-neo4j/pom.xml
@@ -27,33 +27,37 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model-chat-memory-repository-neo4j</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
+		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-neo4j</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-neo4j</artifactId>
 			<optional>true</optional>
 		</dependency>
 

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/pom.xml
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory-redis/pom.xml
@@ -24,43 +24,49 @@
 	<dependencies>
 		<!-- production dependencies -->
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model-chat-memory-repository-redis</artifactId>
 			<version>${project.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
+
+		<!-- Boot dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+
+
 
 
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-data-redis</artifactId>
-			<optional>true</optional>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
 

--- a/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory/pom.xml
+++ b/auto-configurations/models/chat/memory/spring-ai-autoconfigure-model-chat-memory/pom.xml
@@ -27,20 +27,20 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation/pom.xml
+++ b/auto-configurations/models/chat/observation/spring-ai-autoconfigure-model-chat-observation/pom.xml
@@ -28,6 +28,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-client-chat</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -39,15 +40,14 @@
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/models/embedding/observation/spring-ai-autoconfigure-model-embedding-observation/pom.xml
+++ b/auto-configurations/models/embedding/observation/spring-ai-autoconfigure-model-embedding-observation/pom.xml
@@ -28,20 +28,20 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/pom.xml
+++ b/auto-configurations/models/image/observation/spring-ai-autoconfigure-model-image-observation/pom.xml
@@ -28,6 +28,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -39,15 +40,14 @@
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-anthropic/pom.xml
@@ -30,6 +30,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-anthropic</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Spring AI auto configurations -->
@@ -38,12 +39,14 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-bedrock-ai/pom.xml
@@ -40,62 +40,31 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- Spring AI auto configurations -->
-
 		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
-			<version>${project.parent.version}</version>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-observation</artifactId>
+			<optional>true</optional>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-retry</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
 			<optional>true</optional>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-test</artifactId>
-			<scope>test</scope>
-    	</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 
 		<!-- Test dependencies -->
 		<dependency>
@@ -113,14 +82,47 @@
 
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
+			<artifactId>mockito-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
-	
-   <dependency>
-     <groupId>io.micrometer</groupId>
-     <artifactId>micrometer-observation</artifactId>
-   </dependency>
- </dependencies>
+
+		<!-- Spring AI auto configurations -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+
+	</dependencies>
 
 </project>

--- a/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-deepseek/pom.xml
@@ -39,18 +39,21 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-elevenlabs/pom.xml
@@ -39,12 +39,14 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-google-genai/pom.xml
@@ -48,24 +48,28 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-minimax/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-minimax/pom.xml
@@ -39,24 +39,28 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-mistral-ai/pom.xml
@@ -39,30 +39,35 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-ollama/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-ollama/pom.xml
@@ -39,24 +39,28 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-openai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-openai/pom.xml
@@ -30,6 +30,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-openai</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Spring AI auto configurations -->
@@ -38,30 +39,35 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-postgresml-embedding/pom.xml
@@ -39,12 +39,14 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-stability-ai/pom.xml
@@ -39,12 +39,14 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-transformers/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-transformers/pom.xml
@@ -39,6 +39,7 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/pom.xml
+++ b/auto-configurations/models/spring-ai-autoconfigure-model-vertex-ai/pom.xml
@@ -40,24 +40,28 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-retry</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->

--- a/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/pom.xml
+++ b/auto-configurations/models/tool/spring-ai-autoconfigure-model-tool/pom.xml
@@ -28,20 +28,20 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-model</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Boot dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure-cosmos-db/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure-cosmos-db/pom.xml
@@ -45,14 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>com.azure</groupId>
-			<artifactId>azure-identity</artifactId>
-			<version>${azure-identity.version}</version>
-		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -64,6 +61,7 @@
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-azure/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -59,6 +61,7 @@
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-bedrock-knowledgebase/pom.xml
@@ -45,14 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-vector-store</artifactId>
-			<version>${project.parent.version}</version>
-		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -69,6 +66,7 @@
 			<artifactId>jakarta.validation-api</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-cassandra/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-cassandra/pom.xml
@@ -45,13 +45,18 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
+		<!-- our autoconf actually customizes some cassandra-boot behavior -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-cassandra</artifactId>
+			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-cassandra</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -68,6 +73,11 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cassandra</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-chroma/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-couchbase/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-couchbase/pom.xml
@@ -45,13 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-couchbase</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,6 +71,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-couchbase</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-elasticsearch/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-elasticsearch/pom.xml
@@ -45,13 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-elasticsearch</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,6 +71,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-elasticsearch</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-gemfire/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mariadb/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mariadb/pom.xml
@@ -45,13 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,6 +71,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-milvus/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-mongodb-atlas/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -56,19 +58,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-mongodb</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-restclient</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
@@ -79,6 +72,16 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-neo4j/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-neo4j/pom.xml
@@ -45,13 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-neo4j</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,6 +71,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-neo4j</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-observation/pom.xml
@@ -42,15 +42,19 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-vector-store</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-opensearch/pom.xml
@@ -45,6 +45,7 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>apache-client</artifactId>
@@ -63,9 +64,11 @@
 			<version>${awssdk.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-oracle/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-oracle/pom.xml
@@ -45,13 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,6 +71,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/pom.xml
@@ -61,11 +61,17 @@
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pgvector/pom.xml
@@ -45,13 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,6 +71,11 @@
 		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pinecone/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-pinecone/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/pom.xml
@@ -98,9 +98,11 @@
 			<version>${grpc-netty-shaded.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-qdrant/pom.xml
@@ -96,7 +96,7 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-api</artifactId>
 			<version>${grpc-netty-shaded.version}</version>
-			<scope>provided</scope>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis-semantic-cache/pom.xml
@@ -21,34 +21,13 @@
 	</scm>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-redis-semantic-cache</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>redis.clients</groupId>
-			<artifactId>jedis</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
 			<optional>true</optional>
 		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-data-redis</artifactId>
-			<optional>true</optional>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-transformers</artifactId>
@@ -56,10 +35,19 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- Optional dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
 
@@ -69,6 +57,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-redis/pom.xml
@@ -45,13 +45,10 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -74,6 +71,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-s3/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-s3/pom.xml
@@ -43,10 +43,13 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-s3-vector-store</artifactId>
 			<version>${project.parent.version}</version>
+			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-typesense/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-typesense/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/pom.xml
+++ b/auto-configurations/vector-stores/spring-ai-autoconfigure-vector-store-weaviate/pom.xml
@@ -45,9 +45,11 @@
 			<version>${project.parent.version}</version>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/models/spring-ai-bedrock-converse/pom.xml
+++ b/models/spring-ai-bedrock-converse/pom.xml
@@ -96,6 +96,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-observation-test</artifactId>
 			<scope>test</scope>

--- a/models/spring-ai-bedrock/pom.xml
+++ b/models/spring-ai-bedrock/pom.xml
@@ -36,9 +36,6 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencies>
 
 		<!-- production dependencies -->
@@ -70,6 +67,16 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-deepseek/pom.xml
+++ b/models/spring-ai-deepseek/pom.xml
@@ -59,6 +59,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-observation-test</artifactId>
 			<scope>test</scope>

--- a/models/spring-ai-elevenlabs/pom.xml
+++ b/models/spring-ai-elevenlabs/pom.xml
@@ -70,6 +70,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-observation-test</artifactId>
 			<scope>test</scope>

--- a/models/spring-ai-google-genai-embedding/pom.xml
+++ b/models/spring-ai-google-genai-embedding/pom.xml
@@ -36,9 +36,6 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencies>
 
 		<dependency>
@@ -82,6 +79,12 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-google-genai/pom.xml
+++ b/models/spring-ai-google-genai/pom.xml
@@ -37,9 +37,6 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencies>
 
 		<dependency>
@@ -89,6 +86,12 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-minimax/pom.xml
+++ b/models/spring-ai-minimax/pom.xml
@@ -79,6 +79,12 @@
         </dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-observation-test</artifactId>
 			<scope>test</scope>

--- a/models/spring-ai-mistral-ai/pom.xml
+++ b/models/spring-ai-mistral-ai/pom.xml
@@ -78,6 +78,12 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>io.micrometer</groupId>

--- a/models/spring-ai-postgresml/pom.xml
+++ b/models/spring-ai-postgresml/pom.xml
@@ -36,9 +36,6 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
@@ -50,11 +47,6 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 
 		<dependency>

--- a/models/spring-ai-stability-ai/pom.xml
+++ b/models/spring-ai-stability-ai/pom.xml
@@ -36,9 +36,6 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencies>
 
 		<!-- production dependencies -->
@@ -70,6 +67,12 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/models/spring-ai-vertex-ai-embedding/pom.xml
+++ b/models/spring-ai-vertex-ai-embedding/pom.xml
@@ -36,9 +36,6 @@
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-ai.git</developerConnection>
 	</scm>
 
-	<properties>
-	</properties>
-
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -99,6 +96,17 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,21 @@
 								<requireMavenVersion>
 									<version>[3.9.1,)</version>
 								</requireMavenVersion>
+
+								<bannedDependencies>
+									<!-- Spring AI should NOT depend on boot. There are only 4 exceptions to this: -->
+									<!-- 1. test code can currently depend on boot (includes element below)-->
+									<!-- 2. auto-configurations module CAN depend on boot, but should use optional=true on all deps. This enforcer rule sadly can't see those dependencies, so no particular config here -->
+									<!-- 3. starters obviously depend on boot. There is a special profile below in this pom that relaxes the following rule, see further below. -->
+									<!-- 4. docker-compose and testcontainers projects depend on boot and have an override in their respective poms. -->
+									<excludes>
+										<exclude>org.springframework.boot</exclude>
+									</excludes>
+									<includes>
+										<include>org.springframework.boot:*:*:jar:test</include>
+									</includes>
+									<message>Spring AI code should NOT depend on Spring boot. The only exception to this is autoconfigure and starter modules.</message>
+								</bannedDependencies>
 							</rules>
 						</configuration>
 					</execution>
@@ -717,6 +732,41 @@
 						</executions>
 					</plugin>
 
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>starter-banned-dependency-relaxation</id>
+			<!-- This profile relaxes the enforcer rule that prohibits code to depend on boot, for starters/ only. -->
+			<activation>
+				<file>
+					<!-- Trick: since profiles can't be activated via properties in children projects, -->
+					<!-- this profile leverages the fact that starters are the only project type that -->
+					<!-- do not contain source files. -->
+					<missing>src/main</missing>
+				</file>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<version>${maven-enforcer-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>maven-enforcer</id>
+								<configuration>
+									<rules>
+										<bannedDependencies>
+											<includes combine.children="append">
+												<include>org.springframework.boot</include>
+											</includes>
+										</bannedDependencies>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/spring-ai-spring-boot-docker-compose/pom.xml
+++ b/spring-ai-spring-boot-docker-compose/pom.xml
@@ -89,6 +89,13 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-mcp-client-httpclient</artifactId>
 			<version>${project.version}</version>
 			<optional>true</optional>
@@ -103,10 +110,6 @@
 
         <!-- production dependencies -->
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mongodb</artifactId>
@@ -229,4 +232,31 @@
         </dependency>
 
     </dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>${maven-enforcer-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>maven-enforcer</id>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<includes combine.children="append">
+										<!-- allow a compile-time, non-optional dependency to boot. this overrides conf from the parent pom -->
+										<include>org.springframework.boot</include>
+									</includes>
+								</bannedDependencies>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/spring-ai-spring-boot-testcontainers/pom.xml
+++ b/spring-ai-spring-boot-testcontainers/pom.xml
@@ -103,6 +103,13 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-mcp-client-common</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-mcp-client-httpclient</artifactId>
 			<version>${project.version}</version>
 			<optional>true</optional>
@@ -119,14 +126,9 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -237,13 +239,13 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.skyscreamer</groupId>
 					<artifactId>jsonassert</artifactId>
 				</exclusion>
 			</exclusions>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -369,4 +371,29 @@
 
 	</dependencies>
 
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>${maven-enforcer-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>maven-enforcer</id>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<includes combine.children="append">
+										<!-- allow a compile-time, non-optional dependency to boot. this overrides conf from the parent pom -->
+										<include>org.springframework.boot</include>
+									</includes>
+								</bannedDependencies>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/spring-ai-test/pom.xml
+++ b/spring-ai-test/pom.xml
@@ -63,14 +63,13 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>com.vaadin.external.google</groupId>
-					<artifactId>android-json</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
 		</dependency>
 
 		<dependency>

--- a/starters/spring-ai-starter-model-anthropic/pom.xml
+++ b/starters/spring-ai-starter-model-anthropic/pom.xml
@@ -65,6 +65,18 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-chat-memory-repository-cosmos-db/pom.xml
+++ b/starters/spring-ai-starter-model-chat-memory-repository-cosmos-db/pom.xml
@@ -53,6 +53,29 @@
             <artifactId>spring-ai-model-chat-memory-repository-cosmos-db</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-spring-data-cosmos</artifactId>
+			<version>${azure-cosmos.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-identity</artifactId>
+			<version>${azure-identity.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-chat-memory-repository-jdbc/pom.xml
+++ b/starters/spring-ai-starter-model-chat-memory-repository-jdbc/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>spring-ai-model-chat-memory-repository-jdbc</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-jdbc</artifactId>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-chat-memory-repository-mongodb/pom.xml
+++ b/starters/spring-ai-starter-model-chat-memory-repository-mongodb/pom.xml
@@ -53,6 +53,17 @@
             <artifactId>spring-ai-model-chat-memory-repository-mongodb</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-mongodb</artifactId>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-chat-memory-repository-neo4j/pom.xml
+++ b/starters/spring-ai-starter-model-chat-memory-repository-neo4j/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>spring-ai-model-chat-memory-repository-neo4j</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-neo4j</artifactId>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-chat-memory/pom.xml
+++ b/starters/spring-ai-starter-model-chat-memory/pom.xml
@@ -47,6 +47,12 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-model</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-deepseek/pom.xml
+++ b/starters/spring-ai-starter-model-deepseek/pom.xml
@@ -75,6 +75,29 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-elevenlabs/pom.xml
+++ b/starters/spring-ai-starter-model-elevenlabs/pom.xml
@@ -49,6 +49,18 @@
 			<artifactId>spring-ai-elevenlabs</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-google-genai/pom.xml
+++ b/starters/spring-ai-starter-model-google-genai/pom.xml
@@ -65,6 +65,41 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-google-genai-embedding</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-minimax/pom.xml
+++ b/starters/spring-ai-starter-model-minimax/pom.xml
@@ -75,6 +75,30 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-mistral-ai/pom.xml
+++ b/starters/spring-ai-starter-model-mistral-ai/pom.xml
@@ -75,6 +75,36 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-ollama/pom.xml
+++ b/starters/spring-ai-starter-model-ollama/pom.xml
@@ -75,6 +75,30 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-openai/pom.xml
+++ b/starters/spring-ai-starter-model-openai/pom.xml
@@ -65,6 +65,51 @@
 			<artifactId>spring-ai-autoconfigure-model-chat-memory</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webclient</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-restclient</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-postgresml-embedding/pom.xml
+++ b/starters/spring-ai-starter-model-postgresml-embedding/pom.xml
@@ -53,6 +53,23 @@
 			<artifactId>spring-ai-postgresml</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-stability-ai/pom.xml
+++ b/starters/spring-ai-starter-model-stability-ai/pom.xml
@@ -63,6 +63,18 @@
             <artifactId>spring-ai-stability-ai</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-image-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-transformers/pom.xml
+++ b/starters/spring-ai-starter-model-transformers/pom.xml
@@ -53,6 +53,12 @@
 			<artifactId>spring-ai-transformers</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-model-vertex-ai-embedding/pom.xml
+++ b/starters/spring-ai-starter-model-vertex-ai-embedding/pom.xml
@@ -53,6 +53,30 @@
             <artifactId>spring-ai-vertex-ai-embedding</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-retry</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-embedding-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
     </dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-aws-opensearch/pom.xml
+++ b/starters/spring-ai-starter-vector-store-aws-opensearch/pom.xml
@@ -55,6 +55,8 @@
 			<artifactId>spring-ai-opensearch-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+
+		<!-- TODO: move? -->
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>apache-client</artifactId>

--- a/starters/spring-ai-starter-vector-store-azure-cosmos-db/pom.xml
+++ b/starters/spring-ai-starter-vector-store-azure-cosmos-db/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-azure-cosmos-db-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-azure-cosmos-db-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-azure/pom.xml
+++ b/starters/spring-ai-starter-vector-store-azure/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-azure-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-azure-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-bedrock-knowledgebase/pom.xml
+++ b/starters/spring-ai-starter-vector-store-bedrock-knowledgebase/pom.xml
@@ -57,6 +57,11 @@
 			<artifactId>spring-ai-bedrock-knowledgebase-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+	
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-bedrock-knowledgebase/pom.xml
+++ b/starters/spring-ai-starter-vector-store-bedrock-knowledgebase/pom.xml
@@ -49,6 +49,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+			<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-bedrock-knowledgebase-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-vector-store-cassandra/pom.xml
+++ b/starters/spring-ai-starter-vector-store-cassandra/pom.xml
@@ -50,11 +50,15 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-cassandra-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-cassandra-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-cassandra</artifactId>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-chroma/pom.xml
+++ b/starters/spring-ai-starter-vector-store-chroma/pom.xml
@@ -41,6 +41,7 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+		<!-- TODO: needed? -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-restclient</artifactId>
@@ -56,11 +57,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-chroma-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-chroma-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-couchbase/pom.xml
+++ b/starters/spring-ai-starter-vector-store-couchbase/pom.xml
@@ -36,7 +36,7 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
+			<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-couchbase-store</artifactId>
 			<version>${project.parent.version}</version>

--- a/starters/spring-ai-starter-vector-store-elasticsearch/pom.xml
+++ b/starters/spring-ai-starter-vector-store-elasticsearch/pom.xml
@@ -50,7 +50,7 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
+			<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-elasticsearch-store</artifactId>
 			<version>${project.parent.version}</version>

--- a/starters/spring-ai-starter-vector-store-gemfire/pom.xml
+++ b/starters/spring-ai-starter-vector-store-gemfire/pom.xml
@@ -41,6 +41,7 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+		<!-- TODO: needed ? -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webclient</artifactId>
@@ -56,11 +57,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-gemfire-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-gemfire-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-mariadb/pom.xml
+++ b/starters/spring-ai-starter-vector-store-mariadb/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-mariadb-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-mariadb-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-milvus/pom.xml
+++ b/starters/spring-ai-starter-vector-store-milvus/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
+    		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-milvus-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-    </dependencies>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-mongodb-atlas/pom.xml
+++ b/starters/spring-ai-starter-vector-store-mongodb-atlas/pom.xml
@@ -50,7 +50,7 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
+			<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-mongodb-atlas-store</artifactId>
 			<version>${project.parent.version}</version>

--- a/starters/spring-ai-starter-vector-store-neo4j/pom.xml
+++ b/starters/spring-ai-starter-vector-store-neo4j/pom.xml
@@ -50,7 +50,7 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
+			<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-neo4j-store</artifactId>
 			<version>${project.parent.version}</version>

--- a/starters/spring-ai-starter-vector-store-opensearch/pom.xml
+++ b/starters/spring-ai-starter-vector-store-opensearch/pom.xml
@@ -50,7 +50,7 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
+			<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-opensearch-store</artifactId>
 			<version>${project.parent.version}</version>

--- a/starters/spring-ai-starter-vector-store-opensearch/pom.xml
+++ b/starters/spring-ai-starter-vector-store-opensearch/pom.xml
@@ -55,6 +55,24 @@
 			<artifactId>spring-ai-opensearch-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+	
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>apache-client</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
+	
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>regions</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
+	
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>auth</artifactId>
+			<version>${awssdk.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-oracle/pom.xml
+++ b/starters/spring-ai-starter-vector-store-oracle/pom.xml
@@ -50,11 +50,7 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-oracle-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
+
 		<!-- TEMP: Workaround until Spring Boot updates its Oracle version -->
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
@@ -68,6 +64,11 @@
 			<groupId>com.oracle.database.ha</groupId>
 			<artifactId>simplefan</artifactId>
 		</dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-oracle-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-pgvector/pom.xml
+++ b/starters/spring-ai-starter-vector-store-pgvector/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-pgvector-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-pgvector-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-pinecone/pom.xml
+++ b/starters/spring-ai-starter-vector-store-pinecone/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-pinecone-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-pinecone-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-qdrant/pom.xml
+++ b/starters/spring-ai-starter-vector-store-qdrant/pom.xml
@@ -55,6 +55,12 @@
 			<artifactId>spring-ai-qdrant-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+	
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-api</artifactId>
+			<version>${grpc-netty-shaded.version}</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-qdrant/pom.xml
+++ b/starters/spring-ai-starter-vector-store-qdrant/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-qdrant-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-qdrant-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-redis/pom.xml
+++ b/starters/spring-ai-starter-vector-store-redis/pom.xml
@@ -55,6 +55,11 @@
 			<artifactId>spring-ai-redis-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+	
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-redis</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-redis/pom.xml
+++ b/starters/spring-ai-starter-vector-store-redis/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-redis-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-redis-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-s3/pom.xml
+++ b/starters/spring-ai-starter-vector-store-s3/pom.xml
@@ -34,7 +34,7 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-		<dependency>
+			<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-s3-vector-store</artifactId>
 			<version>${project.parent.version}</version>

--- a/starters/spring-ai-starter-vector-store-typesense/pom.xml
+++ b/starters/spring-ai-starter-vector-store-typesense/pom.xml
@@ -52,11 +52,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-typesense-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-typesense-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/starters/spring-ai-starter-vector-store-weaviate/pom.xml
+++ b/starters/spring-ai-starter-vector-store-weaviate/pom.xml
@@ -50,11 +50,11 @@
 			<artifactId>spring-ai-autoconfigure-vector-store-observation</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-weaviate-store</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-    </dependencies>
+    		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-weaviate-store</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/vector-stores/spring-ai-azure-store/pom.xml
+++ b/vector-stores/spring-ai-azure-store/pom.xml
@@ -105,11 +105,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<scope>test</scope>

--- a/vector-stores/spring-ai-chroma-store/pom.xml
+++ b/vector-stores/spring-ai-chroma-store/pom.xml
@@ -46,7 +46,7 @@
 
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-webflux</artifactId>
+			<artifactId>spring-web</artifactId>
 		</dependency>
 
 		<!-- TESTING -->

--- a/vector-stores/spring-ai-coherence-store/pom.xml
+++ b/vector-stores/spring-ai-coherence-store/pom.xml
@@ -41,7 +41,6 @@
 			<groupId>${coherence.groupId}</groupId>
 			<artifactId>coherence</artifactId>
 			<version>${coherence.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${coherence.groupId}</groupId>

--- a/vector-stores/spring-ai-couchbase-store/pom.xml
+++ b/vector-stores/spring-ai-couchbase-store/pom.xml
@@ -55,11 +55,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-testcontainers</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>testcontainers-couchbase</artifactId>
 			<scope>test</scope>

--- a/vector-stores/spring-ai-mariadb-store/pom.xml
+++ b/vector-stores/spring-ai-mariadb-store/pom.xml
@@ -42,17 +42,12 @@
 			<artifactId>spring-ai-vector-store</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-
 		<dependency>
-			<groupId>com.zaxxer</groupId>
-			<artifactId>HikariCP</artifactId>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jdbc</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
-		</dependency>
-
+		<!-- For Driver.enquoteIdentifier() only -->
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
@@ -79,6 +74,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.testcontainers</groupId>

--- a/vector-stores/spring-ai-opensearch-store/pom.xml
+++ b/vector-stores/spring-ai-opensearch-store/pom.xml
@@ -54,11 +54,6 @@
 			<version>${opensearch-client.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.httpcomponents.client5</groupId>
-			<artifactId>httpclient5</artifactId>
-		</dependency>
-
 		<!-- TESTING -->
 		<dependency>
 			<groupId>org.springframework.ai</groupId>

--- a/vector-stores/spring-ai-oracle-store/pom.xml
+++ b/vector-stores/spring-ai-oracle-store/pom.xml
@@ -69,11 +69,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 		</dependency>
@@ -97,6 +92,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-pgvector-store/pom.xml
+++ b/vector-stores/spring-ai-pgvector-store/pom.xml
@@ -49,18 +49,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.zaxxer</groupId>
-			<artifactId>HikariCP</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 
 		<dependency>
@@ -89,7 +79,6 @@
 			<scope>test</scope>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-test</artifactId>
@@ -106,6 +95,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/vector-stores/spring-ai-qdrant-store/pom.xml
+++ b/vector-stores/spring-ai-qdrant-store/pom.xml
@@ -101,11 +101,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.qdrant</groupId>
             <artifactId>client</artifactId>
             <version>${qdrant.version}</version>

--- a/vector-stores/spring-ai-redis-semantic-cache/pom.xml
+++ b/vector-stores/spring-ai-redis-semantic-cache/pom.xml
@@ -46,12 +46,6 @@
         </dependency>
         
         <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-rag</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
         </dependency>
@@ -93,6 +87,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-jdbc</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-redis</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/vector-stores/spring-ai-redis-store/pom.xml
+++ b/vector-stores/spring-ai-redis-store/pom.xml
@@ -54,10 +54,6 @@
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
 
         <dependency>
             <groupId>redis.clients</groupId>
@@ -90,6 +86,13 @@
 			<artifactId>spring-boot-jdbc</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 
 		<dependency>
 			<groupId>com.redis</groupId>

--- a/vector-stores/spring-ai-typesense-store/pom.xml
+++ b/vector-stores/spring-ai-typesense-store/pom.xml
@@ -65,12 +65,6 @@
 			<version>${typesense.version}</version>
         </dependency>
 
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<scope>test</scope>
-		</dependency>
-
         <!-- TESTING -->
         <dependency>
             <groupId>org.springframework.ai</groupId>


### PR DESCRIPTION
With this commit, we ensure that
* the main codebase does NOT depend on spring-boot
* the autoconfigure modules do depend on boot, and ALL dependencies should be depended upon with optional=true
* the starters modules depend on the autoconfigure module, and drag the required dependencies