### PR TITLE
Updated: McpJsonSchemaGenerator supports schema document generation for methods containing only one POJO parameter

### DIFF
--- a/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
+++ b/mcp/mcp-annotations/src/main/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGenerator.java
@@ -144,14 +144,10 @@ public final class McpJsonSchemaGenerator {
 
 		ObjectNode schema = JsonParser.getJsonMapper().createObjectNode();
 		schema.put("$schema", SchemaVersion.DRAFT_2020_12.getIdentifier());
-		schema.put("type", "object");
 
-		ObjectNode properties = schema.putObject("properties");
-		List<String> required = new ArrayList<>();
-
+		List<Integer> nonReservedParamIndexs = new ArrayList<>();
 		for (int i = 0; i < method.getParameterCount(); i++) {
 			Parameter parameter = method.getParameters()[i];
-			String parameterName = parameter.getName();
 			Type parameterType = method.getGenericParameterTypes()[i];
 
 			// Skip parameters annotated with @McpProgressToken
@@ -174,6 +170,28 @@ public final class McpJsonSchemaGenerator {
 							|| ClassUtils.isAssignable(CallToolRequest.class, parameterClass))) {
 				continue;
 			}
+			nonReservedParamIndexs.add(i);
+		}
+		if (nonReservedParamIndexs.size() == 1) {
+			Integer index = nonReservedParamIndexs.get(0);
+			Type parameterType = method.getGenericParameterTypes()[index];
+			ObjectNode parameterNode = SUBTYPE_SCHEMA_GENERATOR.generateSchema(parameterType);
+			if(parameterNode.hasNonNull("properties")) {
+				schema.setAll(parameterNode);
+				return schema.toPrettyString();
+			}
+		}
+
+		schema.put("type", "object");
+
+		ObjectNode properties = schema.putObject("properties");
+		List<String> required = new ArrayList<>();
+
+		for (int i = 0; i < nonReservedParamIndexs.size(); i++) {
+			Integer index = nonReservedParamIndexs.get(i);
+			Parameter parameter = method.getParameters()[index];
+			String parameterName = parameter.getName();
+			Type parameterType = method.getGenericParameterTypes()[index];
 
 			if (isMethodParameterRequired(method, i)) {
 				required.add(parameterName);

--- a/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
+++ b/mcp/mcp-annotations/src/test/java/org/springframework/ai/mcp/annotation/method/tool/utils/McpJsonSchemaGeneratorTests.java
@@ -1,0 +1,84 @@
+package org.springframework.ai.mcp.annotation.method.tool.utils;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+import java.util.Map;
+
+public class McpJsonSchemaGeneratorTests {
+
+	private final JsonMapper jsonMapper = new JsonMapper();
+
+	@Test
+	void mcpJsonSchemaGeneratorSinglePojo() throws Exception {
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(Executor.class.getMethod("execute", Param.class));
+		JsonNode node = jsonMapper.readTree(schema);
+		assert node.findPath("properties").hasNonNull("name");
+	}
+
+	@Test
+	void mcpJsonSchemaGeneratorMultiPojo() throws Exception {
+		String schema = McpJsonSchemaGenerator
+			.generateForMethodInput(Executor.class.getMethod("execute", Param.class, Param.class));
+		JsonNode node = jsonMapper.readTree(schema);
+		assert node.findPath("properties").hasNonNull("param");
+		assert node.findPath("properties").hasNonNull("param2");
+	}
+
+	@Test
+	void mcpJsonSchemaGenerator() throws Exception {
+		String schema = McpJsonSchemaGenerator.generateForMethodInput(Executor.class.getMethod("execute", int.class));
+		JsonNode node = jsonMapper.readTree(schema);
+		assert node.findPath("properties").hasNonNull("param");
+	}
+
+	public static class Executor {
+
+		public void execute(Param param) {
+		}
+
+		public void execute(Param param, Param param2) {
+		}
+
+		public void execute(int param) {
+		}
+
+		public void execute(Map<?, ?> param) {
+		}
+
+		public void execute(List<?> param) {
+		}
+
+	}
+
+	@Schema
+	public static class Param {
+
+		@Schema(name = "name", description = "参数名", requiredMode = Schema.RequiredMode.REQUIRED)
+		private String name;
+
+		@Schema(name = "type", description = "参数类型", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		private String type;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+	}
+
+}


### PR DESCRIPTION
**[Description]**
- Updated: McpJsonSchemaGenerator supports schema document generation for methods containing only one POJO parameter
- Add: Increase McpJsonSchemaGeneratorTests for testing McpJsonSchemaGenerator changes

**[Example]**

```
	public  class Param {

		@Schema(name = "name", description = "???", requiredMode = Schema.RequiredMode.REQUIRED)
		private String name;

		@Schema(name = "type", description = "????", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
		private String type;

             // Omit getters and setters
	}
```
```
	public  class Executor {

		public void execute(Param param) {
		}
     }
```
```
	@Test
	void mcpJsonSchemaGeneratorSinglePojo() throws Exception {
		String schema = McpJsonSchemaGenerator.generateForMethodInput(Executor.class.getMethod("execute", Param.class));
		System.out.println(schema);
	}
```
**[Result]**
```
{
  "$schema" : "https://json-schema.org/draft/2020-12/schema",
  "type" : "object",
  "properties" : {
    "name" : {
      "type" : "string",
      "description" : "参数名"
    },
    "type" : {
      "type" : "string",
      "description" : "参数类型"
    }
  },
  "required" : [ "name" ]
}
```