### PR TITLE
Complete documentation update for OpenAI SDK base URL new behavior

### DIFF
--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/speech/openai-speech.adoc
@@ -90,7 +90,6 @@ The prefix `spring.ai.openai.audio.speech` is used as the property prefix that l
 | spring.ai.openai.audio.speech.api-key    | The API Key           |  -
 | spring.ai.openai.audio.speech.organization-id | Optionally you can specify which organization  used for an API request. |  -
 | spring.ai.openai.audio.speech.project-id      | Optionally, you can specify which project is used for an API request. |  -
-| spring.ai.openai.audio.speech.speech-path | The API endpoint path for audio speech generation. Useful for OpenAI-compatible APIs with different endpoint structures. | /v1/audio/speech
 | spring.ai.openai.audio.speech.options.model  | ID of the model to use for generating the audio. Available models: `gpt-4o-mini-tts` (default, optimized for speed and cost), `gpt-4o-tts` (higher quality), `tts-1` (legacy, optimized for speed), or `tts-1-hd` (legacy, optimized for quality). |  gpt-4o-mini-tts
 | spring.ai.openai.audio.speech.options.voice | The voice to use for synthesis. For OpenAI's TTS API, One of the available voices for the chosen model: alloy, echo, fable, onyx, nova, and shimmer. | alloy
 | spring.ai.openai.audio.speech.options.response-format | The format of the audio output. Supported formats are mp3, opus, aac, flac, wav, and pcm. | mp3
@@ -102,22 +101,6 @@ The `spring.ai.openai.audio.speech.base-url`, `spring.ai.openai.audio.speech.api
 This is useful if you want to use different OpenAI accounts for different models and different model endpoints.
 
 TIP: All properties prefixed with `spring.ai.openai.audio.speech.options` can be overridden at runtime.
-
-=== Custom API Paths
-
-For OpenAI-compatible APIs (such as LocalAI, Ollama with OpenAI compatibility, or custom proxies) that use different endpoint paths, you can configure the speech path:
-
-[source,properties]
-----
-spring.ai.openai.audio.speech.speech-path=/custom/path/to/speech
-----
-
-This is particularly useful when:
-
-* Using API gateways or proxies that modify standard OpenAI paths
-* Working with OpenAI-compatible services that implement different URL structures
-* Testing against mock endpoints with custom paths
-* Deploying in environments with path-based routing requirements
 
 == Runtime Options [[speech-options]]
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/audio/transcriptions/openai-transcriptions.adoc
@@ -88,7 +88,6 @@ The prefix `spring.ai.openai.audio.transcription` is used as the property prefix
 | spring.ai.openai.audio.transcription.api-key    | The API Key           |  -
 | spring.ai.openai.audio.transcription.organization-id | Optionally you can specify which organization  used for an API request. |  -
 | spring.ai.openai.audio.transcription.project-id      | Optionally, you can specify which project is used for an API request. |  -
-| spring.ai.openai.audio.transcription.transcription-path | The API endpoint path for audio transcription. Useful for OpenAI-compatible APIs with different endpoint structures. | /v1/audio/transcriptions
 | spring.ai.openai.audio.transcription.options.model  | ID of the model to use for transcription. Available models: `gpt-4o-transcribe` (speech-to-text powered by GPT-4o), `gpt-4o-mini-transcribe` (speech-to-text powered by GPT-4o mini), or `whisper-1` (general-purpose speech recognition model, default). |  whisper-1
 | spring.ai.openai.audio.transcription.options.response-format | The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt. |  json
 | spring.ai.openai.audio.transcription.options.prompt | An optional text to guide the model's style or continue a previous audio segment. The prompt should match the audio language. |
@@ -102,22 +101,6 @@ The `spring.ai.openai.audio.transcription.base-url`, `spring.ai.openai.audio.tra
 This is useful if you want to use different OpenAI accounts for different models and different model endpoints.
 
 TIP: All properties prefixed with `spring.ai.openai.transcription.options` can be overridden at runtime.
-
-=== Custom API Paths
-
-For OpenAI-compatible APIs (such as LocalAI, Ollama with OpenAI compatibility, or custom proxies) that use different endpoint paths, you can configure the transcription path:
-
-[source,properties]
-----
-spring.ai.openai.audio.transcription.transcription-path=/custom/path/to/transcriptions
-----
-
-This is particularly useful when:
-
-* Using API gateways or proxies that modify standard OpenAI paths
-* Working with OpenAI-compatible services that implement different URL structures
-* Testing against mock endpoints with custom paths
-* Deploying in environments with path-based routing requirements
 
 == Runtime Options [[transcription-options]]
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/dmr-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/dmr-chat.adoc
@@ -3,7 +3,7 @@
 https://docs.docker.com/desktop/features/model-runner/[Docker Model Runner] is an AI Inference Engine offering a wide range of models from link:https://hub.docker.com/u/ai[various providers].
 
 Spring AI integrates with the Docker Model Runner by reusing the existing xref::api/chat/openai-chat.adoc[OpenAI] backed `ChatClient`.
-To do this, set the base URL to `http://localhost:12434/engines` and select one of the provided https://hub.docker.com/u/ai[LLM models].
+To do this, set the base URL to `http://localhost:12434/engines/v1` and select one of the provided https://hub.docker.com/u/ai[LLM models].
 
 Check the https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/DockerModelRunnerWithOpenAiChatModelIT.java[DockerModelRunnerWithOpenAiChatModelIT.java] tests
 for examples of how to use the Docker Model Runner with Spring AI.
@@ -17,7 +17,7 @@ Choose one of the following options to enable the Model Runner:
 Option 1:
 
 * Enable Model Runner `docker desktop enable model-runner --tcp 12434`.
-* Set the base-url to `http://localhost:12434/engines`
+* Set the base-url to `http://localhost:12434/engines/v1`
 
 Option 2:
 
@@ -97,7 +97,7 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 |====
 | Property | Description | Default
 
-| spring.ai.openai.base-url   | The URL to connect to. Must be set to `https://hub.docker.com/u/ai` | -
+| spring.ai.openai.base-url   | The URL to connect to. Must be set to `http://localhost:12434/engines/v1` | -
 | spring.ai.openai.api-key    | Any string           |  -
 |====
 
@@ -122,7 +122,7 @@ The prefix `spring.ai.openai.chat` is the property prefix that lets you configur
 
 | spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
 | spring.ai.model.chat | Enable OpenAI chat model.  | openai
-| spring.ai.openai.chat.base-url   | Optional overrides the `spring.ai.openai.base-url` to provide a chat specific url. Must be set to `http://localhost:12434/engines` |  -
+| spring.ai.openai.chat.base-url   | Optional overrides the `spring.ai.openai.base-url` to provide a chat specific url. Must be set to `http://localhost:12434/engines/v1` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.model | The link:https://hub.docker.com/u/ai[LLM model] to use | -
 | spring.ai.openai.chat.temperature | The sampling temperature that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8
@@ -181,7 +181,7 @@ Here's a simple example of how to use Docker Model Runner function calling with 
 [source,application.properties]
 ----
 spring.ai.openai.api-key=test
-spring.ai.openai.base-url=http://localhost:12434/engines
+spring.ai.openai.base-url=http://localhost:12434/engines/v1
 spring.ai.openai.chat.model=ai/gemma3:4B-F16
 ----
 
@@ -244,7 +244,7 @@ Add a `application.properties` file, under the `src/main/resources` directory, t
 [source,application.properties]
 ----
 spring.ai.openai.api-key=test
-spring.ai.openai.base-url=http://localhost:12434/engines
+spring.ai.openai.base-url=http://localhost:12434/engines/v1
 spring.ai.openai.chat.model=ai/gemma3:4B-F16
 
 # Docker Model Runner doesn't support embeddings, so we need to disable them.

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/groq-chat.adoc
@@ -4,7 +4,7 @@ https://groq.com/[Groq] is an extremely fast,  LPU™ based, AI Inference Engine
 supports `Tool/Function Calling` and exposes a `OpenAI API` compatible endpoint.
 
 Spring AI integrates with the https://groq.com/[Groq] by reusing the existing xref::api/chat/openai-chat.adoc[OpenAI] client. 
-For this you need to obtain a https://console.groq.com/keys[Groq Api Key], set the base-url to https://api.groq.com/openai and select one of the 
+For this you need to obtain a https://console.groq.com/keys[Groq Api Key], set the base-url to https://api.groq.com/openai/v1 and select one of the
 provided https://console.groq.com/docs/models[Groq models].
 
 image::spring-ai-groq-integration.jpg[w=800,align="center"]
@@ -23,7 +23,7 @@ Visit https://console.groq.com/keys[here] to create an API Key.
 The Spring AI project defines a configuration property named `spring.ai.openai.api-key` that you should set to the value of the `API Key` obtained from groq.com.
 
 * **Set the Groq URL**:
-You have to set the `spring.ai.openai.base-url` property to `+https://api.groq.com/openai+`.
+You have to set the `spring.ai.openai.base-url` property to `+https://api.groq.com/openai/v1+`.
 
 * **Select a Groq Model**:
 Use the `spring.ai.openai.chat.model=<model name>` property to select from the available https://console.groq.com/docs/models[Groq Models].
@@ -33,7 +33,7 @@ You can set these configuration properties in your `application.properties` file
 [source,properties]
 ----
 spring.ai.openai.api-key=<your-groq-api-key>
-spring.ai.openai.base-url=https://api.groq.com/openai
+spring.ai.openai.base-url=https://api.groq.com/openai/v1
 spring.ai.openai.chat.model=llama3-70b-8192
 ----
 
@@ -55,7 +55,7 @@ spring:
 ----
 # In your environment or .env file
 export GROQ_API_KEY=<your-groq-api-key>
-export GROQ_BASE_URL=https://api.groq.com/openai
+export GROQ_BASE_URL=https://api.groq.com/openai/v1
 export GROQ_MODEL=llama3-70b-8192
 ----
 
@@ -139,7 +139,7 @@ The prefix `spring.ai.openai` is used as the property prefix that lets you conne
 |====
 | Property | Description | Default
 
-| spring.ai.openai.base-url   | The URL to connect to. Must be set to `+https://api.groq.com/openai+` | -
+| spring.ai.openai.base-url   | The URL to connect to. Must be set to `+https://api.groq.com/openai/v1+` | -
 | spring.ai.openai.api-key    | The Groq API Key           |  -
 |====
 
@@ -165,7 +165,7 @@ The prefix `spring.ai.openai.chat` is the property prefix that lets you configur
 
 | spring.ai.openai.chat.enabled (Removed and no longer valid) | Enable OpenAI chat model.  | true
 | spring.ai.openai.chat | Enable OpenAI chat model.  | openai
-| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `+https://api.groq.com/openai+` |  -
+| spring.ai.openai.chat.base-url   | Optional overrides the spring.ai.openai.base-url to provide chat specific url. Must be set to `+https://api.groq.com/openai/v1+` |  -
 | spring.ai.openai.chat.api-key   | Optional overrides the spring.ai.openai.api-key to provide chat specific api-key |  -
 | spring.ai.openai.chat.model | The https://console.groq.com/docs/models[available model] names are `llama3-8b-8192`, `llama3-70b-8192`, `mixtral-8x7b-32768`, `gemma2-9b-it`. | -
 | spring.ai.openai.chat.temperature | The sampling temperature to use that controls the apparent creativity of generated completions. Higher values will make output more random while lower values will make results more focused and deterministic. It is not recommended to modify temperature and top_p for the same completions request as the interaction of these two settings is difficult to predict. | 0.8
@@ -290,7 +290,7 @@ Add a `application.properties` file, under the `src/main/resources` directory, t
 [source,application.properties]
 ----
 spring.ai.openai.api-key=<GROQ_API_KEY>
-spring.ai.openai.base-url=https://api.groq.com/openai
+spring.ai.openai.base-url=https://api.groq.com/openai/v1
 spring.ai.openai.chat.model=llama3-70b-8192
 spring.ai.openai.chat.temperature=0.7
 ----
@@ -356,7 +356,7 @@ Next, create a `OpenAiChatModel` and use it for text generations:
 ----
 var chatModel = OpenAiChatModel.builder()
     .options(OpenAiChatOptions.builder()
-        .baseUrl("https://api.groq.com/openai")
+        .baseUrl("https://api.groq.com/openai/v1")
         .apiKey(System.getenv("GROQ_API_KEY"))
         .model("llama3-70b-8192")
         .temperature(0.4)

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/mistralai-chat.adoc
@@ -317,7 +317,7 @@ view of the fruit inside.
 == OpenAI API Compatibility
 
 Mistral is OpenAI API-compatible and you can use the xref:api/chat/openai-chat.adoc[Spring AI OpenAI] client to talk to Mistrial.
-For this, you need to configure the OpenAI base URL to the Mistral AI platform: `spring.ai.openai.chat.base-url=https://api.mistral.ai`, and select a Mistral model: `spring.ai.openai.chat.model=mistral-small-latest` and set the Mistral AI API key: `spring.ai.openai.chat.api-key=<YOUR MISTRAL API KEY`.
+For this, you need to configure the OpenAI base URL to the Mistral AI platform: `spring.ai.openai.chat.base-url=https://api.mistral.ai/v1`, and select a Mistral model: `spring.ai.openai.chat.model=mistral-small-latest` and set the Mistral AI API key: `spring.ai.openai.chat.api-key=<YOUR MISTRAL API KEY`.
 
 Check the link:https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/proxy/MistralWithOpenAiChatModelIT.java[MistralWithOpenAiChatModelIT.java] tests for examples of using Mistral over Spring AI OpenAI.
 

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/chat/ollama-chat.adoc
@@ -606,7 +606,7 @@ The `.format(Map)` approach is also supported but requires manual JSON parsing.
 == OpenAI API Compatibility
 
 Ollama is OpenAI API-compatible and you can use the xref:api/chat/openai-chat.adoc[Spring AI OpenAI] client to talk to Ollama and use tools.
-For this, you need to configure the OpenAI base URL to your Ollama instance: `spring.ai.openai.chat.base-url=http://localhost:11434` and select one of the provided Ollama models: `spring.ai.openai.chat.model=mistral`.
+For this, you need to configure the OpenAI base URL to your Ollama instance: `spring.ai.openai.chat.base-url=http://localhost:11434/v1` and select one of the provided Ollama models: `spring.ai.openai.chat.model=mistral`.
 
 TIP: When using the OpenAI client with Ollama, you can pass Ollama-specific parameters (like `top_k`, `repeat_penalty`, `num_predict`) using the xref:api/chat/openai-chat.adoc#openai-compatible-servers[`extraBody` option].
 This allows you to leverage Ollama's full capabilities while using the OpenAI client.
@@ -632,7 +632,7 @@ class OllamaConfig {
     OpenAiChatModel ollamaChatModel() {
         return OpenAiChatModel.builder()
             .options(OpenAiChatOptions.builder()
-                .baseUrl("http://localhost:11434")
+                .baseUrl("http://localhost:11434/v1")
                 .apiKey("ollama")
                 .model("deepseek-r1")  // or qwen3, deepseek-v3.1, etc.
                 .build())

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/embeddings/openai-embeddings.adoc
@@ -145,7 +145,6 @@ The prefix `spring.ai.openai.embedding` is property prefix that configures the `
 | spring.ai.openai.embedding.enabled (Required and no longer valid) | Enable OpenAI embedding model.  | true
 | spring.ai.model.embedding | Enable OpenAI embedding model.  | openai
 | spring.ai.openai.embedding.base-url   | Optional overrides the spring.ai.openai.base-url to provide embedding specific url | -
-| spring.ai.openai.embedding.embeddings-path   | The path to append to the base-url  |  `/v1/embeddings`
 | spring.ai.openai.embedding.api-key    | Optional overrides the spring.ai.openai.api-key to provide embedding specific api-key  | -
 | spring.ai.openai.embedding.organization-id | Optionally you can specify which organization  used for an API request. |  -
 | spring.ai.openai.embedding.project-id      | Optionally, you can specify which project is used for an API request. |  -

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/moderation/openai-moderation.adoc
@@ -84,7 +84,6 @@ The prefix spring.ai.openai.moderation is used as the property prefix for config
 | spring.ai.openai.moderation.api-key    | The API Key           |  -
 | spring.ai.openai.moderation.organization-id | Optionally you can specify which organization is used for an API request. |  -
 | spring.ai.openai.moderation.project-id      | Optionally, you can specify which project is used for an API request. |  -
-| spring.ai.openai.moderation.moderation-path | The API endpoint path for moderation requests. Useful for OpenAI-compatible APIs with different endpoint structures. | /v1/moderations
 | spring.ai.openai.moderation.options.model  | ID of the model to use for moderation. | omni-moderation-latest
 |====
 
@@ -93,22 +92,6 @@ The `spring.ai.openai.moderation.base-url`, `spring.ai.openai.moderation.api-key
 This is useful if you want to use different OpenAI accounts for different models and different model endpoints.
 
 TIP: All properties prefixed with `spring.ai.openai.moderation.options` can be overridden at runtime.
-
-=== Custom API Paths
-
-For OpenAI-compatible APIs (such as LocalAI, custom proxies, or other OpenAI-compatible services) that use different endpoint paths, you can configure the moderation path:
-
-[source,properties]
-----
-spring.ai.openai.moderation.moderation-path=/custom/path/to/moderations
-----
-
-This is particularly useful when:
-
-* Using API gateways or proxies that modify standard OpenAI paths
-* Working with OpenAI-compatible services that implement different URL structures
-* Testing against mock endpoints with custom paths
-* Deploying in environments with path-based routing requirements
 
 == Runtime Options
 The OpenAiModerationOptions class provides the options to use when making a moderation request.


### PR DESCRIPTION
This documentation-only PR follows up on #6036 and completes the OpenAI SDK base URL documentation corrections started in 192eb5ccc. Across 8 documentation files, it corrects the remaining OpenAI-compatible base URLs and removes documentation for properties dropped by the migration.

| File | Problem | Fix |
| --- | --- | --- |
| `api/chat/dmr-chat.adoc` | The `spring.ai.openai.base-url` connection property pointed to `https://hub.docker.com/u/ai`, which is a Docker Hub page rather than an OpenAI-compatible API endpoint. | Changed the documented base URL to `http://localhost:12434/engines/v1`, matching the Docker Model Runner endpoint used elsewhere on the page. |
| `api/embeddings/openai-embeddings.adoc`, `api/audio/speech/openai-speech.adoc`, `api/audio/transcriptions/openai-transcriptions.adoc`, `api/moderation/openai-moderation.adoc` | The `embeddings-path`, `speech-path`, `transcription-path`, and `moderation-path` properties were removed by the openai-java SDK migration in 75fa84486, alongside `completions-path`. | Removed the remaining property table rows and the dedicated custom API path sections that only documented those removed properties. |
| `api/chat/dmr-chat.adoc` | The Docker Model Runner page still used `http://localhost:12434/engines` without `/v1` in 5 OpenAI-compatible occurrences. | Updated them to `http://localhost:12434/engines/v1`, aligning this page with the note added to `openai-chat.adoc` in 192eb5ccc. |
| `api/chat/ollama-chat.adoc` | The OpenAI API compatibility section used `http://localhost:11434` without `/v1` in 2 occurrences. | Updated only the OpenAI-compatible client examples to `http://localhost:11434/v1`; the native `spring.ai.ollama.*` base URL is unchanged. |
| `api/chat/groq-chat.adoc` | The Groq OpenAI-compatible base URL was documented as `https://api.groq.com/openai` without `/v1` in 8 occurrences. | Updated them to `https://api.groq.com/openai/v1`. |
| `api/chat/mistralai-chat.adoc` | The OpenAI API compatibility section used `https://api.mistral.ai` without `/v1`. | Updated only the OpenAI-compatible client example to `https://api.mistral.ai/v1`; the native `spring.ai.mistralai.*` base URL is unchanged. |

All changes are documentation-only, and the affected AsciiDoc structure was verified intact.

Follow-up to #6036.
