### PR TITLE
Restore ChatClient dependency in model starters

### DIFF
--- a/starters/spring-ai-starter-model-anthropic/pom.xml
+++ b/starters/spring-ai-starter-model-anthropic/pom.xml
@@ -56,6 +56,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-model-bedrock-converse/pom.xml
+++ b/starters/spring-ai-starter-model-bedrock-converse/pom.xml
@@ -56,6 +56,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-model-deepseek/pom.xml
+++ b/starters/spring-ai-starter-model-deepseek/pom.xml
@@ -66,6 +66,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-model-google-genai/pom.xml
+++ b/starters/spring-ai-starter-model-google-genai/pom.xml
@@ -56,6 +56,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-model-minimax/pom.xml
+++ b/starters/spring-ai-starter-model-minimax/pom.xml
@@ -66,6 +66,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-model-mistral-ai/pom.xml
+++ b/starters/spring-ai-starter-model-mistral-ai/pom.xml
@@ -66,6 +66,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-model-ollama/pom.xml
+++ b/starters/spring-ai-starter-model-ollama/pom.xml
@@ -66,6 +66,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/starters/spring-ai-starter-model-openai/pom.xml
+++ b/starters/spring-ai-starter-model-openai/pom.xml
@@ -56,6 +56,12 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>


### PR DESCRIPTION
Include explicit dependency on spring-ai-client-chat in all model starters after it was removed as a transitive dependendency on spring-ai-autoconfigure-model-chat-client.

Fixes gh-6094