### PR TITLE
Fix ToolCallAdvisor ignoring auto-configured ToolCallingManager

### DIFF
--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/pom.xml
@@ -63,6 +63,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/main/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfiguration.java
@@ -60,7 +60,7 @@ import org.springframework.context.annotation.Scope;
  * @author Jonatan Ivanov
  * @since 1.0.0
  */
-@AutoConfiguration
+@AutoConfiguration(afterName = "org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration")
 @ConditionalOnClass(ChatClient.class)
 @EnableConfigurationProperties(ChatClientBuilderProperties.class)
 @ConditionalOnProperty(prefix = ChatClientBuilderProperties.CONFIG_PREFIX, name = "enabled", havingValue = "true",

--- a/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
+++ b/auto-configurations/models/chat/client/spring-ai-autoconfigure-model-chat-client/src/test/java/org/springframework/ai/model/chat/client/autoconfigure/ChatClientAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import org.springframework.ai.chat.client.DefaultChatClient;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.autoconfigure.ToolCallingAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -59,6 +60,15 @@ class ChatClientAutoConfigurationTests {
 		this.contextRunner.withBean(ToolCallingManager.class, () -> manager).run(context -> {
 			var advisorBuilder = context.getBean(ToolCallAdvisor.Builder.class);
 			assertThat(ReflectionTestUtils.getField(advisorBuilder, "toolCallingManager")).isSameAs(manager);
+		});
+	}
+
+	@Test
+	void toolCallAdvisorBuilderUsesAutoConfiguredToolCallingManager() {
+		this.contextRunner.withConfiguration(AutoConfigurations.of(ToolCallingAutoConfiguration.class)).run(context -> {
+			var toolCallingManager = context.getBean(ToolCallingManager.class);
+			var advisorBuilder = context.getBean(ToolCallAdvisor.Builder.class);
+			assertThat(ReflectionTestUtils.getField(advisorBuilder, "toolCallingManager")).isSameAs(toolCallingManager);
 		});
 	}
 


### PR DESCRIPTION
The `ChatClientAutoConfiguration` is now applied after `ToolCallingAutoConfiguration`, ensuring the auto-configured `ToolCallingManager` is used correctly when building a `ToolCallAdvisor` instance.

I added an integration test to cover this dependency scenario.

The issue was visible by inspecting the telemetry.

Before my fix, no tool execution span was created:

<img width="405" height="455" alt="1779341828071" src="https://github.com/user-attachments/assets/2a1371ae-57be-4fde-be4f-8c0e578e304f" />

After my fix, the tool execution span is created correctly because the auto-configured ToolCallingManager is now used correctly (which is the one that includes the observability convention configuration).

<img width="531" height="490" alt="Screenshot 2026-05-21 at 08 04 14" src="https://github.com/user-attachments/assets/4865989b-e0dd-4d5b-9716-59f8daf09673" />
