### PR TITLE
Add spring-boot-autoconfigure-processor to the compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,10 @@
 							<groupId>org.springframework.boot</groupId>
 							<artifactId>spring-boot-configuration-processor</artifactId>
 						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-autoconfigure-processor</artifactId>
+						</path>
 					</annotationProcessorPaths>
 				</configuration>
 				<executions>


### PR DESCRIPTION
This processor was previously only referenced in auto-configuration modules, but automatic pickup of processors does not happen anymore in maven/JDK for security reasons.