### PR TITLE
GH-772: Parse API error envelope in default response error handler

### DIFF
--- a/spring-ai-retry/pom.xml
+++ b/spring-ai-retry/pom.xml
@@ -52,6 +52,11 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>tools.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/RetryUtils.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.retry.error.ApiErrorMessageImprover;
 import org.springframework.core.retry.RetryException;
 import org.springframework.core.retry.RetryListener;
 import org.springframework.core.retry.RetryPolicy;
@@ -79,7 +80,7 @@ public abstract class RetryUtils {
 		public void handleError(final ClientHttpResponse response) throws IOException {
 			if (response.getStatusCode().isError()) {
 				String error = StreamUtils.copyToString(response.getBody(), StandardCharsets.UTF_8);
-				String message = String.format("%s - %s", response.getStatusCode().value(), error);
+				String message = ApiErrorMessageImprover.improveErrorMessage(error, response.getStatusCode());
 				/*
 				 * Thrown on 4xx client errors, such as 401 - Incorrect API key provided,
 				 * 401 - You must be a member of an organization to use the API, 429 -

--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/error/ApiErrorMessageImprover.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/error/ApiErrorMessageImprover.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.retry.error;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.util.StringUtils;
+
+/**
+ * Turns raw error response bodies from OpenAI-compatible APIs into user-friendly
+ * messages. Used by {@code RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER} so that providers
+ * sharing the OpenAI error envelope (DeepSeek, Mistral AI, MiniMax, etc.) surface a
+ * status-prefixed message with an actionable hint instead of a raw JSON blob.
+ *
+ * @author stohirov
+ * @since 1.1.0
+ */
+public final class ApiErrorMessageImprover {
+
+	private static final Logger logger = LoggerFactory.getLogger(ApiErrorMessageImprover.class);
+
+	private ApiErrorMessageImprover() {
+	}
+
+	/**
+	 * Attempts to parse and improve an API error message. Falls back to
+	 * {@code "<status> - <body>"} when parsing fails or the body is not the expected JSON
+	 * envelope.
+	 * @param rawError the raw error response body
+	 * @param statusCode the HTTP status code
+	 * @return an improved, user-friendly error message
+	 */
+	public static String improveErrorMessage(String rawError, HttpStatusCode statusCode) {
+		if (!StringUtils.hasText(rawError)) {
+			return createFallbackMessage("Empty error response", statusCode);
+		}
+
+		try {
+			String trimmedError = rawError.trim();
+			if (trimmedError.startsWith("{") && trimmedError.endsWith("}")) {
+				ApiErrorResponse errorResponse = JsonMapper.shared().readValue(trimmedError, ApiErrorResponse.class);
+				if (errorResponse.getError() != null) {
+					return createImprovedMessage(errorResponse.getError(), statusCode);
+				}
+			}
+		}
+		catch (Exception ex) {
+			logger.debug("Failed to parse API error response as JSON: {}", ex.getMessage());
+		}
+
+		return createFallbackMessage(rawError, statusCode);
+	}
+
+	private static String createImprovedMessage(ApiErrorResponse.ErrorDetail errorDetail, HttpStatusCode statusCode) {
+		StringBuilder message = new StringBuilder();
+		message.append(getUserFriendlyPrefix(statusCode));
+
+		if (StringUtils.hasText(errorDetail.getMessage())) {
+			message.append(errorDetail.getMessage());
+		}
+		else {
+			message.append("An error occurred with the API");
+		}
+
+		String helpfulHint = getHelpfulHint(errorDetail.getCode());
+		if (StringUtils.hasText(helpfulHint)) {
+			message.append(" (").append(helpfulHint).append(")");
+		}
+
+		return message.toString();
+	}
+
+	private static String createFallbackMessage(String rawError, HttpStatusCode statusCode) {
+		return String.format("%s - %s", statusCode.value(), rawError);
+	}
+
+	private static String getUserFriendlyPrefix(HttpStatusCode statusCode) {
+		int status = statusCode.value();
+		if (status == 401) {
+			return "Authentication Error: ";
+		}
+		else if (status == 403) {
+			return "Permission Error: ";
+		}
+		else if (status == 429) {
+			return "Rate Limit Error: ";
+		}
+		else if (status == 500) {
+			return "Server Error: ";
+		}
+		else if (status == 503) {
+			return "Service Unavailable: ";
+		}
+		else if (statusCode.is4xxClientError()) {
+			return "Client Error: ";
+		}
+		else {
+			return "API Error: ";
+		}
+	}
+
+	private static @Nullable String getHelpfulHint(@Nullable String errorCode) {
+		if (!StringUtils.hasText(errorCode)) {
+			return null;
+		}
+
+		return switch (errorCode) {
+			case "invalid_api_key" -> "Please verify your API key";
+			case "insufficient_quota" -> "Please check your plan and billing details";
+			case "rate_limit_exceeded" -> "Please wait before making more requests";
+			case "model_not_found" -> "Please verify the model name is correct";
+			case "context_length_exceeded" -> "Please reduce the length of your input";
+			default -> null;
+		};
+	}
+
+}

--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/error/ApiErrorResponse.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/error/ApiErrorResponse.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.retry.error;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Parsed shape of the JSON error envelope returned by OpenAI-compatible APIs (OpenAI,
+ * DeepSeek, Mistral AI, MiniMax, etc.) — used by {@link ApiErrorMessageImprover} to turn
+ * raw error bodies into user-friendly messages.
+ *
+ * @author stohirov
+ * @since 1.1.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiErrorResponse {
+
+	@JsonProperty("error")
+	private @Nullable ErrorDetail error;
+
+	public ApiErrorResponse() {
+	}
+
+	public ApiErrorResponse(@Nullable ErrorDetail error) {
+		this.error = error;
+	}
+
+	public @Nullable ErrorDetail getError() {
+		return this.error;
+	}
+
+	public void setError(@Nullable ErrorDetail error) {
+		this.error = error;
+	}
+
+	@Override
+	public String toString() {
+		return "ApiErrorResponse{" + "error=" + this.error + '}';
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class ErrorDetail {
+
+		@JsonProperty("message")
+		private @Nullable String message;
+
+		@JsonProperty("type")
+		private @Nullable String type;
+
+		@JsonProperty("param")
+		private @Nullable String param;
+
+		@JsonProperty("code")
+		private @Nullable String code;
+
+		public ErrorDetail() {
+		}
+
+		public ErrorDetail(@Nullable String message, @Nullable String type, @Nullable String param,
+				@Nullable String code) {
+			this.message = message;
+			this.type = type;
+			this.param = param;
+			this.code = code;
+		}
+
+		public @Nullable String getMessage() {
+			return this.message;
+		}
+
+		public void setMessage(@Nullable String message) {
+			this.message = message;
+		}
+
+		public @Nullable String getType() {
+			return this.type;
+		}
+
+		public void setType(@Nullable String type) {
+			this.type = type;
+		}
+
+		public @Nullable String getParam() {
+			return this.param;
+		}
+
+		public void setParam(@Nullable String param) {
+			this.param = param;
+		}
+
+		public @Nullable String getCode() {
+			return this.code;
+		}
+
+		public void setCode(@Nullable String code) {
+			this.code = code;
+		}
+
+		@Override
+		public String toString() {
+			return "ErrorDetail{" + "message='" + this.message + '\'' + ", type='" + this.type + '\'' + ", param='"
+					+ this.param + '\'' + ", code='" + this.code + '\'' + '}';
+		}
+
+	}
+
+}

--- a/spring-ai-retry/src/main/java/org/springframework/ai/retry/error/package-info.java
+++ b/spring-ai-retry/src/main/java/org/springframework/ai/retry/error/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package org.springframework.ai.retry.error;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-ai-retry/src/test/java/org/springframework/ai/retry/error/ApiErrorMessageImproverTests.java
+++ b/spring-ai-retry/src/test/java/org/springframework/ai/retry/error/ApiErrorMessageImproverTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.retry.error;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ApiErrorMessageImprover}.
+ *
+ * @author stohirov
+ */
+class ApiErrorMessageImproverTests {
+
+	@Test
+	void improvesAuthenticationErrorWithInvalidApiKeyHint() {
+		String rawError = """
+				{"error":{"message":"Incorrect API key provided: sk-proj-***F2yw.","type":"invalid_request_error","param":null,"code":"invalid_api_key"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.UNAUTHORIZED);
+
+		assertThat(improved).startsWith("Authentication Error: ")
+			.contains("Incorrect API key provided")
+			.endsWith("(Please verify your API key)");
+	}
+
+	@Test
+	void improvesRateLimitErrorWithHint() {
+		String rawError = """
+				{"error":{"message":"Rate limit reached","type":"rate_limit_error","code":"rate_limit_exceeded"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.TOO_MANY_REQUESTS);
+
+		assertThat(improved)
+			.isEqualTo("Rate Limit Error: Rate limit reached (Please wait before making more requests)");
+	}
+
+	@Test
+	void improvesInsufficientQuotaWithBillingHint() {
+		String rawError = """
+				{"error":{"message":"You exceeded your current quota","type":"insufficient_quota","code":"insufficient_quota"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.TOO_MANY_REQUESTS);
+
+		assertThat(improved).isEqualTo(
+				"Rate Limit Error: You exceeded your current quota (Please check your plan and billing details)");
+	}
+
+	@Test
+	void improvesModelNotFoundError() {
+		String rawError = """
+				{"error":{"message":"The model 'foo' does not exist","type":"invalid_request_error","code":"model_not_found"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.NOT_FOUND);
+
+		assertThat(improved)
+			.isEqualTo("Client Error: The model 'foo' does not exist (Please verify the model name is correct)");
+	}
+
+	@Test
+	void improvesContextLengthExceededError() {
+		String rawError = """
+				{"error":{"message":"max context length","type":"invalid_request_error","code":"context_length_exceeded"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.BAD_REQUEST);
+
+		assertThat(improved).isEqualTo("Client Error: max context length (Please reduce the length of your input)");
+	}
+
+	@Test
+	void omitsHintWhenErrorCodeUnknown() {
+		String rawError = """
+				{"error":{"message":"Something happened","type":"server_error","code":"unknown_thing"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.INTERNAL_SERVER_ERROR);
+
+		assertThat(improved).isEqualTo("Server Error: Something happened");
+	}
+
+	@Test
+	void usesServiceUnavailablePrefixFor503() {
+		String rawError = """
+				{"error":{"message":"Service down","type":"server_error"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.SERVICE_UNAVAILABLE);
+
+		assertThat(improved).isEqualTo("Service Unavailable: Service down");
+	}
+
+	@Test
+	void usesPermissionPrefixFor403() {
+		String rawError = """
+				{"error":{"message":"Forbidden","type":"permission_error"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.FORBIDDEN);
+
+		assertThat(improved).isEqualTo("Permission Error: Forbidden");
+	}
+
+	@Test
+	void usesGenericApiErrorForUnclassifiedStatus() {
+		String rawError = """
+				{"error":{"message":"Weird"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.MOVED_PERMANENTLY);
+
+		assertThat(improved).isEqualTo("API Error: Weird");
+	}
+
+	@Test
+	void fallsBackToRawWhenNotJson() {
+		String rawError = "<html>Bad Gateway</html>";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.BAD_GATEWAY);
+
+		assertThat(improved).isEqualTo("502 - <html>Bad Gateway</html>");
+	}
+
+	@Test
+	void fallsBackToRawWhenJsonHasNoErrorField() {
+		String rawError = "{\"foo\":\"bar\"}";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.BAD_REQUEST);
+
+		assertThat(improved).isEqualTo("400 - {\"foo\":\"bar\"}");
+	}
+
+	@Test
+	void fallsBackWhenJsonIsMalformed() {
+		String rawError = "{not json}";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.BAD_REQUEST);
+
+		assertThat(improved).isEqualTo("400 - {not json}");
+	}
+
+	@Test
+	void emptyErrorProducesFallbackMessage() {
+		String improved = ApiErrorMessageImprover.improveErrorMessage("", HttpStatus.INTERNAL_SERVER_ERROR);
+
+		assertThat(improved).isEqualTo("500 - Empty error response");
+	}
+
+	@Test
+	void usesGenericMessageWhenErrorMessageMissing() {
+		String rawError = """
+				{"error":{"type":"server_error","code":"invalid_api_key"}}""";
+
+		String improved = ApiErrorMessageImprover.improveErrorMessage(rawError, HttpStatus.UNAUTHORIZED);
+
+		assertThat(improved)
+			.isEqualTo("Authentication Error: An error occurred with the API (Please verify your API key)");
+	}
+
+}


### PR DESCRIPTION
Fixes GH-772 (https://github.com/spring-projects/spring-ai/issues/772)

Adds `ApiErrorMessageImprover` to turn the OpenAI-shaped JSON error body into a status-prefixed message with an actionable hint, falling back to `<status> - <body>` when the response is not the expected envelope. Wired into `RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER`.
